### PR TITLE
Enable MySQL test containers

### DIFF
--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -65,6 +65,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import com.marketinghub.test.MySqlContainerBase;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.stream.IntStream;
@@ -17,14 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
-public class FacebookAccountControllerTest {
+public class FacebookAccountControllerTest extends MySqlContainerBase {
 
     @Autowired
     MockMvc mockMvc;

--- a/backend/ads-service/src/test/java/com/marketinghub/ai/AiServiceRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ai/AiServiceRepositoryTest.java
@@ -6,16 +6,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import com.marketinghub.test.MySqlContainerBase;
 
 import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
-class AiServiceRepositoryTest {
+class AiServiceRepositoryTest extends MySqlContainerBase {
 
     @Autowired
     AiServiceRepository repository;

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/AngleRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/AngleRepositoryTest.java
@@ -6,14 +6,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import com.marketinghub.test.MySqlContainerBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
-class AngleRepositoryTest {
+class AngleRepositoryTest extends MySqlContainerBase {
 
     @Autowired
     AngleRepository repository;

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
@@ -14,16 +14,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import com.marketinghub.test.MySqlContainerBase;
 
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
-class CreativeAngleIntegrationTest {
+class CreativeAngleIntegrationTest extends MySqlContainerBase {
     @Autowired
     CreativeRepository creativeRepository;
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/web/AngleControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/web/AngleControllerTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
+import com.marketinghub.test.MySqlContainerBase;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -16,14 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(classes = AdsServiceApplication.class)
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
-class AngleControllerTest {
+class AngleControllerTest extends MySqlContainerBase {
     @Autowired
     MockMvc mockMvc;
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import com.marketinghub.test.MySqlContainerBase;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.net.http.HttpClient;
@@ -27,14 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
-class CreativeServiceTest {
+class CreativeServiceTest extends MySqlContainerBase {
 
     @Autowired
     CreativeRepository repository;

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
+import com.marketinghub.test.MySqlContainerBase;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,14 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SpringBootTest(classes = AdsServiceApplication.class)
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
-class CreativeControllerTest {
+class CreativeControllerTest extends MySqlContainerBase {
 
     @Autowired
     MockMvc mockMvc;

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
@@ -10,19 +10,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import com.marketinghub.test.MySqlContainerBase;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
-class AdSetServiceTest {
+class AdSetServiceTest extends MySqlContainerBase {
     @Autowired
     AdSetService service;
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
@@ -10,20 +10,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import com.marketinghub.test.MySqlContainerBase;
 
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
-class CreativeVariantServiceTest {
+class CreativeVariantServiceTest extends MySqlContainerBase {
     @Autowired
     CreativeVariantService service;
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
+import com.marketinghub.test.MySqlContainerBase;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
@@ -21,14 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
-class ExperimentControllerTest {
+class ExperimentControllerTest extends MySqlContainerBase {
     @Autowired
     MockMvc mockMvc;
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -9,7 +9,7 @@ import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import com.marketinghub.test.MySqlContainerBase;
 
 import java.math.BigDecimal;
 
@@ -17,14 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
-class ExperimentServiceTest {
+class ExperimentServiceTest extends MySqlContainerBase {
     @Autowired
     ExperimentService service;
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -16,7 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.context.TestPropertySource;
+import com.marketinghub.test.MySqlContainerBase;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -30,14 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest(classes = AdsServiceApplication.class)
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
-class ExperimentControllerTest {
+class ExperimentControllerTest extends MySqlContainerBase {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -9,7 +9,7 @@ import com.marketinghub.niche.repository.MarketNicheRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
+import com.marketinghub.test.MySqlContainerBase;
 
 import java.math.BigDecimal;
 
@@ -17,15 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
 @org.springframework.transaction.annotation.Transactional
-class HypothesisServiceTest {
+class HypothesisServiceTest extends MySqlContainerBase {
     @Autowired
     HypothesisService service;
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
@@ -6,14 +6,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import com.marketinghub.test.MySqlContainerBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
-class AssetRepositoryTest {
+class AssetRepositoryTest extends MySqlContainerBase {
 
     @Autowired
     AssetRepository repository;

--- a/backend/ads-service/src/test/java/com/marketinghub/niche/MarketNicheRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/niche/MarketNicheRepositoryTest.java
@@ -6,14 +6,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import com.marketinghub.test.MySqlContainerBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
-class MarketNicheRepositoryTest {
+class MarketNicheRepositoryTest extends MySqlContainerBase {
 
     @Autowired
     MarketNicheRepository repository;

--- a/backend/ads-service/src/test/java/com/marketinghub/product/ProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/product/ProductRepositoryTest.java
@@ -6,14 +6,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import com.marketinghub.test.MySqlContainerBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
-class ProductRepositoryTest {
+class ProductRepositoryTest extends MySqlContainerBase {
 
     @Autowired
     ProductRepository repository;

--- a/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
@@ -6,14 +6,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import com.marketinghub.test.MySqlContainerBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(classes = AdsServiceApplication.class)
-@TestPropertySource(properties = "spring.liquibase.enabled=false")
-class SuccessProductRepositoryTest {
+class SuccessProductRepositoryTest extends MySqlContainerBase {
 
     @Autowired
     SuccessProductRepository repository;

--- a/backend/ads-service/src/test/java/com/marketinghub/test/MySqlContainerBase.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/test/MySqlContainerBase.java
@@ -1,0 +1,26 @@
+package com.marketinghub.test;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class MySqlContainerBase {
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:5.7")
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void mysqlProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+    }
+}
+

--- a/success-product-worker/pom.xml
+++ b/success-product-worker/pom.xml
@@ -82,6 +82,18 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
@@ -6,22 +6,17 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import com.marketinghub.worker.test.MySqlContainerBase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ImportAutoConfiguration
 @EntityScan("com.marketinghub.ads")
 @ContextConfiguration(classes = SuccessProductWorkerApplication.class)
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.jpa.hibernate.ddl-auto=create",
-        "spring.liquibase.enabled=false"
-})
-class SuccessProductRepositoryTest {
+class SuccessProductRepositoryTest extends MySqlContainerBase {
 
     @Autowired
     SuccessProductRepository repository;

--- a/success-product-worker/src/test/java/com/marketinghub/worker/test/MySqlContainerBase.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/test/MySqlContainerBase.java
@@ -1,0 +1,26 @@
+package com.marketinghub.worker.test;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class MySqlContainerBase {
+    @Container
+    static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:5.7")
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void mysqlProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Testcontainers dependencies
- start a MySQL 5.7 container for integration tests
- run Liquibase migrations during tests

## Testing
- `mvn -o -s /tmp/m2-settings.xml test` *(fails: artifact org.testcontainers:mysql not pre-downloaded)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836313d74c8321a568a533cce01926