### PR TITLE
Fix JPA test configuration

### DIFF
--- a/success-product-worker/pom.xml
+++ b/success-product-worker/pom.xml
@@ -9,6 +9,10 @@
 
     <properties>
         <java.version>21</java.version>
+        <jboss-logging.version>3.5.0.Final</jboss-logging.version>
+        <classmate.version>1.5.1</classmate.version>
+        <byte-buddy.version>1.14.11</byte-buddy.version>
+        <glassfish-jaxb.version>4.0.2</glassfish-jaxb.version>
     </properties>
 
     <parent>

--- a/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
@@ -4,11 +4,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = SuccessProductWorkerApplication.class)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create"
+})
 class SuccessProductRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- configure SuccessProductRepositoryTest to create schema using H2
- align worker Maven config with backend module for offline build

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d64dec12083218b59a6dc264dc56f