### PR TITLE
feat: improve experiment detail and editing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import EditAiServicePage from "./pages/aiService/EditAiServicePage";
 import ExperimentListPage from "./pages/experiment/ExperimentListPage";
 import NewExperimentPage from "./pages/experiment/NewExperimentPage";
 import ExperimentDetailPage from "./pages/experiment/ExperimentDetailPage";
+import EditExperimentPage from "./pages/experiment/EditExperimentPage";
 import NicheDetailPage from "./pages/niche/NicheDetailPage";
 import HypothesisDetailPage from "./pages/hypothesis/HypothesisDetailPage";
 import HypothesesPage from "./pages/hypothesis/HypothesesPage";
@@ -176,6 +177,7 @@ export default function App() {
         <Route path="/experiments/new" element={<NewExperimentPage />} />
         <Route path="/experiments/:id" element={<AppLayout />}>
           <Route index element={<ExperimentDetailPage />} />
+          <Route path="edit" element={<EditExperimentPage />} />
         </Route>
         <Route path="/hypotheses" element={<HypothesisListPage />} />
         <Route path="/hypotheses/board" element={<HypothesesPage />} />

--- a/frontend/src/__tests__/NicheFlow.test.tsx
+++ b/frontend/src/__tests__/NicheFlow.test.tsx
@@ -89,12 +89,11 @@ describe("niche navigation", () => {
     userEvent.click(screen.getByText("Ver detalhes"));
     await screen.findByText("Criar Experimento");
     userEvent.click(screen.getByText("Abrir"));
-    expect(await screen.findByText(/Teste 100/)).toBeTruthy();
+    expect(await screen.findByText("Exp 1")).toBeTruthy();
     const bc = screen.getByRole("navigation", { name: /breadcrumb/i });
     expect(bc).toBeTruthy();
     expect(within(bc).getByText("Nichos")).toBeTruthy();
     expect(within(bc).getByText("Fitness")).toBeTruthy();
     expect(within(bc).getByText("Hip 1")).toBeTruthy();
-    expect(within(bc).getByText("Exp 1")).toBeTruthy();
   });
 });

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -8,8 +8,11 @@ export interface Experiment {
   name: string;
   hypothesis: string;
   kpiTarget: number;
+  sampleSize?: number | null;
+  mdePercent?: number | null;
   startDate: string | null;
   endDate: string | null;
+  metricPresetId?: string | null;
   status: string;
   platform: string;
   createdAt: string;

--- a/frontend/src/api/experiment/useUpdateExperiment.ts
+++ b/frontend/src/api/experiment/useUpdateExperiment.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Experiment } from "./useExperiments";
+
+export interface UpdateExperiment {
+  name: string;
+  hypothesis: string;
+  kpiTarget: number;
+  metricPresetId?: string;
+  sampleSize?: number;
+  mde?: number;
+  startDate?: string;
+  endDate?: string;
+}
+
+export function useUpdateExperiment(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: UpdateExperiment) => {
+      const { data: experiment } = await axios.put<Experiment>(
+        `/api/experiments/${id}`,
+        data,
+      );
+      return experiment;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["experiment", id] });
+      queryClient.invalidateQueries({ queryKey: ["experiments"] });
+    },
+  });
+}

--- a/frontend/src/pages/experiment/EditExperimentPage.tsx
+++ b/frontend/src/pages/experiment/EditExperimentPage.tsx
@@ -1,0 +1,119 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate, useParams } from "react-router-dom";
+import { useExperiment } from "../../api/experiment/useExperiment";
+import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
+import { useMetricPresets } from "../../api/experiment/useMetricPresets";
+import PageTitle from "../../components/PageTitle";
+
+interface FormData {
+  name: string;
+  hypothesis: string;
+  kpiTarget: string;
+  metricPresetId: string;
+  sampleSize: string;
+  mde: string;
+  startDate: string;
+  endDate: string;
+}
+
+export default function EditExperimentPage() {
+  const { id } = useParams<{ id: string }>();
+  const expId = id as string;
+  const navigate = useNavigate();
+  const { data, isLoading } = useExperiment(expId);
+  const { data: presets } = useMetricPresets();
+  const update = useUpdateExperiment(expId);
+  const { register, handleSubmit, reset } = useForm<FormData>();
+
+  useEffect(() => {
+    if (data) {
+      reset({
+        name: data.name || "",
+        hypothesis: data.hypothesis || "",
+        kpiTarget: data.kpiTarget ? String(data.kpiTarget) : "",
+        metricPresetId: data.metricPresetId || "",
+        sampleSize: data.sampleSize ? String(data.sampleSize) : "",
+        mde: data.mdePercent ? String(data.mdePercent) : "",
+        startDate: data.startDate || "",
+        endDate: data.endDate || "",
+      });
+    }
+  }, [data, reset]);
+
+  const onSubmit = async (values: FormData) => {
+    try {
+      await update.mutateAsync({
+        name: values.name,
+        hypothesis: values.hypothesis,
+        kpiTarget: Number(values.kpiTarget),
+        metricPresetId: values.metricPresetId || undefined,
+        sampleSize: values.sampleSize ? Number(values.sampleSize) : undefined,
+        mde: values.mde ? Number(values.mde) : undefined,
+        startDate: values.startDate || undefined,
+        endDate: values.endDate || undefined,
+      });
+      navigate(-1);
+    } catch {
+      alert("Erro ao salvar Teste");
+    }
+  };
+
+  if (isLoading || !data) return <p>Carregando...</p>;
+
+  return (
+    <div>
+      <PageTitle>Editar Teste</PageTitle>
+      <label className="form-label">Nome</label>
+      <input className="form-control mb-2" {...register("name")} />
+      <label className="form-label">Hipótese</label>
+      <input className="form-control mb-2" {...register("hypothesis")} />
+      <label className="form-label">Meta do KPI</label>
+      <input
+        className="form-control mb-2"
+        type="number"
+        {...register("kpiTarget")}
+      />
+      <label className="form-label">Preset de Métricas</label>
+      <select className="form-select mb-2" {...register("metricPresetId")}>
+        <option value="">Selecione Preset de Métricas</option>
+        {Array.isArray(presets) &&
+          presets.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+      </select>
+      <label className="form-label">Tamanho da amostra</label>
+      <input
+        className="form-control mb-2"
+        type="number"
+        {...register("sampleSize")}
+      />
+      <label className="form-label">MDE %</label>
+      <input className="form-control mb-2" type="number" {...register("mde")} />
+      <label className="form-label">Data de Início</label>
+      <input
+        className="form-control mb-2"
+        type="date"
+        {...register("startDate")}
+      />
+      <label className="form-label">Data de Término</label>
+      <input
+        className="form-control mb-2"
+        type="date"
+        {...register("endDate")}
+      />
+      <button
+        type="button"
+        className="btn btn-primary"
+        disabled={update.isPending}
+        onClick={handleSubmit(onSubmit, (errors) => {
+          console.log("Validation errors", errors);
+        })}
+      >
+        Salvar
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useExperiment } from "../../api/experiment/useExperiment";
+import { useMetricPresets } from "../../api/experiment/useMetricPresets";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import PageTitle from "../../components/PageTitle";
@@ -17,6 +18,7 @@ export default function ExperimentDetailPage() {
     data ? String(data.nicheId) : undefined,
     data ? String(data.hypothesisId) : undefined,
   );
+  const { data: presets } = useMetricPresets();
   const [tab, setTab] = useState("overview");
   useBreadcrumbs([
     { label: "Nichos", to: "/niches" },
@@ -29,22 +31,38 @@ export default function ExperimentDetailPage() {
   ]);
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;
+  const presetName = presets?.find((p) => p.id === data.metricPresetId)?.name;
   const rows = [
-    { label: "Nome", value: data.name },
     {
       label: "Nicho",
       value: <Link to={`/niches/${data.nicheId}/edit`}>{niche?.name}</Link>,
     },
-    { label: "Hipótese", value: data.hypothesis },
+    {
+      label: "Hipótese",
+      value: (
+        <Link to={`/niches/${data.nicheId}/hypotheses/${data.hypothesisId}`}>
+          {hyp?.title || data.hypothesis}
+        </Link>
+      ),
+    },
+    { label: "Preset de Métricas", value: presetName || "—" },
     { label: "KPI", value: data.kpiTarget },
     { label: "Início", value: data.startDate },
     { label: "Término", value: data.endDate },
   ];
   return (
     <div>
-      <div className="d-flex justify-content-between align-items-center">
-        <PageTitle>{`Teste ${data.id}`}</PageTitle>
-        <span className="badge bg-secondary">{data.status}</span>
+      <div className="d-flex justify-content-between align-items-start">
+        <div>
+          <PageTitle>{data.name}</PageTitle>
+          <p className="text-muted mb-0">{data.hypothesis}</p>
+        </div>
+        <div className="d-flex align-items-center">
+          <Link to="edit" className="btn btn-outline-secondary me-2">
+            Editar
+          </Link>
+          <span className="badge bg-secondary">{data.status}</span>
+        </div>
       </div>
       <Tabs.Root value={tab} onValueChange={setTab} className="mt-3">
         <Tabs.List className="nav nav-tabs">


### PR DESCRIPTION
## Summary
- highlight experiment title and hypothesis
- show metric preset and allow editing experiments
- support editing experiments via new API hook

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890e2dd7c0c832188dd4e8c8a75615c