### PR TITLE
Enable Liquibase in tests with MySQL mode

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -18,11 +18,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 public class FacebookAccountControllerTest {
 

--- a/backend/ads-service/src/test/java/com/marketinghub/ai/AiServiceRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ai/AiServiceRepositoryTest.java
@@ -14,7 +14,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=true"
+})
 class AiServiceRepositoryTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/AngleRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/AngleRepositoryTest.java
@@ -12,7 +12,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=true"
+})
 class AngleRepositoryTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
@@ -22,7 +22,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=true"
+})
 class CreativeAngleIntegrationTest {
     @Autowired
     CreativeRepository creativeRepository;

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/web/AngleControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/web/AngleControllerTest.java
@@ -17,11 +17,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = AdsServiceApplication.class)
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 class AngleControllerTest {
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
@@ -28,11 +28,11 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = AdsServiceApplication.class)
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 class CreativeServiceTest {
 

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
@@ -30,11 +30,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = AdsServiceApplication.class)
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 class CreativeControllerTest {
 

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
@@ -16,11 +16,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 class AdSetServiceTest {
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
@@ -17,11 +17,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 class CreativeVariantServiceTest {
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
@@ -22,11 +22,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 class ExperimentControllerTest {
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -18,11 +18,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 class ExperimentServiceTest {
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -31,11 +31,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(classes = AdsServiceApplication.class)
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 class ExperimentControllerTest {
 

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -18,11 +18,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 @org.springframework.transaction.annotation.Transactional
 class HypothesisServiceTest {

--- a/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
@@ -12,7 +12,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=true"
+})
 class AssetRepositoryTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/niche/MarketNicheRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/niche/MarketNicheRepositoryTest.java
@@ -12,7 +12,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=true"
+})
 class MarketNicheRepositoryTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/product/ProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/ProductRepositoryTest.java
@@ -12,7 +12,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=true"
+})
 class ProductRepositoryTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
@@ -12,7 +12,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=true"
+})
 class SuccessProductRepositoryTest {
 
     @Autowired

--- a/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
@@ -15,11 +15,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EntityScan("com.marketinghub.ads")
 @ContextConfiguration(classes = SuccessProductWorkerApplication.class)
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
+        "spring.liquibase.enabled=true"
 })
 class SuccessProductRepositoryTest {
 


### PR DESCRIPTION
## Summary
- update integration tests to run Liquibase
- use H2 in MySQL compatibility mode for testing

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68836313d74c8321a568a533cce01926