### PR TITLE
Add preconditions to skip existing FK constraints

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_hypothesis_to_experiment.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_hypothesis_to_experiment.sql
@@ -1,5 +1,7 @@
 -- liquibase formatted sql
 -- changeset marketinghub:2025-07-01-add-fk-hypothesis-to-experiment
+--preconditions onFail:MARK_RAN onError:HALT
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND CONSTRAINT_NAME = 'fk_experiment_hypothesis' AND CONSTRAINT_TYPE = 'FOREIGN KEY';
 ALTER TABLE experiment
     MODIFY hypothesis_id BINARY(16) NOT NULL;
 ALTER TABLE experiment

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_niche_to_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_niche_to_hypothesis.sql
@@ -1,5 +1,7 @@
 -- liquibase formatted sql
 -- changeset marketinghub:2025-07-01-add-fk-niche-to-hypothesis
+--preconditions onFail:MARK_RAN onError:HALT
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'hypothesis' AND CONSTRAINT_NAME = 'fk_hypothesis_niche' AND CONSTRAINT_TYPE = 'FOREIGN KEY';
 ALTER TABLE hypothesis
     MODIFY market_niche_id BIGINT NOT NULL;
 ALTER TABLE hypothesis


### PR DESCRIPTION
## Summary
- avoid duplicate Liquibase foreign key creation by adding preconditions

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68840b88483883218174b201ec88ec0c