### PR TITLE
Add Teste de Nicho screens

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,9 @@ import EditNichePage from "./pages/niche/EditNichePage";
 import AiServiceListPage from "./pages/aiService/AiServiceListPage";
 import NewAiServicePage from "./pages/aiService/NewAiServicePage";
 import EditAiServicePage from "./pages/aiService/EditAiServicePage";
+import ExperimentListPage from "./pages/experiment/ExperimentListPage";
+import NewExperimentPage from "./pages/experiment/NewExperimentPage";
+import ExperimentDetailPage from "./pages/experiment/ExperimentDetailPage";
 
 export default function App() {
   return (
@@ -51,6 +54,9 @@ export default function App() {
             </Link>
             <Link className="nav-link" to="/niches">
               Nichos
+            </Link>
+            <Link className="nav-link" to="/experiments">
+              Testes de Nicho
             </Link>
             <Link className="nav-link" to="/ai-services">
               IA
@@ -85,6 +91,9 @@ export default function App() {
         <Route path="/niches" element={<NicheListPage />} />
         <Route path="/niches/new" element={<NewNichePage />} />
         <Route path="/niches/:id/edit" element={<EditNichePage />} />
+        <Route path="/experiments" element={<ExperimentListPage />} />
+        <Route path="/experiments/new" element={<NewExperimentPage />} />
+        <Route path="/experiments/:id" element={<ExperimentDetailPage />} />
         <Route path="/ai-services" element={<AiServiceListPage />} />
         <Route path="/ai-services/new" element={<NewAiServicePage />} />
         <Route path="/ai-services/:id/edit" element={<EditAiServicePage />} />

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Experiment } from "./useExperiments";
+
+export interface CreateExperiment {
+  hypothesis: string;
+  kpiGoal: number;
+  startDate: string;
+  endDate: string;
+}
+
+export function useCreateExperiment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreateExperiment) => {
+      const { data: experiment } = await axios.post<Experiment>(
+        "/api/experiments",
+        data,
+      );
+      return experiment;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["experiments"] });
+    },
+  });
+}

--- a/frontend/src/api/experiment/useExperiment.ts
+++ b/frontend/src/api/experiment/useExperiment.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { Experiment } from "./useExperiments";
+
+export function useExperiment(id: number) {
+  return useQuery({
+    queryKey: ["experiment", id],
+    queryFn: async () => {
+      const { data } = await axios.get<Experiment>(`/api/experiments/${id}`);
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface Experiment {
+  id: number;
+  hypothesis: string;
+  kpiGoal: number;
+  startDate: string;
+  endDate: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function useExperiments() {
+  return useQuery({
+    queryKey: ["experiments"],
+    queryFn: async () => {
+      const { data } = await axios.get<Experiment[]>("/api/experiments");
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1,0 +1,47 @@
+import { Fragment } from "react";
+import { useParams } from "react-router-dom";
+import { useExperiment } from "../../api/experiment/useExperiment";
+import PageTitle from "../../components/PageTitle";
+
+export default function ExperimentDetailPage() {
+  const { id } = useParams();
+  const expId = Number(id);
+  const { data, isLoading } = useExperiment(expId);
+
+  if (isLoading) return <p>Carregando...</p>;
+  if (!data) return <p>Não encontrado</p>;
+
+  const rows = [
+    { label: "Hipótese", value: data.hypothesis },
+    { label: "KPI", value: data.kpiGoal },
+    { label: "Início", value: data.startDate },
+    { label: "Término", value: data.endDate },
+    { label: "Status", value: data.status },
+  ];
+
+  return (
+    <div>
+      <PageTitle>Teste {data.id}</PageTitle>
+      <div className="card">
+        <div className="card-body p-0">
+          <dl className="row mb-0">
+            {rows.map((r, idx) => (
+              <Fragment key={r.label}>
+                <dt
+                  className={`col-sm-3 py-2${idx % 2 === 0 ? " bg-light" : ""}`}
+                >
+                  {r.label}
+                </dt>
+                <dd
+                  className={`col-sm-9 py-2${idx % 2 === 0 ? " bg-light" : ""}`}
+                >
+                  {r.value}
+                </dd>
+              </Fragment>
+            ))}
+          </dl>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/experiment/ExperimentListPage.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import ExperimentListPage from "./ExperimentListPage";
+import axios from "axios";
+
+vi.mock("axios");
+
+describe("ExperimentListPage", () => {
+  it("renders table", async () => {
+    (axios.get as any).mockResolvedValue({ data: [] });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <BrowserRouter>
+          <ExperimentListPage />
+        </BrowserRouter>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByText(/Novo Teste/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/experiment/ExperimentListPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.tsx
@@ -1,0 +1,46 @@
+import { Link } from "react-router-dom";
+import { useExperiments } from "../../api/experiment/useExperiments";
+import PageTitle from "../../components/PageTitle";
+
+export default function ExperimentListPage() {
+  const { data, isLoading } = useExperiments();
+  const experiments = Array.isArray(data) ? data : [];
+  if (isLoading) return <p>Carregando...</p>;
+  return (
+    <div>
+      <PageTitle>Testes de Nicho</PageTitle>
+      <Link className="btn btn-primary mb-3" to="/experiments/new">
+        Novo Teste
+      </Link>
+      <div className="table-responsive">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Hipótese</th>
+              <th>Status</th>
+              <th>Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {experiments.map((e) => (
+              <tr key={e.id}>
+                <td>{e.id}</td>
+                <td>{e.hypothesis}</td>
+                <td>{e.status}</td>
+                <td>
+                  <Link
+                    className="btn btn-sm btn-outline-primary"
+                    to={`/experiments/${e.id}`}
+                  >
+                    Visualizar
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { useCreateExperiment } from "../../api/experiment/useCreateExperiment";
+import PageTitle from "../../components/PageTitle";
+
+export default function NewExperimentPage() {
+  const create = useCreateExperiment();
+  const [form, setForm] = useState({
+    hypothesis: "",
+    kpiGoal: "",
+    startDate: "",
+    endDate: "",
+  });
+
+  const submit = async () => {
+    try {
+      await create.mutateAsync({
+        hypothesis: form.hypothesis,
+        kpiGoal: Number(form.kpiGoal),
+        startDate: form.startDate,
+        endDate: form.endDate,
+      });
+      setForm({ hypothesis: "", kpiGoal: "", startDate: "", endDate: "" });
+      alert("Teste salvo!");
+    } catch {
+      alert("Erro ao salvar Teste");
+    }
+  };
+
+  return (
+    <div>
+      <PageTitle>Novo Teste de Nicho</PageTitle>
+      <input
+        className="form-control mb-2"
+        placeholder="Hipótese"
+        value={form.hypothesis}
+        onChange={(e) => setForm({ ...form, hypothesis: e.target.value })}
+      />
+      <input
+        className="form-control mb-2"
+        placeholder="Meta do KPI"
+        type="number"
+        value={form.kpiGoal}
+        onChange={(e) => setForm({ ...form, kpiGoal: e.target.value })}
+      />
+      <input
+        className="form-control mb-2"
+        placeholder="Data de Início"
+        type="date"
+        value={form.startDate}
+        onChange={(e) => setForm({ ...form, startDate: e.target.value })}
+      />
+      <input
+        className="form-control mb-2"
+        placeholder="Data de Término"
+        type="date"
+        value={form.endDate}
+        onChange={(e) => setForm({ ...form, endDate: e.target.value })}
+      />
+      <button className="btn btn-primary" onClick={submit}>
+        Salvar
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement experiment APIs on the frontend
- add pages to create, list and view experiments
- hook up routes and navigation to Testes de Nicho
- test new experiment list page

## Testing
- `npm run test`
- `npm run build`
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact)*
- `mvn -s settings.xml test` *(fails: Could not transfer artifact)*
- `mvn -s ../settings.xml deploy` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68794c488b9083219158ada46935eac0