### PR TITLE
Add precondition for hypothesis table

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_23__create_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_23__create_hypothesis.sql
@@ -1,5 +1,7 @@
 -- liquibase formatted sql
 -- changeset marketinghub:2025-07-23-create-hypothesis
+-- preconditions onFail=MARK_RAN
+--     not tableExists tableName: hypothesis
 CREATE TABLE hypothesis (
     id BINARY(16) PRIMARY KEY,
     experiment_id BIGINT NOT NULL,


### PR DESCRIPTION
## Summary
- avoid errors when `hypothesis` table already exists

## Testing
- `npm run test`
- `npm run build`
- `mvn -s ../settings.xml test` *(fails: Could not resolve parent POM)*
- `mvn -s settings.xml test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6883a26049308321acf56b4c199d1377