### PR TITLE
Fix Angle reference in HypothesisService

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.hypothesis.service;
 
+import com.marketinghub.creative.label.Angle;
 import com.marketinghub.creative.label.repository.AngleRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;


### PR DESCRIPTION
## Summary
- import the Angle class in `HypothesisService`

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6880e067c4348321b733cce0250623eb