### PR TITLE
Add angle taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ O overlay de erros fica acessível em `/__vite__` e os sourcemaps são gerados e
 ## Criativos
 Os criativos representam variações de anúncios vinculados a um experimento. Utilize a rota `/api/experiments/{id}/creatives` para cadastrar e listar. A visualização de um criativo usa `/api/creatives/{id}/preview` que consulta a Marketing API do Facebook.
 
+### Taxonomias reutilizáveis
+Angles, Visual Proofs e Emotional Triggers podem ser gerenciados via `/api/angles`, `/api/visual-proofs` e `/api/emotional-triggers`. Use `PATCH /api/creatives/{id}/labels` para vincular listas de IDs a um criativo.
+
 ## Erros comuns Hibernate
 
 Para evitar `PersistentObjectException: detached entity passed to persist`, anexe

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
@@ -1,6 +1,9 @@
 package com.marketinghub.creative;
 
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.creative.label.Angle;
+import com.marketinghub.creative.label.VisualProof;
+import com.marketinghub.creative.label.EmotionalTrigger;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,4 +35,22 @@ public class Creative {
 
     @Enumerated(EnumType.STRING)
     private CreativeStatus status;
+
+    @ManyToMany
+    @JoinTable(name = "creative_angle",
+            joinColumns = @JoinColumn(name = "creative_id"),
+            inverseJoinColumns = @JoinColumn(name = "angle_id"))
+    private java.util.Set<Angle> angles = new java.util.HashSet<>();
+
+    @ManyToMany
+    @JoinTable(name = "creative_visual_proof",
+            joinColumns = @JoinColumn(name = "creative_id"),
+            inverseJoinColumns = @JoinColumn(name = "proof_id"))
+    private java.util.Set<VisualProof> visualProofs = new java.util.HashSet<>();
+
+    @ManyToMany
+    @JoinTable(name = "creative_emotional_trigger",
+            joinColumns = @JoinColumn(name = "creative_id"),
+            inverseJoinColumns = @JoinColumn(name = "trigger_id"))
+    private java.util.Set<EmotionalTrigger> emotionalTriggers = new java.util.HashSet<>();
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/dto/UpdateCreativeLabelsRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/dto/UpdateCreativeLabelsRequest.java
@@ -1,0 +1,11 @@
+package com.marketinghub.creative.dto;
+
+import java.util.Set;
+import lombok.Data;
+
+@Data
+public class UpdateCreativeLabelsRequest {
+    private Set<Long> angles;
+    private Set<Long> visualProofs;
+    private Set<Long> emotionalTriggers;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/Angle.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/Angle.java
@@ -1,0 +1,22 @@
+package com.marketinghub.creative.label;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Angle {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Lob
+    private String description;
+
+    private String frameType;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/EmotionalTrigger.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/EmotionalTrigger.java
@@ -1,0 +1,23 @@
+package com.marketinghub.creative.label;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmotionalTrigger {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private EmotionalValence valence;
+
+    @Lob
+    private String description;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/EmotionalValence.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/EmotionalValence.java
@@ -1,0 +1,5 @@
+package com.marketinghub.creative.label;
+
+public enum EmotionalValence {
+    POS, NEG
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/VisualProof.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/VisualProof.java
@@ -1,0 +1,22 @@
+package com.marketinghub.creative.label;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VisualProof {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String proofType;
+
+    @Lob
+    private String description;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/AngleDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/AngleDto.java
@@ -1,0 +1,11 @@
+package com.marketinghub.creative.label.dto;
+
+import lombok.Data;
+
+@Data
+public class AngleDto {
+    private Long id;
+    private String name;
+    private String description;
+    private String frameType;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/CreateAngleRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/CreateAngleRequest.java
@@ -1,0 +1,14 @@
+package com.marketinghub.creative.label.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class CreateAngleRequest {
+    @NotBlank
+    @Size(max = 60)
+    private String name;
+    private String description;
+    private String frameType;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/CreateEmotionalTriggerRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/CreateEmotionalTriggerRequest.java
@@ -1,0 +1,15 @@
+package com.marketinghub.creative.label.dto;
+
+import com.marketinghub.creative.label.EmotionalValence;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class CreateEmotionalTriggerRequest {
+    @NotBlank
+    @Size(max = 60)
+    private String name;
+    private EmotionalValence valence;
+    private String description;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/CreateVisualProofRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/CreateVisualProofRequest.java
@@ -1,0 +1,14 @@
+package com.marketinghub.creative.label.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class CreateVisualProofRequest {
+    @NotBlank
+    @Size(max = 60)
+    private String name;
+    private String proofType;
+    private String description;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/EmotionalTriggerDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/EmotionalTriggerDto.java
@@ -1,0 +1,12 @@
+package com.marketinghub.creative.label.dto;
+
+import com.marketinghub.creative.label.EmotionalValence;
+import lombok.Data;
+
+@Data
+public class EmotionalTriggerDto {
+    private Long id;
+    private String name;
+    private EmotionalValence valence;
+    private String description;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/VisualProofDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/VisualProofDto.java
@@ -1,0 +1,11 @@
+package com.marketinghub.creative.label.dto;
+
+import lombok.Data;
+
+@Data
+public class VisualProofDto {
+    private Long id;
+    private String name;
+    private String proofType;
+    private String description;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/mapper/AngleMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/mapper/AngleMapper.java
@@ -1,0 +1,10 @@
+package com.marketinghub.creative.label.mapper;
+
+import com.marketinghub.creative.label.Angle;
+import com.marketinghub.creative.label.dto.AngleDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface AngleMapper {
+    AngleDto toDto(Angle angle);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/mapper/EmotionalTriggerMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/mapper/EmotionalTriggerMapper.java
@@ -1,0 +1,10 @@
+package com.marketinghub.creative.label.mapper;
+
+import com.marketinghub.creative.label.EmotionalTrigger;
+import com.marketinghub.creative.label.dto.EmotionalTriggerDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface EmotionalTriggerMapper {
+    EmotionalTriggerDto toDto(EmotionalTrigger trigger);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/mapper/VisualProofMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/mapper/VisualProofMapper.java
@@ -1,0 +1,10 @@
+package com.marketinghub.creative.label.mapper;
+
+import com.marketinghub.creative.label.VisualProof;
+import com.marketinghub.creative.label.dto.VisualProofDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface VisualProofMapper {
+    VisualProofDto toDto(VisualProof proof);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/repository/AngleRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/repository/AngleRepository.java
@@ -1,0 +1,7 @@
+package com.marketinghub.creative.label.repository;
+
+import com.marketinghub.creative.label.Angle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AngleRepository extends JpaRepository<Angle, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/repository/EmotionalTriggerRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/repository/EmotionalTriggerRepository.java
@@ -1,0 +1,7 @@
+package com.marketinghub.creative.label.repository;
+
+import com.marketinghub.creative.label.EmotionalTrigger;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmotionalTriggerRepository extends JpaRepository<EmotionalTrigger, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/repository/VisualProofRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/repository/VisualProofRepository.java
@@ -1,0 +1,7 @@
+package com.marketinghub.creative.label.repository;
+
+import com.marketinghub.creative.label.VisualProof;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VisualProofRepository extends JpaRepository<VisualProof, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/AngleService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/AngleService.java
@@ -1,0 +1,34 @@
+package com.marketinghub.creative.label.service;
+
+import com.marketinghub.creative.label.Angle;
+import com.marketinghub.creative.label.dto.CreateAngleRequest;
+import com.marketinghub.creative.label.repository.AngleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AngleService {
+    private final AngleRepository repository;
+
+    public AngleService(AngleRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    public Angle create(CreateAngleRequest request) {
+        Angle angle = Angle.builder()
+                .name(request.getName())
+                .description(request.getDescription())
+                .frameType(request.getFrameType())
+                .build();
+        return repository.save(angle);
+    }
+
+    public Angle get(Long id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    public Iterable<Angle> list() {
+        return repository.findAll();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/EmotionalTriggerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/EmotionalTriggerService.java
@@ -1,0 +1,34 @@
+package com.marketinghub.creative.label.service;
+
+import com.marketinghub.creative.label.EmotionalTrigger;
+import com.marketinghub.creative.label.dto.CreateEmotionalTriggerRequest;
+import com.marketinghub.creative.label.repository.EmotionalTriggerRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class EmotionalTriggerService {
+    private final EmotionalTriggerRepository repository;
+
+    public EmotionalTriggerService(EmotionalTriggerRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    public EmotionalTrigger create(CreateEmotionalTriggerRequest request) {
+        EmotionalTrigger trigger = EmotionalTrigger.builder()
+                .name(request.getName())
+                .valence(request.getValence())
+                .description(request.getDescription())
+                .build();
+        return repository.save(trigger);
+    }
+
+    public EmotionalTrigger get(Long id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    public Iterable<EmotionalTrigger> list() {
+        return repository.findAll();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/VisualProofService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/VisualProofService.java
@@ -1,0 +1,34 @@
+package com.marketinghub.creative.label.service;
+
+import com.marketinghub.creative.label.VisualProof;
+import com.marketinghub.creative.label.dto.CreateVisualProofRequest;
+import com.marketinghub.creative.label.repository.VisualProofRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class VisualProofService {
+    private final VisualProofRepository repository;
+
+    public VisualProofService(VisualProofRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    public VisualProof create(CreateVisualProofRequest request) {
+        VisualProof proof = VisualProof.builder()
+                .name(request.getName())
+                .proofType(request.getProofType())
+                .description(request.getDescription())
+                .build();
+        return repository.save(proof);
+    }
+
+    public VisualProof get(Long id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    public Iterable<VisualProof> list() {
+        return repository.findAll();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/web/AngleController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/web/AngleController.java
@@ -1,0 +1,39 @@
+package com.marketinghub.creative.label.web;
+
+import com.marketinghub.creative.label.dto.AngleDto;
+import com.marketinghub.creative.label.dto.CreateAngleRequest;
+import com.marketinghub.creative.label.mapper.AngleMapper;
+import com.marketinghub.creative.label.service.AngleService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+@RestController
+@RequestMapping("/api/angles")
+public class AngleController {
+    private final AngleService service;
+    private final AngleMapper mapper;
+
+    public AngleController(AngleService service, AngleMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @PostMapping
+    public AngleDto create(@RequestBody CreateAngleRequest request) {
+        return mapper.toDto(service.create(request));
+    }
+
+    @GetMapping("/{id}")
+    public AngleDto get(@PathVariable Long id) {
+        return mapper.toDto(service.get(id));
+    }
+
+    @GetMapping
+    public List<AngleDto> list() {
+        return StreamSupport.stream(service.list().spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/web/EmotionalTriggerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/web/EmotionalTriggerController.java
@@ -1,0 +1,39 @@
+package com.marketinghub.creative.label.web;
+
+import com.marketinghub.creative.label.dto.CreateEmotionalTriggerRequest;
+import com.marketinghub.creative.label.dto.EmotionalTriggerDto;
+import com.marketinghub.creative.label.mapper.EmotionalTriggerMapper;
+import com.marketinghub.creative.label.service.EmotionalTriggerService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+@RestController
+@RequestMapping("/api/emotional-triggers")
+public class EmotionalTriggerController {
+    private final EmotionalTriggerService service;
+    private final EmotionalTriggerMapper mapper;
+
+    public EmotionalTriggerController(EmotionalTriggerService service, EmotionalTriggerMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @PostMapping
+    public EmotionalTriggerDto create(@RequestBody CreateEmotionalTriggerRequest request) {
+        return mapper.toDto(service.create(request));
+    }
+
+    @GetMapping("/{id}")
+    public EmotionalTriggerDto get(@PathVariable Long id) {
+        return mapper.toDto(service.get(id));
+    }
+
+    @GetMapping
+    public List<EmotionalTriggerDto> list() {
+        return StreamSupport.stream(service.list().spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/web/VisualProofController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/web/VisualProofController.java
@@ -1,0 +1,39 @@
+package com.marketinghub.creative.label.web;
+
+import com.marketinghub.creative.label.dto.CreateVisualProofRequest;
+import com.marketinghub.creative.label.dto.VisualProofDto;
+import com.marketinghub.creative.label.mapper.VisualProofMapper;
+import com.marketinghub.creative.label.service.VisualProofService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+@RestController
+@RequestMapping("/api/visual-proofs")
+public class VisualProofController {
+    private final VisualProofService service;
+    private final VisualProofMapper mapper;
+
+    public VisualProofController(VisualProofService service, VisualProofMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @PostMapping
+    public VisualProofDto create(@RequestBody CreateVisualProofRequest request) {
+        return mapper.toDto(service.create(request));
+    }
+
+    @GetMapping("/{id}")
+    public VisualProofDto get(@PathVariable Long id) {
+        return mapper.toDto(service.get(id));
+    }
+
+    @GetMapping
+    public List<VisualProofDto> list() {
+        return StreamSupport.stream(service.list().spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.creative.*;
 import com.marketinghub.creative.dto.CreateCreativeRequest;
 import com.marketinghub.creative.repository.CreativeRepository;
+import com.marketinghub.creative.label.repository.AngleRepository;
+import com.marketinghub.creative.label.repository.VisualProofRepository;
+import com.marketinghub.creative.label.repository.EmotionalTriggerRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import org.springframework.stereotype.Service;
@@ -33,6 +36,9 @@ public class CreativeService {
 
     private final CreativeRepository repository;
     private final ExperimentRepository experimentRepository;
+    private final AngleRepository angleRepository;
+    private final VisualProofRepository visualProofRepository;
+    private final EmotionalTriggerRepository emotionalTriggerRepository;
     private final HttpClient httpClient;
 
     /**
@@ -71,6 +77,23 @@ public class CreativeService {
 
     public Iterable<Creative> listByExperiment(Long experimentId) {
         return repository.findByExperimentId(experimentId);
+    }
+
+    @Transactional
+    public Creative updateLabels(Long id, java.util.Set<Long> angleIds,
+                                 java.util.Set<Long> proofIds,
+                                 java.util.Set<Long> triggerIds) {
+        Creative creative = repository.findById(id).orElseThrow();
+        if (angleIds != null) {
+            creative.setAngles(new java.util.HashSet<>(angleRepository.findAllById(angleIds)));
+        }
+        if (proofIds != null) {
+            creative.setVisualProofs(new java.util.HashSet<>(visualProofRepository.findAllById(proofIds)));
+        }
+        if (triggerIds != null) {
+            creative.setEmotionalTriggers(new java.util.HashSet<>(emotionalTriggerRepository.findAllById(triggerIds)));
+        }
+        return creative;
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/web/CreativeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/web/CreativeController.java
@@ -4,6 +4,7 @@ import com.marketinghub.creative.dto.CreateCreativeRequest;
 import com.marketinghub.creative.dto.CreativeDto;
 import com.marketinghub.creative.mapper.CreativeMapper;
 import com.marketinghub.creative.service.CreativeService;
+import com.marketinghub.creative.dto.UpdateCreativeLabelsRequest;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -44,6 +45,13 @@ public class CreativeController {
     @DeleteMapping("/api/creatives/{id}")
     public void delete(@PathVariable Long id) {
         service.delete(id);
+    }
+
+    @PatchMapping("/api/creatives/{id}/labels")
+    public CreativeDto patchLabels(@PathVariable Long id,
+                                   @RequestBody UpdateCreativeLabelsRequest request) {
+        return mapper.toDto(service.updateLabels(id,
+                request.getAngles(), request.getVisualProofs(), request.getEmotionalTriggers()));
     }
 
     @PostMapping("/api/assets")

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/AngleRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/AngleRepositoryTest.java
@@ -1,0 +1,29 @@
+package com.marketinghub.creative.label;
+
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.creative.label.repository.AngleRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ContextConfiguration(classes = AdsServiceApplication.class)
+class AngleRepositoryTest {
+
+    @Autowired
+    AngleRepository repository;
+
+    @Test
+    void testSaveAngle() {
+        Angle angle = Angle.builder()
+                .name("Ganho")
+                .description("Descricao")
+                .frameType("BENEFIT")
+                .build();
+        repository.save(angle);
+        assertThat(repository.findById(angle.getId())).isPresent();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.marketinghub.creative.label;
+
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.creative.Creative;
+import com.marketinghub.creative.CreativeStatus;
+import com.marketinghub.creative.repository.CreativeRepository;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.creative.label.repository.AngleRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ContextConfiguration(classes = AdsServiceApplication.class)
+class CreativeAngleIntegrationTest {
+    @Autowired
+    CreativeRepository creativeRepository;
+    @Autowired
+    ExperimentRepository experimentRepository;
+    @Autowired
+    MarketNicheRepository nicheRepository;
+    @Autowired
+    AngleRepository angleRepository;
+
+    @Test
+    void persistRelationships() {
+        MarketNiche niche = MarketNiche.builder().name("N").build();
+        nicheRepository.save(niche);
+        Experiment exp = Experiment.builder().niche(niche).name("E").status(com.marketinghub.experiment.ExperimentStatus.PLANNED).platform(com.marketinghub.experiment.ExperimentPlatform.FACEBOOK).build();
+        experimentRepository.save(exp);
+        Angle angle = Angle.builder().name("Ganho").build();
+        angleRepository.save(angle);
+        Creative c = Creative.builder()
+                .experiment(exp)
+                .headline("h")
+                .primaryText("p")
+                .imageUrl("i")
+                .status(CreativeStatus.DRAFT)
+                .angles(Set.of(angle))
+                .build();
+        creativeRepository.save(c);
+        Creative found = creativeRepository.findById(c.getId()).orElseThrow();
+        assertThat(found.getAngles()).hasSize(1);
+    }
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -111,3 +111,116 @@ components:
           type: string
           enum: [DRAFT, READY]
 
+  /api/angles:
+    get:
+      summary: Listar angles
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Criar angle
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAngleRequest'
+      responses:
+        '200':
+          description: OK
+  /api/visual-proofs:
+    get:
+      summary: Listar visual proofs
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Criar visual proof
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateVisualProofRequest'
+      responses:
+        '200':
+          description: OK
+  /api/emotional-triggers:
+    get:
+      summary: Listar emotional triggers
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Criar emotional trigger
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEmotionalTriggerRequest'
+      responses:
+        '200':
+          description: OK
+  /api/creatives/{id}/labels:
+    patch:
+      summary: Atualizar labels do criativo
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCreativeLabelsRequest'
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    CreateAngleRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        frameType:
+          type: string
+    CreateVisualProofRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        proofType:
+          type: string
+        description:
+          type: string
+    CreateEmotionalTriggerRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        valence:
+          type: string
+        description:
+          type: string
+    UpdateCreativeLabelsRequest:
+      type: object
+      properties:
+        angles:
+          type: array
+          items:
+            type: integer
+        visualProofs:
+          type: array
+          items:
+            type: integer
+        emotionalTriggers:
+          type: array
+          items:
+            type: integer

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import EditAiServicePage from "./pages/aiService/EditAiServicePage";
 import ExperimentListPage from "./pages/experiment/ExperimentListPage";
 import NewExperimentPage from "./pages/experiment/NewExperimentPage";
 import ExperimentDetailPage from "./pages/experiment/ExperimentDetailPage";
+import AnglesPage from "./pages/AnglesPage";
 
 export default function App() {
   return (
@@ -61,6 +62,7 @@ export default function App() {
             <Link className="nav-link" to="/ai-services">
               IA
             </Link>
+            <Link className="nav-link" to="/angles">Angles</Link>
           </div>
         </div>
       </nav>
@@ -97,6 +99,7 @@ export default function App() {
         <Route path="/ai-services" element={<AiServiceListPage />} />
         <Route path="/ai-services/new" element={<NewAiServicePage />} />
         <Route path="/ai-services/:id/edit" element={<EditAiServicePage />} />
+        <Route path="/angles" element={<AnglesPage />} />
         <Route path="*" element={<div>Início</div>} />
       </Routes>
     </div>

--- a/frontend/src/api/angle/useAngles.ts
+++ b/frontend/src/api/angle/useAngles.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface Angle {
+  id: number;
+  name: string;
+  description?: string;
+  frameType?: string;
+}
+
+export function useAngles() {
+  return useQuery({
+    queryKey: ["angles"],
+    queryFn: async () => {
+      const { data } = await axios.get<Angle[]>("/api/angles");
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/angle/useCreateAngle.ts
+++ b/frontend/src/api/angle/useCreateAngle.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Angle } from "./useAngles";
+
+export interface CreateAngle {
+  name: string;
+  description?: string;
+  frameType?: string;
+}
+
+export function useCreateAngle() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreateAngle) => {
+      const { data: angle } = await axios.post<Angle>("/api/angles", data);
+      return angle;
+    },
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: ["angles"] });
+    },
+  });
+}

--- a/frontend/src/pages/AnglesPage.tsx
+++ b/frontend/src/pages/AnglesPage.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { useAngles } from "../api/angle/useAngles";
+import { useCreateAngle } from "../api/angle/useCreateAngle";
+import PageTitle from "../components/PageTitle";
+
+export default function AnglesPage() {
+  const { data } = useAngles();
+  const angles = Array.isArray(data) ? data : [];
+  const create = useCreateAngle();
+  const [name, setName] = useState("");
+  const submit = async () => {
+    await create.mutateAsync({ name });
+    setName("");
+  };
+  return (
+    <div>
+      <PageTitle>Angles</PageTitle>
+      <input
+        className="form-control mb-2"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <button className="btn btn-primary mb-3" onClick={submit}>
+        Novo Angle
+      </button>
+      <ul>
+        {angles.map((a) => (
+          <li key={a.id}>{a.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- define Angle, VisualProof and EmotionalTrigger entities
- relate creatives to new taxonomies with join tables
- expose CRUD endpoints and label patch API
- document in OpenAPI and README
- add basic angle admin page in React
- provide unit tests for new repositories

## Testing
- `mvn -s ../settings.xml test -q` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test -q` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e5323b3c48321bee9ee24e83b48ca