### PR TITLE
Add new validation fields for hypotheses and experiments

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -38,6 +38,16 @@ public class Experiment {
     private com.marketinghub.hypothesis.Hypothesis hypothesisRef;
 
     private java.math.BigDecimal kpiTarget;
+    /** Stop-loss operacional em CPL. */
+    @Column(precision = 7, scale = 2)
+    private java.math.BigDecimal stopLossCpl;
+
+    /** Tamanho de amostra desejado para o experimento. */
+    private Integer sampleSize;
+
+    /** MDE (Minimum Detectable Effect) percentual. */
+    @Column(precision = 5, scale = 2)
+    private java.math.BigDecimal mde;
     private LocalDate startDate;
     private LocalDate endDate;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
@@ -14,6 +14,9 @@ public class CreateExperimentRequest {
     private String name;
     private String hypothesis;
     private BigDecimal kpiTarget;
+    private BigDecimal stopLossCpl;
+    private Integer sampleSize;
+    private BigDecimal mde;
     private LocalDate startDate;
     private LocalDate endDate;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -18,6 +18,9 @@ public class ExperimentDto {
     private String name;
     private String hypothesis;
     private BigDecimal kpiTarget;
+    private BigDecimal stopLossCpl;
+    private Integer sampleSize;
+    private BigDecimal mde;
     private LocalDate startDate;
     private LocalDate endDate;
     private ExperimentStatus status;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -72,12 +72,21 @@ public class ExperimentService {
         if (repository.existsByNicheAndName(niche, request.getName())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name already exists for niche");
         }
+        if (request.getStopLossCpl() != null && request.getStopLossCpl().compareTo(java.math.BigDecimal.ZERO) <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "stopLossCpl must be positive");
+        }
+        if (request.getSampleSize() != null && request.getSampleSize() <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "sampleSize must be positive");
+        }
         Experiment exp = Experiment.builder()
                 .niche(niche)
                 .name(request.getName())
                 .hypothesis(request.getHypothesis())
                 .hypothesisRef(hyp)
                 .kpiTarget(request.getKpiTarget())
+                .stopLossCpl(request.getStopLossCpl())
+                .sampleSize(request.getSampleSize())
+                .mde(request.getMde())
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
                 .status(ExperimentStatus.PLANNED)
@@ -115,6 +124,9 @@ public class ExperimentService {
                 .hypothesis(original.getHypothesis())
                 .hypothesisRef(original.getHypothesisRef())
                 .kpiTarget(original.getKpiTarget())
+                .stopLossCpl(original.getStopLossCpl())
+                .sampleSize(original.getSampleSize())
+                .mde(original.getMde())
                 .startDate(original.getStartDate())
                 .endDate(original.getEndDate())
                 .status(ExperimentStatus.PLANNED)

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -34,6 +34,22 @@ public class Hypothesis {
     @JoinColumn(name = "premise_angle_id", nullable = false)
     private Angle premiseAngle;
 
+    /** Promessa de valor em até 140 caracteres. */
+    @Column(nullable = false, length = 140)
+    private String promise;
+
+    /** Problema ou insight do cliente em uma frase. */
+    @Column(nullable = false)
+    private String problem;
+
+    /** Persona alvo dentro do nicho. */
+    @Column(nullable = false)
+    private String persona;
+
+    /** Regra de sucesso que define se a hipótese será validada. */
+    @Lob
+    private String successRule;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private OfferType offerType;

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
@@ -6,6 +6,10 @@ public class CreateHypothesisRequest {
     private Long marketNicheId;
     private String title;
     private Long premiseAngleId;
+    private String promise;
+    private String problem;
+    private String persona;
+    private String successRule;
     private String offerType;
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;
@@ -17,6 +21,14 @@ public class CreateHypothesisRequest {
     public void setTitle(String title) { this.title = title; }
     public Long getPremiseAngleId() { return premiseAngleId; }
     public void setPremiseAngleId(Long premiseAngleId) { this.premiseAngleId = premiseAngleId; }
+    public String getPromise() { return promise; }
+    public void setPromise(String promise) { this.promise = promise; }
+    public String getProblem() { return problem; }
+    public void setProblem(String problem) { this.problem = problem; }
+    public String getPersona() { return persona; }
+    public void setPersona(String persona) { this.persona = persona; }
+    public String getSuccessRule() { return successRule; }
+    public void setSuccessRule(String successRule) { this.successRule = successRule; }
     public String getOfferType() { return offerType; }
     public void setOfferType(String offerType) { this.offerType = offerType; }
     public BigDecimal getPrice() { return price; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
@@ -13,6 +13,10 @@ public class HypothesisDto {
     private Long marketNicheId;
     private String title;
     private Long premiseAngleId;
+    private String promise;
+    private String problem;
+    private String persona;
+    private String successRule;
     private OfferType offerType;
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -57,6 +57,21 @@ public class HypothesisService {
         if (req.getPremiseAngleId() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "angle required");
         }
+        if (req.getPromise() == null || req.getPromise().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promise required");
+        }
+        if (req.getPromise().length() > 140) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promise too long");
+        }
+        if (req.getProblem() == null || req.getProblem().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "problem required");
+        }
+        if (req.getPersona() == null || req.getPersona().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "persona required");
+        }
+        if (req.getSuccessRule() == null || req.getSuccessRule().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "successRule required");
+        }
         if (req.getKpiTargetCpl() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "kpiTargetCpl required");
         }
@@ -72,6 +87,10 @@ public class HypothesisService {
                 .marketNiche(attachNiche(req.getMarketNicheId()))
                 .title(req.getTitle())
                 .premiseAngle(attachAngle(req.getPremiseAngleId()))
+                .promise(req.getPromise())
+                .problem(req.getProblem())
+                .persona(req.getPersona())
+                .successRule(req.getSuccessRule())
                 .offerType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()))
                 .price(req.getPrice())
                 .kpiTargetCpl(req.getKpiTargetCpl())

--- a/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
@@ -39,6 +39,10 @@ public class FixtureUtils {
                 .marketNiche(niche)
                 .title("H")
                 .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .successRule("Regra")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(java.math.BigDecimal.ONE)
                 .build();

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
@@ -56,6 +56,9 @@ class ExperimentControllerTest {
         req.setHypothesisId(hyp.getId());
         req.setHypothesis("h");
         req.setKpiTarget(new BigDecimal("11"));
+        req.setStopLossCpl(new BigDecimal("22"));
+        req.setSampleSize(100);
+        req.setMde(new BigDecimal("10"));
         mockMvc.perform(post("/api/niches/" + niche.getId() + "/experiments")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(req)))
@@ -76,6 +79,9 @@ class ExperimentControllerTest {
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setHypothesisId(hyp.getId());
         req.setName("Exp1");
+        req.setStopLossCpl(new BigDecimal("22"));
+        req.setSampleSize(100);
+        req.setMde(new BigDecimal("10"));
         req.setStartDate(java.time.LocalDate.of(2024,2,1));
         req.setEndDate(java.time.LocalDate.of(2024,1,1));
         mockMvc.perform(post("/api/niches/" + niche.getId() + "/experiments")

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -51,6 +51,9 @@ class ExperimentServiceTest {
         req.setName("Exp1");
         req.setHypothesis("Teste");
         req.setKpiTarget(new BigDecimal("10"));
+        req.setStopLossCpl(new BigDecimal("20"));
+        req.setSampleSize(100);
+        req.setMde(new BigDecimal("10"));
         var exp = service.create(req);
         assertThat(exp.getId()).isNotNull();
         assertThat(exp.getPlatform()).isEqualTo(ExperimentPlatform.FACEBOOK);
@@ -71,6 +74,9 @@ class ExperimentServiceTest {
         req.setMarketNicheId(niche.getId());
         req.setHypothesisId(hyp.getId());
         req.setName("Exp1");
+        req.setStopLossCpl(new BigDecimal("20"));
+        req.setSampleSize(100);
+        req.setMde(new BigDecimal("10"));
         req.setStartDate(java.time.LocalDate.of(2024,2,1));
         req.setEndDate(java.time.LocalDate.of(2024,1,1));
         assertThatThrownBy(() -> service.create(req))
@@ -93,6 +99,9 @@ class ExperimentServiceTest {
         req.setMarketNicheId(niche2.getId());
         req.setHypothesisId(hyp.getId());
         req.setName("Exp1");
+        req.setStopLossCpl(new BigDecimal("20"));
+        req.setSampleSize(100);
+        req.setMde(new BigDecimal("10"));
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -84,6 +84,9 @@ class ExperimentControllerTest {
         req.setHypothesisId(hyp.getId());
         req.setHypothesis("H1");
         req.setKpiTarget(BigDecimal.TEN);
+        req.setStopLossCpl(new BigDecimal("20"));
+        req.setSampleSize(100);
+        req.setMde(new BigDecimal("10"));
         req.setStartDate(LocalDate.now());
         req.setEndDate(LocalDate.now().plusDays(5));
 

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -43,6 +43,10 @@ class HypothesisServiceTest {
         req.setMarketNicheId(niche.getId());
         req.setTitle("Teste");
         req.setPremiseAngleId(angle.getId());
+        req.setPromise("Promessa");
+        req.setProblem("Problema");
+        req.setPersona("Persona");
+        req.setSuccessRule("Regra");
         req.setOfferType("LEAD");
         req.setKpiTargetCpl(new BigDecimal("5"));
         Hypothesis h = service.create(req);
@@ -56,6 +60,10 @@ class HypothesisServiceTest {
         CreateHypothesisRequest req = new CreateHypothesisRequest();
         req.setMarketNicheId(niche.getId());
         req.setTitle("   ");
+        req.setPromise("p");
+        req.setProblem("pr");
+        req.setPersona("pe");
+        req.setSuccessRule("sr");
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
@@ -66,6 +74,10 @@ class HypothesisServiceTest {
         CreateHypothesisRequest req = new CreateHypothesisRequest();
         req.setMarketNicheId(niche.getId());
         req.setTitle("T");
+        req.setPromise("p");
+        req.setProblem("pr");
+        req.setPersona("pe");
+        req.setSuccessRule("sr");
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
@@ -78,6 +90,10 @@ class HypothesisServiceTest {
         req.setMarketNicheId(niche.getId());
         req.setTitle("T");
         req.setPremiseAngleId(angle.getId());
+        req.setPromise("p");
+        req.setProblem("pr");
+        req.setPersona("pe");
+        req.setSuccessRule("sr");
         req.setOfferType("TRIPWIRE");
         req.setKpiTargetCpl(new BigDecimal("5"));
         assertThatThrownBy(() -> service.create(req))
@@ -90,6 +106,10 @@ class HypothesisServiceTest {
         var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
         req.setTitle("T");
         req.setPremiseAngleId(angle.getId());
+        req.setPromise("p");
+        req.setProblem("pr");
+        req.setPersona("pe");
+        req.setSuccessRule("sr");
         req.setKpiTargetCpl(new BigDecimal("5"));
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -68,6 +68,12 @@ components:
           type: string
         kpiTarget:
           type: number
+        stopLossCpl:
+          type: number
+        sampleSize:
+          type: integer
+        mde:
+          type: number
         startDate:
           type: string
           format: date
@@ -382,6 +388,14 @@ components:
           type: string
         premiseAngleId:
           type: integer
+        promise:
+          type: string
+        problem:
+          type: string
+        persona:
+          type: string
+        successRule:
+          type: string
         offerType:
           type: string
         price:

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -8,6 +8,9 @@ export interface CreateExperiment {
   name: string;
   hypothesis: string;
   kpiTarget: number;
+  stopLossCpl?: number;
+  sampleSize?: number;
+  mde?: number;
   startDate?: string;
   endDate?: string;
 }

--- a/frontend/src/api/hypothesis/useCreateHypothesis.ts
+++ b/frontend/src/api/hypothesis/useCreateHypothesis.ts
@@ -7,6 +7,10 @@ export interface CreateHypothesis {
   marketNicheId: number;
   title: string;
   premiseAngleId?: number;
+  promise: string;
+  problem: string;
+  persona: string;
+  successRule: string;
   offerType?: string;
   kpiTargetCpl?: number;
 }

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -13,6 +13,9 @@ export default function NewExperimentPage() {
     hypothesisId: "",
     hypothesis: "",
     kpiTarget: "",
+    stopLossCpl: "",
+    sampleSize: "",
+    mde: "",
     startDate: "",
     endDate: "",
   });
@@ -26,6 +29,9 @@ export default function NewExperimentPage() {
         name: form.name,
         hypothesis: form.hypothesis,
         kpiTarget: Number(form.kpiTarget),
+        stopLossCpl: form.stopLossCpl ? Number(form.stopLossCpl) : undefined,
+        sampleSize: form.sampleSize ? Number(form.sampleSize) : undefined,
+        mde: form.mde ? Number(form.mde) : undefined,
         startDate: form.startDate || undefined,
         endDate: form.endDate || undefined,
       });
@@ -35,6 +41,9 @@ export default function NewExperimentPage() {
         name: "",
         hypothesis: "",
         kpiTarget: "",
+        stopLossCpl: "",
+        sampleSize: "",
+        mde: "",
         startDate: "",
         endDate: "",
       });
@@ -105,6 +114,27 @@ export default function NewExperimentPage() {
         type="number"
         value={form.kpiTarget}
         onChange={(e) => setForm({ ...form, kpiTarget: e.target.value })}
+      />
+      <input
+        className="form-control mb-2"
+        placeholder="Stop-loss CPL"
+        type="number"
+        value={form.stopLossCpl}
+        onChange={(e) => setForm({ ...form, stopLossCpl: e.target.value })}
+      />
+      <input
+        className="form-control mb-2"
+        placeholder="Tamanho da amostra"
+        type="number"
+        value={form.sampleSize}
+        onChange={(e) => setForm({ ...form, sampleSize: e.target.value })}
+      />
+      <input
+        className="form-control mb-2"
+        placeholder="MDE %"
+        type="number"
+        value={form.mde}
+        onChange={(e) => setForm({ ...form, mde: e.target.value })}
       />
       <input
         className="form-control mb-2"

--- a/frontend/src/pages/hypothesis/NewHypothesisModal.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisModal.tsx
@@ -11,6 +11,10 @@ const schema = z
       .string()
       .min(8, "mínimo 8 caracteres")
       .max(120, "máx. 120 caracteres"),
+    promise: z.string().min(1, "obrigatório").max(140, "máx. 140"),
+    problem: z.string().min(1, "obrigatório"),
+    persona: z.string().min(1, "obrigatório"),
+    successRule: z.string().min(1, "obrigatório"),
     angleId: z.string().min(1, "obrigatório"),
     offerType: z.enum(["LEAD", "TRIPWIRE"]),
     price: z
@@ -60,6 +64,10 @@ export default function NewHypothesisModal({
   const onSubmit = handleSubmit(async (values) => {
     const body: any = {
       title: values.title,
+      promise: values.promise,
+      problem: values.problem,
+      persona: values.persona,
+      successRule: values.successRule,
       angleId: Number(values.angleId),
       offerType: values.offerType,
       kpiTargetCpl: values.kpiTargetCpl,
@@ -91,7 +99,7 @@ export default function NewHypothesisModal({
                 <label className="form-label" htmlFor="title">
                   Título
                 </label>
-                <input
+               <input
                   id="title"
                   {...register("title")}
                   className={`form-control mb-2 ${errors.title ? "is-invalid" : ""}`}
@@ -100,6 +108,65 @@ export default function NewHypothesisModal({
                 {errors.title && (
                   <div id="title-error" className="invalid-feedback d-block">
                     {errors.title.message}
+                  </div>
+                )}
+
+                <label className="form-label" htmlFor="promise">
+                  Promessa
+                </label>
+                <input
+                  id="promise"
+                  {...register("promise")}
+                  className={`form-control mb-2 ${errors.promise ? "is-invalid" : ""}`}
+                  aria-describedby="promise-error"
+                />
+                {errors.promise && (
+                  <div id="promise-error" className="invalid-feedback d-block">
+                    {errors.promise.message}
+                  </div>
+                )}
+
+                <label className="form-label" htmlFor="problem">
+                  Problema
+                </label>
+                <input
+                  id="problem"
+                  {...register("problem")}
+                  className={`form-control mb-2 ${errors.problem ? "is-invalid" : ""}`}
+                  aria-describedby="problem-error"
+                />
+                {errors.problem && (
+                  <div id="problem-error" className="invalid-feedback d-block">
+                    {errors.problem.message}
+                  </div>
+                )}
+
+                <label className="form-label" htmlFor="persona">Persona</label>
+                <input
+                  id="persona"
+                  {...register("persona")}
+                  className={`form-control mb-2 ${errors.persona ? "is-invalid" : ""}`}
+                  aria-describedby="persona-error"
+                />
+                {errors.persona && (
+                  <div id="persona-error" className="invalid-feedback d-block">
+                    {errors.persona.message}
+                  </div>
+                )}
+
+                <label className="form-label" htmlFor="successRule">
+                  Regra de sucesso
+                </label>
+                <textarea
+                  id="successRule"
+                  rows={2}
+                  {...register("successRule")}
+                  className={`form-control mb-2 ${errors.successRule ? "is-invalid" : ""}`}
+                  aria-describedby="rule-error"
+                />
+                {errors.successRule && (
+                  <div id="rule-error" className="invalid-feedback d-block">
+                    {errors.successRule.message}
                   </div>
                 )}
 

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -12,6 +12,10 @@ const schema = z
       .string()
       .min(8, "mínimo 8 caracteres")
       .max(120, "máx. 120 caracteres"),
+    promise: z.string().min(1, "obrigatório").max(140, "máx. 140"),
+    problem: z.string().min(1, "obrigatório"),
+    persona: z.string().min(1, "obrigatório"),
+    successRule: z.string().min(1, "obrigatório"),
     angleId: z.string().min(1, "obrigatório"),
     offerType: z.enum(["LEAD", "TRIPWIRE"]),
     price: z
@@ -55,6 +59,10 @@ export default function NewHypothesisPage() {
   const onSubmit = handleSubmit(async (values) => {
     const body: any = {
       title: values.title,
+      promise: values.promise,
+      problem: values.problem,
+      persona: values.persona,
+      successRule: values.successRule,
       angleId: Number(values.angleId),
       offerType: values.offerType,
       kpiTargetCpl: values.kpiTargetCpl,
@@ -84,6 +92,59 @@ export default function NewHypothesisPage() {
         {errors.title && (
           <div id="title-error" className="invalid-feedback d-block">
             {errors.title.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="promise">Promessa</label>
+        <input
+          id="promise"
+          {...register("promise")}
+          className={`form-control mb-2 ${errors.promise ? "is-invalid" : ""}`}
+          aria-describedby="promise-error"
+        />
+        {errors.promise && (
+          <div id="promise-error" className="invalid-feedback d-block">
+            {errors.promise.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="problem">Problema</label>
+        <input
+          id="problem"
+          {...register("problem")}
+          className={`form-control mb-2 ${errors.problem ? "is-invalid" : ""}`}
+          aria-describedby="problem-error"
+        />
+        {errors.problem && (
+          <div id="problem-error" className="invalid-feedback d-block">
+            {errors.problem.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="persona">Persona</label>
+        <input
+          id="persona"
+          {...register("persona")}
+          className={`form-control mb-2 ${errors.persona ? "is-invalid" : ""}`}
+          aria-describedby="persona-error"
+        />
+        {errors.persona && (
+          <div id="persona-error" className="invalid-feedback d-block">
+            {errors.persona.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="successRule">Regra de sucesso</label>
+        <textarea
+          id="successRule"
+          rows={2}
+          {...register("successRule")}
+          className={`form-control mb-2 ${errors.successRule ? "is-invalid" : ""}`}
+          aria-describedby="rule-error"
+        />
+        {errors.successRule && (
+          <div id="rule-error" className="invalid-feedback d-block">
+            {errors.successRule.message}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- extend `Hypothesis` with promise, problem, persona and success rule
- extend `Experiment` with stop-loss, sample size and MDE
- validate new fields in service layer
- adjust DTOs, mappers and OpenAPI docs
- update tests and fixtures with extra required fields
- update frontend forms to send/validate new data

## Testing
- `mvn -s ../settings.xml test -q` *(fails: Could not transfer artifact)*
- `mvn -s settings.xml test -q` *(fails: Could not transfer artifact)*
- `npm run test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688646218f088321ab0ed7a77c0ff52f