### PR TITLE
Use deploy-file to publish library

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,16 +46,41 @@ jobs:
       - name: Rodar testes
         run: mvn -B test
 
-      - name: Build and publish to GitHub Packages
-        # <classifier>exec</classifier> gera app.jar (puro) e app-exec.jar
-        # reempacotado pelo plugin; o jar "puro" segue para o GitHub Packages
-        run: mvn -B -s ../settings.xml deploy -DskipTests
+      - name: Build backend
+        run: mvn -B -s ../settings.xml package -DskipTests
+
+      - name: Ajustar nomes dos JARs
+        run: |
+          mv target/app.jar target/app-lib.jar
+          mv target/app-exec.jar target/app.jar
+
+      - name: Enviar lib ao GitHub Packages com Maven Deploy Plugin
+        run: |
+          mvn -B -s ../settings.xml \
+            org.apache.maven.plugins:maven-deploy-plugin:3.1.1:deploy-file \
+            -DrepositoryId=github \
+            -Durl=https://maven.pkg.github.com/paulofor/marketing-hub \
+            -Dfile=target/app-lib.jar \
+            -DgroupId=com.marketinghub \
+            -DartifactId=ads-service \
+            -Dversion=0.0.1-SNAPSHOT \
+            -Dpackaging=jar
+
+      - name: Verificar biblioteca publicada
+        run: |
+          mvn -B -s ../settings.xml dependency:get \
+            -Dartifact=com.marketinghub:ads-service:0.0.1-SNAPSHOT \
+            -Dtransitive=false
+          test -f ~/.m2/repository/com/marketinghub/ads-service/0.0.1-SNAPSHOT/ads-service-0.0.1-SNAPSHOT.jar
+
+      - name: Build Success Product Worker
+        run: cd ../../success-product-worker && mvn -s settings.xml package
 
       - name: Publicar artefato
         uses: actions/upload-artifact@v4
         with:
           name: backend-jar
-          path: backend/ads-service/target/app-exec.jar
+          path: backend/ads-service/target/app.jar
 
 # ─────────────────────────────────────────
 # 2) DEPLOY – transfere JAR e reinicia
@@ -88,6 +113,6 @@ jobs:
 
       - name: Sincronizar JAR e reiniciar serviço
         run: |
-          JAR=target/app-exec.jar
+          JAR=target/app.jar
           rsync -az --delete "$JAR" marketinghub@${VPS_IP}:${APP_DIR}/
-          ssh marketinghub@${VPS_IP} "mv ${APP_DIR}/app-exec.jar ${APP_DIR}/app.jar && sudo -n systemctl restart marketinghub-backend.service"
+          ssh marketinghub@${VPS_IP} "sudo -n systemctl restart marketinghub-backend.service"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,19 @@ cd ../success-product-worker && mvn spring-boot:run
 # The backend builds two JAR files when packaging:
 # - `app.jar` is the thin artifact published to GitHub Packages and
 #   consumed by the Success Product Worker using Maven.
-# - `app-exec.jar` is the fat executable that gets copied to the VPS as
-#   `app.jar`.
+# - `app-exec.jar` is the fat executable. The CI workflow renames it to
+#   `app.jar` for deployment and keeps a copy of the thin JAR as
+#   `app-lib.jar`.
+# The thin JAR can be published manually with:
+#   cd backend/ads-service && mvn -s ../settings.xml \
+#     org.apache.maven.plugins:maven-deploy-plugin:deploy-file \
+#     -DrepositoryId=github -Durl=https://maven.pkg.github.com/paulofor/marketing-hub \
+#     -Dfile=target/app-lib.jar -DgroupId=com.marketinghub \
+#     -DartifactId=ads-service -Dversion=0.0.1-SNAPSHOT -Dpackaging=jar
+# The CI workflow performs the same deploy-file command and then verifies the
+# upload with `mvn dependency:get`.
+# The worker only needs this JAR from GitHub Packages – Maven downloads it
+# automatically when compiling.
 # create a .env file to point the React app to your backend
 echo "VITE_API_URL=http://localhost:8000" > frontend/.env
 # deploy to VPS (Java 21 already installed)


### PR DESCRIPTION
## Summary
- use Maven Deploy Plugin `deploy-file` to upload the thin jar
- note the `deploy-file` command in the README

## Testing
- `mvn -s ../settings.xml deploy` *(fails: Non-resolvable parent POM)*
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml package` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686f7a6f614883219f6fab51524f3480