### PR TITLE
Enhance success product detail page UI

### DIFF
--- a/frontend/src/pages/successProduct/SuccessProductDetailPage.tsx
+++ b/frontend/src/pages/successProduct/SuccessProductDetailPage.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import { useParams } from "react-router-dom";
 import { useSuccessProduct } from "../../api/successProduct/useSuccessProduct";
 import PageTitle from "../../components/PageTitle";
@@ -10,60 +11,43 @@ export default function SuccessProductDetailPage() {
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;
 
+  const rows = [
+    { label: "Descrição", value: data.description, pre: true },
+    { label: "Nicho", value: data.niche },
+    { label: "Avatar", value: data.avatar },
+    { label: "Dor Explícita", value: data.explicitPain, pre: true },
+    { label: "Promessa", value: data.promise, pre: true },
+    { label: "Mecanismo Único", value: data.uniqueMechanism, pre: true },
+    { label: "Tripwire", value: data.tripwire, pre: true },
+    { label: "Reversão de Risco", value: data.riskReversal, pre: true },
+    { label: "Prova Social", value: data.socialProof, pre: true },
+    { label: "Monetização do Checkout", value: data.checkoutMonetization, pre: true },
+    { label: "Funil", value: data.funnel, pre: true },
+    { label: "Volume Criativo", value: data.creativeVolume, pre: true },
+    { label: "Storytelling", value: data.storytelling, pre: true },
+  ];
+
   return (
     <div>
       <PageTitle>Produto de Sucesso {data.id}</PageTitle>
       <div className="card">
-        <div className="card-body">
+        <div className="card-body p-0">
           <dl className="row mb-0">
-            <dt className="col-sm-3">Descrição</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.description}
-            </dd>
-            <dt className="col-sm-3">Nicho</dt>
-            <dd className="col-sm-9">{data.niche}</dd>
-            <dt className="col-sm-3">Avatar</dt>
-            <dd className="col-sm-9">{data.avatar}</dd>
-            <dt className="col-sm-3">Dor Explícita</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.explicitPain}
-            </dd>
-            <dt className="col-sm-3">Promessa</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.promise}
-            </dd>
-            <dt className="col-sm-3">Mecanismo Único</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.uniqueMechanism}
-            </dd>
-            <dt className="col-sm-3">Tripwire</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.tripwire}
-            </dd>
-            <dt className="col-sm-3">Reversão de Risco</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.riskReversal}
-            </dd>
-            <dt className="col-sm-3">Prova Social</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.socialProof}
-            </dd>
-            <dt className="col-sm-3">Monetização do Checkout</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.checkoutMonetization}
-            </dd>
-            <dt className="col-sm-3">Funil</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.funnel}
-            </dd>
-            <dt className="col-sm-3">Volume Criativo</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.creativeVolume}
-            </dd>
-            <dt className="col-sm-3">Storytelling</dt>
-            <dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>
-              {data.storytelling}
-            </dd>
+            {rows.map((r, idx) => (
+              <Fragment key={r.label}>
+                <dt
+                  className={`col-sm-3 py-2${idx % 2 === 0 ? " bg-light" : ""}`}
+                >
+                  {r.label}
+                </dt>
+                <dd
+                  className={`col-sm-9 py-2${idx % 2 === 0 ? " bg-light" : ""}`}
+                  style={r.pre ? { whiteSpace: "pre-wrap" } : undefined}
+                >
+                  {r.value}
+                </dd>
+              </Fragment>
+            ))}
           </dl>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- improve readability of Success Product detail by alternating row background colors

## Testing
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68715138906c8321b80157f7609f6533