### PR TITLE
Add phase field to AI services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Marketing Hub
 This project manages ads, media assets, course plans and now products built with marketing principles.
+Recursos de IA podem ser cadastrados informando em qual fase do marketing atuam.
 
 ```bash
 docker compose up -d      # start MySQL

--- a/backend/ads-service/src/main/java/com/marketinghub/ai/AiService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ai/AiService.java
@@ -28,6 +28,9 @@ public class AiService {
 
     private String url;
 
+    /** Phase of the marketing process where this service is used. */
+    private String phase;
+
     private BigDecimal price;
 
     private BigDecimal cost;

--- a/backend/ads-service/src/main/java/com/marketinghub/ai/dto/AiServiceDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ai/dto/AiServiceDto.java
@@ -13,6 +13,7 @@ public class AiServiceDto {
     private String name;
     private String objective;
     private String url;
+    private String phase;
     private BigDecimal price;
     private BigDecimal cost;
     private Instant createdAt;

--- a/backend/ads-service/src/main/java/com/marketinghub/ai/dto/CreateAiServiceRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ai/dto/CreateAiServiceRequest.java
@@ -11,6 +11,7 @@ public class CreateAiServiceRequest {
     private String name;
     private String objective;
     private String url;
+    private String phase;
     private BigDecimal price;
     private BigDecimal cost;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ai/service/AiServiceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ai/service/AiServiceService.java
@@ -26,6 +26,7 @@ public class AiServiceService {
                 .name(request.getName())
                 .objective(request.getObjective())
                 .url(request.getUrl())
+                .phase(request.getPhase())
                 .price(request.getPrice())
                 .cost(request.getCost())
                 .build();
@@ -47,6 +48,7 @@ public class AiServiceService {
         service.setName(request.getName());
         service.setObjective(request.getObjective());
         service.setUrl(request.getUrl());
+        service.setPhase(request.getPhase());
         service.setPrice(request.getPrice());
         service.setCost(request.getCost());
         return repository.save(service);

--- a/backend/ads-service/src/test/java/com/marketinghub/ai/AiServiceRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ai/AiServiceRepositoryTest.java
@@ -24,6 +24,7 @@ class AiServiceRepositoryTest {
                 .name("OpenAI GPT-4")
                 .objective("Geração de texto")
                 .url("https://example.com")
+                .phase("Planejamento")
                 .price(new BigDecimal("20.0"))
                 .cost(new BigDecimal("20.0"))
                 .build();

--- a/frontend/src/api/aiService/useAiServices.ts
+++ b/frontend/src/api/aiService/useAiServices.ts
@@ -6,6 +6,7 @@ export interface AiService {
   name: string;
   objective: string;
   url: string;
+  phase: string;
   price: number;
   cost: number;
 }

--- a/frontend/src/api/aiService/useCreateAiService.ts
+++ b/frontend/src/api/aiService/useCreateAiService.ts
@@ -6,6 +6,7 @@ export interface CreateAiService {
   name: string;
   objective: string;
   url: string;
+  phase: string;
   price: number;
   cost: number;
 }

--- a/frontend/src/pages/aiService/AiServiceListPage.tsx
+++ b/frontend/src/pages/aiService/AiServiceListPage.tsx
@@ -20,6 +20,7 @@ export default function AiServiceListPage() {
             <th>ID</th>
             <th>Nome</th>
             <th>URL</th>
+            <th>Fase</th>
             <th>Preço</th>
             <th>Custo</th>
             <th>Ações</th>
@@ -31,6 +32,7 @@ export default function AiServiceListPage() {
               <td>{s.id}</td>
               <td>{s.name}</td>
               <td>{s.url}</td>
+              <td>{s.phase}</td>
               <td>{s.price}</td>
               <td>{s.cost}</td>
               <td>

--- a/frontend/src/pages/aiService/EditAiServicePage.tsx
+++ b/frontend/src/pages/aiService/EditAiServicePage.tsx
@@ -16,6 +16,7 @@ export default function EditAiServicePage() {
     name: "",
     objective: "",
     url: "",
+    phase: "",
     price: 0,
     cost: 0,
   });
@@ -51,6 +52,12 @@ export default function EditAiServicePage() {
         className="form-control mb-2"
         value={form.url}
         onChange={(e) => setForm({ ...form, url: e.target.value })}
+      />
+      <label className="form-label">Fase</label>
+      <input
+        className="form-control mb-2"
+        value={form.phase}
+        onChange={(e) => setForm({ ...form, phase: e.target.value })}
       />
       <label className="form-label">Preço</label>
       <input

--- a/frontend/src/pages/aiService/NewAiServicePage.tsx
+++ b/frontend/src/pages/aiService/NewAiServicePage.tsx
@@ -8,6 +8,7 @@ export default function NewAiServicePage() {
     name: "",
     objective: "",
     url: "",
+    phase: "",
     price: "",
     cost: "",
   });
@@ -41,6 +42,12 @@ export default function NewAiServicePage() {
         placeholder="URL"
         value={form.url}
         onChange={(e) => setForm({ ...form, url: e.target.value })}
+      />
+      <input
+        className="form-control mb-2"
+        placeholder="Fase"
+        value={form.phase}
+        onChange={(e) => setForm({ ...form, phase: e.target.value })}
       />
       <input
         className="form-control mb-2"

--- a/schema.sql
+++ b/schema.sql
@@ -28,6 +28,7 @@ CREATE TABLE ai_service (
     name VARCHAR(255),
     objective LONGTEXT,
     url VARCHAR(255),
+    phase VARCHAR(255),
     price DECIMAL(10,2),
     cost DECIMAL(10,2),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- add new `phase` column to AI service entity and DTOs
- store and update `phase` in service layer
- extend repository test for `phase`
- expose `phase` in React API and pages
- document new field in README
- update database schema

## Testing
- `mvn -s ../settings.xml deploy` *(fails: Network is unreachable)*
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml package` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*
- `npm run build`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68782668a2888321ab60fde3d7f712bd