### PR TITLE
Fix creative label loading and test isolation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
@@ -44,19 +44,19 @@ public class Creative {
     @Enumerated(EnumType.STRING)
     private CreativeStatus status;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "creative_angle",
             joinColumns = @JoinColumn(name = "creative_id"),
             inverseJoinColumns = @JoinColumn(name = "angle_id"))
     private java.util.Set<Angle> angles = new java.util.HashSet<>();
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "creative_visual_proof",
             joinColumns = @JoinColumn(name = "creative_id"),
             inverseJoinColumns = @JoinColumn(name = "proof_id"))
     private java.util.Set<VisualProof> visualProofs = new java.util.HashSet<>();
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "creative_emotional_trigger",
             joinColumns = @JoinColumn(name = "creative_id"),
             inverseJoinColumns = @JoinColumn(name = "trigger_id"))

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create"
 })
+@org.springframework.transaction.annotation.Transactional
 class HypothesisServiceTest {
     @Autowired
     HypothesisService service;


### PR DESCRIPTION
## Summary
- eagerly load label relations on Creative to avoid LazyInitializationException
- run HypothesisServiceTest with transactional scope so data is rolled back between tests

## Testing
- `mvn -s ../settings.xml test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6880e1a01ed48321affdd0c5f2838dfe