### PR TITLE
Fix BigDecimal comparison in experiment update test

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -136,6 +136,6 @@ class ExperimentControllerTest {
         var updated = repository.findById(exp.getId()).orElseThrow();
         assertThat(updated.getName()).isEqualTo("Updated");
         assertThat(updated.getSampleSize()).isEqualTo(200);
-        assertThat(updated.getMdePercent()).isEqualTo(new BigDecimal("30"));
+        assertThat(updated.getMdePercent()).isEqualByComparingTo("30");
     }
 }


### PR DESCRIPTION
## Summary
- use AssertJ `isEqualByComparingTo` to ignore BigDecimal scale when validating `mdePercent`

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891b16f44288321949bc174d40f4f33