### PR TITLE
Fix Hypothesis edit build error

### DIFF
--- a/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
@@ -7,6 +7,7 @@ import PageTitle from "../../components/PageTitle";
 import { useAngles } from "../../api/angle/useAngles";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useUpdateHypothesis } from "../../api/hypothesis/useUpdateHypothesis";
+import type { Hypothesis } from "../../api/hypothesis/useHypothesisBoard";
 
 const schema = z
   .object({


### PR DESCRIPTION
## Summary
- import `Hypothesis` type on EditHypothesisPage to resolve TS2304 error

## Testing
- `npm run build`
- `npm run test -- --run` *(fails: NicheFlow.test.tsx unable to find element)*
- `mvn -s ../settings.xml deploy` *(fails: could not resolve Spring Boot parent POM)*
- `mvn -s ../settings.xml test` *(fails: could not resolve Spring Boot parent POM)*
- `mvn -s settings.xml package` *(fails: could not resolve Spring Boot parent POM)*
- `mvn -s settings.xml test` *(fails: could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68899ea5edc88321a500a9024d46fe80