### PR TITLE
Add description field to Angle

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/AngleService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/AngleService.java
@@ -40,6 +40,7 @@ public class AngleService {
         Angle angle = repository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
         angle.setName(dto.getName());
+        angle.setDescription(dto.getDescription());
         return repository.save(angle);
     }
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -215,13 +215,15 @@ components:
           type: string
         frameType:
           type: string
-    AngleDto:
-      type: object
-      properties:
-        id:
-          type: integer
-        name:
-          type: string
+  AngleDto:
+    type: object
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      description:
+        type: string
     CreateVisualProofRequest:
       type: object
       properties:

--- a/frontend/src/api/angle/useUpdateAngle.ts
+++ b/frontend/src/api/angle/useUpdateAngle.ts
@@ -5,6 +5,7 @@ import { Angle } from "./useAngles";
 export interface UpdateAngle {
   id: number;
   name: string;
+  description?: string;
 }
 
 export function useUpdateAngle() {

--- a/frontend/src/pages/AnglesPage.tsx
+++ b/frontend/src/pages/AnglesPage.tsx
@@ -10,8 +10,10 @@ export default function AnglesPage() {
   const create = useCreateAngle();
   const update = useUpdateAngle();
   const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const [editId, setEditId] = useState<number | null>(null);
   const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
 
   useEffect(() => {
     if (Array.isArray(data)) setAngles(data);
@@ -22,9 +24,10 @@ export default function AnglesPage() {
   const submit = async () => {
     if (disabled) return;
     try {
-      const res = await create.mutateAsync({ name });
+      const res = await create.mutateAsync({ name, description });
       setAngles([...angles, res]);
       setName("");
+      setDescription("");
     } catch {
       alert("Erro ao salvar Angle");
     }
@@ -32,7 +35,11 @@ export default function AnglesPage() {
 
   const confirm = async (id: number) => {
     try {
-      const updated = await update.mutateAsync({ id, name: editName });
+      const updated = await update.mutateAsync({
+        id,
+        name: editName,
+        description: editDescription,
+      });
       setAngles(angles.map((a) => (a.id === id ? updated : a)));
       setEditId(null);
     } catch {
@@ -48,6 +55,13 @@ export default function AnglesPage() {
         value={name}
         onChange={(e) => setName(e.target.value)}
       />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Descrição"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        rows={3}
+      />
       <button className="btn btn-primary mb-3" onClick={submit} disabled={disabled}>
         Novo Angle
       </button>
@@ -61,6 +75,13 @@ export default function AnglesPage() {
                   value={editName}
                   onChange={(e) => setEditName(e.target.value)}
                 />
+                <textarea
+                  className="form-control mb-2"
+                  placeholder="Descrição"
+                  value={editDescription}
+                  onChange={(e) => setEditDescription(e.target.value)}
+                  rows={2}
+                />
                 <button className="btn btn-success btn-sm me-1" onClick={() => confirm(a.id)}>
                   ✔️
                 </button>
@@ -71,7 +92,13 @@ export default function AnglesPage() {
             ) : (
               <>
                 {a.name}{" "}
-                <button className="btn btn-link p-0" onClick={() => { setEditId(a.id); setEditName(a.name); }}>
+                <button
+                  className="btn btn-link p-0"
+                  onClick={() => {
+                    setEditId(a.id);
+                    setEditName(a.name);
+                    setEditDescription(a.description || "");
+                  }}>
                   ✏️
                 </button>
               </>


### PR DESCRIPTION
## Summary
- include description in openapi AngleDto
- handle description in AngleService update
- support description when editing Angles in the frontend
- update Angle update API hook

## Testing
- `mvn -s ../settings.xml test -q` *(fails: Network is unreachable)*
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ee6007b708321891c201ab023f071