### PR TITLE
Fix hypothesis creation error

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_29__drop_experiment_id_from_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_29__drop_experiment_id_from_hypothesis.sql
@@ -1,0 +1,5 @@
+-- liquibase formatted sql
+-- changeset marketinghub:2025-07-29-drop-experiment-id
+-- preconditions onFail:MARK_RAN
+--    <columnExists tableName="hypothesis" columnName="experiment_id"/>
+ALTER TABLE hypothesis DROP COLUMN experiment_id;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -20,3 +20,6 @@ databaseChangeLog:
   - include:
       file: V2025_07_01__add_fk_experiment_to_audience_target.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_07_29__drop_experiment_id_from_hypothesis.sql
+      relativeToChangelogFile: true


### PR DESCRIPTION
## Summary
- allow creating hypotheses without an experiment

## Testing
- `mvn -s ../settings.xml test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6887a61dde648321a10037e4a6b153cc