### PR TITLE
Fix tests by requiring hypothesis

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -58,12 +58,12 @@ public class ExperimentService {
     @Transactional
     public Experiment create(Long nicheId, CreateExperimentRequest request) {
         MarketNiche niche = attachNiche(nicheId);
-        com.marketinghub.hypothesis.Hypothesis hyp = null;
-        if (request.getHypothesisId() != null) {
-            hyp = attachHypothesis(request.getHypothesisId());
-            if (!hyp.getMarketNiche().getId().equals(nicheId)) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "hypothesis and experiment niche mismatch");
-            }
+        if (request.getHypothesisId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "hypothesisId required");
+        }
+        com.marketinghub.hypothesis.Hypothesis hyp = attachHypothesis(request.getHypothesisId());
+        if (!hyp.getMarketNiche().getId().equals(nicheId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "hypothesis and experiment niche mismatch");
         }
         if (request.getStartDate() != null && request.getEndDate() != null &&
                 request.getStartDate().isAfter(request.getEndDate())) {
@@ -113,7 +113,10 @@ public class ExperimentService {
                 .niche(original.getNiche())
                 .name(original.getName() + " copy")
                 .hypothesis(original.getHypothesis())
+                .hypothesisRef(original.getHypothesisRef())
                 .kpiTarget(original.getKpiTarget())
+                .startDate(original.getStartDate())
+                .endDate(original.getEndDate())
                 .status(ExperimentStatus.PLANNED)
                 .platform(original.getPlatform())
                 .build();

--- a/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
@@ -3,6 +3,8 @@ package com.marketinghub;
 import com.marketinghub.creative.Creative;
 import com.marketinghub.creative.CreativeStatus;
 import com.marketinghub.creative.repository.CreativeRepository;
+import com.marketinghub.creative.label.repository.AngleRepository;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import com.marketinghub.experiment.*;
 import com.marketinghub.experiment.repository.*;
 import com.marketinghub.niche.MarketNiche;
@@ -21,6 +23,8 @@ public class FixtureUtils {
     private final ExperimentRepository experimentRepository;
     private final CreativeRepository creativeRepository;
     private final AdSetRepository adSetRepository;
+    private final com.marketinghub.creative.label.repository.AngleRepository angleRepository;
+    private final com.marketinghub.hypothesis.repository.HypothesisRepository hypothesisRepository;
 
     public MarketNiche createAndSaveNiche() {
         MarketNiche niche = MarketNiche.builder()
@@ -29,10 +33,25 @@ public class FixtureUtils {
         return nicheRepository.save(niche);
     }
 
+    public com.marketinghub.hypothesis.Hypothesis createAndSaveHypothesis(MarketNiche niche) {
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        com.marketinghub.hypothesis.Hypothesis h = com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("H")
+                .premiseAngle(angle)
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(java.math.BigDecimal.ONE)
+                .build();
+        return hypothesisRepository.save(h);
+    }
+
     public Experiment createAndSaveExperiment(MarketNiche niche) {
+        var hyp = createAndSaveHypothesis(niche);
         Experiment exp = Experiment.builder()
                 .niche(niche)
                 .name("Experiment")
+                .hypothesis("H")
+                .hypothesisRef(hyp)
                 .status(ExperimentStatus.PLANNED)
                 .platform(ExperimentPlatform.FACEBOOK)
                 .build();

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
@@ -9,6 +9,7 @@ import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import com.marketinghub.creative.label.repository.AngleRepository;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -29,12 +30,30 @@ class CreativeAngleIntegrationTest {
     MarketNicheRepository nicheRepository;
     @Autowired
     AngleRepository angleRepository;
+    @Autowired
+    HypothesisRepository hypothesisRepository;
 
     @Test
     void persistRelationships() {
         MarketNiche niche = MarketNiche.builder().name("N").build();
         nicheRepository.save(niche);
-        Experiment exp = Experiment.builder().niche(niche).name("E").status(com.marketinghub.experiment.ExperimentStatus.PLANNED).platform(com.marketinghub.experiment.ExperimentPlatform.FACEBOOK).build();
+        Angle base = angleRepository.save(Angle.builder().name("Base").build());
+        var hyp = com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("H")
+                .premiseAngle(base)
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(java.math.BigDecimal.ONE)
+                .build();
+        hyp = hypothesisRepository.save(hyp);
+        Experiment exp = Experiment.builder()
+                .niche(niche)
+                .name("E")
+                .hypothesis("H")
+                .hypothesisRef(hyp)
+                .status(com.marketinghub.experiment.ExperimentStatus.PLANNED)
+                .platform(com.marketinghub.experiment.ExperimentPlatform.FACEBOOK)
+                .build();
         experimentRepository.save(exp);
         Angle angle = Angle.builder().name("Ganho").build();
         angleRepository.save(angle);

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.creative.label.repository.AngleRepository;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -32,12 +34,25 @@ class ExperimentControllerTest {
     ObjectMapper mapper;
     @Autowired
     MarketNicheRepository nicheRepo;
+    @Autowired
+    AngleRepository angleRepository;
+    @Autowired
+    HypothesisRepository hypothesisRepository;
 
     @Test
     void postExperiment() throws Exception {
         MarketNiche niche = nicheRepo.save(MarketNiche.builder().name("Teste").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("H")
+                .premiseAngle(angle)
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setName("Exp1");
+        req.setHypothesisId(hyp.getId());
         req.setHypothesis("h");
         req.setKpiTarget(new BigDecimal("11"));
         mockMvc.perform(post("/api/niches/" + niche.getId() + "/experiments")
@@ -49,7 +64,16 @@ class ExperimentControllerTest {
     @Test
     void validationFail() throws Exception {
         MarketNiche niche = nicheRepo.save(MarketNiche.builder().name("Teste").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("H")
+                .premiseAngle(angle)
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
+        req.setHypothesisId(hyp.getId());
         req.setName("Exp1");
         req.setStartDate(java.time.LocalDate.of(2024,2,1));
         req.setEndDate(java.time.LocalDate.of(2024,1,1));

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -4,6 +4,8 @@ import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.creative.label.repository.AngleRepository;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,12 +28,25 @@ class ExperimentServiceTest {
     ExperimentService service;
     @Autowired
     MarketNicheRepository nicheRepository;
+    @Autowired
+    com.marketinghub.hypothesis.repository.HypothesisRepository hypothesisRepository;
+    @Autowired
+    com.marketinghub.creative.label.repository.AngleRepository angleRepository;
 
     @Test
     void createNewExperimentWithExistingNiche() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("T")
+                .premiseAngle(angle)
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
         req.setName("Exp1");
         req.setHypothesis("Teste");
         req.setKpiTarget(new BigDecimal("10"));
@@ -43,8 +58,17 @@ class ExperimentServiceTest {
     @Test
     void validateDates() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("T")
+                .premiseAngle(angle)
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
         req.setName("Exp1");
         req.setStartDate(java.time.LocalDate.of(2024,2,1));
         req.setEndDate(java.time.LocalDate.of(2024,1,1));

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -6,6 +6,8 @@ import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.creative.label.repository.AngleRepository;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import com.marketinghub.FixtureUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +47,10 @@ class ExperimentControllerTest {
     @Autowired
     private MarketNicheRepository nicheRepo;
     @Autowired
+    private AngleRepository angleRepository;
+    @Autowired
+    private HypothesisRepository hypothesisRepository;
+    @Autowired
     private com.marketinghub.creative.repository.CreativeRepository creativeRepo;
     @Autowired
     private FixtureUtils fixtures;
@@ -62,8 +68,17 @@ class ExperimentControllerTest {
 
     @Test
     void createEndpointPersists() throws Exception {
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(nicheRepo.findById(nicheId).orElseThrow())
+                .title("H")
+                .premiseAngle(angle)
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(BigDecimal.ONE)
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setName("Exp1");
+        req.setHypothesisId(hyp.getId());
         req.setHypothesis("H1");
         req.setKpiTarget(BigDecimal.TEN);
         req.setStartDate(LocalDate.now());


### PR DESCRIPTION
## Summary
- ensure Experiment creation requires a hypothesis
- copy hypothesis and dates when duplicating experiments
- extend FixtureUtils with helper to create Hypotheses
- adjust tests to provide hypothesis ids

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68823faccdc48321b35ec36f3daf5902