### PR TITLE
feat: add metric preset support

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -37,6 +37,10 @@ public class Experiment {
     @JoinColumn(name = "hypothesis_id", nullable = false)
     private com.marketinghub.hypothesis.Hypothesis hypothesisRef;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "metric_preset_id")
+    private MetricPreset metricPreset;
+
     @Column(precision = 10, scale = 2)
     private java.math.BigDecimal kpiTargetCpl;
     /** Stop-loss operacional em CPL. */
@@ -71,4 +75,19 @@ public class Experiment {
 
     @UpdateTimestamp
     private Instant updatedAt;
+
+    @PrePersist
+    void applyMetricPreset() {
+        if (metricPreset != null) {
+            if (sampleSize == null) {
+                sampleSize = metricPreset.getSampleSize();
+            }
+            if (stopLossCpl == null && kpiTargetCpl != null && metricPreset.getStopLossFactor() != null) {
+                stopLossCpl = kpiTargetCpl.multiply(metricPreset.getStopLossFactor());
+            }
+            if (mdePercent == null) {
+                mdePercent = metricPreset.getDefaultMdePp();
+            }
+        }
+    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/MetricPreset.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/MetricPreset.java
@@ -1,0 +1,29 @@
+package com.marketinghub.experiment;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import lombok.*;
+
+/**
+ * Preset of structural metrics for experiments.
+ */
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "metric_preset")
+public class MetricPreset {
+    @Id
+    private String id;
+
+    private String name;
+
+    private Integer sampleSize;
+
+    @Column(precision = 5, scale = 2)
+    private BigDecimal stopLossFactor;
+
+    @Column(name = "default_mde_pp", precision = 5, scale = 2)
+    private BigDecimal defaultMdePp;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
@@ -14,7 +14,7 @@ public class CreateExperimentRequest {
     private String name;
     private String hypothesis;
     private BigDecimal kpiTargetCpl;
-    private BigDecimal stopLossCpl;
+    private String metricPresetId;
     private Integer sampleSize;
     private BigDecimal baselineCvr;
     private BigDecimal targetCvr;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -29,4 +29,5 @@ public class ExperimentDto {
     private ExperimentPlatform platform;
     private Instant createdAt;
     private Instant updatedAt;
+    private String metricPresetId;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/MetricPresetDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/MetricPresetDto.java
@@ -1,0 +1,16 @@
+package com.marketinghub.experiment.dto;
+
+import java.math.BigDecimal;
+import lombok.Data;
+
+/**
+ * DTO for {@link com.marketinghub.experiment.MetricPreset}.
+ */
+@Data
+public class MetricPresetDto {
+    private String id;
+    private String name;
+    private Integer sampleSize;
+    private BigDecimal stopLossFactor;
+    private BigDecimal defaultMdePp;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/mapper/ExperimentMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/mapper/ExperimentMapper.java
@@ -11,5 +11,6 @@ import org.mapstruct.Mapper;
 public interface ExperimentMapper {
     @org.mapstruct.Mapping(target = "nicheId", source = "niche.id")
     @org.mapstruct.Mapping(target = "hypothesisId", source = "hypothesisRef.id")
+    @org.mapstruct.Mapping(target = "metricPresetId", source = "metricPreset.id")
     ExperimentDto toDto(Experiment experiment);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/mapper/MetricPresetMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/mapper/MetricPresetMapper.java
@@ -1,0 +1,13 @@
+package com.marketinghub.experiment.mapper;
+
+import com.marketinghub.experiment.MetricPreset;
+import com.marketinghub.experiment.dto.MetricPresetDto;
+import org.mapstruct.Mapper;
+
+/**
+ * MapStruct mapper for MetricPreset.
+ */
+@Mapper(componentModel = "spring")
+public interface MetricPresetMapper {
+    MetricPresetDto toDto(MetricPreset preset);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/MetricPresetRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/MetricPresetRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.experiment.repository;
+
+import com.marketinghub.experiment.MetricPreset;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Repository for {@link MetricPreset} entities.
+ */
+public interface MetricPresetRepository extends CrudRepository<MetricPreset, String> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -20,14 +20,17 @@ public class ExperimentService {
     private final ExperimentRepository repository;
     private final MarketNicheRepository nicheRepository;
     private final com.marketinghub.hypothesis.repository.HypothesisRepository hypothesisRepository;
+    private final MetricPresetService metricPresetService;
     private final EntityManager entityManager;
 
     public ExperimentService(ExperimentRepository repository, MarketNicheRepository nicheRepository,
                              com.marketinghub.hypothesis.repository.HypothesisRepository hypothesisRepository,
+                             MetricPresetService metricPresetService,
                              EntityManager entityManager) {
         this.repository = repository;
         this.nicheRepository = nicheRepository;
         this.hypothesisRepository = hypothesisRepository;
+        this.metricPresetService = metricPresetService;
         this.entityManager = entityManager;
     }
 
@@ -72,13 +75,14 @@ public class ExperimentService {
         if (repository.existsByNicheAndName(niche, request.getName())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name already exists for niche");
         }
-        if (request.getStopLossCpl() != null && request.getStopLossCpl().compareTo(java.math.BigDecimal.ZERO) <= 0) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "stopLossCpl must be positive");
+        if (request.getKpiTargetCpl() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "kpiTargetCpl required");
         }
-        if (request.getKpiTargetCpl() != null && request.getStopLossCpl() != null &&
-                request.getStopLossCpl().compareTo(request.getKpiTargetCpl()) < 0) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "stopLossCpl must be >= kpiTargetCpl");
+        if (request.getMetricPresetId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "metricPresetId required");
         }
+        MetricPreset preset = metricPresetService.get(request.getMetricPresetId());
+        java.math.BigDecimal computedStopLoss = request.getKpiTargetCpl().multiply(preset.getStopLossFactor());
         if (request.getSampleSize() != null && request.getSampleSize() < 100) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "sampleSize must be at least 100");
         }
@@ -92,7 +96,8 @@ public class ExperimentService {
                 .hypothesis(request.getHypothesis())
                 .hypothesisRef(hyp)
                 .kpiTargetCpl(request.getKpiTargetCpl())
-                .stopLossCpl(request.getStopLossCpl())
+                .metricPreset(preset)
+                .stopLossCpl(computedStopLoss)
                 .sampleSize(request.getSampleSize())
                 .baselineCvr(request.getBaselineCvr())
                 .targetCvr(request.getTargetCvr())
@@ -134,6 +139,7 @@ public class ExperimentService {
                 .hypothesis(original.getHypothesis())
                 .hypothesisRef(original.getHypothesisRef())
                 .kpiTargetCpl(original.getKpiTargetCpl())
+                .metricPreset(original.getMetricPreset())
                 .stopLossCpl(original.getStopLossCpl())
                 .sampleSize(original.getSampleSize())
                 .baselineCvr(original.getBaselineCvr())

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/MetricPresetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/MetricPresetService.java
@@ -1,0 +1,25 @@
+package com.marketinghub.experiment.service;
+
+import com.marketinghub.experiment.MetricPreset;
+import com.marketinghub.experiment.repository.MetricPresetRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service layer for metric presets.
+ */
+@Service
+public class MetricPresetService {
+    private final MetricPresetRepository repository;
+
+    public MetricPresetService(MetricPresetRepository repository) {
+        this.repository = repository;
+    }
+
+    public Iterable<MetricPreset> list() {
+        return repository.findAll();
+    }
+
+    public MetricPreset get(String id) {
+        return repository.findById(id).orElseThrow();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/MetricPresetController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/MetricPresetController.java
@@ -1,0 +1,33 @@
+package com.marketinghub.experiment.web;
+
+import com.marketinghub.experiment.dto.MetricPresetDto;
+import com.marketinghub.experiment.mapper.MetricPresetMapper;
+import com.marketinghub.experiment.service.MetricPresetService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+/**
+ * REST controller for metric presets.
+ */
+@RestController
+@RequestMapping("/api/metric-presets")
+public class MetricPresetController {
+    private final MetricPresetService service;
+    private final MetricPresetMapper mapper;
+
+    public MetricPresetController(MetricPresetService service, MetricPresetMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @GetMapping
+    public List<MetricPresetDto> list() {
+        return StreamSupport.stream(service.list().spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+}

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -26,3 +26,4 @@ logging.level.org.hibernate.type=TRACE
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 # Enable detailed Liquibase logging
 logging.level.liquibase=DEBUG
+spring.config.import=optional:metrics.yml

--- a/backend/ads-service/src/main/resources/db/changelog/V20250804__metric_preset.xml
+++ b/backend/ads-service/src/main/resources/db/changelog/V20250804__metric_preset.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+    <changeSet id="metric_preset_table" author="codex">
+        <createTable tableName="metric_preset">
+            <column name="id" type="varchar(50)">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(100)"/>
+            <column name="sample_size" type="int"/>
+            <column name="stop_loss_factor" type="decimal(5,2)"/>
+            <column name="default_mde_pp" type="decimal(5,2)"/>
+        </createTable>
+        <insert tableName="metric_preset">
+            <column name="id" value="LEAN_300"/>
+            <column name="name" value="Lean-Startup 300"/>
+            <column name="sample_size" valueNumeric="300"/>
+            <column name="stop_loss_factor" valueNumeric="2.0"/>
+            <column name="default_mde_pp" valueNumeric="9"/>
+        </insert>
+        <insert tableName="metric_preset">
+            <column name="id" value="LEAN_150"/>
+            <column name="name" value="Lean-Startup 150"/>
+            <column name="sample_size" valueNumeric="150"/>
+            <column name="stop_loss_factor" valueNumeric="2.0"/>
+            <column name="default_mde_pp" valueNumeric="12"/>
+        </insert>
+        <insert tableName="metric_preset">
+            <column name="id" value="LEAN_100"/>
+            <column name="name" value="Lean-Startup 100"/>
+            <column name="sample_size" valueNumeric="100"/>
+            <column name="stop_loss_factor" valueNumeric="2.0"/>
+            <column name="default_mde_pp" valueNumeric="14"/>
+        </insert>
+    </changeSet>
+    <changeSet id="metric_preset_fk" author="codex">
+        <addColumn tableName="experiment">
+            <column name="metric_preset_id" type="varchar(50)"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="experiment" baseColumnNames="metric_preset_id"
+                                  referencedTableName="metric_preset" referencedColumnNames="id"
+                                  constraintName="fk_experiment_metric_preset"/>
+    </changeSet>
+</databaseChangeLog>

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -32,3 +32,6 @@ databaseChangeLog:
   - include:
       file: V2025_08_02__lead_and_outbox.sql
       relativeToChangelogFile: true
+  - include:
+      file: V20250804__metric_preset.xml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
@@ -25,6 +25,7 @@ public class FixtureUtils {
     private final AdSetRepository adSetRepository;
     private final com.marketinghub.creative.label.repository.AngleRepository angleRepository;
     private final com.marketinghub.hypothesis.repository.HypothesisRepository hypothesisRepository;
+    private final com.marketinghub.experiment.repository.MetricPresetRepository metricPresetRepository;
 
     public MarketNiche createAndSaveNiche() {
         MarketNiche niche = MarketNiche.builder()
@@ -51,6 +52,14 @@ public class FixtureUtils {
 
     public Experiment createAndSaveExperiment(MarketNiche niche) {
         var hyp = createAndSaveHypothesis(niche);
+        MetricPreset preset = metricPresetRepository.save(
+                MetricPreset.builder()
+                        .id("LEAN_150")
+                        .name("Lean-Startup 150")
+                        .sampleSize(150)
+                        .stopLossFactor(java.math.BigDecimal.valueOf(2))
+                        .defaultMdePp(java.math.BigDecimal.valueOf(12))
+                        .build());
         String name = "Experiment-" + java.util.UUID.randomUUID();
         Experiment exp = Experiment.builder()
                 .niche(niche)
@@ -58,11 +67,9 @@ public class FixtureUtils {
                 .hypothesis("H")
                 .hypothesisRef(hyp)
                 .kpiTargetCpl(java.math.BigDecimal.valueOf(45))
-                .stopLossCpl(java.math.BigDecimal.valueOf(90))
-                .sampleSize(1500)
+                .metricPreset(preset)
                 .baselineCvr(java.math.BigDecimal.valueOf(3))
                 .targetCvr(java.math.BigDecimal.valueOf(5))
-                .mdePercent(java.math.BigDecimal.valueOf(40))
                 .status(ExperimentStatus.PLANNED)
                 .platform(ExperimentPlatform.FACEBOOK)
                 .build();

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.MetricPreset;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
@@ -39,6 +40,8 @@ class ExperimentControllerTest {
     AngleRepository angleRepository;
     @Autowired
     HypothesisRepository hypothesisRepository;
+    @Autowired
+    com.marketinghub.experiment.repository.MetricPresetRepository metricPresetRepository;
 
     @Test
     void postExperiment() throws Exception {
@@ -54,12 +57,19 @@ class ExperimentControllerTest {
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(new BigDecimal("1"))
                 .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setName("Exp1");
         req.setHypothesisId(hyp.getId());
         req.setHypothesis("h");
         req.setKpiTargetCpl(new BigDecimal("45"));
-        req.setStopLossCpl(new BigDecimal("90"));
+        req.setMetricPresetId("LEAN_150");
         req.setSampleSize(1500);
         req.setBaselineCvr(new BigDecimal("3"));
         req.setTargetCvr(new BigDecimal("5"));
@@ -84,10 +94,17 @@ class ExperimentControllerTest {
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(new BigDecimal("1"))
                 .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setHypothesisId(hyp.getId());
         req.setName("Exp1");
-        req.setStopLossCpl(new BigDecimal("90"));
+        req.setMetricPresetId("LEAN_150");
         req.setSampleSize(1500);
         req.setBaselineCvr(new BigDecimal("3"));
         req.setTargetCvr(new BigDecimal("5"));

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.experiment;
 
+import com.marketinghub.experiment.MetricPreset;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.niche.MarketNiche;
@@ -33,6 +34,8 @@ class ExperimentServiceTest {
     com.marketinghub.hypothesis.repository.HypothesisRepository hypothesisRepository;
     @Autowired
     com.marketinghub.creative.label.repository.AngleRepository angleRepository;
+    @Autowired
+    com.marketinghub.experiment.repository.MetricPresetRepository metricPresetRepository;
 
     @Test
     void createNewExperimentWithExistingNiche() {
@@ -48,13 +51,20 @@ class ExperimentServiceTest {
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(new BigDecimal("1"))
                 .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setMarketNicheId(niche.getId());
         req.setHypothesisId(hyp.getId());
         req.setName("Exp1");
         req.setHypothesis("Teste");
         req.setKpiTargetCpl(new BigDecimal("45"));
-        req.setStopLossCpl(new BigDecimal("90"));
+        req.setMetricPresetId("LEAN_150");
         req.setSampleSize(1500);
         req.setBaselineCvr(new BigDecimal("3"));
         req.setTargetCvr(new BigDecimal("5"));
@@ -78,11 +88,18 @@ class ExperimentServiceTest {
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(new BigDecimal("1"))
                 .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setMarketNicheId(niche.getId());
         req.setHypothesisId(hyp.getId());
         req.setName("Exp1");
-        req.setStopLossCpl(new BigDecimal("90"));
+        req.setMetricPresetId("LEAN_150");
         req.setSampleSize(1500);
         req.setBaselineCvr(new BigDecimal("3"));
         req.setTargetCvr(new BigDecimal("5"));
@@ -108,11 +125,18 @@ class ExperimentServiceTest {
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(new BigDecimal("1"))
                 .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setMarketNicheId(niche2.getId());
         req.setHypothesisId(hyp.getId());
         req.setName("Exp1");
-        req.setStopLossCpl(new BigDecimal("90"));
+        req.setMetricPresetId("LEAN_150");
         req.setSampleSize(1500);
         req.setBaselineCvr(new BigDecimal("3"));
         req.setTargetCvr(new BigDecimal("5"));

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -52,6 +52,8 @@ class ExperimentControllerTest {
     @Autowired
     private HypothesisRepository hypothesisRepository;
     @Autowired
+    private com.marketinghub.experiment.repository.MetricPresetRepository metricPresetRepository;
+    @Autowired
     private com.marketinghub.creative.repository.CreativeRepository creativeRepo;
     @Autowired
     private FixtureUtils fixtures;
@@ -82,12 +84,19 @@ class ExperimentControllerTest {
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(BigDecimal.ONE)
                 .build());
+        metricPresetRepository.save(com.marketinghub.experiment.MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setName("Exp1");
         req.setHypothesisId(hyp.getId());
         req.setHypothesis("H1");
         req.setKpiTargetCpl(new BigDecimal("45"));
-        req.setStopLossCpl(new BigDecimal("90"));
+        req.setMetricPresetId("LEAN_150");
         req.setSampleSize(1500);
         req.setBaselineCvr(new BigDecimal("3"));
         req.setTargetCvr(new BigDecimal("5"));

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -68,8 +68,8 @@ components:
           type: string
         kpiTarget:
           type: number
-        stopLossCpl:
-          type: number
+        metricPresetId:
+          type: string
         sampleSize:
           type: integer
         mde:

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -8,7 +8,7 @@ export interface CreateExperiment {
   name: string;
   hypothesis: string;
   kpiTarget: number;
-  stopLossCpl?: number;
+  metricPresetId: string;
   sampleSize?: number;
   mde?: number;
   startDate?: string;

--- a/frontend/src/api/experiment/useMetricPresets.ts
+++ b/frontend/src/api/experiment/useMetricPresets.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface MetricPreset {
+  id: string;
+  name: string;
+  sampleSize: number;
+  stopLossFactor: number;
+  defaultMdePp: number;
+}
+
+export function useMetricPresets() {
+  return useQuery({
+    queryKey: ["metric-presets"],
+    queryFn: async () => {
+      const { data } = await axios.get<MetricPreset[]>("/api/metric-presets");
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { useCreateExperiment } from "../../api/experiment/useCreateExperiment";
 import { useNiches } from "../../api/niche/useNiches";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
+import { useMetricPresets } from "../../api/experiment/useMetricPresets";
 import PageTitle from "../../components/PageTitle";
 
 export default function NewExperimentPage() {
@@ -17,13 +18,14 @@ export default function NewExperimentPage() {
     hypothesisId: hypothesisIdParam,
     hypothesis: "",
     kpiTarget: "",
-    stopLossCpl: "",
+    metricPresetId: "",
     sampleSize: "",
     mde: "",
     startDate: "",
     endDate: "",
   });
   const { data: hypotheses } = useHypothesesByNiche(form.nicheId);
+  const { data: presets } = useMetricPresets();
   const showNicheSelect = nicheIdParam === "";
   const showHypSelect = hypothesisIdParam === "";
 
@@ -35,7 +37,7 @@ export default function NewExperimentPage() {
         name: form.name,
         hypothesis: form.hypothesis,
         kpiTarget: Number(form.kpiTarget),
-        stopLossCpl: form.stopLossCpl ? Number(form.stopLossCpl) : undefined,
+        metricPresetId: form.metricPresetId,
         sampleSize: form.sampleSize ? Number(form.sampleSize) : undefined,
         mde: form.mde ? Number(form.mde) : undefined,
         startDate: form.startDate || undefined,
@@ -47,7 +49,7 @@ export default function NewExperimentPage() {
         name: "",
         hypothesis: "",
         kpiTarget: "",
-        stopLossCpl: "",
+        metricPresetId: "",
         sampleSize: "",
         mde: "",
         startDate: "",
@@ -127,13 +129,19 @@ export default function NewExperimentPage() {
         value={form.kpiTarget}
         onChange={(e) => setForm({ ...form, kpiTarget: e.target.value })}
       />
-      <input
-        className="form-control mb-2"
-        placeholder="Stop-loss CPL"
-        type="number"
-        value={form.stopLossCpl}
-        onChange={(e) => setForm({ ...form, stopLossCpl: e.target.value })}
-      />
+      <select
+        className="form-select mb-2"
+        value={form.metricPresetId}
+        onChange={(e) => setForm({ ...form, metricPresetId: e.target.value })}
+      >
+        <option value="">Selecione Preset de Métricas</option>
+        {Array.isArray(presets) &&
+          presets.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+      </select>
       <input
         className="form-control mb-2"
         placeholder="Tamanho da amostra"

--- a/success-product-worker/src/main/java/com/marketinghub/worker/MetricPresetCache.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/MetricPresetCache.java
@@ -1,0 +1,33 @@
+package com.marketinghub.worker;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * In-memory cache for metric preset limits.
+ */
+@Component
+public class MetricPresetCache {
+    private final Map<Integer, Integer> checkpoints = new HashMap<>();
+
+    public MetricPresetCache() {
+        checkpoints.put(300, 50);
+        checkpoints.put(150, 30);
+        checkpoints.put(100, 25);
+    }
+
+    /**
+     * Returns checkpoint clicks for given sample size.
+     */
+    public int checkpointForSampleSize(int sampleSize) {
+        if (sampleSize >= 300) {
+            return checkpoints.get(300);
+        }
+        if (sampleSize >= 150) {
+            return checkpoints.get(150);
+        }
+        return checkpoints.get(100);
+    }
+}

--- a/success-product-worker/src/main/java/com/marketinghub/worker/StopLossService.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/StopLossService.java
@@ -11,8 +11,15 @@ import org.springframework.stereotype.Service;
 public class StopLossService {
     private static final Logger log = LoggerFactory.getLogger(StopLossService.class);
 
-    public boolean shouldPause(double spend, int impressions, double cpa, double kpiTarget) {
-        boolean result = impressions > 1000 && spend > 0 && cpa > kpiTarget * 2;
+    private final MetricPresetCache presetCache;
+
+    public StopLossService(MetricPresetCache presetCache) {
+        this.presetCache = presetCache;
+    }
+
+    public boolean shouldPause(double spend, int clicks, double cpa, double kpiTarget, int sampleSize) {
+        int checkpoint = presetCache.checkpointForSampleSize(sampleSize);
+        boolean result = clicks >= checkpoint && spend > 0 && cpa > kpiTarget * 2;
         if (result) {
             log.info("Stop-loss acionado: CPA {} > {}", cpa, kpiTarget * 2);
         }

--- a/success-product-worker/src/test/java/com/marketinghub/worker/StopLossServiceTest.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/StopLossServiceTest.java
@@ -6,15 +6,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class StopLossServiceTest {
     @Test
     void shouldPauseWhenThresholdExceeded() {
-        StopLossService svc = new StopLossService();
-        boolean pause = svc.shouldPause(50.0, 1500, 20.0, 5.0);
+        StopLossService svc = new StopLossService(new MetricPresetCache());
+        boolean pause = svc.shouldPause(50.0, 51, 20.0, 5.0, 300);
         assertThat(pause).isTrue();
     }
 
     @Test
     void shouldNotPauseWhenBelowThreshold() {
-        StopLossService svc = new StopLossService();
-        boolean pause = svc.shouldPause(10.0, 900, 8.0, 5.0);
+        StopLossService svc = new StopLossService(new MetricPresetCache());
+        boolean pause = svc.shouldPause(10.0, 10, 8.0, 5.0, 150);
         assertThat(pause).isFalse();
     }
 }


### PR DESCRIPTION
## Summary
- add Liquibase changelog for metric preset table and reference from experiment
- link experiments to metric presets with automatic metric defaults
- expose metric preset API and integrate selection in new experiment form
- cache metric preset checkpoints in worker for dynamic stop-loss

## Testing
- `mvn -s ../settings.xml test` *(failed: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(failed: Non-resolvable parent POM)*
- `npm run test` *(failed: Minified React error #310)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890c10c05b48321b8580de4cd7656c5