### PR TITLE
Publish ads-service to GitHub Packages

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Rodar testes
         run: mvn -B test
 
-      - name: Build JAR
-        run: mvn -B clean package -DskipTests
+      - name: Build and publish to GitHub Packages
+        run: mvn -B -s ../settings.xml deploy -DskipTests
 
       - name: Publicar artefato
         uses: actions/upload-artifact@v4

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -1,0 +1,26 @@
+name: Success Worker CI
+
+on:
+  push:
+    paths:
+      - 'success-product-worker/**'
+  pull_request:
+    paths:
+      - 'success-product-worker/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: success-product-worker
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      - name: Build and test
+        run: mvn -B -s ../backend/settings.xml package

--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -101,4 +101,11 @@
             </plugin>
         </plugins>
     </build>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/paulofor/marketing-hub</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/backend/settings.xml
+++ b/backend/settings.xml
@@ -14,15 +14,14 @@
     </mirror>
   </mirrors>
 
-  <!-- 2️⃣  (Opcional) autenticação se for Artifactory/Nexus interno
+  <!-- 2️⃣  Autenticação para publicar e baixar do GitHub Packages -->
   <servers>
     <server>
-      <id>central-all</id>
-      <username>${env.ARTI_USER}</username>
-      <password>${env.ARTI_PASS}</password>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
     </server>
   </servers>
-  -->
 
   <!-- 3️⃣  Perfil default apenas para manter coerência -->
   <profiles>

--- a/success-product-worker/pom.xml
+++ b/success-product-worker/pom.xml
@@ -7,6 +7,14 @@
     <version>0.0.1-SNAPSHOT</version>
     <name>success-product-worker</name>
 
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/paulofor/marketing-hub</url>
+        </repository>
+    </repositories>
+
     <properties>
         <java.version>21</java.version>
         <jboss-logging.version>3.5.0.Final</jboss-logging.version>


### PR DESCRIPTION
## Summary
- publish ads-service JAR to GitHub Packages via Maven `deploy`
- allow success-product-worker to pull dependencies from GitHub Packages
- configure Maven settings with `GITHUB_ACTOR`/`GITHUB_TOKEN`
- add workflow for success-product-worker

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `mvn -q test` in success-product-worker *(fails: Network is unreachable)*
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d80a89b148321b9c583eea8f93b07