### PR TITLE
Fix Liquibase check for hypothesis table

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_23__create_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_23__create_hypothesis.sql
@@ -7,7 +7,6 @@
 --    </not>
 CREATE TABLE IF NOT EXISTS hypothesis (
     id BINARY(16) PRIMARY KEY,
-    experiment_id BIGINT NOT NULL,
     title VARCHAR(255) NOT NULL,
     premise_angle_id BIGINT NOT NULL,
     offer_type VARCHAR(20) NOT NULL,

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_29__drop_experiment_id_from_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_29__drop_experiment_id_from_hypothesis.sql
@@ -1,5 +1,5 @@
 -- liquibase formatted sql
 -- changeset marketinghub:2025-07-29-drop-experiment-id
--- preconditions onFail:MARK_RAN
---    <columnExists tableName="hypothesis" columnName="experiment_id"/>
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'hypothesis' AND COLUMN_NAME = 'experiment_id';
 ALTER TABLE hypothesis DROP COLUMN experiment_id;


### PR DESCRIPTION
## Summary
- remove obsolete `experiment_id` column from hypothesis table definition
- check for column existence before dropping

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68888fa917508321bbf341df23e14b7c