### PR TITLE
Fix Maven package setup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: backend-jar
-          path: backend/ads-service/target/app.jar
+          path: backend/ads-service/target/app-exec.jar
 
 # ─────────────────────────────────────────
 # 2) DEPLOY – transfere JAR e reinicia

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -25,5 +25,7 @@ jobs:
           distribution: temurin
           java-version: 21
           cache: maven
-      - name: Build and test
+      - name: Run tests
+        run: mvn -B -s settings.xml test
+      - name: Build
         run: mvn -B -s settings.xml package

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ cd ../success-product-worker && mvn spring-boot:run
 # create a .env file to point the React app to your backend
 echo "VITE_API_URL=http://localhost:8000" > frontend/.env
 # deploy to VPS (Java 21 already installed)
-scp target/app.jar <vps>:/opt/marketing-hub/
-ssh <vps> "java -jar /opt/marketing-hub/app.jar"
+scp target/app-exec.jar <vps>:/opt/marketing-hub/
+ssh <vps> "java -jar /opt/marketing-hub/app-exec.jar"
 ```
 
 To run the Media Hub locally:

--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -73,6 +73,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <finalName>app</finalName>
+                    <classifier>exec</classifier>
+                    <attach>true</attach>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
- attach exec jar with classifier for ads service
- reference new artifact name in CI workflow
- split worker CI build and test steps
- update README with exec jar deployment command

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7a736a0c8321b58486a15941a0b1