### PR TITLE
Disable liquibase in tests

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -21,7 +21,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 public class FacebookAccountControllerTest {
 

--- a/backend/ads-service/src/test/java/com/marketinghub/ai/AiServiceRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ai/AiServiceRepositoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
 
@@ -13,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
 class AiServiceRepositoryTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/AngleRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/AngleRepositoryTest.java
@@ -6,11 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
 class AngleRepositoryTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
 import java.util.Set;
 
@@ -21,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
 class CreativeAngleIntegrationTest {
     @Autowired
     CreativeRepository creativeRepository;

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/web/AngleControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/web/AngleControllerTest.java
@@ -20,7 +20,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 class AngleControllerTest {
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
@@ -31,7 +31,8 @@ import static org.mockito.Mockito.when;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 class CreativeServiceTest {
 

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
@@ -32,7 +32,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 class CreativeControllerTest {
 

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
@@ -19,7 +19,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 class AdSetServiceTest {
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
@@ -20,7 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 class CreativeVariantServiceTest {
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
@@ -25,7 +25,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 class ExperimentControllerTest {
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -21,7 +21,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 class ExperimentServiceTest {
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -34,7 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 class ExperimentControllerTest {
 

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -21,7 +21,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 @org.springframework.transaction.annotation.Transactional
 class HypothesisServiceTest {

--- a/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
@@ -6,11 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
 class AssetRepositoryTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/niche/MarketNicheRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/niche/MarketNicheRepositoryTest.java
@@ -6,11 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
 class MarketNicheRepositoryTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/product/ProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/ProductRepositoryTest.java
@@ -6,11 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
 class ProductRepositoryTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
@@ -6,11 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
 class SuccessProductRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- disable Liquibase during tests so that Hibernate-created schema can initialize in H2

## Testing
- `mvn -s ../settings.xml -q -Dtest=AdGeneratorServiceTest test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68826acd4e98832196e019bc16b5e3fb