### PR TITLE
Add niche edit feature

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
@@ -36,6 +36,17 @@ public class MarketNicheService {
         return repository.findById(id).orElseThrow();
     }
 
+    @Transactional
+    public MarketNiche update(Long id, CreateMarketNicheRequest request) {
+        MarketNiche niche = repository.findById(id).orElseThrow();
+        niche.setName(request.getName());
+        niche.setDescription(request.getDescription());
+        niche.setDemandVolume(request.getDemandVolume());
+        niche.setPromises(request.getPromises());
+        niche.setOffers(request.getOffers());
+        return repository.save(niche);
+    }
+
     public Iterable<MarketNiche> list() {
         return repository.findAll();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/web/MarketNicheController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/web/MarketNicheController.java
@@ -33,6 +33,11 @@ public class MarketNicheController {
         return mapper.toDto(service.get(id));
     }
 
+    @PutMapping("/{id}")
+    public MarketNicheDto update(@PathVariable Long id, @RequestBody CreateMarketNicheRequest request) {
+        return mapper.toDto(service.update(id, request));
+    }
+
     @GetMapping
     public List<MarketNicheDto> list() {
         return StreamSupport.stream(service.list().spliterator(), false)

--- a/frontend/src/api/niche/useUpdateNiche.ts
+++ b/frontend/src/api/niche/useUpdateNiche.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { MarketNiche } from "./useNiches";
+
+export function useUpdateNiche() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: MarketNiche) => {
+      const { data: niche } = await axios.put<MarketNiche>(
+        `/api/niches/${data.id}`,
+        data,
+      );
+      return niche;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["niches"] });
+    },
+  });
+}

--- a/frontend/src/pages/niche/NicheListPage.tsx
+++ b/frontend/src/pages/niche/NicheListPage.tsx
@@ -1,10 +1,36 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useNiches } from "../../api/niche/useNiches";
+import { useCreateNiche } from "../../api/niche/useCreateNiche";
+import { useUpdateNiche } from "../../api/niche/useUpdateNiche";
 import PageTitle from "../../components/PageTitle";
 
 export default function NicheListPage() {
   const { data, isLoading } = useNiches();
+  const create = useCreateNiche();
+  const update = useUpdateNiche();
+  const [form, setForm] = useState({
+    id: 0,
+    name: "",
+    description: "",
+    demandVolume: "",
+    promises: "",
+    offers: "",
+  });
+  const [editing, setEditing] = useState<number | null>(null);
+
   if (isLoading) return <p>Carregando...</p>;
+
+  const submit = () => {
+    if (editing) {
+      update.mutate(form);
+    } else {
+      const { id, ...payload } = form;
+      create.mutate(payload);
+    }
+    setForm({ id: 0, name: "", description: "", demandVolume: "", promises: "", offers: "" });
+    setEditing(null);
+  };
   return (
     <div>
       <PageTitle>Nichos de Mercado</PageTitle>
@@ -16,6 +42,7 @@ export default function NicheListPage() {
           <tr>
             <th>ID</th>
             <th>Nome</th>
+            <th>Ações</th>
           </tr>
         </thead>
         <tbody>
@@ -23,10 +50,73 @@ export default function NicheListPage() {
             <tr key={n.id}>
               <td>{n.id}</td>
               <td>{n.name}</td>
+              <td>
+                <button
+                  className="btn btn-sm btn-outline-primary"
+                  onClick={() => {
+                    setForm(n);
+                    setEditing(n.id);
+                  }}
+                >
+                  Editar
+                </button>
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
+
+      <div className="row g-2 mt-2">
+        <div className="col-md-3">
+          <input
+            className="form-control"
+            placeholder="nome"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+          />
+        </div>
+        <div className="col-md-3">
+          <textarea
+            className="form-control"
+            placeholder="descrição"
+            value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
+            rows={1}
+          />
+        </div>
+        <div className="col-md-2">
+          <textarea
+            className="form-control"
+            placeholder="volume"
+            value={form.demandVolume}
+            onChange={(e) => setForm({ ...form, demandVolume: e.target.value })}
+            rows={1}
+          />
+        </div>
+        <div className="col-md-2">
+          <textarea
+            className="form-control"
+            placeholder="promessas"
+            value={form.promises}
+            onChange={(e) => setForm({ ...form, promises: e.target.value })}
+            rows={1}
+          />
+        </div>
+        <div className="col-md-2">
+          <textarea
+            className="form-control"
+            placeholder="ofertas"
+            value={form.offers}
+            onChange={(e) => setForm({ ...form, offers: e.target.value })}
+            rows={1}
+          />
+        </div>
+        <div className="col-md-1">
+          <button className="btn btn-primary w-100" onClick={submit}>
+            {editing ? "Atualizar" : "Criar"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow updating MarketNiche on the backend
- expose PUT `/api/niches/{id}` endpoint
- provide `useUpdateNiche` hook
- enable editing of niches in the list page

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not resolve dependencies)*
- `mvn -s settings.xml test` in worker *(fails: Could not resolve dependencies)*
- `npx vitest run`
- `npm run build`
- `mvn -s ../settings.xml deploy` *(fails: Could not resolve dependencies)*
- `mvn -s settings.xml package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68750bbc32c88321893320daace57d1a