### PR TITLE
Add labels to edit pages

### DIFF
--- a/frontend/src/pages/aiService/EditAiServicePage.tsx
+++ b/frontend/src/pages/aiService/EditAiServicePage.tsx
@@ -33,34 +33,34 @@ export default function EditAiServicePage() {
   return (
     <div>
       <PageTitle>Editar Serviço de IA</PageTitle>
+      <label className="form-label">Nome</label>
       <input
         className="form-control mb-2"
-        placeholder="Nome"
         value={form.name}
         onChange={(e) => setForm({ ...form, name: e.target.value })}
       />
+      <label className="form-label">Objetivo</label>
       <textarea
         className="form-control mb-2"
-        placeholder="Objetivo"
         value={form.objective}
         onChange={(e) => setForm({ ...form, objective: e.target.value })}
         rows={3}
       />
+      <label className="form-label">URL</label>
       <input
         className="form-control mb-2"
-        placeholder="URL"
         value={form.url}
         onChange={(e) => setForm({ ...form, url: e.target.value })}
       />
+      <label className="form-label">Preço</label>
       <input
         className="form-control mb-2"
-        placeholder="Preço"
         value={form.price}
         onChange={(e) => setForm({ ...form, price: Number(e.target.value) })}
       />
+      <label className="form-label">Custo</label>
       <input
         className="form-control mb-2"
-        placeholder="Custo"
         value={form.cost}
         onChange={(e) => setForm({ ...form, cost: Number(e.target.value) })}
       />

--- a/frontend/src/pages/niche/EditNichePage.tsx
+++ b/frontend/src/pages/niche/EditNichePage.tsx
@@ -41,68 +41,68 @@ export default function EditNichePage() {
   return (
     <div>
       <PageTitle>Editar Nicho</PageTitle>
+      <label className="form-label">Nome</label>
       <input
         className="form-control mb-2"
-        placeholder="Nome"
         value={form.name}
         onChange={(e) => setForm({ ...form, name: e.target.value })}
       />
+      <label className="form-label">Descrição</label>
       <textarea
         className="form-control mb-2"
-        placeholder="Descrição"
         value={form.description}
         onChange={(e) => setForm({ ...form, description: e.target.value })}
         rows={3}
       />
+      <label className="form-label">Volume de Demanda</label>
       <textarea
         className="form-control mb-2"
-        placeholder="Volume de Demanda"
         value={form.demandVolume}
         onChange={(e) => setForm({ ...form, demandVolume: e.target.value })}
         rows={3}
       />
+      <label className="form-label">Promessas</label>
       <textarea
         className="form-control mb-2"
-        placeholder="Promessas"
         value={form.promises}
         onChange={(e) => setForm({ ...form, promises: e.target.value })}
         rows={3}
       />
+      <label className="form-label">Ofertas</label>
       <textarea
         className="form-control mb-2"
-        placeholder="Ofertas"
         value={form.offers}
         onChange={(e) => setForm({ ...form, offers: e.target.value })}
         rows={3}
       />
+      <label className="form-label">Segmentação-base (Brasil)</label>
       <textarea
         className="form-control mb-2"
-        placeholder="Segmentação-base (Brasil)"
         value={form.baseSegmentation}
-        onChange={(e) =>
-          setForm({ ...form, baseSegmentation: e.target.value })
-        }
+        onChange={(e) => setForm({ ...form, baseSegmentation: e.target.value })}
         rows={3}
       />
+      <label className="form-label">
+        Principais interesses / comportamentos
+      </label>
       <textarea
         className="form-control mb-2"
-        placeholder="Principais interesses / comportamentos"
         value={form.interests}
         onChange={(e) => setForm({ ...form, interests: e.target.value })}
         rows={3}
       />
+      <label className="form-label">Filtros demográficos & cargos</label>
       <textarea
         className="form-control mb-2"
-        placeholder="Filtros demográficos & cargos"
         value={form.demographicFilters}
         onChange={(e) =>
           setForm({ ...form, demographicFilters: e.target.value })
         }
         rows={3}
       />
+      <label className="form-label">Dicas extras</label>
       <textarea
         className="form-control mb-2"
-        placeholder="Dicas extras"
         value={form.extraTips}
         onChange={(e) => setForm({ ...form, extraTips: e.target.value })}
         rows={3}


### PR DESCRIPTION
## Summary
- show field names when editing Market Niches
- show field names when editing AI Services

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml deploy` *(fails: Network is unreachable)*
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `cd success-product-worker && mvn -s settings.xml package` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*
- `cd frontend && npm install`
- `npm run build`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68753dfc474083218336ebd921f64d77