### PR TITLE
Fix hypothesis UUID handling

### DIFF
--- a/frontend/src/__tests__/NicheFlow.test.tsx
+++ b/frontend/src/__tests__/NicheFlow.test.tsx
@@ -17,7 +17,7 @@ function mockApi() {
       return Promise.resolve({
         data: [
           {
-            id: 10,
+            id: "10",
             title: "Hip 1",
             offerType: "LEAD",
             status: "BACKLOG",

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -4,7 +4,7 @@ import { Experiment } from "./useExperiments";
 
 export interface CreateExperiment {
   nicheId: number;
-  hypothesisId?: number;
+  hypothesisId?: string;
   name: string;
   hypothesis: string;
   kpiTarget: number;

--- a/frontend/src/api/hypothesis/useHypothesis.ts
+++ b/frontend/src/api/hypothesis/useHypothesis.ts
@@ -10,7 +10,7 @@ export function useHypothesis(nicheId?: string, id?: string) {
       const { data } = await axios.get<Hypothesis[]>(
         `/api/niches/${nicheId}/hypotheses`,
       );
-      return data.find((h) => h.id === Number(id));
+      return data.find((h) => h.id === id);
     },
     enabled: !!nicheId && !!id,
   });

--- a/frontend/src/api/hypothesis/useHypothesisBoard.ts
+++ b/frontend/src/api/hypothesis/useHypothesisBoard.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 
 export interface Hypothesis {
-  id: number;
+  id: string;
   marketNicheId: number;
   title: string;
   promise?: string;

--- a/frontend/src/api/hypothesis/useUpdateHypothesisStatus.ts
+++ b/frontend/src/api/hypothesis/useUpdateHypothesisStatus.ts
@@ -6,7 +6,7 @@ import { Hypothesis } from "./useHypothesisBoard";
 export function useUpdateHypothesisStatus(nicheId?: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async (input: { id: number; status: string }) => {
+    mutationFn: async (input: { id: string; status: string }) => {
       const { data } = await axios.patch<Hypothesis>(
         `/api/hypotheses/${input.id}/status?status=${input.status}`,
       );

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -25,7 +25,7 @@ export default function NewExperimentPage() {
     try {
       await create.mutateAsync({
         nicheId: Number(form.nicheId),
-        hypothesisId: form.hypothesisId ? Number(form.hypothesisId) : undefined,
+        hypothesisId: form.hypothesisId || undefined,
         name: form.name,
         hypothesis: form.hypothesis,
         kpiTarget: Number(form.kpiTarget),

--- a/frontend/src/pages/hypothesis/HypothesisBoard.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisBoard.tsx
@@ -92,7 +92,7 @@ export default function HypothesisBoard({ board, nicheId }: BoardProps) {
   );
   const onDragEnd = (e: DragEndEvent) => {
     if (e.over && e.active.data.current) {
-      const id = Number(e.active.id);
+      const id = String(e.active.id);
       const status = String(e.over.id);
       update.mutate({ id, status });
     }


### PR DESCRIPTION
## Summary
- support UUID hypothesis IDs in frontend API hooks and components
- adjust new experiment page and DnD to use string IDs
- fix tests for updated ID type

## Testing
- `npm run test --silent`
- `npm run build`
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68897386811883219b890329f3a9e281