### PR TITLE
Fix jar deploy handling

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,5 +79,6 @@ jobs:
 
       - name: Sincronizar JAR e reiniciar serviço
         run: |
-          rsync -az --delete target/ads-service.jar marketinghub@${VPS_IP}:${APP_DIR}/app.jar
-          ssh marketinghub@${VPS_IP} "sudo systemctl restart marketinghub-backend.service"
+          JAR=$(ls -S target/*.jar | head -n 1)
+          rsync -az --delete "$JAR" marketinghub@${VPS_IP}:${APP_DIR}/
+          ssh marketinghub@${VPS_IP} "sudo -n systemctl restart marketinghub-backend.service"

--- a/marketinghub-backend.service
+++ b/marketinghub-backend.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Marketing Hub Backend
+After=network.target
+
+[Service]
+Type=simple
+User=marketinghub
+WorkingDirectory=/opt/marketinghub/app
+ExecStart=/usr/bin/java -jar /opt/marketinghub/app/ads-service.jar
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/migrate_appjar.sh
+++ b/migrate_appjar.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+APP_DIR="/opt/marketinghub/app"
+TARGET_JAR="$APP_DIR/ads-service.jar"
+
+if [ -d "$APP_DIR/app.jar" ]; then
+  JAR=$(ls -S "$APP_DIR/app.jar"/*.jar | head -n 1)
+  mv "$JAR" "$TARGET_JAR"
+  rm -rf "$APP_DIR/app.jar"
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl restart marketinghub-backend.service


### PR DESCRIPTION
## Summary
- update CI/CD pipeline to select the correct jar before deploying
- add marketinghub backend service unit file example
- add migration helper script

## Testing
- `mvn -B test` *(fails: Could not transfer artifact)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b5bab2688321b5dd051b03e01d06