### PR TITLE
Bugfix add nova hipótese button

### DIFF
--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,9 @@
+import { ButtonHTMLAttributes } from "react";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: string;
+}
+
+export default function Button({ className = "btn btn-primary", variant, ...props }: ButtonProps) {
+  return <button className={className} {...props} />;
+}

--- a/frontend/src/pages/hypothesis/HypothesesPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesesPage.tsx
@@ -3,15 +3,25 @@ import HypothesisBoard from "./HypothesisBoard";
 import NewHypothesisModal from "./NewHypothesisModal";
 import { useSearchParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
+import { useState } from "react";
+import Button from "../../components/ui/Button";
 
 export default function HypothesesPage() {
   const [params] = useSearchParams();
   const experimentId = params.get("experimentId") ?? "1";
   const { data } = useHypothesisBoard(experimentId);
+  const [open, setOpen] = useState(false);
   return (
     <div>
       <PageTitle>Hipóteses</PageTitle>
-      <NewHypothesisModal experimentId={experimentId} />
+      <div className="mb-3">
+        <Button onClick={() => setOpen(true)}>Nova Hipótese</Button>
+      </div>
+      <NewHypothesisModal
+        experimentId={experimentId}
+        open={open}
+        onOpenChange={setOpen}
+      />
       {data && <HypothesisBoard board={data} experimentId={experimentId} />}
     </div>
   );

--- a/frontend/src/pages/hypothesis/HypothesisList.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisList.tsx
@@ -3,11 +3,14 @@ import { useAngles } from "../../api/angle/useAngles";
 import { useHypotheses } from "../../api/hypothesis/useHypotheses";
 import { useUpdateHypothesisStatus } from "../../api/hypothesis/useUpdateHypothesisStatus";
 import type { Hypothesis } from "../../api/hypothesis/useHypothesisBoard";
+import NewHypothesisModal from "./NewHypothesisModal";
+import Button from "../../components/ui/Button";
 
 const statuses = ["ALL", "BACKLOG", "TESTING", "VALIDATED", "INVALIDATED"] as const;
 
 export default function HypothesisList() {
   const [status, setStatus] = useState<string>("ALL");
+  const [open, setOpen] = useState(false);
   const { data, isLoading } = useHypotheses(status);
   const update = useUpdateHypothesisStatus();
   const { data: angles } = useAngles();
@@ -38,6 +41,10 @@ export default function HypothesisList() {
           ))}
         </select>
       </div>
+      <div className="flex justify-end mb-3">
+        <Button onClick={() => setOpen(true)}>Nova Hipótese</Button>
+      </div>
+      <NewHypothesisModal open={open} onOpenChange={setOpen} />
       <div className="table-responsive">
         <table className="table">
           <thead>

--- a/frontend/src/pages/hypothesis/NewHypothesisModal.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+
 import axios from "axios";
 import { useAngles } from "../../api/angle/useAngles";
 import { useForm } from "react-hook-form";
@@ -36,11 +36,14 @@ type FormData = z.infer<typeof schema>;
 
 export default function NewHypothesisModal({
   experimentId,
+  open,
+  onOpenChange,
 }: {
   experimentId?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }) {
   const { data: angles } = useAngles();
-  const [open, setOpen] = useState(false);
   const {
     register,
     handleSubmit,
@@ -66,24 +69,21 @@ export default function NewHypothesisModal({
     }
     await axios.post("/api/hypotheses", body);
     reset({ offerType: "LEAD" });
-    setOpen(false);
+    onOpenChange(false);
   });
 
+  if (!open) return null;
+
   return (
-    <div className="mb-3">
-      <button className="btn btn-primary" onClick={() => setOpen(true)}>
-        Nova Hipótese
-      </button>
-      {open && (
-        <div className="modal d-block" tabIndex={-1}>
-          <div className="modal-dialog" style={{ maxWidth: 480 }}>
-            <form className="modal-content" onSubmit={onSubmit} noValidate>
+    <div className="modal d-block" tabIndex={-1}>
+      <div className="modal-dialog" style={{ maxWidth: 480 }}>
+        <form className="modal-content" onSubmit={onSubmit} noValidate>
               <div className="modal-header">
                 <h5 className="modal-title">Nova Hipótese</h5>
                 <button
                   type="button"
                   className="btn-close"
-                  onClick={() => setOpen(false)}
+                  onClick={() => onOpenChange(false)}
                 />
               </div>
               <div className="modal-body">
@@ -227,7 +227,7 @@ export default function NewHypothesisModal({
                 <button
                   type="button"
                   className="btn btn-outline-secondary"
-                  onClick={() => setOpen(false)}
+                  onClick={() => onOpenChange(false)}
                   disabled={isSubmitting}
                 >
                   Cancelar
@@ -243,7 +243,5 @@ export default function NewHypothesisModal({
             </form>
           </div>
         </div>
-      )}
-    </div>
-  );
+    );
 }


### PR DESCRIPTION
## Summary
- add `Button` component for UI consistency
- refactor `NewHypothesisModal` to be controlled by parent
- add new hypothesis button to `HypothesisList`
- adapt `HypothesesPage` to use the controlled modal

## Testing
- `npm run build`
- `npm run test`
- `mvn -s ../settings.xml deploy` *(fails: Network is unreachable)*
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml package` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6881778813fc8321a53d58f61d52a3fe