### PR TITLE
Add Visual Proof management page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import ExperimentListPage from "./pages/experiment/ExperimentListPage";
 import NewExperimentPage from "./pages/experiment/NewExperimentPage";
 import ExperimentDetailPage from "./pages/experiment/ExperimentDetailPage";
 import AnglesPage from "./pages/AnglesPage";
+import VisualProofsPage from "./pages/VisualProofsPage";
 
 export default function App() {
   return (
@@ -63,6 +64,7 @@ export default function App() {
               IA
             </Link>
             <Link className="nav-link" to="/angles">Angles</Link>
+            <Link className="nav-link" to="/visual-proofs">Provas Visuais</Link>
           </div>
         </div>
       </nav>
@@ -100,6 +102,7 @@ export default function App() {
         <Route path="/ai-services/new" element={<NewAiServicePage />} />
         <Route path="/ai-services/:id/edit" element={<EditAiServicePage />} />
         <Route path="/angles" element={<AnglesPage />} />
+        <Route path="/visual-proofs" element={<VisualProofsPage />} />
         <Route path="*" element={<div>Início</div>} />
       </Routes>
     </div>

--- a/frontend/src/api/visualProof/useCreateVisualProof.ts
+++ b/frontend/src/api/visualProof/useCreateVisualProof.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { VisualProof } from "./useVisualProofs";
+
+export interface CreateVisualProof {
+  name: string;
+  proofType?: string;
+  description?: string;
+}
+
+export function useCreateVisualProof() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreateVisualProof) => {
+      const { data: proof } = await axios.post<VisualProof>(
+        "/api/visual-proofs",
+        data,
+      );
+      return proof;
+    },
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: ["visualProofs"] });
+    },
+  });
+}

--- a/frontend/src/api/visualProof/useUpdateVisualProof.ts
+++ b/frontend/src/api/visualProof/useUpdateVisualProof.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { VisualProof } from "./useVisualProofs";
+
+export interface UpdateVisualProof {
+  id: number;
+  name: string;
+  proofType?: string;
+  description?: string;
+}
+
+export function useUpdateVisualProof() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: UpdateVisualProof) => {
+      const { data: proof } = await axios.put<VisualProof>(
+        `/api/visual-proofs/${data.id}`,
+        data,
+      );
+      return proof;
+    },
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: ["visualProofs"] });
+    },
+  });
+}

--- a/frontend/src/api/visualProof/useVisualProofs.ts
+++ b/frontend/src/api/visualProof/useVisualProofs.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface VisualProof {
+  id: number;
+  name: string;
+  proofType?: string;
+  description?: string;
+}
+
+export function useVisualProofs() {
+  return useQuery({
+    queryKey: ["visualProofs"],
+    queryFn: async () => {
+      const { data } = await axios.get<VisualProof[]>("/api/visual-proofs");
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/VisualProofsPage.test.tsx
+++ b/frontend/src/pages/VisualProofsPage.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi } from "vitest";
+import VisualProofsPage from "./VisualProofsPage";
+import axios from "axios";
+
+vi.mock("axios");
+
+describe("VisualProofsPage", () => {
+  it("não cria item quando input vazio", async () => {
+    (axios.get as any).mockResolvedValue({ data: [] });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <VisualProofsPage />
+      </QueryClientProvider>,
+    );
+    const button = await screen.findByText(/Nova Prova Visual/);
+    fireEvent.click(button);
+    expect((axios.post as any).mock.calls.length).toBe(0);
+  });
+
+  it("edita item e espera texto atualizado", async () => {
+    (axios.get as any).mockResolvedValue({ data: [{ id: 1, name: "A" }] });
+    (axios.put as any).mockResolvedValue({ data: { id: 1, name: "B" } });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <VisualProofsPage />
+      </QueryClientProvider>,
+    );
+    const edit = await screen.findByRole("button", { name: "✏️" });
+    fireEvent.click(edit);
+    const input = screen.getByDisplayValue("A") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "B" } });
+    fireEvent.click(screen.getByRole("button", { name: "✔️" }));
+    expect(await screen.findByText("B")).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/VisualProofsPage.tsx
+++ b/frontend/src/pages/VisualProofsPage.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { useVisualProofs, VisualProof } from "../api/visualProof/useVisualProofs";
+import { useCreateVisualProof } from "../api/visualProof/useCreateVisualProof";
+import { useUpdateVisualProof } from "../api/visualProof/useUpdateVisualProof";
+import PageTitle from "../components/PageTitle";
+
+export default function VisualProofsPage() {
+  const { data } = useVisualProofs();
+  const [proofs, setProofs] = useState<VisualProof[]>([]);
+  const create = useCreateVisualProof();
+  const update = useUpdateVisualProof();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [editId, setEditId] = useState<number | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+
+  useEffect(() => {
+    if (Array.isArray(data)) setProofs(data);
+  }, [data]);
+
+  const disabled = !name.trim();
+
+  const submit = async () => {
+    if (disabled) return;
+    try {
+      const res = await create.mutateAsync({ name, description });
+      setProofs([...proofs, res]);
+      setName("");
+      setDescription("");
+    } catch {
+      alert("Erro ao salvar Prova Visual");
+    }
+  };
+
+  const confirm = async (id: number) => {
+    try {
+      const updated = await update.mutateAsync({
+        id,
+        name: editName,
+        description: editDescription,
+      });
+      setProofs(proofs.map((p) => (p.id === id ? updated : p)));
+      setEditId(null);
+    } catch {
+      alert("Erro ao atualizar Prova Visual");
+    }
+  };
+  return (
+    <div>
+      <PageTitle>Provas Visuais</PageTitle>
+      <input
+        className="form-control mb-2"
+        placeholder="Nome"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Descrição"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        rows={3}
+      />
+      <button className="btn btn-primary mb-3" onClick={submit} disabled={disabled}>
+        Nova Prova Visual
+      </button>
+      <ul>
+        {proofs.map((p) => (
+          <li key={p.id} className="mb-1">
+            {editId === p.id ? (
+              <>
+                <input
+                  className="form-control d-inline-block w-auto me-2"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                />
+                <textarea
+                  className="form-control mb-2"
+                  placeholder="Descrição"
+                  value={editDescription}
+                  onChange={(e) => setEditDescription(e.target.value)}
+                  rows={2}
+                />
+                <button className="btn btn-success btn-sm me-1" onClick={() => confirm(p.id)}>
+                  ✔️
+                </button>
+                <button className="btn btn-secondary btn-sm" onClick={() => setEditId(null)}>
+                  ✖️
+                </button>
+              </>
+            ) : (
+              <div className="d-flex align-items-start">
+                <div className="flex-grow-1">
+                  {p.name}
+                  {p.description && (
+                    <div className="text-muted small">{p.description}</div>
+                  )}
+                </div>
+                <button
+                  className="btn btn-link p-0"
+                  onClick={() => {
+                    setEditId(p.id);
+                    setEditName(p.name);
+                    setEditDescription(p.description || "");
+                  }}
+                >
+                  ✏️
+                </button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add React hooks for Visual Proof CRUD
- create VisualProofsPage with edit/create UI
- expose route and link in navigation
- test VisualProofsPage like Angles

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not resolve dependencies)*
- `mvn -s settings.xml test` *(fails: Could not resolve dependencies)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_687f5bb44cc88321b0eea63f0e11a223