### PR TITLE
Fix entity scanning for success-product-worker

### DIFF
--- a/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductWorkerApplication.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductWorkerApplication.java
@@ -2,9 +2,11 @@ package com.marketinghub.worker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EntityScan({"com.marketinghub.worker", "com.marketinghub.ads"})
 @EnableScheduling
 public class SuccessProductWorkerApplication {
     public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- allow SuccessProductWorker to discover entities from the ads-service dependency by specifying `@EntityScan`

## Testing
- `mvn -s settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_686e7ff050e88321a9915b26d742174e