### PR TITLE
Add SuccessProduct entity

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/SuccessProduct.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/SuccessProduct.java
@@ -1,0 +1,60 @@
+package com.marketinghub.successproduct;
+
+import com.marketinghub.ads.InstagramAccount;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Entity representing a successful product template.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SuccessProduct {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Lob
+    private String description;
+
+    private String niche;
+    private String avatar;
+
+    @ManyToOne
+    @JoinColumn(name = "instagram_account_id")
+    private InstagramAccount instagramAccount;
+
+    @Lob
+    private String explicitPain;
+    @Lob
+    private String promise;
+    @Lob
+    private String uniqueMechanism;
+    @Lob
+    private String tripwire;
+    @Lob
+    private String riskReversal;
+    @Lob
+    private String socialProof;
+    @Lob
+    private String checkoutMonetization;
+    @Lob
+    private String funnel;
+    @Lob
+    private String creativeVolume;
+    @Lob
+    private String storytelling;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/CreateSuccessProductRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/CreateSuccessProductRequest.java
@@ -1,0 +1,11 @@
+package com.marketinghub.successproduct.dto;
+
+import lombok.Data;
+
+/**
+ * Request body for creating a success product.
+ */
+@Data
+public class CreateSuccessProductRequest {
+    private String description;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/SuccessProductDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/SuccessProductDto.java
@@ -1,0 +1,28 @@
+package com.marketinghub.successproduct.dto;
+
+import java.time.Instant;
+import lombok.Data;
+
+/**
+ * Data transfer object for {@link com.marketinghub.successproduct.SuccessProduct}.
+ */
+@Data
+public class SuccessProductDto {
+    private Long id;
+    private String description;
+    private String niche;
+    private String avatar;
+    private Long instagramAccountId;
+    private String explicitPain;
+    private String promise;
+    private String uniqueMechanism;
+    private String tripwire;
+    private String riskReversal;
+    private String socialProof;
+    private String checkoutMonetization;
+    private String funnel;
+    private String creativeVolume;
+    private String storytelling;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/mapper/SuccessProductMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/mapper/SuccessProductMapper.java
@@ -1,0 +1,15 @@
+package com.marketinghub.successproduct.mapper;
+
+import com.marketinghub.successproduct.SuccessProduct;
+import com.marketinghub.successproduct.dto.SuccessProductDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * MapStruct mapper for {@link SuccessProduct}.
+ */
+@Mapper(componentModel = "spring")
+public interface SuccessProductMapper {
+    @Mapping(target = "instagramAccountId", source = "instagramAccount.id")
+    SuccessProductDto toDto(SuccessProduct product);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/repository/SuccessProductRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/repository/SuccessProductRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.successproduct.repository;
+
+import com.marketinghub.successproduct.SuccessProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * JPA repository for {@link SuccessProduct} entities.
+ */
+public interface SuccessProductRepository extends JpaRepository<SuccessProduct, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/service/SuccessProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/service/SuccessProductService.java
@@ -1,0 +1,38 @@
+package com.marketinghub.successproduct.service;
+
+import com.marketinghub.successproduct.SuccessProduct;
+import com.marketinghub.successproduct.dto.CreateSuccessProductRequest;
+import com.marketinghub.successproduct.repository.SuccessProductRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service layer for success products.
+ */
+@Service
+public class SuccessProductService {
+    private final SuccessProductRepository repository;
+
+    public SuccessProductService(SuccessProductRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Creates and stores a success product.
+     */
+    @Transactional
+    public SuccessProduct create(CreateSuccessProductRequest request) {
+        SuccessProduct product = SuccessProduct.builder()
+                .description(request.getDescription())
+                .build();
+        return repository.save(product);
+    }
+
+    public SuccessProduct get(Long id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    public Iterable<SuccessProduct> list() {
+        return repository.findAll();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/web/SuccessProductController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/web/SuccessProductController.java
@@ -1,0 +1,42 @@
+package com.marketinghub.successproduct.web;
+
+import com.marketinghub.successproduct.dto.CreateSuccessProductRequest;
+import com.marketinghub.successproduct.dto.SuccessProductDto;
+import com.marketinghub.successproduct.mapper.SuccessProductMapper;
+import com.marketinghub.successproduct.service.SuccessProductService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+/**
+ * REST controller for success products.
+ */
+@RestController
+@RequestMapping("/api/success-products")
+public class SuccessProductController {
+    private final SuccessProductService service;
+    private final SuccessProductMapper mapper;
+
+    public SuccessProductController(SuccessProductService service, SuccessProductMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @PostMapping
+    public SuccessProductDto create(@RequestBody CreateSuccessProductRequest request) {
+        return mapper.toDto(service.create(request));
+    }
+
+    @GetMapping("/{id}")
+    public SuccessProductDto get(@PathVariable Long id) {
+        return mapper.toDto(service.get(id));
+    }
+
+    @GetMapping
+    public List<SuccessProductDto> list() {
+        return StreamSupport.stream(service.list().spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
@@ -1,0 +1,27 @@
+package com.marketinghub.successproduct;
+
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.successproduct.repository.SuccessProductRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ContextConfiguration(classes = AdsServiceApplication.class)
+class SuccessProductRepositoryTest {
+
+    @Autowired
+    SuccessProductRepository repository;
+
+    @Test
+    void testSaveSuccessProduct() {
+        SuccessProduct product = SuccessProduct.builder()
+                .description("Great product")
+                .build();
+        repository.save(product);
+        assertThat(repository.findById(product.getId())).isPresent();
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import NewCoursePlanPage from "./pages/course/NewCoursePlanPage";
 import CoursePlanDetailPage from "./pages/course/CoursePlanDetailPage";
 import ProductListPage from "./pages/product/ProductListPage";
 import NewProductPage from "./pages/product/NewProductPage";
+import SuccessProductListPage from "./pages/successProduct/SuccessProductListPage";
+import NewSuccessProductPage from "./pages/successProduct/NewSuccessProductPage";
 import InstagramPostsPage from "./pages/post/InstagramPostsPage";
 
 export default function App() {
@@ -36,6 +38,9 @@ export default function App() {
             <Link className="nav-link" to="/products">
               Products
             </Link>
+            <Link className="nav-link" to="/success-products">
+              Success Products
+            </Link>
           </div>
         </div>
       </nav>
@@ -54,6 +59,11 @@ export default function App() {
         <Route path="/courses/:id" element={<CoursePlanDetailPage />} />
         <Route path="/products" element={<ProductListPage />} />
         <Route path="/products/new" element={<NewProductPage />} />
+        <Route path="/success-products" element={<SuccessProductListPage />} />
+        <Route
+          path="/success-products/new"
+          element={<NewSuccessProductPage />}
+        />
         <Route path="*" element={<div>Home</div>} />
       </Routes>
     </div>

--- a/frontend/src/api/successProduct/useCreateSuccessProduct.ts
+++ b/frontend/src/api/successProduct/useCreateSuccessProduct.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { SuccessProduct } from "./useSuccessProducts";
+
+export interface CreateSuccessProduct {
+  description: string;
+}
+
+export function useCreateSuccessProduct() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreateSuccessProduct) => {
+      const { data: product } = await axios.post<SuccessProduct>(
+        "/api/success-products",
+        data,
+      );
+      return product;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["successProducts"] });
+    },
+  });
+}

--- a/frontend/src/api/successProduct/useSuccessProducts.ts
+++ b/frontend/src/api/successProduct/useSuccessProducts.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface SuccessProduct {
+  id: number;
+  description: string;
+  niche: string;
+  avatar: string;
+  instagramAccountId?: number;
+  explicitPain: string;
+  promise: string;
+  uniqueMechanism: string;
+  tripwire: string;
+  riskReversal: string;
+  socialProof: string;
+  checkoutMonetization: string;
+  funnel: string;
+  creativeVolume: string;
+  storytelling: string;
+}
+
+export function useSuccessProducts() {
+  return useQuery({
+    queryKey: ["successProducts"],
+    queryFn: async () => {
+      const { data } = await axios.get<SuccessProduct[]>(
+        "/api/success-products",
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/successProduct/NewSuccessProductPage.tsx
+++ b/frontend/src/pages/successProduct/NewSuccessProductPage.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+import { useCreateSuccessProduct } from "../../api/successProduct/useCreateSuccessProduct";
+import PageTitle from "../../components/PageTitle";
+
+export default function NewSuccessProductPage() {
+  const create = useCreateSuccessProduct();
+  const [description, setDescription] = useState("");
+
+  const submit = () => {
+    create.mutate({ description });
+  };
+
+  return (
+    <div>
+      <PageTitle>New Success Product</PageTitle>
+      <textarea
+        className="form-control mb-2"
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <button className="btn btn-primary" onClick={submit}>
+        Save
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/successProduct/SuccessProductListPage.tsx
+++ b/frontend/src/pages/successProduct/SuccessProductListPage.tsx
@@ -1,0 +1,32 @@
+import { Link } from "react-router-dom";
+import { useSuccessProducts } from "../../api/successProduct/useSuccessProducts";
+import PageTitle from "../../components/PageTitle";
+
+export default function SuccessProductListPage() {
+  const { data, isLoading } = useSuccessProducts();
+  if (isLoading) return <p>Loading...</p>;
+  return (
+    <div>
+      <PageTitle>Success Products</PageTitle>
+      <Link className="btn btn-primary mb-3" to="/success-products/new">
+        New Success Product
+      </Link>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map((p) => (
+            <tr key={p.id}>
+              <td>{p.id}</td>
+              <td>{p.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/schema.sql
+++ b/schema.sql
@@ -42,6 +42,26 @@ CREATE TABLE product (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
+CREATE TABLE success_product (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    description TEXT,
+    niche VARCHAR(255),
+    avatar VARCHAR(255),
+    instagram_account_id BIGINT,
+    explicit_pain TEXT,
+    promise TEXT,
+    unique_mechanism TEXT,
+    tripwire TEXT,
+    risk_reversal TEXT,
+    social_proof TEXT,
+    checkout_monetization TEXT,
+    funnel TEXT,
+    creative_volume TEXT,
+    storytelling TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
 CREATE TABLE instagram_post (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     instagram_account_id BIGINT,


### PR DESCRIPTION
## Summary
- add SuccessProduct entity in backend with REST endpoints
- support creating and listing success products in the frontend
- update database schema for new table

## Testing
- `mvn package` *(fails: Non-resolvable parent POM)*
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm run build --prefix frontend`
- `npm run test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c9de01e4c832197b3e8fe7f7c55b9