### PR TITLE
Implement creative management

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,6 @@ WantedBy=multi-user.target
 \nSwagger UI disponível em /swagger-ui.html quando o backend estiver rodando.
 
 \n## Niches e Experiments\nCada Experiment pertence a um Market Niche. Use as rotas /api/niches/{nicheId}/experiments para criar e listar por nicho.
+
+## Criativos
+Os criativos representam variações de anúncios vinculados a um experimento. Utilize a rota `/api/experiments/{id}/creatives` para cadastrar e listar. A visualização de um criativo usa `/api/creatives/{id}/preview` que consulta a Marketing API do Facebook.

--- a/backend/ads-service/src/main/java/com/marketinghub/WebConfig.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/WebConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 
 @Configuration
 public class WebConfig {
@@ -15,6 +16,12 @@ public class WebConfig {
                 registry.addMapping("/**")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedOrigins("*");
+            }
+
+            @Override
+            public void addResourceHandlers(ResourceHandlerRegistry registry) {
+                registry.addResourceHandler("/uploads/**")
+                        .addResourceLocations("file:uploads/");
             }
         };
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
@@ -1,0 +1,35 @@
+package com.marketinghub.creative;
+
+import com.marketinghub.experiment.Experiment;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Creative linked to an experiment.
+ */
+@Entity
+@Table(name = "creative_variants")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Creative {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "experiment_id")
+    private Experiment experiment;
+
+    private String headline;
+
+    @Column(name = "primary_text")
+    private String primaryText;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    private CreativeStatus status;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/CreativeStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/CreativeStatus.java
@@ -1,0 +1,9 @@
+package com.marketinghub.creative;
+
+/**
+ * Status for creatives.
+ */
+public enum CreativeStatus {
+    DRAFT,
+    READY
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/dto/CreateCreativeRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/dto/CreateCreativeRequest.java
@@ -1,0 +1,15 @@
+package com.marketinghub.creative.dto;
+
+import com.marketinghub.creative.CreativeStatus;
+import lombok.Data;
+
+/**
+ * Request body to create or update a creative.
+ */
+@Data
+public class CreateCreativeRequest {
+    private String headline;
+    private String primaryText;
+    private String imageUrl;
+    private CreativeStatus status;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/dto/CreativeDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/dto/CreativeDto.java
@@ -1,0 +1,17 @@
+package com.marketinghub.creative.dto;
+
+import com.marketinghub.creative.CreativeStatus;
+import lombok.Data;
+
+/**
+ * Data transfer object for Creative.
+ */
+@Data
+public class CreativeDto {
+    private Long id;
+    private Long experimentId;
+    private String headline;
+    private String primaryText;
+    private String imageUrl;
+    private CreativeStatus status;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/mapper/CreativeMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/mapper/CreativeMapper.java
@@ -1,0 +1,15 @@
+package com.marketinghub.creative.mapper;
+
+import com.marketinghub.creative.Creative;
+import com.marketinghub.creative.dto.CreativeDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * MapStruct mapper for Creative.
+ */
+@Mapper(componentModel = "spring")
+public interface CreativeMapper {
+    @Mapping(target = "experimentId", source = "experiment.id")
+    CreativeDto toDto(Creative creative);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/repository/CreativeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/repository/CreativeRepository.java
@@ -1,0 +1,13 @@
+package com.marketinghub.creative.repository;
+
+import com.marketinghub.creative.Creative;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Repository for creatives.
+ */
+public interface CreativeRepository extends JpaRepository<Creative, Long> {
+    List<Creative> findByExperimentId(Long experimentId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
@@ -1,0 +1,121 @@
+package com.marketinghub.creative.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.creative.*;
+import com.marketinghub.creative.dto.CreateCreativeRequest;
+import com.marketinghub.creative.repository.CreativeRepository;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+/**
+ * Service layer for creatives.
+ */
+@Service
+public class CreativeService {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final CreativeRepository repository;
+    private final ExperimentRepository experimentRepository;
+    private final HttpClient httpClient;
+
+    public CreativeService(CreativeRepository repository,
+                           ExperimentRepository experimentRepository) {
+        this(repository, experimentRepository, HttpClient.newHttpClient());
+    }
+
+    // visible for tests
+    CreativeService(CreativeRepository repository,
+                    ExperimentRepository experimentRepository,
+                    HttpClient httpClient) {
+        this.repository = repository;
+        this.experimentRepository = experimentRepository;
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Creates and stores a creative.
+     */
+    @Transactional
+    public Creative create(Long experimentId, CreateCreativeRequest request) {
+        Experiment exp = experimentRepository.findById(experimentId).orElseThrow();
+        Creative creative = Creative.builder()
+                .experiment(exp)
+                .headline(request.getHeadline())
+                .primaryText(request.getPrimaryText())
+                .imageUrl(request.getImageUrl())
+                .status(request.getStatus())
+                .build();
+        return repository.save(creative);
+    }
+
+    /**
+     * Updates an existing creative.
+     */
+    @Transactional
+    public Creative update(Long id, CreateCreativeRequest request) {
+        Creative creative = repository.findById(id).orElseThrow();
+        creative.setHeadline(request.getHeadline());
+        creative.setPrimaryText(request.getPrimaryText());
+        creative.setImageUrl(request.getImageUrl());
+        creative.setStatus(request.getStatus());
+        return creative;
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    public Iterable<Creative> listByExperiment(Long experimentId) {
+        return repository.findByExperimentId(experimentId);
+    }
+
+    /**
+     * Saves the uploaded image and returns a public URL.
+     */
+    public String uploadImage(MultipartFile file) throws IOException {
+        Path dir = Path.of("uploads");
+        Files.createDirectories(dir);
+        Path path = Files.createTempFile(dir, "img", file.getOriginalFilename());
+        file.transferTo(path);
+        return "/uploads/" + path.getFileName();
+    }
+
+    /**
+     * Fetches the preview HTML from Facebook Marketing API.
+     */
+    public String preview(Long creativeId) throws IOException, InterruptedException {
+        String token = System.getenv("FB_ACCESS_TOKEN");
+        if (token == null || token.isBlank()) {
+            return "";
+        }
+        String url = "https://graph.facebook.com/v19.0/adcreatives/" + creativeId
+                + "/previews?access_token=" + URLEncoder.encode(token, StandardCharsets.UTF_8);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(30))
+                .GET()
+                .build();
+        HttpResponse<String> resp = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        JsonNode node = MAPPER.readTree(resp.body());
+        if (node.has("data") && node.get("data").isArray() && node.get("data").size() > 0) {
+            return node.get("data").get(0).get("body").asText();
+        }
+        return "";
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/web/CreativeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/web/CreativeController.java
@@ -1,0 +1,58 @@
+package com.marketinghub.creative.web;
+
+import com.marketinghub.creative.dto.CreateCreativeRequest;
+import com.marketinghub.creative.dto.CreativeDto;
+import com.marketinghub.creative.mapper.CreativeMapper;
+import com.marketinghub.creative.service.CreativeService;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+/**
+ * REST controller for creatives.
+ */
+@RestController
+public class CreativeController {
+    private final CreativeService service;
+    private final CreativeMapper mapper;
+
+    public CreativeController(CreativeService service, CreativeMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @PostMapping("/api/experiments/{id}/creatives")
+    public CreativeDto create(@PathVariable Long id, @RequestBody CreateCreativeRequest request) {
+        return mapper.toDto(service.create(id, request));
+    }
+
+    @GetMapping("/api/experiments/{id}/creatives")
+    public List<CreativeDto> list(@PathVariable Long id) {
+        return StreamSupport.stream(service.listByExperiment(id).spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+
+    @PutMapping("/api/creatives/{id}")
+    public CreativeDto update(@PathVariable Long id, @RequestBody CreateCreativeRequest request) {
+        return mapper.toDto(service.update(id, request));
+    }
+
+    @DeleteMapping("/api/creatives/{id}")
+    public void delete(@PathVariable Long id) {
+        service.delete(id);
+    }
+
+    @PostMapping("/api/assets")
+    public String upload(@RequestParam("file") MultipartFile file) throws IOException {
+        return service.uploadImage(file);
+    }
+
+    @GetMapping("/api/creatives/{id}/preview")
+    public String preview(@PathVariable Long id) throws Exception {
+        return service.preview(id);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/CreativeServiceTest.java
@@ -1,0 +1,66 @@
+package com.marketinghub.creative;
+
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.creative.repository.CreativeRepository;
+import com.marketinghub.creative.service.CreativeService;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create"
+})
+class CreativeServiceTest {
+
+    @Autowired
+    CreativeRepository repository;
+    @Autowired
+    ExperimentRepository experimentRepository;
+
+    CreativeService service;
+
+    @BeforeEach
+    void setup() {
+        HttpClient client = Mockito.mock(HttpClient.class);
+        service = new CreativeService(repository, experimentRepository, client);
+    }
+
+    @Test
+    void uploadImageReturnsPath() throws Exception {
+        MultipartFile file = new org.springframework.mock.web.MockMultipartFile(
+                "file", "test.png", "image/png", new byte[]{1,2});
+        String url = service.uploadImage(file);
+        assertThat(url).contains("/uploads/");
+    }
+
+    @Test
+    void previewParsesHtml() throws Exception {
+        Experiment exp = experimentRepository.save(Experiment.builder().name("E").build());
+        repository.save(Creative.builder().experiment(exp).headline("h").primaryText("p").imageUrl("i").status(CreativeStatus.DRAFT).build());
+
+        HttpClient client = Mockito.mock(HttpClient.class);
+        HttpResponse<String> resp = Mockito.mock(HttpResponse.class);
+        when(resp.body()).thenReturn("{\"data\":[{\"body\":\"<div>ok</div>\"}]}");
+        when(client.send(any(), any())).thenReturn(resp);
+        service = new CreativeService(repository, experimentRepository, client);
+        String html = service.preview(1L);
+        assertThat(html).contains("ok");
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
@@ -1,0 +1,68 @@
+package com.marketinghub.creative.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.creative.CreativeStatus;
+import com.marketinghub.creative.dto.CreateCreativeRequest;
+import com.marketinghub.creative.repository.CreativeRepository;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for CreativeController.
+ */
+@SpringBootTest(classes = AdsServiceApplication.class)
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create"
+})
+class CreativeControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper mapper;
+    @Autowired
+    CreativeRepository repository;
+    @Autowired
+    ExperimentRepository experimentRepository;
+
+    Long expId;
+
+    @BeforeEach
+    void setup() {
+        repository.deleteAll();
+        experimentRepository.deleteAll();
+        Experiment exp = experimentRepository.save(Experiment.builder().name("E").build());
+        expId = exp.getId();
+    }
+
+    @Test
+    void createEndpointPersists() throws Exception {
+        CreateCreativeRequest req = new CreateCreativeRequest();
+        req.setHeadline("H");
+        req.setPrimaryText("P");
+        req.setImageUrl("img");
+        req.setStatus(CreativeStatus.DRAFT);
+        mockMvc.perform(post("/api/experiments/" + expId + "/creatives")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+        assertThat(repository.count()).isEqualTo(1);
+    }
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -58,3 +58,56 @@ components:
         endDate:
           type: string
           format: date
+  /api/experiments/{id}/creatives:
+    post:
+      summary: Criar criativo
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCreativeRequest'
+    get:
+      summary: Listar criativos do experimento
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+  /api/creatives/{id}/preview:
+    get:
+      summary: Preview do criativo
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    CreateCreativeRequest:
+      type: object
+      properties:
+        headline:
+          type: string
+        primaryText:
+          type: string
+        imageUrl:
+          type: string
+        status:
+          type: string
+          enum: [DRAFT, READY]
+

--- a/frontend/src/api/creative/useCreateCreative.ts
+++ b/frontend/src/api/creative/useCreateCreative.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Creative } from "./useCreatives";
+
+export interface CreateCreative {
+  headline: string;
+  primaryText: string;
+  imageUrl: string;
+  status: string;
+}
+
+export function useCreateCreative(expId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreateCreative) => {
+      const { data: creative } = await axios.post<Creative>(
+        `/api/experiments/${expId}/creatives`,
+        data,
+      );
+      return creative;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["creatives", expId] });
+    },
+  });
+}

--- a/frontend/src/api/creative/useCreatives.ts
+++ b/frontend/src/api/creative/useCreatives.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface Creative {
+  id: number;
+  experimentId: number;
+  headline: string;
+  primaryText: string;
+  imageUrl: string;
+  status: string;
+}
+
+export function useCreatives(expId: string) {
+  return useQuery({
+    queryKey: ["creatives", expId],
+    queryFn: async () => {
+      const { data } = await axios.get<Creative[]>(
+        `/api/experiments/${expId}/creatives`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/creative/useDeleteCreative.ts
+++ b/frontend/src/api/creative/useDeleteCreative.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+
+export function useDeleteCreative(id: number, expId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      await axios.delete(`/api/creatives/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["creatives", expId] });
+    },
+  });
+}

--- a/frontend/src/api/creative/usePreviewCreative.ts
+++ b/frontend/src/api/creative/usePreviewCreative.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export function usePreviewCreative(id: number, enabled: boolean) {
+  return useQuery({
+    queryKey: ["creative-preview", id],
+    enabled,
+    queryFn: async () => {
+      const { data } = await axios.get<string>(`/api/creatives/${id}/preview`);
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/creative/useUpdateCreative.ts
+++ b/frontend/src/api/creative/useUpdateCreative.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Creative } from "./useCreatives";
+
+export interface UpdateCreative {
+  headline: string;
+  primaryText: string;
+  imageUrl: string;
+  status: string;
+}
+
+export function useUpdateCreative(id: number, expId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: UpdateCreative) => {
+      const { data: creative } = await axios.put<Creative>(
+        `/api/creatives/${id}`,
+        data,
+      );
+      return creative;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["creatives", expId] });
+    },
+  });
+}

--- a/frontend/src/pages/Experiment/CriativosTab.test.tsx
+++ b/frontend/src/pages/Experiment/CriativosTab.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi } from "vitest";
+import CriativosTab from "./CriativosTab";
+import axios from "axios";
+
+vi.mock("axios");
+
+describe("CriativosTab", () => {
+  it("opens modal", async () => {
+    (axios.get as any).mockResolvedValue({ data: [] });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <CriativosTab experimentId="1" />
+      </QueryClientProvider>,
+    );
+    screen.getByText("Novo Criativo").click();
+    expect(await screen.findByText(/Criativo/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/Experiment/CriativosTab.tsx
+++ b/frontend/src/pages/Experiment/CriativosTab.tsx
@@ -1,0 +1,216 @@
+import { useState } from "react";
+import { Creative, useCreatives } from "../../api/creative/useCreatives";
+import { useCreateCreative } from "../../api/creative/useCreateCreative";
+import { useUpdateCreative } from "../../api/creative/useUpdateCreative";
+import { useDeleteCreative } from "../../api/creative/useDeleteCreative";
+import { usePreviewCreative } from "../../api/creative/usePreviewCreative";
+
+interface Props {
+  experimentId: string;
+}
+
+export default function CriativosTab({ experimentId }: Props) {
+  const { data } = useCreatives(experimentId);
+  const creatives = Array.isArray(data) ? data : [];
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState<Creative | null>(null);
+  const [form, setForm] = useState({
+    headline: "",
+    primaryText: "",
+    imageUrl: "",
+    status: "DRAFT",
+  });
+  const create = useCreateCreative(experimentId);
+  const update = editing ? useUpdateCreative(editing.id, experimentId) : null;
+  const del = useDeleteCreative(0, experimentId); // id changed dynamically
+  const { data: previewHtml, refetch } = usePreviewCreative(
+    editing?.id ?? 0,
+    false,
+  );
+  const [showPreview, setShowPreview] = useState(false);
+
+  const openNew = () => {
+    setEditing(null);
+    setForm({ headline: "", primaryText: "", imageUrl: "", status: "DRAFT" });
+    setShowForm(true);
+  };
+
+  const submit = async () => {
+    if (editing) {
+      await update?.mutateAsync(form);
+    } else {
+      await create.mutateAsync(form);
+    }
+    setShowForm(false);
+  };
+
+  const startPreview = async (c: Creative) => {
+    setEditing(c);
+    setShowPreview(true);
+    await refetch();
+  };
+
+  const remove = async (c: Creative) => {
+    if (!confirm("Excluir criativo?")) return;
+    await useDeleteCreative(c.id, experimentId).mutateAsync();
+  };
+
+  const upload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const img = new Image();
+    img.onload = async () => {
+      if (img.width < 600) {
+        alert("Largura mínima 600px");
+        return;
+      }
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/api/assets", { method: "POST", body: fd });
+      const url = await res.text();
+      setForm({ ...form, imageUrl: url });
+    };
+    img.src = URL.createObjectURL(file);
+  };
+
+  return (
+    <div className="mt-3">
+      <button className="btn btn-primary mb-2" onClick={openNew}>
+        Novo Criativo
+      </button>
+      <div className="table-responsive">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Imagem</th>
+              <th>Headline</th>
+              <th>Primary Text</th>
+              <th>Status</th>
+              <th>Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {creatives.map((c) => (
+              <tr key={c.id}>
+                <td>
+                  <img src={c.imageUrl} style={{ width: 80 }} />
+                </td>
+                <td>{c.headline}</td>
+                <td>{c.primaryText.slice(0, 60)}</td>
+                <td>
+                  <span
+                    className={
+                      c.status === "READY" ? "badge bg-success" : "badge bg-secondary"
+                    }
+                  >
+                    {c.status}
+                  </span>
+                </td>
+                <td>
+                  <button
+                    className="btn btn-sm btn-outline-primary me-1"
+                    onClick={() => {
+                      setEditing(c);
+                      setForm({
+                        headline: c.headline,
+                        primaryText: c.primaryText,
+                        imageUrl: c.imageUrl,
+                        status: c.status,
+                      });
+                      setShowForm(true);
+                    }}
+                  >
+                    🖊
+                  </button>
+                  <button
+                    className="btn btn-sm btn-outline-danger me-1"
+                    onClick={() => remove(c)}
+                  >
+                    🗑
+                  </button>
+                  <button
+                    className="btn btn-sm btn-outline-secondary"
+                    onClick={() => startPreview(c)}
+                  >
+                    👁
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {showForm && (
+        <div className="modal d-block" tabIndex={-1}>
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">{editing ? "Editar" : "Novo"} Criativo</h5>
+                <button className="btn-close" onClick={() => setShowForm(false)} />
+              </div>
+              <div className="modal-body">
+                <input type="file" className="form-control mb-2" onChange={upload} />
+                <input
+                  className="form-control mb-2"
+                  placeholder="Headline"
+                  maxLength={40}
+                  value={form.headline}
+                  title="máx. 40 caracteres"
+                  onChange={(e) => setForm({ ...form, headline: e.target.value })}
+                />
+                <textarea
+                  className="form-control mb-2"
+                  placeholder="Primary Text"
+                  maxLength={125}
+                  value={form.primaryText}
+                  title="máx. 125 caracteres"
+                  onChange={(e) => setForm({ ...form, primaryText: e.target.value })}
+                />
+                <select
+                  className="form-select"
+                  value={form.status}
+                  onChange={(e) => setForm({ ...form, status: e.target.value })}
+                >
+                  <option value="DRAFT">DRAFT</option>
+                  <option value="READY">READY</option>
+                </select>
+              </div>
+              <div className="modal-footer">
+                <button
+                  className="btn btn-secondary"
+                  onClick={() => setShowForm(false)}
+                >
+                  Cancelar
+                </button>
+                <button className="btn btn-primary" onClick={submit}>
+                  Salvar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showPreview && (
+        <div className="modal d-block" tabIndex={-1}>
+          <div className="modal-dialog modal-xl">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Preview</h5>
+                <button className="btn-close" onClick={() => setShowPreview(false)} />
+              </div>
+              <div className="modal-body">
+                <iframe
+                  title="preview"
+                  style={{ width: "100%", height: "80vh" }}
+                  srcDoc={previewHtml || ""}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1,8 +1,9 @@
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useExperiment } from "../../api/experiment/useExperiment";
 import { useNiche } from "../../api/niche/useNiche";
 import PageTitle from "../../components/PageTitle";
+import CriativosTab from "../Experiment/CriativosTab";
 
 export default function ExperimentDetailPage() {
   const { id } = useParams();
@@ -22,6 +23,8 @@ export default function ExperimentDetailPage() {
     { label: "Término", value: data.endDate },
   ];
 
+  const [tab, setTab] = useState("overview");
+
   return (
     <div>
       <div className="d-flex justify-content-between align-items-center">
@@ -30,10 +33,10 @@ export default function ExperimentDetailPage() {
       </div>
       <ul className="nav nav-tabs mt-3">
         <li className="nav-item">
-          <span className="nav-link active">Overview</span>
+          <button className={`nav-link${tab === "overview" ? " active" : ""}`} onClick={() => setTab("overview")}>Overview</button>
         </li>
         <li className="nav-item">
-          <span className="nav-link">Criativos</span>
+          <button className={`nav-link${tab === "creatives" ? " active" : ""}`} onClick={() => setTab("creatives")}>Criativos</button>
         </li>
         <li className="nav-item">
           <span className="nav-link">Públicos</span>
@@ -42,26 +45,21 @@ export default function ExperimentDetailPage() {
           <span className="nav-link">Métricas</span>
         </li>
       </ul>
-      <div className="card">
-        <div className="card-body p-0">
-          <dl className="row mb-0">
-            {rows.map((r, idx) => (
-              <Fragment key={r.label}>
-                <dt
-                  className={`col-sm-3 py-2${idx % 2 === 0 ? " bg-light" : ""}`}
-                >
-                  {r.label}
-                </dt>
-                <dd
-                  className={`col-sm-9 py-2${idx % 2 === 0 ? " bg-light" : ""}`}
-                >
-                  {r.value}
-                </dd>
-              </Fragment>
-            ))}
-          </dl>
+      {tab === "overview" && (
+        <div className="card">
+          <div className="card-body p-0">
+            <dl className="row mb-0">
+              {rows.map((r, idx) => (
+                <Fragment key={r.label}>
+                  <dt className={`col-sm-3 py-2${idx % 2 === 0 ? " bg-light" : ""}`}>{r.label}</dt>
+                  <dd className={`col-sm-9 py-2${idx % 2 === 0 ? " bg-light" : ""}`}>{r.value}</dd>
+                </Fragment>
+              ))}
+            </dl>
+          </div>
         </div>
-      </div>
+      )}
+      {tab === "creatives" && <CriativosTab experimentId={expId} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add creative entity and CRUD endpoints
- expose asset upload and preview API
- serve uploads via web config
- implement creatives tab with modal form and preview
- update experiment detail page to show creatives tab
- document new endpoints and usage
- add tests for creative service, controller and frontend tab

## Testing
- `npm run build`
- `npm run test -- --run`
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_687a6d23bdf08321b53596c58b2b7c6d