### PR TITLE
Add URL field to AI service entity

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ai/AiService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ai/AiService.java
@@ -26,6 +26,8 @@ public class AiService {
     @Lob
     private String objective;
 
+    private String url;
+
     private BigDecimal price;
 
     private BigDecimal cost;

--- a/backend/ads-service/src/main/java/com/marketinghub/ai/dto/AiServiceDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ai/dto/AiServiceDto.java
@@ -12,6 +12,7 @@ public class AiServiceDto {
     private Long id;
     private String name;
     private String objective;
+    private String url;
     private BigDecimal price;
     private BigDecimal cost;
     private Instant createdAt;

--- a/backend/ads-service/src/main/java/com/marketinghub/ai/dto/CreateAiServiceRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ai/dto/CreateAiServiceRequest.java
@@ -10,6 +10,7 @@ import lombok.Data;
 public class CreateAiServiceRequest {
     private String name;
     private String objective;
+    private String url;
     private BigDecimal price;
     private BigDecimal cost;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ai/service/AiServiceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ai/service/AiServiceService.java
@@ -25,6 +25,7 @@ public class AiServiceService {
         AiService service = AiService.builder()
                 .name(request.getName())
                 .objective(request.getObjective())
+                .url(request.getUrl())
                 .price(request.getPrice())
                 .cost(request.getCost())
                 .build();

--- a/backend/ads-service/src/test/java/com/marketinghub/ai/AiServiceRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ai/AiServiceRepositoryTest.java
@@ -23,6 +23,7 @@ class AiServiceRepositoryTest {
         AiService service = AiService.builder()
                 .name("OpenAI GPT-4")
                 .objective("Geração de texto")
+                .url("https://example.com")
                 .price(new BigDecimal("20.0"))
                 .cost(new BigDecimal("20.0"))
                 .build();

--- a/frontend/src/api/aiService/useAiServices.ts
+++ b/frontend/src/api/aiService/useAiServices.ts
@@ -5,6 +5,7 @@ export interface AiService {
   id: number;
   name: string;
   objective: string;
+  url: string;
   price: number;
   cost: number;
 }

--- a/frontend/src/api/aiService/useCreateAiService.ts
+++ b/frontend/src/api/aiService/useCreateAiService.ts
@@ -5,6 +5,7 @@ import { AiService } from "./useAiServices";
 export interface CreateAiService {
   name: string;
   objective: string;
+  url: string;
   price: number;
   cost: number;
 }

--- a/frontend/src/pages/aiService/AiServiceListPage.tsx
+++ b/frontend/src/pages/aiService/AiServiceListPage.tsx
@@ -16,6 +16,7 @@ export default function AiServiceListPage() {
           <tr>
             <th>ID</th>
             <th>Nome</th>
+            <th>URL</th>
             <th>Preço</th>
             <th>Custo</th>
           </tr>
@@ -25,6 +26,7 @@ export default function AiServiceListPage() {
             <tr key={s.id}>
               <td>{s.id}</td>
               <td>{s.name}</td>
+              <td>{s.url}</td>
               <td>{s.price}</td>
               <td>{s.cost}</td>
             </tr>

--- a/frontend/src/pages/aiService/NewAiServicePage.tsx
+++ b/frontend/src/pages/aiService/NewAiServicePage.tsx
@@ -7,6 +7,7 @@ export default function NewAiServicePage() {
   const [form, setForm] = useState({
     name: "",
     objective: "",
+    url: "",
     price: "",
     cost: "",
   });
@@ -34,6 +35,12 @@ export default function NewAiServicePage() {
         value={form.objective}
         onChange={(e) => setForm({ ...form, objective: e.target.value })}
         rows={3}
+      />
+      <input
+        className="form-control mb-2"
+        placeholder="URL"
+        value={form.url}
+        onChange={(e) => setForm({ ...form, url: e.target.value })}
       />
       <input
         className="form-control mb-2"

--- a/schema.sql
+++ b/schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE ai_service (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255),
     objective LONGTEXT,
+    url VARCHAR(255),
     price DECIMAL(10,2),
     cost DECIMAL(10,2),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- add `url` field to AiService entity and related DTOs
- allow creating AI services with URL in backend and frontend
- expose URL in AI service table and creation form
- include new column in database schema

## Testing
- `mvn -s /tmp/settings.xml -o test` *(fails: Could not resolve dependencies)*
- `mvn -Dmaven.repo.local=../codex-cache/m2/repository -s settings.xml test` *(fails: Could not transfer artifact)*
- `npm run test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6873e84b44648321891c7620833a2f73