### PR TITLE
Allow CPL editing with no limits

### DIFF
--- a/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
@@ -24,7 +24,7 @@ const schema = z
         z.number().min(5).max(297),
       )
       .optional(),
-    kpiTargetCpl: z.preprocess(Number, z.number().min(1)),
+    kpiTargetCpl: z.preprocess(Number, z.number()),
   })
   .superRefine((val, ctx) => {
     if (val.offerType === "TRIPWIRE" && val.price === undefined) {
@@ -257,7 +257,6 @@ export default function EditHypothesisPage() {
           type="number"
           step="0.01"
           id="kpiTargetCpl"
-          min={1}
           {...register("kpiTargetCpl", { valueAsNumber: true })}
           className={`form-control mb-2 ${errors.kpiTargetCpl ? "is-invalid" : ""}`}
           aria-describedby="kpi-error"
@@ -282,7 +281,7 @@ export default function EditHypothesisPage() {
             className="btn btn-primary"
             disabled={isSubmitting}
             onClick={handleSubmit(onSubmit, (errors) => {
-              console.log('Validation errors', errors);
+              console.log("Validation errors", errors);
             })}
           >
             Salvar


### PR DESCRIPTION
## Summary
- update edit hypothesis page schema
- remove CPL numeric input limits

## Testing
- `npm run test`
- `npm run build`
- `mvn -s ../settings.xml test` *(fails: Could not resolve artifacts)*
- `mvn -s settings.xml test` *(fails: Could not resolve artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_688c1ef04dc483218cc2f9b200a099c1