### PR TITLE
Fix FK migrations for duplicate index errors

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_hypothesis_to_experiment.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_hypothesis_to_experiment.sql
@@ -2,6 +2,7 @@
 -- changeset marketinghub:2025-07-01-add-fk-hypothesis-to-experiment
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND CONSTRAINT_NAME = 'fk_experiment_hypothesis' AND CONSTRAINT_TYPE = 'FOREIGN KEY';
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND INDEX_NAME = 'fk_experiment_hypothesis';
 ALTER TABLE experiment
     MODIFY hypothesis_id BINARY(16) NOT NULL;
 ALTER TABLE experiment

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_niche_to_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_niche_to_hypothesis.sql
@@ -2,6 +2,7 @@
 -- changeset marketinghub:2025-07-01-add-fk-niche-to-hypothesis
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'hypothesis' AND CONSTRAINT_NAME = 'fk_hypothesis_niche' AND CONSTRAINT_TYPE = 'FOREIGN KEY';
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'hypothesis' AND INDEX_NAME = 'fk_hypothesis_niche';
 ALTER TABLE hypothesis
     MODIFY market_niche_id BIGINT NOT NULL;
 ALTER TABLE hypothesis

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_hypothesis_to_experiment.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_hypothesis_to_experiment.sql
@@ -10,6 +10,7 @@ ALTER TABLE experiment
 --changeset marketinghub:2025-07-24-fk
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND CONSTRAINT_NAME = 'fk_experiment_hypothesis' AND CONSTRAINT_TYPE = 'FOREIGN KEY';
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND INDEX_NAME = 'fk_experiment_hypothesis';
 
 ALTER TABLE experiment
   ADD CONSTRAINT fk_experiment_hypothesis

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_niche_to_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_24__add_fk_niche_to_hypothesis.sql
@@ -5,5 +5,8 @@
 --        <columnExists tableName="hypothesis" columnName="market_niche_id"/>
 --    </not>
 ALTER TABLE hypothesis ADD COLUMN market_niche_id BIGINT NOT NULL;
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'hypothesis' AND CONSTRAINT_NAME = 'fk_hypothesis_niche' AND CONSTRAINT_TYPE = 'FOREIGN KEY';
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'hypothesis' AND INDEX_NAME = 'fk_hypothesis_niche';
 ALTER TABLE hypothesis
     ADD CONSTRAINT fk_hypothesis_niche FOREIGN KEY (market_niche_id) REFERENCES market_niche(id);


### PR DESCRIPTION
## Summary
- prevent FK migrations from creating duplicate indexes

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not resolve parent POM)*
- `mvn -s settings.xml test` in success-product-worker *(fails: Could not resolve parent POM)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841afd7f708321a52ff76974f0907f