### PR TITLE
Improve feedback when editing niche

### DIFF
--- a/frontend/src/pages/niche/EditNichePage.tsx
+++ b/frontend/src/pages/niche/EditNichePage.tsx
@@ -33,6 +33,7 @@ export default function EditNichePage() {
   const submit = () => {
     update.mutate(form, {
       onSuccess: () => navigate("/niches"),
+      onError: () => alert("Erro ao salvar Nicho"),
     });
   };
 
@@ -79,9 +80,7 @@ export default function EditNichePage() {
         className="form-control mb-2"
         placeholder="Segmentação-base (Brasil)"
         value={form.baseSegmentation}
-        onChange={(e) =>
-          setForm({ ...form, baseSegmentation: e.target.value })
-        }
+        onChange={(e) => setForm({ ...form, baseSegmentation: e.target.value })}
         rows={3}
       />
       <textarea
@@ -107,9 +106,26 @@ export default function EditNichePage() {
         onChange={(e) => setForm({ ...form, extraTips: e.target.value })}
         rows={3}
       />
-      <button className="btn btn-primary" onClick={submit}>
-        Salvar
+      <button
+        className="btn btn-primary"
+        onClick={submit}
+        disabled={update.isPending}
+      >
+        {update.isPending ? (
+          <>
+            <span
+              className="spinner-border spinner-border-sm me-2"
+              role="status"
+            />
+            Processando...
+          </>
+        ) : (
+          "Salvar"
+        )}
       </button>
+      {update.isError && (
+        <div className="alert alert-danger mt-2">Erro ao salvar Nicho</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display loading spinner and error alert when saving a niche

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` in `success-product-worker` *(fails: Network is unreachable)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68753f1b95c88321aeae42a86ea0b1a7