### PR TITLE
Fix CORS for PATCH requests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/WebConfig.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/WebConfig.java
@@ -14,7 +14,7 @@ public class WebConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                         .allowedOrigins("*");
             }
 


### PR DESCRIPTION
## Summary
- allow PATCH requests in backend CORS configuration

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_6891aaacf85c832193396e9159d12cc5