### PR TITLE
feat: label funnel builder inputs

### DIFF
--- a/frontend/src/__tests__/FunnelBuilder.test.tsx
+++ b/frontend/src/__tests__/FunnelBuilder.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import FunnelBuilder from "../components/FunnelBuilder";
+
+describe("FunnelBuilder", () => {
+  it("renders labeled inputs", () => {
+    render(<FunnelBuilder />);
+    expect(screen.getByLabelText(/stimulus type/i)).toBeTruthy();
+    expect(screen.getByLabelText(/score increment/i)).toBeTruthy();
+    expect(screen.getByLabelText(/expected action/i)).toBeTruthy();
+  });
+
+  it("logs validation errors on invalid submit", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    render(<FunnelBuilder />);
+    await userEvent.click(
+      screen.getAllByRole("button", { name: /add step/i })[0],
+    );
+    expect(logSpy).toHaveBeenCalledWith("Validation errors", expect.anything());
+    logSpy.mockRestore();
+  });
+});

--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -38,9 +38,22 @@ export default function FunnelBuilder() {
   return (
     <div>
       <form>
-        <input {...register("stimulus_type", { required: true })} />
-        <input type="number" {...register("score_inc", { min: 0 })} />
-        <input {...register("expected_action", { required: true })} />
+        <label htmlFor="stimulus_type">Stimulus Type</label>
+        <input
+          id="stimulus_type"
+          {...register("stimulus_type", { required: true })}
+        />
+        <label htmlFor="score_inc">Score Increment</label>
+        <input
+          id="score_inc"
+          type="number"
+          {...register("score_inc", { min: 0 })}
+        />
+        <label htmlFor="expected_action">Expected Action</label>
+        <input
+          id="expected_action"
+          {...register("expected_action", { required: true })}
+        />
         <button
           type="button"
           onClick={handleSubmit(onSubmit, (errors) => {


### PR DESCRIPTION
## Summary
- add labels to funnel builder input fields
- test funnel builder labels and validation logging

## Testing
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68945da5152483218694c220fc13a20c