### PR TITLE
Fix jar name in backend build

### DIFF
--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -67,6 +67,7 @@
     </dependencies>
 
     <build>
+    <finalName>app</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- ensure Maven build produces `app.jar` by setting `<finalName>` in build

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact)*
- `mvn -s settings.xml test` *(fails: Could not transfer artifact)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686f8412ee348321b2e87e8efbf5a910