### PR TITLE
Fix liquibase syntax for H2

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_audience_target.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_audience_target.sql
@@ -1,3 +1,4 @@
 ALTER TABLE ad_set
-    MODIFY experiment_id BIGINT NOT NULL,
+    ALTER COLUMN experiment_id SET NOT NULL;
+ALTER TABLE ad_set
     ADD CONSTRAINT fk_adset_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id);

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_creative.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_creative.sql
@@ -1,3 +1,4 @@
 ALTER TABLE creative_variants
-    MODIFY experiment_id BIGINT NOT NULL,
+    ALTER COLUMN experiment_id SET NOT NULL;
+ALTER TABLE creative_variants
     ADD CONSTRAINT fk_creative_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id);

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_hypothesis_to_experiment.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_hypothesis_to_experiment.sql
@@ -1,3 +1,4 @@
 ALTER TABLE experiment
-    MODIFY hypothesis_id BINARY(16) NOT NULL,
+    ALTER COLUMN hypothesis_id SET NOT NULL;
+ALTER TABLE experiment
     ADD CONSTRAINT fk_experiment_hypothesis FOREIGN KEY (hypothesis_id) REFERENCES hypothesis(id);

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_niche_to_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_niche_to_hypothesis.sql
@@ -1,3 +1,4 @@
 ALTER TABLE hypothesis
-    MODIFY market_niche_id BIGINT NOT NULL,
+    ALTER COLUMN market_niche_id SET NOT NULL;
+ALTER TABLE hypothesis
     ADD CONSTRAINT fk_hypothesis_niche FOREIGN KEY (market_niche_id) REFERENCES market_niche(id);


### PR DESCRIPTION
## Summary
- update liquibase change sets to use `ALTER COLUMN ... SET NOT NULL`
  so tests can run with the H2 database

## Testing
- `mvn -s ../settings.xml test` *(fails: could not resolve Spring Boot parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_688266a8f71883219be62e5d337eb884