### PR TITLE
Fix test setup with H2 dependency

### DIFF
--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -31,6 +31,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Summary
- add missing H2 database dependency for tests

## Testing
- `mvn test` *(fails: Could not download parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6863292b61e48321961cf8866253d29c