### PR TITLE
Fix JPA repo scan

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/AdsServiceApplication.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/AdsServiceApplication.java
@@ -5,7 +5,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
 @SpringBootApplication(scanBasePackages = "com.marketinghub")
+@EnableJpaRepositories(basePackages = "com.marketinghub")
+@EntityScan(basePackages = "com.marketinghub")
 @EnableAsync
 @EnableScheduling
 public class AdsServiceApplication {

--- a/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
@@ -7,7 +7,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.marketinghub.ads.AdsServiceApplication;
+import org.springframework.test.context.ContextConfiguration;
+
 @DataJpaTest
+@ContextConfiguration(classes = AdsServiceApplication.class)
 class AssetRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- enable entity and repository scanning for all packages
- load application context for AssetRepositoryTest

## Testing
- `mvn -q -o test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68685ccf310083218fa7fa7980b6aa5b