### PR TITLE
Fix GitHub action deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   APP_DIR: /opt/marketinghub/app           # caminho no servidor
   VPS_IP: 191.252.92.222              # ← IP fixo do servidor


### PR DESCRIPTION
## Summary
- ensure GitHub Actions token has permission to publish packages

## Testing
- `mvn package` *(fails: Network is unreachable)*
- `mvn test` *(fails: Network is unreachable)*
- `mvn package` in success-product-worker *(fails: Network is unreachable)*
- `mvn test` in success-product-worker *(fails: Network is unreachable)*
- `npm ci`
- `npm run build`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_686db11bafe48321b22c742bb605cd17