### PR TITLE
Add edit link in hypotheses table

### DIFF
--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -56,6 +56,14 @@ export default function NicheDetailPage() {
                   <td>{h.status}</td>
                   <td>{h.kpiTargetCpl}</td>
                   <td>
+                    {h.status === "BACKLOG" && (
+                      <Link
+                        className="btn btn-sm btn-outline-secondary me-1"
+                        to={`hypotheses/${h.id}/edit`}
+                      >
+                        Editar
+                      </Link>
+                    )}
                     <Link
                       className="btn btn-sm btn-outline-primary"
                       to={`hypotheses/${h.id}`}


### PR DESCRIPTION
## Summary
- allow editing hypotheses directly from a niche detail page

## Testing
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688942311b708321bfc1f8f03489c8cb