### PR TITLE
Adapt migrations and tests for MySQL 5

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -11,9 +11,26 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: marketinghub
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_ACTOR: ${{ github.actor }}
+      TEST_DB_URL: jdbc:mysql://localhost:3306/marketinghub
+      TEST_DB_USERNAME: root
+      TEST_DB_PASSWORD: root
+      TEST_DB_DRIVER: com.mysql.cj.jdbc.Driver
     defaults:
       run:
         working-directory: success-product-worker

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_08_02__lead_and_outbox.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_08_02__lead_and_outbox.sql
@@ -9,10 +9,10 @@ CREATE TABLE lead (
     ad_id BIGINT,
     campaign_id BIGINT,
     experiment_id BIGINT,
-    captured_at TIMESTAMP,
+    captured_at DATETIME DEFAULT NULL,
     nurture_stage ENUM('NEW','WARM','HOT') DEFAULT 'NEW',
     cpl DECIMAL(10,2)
-);
+) ENGINE=InnoDB;
 
 -- changeset marketinghub:2025-08-02-lead-index
 CREATE INDEX idx_lead_captured_experiment ON lead (captured_at, experiment_id);
@@ -22,7 +22,7 @@ CREATE TABLE outbox (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
     aggregate_id BINARY(16),
     event_type VARCHAR(50),
-    payload JSON,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    processed_at TIMESTAMP NULL
-);
+    payload TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    processed_at DATETIME DEFAULT NULL
+) ENGINE=InnoDB;

--- a/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
@@ -15,9 +15,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EntityScan("com.marketinghub.ads")
 @ContextConfiguration(classes = SuccessProductWorkerApplication.class)
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName=org.h2.Driver",
-        "spring.datasource.username=sa",
+        "spring.datasource.url=${TEST_DB_URL:jdbc:h2:mem:testdb}",
+        "spring.datasource.driverClassName=${TEST_DB_DRIVER:org.h2.Driver}",
+        "spring.datasource.username=${TEST_DB_USERNAME:sa}",
+        "spring.datasource.password=${TEST_DB_PASSWORD:}",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })


### PR DESCRIPTION
## Summary
- align 2 Aug 2025 migration with MySQL 5 syntax
- allow worker tests to switch to MySQL via env vars
- run worker CI against MySQL 5.7

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service:0.0.1-SNAPSHOT)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:success-product-worker:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_688eb9942eb883219778c00ca6727262