### PR TITLE
feat: add funnels route and navigation tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ import VisualProofsPage from "./pages/VisualProofsPage";
 import EmotionalTriggersPage from "./pages/EmotionalTriggersPage";
 import LandingPreview from "./pages/landing/LandingPreview";
 import AnalyticsDashboard from "./pages/landing/AnalyticsDashboard";
+import FunnelsPage from "./pages/FunnelsPage";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
@@ -86,6 +87,9 @@ export default function App() {
             </Link>
             <Link className="nav-link" to="/emotional-triggers">
               Gatilhos Emocionais
+            </Link>
+            <Link className="nav-link" to="/funnels">
+              Funil de Vendas
             </Link>
             <div className="nav-item dropdown">
               <span
@@ -189,6 +193,7 @@ export default function App() {
         <Route path="/emotional-triggers" element={<EmotionalTriggersPage />} />
         <Route path="/landing/:id" element={<LandingPreview />} />
         <Route path="/analytics" element={<AnalyticsDashboard />} />
+        <Route path="/funnels" element={<FunnelsPage />} />
         <Route path="*" element={<div>Início</div>} />
       </Routes>
       <ToastContainer position="top-right" />

--- a/frontend/src/__tests__/FunnelNavigation.test.tsx
+++ b/frontend/src/__tests__/FunnelNavigation.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, afterEach } from "vitest";
+import React from "react";
+import App from "../App";
+
+function setup(ui: React.ReactNode, initialEntries: string[]) {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("funnels navigation", () => {
+  it("renders FunnelBuilder on /funnels route", async () => {
+    setup(<App />, ["/funnels"]);
+    expect(
+      await screen.findByRole("button", { name: /add step/i }),
+    ).toBeTruthy();
+  });
+
+  it("has menu link to /funnels", () => {
+    setup(<App />, ["/"]);
+    const link = screen.getByRole("link", { name: /funil de vendas/i });
+    expect(link).toBeTruthy();
+    expect(link.getAttribute("href")).toBe("/funnels");
+  });
+});

--- a/frontend/src/pages/FunnelsPage.tsx
+++ b/frontend/src/pages/FunnelsPage.tsx
@@ -1,0 +1,5 @@
+import FunnelBuilder from "../components/FunnelBuilder";
+
+export default function FunnelsPage() {
+  return <FunnelBuilder />;
+}


### PR DESCRIPTION
## Summary
- add funnels page rendering FunnelBuilder
- link Funil de Vendas in navbar and route /funnels to new page
- test funnel route and navigation link

## Testing
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68937bae587c8321ba894268d578a716