### PR TITLE
Add scheduled worker for success products

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This project manages ads, media assets, course plans and now products built with
 docker compose up -d      # start MySQL
 cd backend/ads-service && mvn spring-boot:run
 cd ../../frontend && npm run dev
+# run the background worker (optional)
+cd ../success-product-worker && mvn spring-boot:run
 # create a .env file to point the React app to your backend
 echo "VITE_API_URL=http://localhost:8000" > frontend/.env
 # deploy to VPS (Java 21 already installed)

--- a/success-product-worker/pom.xml
+++ b/success-product-worker/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.marketinghub</groupId>
+    <artifactId>success-product-worker</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>success-product-worker</name>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <finalName>app</finalName>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/success-product-worker/src/main/java/com/marketinghub/worker/ChatGptClient.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/ChatGptClient.java
@@ -1,0 +1,5 @@
+package com.marketinghub.worker;
+
+public interface ChatGptClient {
+    SuccessProduct enrich(SuccessProduct product);
+}

--- a/success-product-worker/src/main/java/com/marketinghub/worker/DummyChatGptClient.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/DummyChatGptClient.java
@@ -1,0 +1,13 @@
+package com.marketinghub.worker;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DummyChatGptClient implements ChatGptClient {
+    @Override
+    public SuccessProduct enrich(SuccessProduct product) {
+        // TODO connect to ChatGPT API
+        product.setNovo(false);
+        return product;
+    }
+}

--- a/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProduct.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProduct.java
@@ -1,0 +1,55 @@
+package com.marketinghub.worker;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SuccessProduct {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Lob
+    private String description;
+
+    @Builder.Default
+    private boolean novo = true;
+
+    private String niche;
+    private String avatar;
+
+    @Lob
+    private String explicitPain;
+    @Lob
+    private String promise;
+    @Lob
+    private String uniqueMechanism;
+    @Lob
+    private String tripwire;
+    @Lob
+    private String riskReversal;
+    @Lob
+    private String socialProof;
+    @Lob
+    private String checkoutMonetization;
+    @Lob
+    private String funnel;
+    @Lob
+    private String creativeVolume;
+    @Lob
+    private String storytelling;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductAnalyzer.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductAnalyzer.java
@@ -1,0 +1,26 @@
+package com.marketinghub.worker;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class SuccessProductAnalyzer {
+    private final SuccessProductRepository repository;
+    private final ChatGptClient client;
+
+    public SuccessProductAnalyzer(SuccessProductRepository repository, ChatGptClient client) {
+        this.repository = repository;
+        this.client = client;
+    }
+
+    @Transactional
+    public void analyzeNewProducts() {
+        List<SuccessProduct> products = repository.findByNovoTrue();
+        for (SuccessProduct product : products) {
+            SuccessProduct enriched = client.enrich(product);
+            repository.save(enriched);
+        }
+    }
+}

--- a/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductRepository.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductRepository.java
@@ -1,0 +1,9 @@
+package com.marketinghub.worker;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SuccessProductRepository extends JpaRepository<SuccessProduct, Long> {
+    List<SuccessProduct> findByNovoTrue();
+}

--- a/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductScheduler.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductScheduler.java
@@ -1,0 +1,18 @@
+package com.marketinghub.worker;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SuccessProductScheduler {
+    private final SuccessProductAnalyzer analyzer;
+
+    public SuccessProductScheduler(SuccessProductAnalyzer analyzer) {
+        this.analyzer = analyzer;
+    }
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void run() {
+        analyzer.analyzeNewProducts();
+    }
+}

--- a/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductWorkerApplication.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductWorkerApplication.java
@@ -1,0 +1,13 @@
+package com.marketinghub.worker;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class SuccessProductWorkerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SuccessProductWorkerApplication.class, args);
+    }
+}

--- a/success-product-worker/src/main/resources/application.yml
+++ b/success-product-worker/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/marketinghub
+    username: root
+    password: password
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true

--- a/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.worker;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ContextConfiguration(classes = SuccessProductWorkerApplication.class)
+class SuccessProductRepositoryTest {
+
+    @Autowired
+    SuccessProductRepository repository;
+
+    @Test
+    void testSaveSuccessProduct() {
+        SuccessProduct product = SuccessProduct.builder()
+                .description("Great product")
+                .build();
+        repository.save(product);
+        SuccessProduct saved = repository.findById(product.getId()).orElseThrow();
+        assertThat(saved.isNovo()).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- create `success-product-worker` project for background tasks
- add a scheduler to enrich `success_product` entries via ChatGPT stub
- document how to run the worker in README

## Testing
- `mvn package` *(fails: could not resolve Spring Boot parent POM)*
- `mvn test` *(fails: could not resolve Spring Boot parent POM)*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2829fd888321a2b1af2bb91ccc17