### PR TITLE
Fix MySQL 5 support in experiment financial fields

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_08_01__exp_financial_fields.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_08_01__exp_financial_fields.sql
@@ -1,29 +1,35 @@
 -- liquibase formatted sql
--- changeset marketinghub:2025-08-01-exp-financial-fields
+-- changeset marketinghub:2025-08-01-add-kpi-target-cpl
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'kpi_target_cpl';
-ALTER TABLE experiment ADD COLUMN IF NOT EXISTS kpi_target_cpl DECIMAL(10,2) DEFAULT 45.00;
+ALTER TABLE experiment ADD COLUMN kpi_target_cpl DECIMAL(10,2) DEFAULT 45.00;
 
+-- changeset marketinghub:2025-08-01-add-stop-loss-cpl
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'stop_loss_cpl';
-ALTER TABLE experiment ADD COLUMN IF NOT EXISTS stop_loss_cpl DECIMAL(10,2) DEFAULT 90.00;
+ALTER TABLE experiment ADD COLUMN stop_loss_cpl DECIMAL(10,2) DEFAULT 90.00;
 
+-- changeset marketinghub:2025-08-01-add-sample-size
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'sample_size';
-ALTER TABLE experiment ADD COLUMN IF NOT EXISTS sample_size INT DEFAULT 1500;
+ALTER TABLE experiment ADD COLUMN sample_size INT DEFAULT 1500;
 
+-- changeset marketinghub:2025-08-01-add-baseline-cvr
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'baseline_cvr';
-ALTER TABLE experiment ADD COLUMN IF NOT EXISTS baseline_cvr DECIMAL(5,2) DEFAULT 3.00;
+ALTER TABLE experiment ADD COLUMN baseline_cvr DECIMAL(5,2) DEFAULT 3.00;
 
+-- changeset marketinghub:2025-08-01-add-target-cvr
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'target_cvr';
-ALTER TABLE experiment ADD COLUMN IF NOT EXISTS target_cvr DECIMAL(5,2) DEFAULT 5.00;
+ALTER TABLE experiment ADD COLUMN target_cvr DECIMAL(5,2) DEFAULT 5.00;
 
+-- changeset marketinghub:2025-08-01-add-mde-percent
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND COLUMN_NAME = 'mde_percent';
-ALTER TABLE experiment ADD COLUMN IF NOT EXISTS mde_percent DECIMAL(5,2) DEFAULT 40.0;
+ALTER TABLE experiment ADD COLUMN mde_percent DECIMAL(5,2) DEFAULT 40.0;
 
+-- changeset marketinghub:2025-08-01-add-chk-exp-stoploss
 --preconditions onFail:MARK_RAN onError:HALT
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'experiment' AND CONSTRAINT_NAME = 'chk_exp_stoploss' AND CONSTRAINT_TYPE = 'CHECK';
 ALTER TABLE experiment ADD CONSTRAINT chk_exp_stoploss CHECK (stop_loss_cpl >= kpi_target_cpl);


### PR DESCRIPTION
## Summary
- split `V2025_08_01__exp_financial_fields.sql` into separate changesets for each column
- remove `IF NOT EXISTS` so migration works on MySQL 5

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688d1d5484dc8321ba3bc8722465f1c4