### PR TITLE
Improve hypothesis board UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -61,8 +61,11 @@ public class HypothesisService {
         return repository.save(h);
     }
 
-    public Iterable<Hypothesis> listByExperiment(Long experimentId) {
-        return repository.findByExperimentId(experimentId);
+    public Iterable<Hypothesis> listByExperiment(Long experimentId, HypothesisStatus status) {
+        if (status == null) {
+            return repository.findByExperimentId(experimentId);
+        }
+        return repository.findByExperimentIdAndStatus(experimentId, status);
     }
 
     @Transactional

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/web/HypothesisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/web/HypothesisController.java
@@ -31,8 +31,9 @@ public class HypothesisController {
     }
 
     @GetMapping("/experiments/{experimentId}/hypotheses")
-    public List<HypothesisDto> list(@PathVariable Long experimentId) {
-        return StreamSupport.stream(service.listByExperiment(experimentId).spliterator(), false)
+    public List<HypothesisDto> list(@PathVariable Long experimentId,
+                                    @RequestParam(value = "status", required = false) HypothesisStatus status) {
+        return StreamSupport.stream(service.listByExperiment(experimentId, status).spliterator(), false)
                 .map(mapper::toDto)
                 .toList();
     }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -305,6 +305,11 @@ components:
           required: true
           schema:
             type: integer
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: OK

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-router-dom": "^7.6.3",
+        "react-toastify": "^11.0.5",
         "socket.io-client": "^4.7.2",
         "zustand": "^4.4.0"
       },
@@ -2031,6 +2032,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -4078,6 +4088,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/readable-stream": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-router-dom": "^7.6.3",
+    "react-toastify": "^11.0.5",
     "socket.io-client": "^4.7.2",
     "zustand": "^4.4.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,8 @@ import VisualProofsPage from "./pages/VisualProofsPage";
 import EmotionalTriggersPage from "./pages/EmotionalTriggersPage";
 import LandingPreview from "./pages/landing/LandingPreview";
 import AnalyticsDashboard from "./pages/landing/AnalyticsDashboard";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 export default function App() {
   return (
@@ -88,7 +90,10 @@ export default function App() {
               >
                 Teste de Mercado
               </span>
-              <ul className="dropdown-menu" aria-labelledby="market-test-dropdown">
+              <ul
+                className="dropdown-menu"
+                aria-labelledby="market-test-dropdown"
+              >
                 <li>
                   <a className="dropdown-item" href="#">
                     1- Hipotese e Oferta Isca
@@ -160,6 +165,7 @@ export default function App() {
         <Route path="/analytics" element={<AnalyticsDashboard />} />
         <Route path="*" element={<div>Início</div>} />
       </Routes>
+      <ToastContainer position="top-right" />
     </div>
   );
 }

--- a/frontend/src/api/hypothesis/useCreateHypothesis.ts
+++ b/frontend/src/api/hypothesis/useCreateHypothesis.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
+import { toast } from "react-toastify";
 import { Hypothesis } from "./useHypothesisBoard";
 
 export interface CreateHypothesis {
@@ -25,6 +26,10 @@ export function useCreateHypothesis() {
       queryClient.invalidateQueries({
         queryKey: ["hypothesis-board", String(variables.experimentId)],
       });
+      toast.success("Hipótese criada");
+    },
+    onError: () => {
+      toast.error("Erro ao criar hipótese");
     },
   });
 }

--- a/frontend/src/api/hypothesis/useHypothesisBoard.ts
+++ b/frontend/src/api/hypothesis/useHypothesisBoard.ts
@@ -15,10 +15,16 @@ export function useHypothesisBoard(experimentId: string) {
   return useQuery({
     queryKey: ["hypothesis-board", experimentId],
     queryFn: async () => {
-      const { data } = await axios.get<Record<string, Hypothesis[]>>(
-        `/api/experiments/${experimentId}/hypotheses/board`,
+      const statuses = ["BACKLOG", "TESTING", "VALIDATED", "INVALIDATED"] as const;
+      const entries = await Promise.all(
+        statuses.map(async (s) => {
+          const { data } = await axios.get<Hypothesis[]>(
+            `/api/experiments/${experimentId}/hypotheses?status=${s}`,
+          );
+          return [s, data] as const;
+        }),
       );
-      return data;
+      return Object.fromEntries(entries) as Record<string, Hypothesis[]>;
     },
   });
 }

--- a/frontend/src/api/hypothesis/useUpdateHypothesisStatus.ts
+++ b/frontend/src/api/hypothesis/useUpdateHypothesisStatus.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
+import { toast } from "react-toastify";
 import { Hypothesis } from "./useHypothesisBoard";
 
 export function useUpdateHypothesisStatus(experimentId: string) {
@@ -13,6 +14,10 @@ export function useUpdateHypothesisStatus(experimentId: string) {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["hypothesis-board", experimentId] });
+      toast.success("Status atualizado");
+    },
+    onError: () => {
+      toast.error("Erro ao atualizar status");
     },
   });
 }

--- a/frontend/src/pages/hypothesis/HypothesisBoard.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisBoard.tsx
@@ -1,38 +1,79 @@
-import { useDroppable, useDraggable, DndContext, DragEndEvent } from "@dnd-kit/core";
+import {
+  useDroppable,
+  useDraggable,
+  DndContext,
+  DragEndEvent,
+} from "@dnd-kit/core";
 import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
 import { Hypothesis } from "../../api/hypothesis/useHypothesisBoard";
 import { useUpdateHypothesisStatus } from "../../api/hypothesis/useUpdateHypothesisStatus";
 import { CSS } from "@dnd-kit/utilities";
+import { useAngles } from "../../api/angle/useAngles";
 
 interface ColumnProps {
   id: string;
   title: string;
   items: Hypothesis[];
   color: string;
+  angleMap: Map<number, string>;
 }
 
-function Column({ id, title, items, color }: ColumnProps) {
+function Column({ id, title, items, color, angleMap }: ColumnProps) {
   const { setNodeRef } = useDroppable({ id });
   return (
-    <div className="p-2 flex-grow-1" ref={setNodeRef} style={{ background: color, minHeight: 200 }}>
+    <div
+      className="p-2 flex-grow-1"
+      ref={setNodeRef}
+      style={{ background: color, minHeight: 200 }}
+    >
       <h5>{title}</h5>
       {items.map((h) => (
-        <Card key={h.id} item={h} />
+        <Card key={h.id} item={h} angleMap={angleMap} />
       ))}
     </div>
   );
 }
 
-function Card({ item }: { item: Hypothesis }) {
-  const { attributes, listeners, setNodeRef, transform } = useDraggable({ id: item.id });
+function Card({
+  item,
+  angleMap,
+}: {
+  item: Hypothesis;
+  angleMap: Map<number, string>;
+}) {
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({
+    id: item.id,
+  });
   const style = {
     transform: CSS.Translate.toString(transform),
     maxWidth: 280,
   };
   return (
-    <div ref={setNodeRef} style={style} className="card mb-2" {...listeners} {...attributes}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="card mb-2"
+      {...listeners}
+      {...attributes}
+    >
       <div className="card-body p-2">
-        <div className="fw-bold text-truncate" style={{ WebkitLineClamp: 2, overflow: "hidden" }}>{item.title}</div>
+        <div
+          className="fw-bold text-truncate"
+          style={{ WebkitLineClamp: 2, overflow: "hidden" }}
+        >
+          {item.title}
+        </div>
+        <span className="badge bg-secondary">
+          {angleMap.get(item.premiseAngleId ?? 0)} {item.offerType}
+        </span>
+        <div className="mt-2 d-flex gap-1">
+          <button className="btn btn-sm btn-outline-primary">
+            Gerar Landing
+          </button>
+          <button className="btn btn-sm btn-outline-secondary">
+            Criar Criativo
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -45,6 +86,10 @@ interface BoardProps {
 
 export default function HypothesisBoard({ board, experimentId }: BoardProps) {
   const update = useUpdateHypothesisStatus(experimentId);
+  const { data: angles } = useAngles();
+  const angleMap = new Map<number, string>(
+    Array.isArray(angles) ? angles.map((a) => [a.id, a.name]) : [],
+  );
   const onDragEnd = (e: DragEndEvent) => {
     if (e.over && e.active.data.current) {
       const id = Number(e.active.id);
@@ -55,10 +100,34 @@ export default function HypothesisBoard({ board, experimentId }: BoardProps) {
   return (
     <DndContext onDragEnd={onDragEnd} modifiers={[restrictToHorizontalAxis]}>
       <div className="d-flex gap-2">
-        <Column id="BACKLOG" title="Backlog" color="#f1f5f9" items={board.BACKLOG || []} />
-        <Column id="TESTING" title="Em Teste" color="#fee2e2" items={board.TESTING || []} />
-        <Column id="VALIDATED" title="Validada" color="#dcfce7" items={board.VALIDATED || []} />
-        <Column id="INVALIDATED" title="Invalidada" color="#f3f4f6" items={board.INVALIDATED || []} />
+        <Column
+          id="BACKLOG"
+          title="Backlog"
+          color="#f1f5f9"
+          items={board.BACKLOG || []}
+          angleMap={angleMap}
+        />
+        <Column
+          id="TESTING"
+          title="Em Teste"
+          color="#fee2e2"
+          items={board.TESTING || []}
+          angleMap={angleMap}
+        />
+        <Column
+          id="VALIDATED"
+          title="Validada"
+          color="#dcfce7"
+          items={board.VALIDATED || []}
+          angleMap={angleMap}
+        />
+        <Column
+          id="INVALIDATED"
+          title="Invalidada"
+          color="#f3f4f6"
+          items={board.INVALIDATED || []}
+          angleMap={angleMap}
+        />
       </div>
     </DndContext>
   );

--- a/frontend/src/pages/hypothesis/NewHypothesisModal.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisModal.tsx
@@ -2,15 +2,23 @@ import { useState } from "react";
 import { useCreateHypothesis } from "../../api/hypothesis/useCreateHypothesis";
 import { useAngles } from "../../api/angle/useAngles";
 
-export default function NewHypothesisModal({ experimentId }: { experimentId: string }) {
+export default function NewHypothesisModal({
+  experimentId,
+}: {
+  experimentId: string;
+}) {
   const [title, setTitle] = useState("");
   const [angle, setAngle] = useState("");
   const [offer, setOffer] = useState("LEAD");
   const [kpi, setKpi] = useState("0");
+  const [status, setStatus] = useState("BACKLOG");
+  const [submitted, setSubmitted] = useState(false);
   const create = useCreateHypothesis();
   const { data: angles } = useAngles();
 
   const submit = async () => {
+    setSubmitted(true);
+    if (!title.trim()) return;
     await create.mutateAsync({
       experimentId: Number(experimentId),
       title,
@@ -19,17 +27,25 @@ export default function NewHypothesisModal({ experimentId }: { experimentId: str
       kpiTargetCpl: Number(kpi),
     });
     setTitle("");
+    setSubmitted(false);
   };
 
   return (
     <div>
       <input
-        className="form-control mb-2"
+        className={`form-control mb-2 ${submitted && !title.trim() ? "is-invalid" : ""}`}
         placeholder="Título"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
       />
-      <select className="form-select mb-2" value={angle} onChange={(e) => setAngle(e.target.value)}>
+      {submitted && !title.trim() && (
+        <div className="invalid-feedback d-block">Título obrigatório</div>
+      )}
+      <select
+        className="form-select mb-2"
+        value={angle}
+        onChange={(e) => setAngle(e.target.value)}
+      >
         <option value="">Selecione Angle</option>
         {Array.isArray(angles) &&
           angles.map((a) => (
@@ -37,6 +53,16 @@ export default function NewHypothesisModal({ experimentId }: { experimentId: str
               {a.name}
             </option>
           ))}
+      </select>
+      <select
+        className="form-select mb-2"
+        value={status}
+        onChange={(e) => setStatus(e.target.value)}
+      >
+        <option value="BACKLOG">Backlog</option>
+        <option value="TESTING">Em Teste</option>
+        <option value="VALIDATED">Validada</option>
+        <option value="INVALIDATED">Invalidada</option>
       </select>
       <div className="form-check">
         <input
@@ -64,6 +90,14 @@ export default function NewHypothesisModal({ experimentId }: { experimentId: str
           Tripwire
         </label>
       </div>
+      {offer === "TRIPWIRE" && (
+        <input
+          className="form-control mb-2"
+          placeholder="Preço"
+          type="number"
+          min="5"
+        />
+      )}
       <input
         className="form-control mb-2"
         placeholder="KPI CPL"
@@ -71,7 +105,11 @@ export default function NewHypothesisModal({ experimentId }: { experimentId: str
         type="number"
         onChange={(e) => setKpi(e.target.value)}
       />
-      <button className="btn btn-primary" onClick={submit} disabled={!title.trim()}>
+      <button
+        className="btn btn-primary"
+        onClick={submit}
+        disabled={!title.trim()}
+      >
         Criar
       </button>
     </div>


### PR DESCRIPTION
## Summary
- support optional status filter in hypothesis controller
- fetch hypothesis board by status via multiple requests
- show angles in board and add card actions
- add toast notifications and validation to hypothesis form
- document new `status` query param in OpenAPI
- add React Toastify dependency

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s ../settings.xml deploy` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` in success-product-worker *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml package` in success-product-worker *(fails: Non-resolvable parent POM)*
- `npm run test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6880d99d6fd88321878ac9d6634ccf93