### PR TITLE
fix: separate lead and outbox changelog

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_08_02__lead_and_outbox.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_08_02__lead_and_outbox.sql
@@ -1,8 +1,8 @@
 -- liquibase formatted sql
 -- Creates lead and outbox tables
 
--- changeset marketinghub:2025-08-02-create-lead
-CREATE TABLE lead (
+--changeset marketinghub:2025-08-02-create-lead
+CREATE TABLE `lead` (
     id BINARY(16) PRIMARY KEY,
     leadgen_id BIGINT UNIQUE,
     instagram_user_id BIGINT,
@@ -14,10 +14,10 @@ CREATE TABLE lead (
     cpl DECIMAL(10,2)
 ) ENGINE=InnoDB;
 
--- changeset marketinghub:2025-08-02-lead-index
-CREATE INDEX idx_lead_captured_experiment ON lead (captured_at, experiment_id);
+--changeset marketinghub:2025-08-02-lead-index
+CREATE INDEX idx_lead_captured_experiment ON `lead` (captured_at, experiment_id);
 
--- changeset marketinghub:2025-08-02-create-outbox
+--changeset marketinghub:2025-08-02-create-outbox
 CREATE TABLE outbox (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
     aggregate_id BINARY(16),


### PR DESCRIPTION
## Summary
- ensure Liquibase processes lead and outbox schema separately by using proper `--changeset` markers and quoting

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f0fe63bc08321a196817df80adb71