### PR TITLE
Ensure experiment relationships and add FK migrations

### DIFF
--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -73,6 +73,11 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>4.26.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/AdSetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/AdSetService.java
@@ -26,6 +26,11 @@ public class AdSetService {
     @Transactional
     public AdSet create(CreateAdSetRequest request) {
         Experiment exp = experimentRepository.findById(request.getExperimentId()).orElseThrow();
+        if (exp.getStatus() == ExperimentStatus.FINISHED || exp.getStatus() == ExperimentStatus.FAILED) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.BAD_REQUEST,
+                    "experiment not active");
+        }
         AdSet adSet = AdSet.builder()
                 .experiment(exp)
                 .location(request.getLocation())

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/CreativeVariantService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/CreativeVariantService.java
@@ -26,6 +26,11 @@ public class CreativeVariantService {
     @Transactional
     public CreativeVariant create(CreateCreativeRequest request) {
         Experiment exp = experimentRepository.findById(request.getExperimentId()).orElseThrow();
+        if (exp.getStatus() == ExperimentStatus.FINISHED || exp.getStatus() == ExperimentStatus.FAILED) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.BAD_REQUEST,
+                    "experiment not active");
+        }
         CreativeVariant creative = CreativeVariant.builder()
                 .experiment(exp)
                 .type(request.getType())

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -23,3 +23,4 @@ logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.orm.jdbc.bind=TRACE
 logging.level.org.hibernate.type=TRACE
 
+spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_audience_target.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_audience_target.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ad_set
+    MODIFY experiment_id BIGINT NOT NULL,
+    ADD CONSTRAINT fk_adset_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id);

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_creative.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_creative.sql
@@ -1,0 +1,3 @@
+ALTER TABLE creative_variants
+    MODIFY experiment_id BIGINT NOT NULL,
+    ADD CONSTRAINT fk_creative_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id);

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_hypothesis_to_experiment.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_hypothesis_to_experiment.sql
@@ -1,0 +1,3 @@
+ALTER TABLE experiment
+    MODIFY hypothesis_id BINARY(16) NOT NULL,
+    ADD CONSTRAINT fk_experiment_hypothesis FOREIGN KEY (hypothesis_id) REFERENCES hypothesis(id);

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_niche_to_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_niche_to_hypothesis.sql
@@ -1,0 +1,3 @@
+ALTER TABLE hypothesis
+    MODIFY market_niche_id BIGINT NOT NULL,
+    ADD CONSTRAINT fk_hypothesis_niche FOREIGN KEY (market_niche_id) REFERENCES market_niche(id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - include:
+      file: V2025_07_01__add_fk_niche_to_hypothesis.sql
+  - include:
+      file: V2025_07_01__add_fk_hypothesis_to_experiment.sql
+  - include:
+      file: V2025_07_01__add_fk_experiment_to_creative.sql
+  - include:
+      file: V2025_07_01__add_fk_experiment_to_audience_target.sql

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
@@ -1,0 +1,53 @@
+package com.marketinghub.experiment;
+
+import com.marketinghub.FixtureUtils;
+import com.marketinghub.experiment.dto.CreateAdSetRequest;
+import com.marketinghub.experiment.service.AdSetService;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create"
+})
+class AdSetServiceTest {
+    @Autowired
+    AdSetService service;
+    @Autowired
+    FixtureUtils fixtures;
+    @Autowired
+    MarketNicheRepository nicheRepository;
+    @Autowired
+    ExperimentRepository experimentRepository;
+
+    Long experimentId;
+
+    @BeforeEach
+    void setup() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("N").build());
+        Experiment exp = fixtures.createAndSaveExperiment(niche);
+        experimentId = exp.getId();
+    }
+
+    @Test
+    void rejectWhenExperimentFinished() {
+        Experiment exp = fixtures.createAndSaveExperiment(nicheRepository.findById(experimentId).orElseThrow());
+        exp.setStatus(ExperimentStatus.FINISHED);
+        experimentRepository.save(exp);
+        CreateAdSetRequest req = new CreateAdSetRequest();
+        req.setExperimentId(exp.getId());
+        assertThatThrownBy(() -> service.create(req))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
@@ -1,0 +1,54 @@
+package com.marketinghub.experiment;
+
+import com.marketinghub.FixtureUtils;
+import com.marketinghub.experiment.dto.CreateCreativeRequest;
+import com.marketinghub.experiment.service.CreativeVariantService;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create"
+})
+class CreativeVariantServiceTest {
+    @Autowired
+    CreativeVariantService service;
+    @Autowired
+    FixtureUtils fixtures;
+    @Autowired
+    MarketNicheRepository nicheRepository;
+    @Autowired
+    ExperimentRepository experimentRepository;
+
+    Long experimentId;
+
+    @BeforeEach
+    void setup() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("N").build());
+        Experiment exp = fixtures.createAndSaveExperiment(niche);
+        experimentId = exp.getId();
+    }
+
+    @Test
+    void rejectWhenExperimentFinished() {
+        Experiment exp = fixtures.createAndSaveExperiment(nicheRepository.findById(experimentId).orElseThrow());
+        exp.setStatus(ExperimentStatus.FINISHED);
+        experimentRepository.save(exp);
+        CreateCreativeRequest req = new CreateCreativeRequest();
+        req.setExperimentId(exp.getId());
+        assertThatThrownBy(() -> service.create(req))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -75,4 +75,24 @@ class ExperimentServiceTest {
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
+
+    @Test
+    void hypothesisAndNicheMustMatch() {
+        MarketNiche niche1 = nicheRepository.save(MarketNiche.builder().name("N1").build());
+        MarketNiche niche2 = nicheRepository.save(MarketNiche.builder().name("N2").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche1)
+                .title("T")
+                .premiseAngle(angle)
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        req.setMarketNicheId(niche2.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("Exp1");
+        assertThatThrownBy(() -> service.create(req))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+    }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -82,4 +82,15 @@ class HypothesisServiceTest {
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
+
+    @Test
+    void marketNicheIdRequired() {
+        CreateHypothesisRequest req = new CreateHypothesisRequest();
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        req.setTitle("T");
+        req.setPremiseAngleId(angle.getId());
+        req.setKpiTargetCpl(new BigDecimal("5"));
+        assertThatThrownBy(() -> service.create(req))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+    }
 }

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -29,7 +29,15 @@ export default function NewExperimentPage() {
         startDate: form.startDate || undefined,
         endDate: form.endDate || undefined,
       });
-      setForm({ nicheId: "", hypothesisId: "", name: "", hypothesis: "", kpiTarget: "", startDate: "", endDate: "" });
+      setForm({
+        nicheId: "",
+        hypothesisId: "",
+        name: "",
+        hypothesis: "",
+        kpiTarget: "",
+        startDate: "",
+        endDate: "",
+      });
       alert("Teste salvo!");
     } catch {
       alert("Erro ao salvar Teste");
@@ -42,7 +50,9 @@ export default function NewExperimentPage() {
       <select
         className="form-select mb-2"
         value={form.nicheId}
-        onChange={(e) => setForm({ ...form, nicheId: e.target.value, hypothesisId: "" })}
+        onChange={(e) =>
+          setForm({ ...form, nicheId: e.target.value, hypothesisId: "" })
+        }
       >
         <option value="">Selecione o Nicho</option>
         {Array.isArray(niches) &&
@@ -68,6 +78,15 @@ export default function NewExperimentPage() {
           <option value="">Não há hipóteses para este nicho</option>
         )}
       </select>
+      {Array.isArray(hypotheses) && hypotheses.length === 0 && (
+        <button
+          type="button"
+          className="btn btn-link mb-2"
+          onClick={() => (window.location.href = "/hypotheses?open=new")}
+        >
+          Criar nova hipótese
+        </button>
+      )}
       <input
         className="form-control mb-2"
         placeholder="Nome"

--- a/frontend/src/pages/hypothesis/HypothesesPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesesPage.tsx
@@ -10,14 +10,18 @@ export default function HypothesesPage() {
   const [params] = useSearchParams();
   const nicheId = params.get("nicheId") ?? "1";
   const { data } = useHypothesisBoard(nicheId);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(params.get("open") === "new");
   return (
     <div>
       <PageTitle>Hipóteses</PageTitle>
       <div className="mb-3">
         <Button onClick={() => setOpen(true)}>Nova Hipótese</Button>
       </div>
-      <NewHypothesisModal marketNicheId={nicheId} open={open} onOpenChange={setOpen} />
+      <NewHypothesisModal
+        marketNicheId={nicheId}
+        open={open}
+        onOpenChange={setOpen}
+      />
       {data && <HypothesisBoard board={data} nicheId={nicheId} />}
     </div>
   );


### PR DESCRIPTION
## Summary
- enforce active experiment check when creating creatives or ad sets
- add regression tests for experiment and hypothesis validation
- add Liquibase migration skeleton with foreign keys
- expose `open=new` query param to open hypothesis modal
- show button to create hypothesis in experiment form

## Testing
- `npm run test`
- `npm run build`
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68824449816483219271e58ba6458667