### PR TITLE
Configure tests for ads entity

### DIFF
--- a/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
@@ -2,6 +2,8 @@ package com.marketinghub.worker;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -9,6 +11,8 @@ import org.springframework.test.context.TestPropertySource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@ImportAutoConfiguration
+@EntityScan("com.marketinghub.ads")
 @ContextConfiguration(classes = SuccessProductWorkerApplication.class)
 @TestPropertySource(properties = {
         "spring.datasource.url=jdbc:h2:mem:testdb",


### PR DESCRIPTION
## Summary
- register `com.marketinghub.ads` when scanning JPA entities in tests

## Testing
- `mvn -s settings.xml test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e83ed72108321a8507ee63c0b2feb