### PR TITLE
Fix OpenAI temperature for o3

### DIFF
--- a/success-product-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
@@ -60,9 +60,7 @@ public class OpenAiChatGptClient implements ChatGptClient {
                                             "role",
                                             "user",
                                             "content",
-                                            prompt + "\n" + product.getDescription())),
-                            "temperature",
-                            0));
+                                            prompt + "\n" + product.getDescription()))));
 
             if (log.isDebugEnabled()) {
                 log.debug("Sending request to OpenAI: {}", requestBody);


### PR DESCRIPTION
## Summary
- remove the temperature parameter in OpenAiChatGptClient so it works with the `o3` model

## Testing
- `mvn -s ../settings.xml test` *(fails: unable to download dependencies)*
- `mvn -s settings.xml test` *(fails: unable to download dependencies)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6870554fc2a08321b525497d0e386dac