### PR TITLE
Disable eval usage in dev

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,9 +2,10 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react({ fastRefresh: false })],
   server: {
     port: 5173,
+    hmr: false,
     proxy: {
       // Backend now listens on port 8000
       "/api": "http://191.252.92.222:8000",


### PR DESCRIPTION
## Summary
- update Vite configuration to disable React fast refresh and HMR

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68779e7411b08321a5d78aebd690095c