### PR TITLE
Fix worker build with GitHub jar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,12 @@
 
 ## Build & Test
 - **Backend**
-  - Build: `cd backend/ads-service && mvn package`
-  - Tests: `cd backend/ads-service && mvn test`
+  - Build & publish: `cd backend/ads-service && mvn -s ../settings.xml deploy`
+  - Tests: `cd backend/ads-service && mvn -s ../settings.xml test`
 - **Success Product Worker**
-  - Build: `cd success-product-worker && mvn package`
-  - Tests: `cd success-product-worker && mvn test`
-  - Requires the `ads-service` module installed locally with `mvn install`.
+  - Build: `cd success-product-worker && mvn -s settings.xml package`
+  - Tests: `cd success-product-worker && mvn -s settings.xml test`
+  - Downloads the `ads-service` artifact from GitHub Packages.
 - **Frontend**
   - Build: `npm run build`
   - Tests: `npm run test`

--- a/build-success-worker.bat
+++ b/build-success-worker.bat
@@ -1,7 +1,8 @@
 @echo off
 setlocal
 
-rem Builds ads-service and success-product-worker using credentials for GitHub Packages.
+rem Builds ads-service and publishes the JAR to GitHub Packages, then compiles
+rem success-product-worker downloading the dependency.
 rem Defina as variaveis GITHUB_ACTOR e GITHUB_TOKEN antes de executar este script.
 
 if "%GITHUB_ACTOR%"=="" (
@@ -14,9 +15,9 @@ if "%GITHUB_TOKEN%"=="" (
   exit /b 1
 )
 
-echo [1] Instalando modulo ads-service...
+echo [1] Publicando modulo ads-service...
 pushd backend\ads-service
-mvn -s ..\settings.xml install
+mvn -s ..\settings.xml deploy
 if errorlevel 1 (
   echo Falha ao instalar ads-service
   popd
@@ -26,7 +27,7 @@ popd
 
 echo [2] Compilando success-product-worker...
 pushd success-product-worker
-mvn -s settings.xml install
+mvn -s settings.xml package
 if errorlevel 1 (
   echo Falha ao compilar success-product-worker
   popd

--- a/success-product-worker/pom.xml
+++ b/success-product-worker/pom.xml
@@ -13,6 +13,11 @@
             <name>GitHub Packages</name>
             <url>https://maven.pkg.github.com/paulofor/marketing-hub</url>
         </repository>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
     </repositories>
 
     <properties>


### PR DESCRIPTION
## Summary
- point build steps to GitHub Packages
- publish backend JAR to GitHub Packages and fetch in worker
- fix worker POM to also use Maven Central

## Testing
- `mvn -s backend/settings.xml -f backend/ads-service/pom.xml test` *(fails: Network is unreachable)*
- `mvn -s success-product-worker/settings.xml -f success-product-worker/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e3a88dea883218e1032e293f06ef2