### PR TITLE
Add basic product management module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Marketing Hub
+This project manages ads, media assets, course plans and now products built with marketing principles.
 
 ```bash
 docker compose up -d      # start MySQL

--- a/backend/ads-service/src/main/java/com/marketinghub/product/Product.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/Product.java
@@ -1,0 +1,52 @@
+package com.marketinghub.product;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Entity representing a digital product following marketing principles.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String niche;
+    private String avatar;
+
+    @Lob
+    private String explicitPain;
+    @Lob
+    private String promise;
+    @Lob
+    private String uniqueMechanism;
+    @Lob
+    private String tripwire;
+    @Lob
+    private String riskReversal;
+    @Lob
+    private String socialProof;
+    @Lob
+    private String checkoutMonetization;
+    @Lob
+    private String funnel;
+    @Lob
+    private String creativeVolume;
+    @Lob
+    private String storytelling;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/product/dto/CreateProductRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/dto/CreateProductRequest.java
@@ -1,0 +1,22 @@
+package com.marketinghub.product.dto;
+
+import lombok.Data;
+
+/**
+ * Request body for creating a product.
+ */
+@Data
+public class CreateProductRequest {
+    private String niche;
+    private String avatar;
+    private String explicitPain;
+    private String promise;
+    private String uniqueMechanism;
+    private String tripwire;
+    private String riskReversal;
+    private String socialProof;
+    private String checkoutMonetization;
+    private String funnel;
+    private String creativeVolume;
+    private String storytelling;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/product/dto/ProductDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/dto/ProductDto.java
@@ -1,0 +1,26 @@
+package com.marketinghub.product.dto;
+
+import java.time.Instant;
+import lombok.Data;
+
+/**
+ * Data transfer object for {@link com.marketinghub.product.Product}.
+ */
+@Data
+public class ProductDto {
+    private Long id;
+    private String niche;
+    private String avatar;
+    private String explicitPain;
+    private String promise;
+    private String uniqueMechanism;
+    private String tripwire;
+    private String riskReversal;
+    private String socialProof;
+    private String checkoutMonetization;
+    private String funnel;
+    private String creativeVolume;
+    private String storytelling;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/product/mapper/ProductMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/mapper/ProductMapper.java
@@ -1,0 +1,13 @@
+package com.marketinghub.product.mapper;
+
+import com.marketinghub.product.Product;
+import com.marketinghub.product.dto.ProductDto;
+import org.mapstruct.Mapper;
+
+/**
+ * MapStruct mapper for {@link Product}.
+ */
+@Mapper(componentModel = "spring")
+public interface ProductMapper {
+    ProductDto toDto(Product product);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/product/repository/ProductRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.product.repository;
+
+import com.marketinghub.product.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * JPA repository for {@link Product} entities.
+ */
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
@@ -1,0 +1,49 @@
+package com.marketinghub.product.service;
+
+import com.marketinghub.product.Product;
+import com.marketinghub.product.dto.CreateProductRequest;
+import com.marketinghub.product.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service layer for product management.
+ */
+@Service
+public class ProductService {
+    private final ProductRepository repository;
+
+    public ProductService(ProductRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Creates and stores a product.
+     */
+    @Transactional
+    public Product createProduct(CreateProductRequest request) {
+        Product product = Product.builder()
+                .niche(request.getNiche())
+                .avatar(request.getAvatar())
+                .explicitPain(request.getExplicitPain())
+                .promise(request.getPromise())
+                .uniqueMechanism(request.getUniqueMechanism())
+                .tripwire(request.getTripwire())
+                .riskReversal(request.getRiskReversal())
+                .socialProof(request.getSocialProof())
+                .checkoutMonetization(request.getCheckoutMonetization())
+                .funnel(request.getFunnel())
+                .creativeVolume(request.getCreativeVolume())
+                .storytelling(request.getStorytelling())
+                .build();
+        return repository.save(product);
+    }
+
+    public Product getProduct(Long id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    public Iterable<Product> listProducts() {
+        return repository.findAll();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/product/web/ProductController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/web/ProductController.java
@@ -1,0 +1,42 @@
+package com.marketinghub.product.web;
+
+import com.marketinghub.product.dto.CreateProductRequest;
+import com.marketinghub.product.dto.ProductDto;
+import com.marketinghub.product.mapper.ProductMapper;
+import com.marketinghub.product.service.ProductService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+/**
+ * REST controller for products.
+ */
+@RestController
+@RequestMapping("/api/products")
+public class ProductController {
+    private final ProductService service;
+    private final ProductMapper mapper;
+
+    public ProductController(ProductService service, ProductMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @PostMapping
+    public ProductDto create(@RequestBody CreateProductRequest request) {
+        return mapper.toDto(service.createProduct(request));
+    }
+
+    @GetMapping("/{id}")
+    public ProductDto get(@PathVariable Long id) {
+        return mapper.toDto(service.getProduct(id));
+    }
+
+    @GetMapping
+    public List<ProductDto> list() {
+        return StreamSupport.stream(service.listProducts().spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/product/ProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/ProductRepositoryTest.java
@@ -1,0 +1,31 @@
+package com.marketinghub.product;
+
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.product.repository.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ContextConfiguration(classes = AdsServiceApplication.class)
+class ProductRepositoryTest {
+
+    @Autowired
+    ProductRepository repository;
+
+    @Test
+    void testSaveProduct() {
+        Product product = Product.builder()
+                .niche("Health")
+                .avatar("Women")
+                .explicitPain("Lack of energy")
+                .promise("More vitality in 30 days")
+                .uniqueMechanism("Special diet")
+                .build();
+        repository.save(product);
+        assertThat(repository.findById(product.getId())).isPresent();
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import MediaDetailPage from "./pages/media/MediaDetailPage";
 import CoursePlanListPage from "./pages/course/CoursePlanListPage";
 import NewCoursePlanPage from "./pages/course/NewCoursePlanPage";
 import CoursePlanDetailPage from "./pages/course/CoursePlanDetailPage";
+import ProductListPage from "./pages/product/ProductListPage";
+import NewProductPage from "./pages/product/NewProductPage";
 
 export default function App() {
   return (
@@ -30,6 +32,9 @@ export default function App() {
             <Link className="nav-link" to="/courses">
               Courses
             </Link>
+            <Link className="nav-link" to="/products">
+              Products
+            </Link>
           </div>
         </div>
       </nav>
@@ -42,6 +47,8 @@ export default function App() {
         <Route path="/courses" element={<CoursePlanListPage />} />
         <Route path="/courses/new" element={<NewCoursePlanPage />} />
         <Route path="/courses/:id" element={<CoursePlanDetailPage />} />
+        <Route path="/products" element={<ProductListPage />} />
+        <Route path="/products/new" element={<NewProductPage />} />
         <Route path="*" element={<div>Home</div>} />
       </Routes>
     </div>

--- a/frontend/src/api/product/useCreateProduct.ts
+++ b/frontend/src/api/product/useCreateProduct.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Product } from "./useProducts";
+
+export interface CreateProduct {
+  niche: string;
+  avatar: string;
+  explicitPain: string;
+  promise: string;
+  uniqueMechanism: string;
+  tripwire: string;
+  riskReversal: string;
+  socialProof: string;
+  checkoutMonetization: string;
+  funnel: string;
+  creativeVolume: string;
+  storytelling: string;
+}
+
+export function useCreateProduct() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreateProduct) => {
+      const { data: product } = await axios.post<Product>("/api/products", data);
+      return product;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["products"] });
+    },
+  });
+}

--- a/frontend/src/api/product/useProducts.ts
+++ b/frontend/src/api/product/useProducts.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface Product {
+  id: number;
+  niche: string;
+  avatar: string;
+  explicitPain: string;
+  promise: string;
+  uniqueMechanism: string;
+  tripwire: string;
+  riskReversal: string;
+  socialProof: string;
+  checkoutMonetization: string;
+  funnel: string;
+  creativeVolume: string;
+  storytelling: string;
+}
+
+export function useProducts() {
+  return useQuery({
+    queryKey: ["products"],
+    queryFn: async () => {
+      const { data } = await axios.get<Product[]>("/api/products");
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/product/NewProductPage.tsx
+++ b/frontend/src/pages/product/NewProductPage.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { useCreateProduct } from "../../api/product/useCreateProduct";
+
+export default function NewProductPage() {
+  const create = useCreateProduct();
+  const [form, setForm] = useState({
+    niche: "",
+    avatar: "",
+    explicitPain: "",
+    promise: "",
+    uniqueMechanism: "",
+    tripwire: "",
+    riskReversal: "",
+    socialProof: "",
+    checkoutMonetization: "",
+    funnel: "",
+    creativeVolume: "",
+    storytelling: "",
+  });
+
+  const submit = () => {
+    create.mutate(form);
+  };
+
+  return (
+    <div>
+      <input
+        className="form-control mb-2"
+        placeholder="Niche"
+        value={form.niche}
+        onChange={(e) => setForm({ ...form, niche: e.target.value })}
+      />
+      <input
+        className="form-control mb-2"
+        placeholder="Avatar"
+        value={form.avatar}
+        onChange={(e) => setForm({ ...form, avatar: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Explicit Pain"
+        value={form.explicitPain}
+        onChange={(e) => setForm({ ...form, explicitPain: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Transformative Promise"
+        value={form.promise}
+        onChange={(e) => setForm({ ...form, promise: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Unique Mechanism"
+        value={form.uniqueMechanism}
+        onChange={(e) => setForm({ ...form, uniqueMechanism: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Tripwire Offer"
+        value={form.tripwire}
+        onChange={(e) => setForm({ ...form, tripwire: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Risk Reversal"
+        value={form.riskReversal}
+        onChange={(e) => setForm({ ...form, riskReversal: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Social Proof"
+        value={form.socialProof}
+        onChange={(e) => setForm({ ...form, socialProof: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Checkout Monetization"
+        value={form.checkoutMonetization}
+        onChange={(e) =>
+          setForm({ ...form, checkoutMonetization: e.target.value })
+        }
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Funnel"
+        value={form.funnel}
+        onChange={(e) => setForm({ ...form, funnel: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Creative Volume"
+        value={form.creativeVolume}
+        onChange={(e) => setForm({ ...form, creativeVolume: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Storytelling"
+        value={form.storytelling}
+        onChange={(e) => setForm({ ...form, storytelling: e.target.value })}
+      />
+      <button className="btn btn-primary" onClick={submit}>
+        Save
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/product/ProductListPage.test.tsx
+++ b/frontend/src/pages/product/ProductListPage.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import ProductListPage from './ProductListPage';
+import axios from 'axios';
+
+vi.mock('axios');
+
+describe('ProductListPage', () => {
+  it('renders table', async () => {
+    (axios.get as any).mockResolvedValue({ data: [] });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <BrowserRouter>
+          <ProductListPage />
+        </BrowserRouter>
+      </QueryClientProvider>
+    );
+    expect(await screen.findByText(/New Product/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/product/ProductListPage.tsx
+++ b/frontend/src/pages/product/ProductListPage.tsx
@@ -1,0 +1,32 @@
+import { Link } from "react-router-dom";
+import { useProducts } from "../../api/product/useProducts";
+
+export default function ProductListPage() {
+  const { data, isLoading } = useProducts();
+  if (isLoading) return <p>Loading...</p>;
+  return (
+    <div>
+      <Link className="btn btn-primary mb-3" to="/products/new">
+        New Product
+      </Link>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Niche</th>
+            <th>Avatar</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map((p) => (
+            <tr key={p.id}>
+              <td>{p.id}</td>
+              <td>{p.niche}</td>
+              <td>{p.avatar}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/schema.sql
+++ b/schema.sql
@@ -22,3 +22,21 @@ CREATE TABLE course_plan (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
+
+CREATE TABLE product (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    niche VARCHAR(255),
+    avatar VARCHAR(255),
+    explicit_pain TEXT,
+    promise TEXT,
+    unique_mechanism TEXT,
+    tripwire TEXT,
+    risk_reversal TEXT,
+    social_proof TEXT,
+    checkout_monetization TEXT,
+    funnel TEXT,
+    creative_volume TEXT,
+    storytelling TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- introduce backend product entity, controller, service and tests
- support products through REST API and database schema
- add product listing and creation pages in the frontend
- link new product routes in the main navigation
- document product support in README

## Testing
- `mvn package` *(fails: Non-resolvable parent POM)*
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c042ab8a08321ae955ab384a7bebb