### PR TITLE
Add hypothesis CRUD endpoints

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
@@ -3,11 +3,15 @@ package com.marketinghub.hypothesis.dto;
 import java.math.BigDecimal;
 
 public class CreateHypothesisRequest {
+    private Long experimentId;
     private String title;
     private Long premiseAngleId;
     private String offerType;
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;
+
+    public Long getExperimentId() { return experimentId; }
+    public void setExperimentId(Long experimentId) { this.experimentId = experimentId; }
 
     public String getTitle() { return title; }
     public void setTitle(String title) { this.title = title; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/repository/HypothesisRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/repository/HypothesisRepository.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 public interface HypothesisRepository extends JpaRepository<Hypothesis, UUID> {
     List<Hypothesis> findByExperimentId(Long experimentId);
     List<Hypothesis> findByExperimentIdAndStatus(Long experimentId, HypothesisStatus status);
+    List<Hypothesis> findByStatus(HypothesisStatus status);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/web/HypothesisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/web/HypothesisController.java
@@ -26,6 +26,19 @@ public class HypothesisController {
         this.facade = facade;
     }
 
+    @PostMapping("/hypotheses")
+    @ResponseStatus(org.springframework.http.HttpStatus.CREATED)
+    public HypothesisDto create(@RequestBody CreateHypothesisRequest req) {
+        return mapper.toDto(service.create(req));
+    }
+
+    @GetMapping("/hypotheses")
+    public List<HypothesisDto> listAll(@RequestParam(value = "status", required = false) HypothesisStatus status) {
+        return StreamSupport.stream(service.list(status).spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+
     @PostMapping("/experiments/{experimentId}/hypotheses")
     public HypothesisDto create(@PathVariable Long experimentId, @RequestBody CreateHypothesisRequest req) {
         return mapper.toDto(service.create(experimentId, req));
@@ -40,7 +53,8 @@ public class HypothesisController {
     }
 
     @PatchMapping("/hypotheses/{id}/status")
-    public HypothesisDto patchStatus(@PathVariable UUID id, @RequestParam HypothesisStatus status) {
+    public HypothesisDto patchStatus(@PathVariable UUID id, @RequestBody Map<String, HypothesisStatus> body) {
+        HypothesisStatus status = body.get("status");
         return mapper.toDto(service.updateStatus(id, status));
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -44,11 +44,12 @@ class HypothesisServiceTest {
         Experiment exp = fixtures.createAndSaveExperiment(niche);
         var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
         CreateHypothesisRequest req = new CreateHypothesisRequest();
+        req.setExperimentId(exp.getId());
         req.setTitle("Teste");
         req.setPremiseAngleId(angle.getId());
         req.setOfferType("LEAD");
         req.setKpiTargetCpl(new BigDecimal("5"));
-        Hypothesis h = service.create(exp.getId(), req);
+        Hypothesis h = service.create(req);
         assertThat(h.getId()).isNotNull();
         assertThat(h.getStatus()).isEqualTo(HypothesisStatus.BACKLOG);
     }
@@ -58,8 +59,35 @@ class HypothesisServiceTest {
         MarketNiche niche = fixtures.createAndSaveNiche();
         Experiment exp = fixtures.createAndSaveExperiment(niche);
         CreateHypothesisRequest req = new CreateHypothesisRequest();
+        req.setExperimentId(exp.getId());
         req.setTitle("   ");
-        assertThatThrownBy(() -> service.create(exp.getId(), req))
+        assertThatThrownBy(() -> service.create(req))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+    }
+
+    @Test
+    void validateAngleAndKpi() {
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        Experiment exp = fixtures.createAndSaveExperiment(niche);
+        CreateHypothesisRequest req = new CreateHypothesisRequest();
+        req.setExperimentId(exp.getId());
+        req.setTitle("T");
+        assertThatThrownBy(() -> service.create(req))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+    }
+
+    @Test
+    void priceRequiredForTripwire() {
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        Experiment exp = fixtures.createAndSaveExperiment(niche);
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        CreateHypothesisRequest req = new CreateHypothesisRequest();
+        req.setExperimentId(exp.getId());
+        req.setTitle("T");
+        req.setPremiseAngleId(angle.getId());
+        req.setOfferType("TRIPWIRE");
+        req.setKpiTargetCpl(new BigDecimal("5"));
+        assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -313,6 +313,29 @@ components:
       responses:
         '200':
           description: OK
+  /api/hypotheses:
+    post:
+      summary: Criar hipótese
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateHypothesisRequest'
+      responses:
+        '201':
+          description: Created
+    get:
+      summary: Listar hipóteses
+      parameters:
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
   /api/hypotheses/{id}/status:
     patch:
       summary: Atualizar status da hipótese
@@ -321,12 +344,16 @@ components:
           name: id
           required: true
           schema:
-            type: integer
-        - in: query
-          name: status
-          required: true
-          schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
       responses:
         '200':
           description: OK
@@ -347,11 +374,15 @@ components:
     CreateHypothesisRequest:
       type: object
       properties:
+        experimentId:
+          type: integer
         title:
           type: string
         premiseAngleId:
           type: integer
         offerType:
           type: string
+        price:
+          type: number
         kpiTargetCpl:
           type: number


### PR DESCRIPTION
## Summary
- extend HypothesisService validation and add generic create/list
- create REST endpoints for POST/GET /api/hypotheses and PATCH /api/hypotheses/{id}/status
- update HypothesisController mappings
- include additional tests
- document new API routes in OpenAPI spec

## Testing
- `mvn -s ../settings.xml test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880fa05a7408321b21d2dc27c409f9a