### PR TITLE
feat: expand funnel stimulus and action options

### DIFF
--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/ActionType.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/ActionType.java
@@ -7,5 +7,11 @@ public enum ActionType {
     OPEN,
     CLICK,
     REPLY,
-    PURCHASE
+    VIEW,
+    PURCHASE,
+    REGISTRATION,
+    OPT_IN,
+    OPT_OUT,
+    BOUNCE,
+    SHARE
 }

--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/StimulusType.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/StimulusType.java
@@ -5,13 +5,13 @@ package com.example.marketinghub.funnel;
  */
 public enum StimulusType {
     DM,
-    EMAIL,
     IG_POST_BOOST,
     FB_AD,
-    STORY,
     WHATSAPP,
-    CALL,
+    EMAIL,
     SMS,
+    PUSH,
+    STORY,
     WEBINAR,
-    PUSH
+    CALL
 }

--- a/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
+++ b/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
@@ -27,10 +27,10 @@
                 <constraints nullable="false" foreignKeyName="fk_step_funnel" references="sales_funnel(id)"/>
             </column>
             <column name="order_idx" type="INT"/>
-            <column name="stimulus_type" type="ENUM('DM','EMAIL','IG_POST_BOOST','FB_AD','STORY','WHATSAPP','CALL','SMS','WEBINAR','PUSH')"/>
+            <column name="stimulus_type" type="ENUM('DM','IG_POST_BOOST','FB_AD','WHATSAPP','EMAIL','SMS','PUSH','STORY','WEBINAR','CALL')"/>
             <column name="channel" type="VARCHAR(50)"/>
             <column name="template_id" type="VARCHAR(50)"/>
-            <column name="expected_action" type="ENUM('OPEN','CLICK','REPLY','PURCHASE')"/>
+            <column name="expected_action" type="ENUM('OPEN','CLICK','REPLY','VIEW','PURCHASE','REGISTRATION','OPT_IN','OPT_OUT','BOUNCE','SHARE')"/>
             <column name="score_inc" type="INT"/>
             <column name="revenue_target" type="DECIMAL(10,2)"/>
             <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP"/>
@@ -49,7 +49,7 @@
             <column name="funnel_step_id" type="BINARY(16)">
                 <constraints nullable="false" foreignKeyName="fk_response_step" references="funnel_step(id)"/>
             </column>
-            <column name="action" type="ENUM('OPEN','CLICK','REPLY','PURCHASE')"/>
+            <column name="action" type="ENUM('OPEN','CLICK','REPLY','VIEW','PURCHASE','REGISTRATION','OPT_IN','OPT_OUT','BOUNCE','SHARE')"/>
             <column name="value" type="JSON"/>
             <column name="revenue" type="DECIMAL(10,2)"/>
             <column name="occurred_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP"/>

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -244,10 +244,10 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `id` BINARY(16) PRIMARY KEY
 - `funnel_id` BINARY(16) NOT NULL
 - `order_idx` INT
-- `stimulus_type` ENUM('DM','EMAIL','IG_POST_BOOST','FB_AD','STORY','WHATSAPP','CALL','SMS','WEBINAR','PUSH')
+- `stimulus_type` ENUM('DM','IG_POST_BOOST','FB_AD','WHATSAPP','EMAIL','SMS','PUSH','STORY','WEBINAR','CALL')
 - `channel` VARCHAR(50)
 - `template_id` VARCHAR(50)
-- `expected_action` ENUM('OPEN','CLICK','REPLY','PURCHASE')
+- `expected_action` ENUM('OPEN','CLICK','REPLY','VIEW','PURCHASE','REGISTRATION','OPT_IN','OPT_OUT','BOUNCE','SHARE')
 - `score_inc` INT
 - `revenue_target` DECIMAL(10,2)
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -258,7 +258,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `id` BIGINT AUTO_INCREMENT PRIMARY KEY
 - `lead_id` BINARY(16) NOT NULL
 - `funnel_step_id` BINARY(16) NOT NULL
-- `action` ENUM('OPEN','CLICK','REPLY','PURCHASE')
+- `action` ENUM('OPEN','CLICK','REPLY','VIEW','PURCHASE','REGISTRATION','OPT_IN','OPT_OUT','BOUNCE','SHARE')
 - `value` JSON
 - `revenue` DECIMAL(10,2)
 - `occurred_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -387,4 +387,3 @@ erDiagram
     METRIC_PRESET ||--o{ EXPERIMENT : configures
     CHAT_SESSION ||--o{ CHAT_MESSAGE : includes
 ```
-

--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -26,6 +26,32 @@ export default function FunnelBuilder() {
   const { register, handleSubmit } = useForm<Step>();
   const create = useCreateFunnel();
 
+  const stimulusOptions = [
+    "DM",
+    "IG_POST_BOOST",
+    "FB_AD",
+    "WHATSAPP",
+    "EMAIL",
+    "SMS",
+    "PUSH",
+    "STORY",
+    "WEBINAR",
+    "CALL",
+  ];
+
+  const actionOptions = [
+    "OPEN",
+    "CLICK",
+    "REPLY",
+    "VIEW",
+    "PURCHASE",
+    "REGISTRATION",
+    "OPT_IN",
+    "OPT_OUT",
+    "BOUNCE",
+    "SHARE",
+  ];
+
   const onDragEnd = (result: DropResult) => {
     if (!result.destination) return;
     const items = Array.from(steps);
@@ -53,10 +79,16 @@ export default function FunnelBuilder() {
     <div>
       <form>
         <label htmlFor="stimulus_type">Stimulus Type</label>
-        <input
+        <select
           id="stimulus_type"
           {...register("stimulus_type", { required: true })}
-        />
+        >
+          {stimulusOptions.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
         <label htmlFor="score_inc">Score Increment</label>
         <input
           id="score_inc"
@@ -64,10 +96,16 @@ export default function FunnelBuilder() {
           {...register("score_inc", { min: 0 })}
         />
         <label htmlFor="expected_action">Expected Action</label>
-        <input
+        <select
           id="expected_action"
           {...register("expected_action", { required: true })}
-        />
+        >
+          {actionOptions.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
         <button
           type="button"
           onClick={handleSubmit(onSubmit, (errors) => {


### PR DESCRIPTION
## Summary
- align stimulus and action enums with marketing benchmarks
- expose stimulus and action dropdowns in funnel builder
- document new sales funnel stimulus/action enums

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: FunnelBuilder.logs validation errors on invalid submit)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894a770b7088321aaf1c2602d4f45a1