### PR TITLE
Fix duplicate Autowired in HypothesisServiceTest

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -28,7 +28,6 @@ class HypothesisServiceTest {
     @Autowired
     HypothesisService service;
     @Autowired
-    @Autowired
     MarketNicheRepository nicheRepository;
     @Autowired
     AngleRepository angleRepository;


### PR DESCRIPTION
## Summary
- remove duplicated `@Autowired` from `HypothesisServiceTest`

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM due to network)*
- `mvn -s settings.xml test` in `success-product-worker` *(fails: Non-resolvable parent POM due to network)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68823d4f9e5c8321b7a710aaa91dbe3f