### PR TITLE
Update Maven settings for GitHub packages

### DIFF
--- a/backend/settings.xml
+++ b/backend/settings.xml
@@ -10,7 +10,7 @@
       <id>central-all</id>
       <name>Maven Central (HTTPS)</name>
       <url>https://repo.maven.apache.org/maven2</url>
-      <mirrorOf>*</mirrorOf>   <!-- cobre central, plugins, snapshots etc. -->
+      <mirrorOf>central</mirrorOf>   <!-- apenas o repositório central -->
     </mirror>
   </mirrors>
 

--- a/success-product-worker/settings.xml
+++ b/success-product-worker/settings.xml
@@ -10,7 +10,7 @@
       <id>central-all</id>
       <name>Maven Central (HTTPS)</name>
       <url>https://repo.maven.apache.org/maven2</url>
-      <mirrorOf>*</mirrorOf>   <!-- cobre central, plugins, snapshots etc. -->
+      <mirrorOf>central</mirrorOf>   <!-- apenas o repositório central -->
     </mirror>
   </mirrors>
 


### PR DESCRIPTION
## Summary
- adjust mirror settings so Maven can use GitHub Packages

## Testing
- `mvn -s ../settings.xml package -DskipTests` *(fails: Network is unreachable)*
- `mvn -s settings.xml package -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d871c99a88321b2bd91593c813fcf