### PR TITLE
Show success product name

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/SuccessProduct.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/SuccessProduct.java
@@ -25,6 +25,8 @@ public class SuccessProduct {
     @Column(columnDefinition = "LONGTEXT")
     private String description;
 
+    private String name;
+
     /** Flag to indicate newly created entries. */
     @Builder.Default
     private boolean novo = true;

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/SuccessProductDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/SuccessProductDto.java
@@ -10,6 +10,7 @@ import lombok.Data;
 public class SuccessProductDto {
     private Long id;
     private String description;
+    private String name;
     private boolean novo;
     private String niche;
     private String avatar;

--- a/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
@@ -24,6 +24,7 @@ class SuccessProductRepositoryTest {
         repository.save(product);
         SuccessProduct saved = repository.findById(product.getId()).orElseThrow();
         assertThat(saved.isNovo()).isTrue();
+        assertThat(saved.getName()).isNull();
     }
 
     @Test

--- a/frontend/src/api/successProduct/useSuccessProducts.ts
+++ b/frontend/src/api/successProduct/useSuccessProducts.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 export interface SuccessProduct {
   id: number;
   description: string;
+  name?: string;
   novo: boolean;
   niche: string;
   avatar: string;

--- a/frontend/src/pages/successProduct/SuccessProductDetailPage.tsx
+++ b/frontend/src/pages/successProduct/SuccessProductDetailPage.tsx
@@ -35,7 +35,7 @@ export default function SuccessProductDetailPage() {
 
   return (
     <div>
-      <PageTitle>Produto de Sucesso {data.id}</PageTitle>
+      <PageTitle>{data.name || `Produto de Sucesso ${data.id}`}</PageTitle>
       <div className="card">
         <div className="card-body p-0">
           <dl className="row mb-0">


### PR DESCRIPTION
## Summary
- add `name` field to SuccessProduct entity and DTO
- update SuccessProductRepositoryTest expectation
- expose the name in the frontend API type
- show the product name as page title on the detail screen

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687162eaf4408321a43867ce0cdf3e16