### PR TITLE
Update success-product worker dependency URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - **Success Product Worker**
   - Build: `cd success-product-worker && mvn -s settings.xml package`
   - Tests: `cd success-product-worker && mvn -s settings.xml test`
-  - Downloads the `ads-service` artifact from GitHub Packages.
+  - Downloads the `ads-service` artifact from the `paulofor/ads-service` GitHub Packages repository.
 - **Frontend**
   - Build: `npm run build`
   - Tests: `npm run test`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ cd backend/ads-service && mvn spring-boot:run
 cd ../../frontend && npm run dev
 # run the background worker (optional)
 cd ../success-product-worker && mvn spring-boot:run
+# the worker fetches the ads-service dependency from
+# https://maven.pkg.github.com/paulofor/ads-service
 # create a .env file to point the React app to your backend
 echo "VITE_API_URL=http://localhost:8000" > frontend/.env
 # deploy to VPS (Java 21 already installed)

--- a/success-product-worker/pom.xml
+++ b/success-product-worker/pom.xml
@@ -11,7 +11,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/paulofor/marketing-hub</url>
+            <url>https://maven.pkg.github.com/paulofor/ads-service</url>
         </repository>
         <repository>
             <id>central</id>
@@ -61,11 +61,11 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- reuse entities from the ads-service module -->
+        <!-- reuse entities from the ads-service package hosted on GitHub Packages -->
         <dependency>
-            <groupId>com.marketinghub</groupId>
+            <groupId>com.paulofor</groupId>
             <artifactId>ads-service</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- update success-product worker to pull `ads-service` from `paulofor/ads-service`
- note the new dependency location in docs
- clarify AGENTS instructions

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s ../settings.xml deploy` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml package` *(fails: Network is unreachable)*
- `npm run test --silent` *(fails: vitest not found)*
- `npm run build --silent` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3dc1a8f88321b0e662bf143b4929