### PR TITLE
Add Emotional Triggers page

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/EmotionalTriggerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/service/EmotionalTriggerService.java
@@ -2,6 +2,7 @@ package com.marketinghub.creative.label.service;
 
 import com.marketinghub.creative.label.EmotionalTrigger;
 import com.marketinghub.creative.label.dto.CreateEmotionalTriggerRequest;
+import com.marketinghub.creative.label.dto.EmotionalTriggerDto;
 import com.marketinghub.creative.label.repository.EmotionalTriggerRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,5 +31,14 @@ public class EmotionalTriggerService {
 
     public Iterable<EmotionalTrigger> list() {
         return repository.findAll();
+    }
+
+    @Transactional
+    public EmotionalTrigger update(Long id, EmotionalTriggerDto dto) {
+        EmotionalTrigger trigger = repository.findById(id).orElseThrow();
+        trigger.setName(dto.getName());
+        trigger.setValence(dto.getValence());
+        trigger.setDescription(dto.getDescription());
+        return repository.save(trigger);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/label/web/EmotionalTriggerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/label/web/EmotionalTriggerController.java
@@ -25,6 +25,11 @@ public class EmotionalTriggerController {
         return mapper.toDto(service.create(request));
     }
 
+    @PutMapping("/{id}")
+    public EmotionalTriggerDto update(@PathVariable Long id, @RequestBody EmotionalTriggerDto dto) {
+        return mapper.toDto(service.update(id, dto));
+    }
+
     @GetMapping("/{id}")
     public EmotionalTriggerDto get(@PathVariable Long id) {
         return mapper.toDto(service.get(id));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,5 @@
 import { Route, Routes, Link } from "react-router-dom";
 
-
 import FacebookAccountsPage from "./pages/FacebookAccountsPage";
 import InstagramAccountsPage from "./pages/InstagramAccountsPage";
 import MediaListPage from "./pages/media/MediaListPage";
@@ -26,6 +25,7 @@ import NewExperimentPage from "./pages/experiment/NewExperimentPage";
 import ExperimentDetailPage from "./pages/experiment/ExperimentDetailPage";
 import AnglesPage from "./pages/AnglesPage";
 import VisualProofsPage from "./pages/VisualProofsPage";
+import EmotionalTriggersPage from "./pages/EmotionalTriggersPage";
 
 export default function App() {
   return (
@@ -63,8 +63,15 @@ export default function App() {
             <Link className="nav-link" to="/ai-services">
               IA
             </Link>
-            <Link className="nav-link" to="/angles">Angles</Link>
-            <Link className="nav-link" to="/visual-proofs">Provas Visuais</Link>
+            <Link className="nav-link" to="/angles">
+              Angles
+            </Link>
+            <Link className="nav-link" to="/visual-proofs">
+              Provas Visuais
+            </Link>
+            <Link className="nav-link" to="/emotional-triggers">
+              Gatilhos Emocionais
+            </Link>
           </div>
         </div>
       </nav>
@@ -103,6 +110,7 @@ export default function App() {
         <Route path="/ai-services/:id/edit" element={<EditAiServicePage />} />
         <Route path="/angles" element={<AnglesPage />} />
         <Route path="/visual-proofs" element={<VisualProofsPage />} />
+        <Route path="/emotional-triggers" element={<EmotionalTriggersPage />} />
         <Route path="*" element={<div>Início</div>} />
       </Routes>
     </div>

--- a/frontend/src/api/emotionalTrigger/useCreateEmotionalTrigger.ts
+++ b/frontend/src/api/emotionalTrigger/useCreateEmotionalTrigger.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { EmotionalTrigger } from "./useEmotionalTriggers";
+
+export interface CreateEmotionalTrigger {
+  name: string;
+  valence?: string;
+  description?: string;
+}
+
+export function useCreateEmotionalTrigger() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreateEmotionalTrigger) => {
+      const { data: trigger } = await axios.post<EmotionalTrigger>(
+        "/api/emotional-triggers",
+        data,
+      );
+      return trigger;
+    },
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: ["emotionalTriggers"] });
+    },
+  });
+}

--- a/frontend/src/api/emotionalTrigger/useEmotionalTriggers.ts
+++ b/frontend/src/api/emotionalTrigger/useEmotionalTriggers.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface EmotionalTrigger {
+  id: number;
+  name: string;
+  valence?: string;
+  description?: string;
+}
+
+export function useEmotionalTriggers() {
+  return useQuery({
+    queryKey: ["emotionalTriggers"],
+    queryFn: async () => {
+      const { data } = await axios.get<EmotionalTrigger[]>(
+        "/api/emotional-triggers",
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/emotionalTrigger/useUpdateEmotionalTrigger.ts
+++ b/frontend/src/api/emotionalTrigger/useUpdateEmotionalTrigger.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { EmotionalTrigger } from "./useEmotionalTriggers";
+
+export interface UpdateEmotionalTrigger {
+  id: number;
+  name: string;
+  valence?: string;
+  description?: string;
+}
+
+export function useUpdateEmotionalTrigger() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: UpdateEmotionalTrigger) => {
+      const { data: trigger } = await axios.put<EmotionalTrigger>(
+        `/api/emotional-triggers/${data.id}`,
+        data,
+      );
+      return trigger;
+    },
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: ["emotionalTriggers"] });
+    },
+  });
+}

--- a/frontend/src/pages/EmotionalTriggersPage.test.tsx
+++ b/frontend/src/pages/EmotionalTriggersPage.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi } from "vitest";
+import EmotionalTriggersPage from "./EmotionalTriggersPage";
+import axios from "axios";
+
+vi.mock("axios");
+
+describe("EmotionalTriggersPage", () => {
+  it("não cria item quando input vazio", async () => {
+    (axios.get as any).mockResolvedValue({ data: [] });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <EmotionalTriggersPage />
+      </QueryClientProvider>,
+    );
+    const button = await screen.findByText(/Novo Gatilho Emocional/);
+    fireEvent.click(button);
+    expect((axios.post as any).mock.calls.length).toBe(0);
+  });
+
+  it("edita item e espera texto atualizado", async () => {
+    (axios.get as any).mockResolvedValue({ data: [{ id: 1, name: "A" }] });
+    (axios.put as any).mockResolvedValue({ data: { id: 1, name: "B" } });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <EmotionalTriggersPage />
+      </QueryClientProvider>,
+    );
+    const edit = await screen.findByRole("button", { name: "✏️" });
+    fireEvent.click(edit);
+    const input = screen.getByDisplayValue("A") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "B" } });
+    fireEvent.click(screen.getByRole("button", { name: "✔️" }));
+    expect(await screen.findByText("B")).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/EmotionalTriggersPage.tsx
+++ b/frontend/src/pages/EmotionalTriggersPage.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import {
+  useEmotionalTriggers,
+  EmotionalTrigger,
+} from "../api/emotionalTrigger/useEmotionalTriggers";
+import { useCreateEmotionalTrigger } from "../api/emotionalTrigger/useCreateEmotionalTrigger";
+import { useUpdateEmotionalTrigger } from "../api/emotionalTrigger/useUpdateEmotionalTrigger";
+import PageTitle from "../components/PageTitle";
+
+export default function EmotionalTriggersPage() {
+  const { data } = useEmotionalTriggers();
+  const [triggers, setTriggers] = useState<EmotionalTrigger[]>([]);
+  const create = useCreateEmotionalTrigger();
+  const update = useUpdateEmotionalTrigger();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [editId, setEditId] = useState<number | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+
+  useEffect(() => {
+    if (Array.isArray(data)) setTriggers(data);
+  }, [data]);
+
+  const disabled = !name.trim();
+
+  const submit = async () => {
+    if (disabled) return;
+    try {
+      const res = await create.mutateAsync({ name, description });
+      setTriggers([...triggers, res]);
+      setName("");
+      setDescription("");
+    } catch {
+      alert("Erro ao salvar Gatilho Emocional");
+    }
+  };
+
+  const confirm = async (id: number) => {
+    try {
+      const updated = await update.mutateAsync({
+        id,
+        name: editName,
+        description: editDescription,
+      });
+      setTriggers(triggers.map((t) => (t.id === id ? updated : t)));
+      setEditId(null);
+    } catch {
+      alert("Erro ao atualizar Gatilho Emocional");
+    }
+  };
+  return (
+    <div>
+      <PageTitle>Gatilhos Emocionais</PageTitle>
+      <input
+        className="form-control mb-2"
+        placeholder="Nome"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <textarea
+        className="form-control mb-2"
+        placeholder="Descrição"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        rows={3}
+      />
+      <button
+        className="btn btn-primary mb-3"
+        onClick={submit}
+        disabled={disabled}
+      >
+        Novo Gatilho Emocional
+      </button>
+      <ul>
+        {triggers.map((t) => (
+          <li key={t.id} className="mb-1">
+            {editId === t.id ? (
+              <>
+                <input
+                  className="form-control d-inline-block w-auto me-2"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                />
+                <textarea
+                  className="form-control mb-2"
+                  placeholder="Descrição"
+                  value={editDescription}
+                  onChange={(e) => setEditDescription(e.target.value)}
+                  rows={2}
+                />
+                <button
+                  className="btn btn-success btn-sm me-1"
+                  onClick={() => confirm(t.id)}
+                >
+                  ✔️
+                </button>
+                <button
+                  className="btn btn-secondary btn-sm"
+                  onClick={() => setEditId(null)}
+                >
+                  ✖️
+                </button>
+              </>
+            ) : (
+              <div className="d-flex align-items-start">
+                <div className="flex-grow-1">
+                  {t.name}
+                  {t.description && (
+                    <div className="text-muted small">{t.description}</div>
+                  )}
+                </div>
+                <button
+                  className="btn btn-link p-0"
+                  onClick={() => {
+                    setEditId(t.id);
+                    setEditName(t.name);
+                    setEditDescription(t.description || "");
+                  }}
+                >
+                  ✏️
+                </button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add emotional trigger CRUD hooks
- add emotional triggers management page
- support updating emotional triggers on backend
- link new page in the app

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `mvn -s settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f9b8acdd48321ae36d718109954ef