### PR TITLE
fix: guard default sales funnel inserts

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
+++ b/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
@@ -89,6 +89,11 @@
     </changeSet>
 
     <changeSet id="20250825-6" author="codex">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT CASE WHEN EXISTS (SELECT 1 FROM experiment WHERE id = 1) THEN 1 ELSE 0 END
+            </sqlCheck>
+        </preConditions>
         <insert tableName="sales_funnel">
             <column name="id" valueComputed="UNHEX(REPLACE(UUID(), '-', ''))"/>
             <column name="experiment_id" valueNumeric="1"/>
@@ -106,6 +111,11 @@
     </changeSet>
 
     <changeSet id="20250825-7" author="codex">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="2">
+                SELECT COUNT(*) FROM sales_funnel WHERE name IN ('DEFAULT_LEAD_MAGNET','DEFAULT_RETARGET')
+            </sqlCheck>
+        </preConditions>
         <sql>
             INSERT INTO funnel_step(id, funnel_id, order_idx, stimulus_type, channel, template_id, expected_action, score_inc, is_active)
             VALUES (UNHEX(REPLACE(UUID(), '-', '')), (SELECT id FROM sales_funnel WHERE name='DEFAULT_LEAD_MAGNET' LIMIT 1), 1, 'DM', 'DM', 'welcome_tpl', 'OPEN', 10, 1);


### PR DESCRIPTION
## Summary
- prevent default sales funnel data insertion when experiment 1 is missing by adding Liquibase preconditions
- skip funnel step inserts unless default sales funnels exist

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM due to unreachable repository)*

------
https://chatgpt.com/codex/tasks/task_e_6894e3c069408321a11733f851e93c0e