### PR TITLE
Fix missing websocket dependency

### DIFF
--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- include spring-boot-starter-websocket for MediaService

## Testing
- `mvn -q package` *(fails: Non-resolvable parent POM - Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686857eeacd4832187c712212563b4ff