### PR TITLE
Support ALL keyword for hypothesis queries

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/web/HypothesisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/web/HypothesisController.java
@@ -6,6 +6,8 @@ import com.marketinghub.hypothesis.dto.HypothesisDto;
 import com.marketinghub.hypothesis.mapper.HypothesisMapper;
 import com.marketinghub.hypothesis.service.HypothesisKanbanFacade;
 import com.marketinghub.hypothesis.service.HypothesisService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -33,16 +35,18 @@ public class HypothesisController {
     }
 
     @GetMapping("/hypotheses")
-    public List<HypothesisDto> listAll(@RequestParam(value = "status", required = false) HypothesisStatus status) {
-        return StreamSupport.stream(service.list(status).spliterator(), false)
+    public List<HypothesisDto> listAll(@RequestParam(value = "status", required = false) String status) {
+        HypothesisStatus parsed = parseStatus(status);
+        return StreamSupport.stream(service.list(parsed).spliterator(), false)
                 .map(mapper::toDto)
                 .toList();
     }
 
     @GetMapping("/niches/{nicheId}/hypotheses")
     public List<HypothesisDto> listByNiche(@PathVariable Long nicheId,
-                                           @RequestParam(value = "status", required = false) HypothesisStatus status) {
-        return StreamSupport.stream(service.listByMarketNiche(nicheId, status).spliterator(), false)
+                                           @RequestParam(value = "status", required = false) String status) {
+        HypothesisStatus parsed = parseStatus(status);
+        return StreamSupport.stream(service.listByMarketNiche(nicheId, parsed).spliterator(), false)
                 .map(mapper::toDto)
                 .toList();
     }
@@ -56,5 +60,16 @@ public class HypothesisController {
     @GetMapping("/niches/{nicheId}/hypotheses/board")
     public Map<HypothesisStatus, List<HypothesisDto>> board(@PathVariable Long nicheId) {
         return facade.board(nicheId);
+    }
+
+    private HypothesisStatus parseStatus(String raw) {
+        if (raw == null || raw.isBlank() || "ALL".equalsIgnoreCase(raw)) {
+            return null;
+        }
+        try {
+            return HypothesisStatus.valueOf(raw);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid status");
+        }
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -114,4 +114,32 @@ class HypothesisServiceTest {
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
+
+    @Test
+    void listByMarketNicheWithNullStatusReturnsAll() {
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+
+        CreateHypothesisRequest req = new CreateHypothesisRequest();
+        req.setMarketNicheId(niche.getId());
+        req.setTitle("H1");
+        req.setPremiseAngleId(angle.getId());
+        req.setPromise("p");
+        req.setProblem("pr");
+        req.setPersona("pe");
+        req.setSuccessRule("sr");
+        req.setOfferType("LEAD");
+        req.setKpiTargetCpl(BigDecimal.ONE);
+
+        Hypothesis h1 = service.create(req);
+        Hypothesis h2 = service.create(req);
+        service.updateStatus(h2.getId(), HypothesisStatus.TESTING);
+
+        Iterable<Hypothesis> all = service.listByMarketNiche(niche.getId(), null);
+        java.util.List<Hypothesis> list = java.util.stream.StreamSupport
+                .stream(all.spliterator(), false)
+                .toList();
+
+        assertThat(list).hasSize(2);
+    }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/web/HypothesisControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/web/HypothesisControllerTest.java
@@ -1,0 +1,48 @@
+package com.marketinghub.hypothesis.web;
+
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.FixtureUtils;
+import com.marketinghub.hypothesis.HypothesisStatus;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = AdsServiceApplication.class)
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
+})
+class HypothesisControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    FixtureUtils fixtures;
+    @Autowired
+    HypothesisRepository repository;
+
+    @Test
+    void listByNicheAcceptsAllKeyword() throws Exception {
+        var niche = fixtures.createAndSaveNiche();
+        fixtures.createAndSaveHypothesis(niche);
+        var h2 = fixtures.createAndSaveHypothesis(niche);
+        h2.setStatus(HypothesisStatus.TESTING);
+        repository.save(h2);
+
+        mockMvc.perform(get("/api/niches/" + niche.getId() + "/hypotheses")
+                        .param("status", "ALL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+}


### PR DESCRIPTION
## Summary
- interpret `status=ALL` in hypothesis controller without altering enum values
- skip filtering when status is `ALL`
- adjust service and tests for the new logic
- add controller test covering the `ALL` keyword

## Testing
- `mvn -s ../settings.xml test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688904d0ae988321b94315580db5b499