### PR TITLE
feat: support experiment update endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
@@ -1,0 +1,24 @@
+package com.marketinghub.experiment.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Data;
+
+/**
+ * Request body for updating an experiment.
+ */
+@Data
+public class UpdateExperimentRequest {
+    private String name;
+    private String hypothesis;
+    @JsonProperty("kpiTarget")
+    private BigDecimal kpiTargetCpl;
+    private String metricPresetId;
+    private Integer sampleSize;
+    @JsonProperty("mde")
+    private BigDecimal mdePercent;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}
+

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment.service;
 
 import com.marketinghub.experiment.*;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
+import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
@@ -165,6 +166,56 @@ public class ExperimentService {
             }
         }
         exp.setStatus(status);
+        return exp;
+    }
+
+    /**
+     * Updates mutable fields of an experiment.
+     */
+    @Transactional
+    public Experiment update(Long id, UpdateExperimentRequest request) {
+        Experiment exp = repository.findById(id).orElseThrow();
+
+        if (request.getName() == null || request.getKpiTargetCpl() == null
+                || request.getHypothesis() == null || request.getMetricPresetId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "required fields missing");
+        }
+
+        if (!exp.getName().equals(request.getName()) &&
+                repository.existsByNicheAndName(exp.getNiche(), request.getName())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name already exists for niche");
+        }
+
+        if (request.getStartDate() != null && request.getEndDate() != null
+                && request.getStartDate().isAfter(request.getEndDate())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "startDate must be before endDate");
+        }
+
+        if (request.getSampleSize() != null && request.getSampleSize() < 100) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "sampleSize must be at least 100");
+        }
+
+        MetricPreset preset = metricPresetService.get(request.getMetricPresetId());
+
+        exp.setName(request.getName());
+        exp.setHypothesis(request.getHypothesis());
+        exp.setKpiTargetCpl(request.getKpiTargetCpl());
+        exp.setMetricPreset(preset);
+        if (request.getSampleSize() != null) {
+            exp.setSampleSize(request.getSampleSize());
+        } else {
+            exp.setSampleSize(preset.getSampleSize());
+        }
+        if (request.getMdePercent() != null) {
+            exp.setMdePercent(request.getMdePercent());
+        } else {
+            exp.setMdePercent(preset.getDefaultMdePp());
+        }
+        if (request.getKpiTargetCpl() != null && preset.getStopLossFactor() != null) {
+            exp.setStopLossCpl(request.getKpiTargetCpl().multiply(preset.getStopLossFactor()));
+        }
+        exp.setStartDate(request.getStartDate());
+        exp.setEndDate(request.getEndDate());
         return exp;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment.web;
 
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.dto.ExperimentDto;
+import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.mapper.ExperimentMapper;
 import com.marketinghub.experiment.service.ExperimentService;
 import org.springframework.web.bind.annotation.*;
@@ -53,6 +54,11 @@ public class ExperimentController {
             @PathVariable Long id,
             @RequestParam com.marketinghub.experiment.ExperimentStatus status) {
         return mapper.toDto(service.updateStatus(id, status));
+    }
+
+    @PutMapping("/{id}")
+    public ExperimentDto update(@PathVariable Long id, @RequestBody UpdateExperimentRequest request) {
+        return mapper.toDto(service.update(id, request));
     }
 
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -3,6 +3,7 @@ package com.marketinghub.experiment.web;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.ads.AdsServiceApplication;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
+import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
@@ -22,6 +23,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -110,5 +112,30 @@ class ExperimentControllerTest {
                 .andExpect(status().isOk());
 
         assertThat(repository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void updateEndpointUpdatesFields() throws Exception {
+        var niche = nicheRepo.findById(nicheId).orElseThrow();
+        var exp = fixtures.createAndSaveExperiment(niche);
+        UpdateExperimentRequest req = new UpdateExperimentRequest();
+        req.setName("Updated");
+        req.setHypothesis("Hyp");
+        req.setKpiTargetCpl(new BigDecimal("50"));
+        req.setMetricPresetId("LEAN_150");
+        req.setSampleSize(200);
+        req.setMdePercent(new BigDecimal("30"));
+        req.setStartDate(LocalDate.now());
+        req.setEndDate(LocalDate.now().plusDays(2));
+
+        mockMvc.perform(put("/api/experiments/" + exp.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+
+        var updated = repository.findById(exp.getId()).orElseThrow();
+        assertThat(updated.getName()).isEqualTo("Updated");
+        assertThat(updated.getSampleSize()).isEqualTo(200);
+        assertThat(updated.getMdePercent()).isEqualTo(new BigDecimal("30"));
     }
 }


### PR DESCRIPTION
## Summary
- add DTO and service/controller logic to update experiments
- cover experiment updates with integration test

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68910f59ac58832182fd59f7eb2d47e8