### PR TITLE
Fix experiment table UUID mismatch

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 public class Experiment {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "BINARY(16)")
     private java.util.UUID id;
 
     @ManyToOne(optional = false)

--- a/schema.sql
+++ b/schema.sql
@@ -106,19 +106,22 @@ CREATE TABLE market_niche (
 );
 
 CREATE TABLE experiment (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    hypothesis VARCHAR(500),
-    kpi_goal DECIMAL(10,2),
+    id BINARY(16) PRIMARY KEY,
+    niche_id BIGINT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    hypothesis VARCHAR(255),
+    kpi_target DECIMAL(10,2),
     start_date DATE,
     end_date DATE,
     status VARCHAR(20),
+    platform VARCHAR(50),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE creative_variant (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    experiment_id BIGINT,
+    experiment_id BINARY(16),
     type VARCHAR(20),
     asset_url VARCHAR(500),
     titles LONGTEXT,
@@ -129,7 +132,7 @@ CREATE TABLE creative_variant (
 
 CREATE TABLE ad_set (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    experiment_id BIGINT,
+    experiment_id BINARY(16),
     location VARCHAR(255),
     interests LONGTEXT,
     lookalikes LONGTEXT,


### PR DESCRIPTION
## Summary
- map `Experiment.id` to `BINARY(16)` so Hibernate stores UUIDs correctly
- update `schema.sql` for `experiment` and referencing tables

## Testing
- `npm run test --silent`
- `mvn -s ../settings.xml test -q` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68798f674eec83218b6043fc64b45cd7