### PR TITLE
Add Windows worker build script

### DIFF
--- a/build-success-worker.bat
+++ b/build-success-worker.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal
+
+rem Builds ads-service and success-product-worker using credentials for GitHub Packages.
+rem Defina as variaveis GITHUB_ACTOR e GITHUB_TOKEN antes de executar este script.
+
+if "%GITHUB_ACTOR%"=="" (
+  echo Defina a variavel de ambiente GITHUB_ACTOR com seu usuario do GitHub.
+  exit /b 1
+)
+
+if "%GITHUB_TOKEN%"=="" (
+  echo Defina a variavel de ambiente GITHUB_TOKEN com um token que tenha acesso ao GitHub Packages.
+  exit /b 1
+)
+
+echo [1] Instalando modulo ads-service...
+pushd backend\ads-service
+mvn -s ..\settings.xml install
+if errorlevel 1 (
+  echo Falha ao instalar ads-service
+  popd
+  exit /b 1
+)
+popd
+
+echo [2] Compilando success-product-worker...
+pushd success-product-worker
+mvn -s settings.xml install
+if errorlevel 1 (
+  echo Falha ao compilar success-product-worker
+  popd
+  exit /b 1
+)
+popd
+
+echo Build concluido com sucesso!
+exit /b 0


### PR DESCRIPTION
## Summary
- add `build-success-worker.bat` to install `ads-service` and build `success-product-worker`

## Testing
- `mvn -q package` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*
- `mvn -q package` in `success-product-worker` *(fails: Network is unreachable)*
- `mvn -q test` in `success-product-worker` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686db7b17fb48321886622fa8db999f9