### PR TITLE
Replace Flyway with Liquibase for ads-service migrations

### DIFF
--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -78,10 +78,6 @@
             <artifactId>liquibase-core</artifactId>
             <version>4.26.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_08_02__lead_and_outbox.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_08_02__lead_and_outbox.sql
@@ -1,3 +1,7 @@
+-- Creates lead and outbox tables
+-- liquibase formatted sql
+
+-- changeset marketinghub:2025-08-02-create-lead
 CREATE TABLE lead (
     id BINARY(16) PRIMARY KEY,
     leadgen_id BIGINT UNIQUE,
@@ -10,8 +14,10 @@ CREATE TABLE lead (
     cpl DECIMAL(10,2)
 );
 
+-- changeset marketinghub:2025-08-02-lead-index
 CREATE INDEX idx_lead_captured_experiment ON lead (captured_at, experiment_id);
 
+-- changeset marketinghub:2025-08-02-create-outbox
 CREATE TABLE outbox (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
     aggregate_id BINARY(16),

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -29,3 +29,6 @@ databaseChangeLog:
   - include:
       file: V2025_08_01__exp_financial_fields.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_08_02__lead_and_outbox.sql
+      relativeToChangelogFile: true


### PR DESCRIPTION
## Summary
- Drop Flyway dependency
- Move lead/outbox SQL into Liquibase changelog
- Reference new migration in Liquibase master file

## Testing
- `mvn -s ../settings.xml test` *(failed: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ea578722c8321bca30b1154289090