### PR TITLE
Fix GitHub Packages authentication

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,6 +15,9 @@ jobs:
 # ─────────────────────────────────────────
   build:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_ACTOR: ${{ github.actor }}
     defaults:                     # 👉 força todos os steps a rodarem em backend/ads-service
       run:
         working-directory: backend/ads-service

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_ACTOR: ${{ github.actor }}
     defaults:
       run:
         working-directory: success-product-worker


### PR DESCRIPTION
## Summary
- export `GITHUB_TOKEN` and `GITHUB_ACTOR` in backend and worker workflows

## Testing
- `mvn -q package` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686dafc0f3488321884d2d820938dc13