### PR TITLE
fix: accept prior lead changelog checksums

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_08_02__lead_and_outbox.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_08_02__lead_and_outbox.sql
@@ -1,7 +1,7 @@
 -- liquibase formatted sql
 -- Creates lead and outbox tables
 
---changeset marketinghub:2025-08-02-create-lead
+--changeset marketinghub:2025-08-02-create-lead validCheckSum:9:59377eb84c77f99a62db5b10494e8299
 CREATE TABLE `lead` (
     id BINARY(16) PRIMARY KEY,
     leadgen_id BIGINT UNIQUE,
@@ -14,7 +14,7 @@ CREATE TABLE `lead` (
     cpl DECIMAL(10,2)
 ) ENGINE=InnoDB;
 
---changeset marketinghub:2025-08-02-lead-index
+--changeset marketinghub:2025-08-02-lead-index validCheckSum:9:d2b6d6ee31ec84b98fd1e17a4305d0e5
 CREATE INDEX idx_lead_captured_experiment ON `lead` (captured_at, experiment_id);
 
 --changeset marketinghub:2025-08-02-create-outbox


### PR DESCRIPTION
## Summary
- add valid checksum markers for lead creation and index changesets

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_688f18115f948321b6fb07597722477a