### PR TITLE
Fix tests by populating required Hypothesis fields

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/CreativeAngleIntegrationTest.java
@@ -44,6 +44,9 @@ class CreativeAngleIntegrationTest {
                 .marketNiche(niche)
                 .title("H")
                 .premiseAngle(base)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(java.math.BigDecimal.ONE)
                 .build();

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
@@ -48,6 +48,9 @@ class ExperimentControllerTest {
                 .marketNiche(niche)
                 .title("H")
                 .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(new BigDecimal("1"))
                 .build());
@@ -73,6 +76,9 @@ class ExperimentControllerTest {
                 .marketNiche(niche)
                 .title("H")
                 .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(new BigDecimal("1"))
                 .build());

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -42,6 +42,9 @@ class ExperimentServiceTest {
                 .marketNiche(niche)
                 .title("T")
                 .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(new BigDecimal("1"))
                 .build());
@@ -67,6 +70,9 @@ class ExperimentServiceTest {
                 .marketNiche(niche)
                 .title("T")
                 .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(new BigDecimal("1"))
                 .build());
@@ -92,6 +98,9 @@ class ExperimentServiceTest {
                 .marketNiche(niche1)
                 .title("T")
                 .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(new BigDecimal("1"))
                 .build());

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -76,6 +76,9 @@ class ExperimentControllerTest {
                 .marketNiche(nicheRepo.findById(nicheId).orElseThrow())
                 .title("H")
                 .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(BigDecimal.ONE)
                 .build());


### PR DESCRIPTION
## Summary
- populate `promise`, `problem`, and `persona` when creating `Hypothesis` in tests

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68865870fbf88321836ed85215a1e162