### PR TITLE
Change backend to port 8000

### DIFF
--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.datasource.username=${db.username}
 spring.datasource.password=${db.password}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
+
+# Use port 8000 instead of the Spring Boot default 8080
+server.port=8000

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,15 +1,16 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:8080'
-    }
+      // Backend now listens on port 8000
+      "/api": "http://localhost:8000",
+    },
   },
   test: {
-    environment: 'jsdom'
-  }
+    environment: "jsdom",
+  },
 });


### PR DESCRIPTION
## Summary
- update Spring Boot config to use port 8000
- update Vite proxy for new backend port

## Testing
- `npx prettier -w frontend/vite.config.ts`
- `../mvnw -q spotless:apply` *(fails: Non-resolvable parent POM)*
- `../mvnw -q package` *(fails: Non-resolvable parent POM)*
- `../mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869cb16a880832184531d275360a3c6