### PR TITLE
Enable PATCH on experiment update endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -56,8 +56,7 @@ public class ExperimentController {
         return mapper.toDto(service.updateStatus(id, status));
     }
 
-    @PutMapping("/{id}")
-    @PatchMapping("/{id}")
+    @RequestMapping(value = "/{id}", method = {RequestMethod.PUT, RequestMethod.PATCH})
     public ExperimentDto update(@PathVariable Long id, @RequestBody UpdateExperimentRequest request) {
         return mapper.toDto(service.update(id, request));
     }


### PR DESCRIPTION
## Summary
- Map experiment update endpoint with `@RequestMapping` supporting PUT and PATCH methods to prevent 405 errors when updating experiments.

## Testing
- `mvn -s ../settings.xml spotless:apply` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_6891ae19cf9c8321b7091ff3753341c8