### PR TITLE
Fix precondition for Liquibase migration

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_hypothesis_to_experiment.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_hypothesis_to_experiment.sql
@@ -1,11 +1,9 @@
 -- liquibase formatted sql
 -- changeset marketinghub:2025-07-24-add-fk-hypothesis-to-experiment
 -- preconditions onFail:MARK_RAN onError:HALT
---   sql-check expectedResult:0 SELECT COUNT(*) 
---     FROM INFORMATION_SCHEMA.COLUMNS
---     WHERE TABLE_SCHEMA='marketinghubdb'
---       AND TABLE_NAME='experiment'
---       AND COLUMN_NAME='hypothesis_id';
+--    <not>
+--        <columnExists tableName="experiment" columnName="hypothesis_id"/>
+--    </not>
 
 ALTER TABLE experiment ADD COLUMN hypothesis_id BINARY(16) NOT NULL;
 


### PR DESCRIPTION
## Summary
- adjust Liquibase precondition so migration is skipped when column already exists

## Testing
- `mvn -s ../settings.xml -q spotless:apply` *(fails: Non-resolvable parent POM)*
- `mvn -s ../settings.xml -q test` *(fails: Non-resolvable parent POM)*
- `mvn -s ../settings.xml -q package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6883c8542c548321a8e8d9fca9081505