### PR TITLE
Instagram account posts management

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/DataSeeder.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/DataSeeder.java
@@ -21,9 +21,9 @@ public class DataSeeder {
                 fbRepo.save(new FacebookAccount(3L, "Account C", "GBP"));
             }
             if (igRepo.count() == 0) {
-                igRepo.save(new InstagramAccount(1L, "Insta A", "USD"));
-                igRepo.save(new InstagramAccount(2L, "Insta B", "EUR"));
-                igRepo.save(new InstagramAccount(3L, "Insta C", "GBP"));
+                igRepo.save(new InstagramAccount(1L, "Insta A", "USD", "https://example.com/a.png"));
+                igRepo.save(new InstagramAccount(2L, "Insta B", "EUR", "https://example.com/b.png"));
+                igRepo.save(new InstagramAccount(3L, "Insta C", "GBP", "https://example.com/c.png"));
             }
         };
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccount.java
@@ -9,13 +9,19 @@ public class InstagramAccount {
     private Long id;
     private String name;
     private String currency;
+    private String avatarUrl;
 
     public InstagramAccount() {}
 
-    public InstagramAccount(Long id, String name, String currency) {
+    public InstagramAccount(Long id, String name, String currency, String avatarUrl) {
         this.id = id;
         this.name = name;
         this.currency = currency;
+        this.avatarUrl = avatarUrl;
+    }
+
+    public InstagramAccount(Long id, String name, String currency) {
+        this(id, name, currency, null);
     }
 
     public Long getId() {
@@ -40,5 +46,13 @@ public class InstagramAccount {
 
     public void setCurrency(String currency) {
         this.currency = currency;
+    }
+
+    public String getAvatarUrl() {
+        return avatarUrl;
+    }
+
+    public void setAvatarUrl(String avatarUrl) {
+        this.avatarUrl = avatarUrl;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/post/InstagramPost.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/post/InstagramPost.java
@@ -1,0 +1,36 @@
+package com.marketinghub.ads.post;
+
+import com.marketinghub.ads.InstagramAccount;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InstagramPost {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "instagram_account_id")
+    private InstagramAccount account;
+
+    private String caption;
+    private String mediaUrl;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/post/InstagramPostController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/post/InstagramPostController.java
@@ -1,0 +1,44 @@
+package com.marketinghub.ads.post;
+
+import com.marketinghub.ads.InstagramAccount;
+import com.marketinghub.ads.InstagramAccountRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/accounts/instagram/{accountId}/posts")
+public class InstagramPostController {
+    private final InstagramAccountRepository accountRepository;
+    private final InstagramPostRepository repository;
+
+    public InstagramPostController(InstagramAccountRepository accountRepository, InstagramPostRepository repository) {
+        this.accountRepository = accountRepository;
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<InstagramPost> list(@PathVariable Long accountId) {
+        return repository.findByAccountId(accountId);
+    }
+
+    @PostMapping
+    public InstagramPost create(@PathVariable Long accountId, @RequestBody InstagramPost post) {
+        InstagramAccount account = accountRepository.findById(accountId).orElseThrow();
+        post.setAccount(account);
+        return repository.save(post);
+    }
+
+    @PutMapping("/{postId}")
+    public InstagramPost update(@PathVariable Long accountId, @PathVariable Long postId, @RequestBody InstagramPost post) {
+        InstagramAccount account = accountRepository.findById(accountId).orElseThrow();
+        post.setId(postId);
+        post.setAccount(account);
+        return repository.save(post);
+    }
+
+    @DeleteMapping("/{postId}")
+    public void delete(@PathVariable Long postId) {
+        repository.deleteById(postId);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/post/InstagramPostRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/post/InstagramPostRepository.java
@@ -1,0 +1,9 @@
+package com.marketinghub.ads.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InstagramPostRepository extends JpaRepository<InstagramPost, Long> {
+    List<InstagramPost> findByAccountId(Long accountId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/product/Product.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/Product.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import com.marketinghub.ads.InstagramAccount;
 
 import java.time.Instant;
 
@@ -22,6 +23,10 @@ public class Product {
 
     private String niche;
     private String avatar;
+
+    @ManyToOne
+    @JoinColumn(name = "instagram_account_id")
+    private InstagramAccount instagramAccount;
 
     @Lob
     private String explicitPain;

--- a/backend/ads-service/src/main/java/com/marketinghub/product/dto/CreateProductRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/dto/CreateProductRequest.java
@@ -9,6 +9,7 @@ import lombok.Data;
 public class CreateProductRequest {
     private String niche;
     private String avatar;
+    private Long instagramAccountId;
     private String explicitPain;
     private String promise;
     private String uniqueMechanism;

--- a/backend/ads-service/src/main/java/com/marketinghub/product/dto/ProductDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/dto/ProductDto.java
@@ -11,6 +11,7 @@ public class ProductDto {
     private Long id;
     private String niche;
     private String avatar;
+    private Long instagramAccountId;
     private String explicitPain;
     private String promise;
     private String uniqueMechanism;

--- a/backend/ads-service/src/main/java/com/marketinghub/product/mapper/ProductMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/mapper/ProductMapper.java
@@ -3,11 +3,13 @@ package com.marketinghub.product.mapper;
 import com.marketinghub.product.Product;
 import com.marketinghub.product.dto.ProductDto;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /**
  * MapStruct mapper for {@link Product}.
  */
 @Mapper(componentModel = "spring")
 public interface ProductMapper {
+    @Mapping(target = "instagramAccountId", source = "instagramAccount.id")
     ProductDto toDto(Product product);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/product/service/ProductService.java
@@ -3,6 +3,8 @@ package com.marketinghub.product.service;
 import com.marketinghub.product.Product;
 import com.marketinghub.product.dto.CreateProductRequest;
 import com.marketinghub.product.repository.ProductRepository;
+import com.marketinghub.ads.InstagramAccountRepository;
+import com.marketinghub.ads.InstagramAccount;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,9 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ProductService {
     private final ProductRepository repository;
+    private final InstagramAccountRepository accountRepository;
 
-    public ProductService(ProductRepository repository) {
+    public ProductService(ProductRepository repository, InstagramAccountRepository accountRepository) {
         this.repository = repository;
+        this.accountRepository = accountRepository;
     }
 
     /**
@@ -25,6 +29,7 @@ public class ProductService {
         Product product = Product.builder()
                 .niche(request.getNiche())
                 .avatar(request.getAvatar())
+                .instagramAccount(resolveAccount(request.getInstagramAccountId()))
                 .explicitPain(request.getExplicitPain())
                 .promise(request.getPromise())
                 .uniqueMechanism(request.getUniqueMechanism())
@@ -37,6 +42,13 @@ public class ProductService {
                 .storytelling(request.getStorytelling())
                 .build();
         return repository.save(product);
+    }
+
+    private InstagramAccount resolveAccount(Long id) {
+        if (id == null) {
+            return null;
+        }
+        return accountRepository.findById(id).orElseThrow();
     }
 
     public Product getProduct(Long id) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import NewCoursePlanPage from "./pages/course/NewCoursePlanPage";
 import CoursePlanDetailPage from "./pages/course/CoursePlanDetailPage";
 import ProductListPage from "./pages/product/ProductListPage";
 import NewProductPage from "./pages/product/NewProductPage";
+import InstagramPostsPage from "./pages/post/InstagramPostsPage";
 
 export default function App() {
   return (
@@ -41,6 +42,10 @@ export default function App() {
       <Routes>
         <Route path="/accounts/facebook" element={<FacebookAccountsPage />} />
         <Route path="/accounts/instagram" element={<InstagramAccountsPage />} />
+        <Route
+          path="/accounts/instagram/:id/posts"
+          element={<InstagramPostsPage />}
+        />
         <Route path="/media" element={<MediaListPage />} />
         <Route path="/media/new" element={<NewMediaPage />} />
         <Route path="/media/:id" element={<MediaDetailPage />} />

--- a/frontend/src/api/post/instagramPostMutations.ts
+++ b/frontend/src/api/post/instagramPostMutations.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { InstagramPost } from "./useInstagramPosts";
+
+export function useCreateInstagramPost(accountId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (post: InstagramPost) =>
+      axios.post(`/api/accounts/instagram/${accountId}/posts`, post),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ["instagram-posts", accountId],
+      }),
+  });
+}
+
+export function useUpdateInstagramPost(accountId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (post: InstagramPost) =>
+      axios.put(`/api/accounts/instagram/${accountId}/posts/${post.id}`, post),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ["instagram-posts", accountId],
+      }),
+  });
+}
+
+export function useDeleteInstagramPost(accountId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) =>
+      axios.delete(`/api/accounts/instagram/${accountId}/posts/${id}`),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ["instagram-posts", accountId],
+      }),
+  });
+}

--- a/frontend/src/api/post/useInstagramPosts.ts
+++ b/frontend/src/api/post/useInstagramPosts.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface InstagramPost {
+  id: number;
+  caption: string;
+  mediaUrl: string;
+}
+
+export function useInstagramPosts(accountId: string) {
+  return useQuery({
+    queryKey: ["instagram-posts", accountId],
+    queryFn: async () => {
+      const { data } = await axios.get<InstagramPost[]>(
+        `/api/accounts/instagram/${accountId}/posts`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/product/useCreateProduct.ts
+++ b/frontend/src/api/product/useCreateProduct.ts
@@ -5,6 +5,7 @@ import { Product } from "./useProducts";
 export interface CreateProduct {
   niche: string;
   avatar: string;
+  instagramAccountId?: number;
   explicitPain: string;
   promise: string;
   uniqueMechanism: string;
@@ -21,7 +22,10 @@ export function useCreateProduct() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (data: CreateProduct) => {
-      const { data: product } = await axios.post<Product>("/api/products", data);
+      const { data: product } = await axios.post<Product>(
+        "/api/products",
+        data,
+      );
       return product;
     },
     onSuccess: () => {

--- a/frontend/src/api/product/useProducts.ts
+++ b/frontend/src/api/product/useProducts.ts
@@ -5,6 +5,7 @@ export interface Product {
   id: number;
   niche: string;
   avatar: string;
+  instagramAccountId?: number;
   explicitPain: string;
   promise: string;
   uniqueMechanism: string;

--- a/frontend/src/pages/InstagramAccountsPage.tsx
+++ b/frontend/src/pages/InstagramAccountsPage.tsx
@@ -46,6 +46,12 @@ export default function InstagramAccountsPage() {
               <td>{name}</td>
               <td>{currency}</td>
               <td>
+                <a
+                  className="btn btn-sm btn-outline-secondary me-2"
+                  href={`/accounts/instagram/${id}/posts`}
+                >
+                  Posts
+                </a>
                 <button
                   className="btn btn-sm btn-outline-primary me-2"
                   onClick={() => {

--- a/frontend/src/pages/post/InstagramPostsPage.tsx
+++ b/frontend/src/pages/post/InstagramPostsPage.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import {
+  useCreateInstagramPost,
+  useDeleteInstagramPost,
+  useUpdateInstagramPost,
+} from "../../api/post/instagramPostMutations";
+import { useInstagramPosts } from "../../api/post/useInstagramPosts";
+
+export default function InstagramPostsPage() {
+  const { id = "" } = useParams<{ id: string }>();
+  const { data } = useInstagramPosts(id);
+  const create = useCreateInstagramPost(id);
+  const update = useUpdateInstagramPost(id);
+  const remove = useDeleteInstagramPost(id);
+  const [form, setForm] = useState({ id: 0, caption: "", mediaUrl: "" });
+  const [editing, setEditing] = useState<number | null>(null);
+
+  const submit = () => {
+    if (editing) {
+      update.mutate(form);
+    } else {
+      create.mutate(form);
+    }
+    setForm({ id: 0, caption: "", mediaUrl: "" });
+    setEditing(null);
+  };
+
+  return (
+    <div>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Caption</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map((p) => (
+            <tr key={p.id}>
+              <td>{p.id}</td>
+              <td>{p.caption}</td>
+              <td>
+                <button
+                  className="btn btn-sm btn-outline-primary me-2"
+                  onClick={() => {
+                    setForm(p);
+                    setEditing(p.id);
+                  }}
+                >
+                  Edit
+                </button>
+                <button
+                  className="btn btn-sm btn-outline-danger"
+                  onClick={() => remove.mutate(p.id)}
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="row g-2">
+        <div className="col-md-5">
+          <input
+            className="form-control"
+            placeholder="caption"
+            value={form.caption}
+            onChange={(e) => setForm({ ...form, caption: e.target.value })}
+          />
+        </div>
+        <div className="col-md-5">
+          <input
+            className="form-control"
+            placeholder="media url"
+            value={form.mediaUrl}
+            onChange={(e) => setForm({ ...form, mediaUrl: e.target.value })}
+          />
+        </div>
+        <div className="col-md-2">
+          <button className="btn btn-primary w-100" onClick={submit}>
+            {editing ? "Update" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/product/NewProductPage.tsx
+++ b/frontend/src/pages/product/NewProductPage.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
 import { useCreateProduct } from "../../api/product/useCreateProduct";
+import { useInstagramAccounts } from "../../api/useInstagramAccounts";
 
 export default function NewProductPage() {
   const create = useCreateProduct();
+  const { data: accounts } = useInstagramAccounts();
   const [form, setForm] = useState({
     niche: "",
     avatar: "",
+    instagramAccountId: "",
     explicitPain: "",
     promise: "",
     uniqueMechanism: "",
@@ -19,7 +22,10 @@ export default function NewProductPage() {
   });
 
   const submit = () => {
-    create.mutate(form);
+    create.mutate({
+      ...form,
+      instagramAccountId: Number(form.instagramAccountId) || undefined,
+    });
   };
 
   return (
@@ -36,6 +42,20 @@ export default function NewProductPage() {
         value={form.avatar}
         onChange={(e) => setForm({ ...form, avatar: e.target.value })}
       />
+      <select
+        className="form-select mb-2"
+        value={form.instagramAccountId}
+        onChange={(e) =>
+          setForm({ ...form, instagramAccountId: e.target.value })
+        }
+      >
+        <option value="">Select Instagram Account</option>
+        {accounts?.map((a) => (
+          <option key={a.id} value={a.id}>
+            {a.name}
+          </option>
+        ))}
+      </select>
       <textarea
         className="form-control mb-2"
         placeholder="Explicit Pain"

--- a/frontend/src/pages/product/ProductListPage.tsx
+++ b/frontend/src/pages/product/ProductListPage.tsx
@@ -15,6 +15,7 @@ export default function ProductListPage() {
             <th>ID</th>
             <th>Niche</th>
             <th>Avatar</th>
+            <th>Instagram</th>
           </tr>
         </thead>
         <tbody>
@@ -23,6 +24,7 @@ export default function ProductListPage() {
               <td>{p.id}</td>
               <td>{p.niche}</td>
               <td>{p.avatar}</td>
+              <td>{p.instagramAccountId}</td>
             </tr>
           ))}
         </tbody>

--- a/schema.sql
+++ b/schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE product (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     niche VARCHAR(255),
     avatar VARCHAR(255),
+    instagram_account_id BIGINT,
     explicit_pain TEXT,
     promise TEXT,
     unique_mechanism TEXT,
@@ -37,6 +38,15 @@ CREATE TABLE product (
     funnel TEXT,
     creative_volume TEXT,
     storytelling TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE instagram_post (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    instagram_account_id BIGINT,
+    caption TEXT,
+    media_url VARCHAR(500),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- extend InstagramAccount with avatar URL
- seed avatar URLs in DataSeeder
- relate Product to InstagramAccount
- map instagram account field in DTOs and mapper
- add InstagramPost entity, repository and controller
- expose Instagram post management UI
- support instagramAccountId in product API and UI

## Testing
- `mvn -q package` *(fails: Could not transfer artifact)*
- `mvn -q test` *(fails: Could not transfer artifact)*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c07bce2a883218b5ea4e669b2f7f1