### PR TITLE
Add OpenAI request logging

### DIFF
--- a/success-product-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
@@ -89,6 +89,7 @@ public class OpenAiChatGptClient implements ChatGptClient {
                         "tool_choice", "auto"));
 
                 log.info("Sending ChatGPT request with {} messages", messages.size());
+                log.info("ChatGPT request body: {}", requestBody);
 
                 HttpRequest request = HttpRequest.newBuilder()
                         .uri(URI.create("https://api.openai.com/v1/chat/completions"))
@@ -100,6 +101,8 @@ public class OpenAiChatGptClient implements ChatGptClient {
 
                 HttpResponse<String> response =
                         httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+                log.info("ChatGPT response body: {}", response.body());
 
                 JsonNode choice = MAPPER.readTree(response.body())
                         .path("choices").get(0);


### PR DESCRIPTION
## Summary
- log full request and response bodies when calling ChatGPT

## Testing
- `mvn -s ../settings.xml test` *(failed: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(failed: Non-resolvable parent POM)*
- `npm run test` *(failed: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687187da697c8321a59ff489d31ee8df