### PR TITLE
Show all hypothesis data and simplify experiment creation

### DIFF
--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -1,16 +1,29 @@
 import { useState } from "react";
 import { useCreateExperiment } from "../../api/experiment/useCreateExperiment";
 import { useNiches } from "../../api/niche/useNiches";
+import { useNiche } from "../../api/niche/useNiche";
+import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
 import PageTitle from "../../components/PageTitle";
+import { useSearchParams } from "react-router-dom";
 
 export default function NewExperimentPage() {
   const create = useCreateExperiment();
+  const [searchParams] = useSearchParams();
+  const paramNicheId = searchParams.get("nicheId") || "";
+  const paramHypothesisId = searchParams.get("hypothesisId") || "";
+
   const { data: niches } = useNiches();
+  const { data: niche } = useNiche(Number(paramNicheId));
+  const { data: currentHypothesis } = useHypothesis(
+    paramNicheId || undefined,
+    paramHypothesisId || undefined,
+  );
+
   const [form, setForm] = useState({
-    nicheId: "",
+    nicheId: paramNicheId,
     name: "",
-    hypothesisId: "",
+    hypothesisId: paramHypothesisId,
     hypothesis: "",
     kpiTarget: "",
     stopLossCpl: "",
@@ -36,8 +49,8 @@ export default function NewExperimentPage() {
         endDate: form.endDate || undefined,
       });
       setForm({
-        nicheId: "",
-        hypothesisId: "",
+        nicheId: paramNicheId,
+        hypothesisId: paramHypothesisId,
         name: "",
         hypothesis: "",
         kpiTarget: "",
@@ -56,45 +69,60 @@ export default function NewExperimentPage() {
   return (
     <div>
       <PageTitle>Novo Teste de Nicho</PageTitle>
-      <select
-        className="form-select mb-2"
-        value={form.nicheId}
-        onChange={(e) =>
-          setForm({ ...form, nicheId: e.target.value, hypothesisId: "" })
-        }
-      >
-        <option value="">Selecione o Nicho</option>
-        {Array.isArray(niches) &&
-          niches.map((n) => (
-            <option key={n.id} value={n.id}>
-              {n.name}
-            </option>
-          ))}
-      </select>
-      <select
-        className="form-select mb-2"
-        value={form.hypothesisId}
-        onChange={(e) => setForm({ ...form, hypothesisId: e.target.value })}
-      >
-        <option value="">Selecione Hipótese</option>
-        {Array.isArray(hypotheses) && hypotheses.length > 0 ? (
-          hypotheses.map((h) => (
-            <option key={h.id} value={h.id}>
-              {h.title}
-            </option>
-          ))
-        ) : (
-          <option value="">Não há hipóteses para este nicho</option>
-        )}
-      </select>
-      {Array.isArray(hypotheses) && hypotheses.length === 0 && (
-        <button
-          type="button"
-          className="btn btn-link mb-2"
-          onClick={() => (window.location.href = "/hypotheses?open=new")}
+      {paramNicheId ? (
+        <p className="mb-2">
+          Nicho: <strong>{niche?.name || paramNicheId}</strong>
+        </p>
+      ) : (
+        <select
+          className="form-select mb-2"
+          value={form.nicheId}
+          onChange={(e) =>
+            setForm({ ...form, nicheId: e.target.value, hypothesisId: "" })
+          }
         >
-          Criar nova hipótese
-        </button>
+          <option value="">Selecione o Nicho</option>
+          {Array.isArray(niches) &&
+            niches.map((n) => (
+              <option key={n.id} value={n.id}>
+                {n.name}
+              </option>
+            ))}
+        </select>
+      )}
+      {paramHypothesisId ? (
+        <p className="mb-2">
+          Hipótese:{" "}
+          <strong>{currentHypothesis?.title || paramHypothesisId}</strong>
+        </p>
+      ) : (
+        <>
+          <select
+            className="form-select mb-2"
+            value={form.hypothesisId}
+            onChange={(e) => setForm({ ...form, hypothesisId: e.target.value })}
+          >
+            <option value="">Selecione Hipótese</option>
+            {Array.isArray(hypotheses) && hypotheses.length > 0 ? (
+              hypotheses.map((h) => (
+                <option key={h.id} value={h.id}>
+                  {h.title}
+                </option>
+              ))
+            ) : (
+              <option value="">Não há hipóteses para este nicho</option>
+            )}
+          </select>
+          {Array.isArray(hypotheses) && hypotheses.length === 0 && (
+            <button
+              type="button"
+              className="btn btn-link mb-2"
+              onClick={() => (window.location.href = "/hypotheses?open=new")}
+            >
+              Criar nova hipótese
+            </button>
+          )}
+        </>
       )}
       <input
         className="form-control mb-2"

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from "react-router-dom";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useExperimentsByHypothesis } from "../../api/experiment/useExperimentsByHypothesis";
+import { useAngles } from "../../api/angle/useAngles";
 import PageTitle from "../../components/PageTitle";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 
@@ -12,6 +13,10 @@ export default function HypothesisDetailPage() {
   const { data: experiments } = useExperimentsByHypothesis(
     nicheId,
     hypothesisId,
+  );
+  const { data: angles } = useAngles();
+  const angleMap = new Map<number, string>(
+    Array.isArray(angles) ? angles.map((a) => [a.id, a.name]) : [],
   );
   useBreadcrumbs([
     { label: "Nichos", to: "/niches" },
@@ -44,12 +49,28 @@ export default function HypothesisDetailPage() {
         </div>
       </div>
       <dl className="row">
+        <dt className="col-sm-3">Ângulo</dt>
+        <dd className="col-sm-9">
+          {angleMap.get(data.premiseAngleId ?? 0) || "-"}
+        </dd>
+        <dt className="col-sm-3">Promessa</dt>
+        <dd className="col-sm-9">{data.promise || "-"}</dd>
+        <dt className="col-sm-3">Problema</dt>
+        <dd className="col-sm-9">{data.problem || "-"}</dd>
+        <dt className="col-sm-3">Persona</dt>
+        <dd className="col-sm-9">{data.persona || "-"}</dd>
+        <dt className="col-sm-3">Regra de sucesso</dt>
+        <dd className="col-sm-9">{data.successRule || "-"}</dd>
         <dt className="col-sm-3">Oferta</dt>
         <dd className="col-sm-9">
-          {data.offerType === "TRIPWIRE"
-            ? `Tripwire R$ ${data.price ?? ""}`
-            : "Lead Magnet"}
+          {data.offerType === "TRIPWIRE" ? "Tripwire" : "Lead Magnet"}
         </dd>
+        {data.offerType === "TRIPWIRE" && (
+          <>
+            <dt className="col-sm-3">Preço</dt>
+            <dd className="col-sm-9">R$ {data.price ?? ""}</dd>
+          </>
+        )}
         <dt className="col-sm-3">KPI</dt>
         <dd className="col-sm-9">{data.kpiTargetCpl}</dd>
         <dt className="col-sm-3">Status</dt>


### PR DESCRIPTION
## Summary
- display all hypothesis info on detail page
- keep context niche and hypothesis when creating new experiment

## Testing
- `npm run test`
- `npm run build`
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688ce1c22c448321bf0c75a669bdb60a