### PR TITLE
Fix DataSeeder experiment build

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/DataSeeder.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/DataSeeder.java
@@ -32,7 +32,7 @@ public class DataSeeder {
             if (expRepo.count() == 0) {
                 expRepo.save(Experiment.builder()
                         .hypothesis("Default hypothesis")
-                        .kpiGoal(java.math.BigDecimal.valueOf(10))
+                        .kpiTarget(java.math.BigDecimal.valueOf(10))
                         .status(ExperimentStatus.PLANNED)
                         .build());
             }


### PR DESCRIPTION
## Summary
- use `kpiTarget` instead of nonexistent `kpiGoal` when seeding default Experiment

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_687974ffa8f48321a6c1b2c7ba875780