### PR TITLE
Add creative label selection

### DIFF
--- a/frontend/src/api/creative/useUpdateCreativeLabels.ts
+++ b/frontend/src/api/creative/useUpdateCreativeLabels.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Creative } from "./useCreatives";
+
+export interface UpdateCreativeLabels {
+  angles: number[];
+  visualProofs: number[];
+  emotionalTriggers: number[];
+}
+
+export interface UpdateCreativeLabelsVariables {
+  id: number;
+  labels: UpdateCreativeLabels;
+}
+
+export function useUpdateCreativeLabels(expId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, labels }: UpdateCreativeLabelsVariables) => {
+      const { data: creative } = await axios.patch<Creative>(
+        `/api/creatives/${id}/labels`,
+        labels,
+      );
+      return creative;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["creatives", expId] });
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- allow selecting angles, visual proofs and emotional triggers for new creatives
- support updating creative labels via new API hook

## Testing
- `npm run build`
- `npm run test`
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687fd5e43ab48321a3c8e19dee4435a2