### PR TITLE
fix: avoid reserved word for sequence step condition

### DIFF
--- a/backend/ads-service/src/main/java/com/example/marketinghub/model/SequenceStep.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/model/SequenceStep.java
@@ -24,7 +24,9 @@ public class SequenceStep {
     /** delay in seconds before sending this step */
     private Integer delaySeconds;
 
-    private String condition;
+    /** optional condition expression to evaluate before sending */
+    @Column(name = "condition_expression")
+    private String conditionExpression;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sequence_template_id")


### PR DESCRIPTION
## Summary
- rename SequenceStep.condition to conditionExpression to avoid MySQL reserved word

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894f3c2ebfc8321bbb716ccad14da77