### PR TITLE
Enable ChatGPT web search

### DIFF
--- a/success-product-worker/README.md
+++ b/success-product-worker/README.md
@@ -28,7 +28,7 @@ mvn spring-boot:run
 A aplicação agenda a tarefa `SuccessProductScheduler` para rodar a cada hora (`0 0 * * * *`). O método `analyzeNewProducts` busca registros com `novo=true`, chama `ChatGptClient` para preencher os campos e persiste o resultado. Agora a implementação padrão utiliza a API da OpenAI (`OpenAiChatGptClient`). Caso queira utilizar a versão de testes sem chamadas externas, ative o perfil `dummy`.
 
 Para que a integração funcione é necessário definir a variável de ambiente `OPENAI_API_KEY` ou a propriedade `openai.api-key` com o token de acesso. O modelo utilizado pode ser configurado pela propriedade `openai.model` (padrão `o3`).
-Caso queira permitir buscas na Internet pelo modelo, defina também `BING_API_KEY` ou a propriedade `bing.api-key` com a chave do Bing Search.
+Caso queira permitir buscas na Internet pelo modelo, defina também `GOOGLE_API_KEY` e `GOOGLE_SEARCH_ID` ou as propriedades `google.api-key` e `google.search-id` com as credenciais do Google Search.
 
 Durante a execução, o worker registra logs informando o início e o término da tarefa, além de detalhes sobre cada produto processado. Verifique o console para acompanhar o andamento.
 

--- a/success-product-worker/README.md
+++ b/success-product-worker/README.md
@@ -28,6 +28,7 @@ mvn spring-boot:run
 A aplicação agenda a tarefa `SuccessProductScheduler` para rodar a cada hora (`0 0 * * * *`). O método `analyzeNewProducts` busca registros com `novo=true`, chama `ChatGptClient` para preencher os campos e persiste o resultado. Agora a implementação padrão utiliza a API da OpenAI (`OpenAiChatGptClient`). Caso queira utilizar a versão de testes sem chamadas externas, ative o perfil `dummy`.
 
 Para que a integração funcione é necessário definir a variável de ambiente `OPENAI_API_KEY` ou a propriedade `openai.api-key` com o token de acesso. O modelo utilizado pode ser configurado pela propriedade `openai.model` (padrão `o3`).
+Caso queira permitir buscas na Internet pelo modelo, defina também `BING_API_KEY` ou a propriedade `bing.api-key` com a chave do Bing Search.
 
 Durante a execução, o worker registra logs informando o início e o término da tarefa, além de detalhes sobre cada produto processado. Verifique o console para acompanhar o andamento.
 

--- a/success-product-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
@@ -3,11 +3,14 @@ package com.marketinghub.worker;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -16,25 +19,29 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
- * ChatGptClient implementation that calls the OpenAI API.
+ * OpenAI client que suporta Function Calling + busca na web via Bing Search API.
  */
 @Component
 public class OpenAiChatGptClient implements ChatGptClient {
+
     private static final Logger log = LoggerFactory.getLogger(OpenAiChatGptClient.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private final HttpClient httpClient = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(30))
-            .build();
-
+    private final HttpClient httpClient;
     private final String apiKey;
     private final String model;
+    private final String bingKey;
 
     public OpenAiChatGptClient(
             @Value("${openai.api-key:}") String apiKey,
-            @Value("${openai.model:o3}") String model) {
+            @Value("${openai.model:o3}") String model,
+            @Value("${bing.api-key:}") String bingKey) {
         this.apiKey = apiKey;
         this.model = model;
+        this.bingKey = bingKey;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
     }
 
     @Override
@@ -43,93 +50,142 @@ public class OpenAiChatGptClient implements ChatGptClient {
             log.warn("OpenAI API key not configured, returning product unchanged");
             return product;
         }
-        String requestBody = null;
-        String body = null;
+
+        // ===== 1. Mensagens iniciais
+        List<Map<String, Object>> messages = new ArrayList<>();
+        messages.add(Map.of("role", "system", "content", "Você é um especialista em marketing."));
+        String prompt = "Preencha os campos explicitPain, promise, uniqueMechanism, " +
+                "tripwire, riskReversal, socialProof, checkoutMonetization, funnel, " +
+                "creativeVolume, storytelling em formato JSON.";
+        messages.add(Map.of("role", "user", "content", prompt + "\n" + product.getDescription()));
+
+        // ===== 2. Definição do tool search_web
+        Map<String, Object> searchTool = Map.of(
+                "type", "function",
+                "function", Map.of(
+                        "name", "search_web",
+                        "description", "Busca na Internet e devolve até 5 resultados relevantes.",
+                        "parameters", Map.of(
+                                "type", "object",
+                                "properties", Map.of("query", Map.of("type", "string")),
+                                "required", List.of("query"))));
+        List<Object> tools = List.of(searchTool);
+
         try {
-            String prompt = "Preencha os campos explicitPain, promise, uniqueMechanism, "
-                    + "tripwire, riskReversal, socialProof, checkoutMonetization, funnel, "
-                    + "creativeVolume, storytelling em formato JSON.";
-            requestBody = MAPPER.writeValueAsString(
-                    Map.of(
-                            "model",
-                            model,
-                            "messages",
-                            List.of(
-                                    Map.of("role", "system", "content", "Você é um especialista em marketing."),
-                                    Map.of(
-                                            "role",
-                                            "user",
-                                            "content",
-                                            prompt + "\n" + product.getDescription()))));
+            // ===== 3. Loop principal (tool calling)
+            while (true) {
+                String requestBody = MAPPER.writeValueAsString(Map.of(
+                        "model", model,
+                        "messages", messages,
+                        "tools", tools,
+                        "tool_choice", "auto"));
 
-            if (log.isDebugEnabled()) {
-                log.debug("Sending request to OpenAI: {}", requestBody);
-            }
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create("https://api.openai.com/v1/chat/completions"))
+                        .timeout(Duration.ofMinutes(2))
+                        .header("Authorization", "Bearer " + apiKey)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
+                        .build();
 
-            HttpRequest request =
-                    HttpRequest.newBuilder()
-                            .uri(URI.create("https://api.openai.com/v1/chat/completions"))
-                            .timeout(Duration.ofMinutes(2))
-                            .header("Authorization", "Bearer " + apiKey)
-                            .header("Content-Type", "application/json")
-                            .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
-                            .build();
+                HttpResponse<String> response =
+                        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
-            HttpResponse<String> response =
-                    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+                JsonNode choice = MAPPER.readTree(response.body())
+                        .path("choices").get(0);
+                String finishReason = choice.path("finish_reason").asText();
 
-            body = response.body();
-            log.debug("OpenAI status: {}", response.statusCode());
-            log.trace("OpenAI response body: {}", body);
+                // ===== 3a. Modelo quer usar o tool search_web
+                if ("tool".equals(finishReason)) {
+                    String query = choice.path("message").path("tool_call")
+                            .path("arguments").path("query").asText();
+                    List<SearchResult> results = searchWeb(query);
+                    String toolContent = MAPPER.writeValueAsString(Map.of("results", results));
 
-            JsonNode root = MAPPER.readTree(body);
-            JsonNode choices = root.path("choices");
-            if (!choices.isArray() || choices.isEmpty()) {
-                log.warn("Unexpected OpenAI response format: {}", body);
+                    messages.add(Map.of(
+                            "role", "tool",
+                            "name", "search_web",
+                            "content", toolContent));
+                    continue; // volta ao início do loop
+                }
+
+                // ===== 3b. Resposta final do modelo
+                String content = choice.path("message").path("content").asText();
+                content = stripCodeFence(content);
+                JsonNode data = MAPPER.readTree(content);
+
+                product.setExplicitPain(asText(data, "explicitPain"));
+                product.setPromise(asText(data, "promise"));
+                product.setUniqueMechanism(asText(data, "uniqueMechanism"));
+                product.setTripwire(asText(data, "tripwire"));
+                product.setRiskReversal(asText(data, "riskReversal"));
+                product.setSocialProof(asText(data, "socialProof"));
+                product.setCheckoutMonetization(asText(data, "checkoutMonetization"));
+                product.setFunnel(asText(data, "funnel"));
+                product.setCreativeVolume(asText(data, "creativeVolume"));
+                product.setStorytelling(asText(data, "storytelling"));
+                product.setNovo(false);
                 return product;
             }
-            String content = choices.get(0).path("message").path("content").asText();
-            content = stripCodeFence(content);
-            JsonNode data = MAPPER.readTree(content);
-            product.setExplicitPain(asText(data, "explicitPain"));
-            product.setPromise(asText(data, "promise"));
-            product.setUniqueMechanism(asText(data, "uniqueMechanism"));
-            product.setTripwire(asText(data, "tripwire"));
-            product.setRiskReversal(asText(data, "riskReversal"));
-            product.setSocialProof(asText(data, "socialProof"));
-            product.setCheckoutMonetization(asText(data, "checkoutMonetization"));
-            product.setFunnel(asText(data, "funnel"));
-            product.setCreativeVolume(asText(data, "creativeVolume"));
-            product.setStorytelling(asText(data, "storytelling"));
-            product.setNovo(false);
-            return product;
         } catch (Exception e) {
-            if (requestBody != null) {
-                log.error("Failed to call OpenAI API. Request: {} Response: {}", requestBody, body, e);
-            } else {
-                log.error("Failed to call OpenAI API", e);
-            }
+            log.error("Failed to call OpenAI API", e);
             return product;
         }
     }
 
-    private static String asText(JsonNode node, String field) {
-        JsonNode value = node.get(field);
-        return value != null && !value.isNull() ? value.asText() : null;
+    /**
+     * Executa busca na Web usando Bing Search API.
+     */
+    private List<SearchResult> searchWeb(String query) throws Exception {
+        if (bingKey == null || bingKey.isBlank()) {
+            return Collections.emptyList();
+        }
+        String endpoint = "https://api.bing.microsoft.com/v7.0/search?q=" +
+                URLEncoder.encode(query, StandardCharsets.UTF_8);
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(endpoint))
+                .timeout(Duration.ofSeconds(15))
+                .header("Ocp-Apim-Subscription-Key", bingKey)
+                .GET()
+                .build();
+        HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+        JsonNode webPages = MAPPER.readTree(resp.body()).path("webPages").path("value");
+
+        List<SearchResult> list = new ArrayList<>();
+        for (JsonNode item : webPages) {
+            list.add(new SearchResult(
+                    item.path("name").asText(),
+                    item.path("url").asText(),
+                    item.path("snippet").asText()));
+        }
+        return list.size() > 5 ? list.subList(0, 5) : list;
     }
 
     private static String stripCodeFence(String text) {
-        if (text == null) {
-            return null;
+        if (text == null) return null;
+        String t = text.trim();
+        if (t.startsWith("```") && t.contains("```")) {
+            int start = t.indexOf('\n');
+            int end = t.lastIndexOf("```");
+            if (start >= 0 && end > start) return t.substring(start + 1, end).trim();
         }
-        String trimmed = text.trim();
-        if (trimmed.startsWith("```") && trimmed.contains("```")) {
-            int start = trimmed.indexOf('\n');
-            int end = trimmed.lastIndexOf("```");
-            if (start >= 0 && end > start) {
-                return trimmed.substring(start + 1, end).trim();
-            }
+        return t;
+    }
+
+    private static String asText(JsonNode node, String field) {
+        JsonNode v = node.get(field);
+        return (v != null && !v.isNull()) ? v.asText() : null;
+    }
+
+    /** Resultado simplificado de busca. */
+    public static class SearchResult {
+        public final String title;
+        public final String url;
+        public final String snippet;
+        public SearchResult(String title, String url, String snippet) {
+            this.title = title;
+            this.url = url;
+            this.snippet = snippet;
         }
-        return trimmed;
     }
 }

--- a/success-product-worker/src/main/resources/application.properties
+++ b/success-product-worker/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.format_sql=true
 openai.api-key=${OPENAI_API_KEY:}
 openai.model=${OPENAI_MODEL:o3}
+bing.api-key=${BING_API_KEY:}

--- a/success-product-worker/src/main/resources/application.properties
+++ b/success-product-worker/src/main/resources/application.properties
@@ -6,4 +6,5 @@ spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.format_sql=true
 openai.api-key=${OPENAI_API_KEY:}
 openai.model=${OPENAI_MODEL:o3}
-bing.api-key=${BING_API_KEY:}
+google.api-key=${GOOGLE_API_KEY:}
+google.search-id=${GOOGLE_SEARCH_ID:}


### PR DESCRIPTION
## Summary
- implement Bing-powered function calling in `OpenAiChatGptClient`
- expose `bing.api-key` property and document usage

## Testing
- `mvn -s settings.xml package` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s ../settings.xml deploy` *(fails: Non-resolvable parent POM)*
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687138eb48608321a05fae8e7a818f20