### PR TITLE
Fix tests and data seeding

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/DataSeeder.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/DataSeeder.java
@@ -10,14 +10,19 @@ import com.marketinghub.ads.FacebookAccount;
 import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.experiment.ExperimentPlatform;
 import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
 
-@Configuration
+@Configuration("adsDataSeeder")
 public class DataSeeder {
 
     @Bean
-    CommandLineRunner seed(FacebookAccountRepository fbRepo, InstagramAccountRepository igRepo,
-                          ExperimentRepository expRepo) {
+    CommandLineRunner seed(FacebookAccountRepository fbRepo,
+                          InstagramAccountRepository igRepo,
+                          ExperimentRepository expRepo,
+                          MarketNicheRepository nicheRepo) {
         return args -> {
             if (fbRepo.count() == 0) {
                 fbRepo.save(new FacebookAccount(1L, "Account A", "USD"));
@@ -30,10 +35,15 @@ public class DataSeeder {
                 igRepo.save(new InstagramAccount(3L, "Insta C", "GBP", "https://example.com/c.png"));
             }
             if (expRepo.count() == 0) {
+                MarketNiche niche = nicheRepo.findAll().stream().findFirst()
+                        .orElseGet(() -> nicheRepo.save(MarketNiche.builder().name("Default Niche").build()));
                 expRepo.save(Experiment.builder()
+                        .niche(niche)
+                        .name("Default Experiment")
                         .hypothesis("Default hypothesis")
                         .kpiTarget(java.math.BigDecimal.valueOf(10))
                         .status(ExperimentStatus.PLANNED)
+                        .platform(ExperimentPlatform.FACEBOOK)
                         .build());
             }
         };

--- a/backend/ads-service/src/main/java/com/marketinghub/config/DataSeeder.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/config/DataSeeder.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import java.math.BigDecimal;
 import java.util.Arrays;
 
-@Configuration
+@Configuration("nicheDataSeeder")
 public class DataSeeder {
     @Bean
     CommandLineRunner seedData(MarketNicheRepository nicheRepo, ExperimentRepository expRepo) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
@@ -17,10 +17,12 @@ import java.math.BigDecimal;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
         "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create"
 })
 class ExperimentControllerTest {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -14,9 +14,11 @@ import java.math.BigDecimal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
+@SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
 @TestPropertySource(properties = {
         "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create"
 })
 class ExperimentServiceTest {
@@ -45,6 +47,6 @@ class ExperimentServiceTest {
         req.setStartDate(java.time.LocalDate.of(2024,2,1));
         req.setEndDate(java.time.LocalDate.of(2024,1,1));
         assertThatThrownBy(() -> service.create(niche.getId(), req))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -48,12 +48,13 @@ class ExperimentControllerTest {
     @Test
     void createEndpointPersists() throws Exception {
         CreateExperimentRequest req = new CreateExperimentRequest();
+        req.setName("Exp1");
         req.setHypothesis("H1");
         req.setKpiTarget(BigDecimal.TEN);
         req.setStartDate(LocalDate.now());
         req.setEndDate(LocalDate.now().plusDays(5));
 
-        mockMvc.perform(post("/api/experiments")
+        mockMvc.perform(post("/api/niches/1/experiments")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(req)))
                 .andExpect(status().isOk());


### PR DESCRIPTION
## Summary
- avoid bean name collision and seed default niche
- specify AdsServiceApplication for experiment tests
- update create endpoint test and expectation

## Testing
- `mvn -s ../settings.xml test` in `backend/ads-service`
- `mvn -s settings.xml test` in `success-product-worker` *(failed: Could not transfer artifact)*
- `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6879792df94483219f871bdd3a2ee0f3