### PR TITLE
Add lead intake and outbox infrastructure

### DIFF
--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -78,6 +78,10 @@
             <artifactId>liquibase-core</artifactId>
             <version>4.26.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/ads-service/src/main/java/com/example/marketinghub/config/AsyncConfig.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.example.marketinghub.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * Asynchronous execution configuration.
+ */
+@Configuration
+public class AsyncConfig {
+    /**
+     * Executor used for async tasks.
+     */
+    @Bean(name = "taskExecutor")
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setQueueCapacity(500);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/dto/LeadDTO.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/dto/LeadDTO.java
@@ -1,0 +1,17 @@
+package com.example.marketinghub.dto;
+
+import com.example.marketinghub.model.NurtureStage;
+
+import java.time.Instant;
+
+/**
+ * Data transfer object for incoming leads.
+ */
+public record LeadDTO(Long leadgenId,
+                      Long instagramUserId,
+                      Long adId,
+                      Long campaignId,
+                      Long experimentId,
+                      Instant capturedAt,
+                      NurtureStage nurtureStage) {
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/CreativeTag.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/CreativeTag.java
@@ -1,0 +1,21 @@
+package com.example.marketinghub.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Tag applied to creatives for segmentation.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreativeTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/Lead.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/Lead.java
@@ -1,0 +1,41 @@
+package com.example.marketinghub.model;
+
+import com.marketinghub.experiment.Experiment;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Lead captured from webhook.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Lead {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Column(unique = true)
+    private Long leadgenId;
+    private Long instagramUserId;
+    private Long adId;
+    private Long campaignId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_id")
+    private Experiment experiment;
+
+    private Instant capturedAt;
+
+    @Enumerated(EnumType.STRING)
+    private NurtureStage nurtureStage = NurtureStage.NEW;
+
+    private BigDecimal cpl;
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/LeadSequence.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/LeadSequence.java
@@ -1,0 +1,24 @@
+package com.example.marketinghub.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Association between a lead and a sequence template.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeadSequence {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Lead lead;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private SequenceTemplate sequenceTemplate;
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/NurtureStage.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/NurtureStage.java
@@ -1,0 +1,10 @@
+package com.example.marketinghub.model;
+
+/**
+ * Lead nurture stage lifecycle.
+ */
+public enum NurtureStage {
+    NEW,
+    WARM,
+    HOT
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/OutboxEvent.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/OutboxEvent.java
@@ -1,0 +1,32 @@
+package com.example.marketinghub.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Event stored for reliable delivery.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutboxEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID aggregateId;
+
+    private String eventType;
+
+    @Column(columnDefinition = "json")
+    private String payload;
+
+    private Instant createdAt;
+    private Instant processedAt;
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/SequenceTemplate.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/SequenceTemplate.java
@@ -1,0 +1,23 @@
+package com.example.marketinghub.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Template defining a message sequence.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SequenceTemplate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Lob
+    private String content;
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/repository/LeadRepository.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/repository/LeadRepository.java
@@ -1,0 +1,23 @@
+package com.example.marketinghub.repository;
+
+import com.example.marketinghub.model.Lead;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Repository for Lead entity.
+ */
+public interface LeadRepository extends JpaRepository<Lead, UUID> {
+    @EntityGraph(attributePaths = {"experiment"})
+    @Query("select l from Lead l where l.cpl <= :cpl and l.capturedAt between :start and :end")
+    List<Lead> findByCplAndPeriod(@Param("cpl") BigDecimal cpl,
+                                  @Param("start") Instant start,
+                                  @Param("end") Instant end);
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/repository/OutboxRepository.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/repository/OutboxRepository.java
@@ -1,0 +1,20 @@
+package com.example.marketinghub.repository;
+
+import com.example.marketinghub.model.OutboxEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Repository for Outbox events.
+ */
+public interface OutboxRepository extends JpaRepository<OutboxEvent, Long> {
+    List<OutboxEvent> findByProcessedAtIsNull();
+
+    @Query("select e from OutboxEvent e where e.createdAt between :start and :end")
+    List<OutboxEvent> findByPeriod(@Param("start") Instant start,
+                                   @Param("end") Instant end);
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/service/GraphApiClient.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/service/GraphApiClient.java
@@ -1,0 +1,15 @@
+package com.example.marketinghub.service;
+
+import com.example.marketinghub.model.Lead;
+
+/**
+ * Client for Facebook Graph API.
+ */
+public interface GraphApiClient {
+    /**
+     * Sends welcome message asynchronously.
+     *
+     * @param lead lead to welcome
+     */
+    void sendWelcomeAsync(Lead lead);
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/service/GraphApiClientImpl.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/service/GraphApiClientImpl.java
@@ -1,0 +1,21 @@
+package com.example.marketinghub.service;
+
+import com.example.marketinghub.model.Lead;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+/**
+ * Trivial implementation that logs the welcome message.
+ */
+@Service
+public class GraphApiClientImpl implements GraphApiClient {
+    private static final Logger log = LoggerFactory.getLogger(GraphApiClientImpl.class);
+
+    @Override
+    @Async("taskExecutor")
+    public void sendWelcomeAsync(Lead lead) {
+        log.info("Sending welcome to lead {}", lead.getId());
+    }
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/service/LeadService.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/service/LeadService.java
@@ -1,0 +1,68 @@
+package com.example.marketinghub.service;
+
+import com.example.marketinghub.dto.LeadDTO;
+import com.example.marketinghub.model.*;
+import com.example.marketinghub.repository.LeadRepository;
+import com.example.marketinghub.repository.OutboxRepository;
+import com.marketinghub.experiment.Experiment;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+/**
+ * Handles lead persistence and outbox creation.
+ */
+@Service
+public class LeadService {
+    private final LeadRepository leadRepository;
+    private final OutboxRepository outboxRepository;
+    private final GraphApiClient graphApiClient;
+    private final TaskExecutor taskExecutor;
+
+    public LeadService(LeadRepository leadRepository,
+                       OutboxRepository outboxRepository,
+                       GraphApiClient graphApiClient,
+                       TaskExecutor taskExecutor) {
+        this.leadRepository = leadRepository;
+        this.outboxRepository = outboxRepository;
+        this.graphApiClient = graphApiClient;
+        this.taskExecutor = taskExecutor;
+    }
+
+    /**
+     * Saves a lead from webhook and enqueues an outbox event.
+     *
+     * @param dto incoming lead data
+     * @return persisted lead
+     */
+    @Transactional
+    public Lead saveFromWebhook(LeadDTO dto) {
+        Lead lead = Lead.builder()
+                .leadgenId(dto.leadgenId())
+                .instagramUserId(dto.instagramUserId())
+                .adId(dto.adId())
+                .campaignId(dto.campaignId())
+                .capturedAt(dto.capturedAt())
+                .nurtureStage(dto.nurtureStage() != null ? dto.nurtureStage() : NurtureStage.NEW)
+                .build();
+        if (dto.experimentId() != null) {
+            Experiment exp = new Experiment();
+            exp.setId(dto.experimentId());
+            lead.setExperiment(exp);
+        }
+        leadRepository.save(lead);
+
+        OutboxEvent event = OutboxEvent.builder()
+                .aggregateId(lead.getId())
+                .eventType("LEAD_CREATED")
+                .payload("{}")
+                .createdAt(Instant.now())
+                .build();
+        outboxRepository.save(event);
+
+        taskExecutor.execute(() -> graphApiClient.sendWelcomeAsync(lead));
+        return lead;
+    }
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/service/OutboxScheduler.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/service/OutboxScheduler.java
@@ -1,0 +1,36 @@
+package com.example.marketinghub.service;
+
+import com.example.marketinghub.model.OutboxEvent;
+import com.example.marketinghub.repository.OutboxRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Periodically processes pending outbox events.
+ */
+@Component
+public class OutboxScheduler {
+    private final OutboxRepository outboxRepository;
+    private final GraphApiClient graphApiClient;
+
+    public OutboxScheduler(OutboxRepository outboxRepository, GraphApiClient graphApiClient) {
+        this.outboxRepository = outboxRepository;
+        this.graphApiClient = graphApiClient;
+    }
+
+    /**
+     * Re-sends events not yet processed.
+     */
+    @Scheduled(fixedRate = 60000)
+    public void processPending() {
+        List<OutboxEvent> events = outboxRepository.findByProcessedAtIsNull();
+        for (OutboxEvent e : events) {
+            graphApiClient.sendWelcomeAsync(null);
+            e.setProcessedAt(Instant.now());
+            outboxRepository.save(e);
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/web/LeadWebhookController.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/web/LeadWebhookController.java
@@ -1,0 +1,28 @@
+package com.example.marketinghub.web;
+
+import com.example.marketinghub.dto.LeadDTO;
+import com.example.marketinghub.service.LeadService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Webhook endpoint receiving leadgen payloads.
+ */
+@RestController
+@RequestMapping("/webhook")
+public class LeadWebhookController {
+    private final LeadService leadService;
+
+    public LeadWebhookController(LeadService leadService) {
+        this.leadService = leadService;
+    }
+
+    @PostMapping("/leadgen")
+    public ResponseEntity<Void> receiveLead(@RequestBody LeadDTO dto) {
+        leadService.saveFromWebhook(dto);
+        return ResponseEntity.accepted().build();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/AdsServiceApplication.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/AdsServiceApplication.java
@@ -7,9 +7,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "com.marketinghub")
-@EntityScan(basePackages = "com.marketinghub")
-@EnableJpaRepositories(basePackages = "com.marketinghub")
+@SpringBootApplication(scanBasePackages = {"com.marketinghub", "com.example.marketinghub"})
+@EntityScan(basePackages = {"com.marketinghub", "com.example.marketinghub"})
+@EnableJpaRepositories(basePackages = {"com.marketinghub", "com.example.marketinghub"})
 @EnableAsync
 @EnableScheduling
 public class AdsServiceApplication {

--- a/backend/ads-service/src/main/resources/db/migration/V20250802__lead_and_outbox.sql
+++ b/backend/ads-service/src/main/resources/db/migration/V20250802__lead_and_outbox.sql
@@ -1,0 +1,21 @@
+CREATE TABLE lead (
+    id BINARY(16) PRIMARY KEY,
+    leadgen_id BIGINT UNIQUE,
+    instagram_user_id BIGINT,
+    ad_id BIGINT,
+    campaign_id BIGINT,
+    experiment_id BIGINT,
+    captured_at TIMESTAMP,
+    nurture_stage ENUM('NEW','WARM','HOT') DEFAULT 'NEW',
+    cpl DECIMAL(10,2),
+    INDEX idx_lead_captured_experiment (captured_at, experiment_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE outbox (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    aggregate_id BINARY(16),
+    event_type VARCHAR(50),
+    payload JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    processed_at TIMESTAMP NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/backend/ads-service/src/test/java/com/example/marketinghub/service/LeadServiceTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/service/LeadServiceTest.java
@@ -1,0 +1,53 @@
+package com.example.marketinghub.service;
+
+import com.example.marketinghub.dto.LeadDTO;
+import com.example.marketinghub.model.Lead;
+import com.example.marketinghub.model.NurtureStage;
+import com.example.marketinghub.repository.LeadRepository;
+import com.example.marketinghub.repository.OutboxRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.TaskExecutor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+class LeadServiceTest {
+    @Mock
+    LeadRepository leadRepository;
+    @Mock
+    OutboxRepository outboxRepository;
+    @Mock
+    GraphApiClient graphApiClient;
+
+    TaskExecutor taskExecutor = Runnable::run;
+
+    @InjectMocks
+    LeadService leadService = new LeadService(leadRepository, outboxRepository, graphApiClient, taskExecutor);
+
+    @Test
+    void saveFromWebhookPersistsEntitiesAndCallsGraph() {
+        when(leadRepository.save(any())).thenAnswer(inv -> {
+            Lead l = inv.getArgument(0);
+            l.setId(UUID.randomUUID());
+            return l;
+        });
+
+        LeadDTO dto = new LeadDTO(1L, 2L, 3L, 4L, null, Instant.now(), NurtureStage.NEW);
+        Lead lead = leadService.saveFromWebhook(dto);
+
+        verify(leadRepository).save(any());
+        verify(outboxRepository).save(any());
+        verify(graphApiClient).sendWelcomeAsync(any());
+        assertEquals(dto.leadgenId(), lead.getLeadgenId());
+    }
+}

--- a/backend/ads-service/src/test/java/com/example/marketinghub/service/OutboxSchedulerTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/service/OutboxSchedulerTest.java
@@ -1,0 +1,36 @@
+package com.example.marketinghub.service;
+
+import com.example.marketinghub.model.OutboxEvent;
+import com.example.marketinghub.repository.OutboxRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxSchedulerTest {
+    @Mock
+    OutboxRepository outboxRepository;
+    @Mock
+    GraphApiClient graphApiClient;
+
+    @InjectMocks
+    OutboxScheduler scheduler;
+
+    @Test
+    void processPendingMarksEventsProcessed() {
+        OutboxEvent event = OutboxEvent.builder().build();
+        when(outboxRepository.findByProcessedAtIsNull()).thenReturn(Collections.singletonList(event));
+
+        scheduler.processPending();
+
+        assertNotNull(event.getProcessedAt());
+        verify(outboxRepository).save(event);
+    }
+}

--- a/frontend/src/pages/LeadTester.tsx
+++ b/frontend/src/pages/LeadTester.tsx
@@ -1,0 +1,49 @@
+import { useForm } from "react-hook-form";
+
+interface LeadForm {
+  leadgenId: string;
+  instagramUserId: string;
+  adId: string;
+  campaignId: string;
+  experimentId: string;
+}
+
+/**
+ * Simple page to manually post a lead to the backend webhook.
+ */
+export default function LeadTester() {
+  const { register, handleSubmit, reset } = useForm<LeadForm>();
+
+  const onSubmit = async (data: LeadForm) => {
+    await fetch("/webhook/leadgen", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...data,
+        capturedAt: new Date().toISOString(),
+      }),
+    });
+    reset();
+  };
+
+  return (
+    <div className="container">
+      <h1>Lead Tester</h1>
+      <form>
+        <input placeholder="leadgenId" {...register("leadgenId")} />
+        <input placeholder="instagramUserId" {...register("instagramUserId")} />
+        <input placeholder="adId" {...register("adId")} />
+        <input placeholder="campaignId" {...register("campaignId")} />
+        <input placeholder="experimentId" {...register("experimentId")} />
+        <button
+          type="button"
+          onClick={handleSubmit(onSubmit, (errors) => {
+            console.log("Validation errors", errors);
+          })}
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Flyway migration for `lead` and `outbox` tables
- implement lead capture models, repositories, services, and webhook controller
- add React Hook Form LeadTester page for manual lead submission

## Testing
- `mvn -s ../settings.xml clean package` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e18b0ac6483218de81f85aca5caca