### PR TITLE
Fix tests setup and cleanup

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
@@ -33,17 +33,19 @@ class AdSetServiceTest {
     ExperimentRepository experimentRepository;
 
     Long experimentId;
+    Long nicheId;
 
     @BeforeEach
     void setup() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("N").build());
         Experiment exp = fixtures.createAndSaveExperiment(niche);
         experimentId = exp.getId();
+        nicheId = niche.getId();
     }
 
     @Test
     void rejectWhenExperimentFinished() {
-        Experiment exp = fixtures.createAndSaveExperiment(nicheRepository.findById(experimentId).orElseThrow());
+        Experiment exp = fixtures.createAndSaveExperiment(nicheRepository.findById(nicheId).orElseThrow());
         exp.setStatus(ExperimentStatus.FINISHED);
         experimentRepository.save(exp);
         CreateAdSetRequest req = new CreateAdSetRequest();

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
@@ -34,17 +34,19 @@ class CreativeVariantServiceTest {
     ExperimentRepository experimentRepository;
 
     Long experimentId;
+    Long nicheId;
 
     @BeforeEach
     void setup() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("N").build());
         Experiment exp = fixtures.createAndSaveExperiment(niche);
         experimentId = exp.getId();
+        nicheId = niche.getId();
     }
 
     @Test
     void rejectWhenExperimentFinished() {
-        Experiment exp = fixtures.createAndSaveExperiment(nicheRepository.findById(experimentId).orElseThrow());
+        Experiment exp = fixtures.createAndSaveExperiment(nicheRepository.findById(nicheId).orElseThrow());
         exp.setStatus(ExperimentStatus.FINISHED);
         experimentRepository.save(exp);
         CreateCreativeRequest req = new CreateCreativeRequest();

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -62,6 +62,8 @@ class ExperimentControllerTest {
     void cleanDb() {
         creativeRepo.deleteAll();
         repository.deleteAll();
+        hypothesisRepository.deleteAll();
+        angleRepository.deleteAll();
         nicheRepo.deleteAll();
         MarketNiche niche = fixtures.createAndSaveNiche();
         nicheId = niche.getId();


### PR DESCRIPTION
## Summary
- store the market niche id during ad set and creative variant tests
- clear hypothesis and angle tables before running ExperimentController tests

## Testing
- `mvn -s ../settings.xml -o test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml -o test` in `success-product-worker` *(fails: Non-resolvable parent POM)*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882722be1c88321a63cd87b832e50b4