### PR TITLE
Disable Liquibase during repository tests

### DIFF
--- a/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
@@ -18,7 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create"
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
 })
 class SuccessProductRepositoryTest {
 


### PR DESCRIPTION
## Summary
- disable Liquibase when running `SuccessProductRepositoryTest`

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68828af1bad48321a6f5484037701835