### PR TITLE
Fix jar naming for VPS deployment

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,4 +90,4 @@ jobs:
         run: |
           JAR=target/app-exec.jar
           rsync -az --delete "$JAR" marketinghub@${VPS_IP}:${APP_DIR}/
-          ssh marketinghub@${VPS_IP} "sudo -n systemctl restart marketinghub-backend.service"
+          ssh marketinghub@${VPS_IP} "mv ${APP_DIR}/app-exec.jar ${APP_DIR}/app.jar && sudo -n systemctl restart marketinghub-backend.service"

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ cd ../success-product-worker && mvn spring-boot:run
 # The backend builds two JAR files when packaging:
 # - `app.jar` is the thin artifact published to GitHub Packages and
 #   consumed by the Success Product Worker using Maven.
-# - `app-exec.jar` is the fat executable that gets copied to the VPS.
+# - `app-exec.jar` is the fat executable that gets copied to the VPS as
+#   `app.jar`.
 # create a .env file to point the React app to your backend
 echo "VITE_API_URL=http://localhost:8000" > frontend/.env
 # deploy to VPS (Java 21 already installed)
-scp target/app-exec.jar <vps>:/opt/marketing-hub/
-ssh <vps> "java -jar /opt/marketing-hub/app-exec.jar"
+scp target/app-exec.jar <vps>:/opt/marketinghub/app/app.jar
+ssh <vps> "java -jar /opt/marketinghub/app/app.jar"
 ```
 
 To run the Media Hub locally:


### PR DESCRIPTION
## Summary
- rename fat jar on copy to `app.jar` in the deploy job
- update README to copy jar to `/opt/marketinghub/app/app.jar`

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*
- `npm run test --silent` *(fails: vitest: not found)*
- `npm run build --silent` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f06b7c9bc8321afc7599f9cc07e2f