### PR TITLE
Fix backend workflow build steps

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend/ads-service
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
@@ -19,7 +22,7 @@ jobs:
           distribution: temurin
           java-version: 21
           cache: maven
-      - name: Build with Maven
-        run: |
-          cd backend/ads-service
-          mvn -B package
+      - name: Run tests
+        run: mvn -B test
+      - name: Package application
+        run: mvn -B package -DskipTests


### PR DESCRIPTION
## Summary
- improve GitHub Actions build for the backend
- run tests separately and package with skipTests
- set default working directory for Maven commands

## Testing
- `mvn package -q` *(fails: Could not resolve dependencies)*
- `mvn test -q` *(fails: Could not resolve dependencies)*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686973cc67e48321a507824f1832e818