### PR TITLE
Fix bean name conflict

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/CreativeVariantController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/CreativeVariantController.java
@@ -14,11 +14,11 @@ import java.util.stream.StreamSupport;
  */
 @RestController
 @RequestMapping("/api/creatives")
-public class CreativeController {
+public class CreativeVariantController {
     private final CreativeVariantService service;
     private final CreativeVariantMapper mapper;
 
-    public CreativeController(CreativeVariantService service, CreativeVariantMapper mapper) {
+    public CreativeVariantController(CreativeVariantService service, CreativeVariantMapper mapper) {
         this.service = service;
         this.mapper = mapper;
     }


### PR DESCRIPTION
## Summary
- rename experiment `CreativeController` to `CreativeVariantController`

## Testing
- `mvn -s ../settings.xml test -q` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687aa133f2f4832186866e5b33464e59