### PR TITLE
Add verbose Hibernate logging

### DIFF
--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -18,3 +18,8 @@ management.endpoint.health.show-details=always
 
 server.port=8000
 
+# Enable detailed Hibernate logging
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.orm.jdbc.bind=TRACE
+logging.level.org.hibernate.type=TRACE
+


### PR DESCRIPTION
## Summary
- configure application.properties for detailed Hibernate SQL logging

## Testing
- `npm run test`
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687af3eed8dc8321bad82b8968a945af