### PR TITLE
Fix AssetRepositoryTest to run without Docker

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
@@ -4,26 +4,11 @@ import com.marketinghub.media.repository.AssetRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Testcontainers
 @DataJpaTest
 class AssetRepositoryTest {
-    @Container
-    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0");
-
-    @DynamicPropertySource
-    static void mysqlProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", mysql::getJdbcUrl);
-        registry.add("spring.datasource.username", mysql::getUsername);
-        registry.add("spring.datasource.password", mysql::getPassword);
-    }
 
     @Autowired
     AssetRepository repository;


### PR DESCRIPTION
## Summary
- update `AssetRepositoryTest` to remove MySQL Testcontainers usage

## Testing
- `mvn -o -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68680588b9408321b37a3545dfde0e22