### PR TITLE
Fix Liquibase migrations when column already exists

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_hypothesis_to_experiment.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_hypothesis_to_experiment.sql
@@ -1,5 +1,9 @@
 -- liquibase formatted sql
 -- changeset marketinghub:2025-07-24-add-fk-hypothesis-to-experiment
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <columnExists tableName="experiment" columnName="hypothesis_id"/>
+--    </not>
 ALTER TABLE experiment ADD COLUMN hypothesis_id BINARY(16) NOT NULL;
 ALTER TABLE experiment
     ADD CONSTRAINT fk_experiment_hypothesis FOREIGN KEY (hypothesis_id) REFERENCES hypothesis(id);

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_niche_to_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_niche_to_hypothesis.sql
@@ -1,5 +1,9 @@
 -- liquibase formatted sql
 -- changeset marketinghub:2025-07-24-add-fk-niche-to-hypothesis
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <columnExists tableName="hypothesis" columnName="market_niche_id"/>
+--    </not>
 ALTER TABLE hypothesis ADD COLUMN market_niche_id BIGINT NOT NULL;
 ALTER TABLE hypothesis
     ADD CONSTRAINT fk_hypothesis_niche FOREIGN KEY (market_niche_id) REFERENCES market_niche(id);


### PR DESCRIPTION
## Summary
- add preconditions to skip FK migrations if the columns already exist

## Testing
- `mvn -s ../settings.xml test` *(failed: Could not resolve dependencies)*
- `mvn -s settings.xml test` in `success-product-worker` *(failed: Could not resolve dependencies)*
- `npm install`
- `npm test` *(passed but required manual termination)*

------
https://chatgpt.com/codex/tasks/task_e_6883c10b777c8321a159d1503ad9d7b9