### PR TITLE
Implement hypothesis list page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import ExperimentListPage from "./pages/experiment/ExperimentListPage";
 import NewExperimentPage from "./pages/experiment/NewExperimentPage";
 import ExperimentDetailPage from "./pages/experiment/ExperimentDetailPage";
 import HypothesesPage from "./pages/hypothesis/HypothesesPage";
+import HypothesisListPage from "./pages/hypothesis/HypothesisListPage";
 import AnglesPage from "./pages/AnglesPage";
 import VisualProofsPage from "./pages/VisualProofsPage";
 import EmotionalTriggersPage from "./pages/EmotionalTriggersPage";
@@ -154,7 +155,8 @@ export default function App() {
         <Route path="/experiments" element={<ExperimentListPage />} />
         <Route path="/experiments/new" element={<NewExperimentPage />} />
         <Route path="/experiments/:id" element={<ExperimentDetailPage />} />
-        <Route path="/hypotheses" element={<HypothesesPage />} />
+        <Route path="/hypotheses" element={<HypothesisListPage />} />
+        <Route path="/hypotheses/board" element={<HypothesesPage />} />
         <Route path="/ai-services" element={<AiServiceListPage />} />
         <Route path="/ai-services/new" element={<NewAiServicePage />} />
         <Route path="/ai-services/:id/edit" element={<EditAiServicePage />} />

--- a/frontend/src/api/hypothesis/useHypotheses.ts
+++ b/frontend/src/api/hypothesis/useHypotheses.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { Hypothesis } from "./useHypothesisBoard";
+
+export function useHypotheses(status: string = "ALL") {
+  return useQuery({
+    queryKey: ["hypotheses", status],
+    queryFn: async () => {
+      const { data } = await axios.get<Hypothesis[]>(
+        `/api/hypotheses?status=${status}`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/hypothesis/useHypothesisBoard.ts
+++ b/frontend/src/api/hypothesis/useHypothesisBoard.ts
@@ -7,6 +7,7 @@ export interface Hypothesis {
   title: string;
   premiseAngleId?: number;
   offerType?: string;
+  price?: number;
   kpiTargetCpl?: number;
   status: string;
 }

--- a/frontend/src/api/hypothesis/useUpdateHypothesisStatus.ts
+++ b/frontend/src/api/hypothesis/useUpdateHypothesisStatus.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import { toast } from "react-toastify";
 import { Hypothesis } from "./useHypothesisBoard";
 
-export function useUpdateHypothesisStatus(experimentId: string) {
+export function useUpdateHypothesisStatus(experimentId?: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (input: { id: number; status: string }) => {
@@ -13,7 +13,10 @@ export function useUpdateHypothesisStatus(experimentId: string) {
       return data;
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["hypothesis-board", experimentId] });
+      if (experimentId) {
+        qc.invalidateQueries({ queryKey: ["hypothesis-board", experimentId] });
+      }
+      qc.invalidateQueries({ queryKey: ["hypotheses"] });
       toast.success("Status atualizado");
     },
     onError: () => {

--- a/frontend/src/pages/hypothesis/HypothesisList.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisList.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { useAngles } from "../../api/angle/useAngles";
+import { useHypotheses } from "../../api/hypothesis/useHypotheses";
+import { useUpdateHypothesisStatus } from "../../api/hypothesis/useUpdateHypothesisStatus";
+import type { Hypothesis } from "../../api/hypothesis/useHypothesisBoard";
+
+const statuses = ["ALL", "BACKLOG", "TESTING", "VALIDATED", "INVALIDATED"] as const;
+
+export default function HypothesisList() {
+  const [status, setStatus] = useState<string>("ALL");
+  const { data, isLoading } = useHypotheses(status);
+  const update = useUpdateHypothesisStatus();
+  const { data: angles } = useAngles();
+  const angleMap = new Map<number, string>(
+    Array.isArray(angles) ? angles.map((a) => [a.id, a.name]) : [],
+  );
+  const list = Array.isArray(data) ? data : [];
+
+  const changeStatus = async (h: Hypothesis, s: string) => {
+    if (s === h.status) return;
+    await update.mutateAsync({ id: h.id, status: s });
+  };
+
+  if (isLoading) return <p>Carregando...</p>;
+
+  return (
+    <div>
+      <div className="mb-3">
+        <select
+          className="form-select w-auto"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+        >
+          {statuses.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="table-responsive">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Título</th>
+              <th>Ângulo</th>
+              <th>Oferta</th>
+              <th>CPL</th>
+              <th>Status</th>
+              <th>Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.map((h) => (
+              <tr key={h.id}>
+                <td>{h.title}</td>
+                <td>{angleMap.get(h.premiseAngleId ?? 0)}</td>
+                <td>
+                  {h.offerType === "TRIPWIRE"
+                    ? `Tripwire R$ ${h.price ?? ""}`
+                    : "Lead Magnet"}
+                </td>
+                <td>{h.kpiTargetCpl}</td>
+                <td>
+                  <select
+                    className="form-select form-select-sm"
+                    value={h.status}
+                    onChange={(e) => changeStatus(h, e.target.value)}
+                  >
+                    {statuses
+                      .filter((s) => s !== "ALL")
+                      .map((s) => (
+                        <option key={s} value={s}>
+                          {s}
+                        </option>
+                      ))}
+                  </select>
+                </td>
+                <td>
+                  <button className="btn btn-sm btn-outline-primary me-1">
+                    Gerar Landing
+                  </button>
+                  <button className="btn btn-sm btn-outline-secondary me-1">
+                    Criar Criativo
+                  </button>
+                  <button className="btn btn-sm btn-outline-danger">Excluir</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/hypothesis/HypothesisListPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisListPage.tsx
@@ -1,0 +1,11 @@
+import PageTitle from "../../components/PageTitle";
+import HypothesisList from "./HypothesisList";
+
+export default function HypothesisListPage() {
+  return (
+    <div>
+      <PageTitle>Hipóteses</PageTitle>
+      <HypothesisList />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `useHypotheses` hook for GET /api/hypotheses
- allow `useUpdateHypothesisStatus` to be optional
- expose `price` in Hypothesis model
- create `<HypothesisList>` and page
- route `/hypotheses` to list page and keep board at `/hypotheses/board`

## Testing
- `npm run build`
- `npm run test`
- `mvn -s ../settings.xml test -q` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68810ce021d48321afa91ec014c34f31