### PR TITLE
Fix Liquibase script for hypothesis table

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_23__create_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_23__create_hypothesis.sql
@@ -5,7 +5,7 @@
 --    <not>
 --        <tableExists tableName="hypothesis"/>
 --    </not>
-CREATE TABLE hypothesis (
+CREATE TABLE IF NOT EXISTS hypothesis (
     id BINARY(16) PRIMARY KEY,
     experiment_id BIGINT NOT NULL,
     title VARCHAR(255) NOT NULL,


### PR DESCRIPTION
## Summary
- avoid liquibase failures when hypothesis table already exists by using `CREATE TABLE IF NOT EXISTS`

## Testing
- `../mvnw -s ../settings.xml test` *(fails: could not resolve Spring Boot parent POM)*
- `mvn -s settings.xml test` *(fails: could not resolve Spring Boot parent POM)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6883b60ab8d883218e47d9b923f62779