### PR TITLE
Add DB config variables

### DIFF
--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+db.host=${MYSQL_HOST:localhost}
+db.port=${MYSQL_PORT:3306}
+db.name=${MYSQL_DB:ads}
+db.username=${MYSQL_USER:root}
+db.password=${MYSQL_PASS:password}
+
+spring.datasource.url=jdbc:mysql://${db.host}:${db.port}/${db.name}
+spring.datasource.username=${db.username}
+spring.datasource.password=${db.password}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update

--- a/backend/ads-service/src/main/resources/application.yml
+++ b/backend/ads-service/src/main/resources/application.yml
@@ -1,9 +1,0 @@
-spring:
-  datasource:
-    url: jdbc:mysql://${MYSQL_HOST:localhost}:3306/${MYSQL_DB:ads}
-    username: ${MYSQL_USER:root}
-    password: ${MYSQL_PASS:password}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-  jpa:
-    hibernate:
-      ddl-auto: update


### PR DESCRIPTION
## Summary
- centralize DB connection properties under a `db` section in `application.properties`

## Testing
- `mvn package` *(fails: command not found)*
- `mvn test` *(fails: command not found)*
- `npm run build` *(fails: package.json missing)*
- `npm run test` *(fails: package.json missing)*


------
https://chatgpt.com/codex/tasks/task_e_6866982848808321a3f2827f44c8439f