### PR TITLE
feat: add lead scoring and funnel stimulus tracking

### DIFF
--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/FunnelEvent.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/FunnelEvent.java
@@ -1,0 +1,31 @@
+package com.example.marketinghub.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Event emitted by the sales funnel for a given lead.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FunnelEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lead_id")
+    private Lead lead;
+
+    @Enumerated(EnumType.STRING)
+    private FunnelStimulus stimulus;
+
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/FunnelStimulus.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/FunnelStimulus.java
@@ -1,0 +1,12 @@
+package com.example.marketinghub.model;
+
+/**
+ * Stimuli emitted in the sales funnel that can influence lead score.
+ */
+public enum FunnelStimulus {
+    LEAD_CAPTURED,
+    LANDING_VIEW,
+    CHATBOT_INTERACTION,
+    CHECKOUT_VIEW,
+    PURCHASE
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/Lead.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/Lead.java
@@ -34,8 +34,12 @@ public class Lead {
 
     private Instant capturedAt;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     private NurtureStage nurtureStage = NurtureStage.NEW;
+
+    @Builder.Default
+    private int score = 0;
 
     private BigDecimal cpl;
 }

--- a/backend/ads-service/src/main/java/com/example/marketinghub/repository/FunnelEventRepository.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/repository/FunnelEventRepository.java
@@ -1,0 +1,12 @@
+package com.example.marketinghub.repository;
+
+import com.example.marketinghub.model.FunnelEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+/**
+ * Repository for funnel events.
+ */
+public interface FunnelEventRepository extends JpaRepository<FunnelEvent, UUID> {
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/service/LeadScoreService.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/service/LeadScoreService.java
@@ -1,0 +1,60 @@
+package com.example.marketinghub.service;
+
+import com.example.marketinghub.model.*;
+import com.example.marketinghub.repository.FunnelEventRepository;
+import com.example.marketinghub.repository.LeadRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Applies scoring rules based on funnel stimuli.
+ */
+@Service
+@RequiredArgsConstructor
+public class LeadScoreService {
+
+    private final LeadRepository leadRepository;
+    private final FunnelEventRepository funnelEventRepository;
+
+    private static final Map<FunnelStimulus, Integer> WEIGHTS = Map.of(
+            FunnelStimulus.LEAD_CAPTURED, 1,
+            FunnelStimulus.LANDING_VIEW, 1,
+            FunnelStimulus.CHECKOUT_VIEW, 2,
+            FunnelStimulus.CHATBOT_INTERACTION, 1,
+            FunnelStimulus.PURCHASE, 5
+    );
+
+    /**
+     * Records a stimulus for the lead and updates its score and nurture stage.
+     * @param lead lead to update
+     * @param stimulus funnel stimulus emitted
+     */
+    @Transactional
+    public void recordEvent(Lead lead, FunnelStimulus stimulus) {
+        int weight = WEIGHTS.getOrDefault(stimulus, 0);
+        lead.setScore(lead.getScore() + weight);
+        updateStage(lead);
+        leadRepository.save(lead);
+
+        FunnelEvent event = FunnelEvent.builder()
+                .lead(lead)
+                .stimulus(stimulus)
+                .createdAt(Instant.now())
+                .build();
+        funnelEventRepository.save(event);
+    }
+
+    private void updateStage(Lead lead) {
+        if (lead.getScore() >= 5) {
+            lead.setNurtureStage(NurtureStage.HOT);
+        } else if (lead.getScore() >= 2) {
+            lead.setNurtureStage(NurtureStage.WARM);
+        } else {
+            lead.setNurtureStage(NurtureStage.NEW);
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/service/LeadService.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/service/LeadService.java
@@ -19,15 +19,18 @@ public class LeadService {
     private final LeadRepository leadRepository;
     private final OutboxRepository outboxRepository;
     private final GraphApiClient graphApiClient;
+    private final LeadScoreService leadScoreService;
     private final TaskExecutor taskExecutor;
 
     public LeadService(LeadRepository leadRepository,
                        OutboxRepository outboxRepository,
                        GraphApiClient graphApiClient,
+                       LeadScoreService leadScoreService,
                        TaskExecutor taskExecutor) {
         this.leadRepository = leadRepository;
         this.outboxRepository = outboxRepository;
         this.graphApiClient = graphApiClient;
+        this.leadScoreService = leadScoreService;
         this.taskExecutor = taskExecutor;
     }
 
@@ -63,6 +66,8 @@ public class LeadService {
         outboxRepository.save(event);
 
         taskExecutor.execute(() -> graphApiClient.sendWelcomeAsync(lead));
+
+        leadScoreService.recordEvent(lead, FunnelStimulus.LEAD_CAPTURED);
         return lead;
     }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_08_03__lead_scoring.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_08_03__lead_scoring.sql
@@ -1,0 +1,13 @@
+-- Adds score column to lead and creates funnel_event table
+--changeset marketinghub:2025-08-03-lead-score
+ALTER TABLE `lead` ADD COLUMN score INT NOT NULL DEFAULT 0;
+
+--changeset marketinghub:2025-08-03-funnel-event
+CREATE TABLE `funnel_event` (
+    id BINARY(16) PRIMARY KEY,
+    lead_id BINARY(16),
+    stimulus VARCHAR(50),
+    created_at DATETIME(6),
+    CONSTRAINT fk_funnel_event_lead FOREIGN KEY (lead_id) REFERENCES `lead`(id)
+);
+CREATE INDEX idx_funnel_event_lead ON `funnel_event` (lead_id, created_at);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -33,5 +33,8 @@ databaseChangeLog:
       file: V2025_08_02__lead_and_outbox.sql
       relativeToChangelogFile: true
   - include:
+      file: V2025_08_03__lead_scoring.sql
+      relativeToChangelogFile: true
+  - include:
       file: V20250804__metric_preset.xml
       relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/example/marketinghub/service/LeadScoreServiceTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/service/LeadScoreServiceTest.java
@@ -1,0 +1,46 @@
+package com.example.marketinghub.service;
+
+import com.example.marketinghub.model.*;
+import com.example.marketinghub.repository.FunnelEventRepository;
+import com.example.marketinghub.repository.LeadRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeadScoreServiceTest {
+
+    @Mock
+    LeadRepository leadRepository;
+    @Mock
+    FunnelEventRepository funnelEventRepository;
+
+    LeadScoreService leadScoreService;
+
+    @BeforeEach
+    void setUp() {
+        leadScoreService = new LeadScoreService(leadRepository, funnelEventRepository);
+    }
+
+    @Test
+    void recordEventUpdatesScoreAndStage() {
+        Lead lead = Lead.builder().id(UUID.randomUUID()).score(0).nurtureStage(NurtureStage.NEW).build();
+        when(leadRepository.save(any())).thenReturn(lead);
+
+        leadScoreService.recordEvent(lead, FunnelStimulus.CHECKOUT_VIEW);
+
+        assertEquals(2, lead.getScore());
+        assertEquals(NurtureStage.WARM, lead.getNurtureStage());
+        verify(funnelEventRepository).save(any());
+        verify(leadRepository).save(lead);
+    }
+}

--- a/backend/ads-service/src/test/java/com/example/marketinghub/service/LeadServiceTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/service/LeadServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.marketinghub.service;
 
 import com.example.marketinghub.dto.LeadDTO;
+import com.example.marketinghub.model.FunnelStimulus;
 import com.example.marketinghub.model.Lead;
 import com.example.marketinghub.model.NurtureStage;
 import com.example.marketinghub.repository.LeadRepository;
@@ -16,6 +17,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -27,6 +29,8 @@ class LeadServiceTest {
     OutboxRepository outboxRepository;
     @Mock
     GraphApiClient graphApiClient;
+    @Mock
+    LeadScoreService leadScoreService;
 
     TaskExecutor taskExecutor = Runnable::run;
 
@@ -34,7 +38,7 @@ class LeadServiceTest {
 
     @BeforeEach
     void setUp() {
-        leadService = new LeadService(leadRepository, outboxRepository, graphApiClient, taskExecutor);
+        leadService = new LeadService(leadRepository, outboxRepository, graphApiClient, leadScoreService, taskExecutor);
     }
 
     @Test
@@ -51,6 +55,7 @@ class LeadServiceTest {
         verify(leadRepository).save(any());
         verify(outboxRepository).save(any());
         verify(graphApiClient).sendWelcomeAsync(any());
+        verify(leadScoreService).recordEvent(any(), eq(FunnelStimulus.LEAD_CAPTURED));
         assertEquals(dto.leadgenId(), lead.getLeadgenId());
     }
 }


### PR DESCRIPTION
## Summary
- track funnel stimuli and record lead scores
- store funnel events and update lead nurture stage

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service)*

------
https://chatgpt.com/codex/tasks/task_e_68924ce28414832199c2760d9262d039