### PR TITLE
Fix MySQL driver version

### DIFF
--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -27,6 +27,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- specify `mysql-connector-j` version so Maven builds don't fail

## Testing
- `mvn package` *(fails: command not found)*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617ecf8fac8321a4cd76a01ba1c832