### PR TITLE
Fix liquibase migration precondition

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_08_01__exp_financial_fields.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_08_01__exp_financial_fields.sql
@@ -2,27 +2,27 @@
 -- changeset marketinghub:2025-08-01-exp-financial-fields
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'kpi_target_cpl';
-ALTER TABLE experiment ADD COLUMN kpi_target_cpl DECIMAL(10,2) DEFAULT 45.00;
+ALTER TABLE experiment ADD COLUMN IF NOT EXISTS kpi_target_cpl DECIMAL(10,2) DEFAULT 45.00;
 
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'stop_loss_cpl';
-ALTER TABLE experiment ADD COLUMN stop_loss_cpl DECIMAL(10,2) DEFAULT 90.00;
+ALTER TABLE experiment ADD COLUMN IF NOT EXISTS stop_loss_cpl DECIMAL(10,2) DEFAULT 90.00;
 
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'sample_size';
-ALTER TABLE experiment ADD COLUMN sample_size INT DEFAULT 1500;
+ALTER TABLE experiment ADD COLUMN IF NOT EXISTS sample_size INT DEFAULT 1500;
 
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'baseline_cvr';
-ALTER TABLE experiment ADD COLUMN baseline_cvr DECIMAL(5,2) DEFAULT 3.00;
+ALTER TABLE experiment ADD COLUMN IF NOT EXISTS baseline_cvr DECIMAL(5,2) DEFAULT 3.00;
 
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'target_cvr';
-ALTER TABLE experiment ADD COLUMN target_cvr DECIMAL(5,2) DEFAULT 5.00;
+ALTER TABLE experiment ADD COLUMN IF NOT EXISTS target_cvr DECIMAL(5,2) DEFAULT 5.00;
 
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'mde_percent';
-ALTER TABLE experiment ADD COLUMN mde_percent DECIMAL(5,2) DEFAULT 40.0;
+ALTER TABLE experiment ADD COLUMN IF NOT EXISTS mde_percent DECIMAL(5,2) DEFAULT 40.0;
 
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND CONSTRAINT_NAME = 'chk_exp_stoploss' AND CONSTRAINT_TYPE = 'CHECK';


### PR DESCRIPTION
## Summary
- use `ADD COLUMN IF NOT EXISTS` in financial fields migration

## Testing
- `npm run build`
- `npm run test` *(fails: waiting for file changes then manually cancelled but tests passed)*
- `mvn -s ../settings.xml deploy` *(fails: unable to download dependencies)*
- `mvn -s ../settings.xml test` *(fails: unable to download dependencies)*
- `mvn -s settings.xml package` *(fails: unable to download dependencies)*
- `mvn -s settings.xml test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688d198e3d4883219f78422be190a3ed