### PR TITLE
Fix missing AssetRepository bean

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/AdsServiceApplication.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/AdsServiceApplication.java
@@ -2,10 +2,14 @@ package com.marketinghub.ads;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.marketinghub")
+@EntityScan(basePackages = "com.marketinghub")
+@EnableJpaRepositories(basePackages = "com.marketinghub")
 @EnableAsync
 @EnableScheduling
 public class AdsServiceApplication {


### PR DESCRIPTION
## Summary
- configure entity and repository scanning in `AdsServiceApplication`

## Testing
- `mvn -q --offline test` *(fails: Cannot access central and artifact not downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_686873c4c65483219b143a23fe699dcf