### PR TITLE
Use Long for experiment ID in funnel queries

### DIFF
--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelController.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelController.java
@@ -16,7 +16,7 @@ public class FunnelController {
     private final FunnelService funnelService;
 
     @GetMapping
-    public List<SalesFunnel> listByExperiment(@RequestParam UUID experimentId) {
+    public List<SalesFunnel> listByExperiment(@RequestParam Long experimentId) {
         return funnelService.findByExperiment(experimentId);
     }
 

--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelService.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelService.java
@@ -45,7 +45,7 @@ public class FunnelService {
                 .reduce(java.math.BigDecimal.ZERO, java.math.BigDecimal::add);
     }
 
-    public List<SalesFunnel> findByExperiment(UUID experimentId) {
+    public List<SalesFunnel> findByExperiment(Long experimentId) {
         return funnelRepository.findByExperimentId(experimentId);
     }
 

--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/SalesFunnelRepository.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/SalesFunnelRepository.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 /** Repository for {@link SalesFunnel}. */
 public interface SalesFunnelRepository extends JpaRepository<SalesFunnel, UUID> {
-    List<SalesFunnel> findByExperimentId(UUID experimentId);
+    List<SalesFunnel> findByExperimentId(Long experimentId);
 
     @EntityGraph(attributePaths = "steps")
     Optional<SalesFunnel> findWithStepsById(UUID id);


### PR DESCRIPTION
## Summary
- use `Long` instead of `UUID` to look up funnels by experiment ID
- update funnel service and controller to match repository change

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893774c5318832187000f67acd54c7c