### PR TITLE
Fix bean name conflict

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/CreativeVariantService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/CreativeVariantService.java
@@ -11,11 +11,11 @@ import org.springframework.transaction.annotation.Transactional;
  * Service layer for creative variants.
  */
 @Service
-public class CreativeService {
+public class CreativeVariantService {
     private final CreativeVariantRepository repository;
     private final ExperimentRepository experimentRepository;
 
-    public CreativeService(CreativeVariantRepository repository, ExperimentRepository experimentRepository) {
+    public CreativeVariantService(CreativeVariantRepository repository, ExperimentRepository experimentRepository) {
         this.repository = repository;
         this.experimentRepository = experimentRepository;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/CreativeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/CreativeController.java
@@ -3,7 +3,7 @@ package com.marketinghub.experiment.web;
 import com.marketinghub.experiment.dto.CreateCreativeRequest;
 import com.marketinghub.experiment.dto.CreativeVariantDto;
 import com.marketinghub.experiment.mapper.CreativeVariantMapper;
-import com.marketinghub.experiment.service.CreativeService;
+import com.marketinghub.experiment.service.CreativeVariantService;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,10 +15,10 @@ import java.util.stream.StreamSupport;
 @RestController
 @RequestMapping("/api/creatives")
 public class CreativeController {
-    private final CreativeService service;
+    private final CreativeVariantService service;
     private final CreativeVariantMapper mapper;
 
-    public CreativeController(CreativeService service, CreativeVariantMapper mapper) {
+    public CreativeController(CreativeVariantService service, CreativeVariantMapper mapper) {
         this.service = service;
         this.mapper = mapper;
     }


### PR DESCRIPTION
## Summary
- rename experiment CreativeService -> CreativeVariantService
- update CreativeController to use the renamed service

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a8c7a9fb88321b25f1eb0b5f41656