### PR TITLE
Add Facebook Ads Client project

### DIFF
--- a/facebook-ads-client/README.md
+++ b/facebook-ads-client/README.md
@@ -1,0 +1,18 @@
+# Facebook Ads Client
+
+Este projeto se comunica com a API do Facebook Ads. Ele utiliza Spring Boot e pode ser executado como um serviço independente ou incluído em outros módulos.
+
+## Pré-requisitos
+- Java 21
+- Maven configurado com as variáveis `GITHUB_ACTOR` e `GITHUB_TOKEN` se precisar publicar artefatos.
+
+## Como compilar
+```bash
+mvn -s settings.xml test
+```
+
+## Execução
+```bash
+mvn spring-boot:run
+```
+Configure as propriedades `facebook.token` e `facebook.version` para acessar a API oficial.

--- a/facebook-ads-client/pom.xml
+++ b/facebook-ads-client/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.marketinghub</groupId>
+    <artifactId>facebook-ads-client</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>facebook-ads-client</name>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <finalName>app</finalName>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/facebook-ads-client/settings.xml
+++ b/facebook-ads-client/settings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <!-- 1️⃣  Redireciona TODAS as requisições a este host -->
+  <mirrors>
+    <mirror>
+      <id>central-repo1</id>
+      <name>Maven Central via Fastly (repo1.maven.org)</name>
+      <url>https://repo1.maven.org/maven2/</url>
+      <!-- só o repositório "central" é redirecionado -->
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+
+  <!-- 2️⃣  Autenticação para publicar e baixar do GitHub Packages -->
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+
+  <!-- 3️⃣  Perfil default apenas para manter coerência -->
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+    </profile>
+  </profiles>
+</settings>

--- a/facebook-ads-client/src/main/java/com/marketinghub/facebookads/DefaultFacebookAdsClient.java
+++ b/facebook-ads-client/src/main/java/com/marketinghub/facebookads/DefaultFacebookAdsClient.java
@@ -1,0 +1,65 @@
+package com.marketinghub.facebookads;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implementação padrão utilizando {@link java.net.http.HttpClient}.
+ */
+@Component
+public class DefaultFacebookAdsClient implements FacebookAdsClient {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultFacebookAdsClient.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final HttpClient httpClient;
+    private final String token;
+    private final String apiVersion;
+    private final String baseUrl;
+
+    public DefaultFacebookAdsClient(
+            @Value("${facebook.token:}") String token,
+            @Value("${facebook.version:v19.0}") String apiVersion,
+            @Value("${facebook.url:https://graph.facebook.com}") String baseUrl) {
+        this.token = token;
+        this.apiVersion = apiVersion;
+        this.baseUrl = baseUrl;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+    }
+
+    @Override
+    public JsonNode getAdAccounts() {
+        if (token == null || token.isBlank()) {
+            log.warn("Facebook token not configured, returning empty result");
+            return MAPPER.createObjectNode();
+        }
+        try {
+            String endpoint = baseUrl + "/" + apiVersion + "/me/adaccounts?access_token=" +
+                    URLEncoder.encode(token, StandardCharsets.UTF_8);
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .timeout(Duration.ofSeconds(30))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            log.debug("Facebook response: {}", response.body());
+            return MAPPER.readTree(response.body());
+        } catch (Exception e) {
+            log.error("Failed to call Facebook API", e);
+            return MAPPER.createObjectNode();
+        }
+    }
+}

--- a/facebook-ads-client/src/main/java/com/marketinghub/facebookads/DummyFacebookAdsClient.java
+++ b/facebook-ads-client/src/main/java/com/marketinghub/facebookads/DummyFacebookAdsClient.java
@@ -1,0 +1,32 @@
+package com.marketinghub.facebookads;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implementação que devolve dados estáticos para testes.
+ */
+@Component
+@Profile("dummy")
+public class DummyFacebookAdsClient implements FacebookAdsClient {
+    private static final Logger log = LoggerFactory.getLogger(DummyFacebookAdsClient.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public JsonNode getAdAccounts() {
+        log.debug("Returning dummy Facebook accounts");
+        ObjectNode root = MAPPER.createObjectNode();
+        ArrayNode data = root.putArray("data");
+        ObjectNode acc = MAPPER.createObjectNode();
+        acc.put("id", "123");
+        acc.put("name", "Dummy Account");
+        data.add(acc);
+        return root;
+    }
+}

--- a/facebook-ads-client/src/main/java/com/marketinghub/facebookads/FacebookAdsClient.java
+++ b/facebook-ads-client/src/main/java/com/marketinghub/facebookads/FacebookAdsClient.java
@@ -1,0 +1,13 @@
+package com.marketinghub.facebookads;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Cliente simplificado para a API do Facebook Ads.
+ */
+public interface FacebookAdsClient {
+    /**
+     * Lista as contas de anúncio associadas ao usuário.
+     */
+    JsonNode getAdAccounts();
+}

--- a/facebook-ads-client/src/main/java/com/marketinghub/facebookads/FacebookAdsClientApplication.java
+++ b/facebook-ads-client/src/main/java/com/marketinghub/facebookads/FacebookAdsClientApplication.java
@@ -1,0 +1,29 @@
+package com.marketinghub.facebookads;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FacebookAdsClientApplication implements CommandLineRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(FacebookAdsClientApplication.class);
+    private final FacebookAdsClient client;
+
+    public FacebookAdsClientApplication(FacebookAdsClient client) {
+        this.client = client;
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(FacebookAdsClientApplication.class, args);
+    }
+
+    @Override
+    public void run(String... args) {
+        JsonNode accounts = client.getAdAccounts();
+        log.info("Fetched accounts: {}", accounts);
+    }
+}

--- a/facebook-ads-client/src/main/resources/application.properties
+++ b/facebook-ads-client/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+facebook.token=
+facebook.version=v19.0

--- a/facebook-ads-client/src/test/java/com/marketinghub/facebookads/FacebookAdsClientTest.java
+++ b/facebook-ads-client/src/test/java/com/marketinghub/facebookads/FacebookAdsClientTest.java
@@ -1,0 +1,25 @@
+package com.marketinghub.facebookads;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+
+class FacebookAdsClientTest {
+
+    @Test
+    void getAdAccountsReturnsJson() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody("{\"data\":[{\"id\":\"1\",\"name\":\"Test\"}]}"));
+        server.start();
+
+        String baseUrl = server.url("/").toString();
+        DefaultFacebookAdsClient client = new DefaultFacebookAdsClient("TOKEN", "v19.0", baseUrl);
+        JsonNode json = client.getAdAccounts();
+
+        assertThat(json.path("data").get(0).path("id").asText()).isEqualTo("1");
+        server.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary
- create new `facebook-ads-client` project
- provide a simple HTTP client for Facebook Ads API
- allow dummy implementation via Spring profile
- include basic README and Maven settings
- add unit test for the client

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM due to network)*
- `mvn -s settings.xml package` *(fails: Non-resolvable parent POM due to network)*
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM due to network)*
- `mvn -s ../settings.xml deploy` *(fails: Non-resolvable parent POM due to network)*
- `npm run test` *(fails: npm not found)*
- `npm run build` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_687922b420a08321ac9edc5cff08e2ba