### PR TITLE
Add dedicated niche edit page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import SuccessProductDetailPage from "./pages/successProduct/SuccessProductDetai
 import InstagramPostsPage from "./pages/post/InstagramPostsPage";
 import NicheListPage from "./pages/niche/NicheListPage";
 import NewNichePage from "./pages/niche/NewNichePage";
+import EditNichePage from "./pages/niche/EditNichePage";
 import AiServiceListPage from "./pages/aiService/AiServiceListPage";
 import NewAiServicePage from "./pages/aiService/NewAiServicePage";
 
@@ -81,6 +82,7 @@ export default function App() {
         />
         <Route path="/niches" element={<NicheListPage />} />
         <Route path="/niches/new" element={<NewNichePage />} />
+        <Route path="/niches/:id/edit" element={<EditNichePage />} />
         <Route path="/ai-services" element={<AiServiceListPage />} />
         <Route path="/ai-services/new" element={<NewAiServicePage />} />
         <Route path="*" element={<div>Início</div>} />

--- a/frontend/src/api/niche/useNiche.ts
+++ b/frontend/src/api/niche/useNiche.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { MarketNiche } from "./useNiches";
+
+export function useNiche(id: number) {
+  return useQuery({
+    queryKey: ["niche", id],
+    queryFn: async () => {
+      const { data } = await axios.get<MarketNiche>(`/api/niches/${id}`);
+      return data;
+    },
+    enabled: !!id,
+  });
+}

--- a/frontend/src/pages/niche/EditNichePage.tsx
+++ b/frontend/src/pages/niche/EditNichePage.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useUpdateNiche } from "../../api/niche/useUpdateNiche";
+import { useNiche } from "../../api/niche/useNiche";
+import PageTitle from "../../components/PageTitle";
+import { MarketNiche } from "../../api/niche/useNiches";
+
+export default function EditNichePage() {
+  const { id } = useParams<{ id: string }>();
+  const nicheId = Number(id);
+  const { data, isLoading } = useNiche(nicheId);
+  const update = useUpdateNiche();
+  const navigate = useNavigate();
+  const [form, setForm] = useState<MarketNiche>({
+    id: nicheId,
+    name: "",
+    description: "",
+    demandVolume: "",
+    promises: "",
+    offers: "",
+  });
+
+  useEffect(() => {
+    if (data) {
+      setForm(data);
+    }
+  }, [data]);
+
+  const submit = () => {
+    update.mutate(form, {
+      onSuccess: () => navigate("/niches"),
+    });
+  };
+
+  if (isLoading) return <p>Carregando...</p>;
+
+  return (
+    <div>
+      <PageTitle>Editar Nicho</PageTitle>
+      <input
+        className="form-control mb-2"
+        placeholder="Nome"
+        value={form.name}
+        onChange={(e) => setForm({ ...form, name: e.target.value })}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Descrição"
+        value={form.description}
+        onChange={(e) => setForm({ ...form, description: e.target.value })}
+        rows={3}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Volume de Demanda"
+        value={form.demandVolume}
+        onChange={(e) => setForm({ ...form, demandVolume: e.target.value })}
+        rows={3}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Promessas"
+        value={form.promises}
+        onChange={(e) => setForm({ ...form, promises: e.target.value })}
+        rows={3}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Ofertas"
+        value={form.offers}
+        onChange={(e) => setForm({ ...form, offers: e.target.value })}
+        rows={3}
+      />
+      <button className="btn btn-primary" onClick={submit}>
+        Salvar
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/niche/NicheListPage.tsx
+++ b/frontend/src/pages/niche/NicheListPage.tsx
@@ -1,36 +1,11 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useNiches } from "../../api/niche/useNiches";
-import { useCreateNiche } from "../../api/niche/useCreateNiche";
-import { useUpdateNiche } from "../../api/niche/useUpdateNiche";
 import PageTitle from "../../components/PageTitle";
 
 export default function NicheListPage() {
   const { data, isLoading } = useNiches();
-  const create = useCreateNiche();
-  const update = useUpdateNiche();
-  const [form, setForm] = useState({
-    id: 0,
-    name: "",
-    description: "",
-    demandVolume: "",
-    promises: "",
-    offers: "",
-  });
-  const [editing, setEditing] = useState<number | null>(null);
 
   if (isLoading) return <p>Carregando...</p>;
-
-  const submit = () => {
-    if (editing) {
-      update.mutate(form);
-    } else {
-      const { id, ...payload } = form;
-      create.mutate(payload);
-    }
-    setForm({ id: 0, name: "", description: "", demandVolume: "", promises: "", offers: "" });
-    setEditing(null);
-  };
   return (
     <div>
       <PageTitle>Nichos de Mercado</PageTitle>
@@ -51,72 +26,17 @@ export default function NicheListPage() {
               <td>{n.id}</td>
               <td>{n.name}</td>
               <td>
-                <button
+                <Link
                   className="btn btn-sm btn-outline-primary"
-                  onClick={() => {
-                    setForm(n);
-                    setEditing(n.id);
-                  }}
+                  to={`/niches/${n.id}/edit`}
                 >
                   Editar
-                </button>
+                </Link>
               </td>
             </tr>
           ))}
         </tbody>
       </table>
-
-      <div className="row g-2 mt-2">
-        <div className="col-md-3">
-          <input
-            className="form-control"
-            placeholder="nome"
-            value={form.name}
-            onChange={(e) => setForm({ ...form, name: e.target.value })}
-          />
-        </div>
-        <div className="col-md-3">
-          <textarea
-            className="form-control"
-            placeholder="descrição"
-            value={form.description}
-            onChange={(e) => setForm({ ...form, description: e.target.value })}
-            rows={1}
-          />
-        </div>
-        <div className="col-md-2">
-          <textarea
-            className="form-control"
-            placeholder="volume"
-            value={form.demandVolume}
-            onChange={(e) => setForm({ ...form, demandVolume: e.target.value })}
-            rows={1}
-          />
-        </div>
-        <div className="col-md-2">
-          <textarea
-            className="form-control"
-            placeholder="promessas"
-            value={form.promises}
-            onChange={(e) => setForm({ ...form, promises: e.target.value })}
-            rows={1}
-          />
-        </div>
-        <div className="col-md-2">
-          <textarea
-            className="form-control"
-            placeholder="ofertas"
-            value={form.offers}
-            onChange={(e) => setForm({ ...form, offers: e.target.value })}
-            rows={1}
-          />
-        </div>
-        <div className="col-md-1">
-          <button className="btn btn-primary w-100" onClick={submit}>
-            {editing ? "Atualizar" : "Criar"}
-          </button>
-        </div>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `useNiche` hook for fetching a single niche
- create `EditNichePage` for editing niches using a separate screen
- simplify `NicheListPage` to remove inline edit form and link to the new page
- register the edit page route in `App`

## Testing
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875127a2628832193a2dd3e65b2d716