### PR TITLE
Fix Liquibase preconditions and validate in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,6 +46,15 @@ jobs:
       - name: Rodar testes
         run: mvn -B test
 
+      - name: Validar changelogs Liquibase
+        run: |
+          mvn -B \
+            org.liquibase:liquibase-maven-plugin:4.26.0:validate \
+            -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml \
+            -Dliquibase.url=jdbc:h2:mem:validate \
+            -Dliquibase.username=sa \
+            -Dliquibase.password=
+
       - name: Build backend
         run: mvn -B -s ../settings.xml package -DskipTests
 

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_23__create_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_23__create_hypothesis.sql
@@ -1,7 +1,10 @@
+-- Creates table to store experiment hypotheses
 -- liquibase formatted sql
 -- changeset marketinghub:2025-07-23-create-hypothesis
--- preconditions onFail=MARK_RAN
---     not tableExists tableName: hypothesis
+--preconditions onFail:MARK_RAN
+--    <not>
+--        <tableExists tableName="hypothesis"/>
+--    </not>
 CREATE TABLE hypothesis (
     id BINARY(16) PRIMARY KEY,
     experiment_id BIGINT NOT NULL,


### PR DESCRIPTION
## Summary
- add header comment and proper precondition markup to `V2025_07_23__create_hypothesis.sql`
- run `liquibase validate` during backend build

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` in worker *(fails: Non-resolvable parent POM)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b0d254708321b81850630402c944