### PR TITLE
feat: allow updating experiments

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
@@ -1,0 +1,22 @@
+package com.marketinghub.experiment.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Request body for updating an experiment.
+ */
+@Data
+public class UpdateExperimentRequest {
+    private String name;
+    private String hypothesis;
+    /** KPI target in CPL. */
+    private BigDecimal kpiTarget;
+    private String metricPresetId;
+    private Integer sampleSize;
+    private BigDecimal mde;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment.service;
 
 import com.marketinghub.experiment.*;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
+import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
@@ -151,6 +152,56 @@ public class ExperimentService {
                 .platform(original.getPlatform())
                 .build();
         return repository.save(copy);
+    }
+
+    /**
+     * Updates an existing experiment.
+     */
+    @Transactional
+    public Experiment update(Long id, UpdateExperimentRequest req) {
+        Experiment exp = repository.findById(id).orElseThrow();
+        if (req.getName() != null && !req.getName().equals(exp.getName())) {
+            if (repository.existsByNicheAndName(exp.getNiche(), req.getName())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name already exists for niche");
+            }
+            exp.setName(req.getName());
+        }
+        if (req.getHypothesis() != null) {
+            exp.setHypothesis(req.getHypothesis());
+        }
+        if (req.getStartDate() != null && req.getEndDate() != null &&
+                req.getStartDate().isAfter(req.getEndDate())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "startDate must be before endDate");
+        }
+        if (req.getStartDate() != null) {
+            exp.setStartDate(req.getStartDate());
+        }
+        if (req.getEndDate() != null) {
+            exp.setEndDate(req.getEndDate());
+        }
+        if (req.getMetricPresetId() != null) {
+            MetricPreset preset = metricPresetService.get(req.getMetricPresetId());
+            exp.setMetricPreset(preset);
+            if (exp.getKpiTargetCpl() != null && preset.getStopLossFactor() != null) {
+                exp.setStopLossCpl(exp.getKpiTargetCpl().multiply(preset.getStopLossFactor()));
+            }
+        }
+        if (req.getKpiTarget() != null) {
+            exp.setKpiTargetCpl(req.getKpiTarget());
+            if (exp.getMetricPreset() != null && exp.getMetricPreset().getStopLossFactor() != null) {
+                exp.setStopLossCpl(req.getKpiTarget().multiply(exp.getMetricPreset().getStopLossFactor()));
+            }
+        }
+        if (req.getSampleSize() != null) {
+            if (req.getSampleSize() < 100) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "sampleSize must be at least 100");
+            }
+            exp.setSampleSize(req.getSampleSize());
+        }
+        if (req.getMde() != null) {
+            exp.setMdePercent(req.getMde());
+        }
+        return exp;
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment.web;
 
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.dto.ExperimentDto;
+import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.mapper.ExperimentMapper;
 import com.marketinghub.experiment.service.ExperimentService;
 import org.springframework.web.bind.annotation.*;
@@ -26,6 +27,11 @@ public class ExperimentController {
     @PostMapping
     public ExperimentDto create(@RequestBody CreateExperimentRequest request) {
         return mapper.toDto(service.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public ExperimentDto update(@PathVariable Long id, @RequestBody UpdateExperimentRequest request) {
+        return mapper.toDto(service.update(id, request));
     }
 
     @PostMapping("/{id}/duplicate")

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -110,5 +111,28 @@ class ExperimentControllerTest {
                 .andExpect(status().isOk());
 
         assertThat(repository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void updateEndpointChangesFields() throws Exception {
+        var exp = fixtures.createAndSaveExperiment(nicheRepo.findById(nicheId).orElseThrow());
+        var body = new java.util.HashMap<String, Object>();
+        body.put("name", "Updated");
+        body.put("hypothesis", "Nova");
+        body.put("kpiTarget", new BigDecimal("99"));
+        body.put("sampleSize", 1500);
+        body.put("startDate", LocalDate.now());
+        body.put("endDate", LocalDate.now().plusDays(10));
+
+        mockMvc.perform(put("/api/experiments/" + exp.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(body)))
+                .andExpect(status().isOk());
+
+        var updated = repository.findById(exp.getId()).orElseThrow();
+        assertThat(updated.getName()).isEqualTo("Updated");
+        assertThat(updated.getHypothesis()).isEqualTo("Nova");
+        assertThat(updated.getKpiTargetCpl()).isEqualByComparingTo("99");
+        assertThat(updated.getSampleSize()).isEqualTo(1500);
     }
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -41,6 +41,24 @@ paths:
       responses:
         '200':
           description: OK
+  /api/experiments/{id}:
+    put:
+      summary: Atualizar experimento
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateExperimentRequest'
+      responses:
+        '200':
+          description: OK
   /api/experiments/{id}/duplicate:
     post:
       summary: Duplicar experimento
@@ -62,6 +80,27 @@ components:
           type: integer
         hypothesisId:
           type: string
+        name:
+          type: string
+        hypothesis:
+          type: string
+        kpiTarget:
+          type: number
+        metricPresetId:
+          type: string
+        sampleSize:
+          type: integer
+        mde:
+          type: number
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+    UpdateExperimentRequest:
+      type: object
+      properties:
         name:
           type: string
         hypothesis:


### PR DESCRIPTION
## Summary
- add PUT /api/experiments/{id} to update experiment details
- document update endpoint in OpenAPI spec
- cover experiment update with integration test

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -s ../settings.xml deploy` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68910f59ac58832182fd59f7eb2d47e8