### PR TITLE
Update CI/CD for exec JAR artifact

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,6 +47,8 @@ jobs:
         run: mvn -B test
 
       - name: Build and publish to GitHub Packages
+        # <classifier>exec</classifier> gera app.jar (puro) e app-exec.jar
+        # reempacotado pelo plugin; o jar "puro" segue para o GitHub Packages
         run: mvn -B -s ../settings.xml deploy -DskipTests
 
       - name: Publicar artefato
@@ -86,6 +88,6 @@ jobs:
 
       - name: Sincronizar JAR e reiniciar serviço
         run: |
-          JAR=$(ls -S target/*.jar | head -n 1)
+          JAR=target/app-exec.jar
           rsync -az --delete "$JAR" marketinghub@${VPS_IP}:${APP_DIR}/
           ssh marketinghub@${VPS_IP} "sudo -n systemctl restart marketinghub-backend.service"


### PR DESCRIPTION
## Summary
- package Spring Boot with exec classifier
- keep pure JAR on deploy to GitHub Packages
- transfer only exec JAR to VPS

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eaec545708321befa8ce6ca5a94b9