### PR TITLE
Add frontend dev env with localhost backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ SYNTHESIA_API_KEY=changeme
 HEYGEN_API_KEY=changeme
 ELEVENLABS_API_KEY=changeme
 RUNWAY_API_KEY=changeme
+
+# Frontend
+# Base URL of backend API for the React app
+VITE_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 docker compose up -d      # start MySQL
 cd backend/ads-service && mvn spring-boot:run
 cd ../../frontend && npm run dev
+# create a .env file to point the React app to your backend
+echo "VITE_API_URL=http://localhost:8000" > frontend/.env
 # deploy to VPS (Java 21 already installed)
 scp target/app.jar <vps>:/opt/marketing-hub/
 ssh <vps> "java -jar /opt/marketing-hub/app.jar"

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,9 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { io } from "socket.io-client";
 import App from "./App";
+import axios from "axios";
+
+axios.defaults.baseURL = import.meta.env.VITE_API_URL || "";
 
 const queryClient = new QueryClient();
 const socket = io({ path: "/ws" });


### PR DESCRIPTION
## Summary
- configure axios base URL from `VITE_API_URL`
- document dev environment setup for frontend
- provide `VITE_API_URL` example in `.env.example`

## Testing
- `npm run test -- --run`
- `npm run build`
- `mvn test -q` *(fails: Non-resolvable parent POM)*
- `mvn package -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686bd5dd0c3483218f485dd9301b46b3