### PR TITLE
Fix CI Maven path

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,9 +14,9 @@ jobs:
 # ─────────────────────────────────────────
   build:
     runs-on: ubuntu-latest
-    defaults:                     # 👉 força todos os steps a rodarem em backend/
+    defaults:                     # 👉 força todos os steps a rodarem em backend/ads-service
       run:
-        working-directory: backend
+        working-directory: backend/ads-service
 
     steps:
       - uses: actions/checkout@v4           # clona o repositório
@@ -38,13 +38,13 @@ jobs:
       - name: Testes e build
         run: |
           mvn -B verify               # executa testes
-          mvn -B package -DskipTests  # gera backend/target/*.jar
+          mvn -B package -DskipTests  # gera target/*.jar
 
       - name: Publicar artefato
         uses: actions/upload-artifact@v4
         with:
           name: backend-jar
-          path: backend/target/*.jar  # ⬅️ caminho relativo ao repo
+          path: backend/ads-service/target/*.jar  # ⬅️ caminho relativo ao repo
 
 # ─────────────────────────────────────────
 # 2) DEPLOY – transfere JAR e reinicia


### PR DESCRIPTION
## Summary
- fix workflow's working directory for Maven commands
- upload artifact from correct Maven target directory

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `mvn -q package` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684ac596e48321a3cfbe90ddbb4671