### PR TITLE
Fix worker module build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 - **Backend**
   - Build: `cd backend/ads-service && mvn package`
   - Tests: `cd backend/ads-service && mvn test`
+- **Success Product Worker**
+  - Build: `cd success-product-worker && mvn package`
+  - Tests: `cd success-product-worker && mvn test`
+  - Requires the `ads-service` module installed locally with `mvn install`.
 - **Frontend**
   - Build: `npm run build`
   - Tests: `npm run test`

--- a/success-product-worker/pom.xml
+++ b/success-product-worker/pom.xml
@@ -48,6 +48,12 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- reuse entities from the ads-service module -->
+        <dependency>
+            <groupId>com.marketinghub</groupId>
+            <artifactId>ads-service</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
## Summary
- link Success Product Worker with ads-service module to fix missing classes
- document how to build and test worker in `AGENTS.md`

## Testing
- `mvn -o package` *(fails: Cannot access central)*
- `mvn -o test` *(fails: Cannot access central)*

------
https://chatgpt.com/codex/tasks/task_e_686d7a545f08832197ed2052104e4846