### PR TITLE
Fix failing tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
@@ -88,7 +88,10 @@ public class CreativeService {
      * Fetches the preview HTML from Facebook Marketing API.
      */
     public String preview(Long creativeId) throws IOException, InterruptedException {
-        String token = System.getenv("FB_ACCESS_TOKEN");
+        String token = System.getProperty("FB_ACCESS_TOKEN");
+        if (token == null || token.isBlank()) {
+            token = System.getenv("FB_ACCESS_TOKEN");
+        }
         if (token == null || token.isBlank()) {
             return "";
         }

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
@@ -65,8 +65,13 @@ class CreativeServiceTest {
         HttpResponse<String> resp = Mockito.mock(HttpResponse.class);
         when(resp.body()).thenReturn("{\"data\":[{\"body\":\"<div>ok</div>\"}]}");
         when(client.send(any(), any())).thenReturn((HttpResponse) resp);
-        service = new CreativeService(repository, experimentRepository, client);
-        String html = service.preview(1L);
-        assertThat(html).contains("ok");
+        System.setProperty("FB_ACCESS_TOKEN", "dummy");
+        try {
+            service = new CreativeService(repository, experimentRepository, client);
+            String html = service.preview(1L);
+            assertThat(html).contains("ok");
+        } finally {
+            System.clearProperty("FB_ACCESS_TOKEN");
+        }
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -45,12 +45,15 @@ class ExperimentControllerTest {
     @Autowired
     private MarketNicheRepository nicheRepo;
     @Autowired
+    private com.marketinghub.creative.repository.CreativeRepository creativeRepo;
+    @Autowired
     private FixtureUtils fixtures;
 
     Long nicheId;
 
     @BeforeEach
     void cleanDb() {
+        creativeRepo.deleteAll();
         repository.deleteAll();
         nicheRepo.deleteAll();
         MarketNiche niche = fixtures.createAndSaveNiche();


### PR DESCRIPTION
## Summary
- allow setting FB token via system property for easier tests
- set FB_ACCESS_TOKEN in CreativeServiceTest
- clean up creatives before removing experiments in ExperimentControllerTest

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` in success-product-worker *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687af9d1f8f88321af8782a823fb0c90