### PR TITLE
Link experiments to sales funnels

### DIFF
--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelController.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelController.java
@@ -16,13 +16,13 @@ public class FunnelController {
     private final FunnelService funnelService;
 
     @GetMapping
-    public List<SalesFunnel> listByExperiment(@RequestParam Long experimentId) {
-        return funnelService.findByExperiment(experimentId);
+    public List<SalesFunnel> list() {
+        return funnelService.list();
     }
 
     @PostMapping
-    public SalesFunnel create(@RequestParam Long experimentId, @RequestBody SalesFunnel funnel) {
-        return funnelService.create(experimentId, funnel);
+    public SalesFunnel create(@RequestBody SalesFunnel funnel) {
+        return funnelService.create(funnel);
     }
 
     @PostMapping("/{id}/steps")

--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelService.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelService.java
@@ -3,8 +3,6 @@ package com.example.marketinghub.funnel;
 import com.example.marketinghub.model.Lead;
 import com.example.marketinghub.model.NurtureStage;
 import com.example.marketinghub.repository.LeadRepository;
-import com.marketinghub.experiment.Experiment;
-import com.marketinghub.experiment.repository.ExperimentRepository;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
@@ -27,7 +25,6 @@ public class FunnelService {
     private final LeadRepository leadRepository;
     private final LeadResponseRepository responseRepository;
     private final StepMetricSnapshotRepository snapshotRepository;
-    private final ExperimentRepository experimentRepository;
 
     public List<StepMetricSnapshot> getSnapshots(UUID funnelId) {
         return stepRepository.findByFunnelId(funnelId).stream()
@@ -48,13 +45,11 @@ public class FunnelService {
                 .reduce(java.math.BigDecimal.ZERO, java.math.BigDecimal::add);
     }
 
-    public List<SalesFunnel> findByExperiment(Long experimentId) {
-        return funnelRepository.findByExperimentId(experimentId);
+    public List<SalesFunnel> list() {
+        return funnelRepository.findAll();
     }
 
-    public SalesFunnel create(Long experimentId, SalesFunnel funnel) {
-        Experiment experiment = experimentRepository.findById(experimentId).orElseThrow();
-        funnel.setExperiment(experiment);
+    public SalesFunnel create(SalesFunnel funnel) {
         if (funnel.getSteps() != null) {
             funnel.getSteps().forEach(step -> step.setFunnel(funnel));
         }

--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/SalesFunnel.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/SalesFunnel.java
@@ -1,6 +1,5 @@
 package com.example.marketinghub.funnel;
 
-import com.marketinghub.experiment.Experiment;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -11,7 +10,7 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Sales funnel for an experiment.
+ * Sales funnel definition.
  */
 @Entity
 @Data
@@ -23,10 +22,6 @@ public class SalesFunnel {
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     private UUID id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "experiment_id")
-    private Experiment experiment;
 
     private String name;
     private String objective;

--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/SalesFunnelRepository.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/SalesFunnelRepository.java
@@ -3,14 +3,11 @@ package com.example.marketinghub.funnel;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 /** Repository for {@link SalesFunnel}. */
 public interface SalesFunnelRepository extends JpaRepository<SalesFunnel, UUID> {
-    List<SalesFunnel> findByExperimentId(Long experimentId);
-
     @EntityGraph(attributePaths = "steps")
     Optional<SalesFunnel> findWithStepsById(UUID id);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -5,6 +5,7 @@ import lombok.*;
 import com.marketinghub.niche.MarketNiche;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import com.example.marketinghub.funnel.SalesFunnel;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -40,6 +41,10 @@ public class Experiment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "metric_preset_id")
     private MetricPreset metricPreset;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sales_funnel_id")
+    private SalesFunnel salesFunnel;
 
     @Column(precision = 10, scale = 2)
     private java.math.BigDecimal kpiTargetCpl;

--- a/backend/ads-service/src/main/resources/db/changelog/V20250901__link_experiment_sales_funnel.xml
+++ b/backend/ads-service/src/main/resources/db/changelog/V20250901__link_experiment_sales_funnel.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="20250901-1" author="codex">
+        <addColumn tableName="experiment">
+            <column name="sales_funnel_id" type="BINARY(16)">
+                <constraints foreignKeyName="fk_experiment_sales_funnel" references="sales_funnel(id)"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="20250901-2" author="codex">
+        <dropForeignKeyConstraint baseTableName="sales_funnel" constraintName="fk_funnel_experiment"/>
+        <dropColumn tableName="sales_funnel" columnName="experiment_id"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -40,5 +40,9 @@ databaseChangeLog:
       relativeToChangelogFile: true
 
   - include:
+      file: V20250901__link_experiment_sales_funnel.xml
+      relativeToChangelogFile: true
+
+  - include:
       file: V2025_08_06__create_chat_tables.sql
       relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/example/marketinghub/funnel/FunnelServiceTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/funnel/FunnelServiceTest.java
@@ -3,8 +3,6 @@ package com.example.marketinghub.funnel;
 import com.example.marketinghub.model.Lead;
 import com.example.marketinghub.model.NurtureStage;
 import com.example.marketinghub.repository.LeadRepository;
-import com.marketinghub.experiment.Experiment;
-import com.marketinghub.experiment.repository.ExperimentRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -27,7 +25,6 @@ class FunnelServiceTest {
     @Mock private LeadRepository leadRepository;
     @Mock private LeadResponseRepository responseRepository;
     @Mock private StepMetricSnapshotRepository snapshotRepository;
-    @Mock private ExperimentRepository experimentRepository;
 
     @Test
     void registerResponseUpdatesScoreAndStage() {
@@ -50,15 +47,11 @@ class FunnelServiceTest {
     void createSetsBackReferenceOnSteps() {
         FunnelStep step = FunnelStep.builder().build();
         SalesFunnel funnel = SalesFunnel.builder().name("test").steps(java.util.List.of(step)).build();
-        Long expId = 1L;
-        Experiment experiment = new Experiment();
-        when(experimentRepository.findById(expId)).thenReturn(java.util.Optional.of(experiment));
         when(funnelRepository.save(funnel)).thenReturn(funnel);
 
-        SalesFunnel saved = service.create(expId, funnel);
+        SalesFunnel saved = service.create(funnel);
 
         assertSame(saved, step.getFunnel());
-        assertSame(experiment, saved.getExperiment());
         verify(funnelRepository).save(funnel);
     }
 }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -129,6 +129,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `status` VARCHAR(20)
 - `platform` VARCHAR(50)
 - `metric_preset_id` VARCHAR(50)
+- `sales_funnel_id` BINARY(16)
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 
@@ -234,7 +235,6 @@ This document summarizes the current database schema defined in `schema.sql`.
 ### sales_funnel
 
 - `id` BINARY(16) PRIMARY KEY
-- `experiment_id` BIGINT NOT NULL
 - `name` VARCHAR(100)
 - `objective` VARCHAR(255)
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -317,6 +317,7 @@ erDiagram
         BIGINT niche_id FK
         BINARY hypothesis_id FK
         VARCHAR metric_preset_id FK
+        BINARY sales_funnel_id FK
     }
     CREATIVE_VARIANT {
         BIGINT id PK
@@ -351,7 +352,6 @@ erDiagram
     }
     SALES_FUNNEL {
         BINARY id PK
-        BIGINT experiment_id FK
     }
     FUNNEL_STEP {
         BINARY id PK
@@ -377,7 +377,7 @@ erDiagram
     EXPERIMENT ||--o{ AD_SET : configures
     EXPERIMENT ||--o{ LANDING_PAGE : uses
     EXPERIMENT ||--o{ LEAD : generates
-    EXPERIMENT ||--o{ SALES_FUNNEL : orchestrates
+    SALES_FUNNEL ||--o{ EXPERIMENT : used_by
     SALES_FUNNEL ||--o{ FUNNEL_STEP : includes
     FUNNEL_STEP ||--o{ LEAD_RESPONSE : triggers
     LEAD ||--o{ LEAD_RESPONSE : receives

--- a/frontend/src/__tests__/FunnelBuilder.test.tsx
+++ b/frontend/src/__tests__/FunnelBuilder.test.tsx
@@ -17,7 +17,6 @@ describe("FunnelBuilder", () => {
     expect(screen.getByLabelText(/stimulus type/i)).toBeTruthy();
     expect(screen.getByLabelText(/score increment/i)).toBeTruthy();
     expect(screen.getByLabelText(/expected action/i)).toBeTruthy();
-    expect(screen.getByLabelText(/experiment id/i)).toBeTruthy();
   });
 
   it("adds step to list on submit", async () => {

--- a/frontend/src/api/funnel/useCreateFunnel.ts
+++ b/frontend/src/api/funnel/useCreateFunnel.ts
@@ -8,7 +8,6 @@ export interface CreateFunnelStep {
 }
 
 export interface CreateFunnel {
-  experimentId: number;
   name: string;
   steps: CreateFunnelStep[];
 }
@@ -17,11 +16,7 @@ export function useCreateFunnel() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (data: CreateFunnel) => {
-      const { experimentId, ...body } = data;
-      const { data: funnel } = await axios.post(
-        `/api/funnels?experimentId=${experimentId}`,
-        body,
-      );
+      const { data: funnel } = await axios.post(`/api/funnels`, data);
       return funnel;
     },
     onSuccess: () => {

--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -23,7 +23,6 @@ interface Step {
 export default function FunnelBuilder() {
   const [steps, setSteps] = useState<Step[]>([]);
   const [name, setName] = useState("");
-  const [experimentId, setExperimentId] = useState<string>("");
   const { register, handleSubmit } = useForm<Step>();
   const create = useCreateFunnel();
 
@@ -67,7 +66,6 @@ export default function FunnelBuilder() {
 
   const saveFunnel = () => {
     create.mutate({
-      experimentId: Number(experimentId),
       name,
       steps: steps.map((s) => ({
         stimulusType: s.stimulus_type,
@@ -140,12 +138,6 @@ export default function FunnelBuilder() {
           )}
         </Droppable>
       </DragDropContext>
-      <label htmlFor="experiment_id">Experiment ID</label>
-      <input
-        id="experiment_id"
-        value={experimentId}
-        onChange={(e) => setExperimentId(e.target.value)}
-      />
       <label htmlFor="funnel_name">Funnel Name</label>
       <input
         id="funnel_name"

--- a/schema.sql
+++ b/schema.sql
@@ -120,6 +120,7 @@ CREATE TABLE experiment (
     end_date DATE,
     status VARCHAR(20),
     platform VARCHAR(50),
+    sales_funnel_id BINARY(16),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- Attach experiments to sales funnels via `sales_funnel_id`
- Decouple sales funnels from experiments and simplify funnel service API
- Update data model docs and frontend FunnelBuilder flow

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6895372901648321b8cc39153fef263a