### PR TITLE
Fix FacebookAccountControllerTest

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -7,6 +7,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.stream.IntStream;
+
+import com.marketinghub.ads.FacebookAccount;
+import com.marketinghub.ads.FacebookAccountRepository;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -23,8 +28,17 @@ public class FacebookAccountControllerTest {
     @Autowired
     MockMvc mockMvc;
 
+    @Autowired
+    FacebookAccountRepository repository;
+
     @Test
     void shouldReturnThreeAccounts() throws Exception {
+        IntStream.rangeClosed(1, 3)
+                .forEach(i -> repository.save(FacebookAccount.builder()
+                        .name("Account " + i)
+                        .currency("USD")
+                        .build()));
+
         mockMvc.perform(get("/accounts/facebook"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(3));


### PR DESCRIPTION
## Summary
- seed three accounts in FacebookAccountControllerTest

## Testing
- `mvn -s ../settings.xml -o test` *(fails: Cannot access central-all repository in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_687afc2e3abc8321ae2851474f1352b3