### PR TITLE
Fix save button on edit hypothesis page

### DIFF
--- a/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
@@ -278,8 +278,9 @@ export default function EditHypothesisPage() {
             Cancelar
           </button>
           <button
-            type="submit"
+            type="button"
             className="btn btn-primary"
+            onClick={onSubmit}
             disabled={isSubmitting}
           >
             Salvar


### PR DESCRIPTION
## Summary
- ensure Save button submits form when editing hypothesis

## Testing
- `npm run test --silent` *(fails: Unable to find an element with the text: Fitness)*
- `npm run build`
- `mvn -s ../settings.xml test` in `backend/ads-service` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` in `success-product-worker` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6889883f91108321b21bac8b84df031a