### PR TITLE
Fix DataJpaTest config

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
@@ -1,13 +1,16 @@
 package com.marketinghub.media;
 
 import com.marketinghub.media.repository.AssetRepository;
+import com.marketinghub.ads.AdsServiceApplication;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@ContextConfiguration(classes = AdsServiceApplication.class)
 class AssetRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- wire in the application configuration for AssetRepositoryTest

## Testing
- `mvn test` *(fails: Non-resolvable parent POM -- Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68684c0a87b883219e13a550845afa82