### PR TITLE
Fix LeadServiceTest mock initialization

### DIFF
--- a/backend/ads-service/src/test/java/com/example/marketinghub/service/LeadServiceTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/service/LeadServiceTest.java
@@ -5,9 +5,8 @@ import com.example.marketinghub.model.Lead;
 import com.example.marketinghub.model.NurtureStage;
 import com.example.marketinghub.repository.LeadRepository;
 import com.example.marketinghub.repository.OutboxRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.task.TaskExecutor;
@@ -31,8 +30,12 @@ class LeadServiceTest {
 
     TaskExecutor taskExecutor = Runnable::run;
 
-    @InjectMocks
-    LeadService leadService = new LeadService(leadRepository, outboxRepository, graphApiClient, taskExecutor);
+    LeadService leadService;
+
+    @BeforeEach
+    void setUp() {
+        leadService = new LeadService(leadRepository, outboxRepository, graphApiClient, taskExecutor);
+    }
 
     @Test
     void saveFromWebhookPersistsEntitiesAndCallsGraph() {


### PR DESCRIPTION
## Summary
- Initialize LeadService after Mockito creates mocks to avoid NullPointerException in tests

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e73f615448321ac87b5177e1ef909