### PR TITLE
Fix axios default base URL

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,7 +7,8 @@ import { io } from "socket.io-client";
 import App from "./App";
 import axios from "axios";
 
-axios.defaults.baseURL = import.meta.env.VITE_API_URL || "";
+const defaultBaseURL = `${window.location.protocol}//${window.location.hostname}:8000`;
+axios.defaults.baseURL = import.meta.env.VITE_API_URL || defaultBaseURL;
 
 const queryClient = new QueryClient();
 const socket = io({ path: "/ws" });


### PR DESCRIPTION
## Summary
- default axios baseURL to the backend if VITE_API_URL is not set

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*
- `npm install`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6877a7fc286083218bba7c3136d8770f