### PR TITLE
Implement Angle validation and editing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/AngleDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/dto/AngleDto.java
@@ -1,10 +1,14 @@
 package com.marketinghub.creative.label.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class AngleDto {
     private Long id;
+    @NotBlank(message = "Name is mandatory")
+    @Size(max = 60)
     private String name;
     private String description;
     private String frameType;

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/AngleService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/AngleService.java
@@ -1,10 +1,13 @@
 package com.marketinghub.creative.label.service;
 
 import com.marketinghub.creative.label.Angle;
+import com.marketinghub.creative.label.dto.AngleDto;
 import com.marketinghub.creative.label.dto.CreateAngleRequest;
 import com.marketinghub.creative.label.repository.AngleRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class AngleService {
@@ -30,5 +33,13 @@ public class AngleService {
 
     public Iterable<Angle> list() {
         return repository.findAll();
+    }
+
+    @Transactional
+    public Angle update(Long id, AngleDto dto) {
+        Angle angle = repository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        angle.setName(dto.getName());
+        return repository.save(angle);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/web/AngleController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/web/AngleController.java
@@ -4,6 +4,7 @@ import com.marketinghub.creative.label.dto.AngleDto;
 import com.marketinghub.creative.label.dto.CreateAngleRequest;
 import com.marketinghub.creative.label.mapper.AngleMapper;
 import com.marketinghub.creative.label.service.AngleService;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,8 +22,13 @@ public class AngleController {
     }
 
     @PostMapping
-    public AngleDto create(@RequestBody CreateAngleRequest request) {
+    public AngleDto create(@Valid @RequestBody CreateAngleRequest request) {
         return mapper.toDto(service.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public AngleDto update(@PathVariable Long id, @Valid @RequestBody AngleDto dto) {
+        return mapper.toDto(service.update(id, dto));
     }
 
     @GetMapping("/{id}")

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/web/AngleControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/web/AngleControllerTest.java
@@ -1,0 +1,40 @@
+package com.marketinghub.creative.label.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.creative.label.dto.CreateAngleRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = AdsServiceApplication.class)
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create"
+})
+class AngleControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper mapper;
+
+    @Test
+    void postAngle_emptyName_returns400() throws Exception {
+        CreateAngleRequest req = new CreateAngleRequest();
+        req.setName("");
+        mockMvc.perform(post("/api/angles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -128,6 +128,30 @@ components:
       responses:
         '200':
           description: OK
+        '400':
+          description: Invalid data
+  /api/angles/{id}:
+    put:
+      summary: Atualizar angle
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AngleDto'
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Invalid data
+        '404':
+          description: Not found
   /api/visual-proofs:
     get:
       summary: Listar visual proofs
@@ -190,6 +214,13 @@ components:
         description:
           type: string
         frameType:
+          type: string
+    AngleDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
           type: string
     CreateVisualProofRequest:
       type: object

--- a/frontend/src/api/angle/useUpdateAngle.ts
+++ b/frontend/src/api/angle/useUpdateAngle.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Angle } from "./useAngles";
+
+export interface UpdateAngle {
+  id: number;
+  name: string;
+}
+
+export function useUpdateAngle() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: UpdateAngle) => {
+      const { data: angle } = await axios.put<Angle>(`/api/angles/${data.id}`, data);
+      return angle;
+    },
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: ["angles"] });
+    },
+  });
+}

--- a/frontend/src/pages/AnglesPage.test.tsx
+++ b/frontend/src/pages/AnglesPage.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi } from "vitest";
+import AnglesPage from "./AnglesPage";
+import axios from "axios";
+
+vi.mock("axios");
+
+describe("AnglesPage", () => {
+  it("não cria item quando input vazio", async () => {
+    (axios.get as any).mockResolvedValue({ data: [] });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <AnglesPage />
+      </QueryClientProvider>,
+    );
+    const button = await screen.findByText(/Novo Angle/);
+    fireEvent.click(button);
+    expect((axios.post as any).mock.calls.length).toBe(0);
+  });
+
+  it("edita item e espera texto atualizado", async () => {
+    (axios.get as any).mockResolvedValue({ data: [{ id: 1, name: "A" }] });
+    (axios.put as any).mockResolvedValue({ data: { id: 1, name: "B" } });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <AnglesPage />
+      </QueryClientProvider>,
+    );
+    const edit = await screen.findByRole("button", { name: "✏️" });
+    fireEvent.click(edit);
+    const input = screen.getByDisplayValue("A") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "B" } });
+    fireEvent.click(screen.getByRole("button", { name: "✔️" }));
+    expect(await screen.findByText("B")).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/AnglesPage.tsx
+++ b/frontend/src/pages/AnglesPage.tsx
@@ -1,16 +1,43 @@
-import { useState } from "react";
-import { useAngles } from "../api/angle/useAngles";
+import { useEffect, useState } from "react";
+import { useAngles, Angle } from "../api/angle/useAngles";
 import { useCreateAngle } from "../api/angle/useCreateAngle";
+import { useUpdateAngle } from "../api/angle/useUpdateAngle";
 import PageTitle from "../components/PageTitle";
 
 export default function AnglesPage() {
   const { data } = useAngles();
-  const angles = Array.isArray(data) ? data : [];
+  const [angles, setAngles] = useState<Angle[]>([]);
   const create = useCreateAngle();
+  const update = useUpdateAngle();
   const [name, setName] = useState("");
+  const [editId, setEditId] = useState<number | null>(null);
+  const [editName, setEditName] = useState("");
+
+  useEffect(() => {
+    if (Array.isArray(data)) setAngles(data);
+  }, [data]);
+
+  const disabled = !name.trim();
+
   const submit = async () => {
-    await create.mutateAsync({ name });
-    setName("");
+    if (disabled) return;
+    try {
+      const res = await create.mutateAsync({ name });
+      setAngles([...angles, res]);
+      setName("");
+    } catch {
+      alert("Erro ao salvar Angle");
+    }
+  };
+
+  const confirm = async (id: number) => {
+    try {
+      const updated = await update.mutateAsync({ id, name: editName });
+      setAngles(angles.map((a) => (a.id === id ? updated : a)));
+      setEditId(null);
+    } catch {
+      alert("Erro ao atualizar Angle");
+    }
   };
   return (
     <div>
@@ -21,12 +48,35 @@ export default function AnglesPage() {
         value={name}
         onChange={(e) => setName(e.target.value)}
       />
-      <button className="btn btn-primary mb-3" onClick={submit}>
+      <button className="btn btn-primary mb-3" onClick={submit} disabled={disabled}>
         Novo Angle
       </button>
       <ul>
         {angles.map((a) => (
-          <li key={a.id}>{a.name}</li>
+          <li key={a.id} className="mb-1">
+            {editId === a.id ? (
+              <>
+                <input
+                  className="form-control d-inline-block w-auto me-2"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                />
+                <button className="btn btn-success btn-sm me-1" onClick={() => confirm(a.id)}>
+                  ✔️
+                </button>
+                <button className="btn btn-secondary btn-sm" onClick={() => setEditId(null)}>
+                  ✖️
+                </button>
+              </>
+            ) : (
+              <>
+                {a.name}{" "}
+                <button className="btn btn-link p-0" onClick={() => { setEditId(a.id); setEditName(a.name); }}>
+                  ✏️
+                </button>
+              </>
+            )}
+          </li>
         ))}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- enforce @NotBlank on AngleDto name
- validate create endpoint and add PUT /angles/{id}
- update AngleService with update method
- document angles PUT and validation responses in OpenAPI
- add React hook to edit angles inline with controlled inputs
- expose update API hook
- test backend validation with MockMvc
- add vitest coverage for new Angle features

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not download dependencies)*
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e5e83251083218a462b167ab997db