### PR TITLE
Fix Node cache path for CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Install deps and build
         run: |
           cd frontend


### PR DESCRIPTION
## Summary
- fix Node cache path to `frontend/package-lock.json` in `frontend.yml`

## Testing
- `mvn package -q` *(fails: Network is unreachable)*
- `npm ci`
- `npm run build`
- `npm run test` *(canceled via Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_686c86f636a08321bdc3c7b3525f0633