### PR TITLE
fix: remove GitHub package wildcard

### DIFF
--- a/success-product-worker/.idea/jarRepositories.xml
+++ b/success-product-worker/.idea/jarRepositories.xml
@@ -4,7 +4,7 @@
     <remote-repository>
       <option name="id" value="github" />
       <option name="name" value="github" />
-      <option name="url" value="https://maven.pkg.github.com/paulofor/*" />
+      <option name="url" value="https://maven.pkg.github.com/paulofor/marketing-hub" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="central" />

--- a/success-product-worker/pom.xml
+++ b/success-product-worker/pom.xml
@@ -11,8 +11,7 @@
     <repositories>
         <repository>
             <id>github</id>
-            <!-- wildcard evita erro se mudar de repositório no futuro -->
-            <url>https://maven.pkg.github.com/paulofor/*</url>
+            <url>https://maven.pkg.github.com/paulofor/marketing-hub</url>
             <releases><enabled>true</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </repository>


### PR DESCRIPTION
## Summary
- point `success-product-worker` GitHub repository URL to `marketing-hub`
- update IntelliJ jar repository configuration

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s ../settings.xml deploy` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml package` *(fails: Network is unreachable)*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe435d2c08321ab9008057570b9e7