### PR TITLE
Fix seeded accounts without fixed ids

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/DataSeeder.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/DataSeeder.java
@@ -27,14 +27,35 @@ public class DataSeeder {
                           MarketNicheRepository nicheRepo) {
         return args -> {
             if (fbRepo.count() == 0) {
-                fbRepo.save(new FacebookAccount(1L, "Account A", "USD"));
-                fbRepo.save(new FacebookAccount(2L, "Account B", "EUR"));
-                fbRepo.save(new FacebookAccount(3L, "Account C", "GBP"));
+                fbRepo.save(FacebookAccount.builder()
+                        .name("Account A")
+                        .currency("USD")
+                        .build());
+                fbRepo.save(FacebookAccount.builder()
+                        .name("Account B")
+                        .currency("EUR")
+                        .build());
+                fbRepo.save(FacebookAccount.builder()
+                        .name("Account C")
+                        .currency("GBP")
+                        .build());
             }
             if (igRepo.count() == 0) {
-                igRepo.save(new InstagramAccount(1L, "Insta A", "USD", "https://example.com/a.png"));
-                igRepo.save(new InstagramAccount(2L, "Insta B", "EUR", "https://example.com/b.png"));
-                igRepo.save(new InstagramAccount(3L, "Insta C", "GBP", "https://example.com/c.png"));
+                igRepo.save(InstagramAccount.builder()
+                        .name("Insta A")
+                        .currency("USD")
+                        .avatarUrl("https://example.com/a.png")
+                        .build());
+                igRepo.save(InstagramAccount.builder()
+                        .name("Insta B")
+                        .currency("EUR")
+                        .avatarUrl("https://example.com/b.png")
+                        .build());
+                igRepo.save(InstagramAccount.builder()
+                        .name("Insta C")
+                        .currency("GBP")
+                        .avatarUrl("https://example.com/c.png")
+                        .build());
             }
             if (expRepo.count() == 0) {
                 MarketNiche niche = nicheRepo.findAll().stream().findFirst()

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
@@ -1,44 +1,24 @@
 package com.marketinghub.ads;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity(name = "fb_account")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class FacebookAccount {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String name;
     private String currency;
-
-    public FacebookAccount() {}
-
-    public FacebookAccount(Long id, String name, String currency) {
-        this.id = id;
-        this.name = name;
-        this.currency = currency;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getCurrency() {
-        return currency;
-    }
-
-    public void setCurrency(String currency) {
-        this.currency = currency;
-    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccount.java
@@ -1,58 +1,25 @@
 package com.marketinghub.ads;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity(name = "ig_account")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class InstagramAccount {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String name;
     private String currency;
     private String avatarUrl;
-
-    public InstagramAccount() {}
-
-    public InstagramAccount(Long id, String name, String currency, String avatarUrl) {
-        this.id = id;
-        this.name = name;
-        this.currency = currency;
-        this.avatarUrl = avatarUrl;
-    }
-
-    public InstagramAccount(Long id, String name, String currency) {
-        this(id, name, currency, null);
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getCurrency() {
-        return currency;
-    }
-
-    public void setCurrency(String currency) {
-        this.currency = currency;
-    }
-
-    public String getAvatarUrl() {
-        return avatarUrl;
-    }
-
-    public void setAvatarUrl(String avatarUrl) {
-        this.avatarUrl = avatarUrl;
-    }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/DataSeederIntegrationTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/DataSeederIntegrationTest.java
@@ -1,0 +1,38 @@
+package com.marketinghub.ads;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DataJpaTest
+@ImportAutoConfiguration
+@ContextConfiguration(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb", 
+        "spring.datasource.driverClassName=org.h2.Driver", 
+        "spring.jpa.hibernate.ddl-auto=create"
+})
+class DataSeederIntegrationTest {
+
+    @Autowired
+    ApplicationContext context;
+
+    @Test
+    void allSeedersRunWithoutException() {
+        Collection<org.springframework.boot.CommandLineRunner> runners =
+                context.getBeansOfType(org.springframework.boot.CommandLineRunner.class).values();
+        assertThatCode(() -> {
+            for (org.springframework.boot.CommandLineRunner runner : runners) {
+                runner.run(new String[]{});
+            }
+        }).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary
- refactor FacebookAccount and InstagramAccount entities to use Lombok and auto-generated ids
- update ads DataSeeder to use builders without specifying ids
- add DataSeederIntegrationTest to ensure seeders run without PersistentObjectException

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact)*
- `mvn -s settings.xml test` *(fails: Could not transfer artifact)*
- `npm run test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae7f32cf483218f12941716fec846