### PR TITLE
Add Success Product detail page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import ProductListPage from "./pages/product/ProductListPage";
 import NewProductPage from "./pages/product/NewProductPage";
 import SuccessProductListPage from "./pages/successProduct/SuccessProductListPage";
 import NewSuccessProductPage from "./pages/successProduct/NewSuccessProductPage";
+import SuccessProductDetailPage from "./pages/successProduct/SuccessProductDetailPage";
 import InstagramPostsPage from "./pages/post/InstagramPostsPage";
 
 export default function App() {
@@ -63,6 +64,10 @@ export default function App() {
         <Route
           path="/success-products/new"
           element={<NewSuccessProductPage />}
+        />
+        <Route
+          path="/success-products/:id"
+          element={<SuccessProductDetailPage />}
         />
         <Route path="*" element={<div>Início</div>} />
       </Routes>

--- a/frontend/src/api/successProduct/useSuccessProduct.ts
+++ b/frontend/src/api/successProduct/useSuccessProduct.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { SuccessProduct } from "./useSuccessProducts";
+
+export function useSuccessProduct(id: number) {
+  return useQuery({
+    queryKey: ["successProduct", id],
+    queryFn: async () => {
+      const { data } = await axios.get<SuccessProduct>(
+        `/api/success-products/${id}`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/successProduct/SuccessProductDetailPage.tsx
+++ b/frontend/src/pages/successProduct/SuccessProductDetailPage.tsx
@@ -1,0 +1,44 @@
+import { useParams } from "react-router-dom";
+import { useSuccessProduct } from "../../api/successProduct/useSuccessProduct";
+import PageTitle from "../../components/PageTitle";
+
+export default function SuccessProductDetailPage() {
+  const { id } = useParams();
+  const productId = Number(id);
+  const { data, isLoading } = useSuccessProduct(productId);
+
+  if (isLoading) return <p>Carregando...</p>;
+  if (!data) return <p>Não encontrado</p>;
+
+  return (
+    <div>
+      <PageTitle>Produto de Sucesso {data.id}</PageTitle>
+      <h3>Descrição</h3>
+      <pre>{data.description}</pre>
+      <h3>Nicho</h3>
+      <p>{data.niche}</p>
+      <h3>Avatar</h3>
+      <p>{data.avatar}</p>
+      <h3>Dor Explícita</h3>
+      <pre>{data.explicitPain}</pre>
+      <h3>Promessa</h3>
+      <pre>{data.promise}</pre>
+      <h3>Mecanismo Único</h3>
+      <pre>{data.uniqueMechanism}</pre>
+      <h3>Tripwire</h3>
+      <pre>{data.tripwire}</pre>
+      <h3>Reversão de Risco</h3>
+      <pre>{data.riskReversal}</pre>
+      <h3>Prova Social</h3>
+      <pre>{data.socialProof}</pre>
+      <h3>Monetização do Checkout</h3>
+      <pre>{data.checkoutMonetization}</pre>
+      <h3>Funil</h3>
+      <pre>{data.funnel}</pre>
+      <h3>Volume Criativo</h3>
+      <pre>{data.creativeVolume}</pre>
+      <h3>Storytelling</h3>
+      <pre>{data.storytelling}</pre>
+    </div>
+  );
+}

--- a/frontend/src/pages/successProduct/SuccessProductListPage.tsx
+++ b/frontend/src/pages/successProduct/SuccessProductListPage.tsx
@@ -16,6 +16,8 @@ export default function SuccessProductListPage() {
           <tr>
             <th>ID</th>
             <th>Descrição</th>
+            <th>Novo</th>
+            <th>Ações</th>
           </tr>
         </thead>
         <tbody>
@@ -24,6 +26,14 @@ export default function SuccessProductListPage() {
               <td>{p.id}</td>
               <td>{p.description}</td>
               <td>{p.novo ? "Yes" : "No"}</td>
+              <td>
+                <Link
+                  className="btn btn-sm btn-outline-primary"
+                  to={`/success-products/${p.id}`}
+                >
+                  Visualizar
+                </Link>
+              </td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- add API hook to fetch single Success Product
- show details of Success Product fetched from worker
- link to detail page from list
- register new route for Success Product details

## Testing
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68712eae4be48321b6500089643cdb54