### PR TITLE
Expand hypothesis detail and prefill experiment form

### DIFF
--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -1,16 +1,20 @@
 import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useCreateExperiment } from "../../api/experiment/useCreateExperiment";
 import { useNiches } from "../../api/niche/useNiches";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
 import PageTitle from "../../components/PageTitle";
 
 export default function NewExperimentPage() {
+  const [params] = useSearchParams();
+  const nicheIdParam = params.get("nicheId") ?? "";
+  const hypothesisIdParam = params.get("hypothesisId") ?? "";
   const create = useCreateExperiment();
   const { data: niches } = useNiches();
   const [form, setForm] = useState({
-    nicheId: "",
+    nicheId: nicheIdParam,
     name: "",
-    hypothesisId: "",
+    hypothesisId: hypothesisIdParam,
     hypothesis: "",
     kpiTarget: "",
     stopLossCpl: "",
@@ -20,6 +24,8 @@ export default function NewExperimentPage() {
     endDate: "",
   });
   const { data: hypotheses } = useHypothesesByNiche(form.nicheId);
+  const showNicheSelect = nicheIdParam === "";
+  const showHypSelect = hypothesisIdParam === "";
 
   const submit = async () => {
     try {
@@ -36,8 +42,8 @@ export default function NewExperimentPage() {
         endDate: form.endDate || undefined,
       });
       setForm({
-        nicheId: "",
-        hypothesisId: "",
+        nicheId: nicheIdParam,
+        hypothesisId: hypothesisIdParam,
         name: "",
         hypothesis: "",
         kpiTarget: "",
@@ -56,45 +62,51 @@ export default function NewExperimentPage() {
   return (
     <div>
       <PageTitle>Novo Teste de Nicho</PageTitle>
-      <select
-        className="form-select mb-2"
-        value={form.nicheId}
-        onChange={(e) =>
-          setForm({ ...form, nicheId: e.target.value, hypothesisId: "" })
-        }
-      >
-        <option value="">Selecione o Nicho</option>
-        {Array.isArray(niches) &&
-          niches.map((n) => (
-            <option key={n.id} value={n.id}>
-              {n.name}
-            </option>
-          ))}
-      </select>
-      <select
-        className="form-select mb-2"
-        value={form.hypothesisId}
-        onChange={(e) => setForm({ ...form, hypothesisId: e.target.value })}
-      >
-        <option value="">Selecione Hipótese</option>
-        {Array.isArray(hypotheses) && hypotheses.length > 0 ? (
-          hypotheses.map((h) => (
-            <option key={h.id} value={h.id}>
-              {h.title}
-            </option>
-          ))
-        ) : (
-          <option value="">Não há hipóteses para este nicho</option>
-        )}
-      </select>
-      {Array.isArray(hypotheses) && hypotheses.length === 0 && (
-        <button
-          type="button"
-          className="btn btn-link mb-2"
-          onClick={() => (window.location.href = "/hypotheses?open=new")}
+      {showNicheSelect && (
+        <select
+          className="form-select mb-2"
+          value={form.nicheId}
+          onChange={(e) =>
+            setForm({ ...form, nicheId: e.target.value, hypothesisId: "" })
+          }
         >
-          Criar nova hipótese
-        </button>
+          <option value="">Selecione o Nicho</option>
+          {Array.isArray(niches) &&
+            niches.map((n) => (
+              <option key={n.id} value={n.id}>
+                {n.name}
+              </option>
+            ))}
+        </select>
+      )}
+      {showHypSelect && (
+        <>
+          <select
+            className="form-select mb-2"
+            value={form.hypothesisId}
+            onChange={(e) => setForm({ ...form, hypothesisId: e.target.value })}
+          >
+            <option value="">Selecione Hipótese</option>
+            {Array.isArray(hypotheses) && hypotheses.length > 0 ? (
+              hypotheses.map((h) => (
+                <option key={h.id} value={h.id}>
+                  {h.title}
+                </option>
+              ))
+            ) : (
+              <option value="">Não há hipóteses para este nicho</option>
+            )}
+          </select>
+          {Array.isArray(hypotheses) && hypotheses.length === 0 && (
+            <button
+              type="button"
+              className="btn btn-link mb-2"
+              onClick={() => (window.location.href = "/hypotheses?open=new")}
+            >
+              Criar nova hipótese
+            </button>
+          )}
+        </>
       )}
       <input
         className="form-control mb-2"

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -1,7 +1,9 @@
+import { Fragment } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useExperimentsByHypothesis } from "../../api/experiment/useExperimentsByHypothesis";
+import { useAngles } from "../../api/angle/useAngles";
 import PageTitle from "../../components/PageTitle";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 
@@ -13,6 +15,7 @@ export default function HypothesisDetailPage() {
     nicheId,
     hypothesisId,
   );
+  const { data: angles } = useAngles();
   useBreadcrumbs([
     { label: "Nichos", to: "/niches" },
     { label: niche?.name || "...", to: `/niches/${nicheId}` },
@@ -22,6 +25,23 @@ export default function HypothesisDetailPage() {
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;
   const list = Array.isArray(experiments) ? experiments : [];
+  const angleName = angles?.find((a) => a.id === data.premiseAngleId)?.name;
+  const rows = [
+    { label: "Promessa", value: data.promise },
+    { label: "Problema", value: data.problem },
+    { label: "Persona", value: data.persona },
+    { label: "Regra de sucesso", value: data.successRule },
+    { label: "Ângulo", value: angleName },
+    {
+      label: "Oferta",
+      value:
+        data.offerType === "TRIPWIRE"
+          ? `Tripwire R$ ${data.price ?? ""}`
+          : "Lead Magnet",
+    },
+    { label: "KPI", value: data.kpiTargetCpl },
+    { label: "Status", value: data.status },
+  ];
   return (
     <div>
       <div className="d-flex justify-content-between align-items-center">
@@ -43,17 +63,17 @@ export default function HypothesisDetailPage() {
           </Link>
         </div>
       </div>
-      <dl className="row">
-        <dt className="col-sm-3">Oferta</dt>
-        <dd className="col-sm-9">
-          {data.offerType === "TRIPWIRE"
-            ? `Tripwire R$ ${data.price ?? ""}`
-            : "Lead Magnet"}
-        </dd>
-        <dt className="col-sm-3">KPI</dt>
-        <dd className="col-sm-9">{data.kpiTargetCpl}</dd>
-        <dt className="col-sm-3">Status</dt>
-        <dd className="col-sm-9">{data.status}</dd>
+      <dl className="row mb-0">
+        {rows.map((r, idx) => (
+          <Fragment key={r.label}>
+            <dt className={`col-sm-3 py-2${idx % 2 === 0 ? " bg-light" : ""}`}>
+              {r.label}
+            </dt>
+            <dd className={`col-sm-9 py-2${idx % 2 === 0 ? " bg-light" : ""}`}>
+              {r.value}
+            </dd>
+          </Fragment>
+        ))}
       </dl>
       {list.length === 0 ? (
         <p>Nenhum experimento ainda. Crie um agora.</p>


### PR DESCRIPTION
## Summary
- expose all fields on hypothesis detail page
- auto-fill niche and hypothesis when creating an experiment
- hide selects when niche/hypothesis comes from current context

## Testing
- `npm run build`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688ce1c22c448321bf0c75a669bdb60a