### PR TITLE
Add Kajabi course integration

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/course/CoursePlan.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/course/CoursePlan.java
@@ -1,0 +1,43 @@
+package com.marketinghub.course;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Entity representing a course plan proposed by Kajabi AI.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CoursePlan {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String targetAudience;
+    private String transformation;
+
+    @Lob
+    private String macroTopics;
+
+    @Lob
+    private String modules;
+
+    @Lob
+    private String objectives;
+
+    @Lob
+    private String resources;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/course/client/KajabiClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/course/client/KajabiClient.java
@@ -1,0 +1,27 @@
+package com.marketinghub.course.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+/**
+ * Client for Kajabi AI API.
+ */
+@Component
+public class KajabiClient {
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+
+    public KajabiClient(RestTemplate restTemplate,
+                        @Value("${kajabi.base-url:https://api.kajabi.com}") String baseUrl) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+    }
+
+    public Map<String, Object> proposeCoursePlan(Map<String, Object> request) {
+        String url = baseUrl + "/ai/course-plan";
+        return restTemplate.postForObject(url, request, Map.class);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/course/dto/CoursePlanDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/course/dto/CoursePlanDto.java
@@ -1,0 +1,20 @@
+package com.marketinghub.course.dto;
+
+import java.time.Instant;
+import lombok.Data;
+
+/**
+ * Data transfer object for {@link com.marketinghub.course.CoursePlan}.
+ */
+@Data
+public class CoursePlanDto {
+    private Long id;
+    private String targetAudience;
+    private String transformation;
+    private String macroTopics;
+    private String modules;
+    private String objectives;
+    private String resources;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/course/dto/CreateCoursePlanRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/course/dto/CreateCoursePlanRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.course.dto;
+
+import lombok.Data;
+
+/**
+ * Request body for creating a course plan.
+ */
+@Data
+public class CreateCoursePlanRequest {
+    private String targetAudience;
+    private String transformation;
+    private String macroTopics;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/course/mapper/CoursePlanMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/course/mapper/CoursePlanMapper.java
@@ -1,0 +1,13 @@
+package com.marketinghub.course.mapper;
+
+import com.marketinghub.course.CoursePlan;
+import com.marketinghub.course.dto.CoursePlanDto;
+import org.mapstruct.Mapper;
+
+/**
+ * MapStruct mapper for {@link CoursePlan}.
+ */
+@Mapper(componentModel = "spring")
+public interface CoursePlanMapper {
+    CoursePlanDto toDto(CoursePlan plan);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/course/repository/CoursePlanRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/course/repository/CoursePlanRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.course.repository;
+
+import com.marketinghub.course.CoursePlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * JPA repository for {@link CoursePlan} entities.
+ */
+public interface CoursePlanRepository extends JpaRepository<CoursePlan, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/course/service/CoursePlanService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/course/service/CoursePlanService.java
@@ -1,0 +1,56 @@
+package com.marketinghub.course.service;
+
+import com.marketinghub.course.CoursePlan;
+import com.marketinghub.course.client.KajabiClient;
+import com.marketinghub.course.dto.CreateCoursePlanRequest;
+import com.marketinghub.course.repository.CoursePlanRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+/**
+ * Service layer for course plan generation using Kajabi AI.
+ */
+@Service
+public class CoursePlanService {
+    private final CoursePlanRepository repository;
+    private final KajabiClient client;
+
+    public CoursePlanService(CoursePlanRepository repository, KajabiClient client) {
+        this.repository = repository;
+        this.client = client;
+    }
+
+    /**
+     * Creates a course plan by delegating to Kajabi AI.
+     */
+    @Transactional
+    public CoursePlan createPlan(CreateCoursePlanRequest request) {
+        CoursePlan plan = CoursePlan.builder()
+                .targetAudience(request.getTargetAudience())
+                .transformation(request.getTransformation())
+                .macroTopics(request.getMacroTopics())
+                .build();
+        repository.save(plan);
+
+        Map<String, Object> resp = client.proposeCoursePlan(Map.of(
+                "audience", request.getTargetAudience(),
+                "transformation", request.getTransformation(),
+                "topics", request.getMacroTopics()
+        ));
+
+        plan.setModules(String.valueOf(resp.get("modules")));
+        plan.setObjectives(String.valueOf(resp.get("objectives")));
+        plan.setResources(String.valueOf(resp.get("resources")));
+        return repository.save(plan);
+    }
+
+    public CoursePlan getPlan(Long id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    public Iterable<CoursePlan> listPlans() {
+        return repository.findAll();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/course/web/CoursePlanController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/course/web/CoursePlanController.java
@@ -1,0 +1,42 @@
+package com.marketinghub.course.web;
+
+import com.marketinghub.course.dto.CoursePlanDto;
+import com.marketinghub.course.dto.CreateCoursePlanRequest;
+import com.marketinghub.course.mapper.CoursePlanMapper;
+import com.marketinghub.course.service.CoursePlanService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+/**
+ * REST controller for course plans.
+ */
+@RestController
+@RequestMapping("/api/courses")
+public class CoursePlanController {
+    private final CoursePlanService service;
+    private final CoursePlanMapper mapper;
+
+    public CoursePlanController(CoursePlanService service, CoursePlanMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @PostMapping
+    public CoursePlanDto create(@RequestBody CreateCoursePlanRequest request) {
+        return mapper.toDto(service.createPlan(request));
+    }
+
+    @GetMapping("/{id}")
+    public CoursePlanDto get(@PathVariable Long id) {
+        return mapper.toDto(service.getPlan(id));
+    }
+
+    @GetMapping
+    public List<CoursePlanDto> list() {
+        return StreamSupport.stream(service.listPlans().spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,9 @@ import InstagramAccountsPage from "./pages/InstagramAccountsPage";
 import MediaListPage from "./pages/media/MediaListPage";
 import NewMediaPage from "./pages/media/NewMediaPage";
 import MediaDetailPage from "./pages/media/MediaDetailPage";
+import CoursePlanListPage from "./pages/course/CoursePlanListPage";
+import NewCoursePlanPage from "./pages/course/NewCoursePlanPage";
+import CoursePlanDetailPage from "./pages/course/CoursePlanDetailPage";
 
 export default function App() {
   return (
@@ -21,7 +24,12 @@ export default function App() {
             <Link className="nav-link" to="/accounts/instagram">
               Instagram Accounts
             </Link>
-            <Link className="nav-link" to="/media">Media</Link>
+            <Link className="nav-link" to="/media">
+              Media
+            </Link>
+            <Link className="nav-link" to="/courses">
+              Courses
+            </Link>
           </div>
         </div>
       </nav>
@@ -31,6 +39,9 @@ export default function App() {
         <Route path="/media" element={<MediaListPage />} />
         <Route path="/media/new" element={<NewMediaPage />} />
         <Route path="/media/:id" element={<MediaDetailPage />} />
+        <Route path="/courses" element={<CoursePlanListPage />} />
+        <Route path="/courses/new" element={<NewCoursePlanPage />} />
+        <Route path="/courses/:id" element={<CoursePlanDetailPage />} />
         <Route path="*" element={<div>Home</div>} />
       </Routes>
     </div>

--- a/frontend/src/api/course/useCoursePlans.ts
+++ b/frontend/src/api/course/useCoursePlans.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface CoursePlan {
+  id: number;
+  targetAudience: string;
+  transformation: string;
+  macroTopics: string;
+  modules: string;
+  objectives: string;
+  resources: string;
+}
+
+/** Query to list course plans */
+export function useCoursePlans() {
+  return useQuery({
+    queryKey: ["coursePlans"],
+    queryFn: async () => {
+      const { data } = await axios.get<CoursePlan[]>("/api/courses");
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/course/useCreateCoursePlan.ts
+++ b/frontend/src/api/course/useCreateCoursePlan.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { CoursePlan } from "./useCoursePlans";
+
+export interface CreateCoursePlan {
+  targetAudience: string;
+  transformation: string;
+  macroTopics: string;
+}
+
+/** Mutation to create a course plan */
+export function useCreateCoursePlan() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreateCoursePlan) => {
+      const { data: plan } = await axios.post<CoursePlan>("/api/courses", data);
+      return plan;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["coursePlans"] });
+    },
+  });
+}

--- a/frontend/src/pages/course/CoursePlanDetailPage.tsx
+++ b/frontend/src/pages/course/CoursePlanDetailPage.tsx
@@ -1,0 +1,27 @@
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { CoursePlan } from "../../api/course/useCoursePlans";
+
+export default function CoursePlanDetailPage() {
+  const { id } = useParams();
+  const { data, isLoading } = useQuery({
+    queryKey: ["coursePlan", id],
+    queryFn: async () => {
+      const { data } = await axios.get<CoursePlan>(`/api/courses/${id}`);
+      return data;
+    },
+  });
+  if (isLoading) return <p>Loading...</p>;
+  if (!data) return <p>Not found</p>;
+  return (
+    <div>
+      <h3>Modules</h3>
+      <pre>{data.modules}</pre>
+      <h3>Objectives</h3>
+      <pre>{data.objectives}</pre>
+      <h3>Resources</h3>
+      <pre>{data.resources}</pre>
+    </div>
+  );
+}

--- a/frontend/src/pages/course/CoursePlanListPage.tsx
+++ b/frontend/src/pages/course/CoursePlanListPage.tsx
@@ -1,0 +1,41 @@
+import { Link } from "react-router-dom";
+import { useCoursePlans } from "../../api/course/useCoursePlans";
+
+export default function CoursePlanListPage() {
+  const { data, isLoading } = useCoursePlans();
+  if (isLoading) return <p>Loading...</p>;
+  return (
+    <div>
+      <Link className="btn btn-primary mb-3" to="/courses/new">
+        New Course Plan
+      </Link>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Audience</th>
+            <th>Transformation</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map((p) => (
+            <tr key={p.id}>
+              <td>{p.id}</td>
+              <td>{p.targetAudience}</td>
+              <td>{p.transformation}</td>
+              <td>
+                <Link
+                  className="btn btn-sm btn-outline-primary"
+                  to={`/courses/${p.id}`}
+                >
+                  View
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/course/NewCoursePlanPage.tsx
+++ b/frontend/src/pages/course/NewCoursePlanPage.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { useCreateCoursePlan } from "../../api/course/useCreateCoursePlan";
+
+export default function NewCoursePlanPage() {
+  const create = useCreateCoursePlan();
+  const [form, setForm] = useState({
+    targetAudience: "",
+    transformation: "",
+    macroTopics: "",
+  });
+
+  const submit = () => {
+    create.mutate(form);
+  };
+
+  return (
+    <div>
+      <input
+        className="form-control mb-2"
+        placeholder="Target Audience"
+        value={form.targetAudience}
+        onChange={(e) => setForm({ ...form, targetAudience: e.target.value })}
+      />
+      <input
+        className="form-control mb-2"
+        placeholder="Transformation"
+        value={form.transformation}
+        onChange={(e) => setForm({ ...form, transformation: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Macro Topics"
+        value={form.macroTopics}
+        onChange={(e) => setForm({ ...form, macroTopics: e.target.value })}
+      />
+      <button className="btn btn-primary" onClick={submit}>
+        Generate
+      </button>
+    </div>
+  );
+}

--- a/schema.sql
+++ b/schema.sql
@@ -10,3 +10,15 @@ CREATE TABLE asset (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
+
+CREATE TABLE course_plan (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    target_audience VARCHAR(255),
+    transformation VARCHAR(255),
+    macro_topics TEXT,
+    modules TEXT,
+    objectives TEXT,
+    resources TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- integrate Kajabi AI with backend
- expose course planning API and endpoints
- store course plans in DB
- support course plan creation/listing in frontend

## Testing
- `mvn package` *(fails: Non-resolvable parent POM)*
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bdc9bc3608321ac95017d256fad04