### PR TITLE
Fix test fixtures for unique experiment names

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
@@ -47,9 +47,10 @@ public class FixtureUtils {
 
     public Experiment createAndSaveExperiment(MarketNiche niche) {
         var hyp = createAndSaveHypothesis(niche);
+        String name = "Experiment-" + java.util.UUID.randomUUID();
         Experiment exp = Experiment.builder()
                 .niche(niche)
-                .name("Experiment")
+                .name(name)
                 .hypothesis("H")
                 .hypothesisRef(hyp)
                 .status(ExperimentStatus.PLANNED)


### PR DESCRIPTION
## Summary
- avoid unique constraint violations when creating test experiments

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM, network unreachable)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6882858b7ccc83219f952d616cdd687e