### PR TITLE
fix: allow patch updates for experiments

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -57,6 +57,7 @@ public class ExperimentController {
     }
 
     @PutMapping("/{id}")
+    @PatchMapping("/{id}")
     public ExperimentDto update(@PathVariable Long id, @RequestBody UpdateExperimentRequest request) {
         return mapper.toDto(service.update(id, request));
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -23,7 +23,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -128,7 +128,7 @@ class ExperimentControllerTest {
         req.setStartDate(LocalDate.now());
         req.setEndDate(LocalDate.now().plusDays(2));
 
-        mockMvc.perform(put("/api/experiments/" + exp.getId())
+        mockMvc.perform(patch("/api/experiments/" + exp.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(req)))
                 .andExpect(status().isOk());

--- a/frontend/src/api/experiment/useUpdateExperiment.ts
+++ b/frontend/src/api/experiment/useUpdateExperiment.ts
@@ -17,7 +17,7 @@ export function useUpdateExperiment(id: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (data: UpdateExperiment) => {
-      const { data: experiment } = await axios.put<Experiment>(
+      const { data: experiment } = await axios.patch<Experiment>(
         `/api/experiments/${id}`,
         data,
       );


### PR DESCRIPTION
## Summary
- allow experiment updates via PATCH
- update experiment tests for patch handling
- switch frontend experiment update to PATCH

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891169dfa1c8321b28f825adaea365c