### PR TITLE
Add backlog hypothesis editing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
@@ -1,0 +1,42 @@
+package com.marketinghub.hypothesis.dto;
+
+import java.math.BigDecimal;
+
+public class UpdateHypothesisRequest {
+    private String title;
+    private Long premiseAngleId;
+    private String promise;
+    private String problem;
+    private String persona;
+    private String successRule;
+    private String offerType;
+    private BigDecimal price;
+    private BigDecimal kpiTargetCpl;
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public Long getPremiseAngleId() { return premiseAngleId; }
+    public void setPremiseAngleId(Long premiseAngleId) { this.premiseAngleId = premiseAngleId; }
+
+    public String getPromise() { return promise; }
+    public void setPromise(String promise) { this.promise = promise; }
+
+    public String getProblem() { return problem; }
+    public void setProblem(String problem) { this.problem = problem; }
+
+    public String getPersona() { return persona; }
+    public void setPersona(String persona) { this.persona = persona; }
+
+    public String getSuccessRule() { return successRule; }
+    public void setSuccessRule(String successRule) { this.successRule = successRule; }
+
+    public String getOfferType() { return offerType; }
+    public void setOfferType(String offerType) { this.offerType = offerType; }
+
+    public BigDecimal getPrice() { return price; }
+    public void setPrice(BigDecimal price) { this.price = price; }
+
+    public BigDecimal getKpiTargetCpl() { return kpiTargetCpl; }
+    public void setKpiTargetCpl(BigDecimal kpiTargetCpl) { this.kpiTargetCpl = kpiTargetCpl; }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -6,6 +6,7 @@ import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import com.marketinghub.hypothesis.*;
 import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
+import com.marketinghub.hypothesis.dto.UpdateHypothesisRequest;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import java.util.UUID;
 import jakarta.persistence.EntityManager;
@@ -116,6 +117,55 @@ public class HypothesisService {
     public Hypothesis updateStatus(UUID id, HypothesisStatus status) {
         Hypothesis h = repository.findById(id).orElseThrow();
         h.setStatus(status);
+        return h;
+    }
+
+    private void validate(UpdateHypothesisRequest req) {
+        if (req.getTitle() == null || req.getTitle().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "title required");
+        }
+        if (req.getPremiseAngleId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "angle required");
+        }
+        if (req.getPromise() == null || req.getPromise().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promise required");
+        }
+        if (req.getPromise().length() > 140) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promise too long");
+        }
+        if (req.getProblem() == null || req.getProblem().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "problem required");
+        }
+        if (req.getPersona() == null || req.getPersona().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "persona required");
+        }
+        if (req.getSuccessRule() == null || req.getSuccessRule().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "successRule required");
+        }
+        if (req.getKpiTargetCpl() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "kpiTargetCpl required");
+        }
+        if ("TRIPWIRE".equals(req.getOfferType()) && req.getPrice() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "price required for TRIPWIRE");
+        }
+    }
+
+    @Transactional
+    public Hypothesis update(UUID id, UpdateHypothesisRequest req) {
+        validate(req);
+        Hypothesis h = repository.findById(id).orElseThrow();
+        if (h.getStatus() != HypothesisStatus.BACKLOG) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "only BACKLOG hypotheses can be edited");
+        }
+        h.setTitle(req.getTitle());
+        h.setPremiseAngle(attachAngle(req.getPremiseAngleId()));
+        h.setPromise(req.getPromise());
+        h.setProblem(req.getProblem());
+        h.setPersona(req.getPersona());
+        h.setSuccessRule(req.getSuccessRule());
+        h.setOfferType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()));
+        h.setPrice(req.getPrice());
+        h.setKpiTargetCpl(req.getKpiTargetCpl());
         return h;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/web/HypothesisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/web/HypothesisController.java
@@ -3,6 +3,7 @@ package com.marketinghub.hypothesis.web;
 import com.marketinghub.hypothesis.HypothesisStatus;
 import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
 import com.marketinghub.hypothesis.dto.HypothesisDto;
+import com.marketinghub.hypothesis.dto.UpdateHypothesisRequest;
 import com.marketinghub.hypothesis.mapper.HypothesisMapper;
 import com.marketinghub.hypothesis.service.HypothesisKanbanFacade;
 import com.marketinghub.hypothesis.service.HypothesisService;
@@ -32,6 +33,11 @@ public class HypothesisController {
     @ResponseStatus(org.springframework.http.HttpStatus.CREATED)
     public HypothesisDto create(@RequestBody CreateHypothesisRequest req) {
         return mapper.toDto(service.create(req));
+    }
+
+    @PutMapping("/hypotheses/{id}")
+    public HypothesisDto update(@PathVariable UUID id, @RequestBody UpdateHypothesisRequest req) {
+        return mapper.toDto(service.update(id, req));
     }
 
     @GetMapping("/hypotheses")

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -142,4 +142,39 @@ class HypothesisServiceTest {
 
         assertThat(list).hasSize(2);
     }
+
+    @Test
+    void updateHypothesisOnlyWhenBacklog() {
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        CreateHypothesisRequest req = new CreateHypothesisRequest();
+        req.setMarketNicheId(niche.getId());
+        req.setTitle("H1");
+        req.setPremiseAngleId(angle.getId());
+        req.setPromise("p");
+        req.setProblem("pr");
+        req.setPersona("pe");
+        req.setSuccessRule("sr");
+        req.setOfferType("LEAD");
+        req.setKpiTargetCpl(BigDecimal.ONE);
+
+        Hypothesis h = service.create(req);
+
+        com.marketinghub.hypothesis.dto.UpdateHypothesisRequest u = new com.marketinghub.hypothesis.dto.UpdateHypothesisRequest();
+        u.setTitle("H2");
+        u.setPremiseAngleId(angle.getId());
+        u.setPromise("p2");
+        u.setProblem("pr2");
+        u.setPersona("pe2");
+        u.setSuccessRule("sr2");
+        u.setOfferType("LEAD");
+        u.setKpiTargetCpl(BigDecimal.TEN);
+
+        Hypothesis updated = service.update(h.getId(), u);
+        assertThat(updated.getTitle()).isEqualTo("H2");
+
+        service.updateStatus(h.getId(), HypothesisStatus.TESTING);
+        assertThatThrownBy(() -> service.update(h.getId(), u))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+    }
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -344,6 +344,24 @@ components:
       responses:
         '200':
           description: OK
+  /api/hypotheses/{id}:
+    put:
+      summary: Atualizar hipótese
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateHypothesisRequest'
+      responses:
+        '200':
+          description: OK
   /api/hypotheses/{id}/status:
     patch:
       summary: Atualizar status da hipótese

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import HypothesisDetailPage from "./pages/hypothesis/HypothesisDetailPage";
 import HypothesesPage from "./pages/hypothesis/HypothesesPage";
 import HypothesisListPage from "./pages/hypothesis/HypothesisListPage";
 import NewHypothesisPage from "./pages/hypothesis/NewHypothesisPage";
+import EditHypothesisPage from "./pages/hypothesis/EditHypothesisPage";
 import AppLayout from "./app/AppLayout";
 import AnglesPage from "./pages/AnglesPage";
 import VisualProofsPage from "./pages/VisualProofsPage";
@@ -165,6 +166,10 @@ export default function App() {
           <Route
             path=":nicheId/hypotheses/:hypothesisId"
             element={<HypothesisDetailPage />}
+          />
+          <Route
+            path=":nicheId/hypotheses/:hypothesisId/edit"
+            element={<EditHypothesisPage />}
           />
         </Route>
         <Route path="/experiments" element={<ExperimentListPage />} />

--- a/frontend/src/api/hypothesis/useHypothesisBoard.ts
+++ b/frontend/src/api/hypothesis/useHypothesisBoard.ts
@@ -5,6 +5,10 @@ export interface Hypothesis {
   id: number;
   marketNicheId: number;
   title: string;
+  promise?: string;
+  problem?: string;
+  persona?: string;
+  successRule?: string;
   premiseAngleId?: number;
   offerType?: string;
   price?: number;
@@ -16,7 +20,12 @@ export function useHypothesisBoard(nicheId: string) {
   return useQuery({
     queryKey: ["hypothesis-board", nicheId],
     queryFn: async () => {
-      const statuses = ["BACKLOG", "TESTING", "VALIDATED", "INVALIDATED"] as const;
+      const statuses = [
+        "BACKLOG",
+        "TESTING",
+        "VALIDATED",
+        "INVALIDATED",
+      ] as const;
       const entries = await Promise.all(
         statuses.map(async (s) => {
           const { data } = await axios.get<Hypothesis[]>(

--- a/frontend/src/api/hypothesis/useUpdateHypothesis.ts
+++ b/frontend/src/api/hypothesis/useUpdateHypothesis.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { toast } from "react-toastify";
+import { Hypothesis } from "./useHypothesisBoard";
+
+export function useUpdateHypothesis(nicheId?: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (h: Hypothesis) => {
+      const { id, ...body } = h;
+      const { data } = await axios.put<Hypothesis>(
+        `/api/hypotheses/${id}`,
+        body,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      if (nicheId) {
+        qc.invalidateQueries({ queryKey: ["hypothesis-board", nicheId] });
+      }
+      qc.invalidateQueries({ queryKey: ["hypotheses"] });
+      toast.success("Hipótese atualizada");
+    },
+    onError: () => {
+      toast.error("Erro ao atualizar hipótese");
+    },
+  });
+}

--- a/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
@@ -1,0 +1,286 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate, useParams } from "react-router-dom";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import axios from "axios";
+import PageTitle from "../../components/PageTitle";
+import { useAngles } from "../../api/angle/useAngles";
+import { useHypothesis } from "../../api/hypothesis/useHypothesis";
+
+const schema = z
+  .object({
+    title: z.string().min(8).max(120),
+    promise: z.string().min(1).max(140),
+    problem: z.string().min(1),
+    persona: z.string().min(1),
+    successRule: z.string().min(1),
+    premiseAngleId: z.string().min(1),
+    offerType: z.enum(["LEAD", "TRIPWIRE"]),
+    price: z
+      .preprocess(
+        (v) => (v === "" || v === undefined ? undefined : Number(v)),
+        z.number().min(5).max(297),
+      )
+      .optional(),
+    kpiTargetCpl: z.preprocess(Number, z.number().min(1)),
+  })
+  .superRefine((val, ctx) => {
+    if (val.offerType === "TRIPWIRE" && val.price === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Preço obrigatório",
+        path: ["price"],
+      });
+    }
+  });
+
+type FormData = z.infer<typeof schema>;
+
+export default function EditHypothesisPage() {
+  const { nicheId, hypothesisId } = useParams();
+  const navigate = useNavigate();
+  const { data, isLoading } = useHypothesis(nicheId, hypothesisId);
+  const { data: angles } = useAngles();
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  useEffect(() => {
+    if (data) {
+      reset({
+        title: data.title,
+        promise: data.promise || "",
+        problem: data.problem || "",
+        persona: data.persona || "",
+        successRule: data.successRule || "",
+        premiseAngleId: String(data.premiseAngleId ?? ""),
+        offerType: (data.offerType as "LEAD" | "TRIPWIRE") || "LEAD",
+        price: data.price,
+        kpiTargetCpl: data.kpiTargetCpl,
+      });
+    }
+  }, [data, reset]);
+
+  const offerType = watch("offerType");
+
+  const onSubmit = handleSubmit(async (values) => {
+    const body: any = {
+      title: values.title,
+      promise: values.promise,
+      problem: values.problem,
+      persona: values.persona,
+      successRule: values.successRule,
+      premiseAngleId: Number(values.premiseAngleId),
+      offerType: values.offerType,
+      kpiTargetCpl: values.kpiTargetCpl,
+    };
+    if (values.offerType === "TRIPWIRE") body.price = values.price;
+    await axios.put(`/api/hypotheses/${hypothesisId}`, body);
+    navigate(-1);
+  });
+
+  if (isLoading || !data) return <p>Carregando...</p>;
+  if (data.status !== "BACKLOG")
+    return <p>Edição permitida apenas para hipóteses em Backlog.</p>;
+
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <PageTitle>Editar Hipótese</PageTitle>
+      <form onSubmit={onSubmit} noValidate>
+        <label className="form-label" htmlFor="title">
+          Título
+        </label>
+        <input
+          id="title"
+          {...register("title")}
+          className={`form-control mb-2 ${errors.title ? "is-invalid" : ""}`}
+          aria-describedby="title-error"
+        />
+        {errors.title && (
+          <div id="title-error" className="invalid-feedback d-block">
+            {errors.title.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="promise">
+          Promessa
+        </label>
+        <input
+          id="promise"
+          {...register("promise")}
+          className={`form-control mb-2 ${errors.promise ? "is-invalid" : ""}`}
+          aria-describedby="promise-error"
+        />
+        {errors.promise && (
+          <div id="promise-error" className="invalid-feedback d-block">
+            {errors.promise.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="problem">
+          Problema
+        </label>
+        <input
+          id="problem"
+          {...register("problem")}
+          className={`form-control mb-2 ${errors.problem ? "is-invalid" : ""}`}
+          aria-describedby="problem-error"
+        />
+        {errors.problem && (
+          <div id="problem-error" className="invalid-feedback d-block">
+            {errors.problem.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="persona">
+          Persona
+        </label>
+        <input
+          id="persona"
+          {...register("persona")}
+          className={`form-control mb-2 ${errors.persona ? "is-invalid" : ""}`}
+          aria-describedby="persona-error"
+        />
+        {errors.persona && (
+          <div id="persona-error" className="invalid-feedback d-block">
+            {errors.persona.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="successRule">
+          Regra de sucesso
+        </label>
+        <textarea
+          id="successRule"
+          rows={2}
+          {...register("successRule")}
+          className={`form-control mb-2 ${errors.successRule ? "is-invalid" : ""}`}
+          aria-describedby="rule-error"
+        />
+        {errors.successRule && (
+          <div id="rule-error" className="invalid-feedback d-block">
+            {errors.successRule.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="angle">
+          Ângulo
+        </label>
+        <select
+          id="angle"
+          {...register("premiseAngleId")}
+          className={`form-select mb-2 ${errors.premiseAngleId ? "is-invalid" : ""}`}
+          aria-describedby="angle-error"
+        >
+          <option value="">Selecione Angle</option>
+          {Array.isArray(angles) &&
+            angles.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name}
+              </option>
+            ))}
+        </select>
+        {errors.premiseAngleId && (
+          <div id="angle-error" className="invalid-feedback d-block">
+            {errors.premiseAngleId.message}
+          </div>
+        )}
+
+        <div className="mb-2">
+          <div className="form-check">
+            <input
+              className="form-check-input"
+              type="radio"
+              id="offer-lead"
+              value="LEAD"
+              {...register("offerType")}
+            />
+            <label className="form-check-label" htmlFor="offer-lead">
+              Lead Magnet
+            </label>
+          </div>
+          <div className="form-check">
+            <input
+              className="form-check-input"
+              type="radio"
+              id="offer-trip"
+              value="TRIPWIRE"
+              {...register("offerType")}
+            />
+            <label className="form-check-label" htmlFor="offer-trip">
+              Tripwire
+            </label>
+          </div>
+          {errors.offerType && (
+            <div id="offer-error" className="invalid-feedback d-block">
+              {errors.offerType.message}
+            </div>
+          )}
+        </div>
+
+        {offerType === "TRIPWIRE" && (
+          <div>
+            <label className="form-label" htmlFor="price">
+              Preço
+            </label>
+            <input
+              type="number"
+              id="price"
+              min={5}
+              max={297}
+              {...register("price", { valueAsNumber: true })}
+              className={`form-control mb-2 ${errors.price ? "is-invalid" : ""}`}
+              aria-describedby="price-error"
+            />
+            {errors.price && (
+              <div id="price-error" className="invalid-feedback d-block">
+                {errors.price.message}
+              </div>
+            )}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="kpiTargetCpl">
+          KPI alvo (CPL em R$)
+        </label>
+        <input
+          type="number"
+          step="0.01"
+          id="kpiTargetCpl"
+          min={1}
+          {...register("kpiTargetCpl", { valueAsNumber: true })}
+          className={`form-control mb-2 ${errors.kpiTargetCpl ? "is-invalid" : ""}`}
+          aria-describedby="kpi-error"
+        />
+        {errors.kpiTargetCpl && (
+          <div id="kpi-error" className="invalid-feedback d-block">
+            {errors.kpiTargetCpl.message}
+          </div>
+        )}
+
+        <div className="mt-3 d-flex justify-content-end">
+          <button
+            type="button"
+            className="btn btn-outline-secondary me-2"
+            onClick={() => navigate(-1)}
+            disabled={isSubmitting}
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={isSubmitting}
+          >
+            Salvar
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -9,7 +9,10 @@ export default function HypothesisDetailPage() {
   const { nicheId, hypothesisId } = useParams();
   const { data: niche } = useNiche(Number(nicheId));
   const { data, isLoading } = useHypothesis(nicheId, hypothesisId);
-  const { data: experiments } = useExperimentsByHypothesis(nicheId, hypothesisId);
+  const { data: experiments } = useExperimentsByHypothesis(
+    nicheId,
+    hypothesisId,
+  );
   useBreadcrumbs([
     { label: "Nichos", to: "/niches" },
     { label: niche?.name || "...", to: `/niches/${nicheId}` },
@@ -23,17 +26,29 @@ export default function HypothesisDetailPage() {
     <div>
       <div className="d-flex justify-content-between align-items-center">
         <PageTitle>{data.title}</PageTitle>
-        <Link
-          className="btn btn-primary"
-          to={`/experiments/new?nicheId=${nicheId}&hypothesisId=${hypothesisId}`}
-        >
-          Criar Experimento
-        </Link>
+        <div className="d-flex gap-2">
+          {data.status === "BACKLOG" && (
+            <Link
+              className="btn btn-outline-secondary"
+              to={`/niches/${nicheId}/hypotheses/${hypothesisId}/edit`}
+            >
+              Editar
+            </Link>
+          )}
+          <Link
+            className="btn btn-primary"
+            to={`/experiments/new?nicheId=${nicheId}&hypothesisId=${hypothesisId}`}
+          >
+            Criar Experimento
+          </Link>
+        </div>
       </div>
       <dl className="row">
         <dt className="col-sm-3">Oferta</dt>
         <dd className="col-sm-9">
-          {data.offerType === "TRIPWIRE" ? `Tripwire R$ ${data.price ?? ""}` : "Lead Magnet"}
+          {data.offerType === "TRIPWIRE"
+            ? `Tripwire R$ ${data.price ?? ""}`
+            : "Lead Magnet"}
         </dd>
         <dt className="col-sm-3">KPI</dt>
         <dd className="col-sm-9">{data.kpiTargetCpl}</dd>


### PR DESCRIPTION
## Summary
- allow backlog hypotheses to be edited
- document new endpoint
- add page to edit hypothesis in the frontend
- include link to edit on hypothesis detail page

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891d8473608321b8567a4db4a39cad