### PR TITLE
Fix Liquibase checksum for hypothesis table

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_23__create_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_23__create_hypothesis.sql
@@ -7,6 +7,7 @@
 --    </not>
 CREATE TABLE IF NOT EXISTS hypothesis (
     id BINARY(16) PRIMARY KEY,
+    experiment_id BIGINT NOT NULL,
     title VARCHAR(255) NOT NULL,
     premise_angle_id BIGINT NOT NULL,
     offer_type VARCHAR(20) NOT NULL,


### PR DESCRIPTION
## Summary
- restore `experiment_id` column in `V2025_07_23__create_hypothesis.sql`

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6888ef5f1e048321987a86bab128a966