### PR TITLE
feat: add structured sequence steps to templates

### DIFF
--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/SequenceStep.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/SequenceStep.java
@@ -1,0 +1,32 @@
+package com.example.marketinghub.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * A single step in a message sequence.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SequenceStep {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer stepOrder;
+
+    @Lob
+    private String content;
+
+    /** delay in seconds before sending this step */
+    private Integer delaySeconds;
+
+    private String condition;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sequence_template_id")
+    private SequenceTemplate sequenceTemplate;
+}

--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/SequenceTemplate.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/SequenceTemplate.java
@@ -3,6 +3,9 @@ package com.example.marketinghub.model;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Template defining a message sequence.
  */
@@ -18,6 +21,8 @@ public class SequenceTemplate {
 
     private String name;
 
-    @Lob
-    private String content;
+    @OneToMany(mappedBy = "sequenceTemplate", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("stepOrder ASC")
+    @Builder.Default
+    private List<SequenceStep> steps = new ArrayList<>();
 }

--- a/backend/ads-service/src/main/java/com/example/marketinghub/service/GraphApiClient.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/service/GraphApiClient.java
@@ -1,6 +1,7 @@
 package com.example.marketinghub.service;
 
 import com.example.marketinghub.model.Lead;
+import com.example.marketinghub.model.SequenceTemplate;
 
 /**
  * Client for Facebook Graph API.
@@ -10,6 +11,7 @@ public interface GraphApiClient {
      * Sends welcome message asynchronously.
      *
      * @param lead lead to welcome
+     * @param template message sequence template
      */
-    void sendWelcomeAsync(Lead lead);
+    void sendWelcomeAsync(Lead lead, SequenceTemplate template);
 }

--- a/backend/ads-service/src/main/java/com/example/marketinghub/service/GraphApiClientImpl.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/service/GraphApiClientImpl.java
@@ -1,6 +1,8 @@
 package com.example.marketinghub.service;
 
 import com.example.marketinghub.model.Lead;
+import com.example.marketinghub.model.SequenceStep;
+import com.example.marketinghub.model.SequenceTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
@@ -15,7 +17,21 @@ public class GraphApiClientImpl implements GraphApiClient {
 
     @Override
     @Async("taskExecutor")
-    public void sendWelcomeAsync(Lead lead) {
-        log.info("Sending welcome to lead {}", lead.getId());
+    public void sendWelcomeAsync(Lead lead, SequenceTemplate template) {
+        if (lead == null || template == null || template.getSteps() == null) {
+            log.info("No lead or template provided");
+            return;
+        }
+        for (SequenceStep step : template.getSteps()) {
+            log.info("Sending step {} to lead {}: {}", step.getStepOrder(), lead.getId(), step.getContent());
+            Integer delay = step.getDelaySeconds();
+            if (delay != null && delay > 0) {
+                try {
+                    Thread.sleep(delay * 1000L);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
     }
 }

--- a/backend/ads-service/src/main/java/com/example/marketinghub/service/LeadService.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/service/LeadService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.List;
 
 /**
  * Handles lead persistence and outbox creation.
@@ -62,7 +63,16 @@ public class LeadService {
                 .build();
         outboxRepository.save(event);
 
-        taskExecutor.execute(() -> graphApiClient.sendWelcomeAsync(lead));
+        SequenceTemplate template = SequenceTemplate.builder()
+                .name("Welcome")
+                .steps(List.of(
+                        SequenceStep.builder().stepOrder(1).content("Welcome!").delaySeconds(0).build(),
+                        SequenceStep.builder().stepOrder(2).content("How can we help?").delaySeconds(5).build()
+                ))
+                .build();
+        template.getSteps().forEach(s -> s.setSequenceTemplate(template));
+
+        taskExecutor.execute(() -> graphApiClient.sendWelcomeAsync(lead, template));
         return lead;
     }
 }

--- a/backend/ads-service/src/main/java/com/example/marketinghub/service/OutboxScheduler.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/service/OutboxScheduler.java
@@ -28,7 +28,7 @@ public class OutboxScheduler {
     public void processPending() {
         List<OutboxEvent> events = outboxRepository.findByProcessedAtIsNull();
         for (OutboxEvent e : events) {
-            graphApiClient.sendWelcomeAsync(null);
+            graphApiClient.sendWelcomeAsync(null, null);
             e.setProcessedAt(Instant.now());
             outboxRepository.save(e);
         }

--- a/backend/ads-service/src/test/java/com/example/marketinghub/service/LeadServiceTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/service/LeadServiceTest.java
@@ -50,7 +50,7 @@ class LeadServiceTest {
 
         verify(leadRepository).save(any());
         verify(outboxRepository).save(any());
-        verify(graphApiClient).sendWelcomeAsync(any());
+        verify(graphApiClient).sendWelcomeAsync(any(), any());
         assertEquals(dto.leadgenId(), lead.getLeadgenId());
     }
 }


### PR DESCRIPTION
## Summary
- model sequence step entity and embed steps into templates
- iterate over structured steps when sending welcome messages
- exercise new API in lead service and scheduler

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_689384fce6c883219c5cafeebf092f91