### PR TITLE
Add AI service edit page with loading indicator

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ai/service/AiServiceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ai/service/AiServiceService.java
@@ -39,4 +39,16 @@ public class AiServiceService {
     public Iterable<AiService> list() {
         return repository.findAll();
     }
+
+    /** Update an existing AI service. */
+    @Transactional
+    public AiService update(Long id, CreateAiServiceRequest request) {
+        AiService service = repository.findById(id).orElseThrow();
+        service.setName(request.getName());
+        service.setObjective(request.getObjective());
+        service.setUrl(request.getUrl());
+        service.setPrice(request.getPrice());
+        service.setCost(request.getCost());
+        return repository.save(service);
+    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ai/web/AiServiceController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ai/web/AiServiceController.java
@@ -33,6 +33,11 @@ public class AiServiceController {
         return mapper.toDto(service.get(id));
     }
 
+    @PutMapping("/{id}")
+    public AiServiceDto update(@PathVariable Long id, @RequestBody CreateAiServiceRequest request) {
+        return mapper.toDto(service.update(id, request));
+    }
+
     @GetMapping
     public List<AiServiceDto> list() {
         return StreamSupport.stream(service.list().spliterator(), false)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import NewNichePage from "./pages/niche/NewNichePage";
 import EditNichePage from "./pages/niche/EditNichePage";
 import AiServiceListPage from "./pages/aiService/AiServiceListPage";
 import NewAiServicePage from "./pages/aiService/NewAiServicePage";
+import EditAiServicePage from "./pages/aiService/EditAiServicePage";
 
 export default function App() {
   return (
@@ -85,6 +86,7 @@ export default function App() {
         <Route path="/niches/:id/edit" element={<EditNichePage />} />
         <Route path="/ai-services" element={<AiServiceListPage />} />
         <Route path="/ai-services/new" element={<NewAiServicePage />} />
+        <Route path="/ai-services/:id/edit" element={<EditAiServicePage />} />
         <Route path="*" element={<div>Início</div>} />
       </Routes>
     </div>

--- a/frontend/src/api/aiService/useAiService.ts
+++ b/frontend/src/api/aiService/useAiService.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { AiService } from "./useAiServices";
+
+export function useAiService(id: number) {
+  return useQuery({
+    queryKey: ["aiService", id],
+    queryFn: async () => {
+      const { data } = await axios.get<AiService>(`/api/ai-services/${id}`);
+      return data;
+    },
+    enabled: !!id,
+  });
+}

--- a/frontend/src/api/aiService/useUpdateAiService.ts
+++ b/frontend/src/api/aiService/useUpdateAiService.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { AiService } from "./useAiServices";
+
+export function useUpdateAiService() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: AiService) => {
+      const { data: service } = await axios.put<AiService>(
+        `/api/ai-services/${data.id}`,
+        data,
+      );
+      return service;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["aiServices"] });
+    },
+  });
+}

--- a/frontend/src/pages/aiService/AiServiceListPage.tsx
+++ b/frontend/src/pages/aiService/AiServiceListPage.tsx
@@ -19,6 +19,7 @@ export default function AiServiceListPage() {
             <th>URL</th>
             <th>Preço</th>
             <th>Custo</th>
+            <th>Ações</th>
           </tr>
         </thead>
         <tbody>
@@ -29,6 +30,14 @@ export default function AiServiceListPage() {
               <td>{s.url}</td>
               <td>{s.price}</td>
               <td>{s.cost}</td>
+              <td>
+                <Link
+                  className="btn btn-sm btn-outline-primary"
+                  to={`/ai-services/${s.id}/edit`}
+                >
+                  Editar
+                </Link>
+              </td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/pages/aiService/EditAiServicePage.tsx
+++ b/frontend/src/pages/aiService/EditAiServicePage.tsx
@@ -1,28 +1,38 @@
-import { useState } from "react";
-import { useCreateAiService } from "../../api/aiService/useCreateAiService";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
+import { useAiService } from "../../api/aiService/useAiService";
+import { useUpdateAiService } from "../../api/aiService/useUpdateAiService";
+import { AiService } from "../../api/aiService/useAiServices";
 
-export default function NewAiServicePage() {
-  const create = useCreateAiService();
-  const [form, setForm] = useState({
+export default function EditAiServicePage() {
+  const { id } = useParams<{ id: string }>();
+  const serviceId = Number(id);
+  const { data, isLoading } = useAiService(serviceId);
+  const update = useUpdateAiService();
+  const navigate = useNavigate();
+  const [form, setForm] = useState<AiService>({
+    id: serviceId,
     name: "",
     objective: "",
     url: "",
-    price: "",
-    cost: "",
+    price: 0,
+    cost: 0,
   });
 
+  useEffect(() => {
+    if (data) setForm(data);
+  }, [data]);
+
   const submit = () => {
-    create.mutate({
-      ...form,
-      price: Number(form.price),
-      cost: Number(form.cost),
-    });
+    update.mutate(form, { onSuccess: () => navigate("/ai-services") });
   };
+
+  if (isLoading) return <p>Carregando...</p>;
 
   return (
     <div>
-      <PageTitle>Novo Serviço de IA</PageTitle>
+      <PageTitle>Editar Serviço de IA</PageTitle>
       <input
         className="form-control mb-2"
         placeholder="Nome"
@@ -46,20 +56,20 @@ export default function NewAiServicePage() {
         className="form-control mb-2"
         placeholder="Preço"
         value={form.price}
-        onChange={(e) => setForm({ ...form, price: e.target.value })}
+        onChange={(e) => setForm({ ...form, price: Number(e.target.value) })}
       />
       <input
         className="form-control mb-2"
         placeholder="Custo"
         value={form.cost}
-        onChange={(e) => setForm({ ...form, cost: e.target.value })}
+        onChange={(e) => setForm({ ...form, cost: Number(e.target.value) })}
       />
       <button
         className="btn btn-primary"
         onClick={submit}
-        disabled={create.isPending}
+        disabled={update.isPending}
       >
-        {create.isPending ? (
+        {update.isPending ? (
           <>
             <span
               className="spinner-border spinner-border-sm me-2"


### PR DESCRIPTION
## Summary
- allow updating AI services on the backend
- expose PUT /api/ai-services/{id}
- add hooks to fetch and update a single AI service
- create EditAiServicePage and link from list
- show spinner while saving new or updated AI services

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact)*
- `mvn -s settings.xml test` *(fails: Could not transfer artifact)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687522efff1c8321bc6a43ea7934591d