### PR TITLE
Fix AssetRepository test context

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
@@ -1,13 +1,16 @@
 package com.marketinghub.media;
 
+import com.marketinghub.ads.AdsServiceApplication;
 import com.marketinghub.media.repository.AssetRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@ContextConfiguration(classes = AdsServiceApplication.class)
 class AssetRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- use `@ContextConfiguration` to load `AdsServiceApplication` in the `AssetRepositoryTest`

## Testing
- `mvn test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686876275dbc8321bb856c65d001d1af