### PR TITLE
Update Success Product worker

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE product (
 CREATE TABLE success_product (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     description LONGTEXT,
+    name VARCHAR(255),
     novo BOOLEAN DEFAULT TRUE,
     niche VARCHAR(255),
     avatar VARCHAR(255),

--- a/success-product-worker/README.md
+++ b/success-product-worker/README.md
@@ -1,6 +1,6 @@
 # Success Product Worker
 
-Este projeto executa em segundo plano para analisar novos produtos cadastrados no Marketing Hub e enriquecê-los com características de marketing. Ele utiliza as entidades do **ads-service** publicadas no GitHub Packages e roda tarefas agendadas a cada hora.
+Este projeto executa em segundo plano para analisar novos produtos cadastrados no Marketing Hub e enriquecê-los com características de marketing. Ele utiliza as entidades do **ads-service** publicadas no GitHub Packages e roda tarefas agendadas a cada cinco minutos. Durante o enriquecimento, o ChatGPT também define o campo `name` de cada produto.
 
 ## Pré-requisitos
 - Java 21
@@ -25,7 +25,7 @@ mvn -s settings.xml test
 mvn spring-boot:run
 ```
 
-A aplicação agenda a tarefa `SuccessProductScheduler` para rodar a cada hora (`0 0 * * * *`). O método `analyzeNewProducts` busca registros com `novo=true`, chama `ChatGptClient` para preencher os campos e persiste o resultado. Agora a implementação padrão utiliza a API da OpenAI (`OpenAiChatGptClient`). Caso queira utilizar a versão de testes sem chamadas externas, ative o perfil `dummy`.
+A aplicação agenda a tarefa `SuccessProductScheduler` para rodar a cada cinco minutos (`0 */5 * * * *`). O método `analyzeNewProducts` busca registros com `novo=true`, chama `ChatGptClient` para preencher os campos (incluindo `name`) e persiste o resultado. Agora a implementação padrão utiliza a API da OpenAI (`OpenAiChatGptClient`). Caso queira utilizar a versão de testes sem chamadas externas, ative o perfil `dummy`.
 
 Para que a integração funcione é necessário definir a variável de ambiente `OPENAI_API_KEY` ou a propriedade `openai.api-key` com o token de acesso. O modelo utilizado pode ser configurado pela propriedade `openai.model` (padrão `o3`).
 Caso queira permitir buscas na Internet pelo modelo, defina também `GOOGLE_API_KEY` e `GOOGLE_SEARCH_ID` ou as propriedades `google.api-key` e `google.search-id` com as credenciais do Google Search.

--- a/success-product-worker/src/main/java/com/marketinghub/worker/DummyChatGptClient.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/DummyChatGptClient.java
@@ -13,6 +13,7 @@ public class DummyChatGptClient implements ChatGptClient {
     public SuccessProduct enrich(SuccessProduct product) {
         log.debug("Enriching product {} using DummyChatGptClient", product.getId());
         // TODO connect to ChatGPT API
+        product.setName("Produto Teste");
         product.setNovo(false);
         return product;
     }

--- a/success-product-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
@@ -57,7 +57,7 @@ public class OpenAiChatGptClient implements ChatGptClient {
         // ===== 1. Mensagens iniciais
         List<Map<String, Object>> messages = new ArrayList<>();
         messages.add(Map.of("role", "system", "content", "Você é um especialista em marketing."));
-        String prompt = "Preencha os campos explicitPain, promise, uniqueMechanism, " +
+        String prompt = "Preencha os campos name, explicitPain, promise, uniqueMechanism, " +
                 "tripwire, riskReversal, socialProof, checkoutMonetization, funnel, " +
                 "creativeVolume, storytelling em formato JSON.";
         messages.add(Map.of("role", "user", "content", prompt + "\n" + product.getDescription()));
@@ -117,6 +117,7 @@ public class OpenAiChatGptClient implements ChatGptClient {
                 content = stripCodeFence(content);
                 JsonNode data = MAPPER.readTree(content);
 
+                product.setName(asText(data, "name"));
                 product.setExplicitPain(asText(data, "explicitPain"));
                 product.setPromise(asText(data, "promise"));
                 product.setUniqueMechanism(asText(data, "uniqueMechanism"));

--- a/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProduct.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProduct.java
@@ -22,6 +22,8 @@ public class SuccessProduct {
     @Column(columnDefinition = "LONGTEXT")
     private String description;
 
+    private String name;
+
     @Builder.Default
     private boolean novo = true;
 

--- a/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductScheduler.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductScheduler.java
@@ -14,7 +14,7 @@ public class SuccessProductScheduler {
         this.analyzer = analyzer;
     }
 
-    @Scheduled(cron = "0 0 * * * *")
+    @Scheduled(cron = "0 */5 * * * *")
     public void run() {
         log.info("SuccessProductScheduler started");
         try {

--- a/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
@@ -29,10 +29,12 @@ class SuccessProductRepositoryTest {
     void testSaveSuccessProduct() {
         SuccessProduct product = SuccessProduct.builder()
                 .description("Great product")
+                .name("Produto")
                 .build();
         repository.save(product);
         SuccessProduct saved = repository.findById(product.getId()).orElseThrow();
         assertThat(saved.isNovo()).isTrue();
+        assertThat(saved.getName()).isEqualTo("Produto");
     }
 
     @Test
@@ -54,9 +56,11 @@ class SuccessProductRepositoryTest {
 
         SuccessProduct product = SuccessProduct.builder()
                 .description(description)
+                .name("Produto")
                 .build();
         repository.save(product);
         SuccessProduct saved = repository.findById(product.getId()).orElseThrow();
         assertThat(saved.getDescription()).isEqualTo(description);
+        assertThat(saved.getName()).isEqualTo("Produto");
     }
 }


### PR DESCRIPTION
## Summary
- use ChatGPT to set new `name` field on success product
- poll for new products every five minutes
- document the new schedule and field
- cover new field in repository tests

## Testing
- `mvn -s settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom)*
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom)*
- `npm run test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715da7659083219acb3734c0ba527f