### PR TITLE
Adjust price validation on hypothesis edit

### DIFF
--- a/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
@@ -21,7 +21,7 @@ const schema = z
     price: z
       .preprocess(
         (v) => (v === "" || v === undefined ? undefined : Number(v)),
-        z.number().min(5).max(297),
+        z.number(),
       )
       .optional(),
     kpiTargetCpl: z.preprocess(Number, z.number()),
@@ -236,8 +236,6 @@ export default function EditHypothesisPage() {
             <input
               type="number"
               id="price"
-              min={5}
-              max={297}
               {...register("price", { valueAsNumber: true })}
               className={`form-control mb-2 ${errors.price ? "is-invalid" : ""}`}
               aria-describedby="price-error"


### PR DESCRIPTION
## Summary
- loosen price validation on EditHypothesisPage

## Testing
- `npx vitest run`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c2b9aa2208321b219026665a98a7a