### PR TITLE
Fix MarketNiche persistence in experiment tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -23,8 +23,9 @@ public class Experiment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "niche_id")
+    @ManyToOne(optional = false, fetch = FetchType.LAZY,
+            cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "niche_id", nullable = false)
     private MarketNiche niche;
 
     @Column(nullable = false)

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
@@ -6,6 +6,8 @@ import com.marketinghub.creative.CreativeStatus;
 import com.marketinghub.creative.repository.CreativeRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -34,6 +36,8 @@ class CreativeServiceTest {
     CreativeRepository repository;
     @Autowired
     ExperimentRepository experimentRepository;
+    @Autowired
+    MarketNicheRepository marketNicheRepository;
 
     CreativeService service;
 
@@ -53,7 +57,10 @@ class CreativeServiceTest {
 
     @Test
     void previewParsesHtml() throws Exception {
-        Experiment exp = experimentRepository.save(Experiment.builder().name("E").build());
+        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder()
+                .name("Digital Marketing").build());
+        Experiment exp = experimentRepository.save(Experiment.builder()
+                .name("E").niche(niche).build());
         repository.save(Creative.builder().experiment(exp).headline("h").primaryText("p").imageUrl("i").status(CreativeStatus.DRAFT).build());
 
         HttpClient client = Mockito.mock(HttpClient.class);

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
@@ -7,6 +7,8 @@ import com.marketinghub.creative.dto.CreateCreativeRequest;
 import com.marketinghub.creative.repository.CreativeRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +43,8 @@ class CreativeControllerTest {
     CreativeRepository repository;
     @Autowired
     ExperimentRepository experimentRepository;
+    @Autowired
+    MarketNicheRepository marketNicheRepository;
 
     Long expId;
 
@@ -48,7 +52,11 @@ class CreativeControllerTest {
     void setup() {
         repository.deleteAll();
         experimentRepository.deleteAll();
-        Experiment exp = experimentRepository.save(Experiment.builder().name("E").build());
+        marketNicheRepository.deleteAll();
+        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder()
+                .name("Digital Marketing").build());
+        Experiment exp = experimentRepository.save(Experiment.builder()
+                .name("E").niche(niche).build());
         expId = exp.getId();
     }
 


### PR DESCRIPTION
## Summary
- add cascade persist to `Experiment.niche`
- prepare MarketNiche in creative service/controller tests

## Testing
- `mvn -q -s ../settings.xml test` *(fails: Could not transfer artifact spring-boot-starter-parent-3.2.5.pom)*

------
https://chatgpt.com/codex/tasks/task_e_687ab0c291c483218299ba95760d0cfe