### PR TITLE
Fix Liquibase SQL syntax

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_audience_target.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_audience_target.sql
@@ -1,4 +1,4 @@
 ALTER TABLE ad_set
-    ALTER COLUMN experiment_id SET NOT NULL;
+    MODIFY experiment_id BIGINT NOT NULL;
 ALTER TABLE ad_set
     ADD CONSTRAINT fk_adset_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id);

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_creative.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_creative.sql
@@ -1,4 +1,4 @@
 ALTER TABLE creative_variants
-    ALTER COLUMN experiment_id SET NOT NULL;
+    MODIFY experiment_id BIGINT NOT NULL;
 ALTER TABLE creative_variants
     ADD CONSTRAINT fk_creative_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id);

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_hypothesis_to_experiment.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_hypothesis_to_experiment.sql
@@ -1,4 +1,4 @@
 ALTER TABLE experiment
-    ALTER COLUMN hypothesis_id SET NOT NULL;
+    MODIFY hypothesis_id BINARY(16) NOT NULL;
 ALTER TABLE experiment
     ADD CONSTRAINT fk_experiment_hypothesis FOREIGN KEY (hypothesis_id) REFERENCES hypothesis(id);

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_niche_to_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_niche_to_hypothesis.sql
@@ -1,4 +1,4 @@
 ALTER TABLE hypothesis
-    ALTER COLUMN market_niche_id SET NOT NULL;
+    MODIFY market_niche_id BIGINT NOT NULL;
 ALTER TABLE hypothesis
     ADD CONSTRAINT fk_hypothesis_niche FOREIGN KEY (market_niche_id) REFERENCES market_niche(id);


### PR DESCRIPTION
## Summary
- fix MySQL syntax in Liquibase changelog SQL files

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s ../settings.xml -q spotless:apply` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68835a4913b48321abd9b1dc58b97264