### PR TITLE
Fix liquibase sql precondition

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_hypothesis_to_experiment.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_hypothesis_to_experiment.sql
@@ -2,25 +2,14 @@
 
 --changeset marketinghub:2025-07-24-col
 --preconditions onFail:MARK_RAN onError:HALT
---precondition-sql-check expectedResult:0
--- SELECT COUNT(*) 
---   FROM INFORMATION_SCHEMA.COLUMNS
---  WHERE TABLE_SCHEMA = DATABASE()
---    AND TABLE_NAME   = 'experiment'
---    AND COLUMN_NAME  = 'hypothesis_id';
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'hypothesis_id';
 
 ALTER TABLE experiment
   ADD COLUMN hypothesis_id BINARY(16) NOT NULL;
 
 --changeset marketinghub:2025-07-24-fk
 --preconditions onFail:MARK_RAN onError:HALT
---precondition-sql-check expectedResult:0
--- SELECT COUNT(*)
---   FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
---  WHERE CONSTRAINT_SCHEMA = DATABASE()
---    AND TABLE_NAME        = 'experiment'
---    AND CONSTRAINT_NAME   = 'fk_experiment_hypothesis'
---    AND CONSTRAINT_TYPE   = 'FOREIGN KEY';
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND CONSTRAINT_NAME = 'fk_experiment_hypothesis' AND CONSTRAINT_TYPE = 'FOREIGN KEY';
 
 ALTER TABLE experiment
   ADD CONSTRAINT fk_experiment_hypothesis


### PR DESCRIPTION
## Summary
- correct Liquibase `precondition-sql-check` format in hypothesis changelog

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6883f7a4168483219d686865ab6de9ca