### PR TITLE
Fix JPA relations and tests for DB constraints

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
@@ -18,8 +18,9 @@ public class Creative {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "experiment_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false,
+            cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "experiment_id", nullable = false)
     private Experiment experiment;
 
     private String headline;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/AdSet.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/AdSet.java
@@ -20,8 +20,9 @@ public class AdSet {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "experiment_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false,
+            cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "experiment_id", nullable = false)
     private Experiment experiment;
 
     private String location;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/CreativeVariant.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/CreativeVariant.java
@@ -20,8 +20,9 @@ public class CreativeVariant {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "experiment_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false,
+            cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "experiment_id", nullable = false)
     private Experiment experiment;
 
     @Enumerated(EnumType.STRING)

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/MetricSnapshot.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/MetricSnapshot.java
@@ -19,12 +19,12 @@ public class MetricSnapshot {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "creative_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "creative_id", nullable = false)
     private CreativeVariant creative;
 
-    @ManyToOne
-    @JoinColumn(name = "ad_set_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "ad_set_id", nullable = false)
     private AdSet adSet;
 
     private Integer impressions;

--- a/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
@@ -1,0 +1,61 @@
+package com.marketinghub;
+
+import com.marketinghub.creative.Creative;
+import com.marketinghub.creative.CreativeStatus;
+import com.marketinghub.creative.repository.CreativeRepository;
+import com.marketinghub.experiment.*;
+import com.marketinghub.experiment.repository.*;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Utility methods to create and persist test fixtures respecting
+ * entity relationships.
+ */
+@Component
+@RequiredArgsConstructor
+public class FixtureUtils {
+    private final MarketNicheRepository nicheRepository;
+    private final ExperimentRepository experimentRepository;
+    private final CreativeRepository creativeRepository;
+    private final AdSetRepository adSetRepository;
+
+    public MarketNiche createAndSaveNiche() {
+        MarketNiche niche = MarketNiche.builder()
+                .name("Niche")
+                .build();
+        return nicheRepository.save(niche);
+    }
+
+    public Experiment createAndSaveExperiment(MarketNiche niche) {
+        Experiment exp = Experiment.builder()
+                .niche(niche)
+                .name("Experiment")
+                .status(ExperimentStatus.PLANNED)
+                .platform(ExperimentPlatform.FACEBOOK)
+                .build();
+        return experimentRepository.save(exp);
+    }
+
+    public Creative createAndSaveCreative(Experiment exp) {
+        Creative creative = Creative.builder()
+                .experiment(exp)
+                .headline("h")
+                .primaryText("p")
+                .imageUrl("i")
+                .status(CreativeStatus.DRAFT)
+                .build();
+        return creativeRepository.save(creative);
+    }
+
+    public AdSet createAndSaveAdSet(Experiment exp) {
+        AdSet adSet = AdSet.builder()
+                .experiment(exp)
+                .location("BR")
+                .durationDays(1)
+                .build();
+        return adSetRepository.save(adSet);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
@@ -7,7 +7,7 @@ import com.marketinghub.creative.repository.CreativeRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.niche.MarketNiche;
-import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.FixtureUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -37,7 +37,7 @@ class CreativeServiceTest {
     @Autowired
     ExperimentRepository experimentRepository;
     @Autowired
-    MarketNicheRepository marketNicheRepository;
+    FixtureUtils fixtures;
 
     CreativeService service;
 
@@ -57,11 +57,9 @@ class CreativeServiceTest {
 
     @Test
     void previewParsesHtml() throws Exception {
-        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder()
-                .name("Digital Marketing").build());
-        Experiment exp = experimentRepository.save(Experiment.builder()
-                .name("E").niche(niche).build());
-        repository.save(Creative.builder().experiment(exp).headline("h").primaryText("p").imageUrl("i").status(CreativeStatus.DRAFT).build());
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        Experiment exp = fixtures.createAndSaveExperiment(niche);
+        fixtures.createAndSaveCreative(exp);
 
         HttpClient client = Mockito.mock(HttpClient.class);
         HttpResponse<String> resp = Mockito.mock(HttpResponse.class);

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
@@ -9,6 +9,7 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.FixtureUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +46,8 @@ class CreativeControllerTest {
     ExperimentRepository experimentRepository;
     @Autowired
     MarketNicheRepository marketNicheRepository;
+    @Autowired
+    FixtureUtils fixtures;
 
     Long expId;
 
@@ -53,10 +56,8 @@ class CreativeControllerTest {
         repository.deleteAll();
         experimentRepository.deleteAll();
         marketNicheRepository.deleteAll();
-        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder()
-                .name("Digital Marketing").build());
-        Experiment exp = experimentRepository.save(Experiment.builder()
-                .name("E").niche(niche).build());
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        Experiment exp = fixtures.createAndSaveExperiment(niche);
         expId = exp.getId();
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.ads.AdsServiceApplication;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.FixtureUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,10 +42,19 @@ class ExperimentControllerTest {
     private ObjectMapper mapper;
     @Autowired
     private ExperimentRepository repository;
+    @Autowired
+    private MarketNicheRepository nicheRepo;
+    @Autowired
+    private FixtureUtils fixtures;
+
+    Long nicheId;
 
     @BeforeEach
     void cleanDb() {
         repository.deleteAll();
+        nicheRepo.deleteAll();
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        nicheId = niche.getId();
     }
 
     @Test
@@ -54,7 +66,7 @@ class ExperimentControllerTest {
         req.setStartDate(LocalDate.now());
         req.setEndDate(LocalDate.now().plusDays(5));
 
-        mockMvc.perform(post("/api/niches/1/experiments")
+        mockMvc.perform(post("/api/niches/" + nicheId + "/experiments")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(req)))
                 .andExpect(status().isOk());


### PR DESCRIPTION
## Summary
- enforce NOT NULL FKs on Creative, CreativeVariant, AdSet and MetricSnapshot
- add FixtureUtils helpers for creating persisted entities in tests
- use fixtures in Creative and Experiment controller/service tests

## Testing
- `mvn -s ../settings.xml -q clean package -DskipTests` *(fails: Non-resolvable parent POM)*
- `mvn -s ../settings.xml -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687ab5f260308321a8db8b94b3ad9159