### PR TITLE
Fix CreativeControllerTest cleanup

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
@@ -10,6 +10,7 @@ import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import com.marketinghub.FixtureUtils;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +49,8 @@ class CreativeControllerTest {
     @Autowired
     MarketNicheRepository marketNicheRepository;
     @Autowired
+    HypothesisRepository hypothesisRepository;
+    @Autowired
     FixtureUtils fixtures;
     @Autowired
     com.marketinghub.creative.label.repository.AngleRepository angleRepository;
@@ -62,6 +65,7 @@ class CreativeControllerTest {
     void setup() {
         repository.deleteAll();
         experimentRepository.deleteAll();
+        hypothesisRepository.deleteAll();
         marketNicheRepository.deleteAll();
         MarketNiche niche = fixtures.createAndSaveNiche();
         Experiment exp = fixtures.createAndSaveExperiment(niche);


### PR DESCRIPTION
## Summary
- ensure test teardown removes hypotheses linked to niches

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68826f403f6c8321aab06f5a6151072b