### PR TITLE
Add sales funnel listing with experiment counts

### DIFF
--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelController.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
+import com.example.marketinghub.funnel.dto.SalesFunnelDto;
 
 /**
  * REST endpoints for managing funnels.
@@ -16,8 +17,18 @@ public class FunnelController {
     private final FunnelService funnelService;
 
     @GetMapping
-    public List<SalesFunnel> list() {
+    public List<SalesFunnelDto> list() {
         return funnelService.list();
+    }
+
+    @GetMapping("/{id}")
+    public SalesFunnel get(@PathVariable UUID id) {
+        return funnelService.get(id);
+    }
+
+    @PutMapping("/{id}")
+    public SalesFunnel update(@PathVariable UUID id, @RequestBody SalesFunnel funnel) {
+        return funnelService.update(id, funnel);
     }
 
     @PostMapping

--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelService.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelService.java
@@ -3,6 +3,8 @@ package com.example.marketinghub.funnel;
 import com.example.marketinghub.model.Lead;
 import com.example.marketinghub.model.NurtureStage;
 import com.example.marketinghub.repository.LeadRepository;
+import com.example.marketinghub.funnel.dto.SalesFunnelDto;
+import com.marketinghub.experiment.repository.ExperimentRepository;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ public class FunnelService {
     private final LeadRepository leadRepository;
     private final LeadResponseRepository responseRepository;
     private final StepMetricSnapshotRepository snapshotRepository;
+    private final ExperimentRepository experimentRepository;
 
     public List<StepMetricSnapshot> getSnapshots(UUID funnelId) {
         return stepRepository.findByFunnelId(funnelId).stream()
@@ -45,11 +48,32 @@ public class FunnelService {
                 .reduce(java.math.BigDecimal.ZERO, java.math.BigDecimal::add);
     }
 
-    public List<SalesFunnel> list() {
-        return funnelRepository.findAll();
+    public List<SalesFunnelDto> list() {
+        return funnelRepository.findAll().stream()
+                .map(f -> {
+                    SalesFunnelDto dto = new SalesFunnelDto();
+                    dto.setId(f.getId());
+                    dto.setName(f.getName());
+                    dto.setObjective(f.getObjective());
+                    dto.setExperimentCount(experimentRepository.countBySalesFunnelId(f.getId()));
+                    return dto;
+                })
+                .collect(Collectors.toList());
     }
 
     public SalesFunnel create(SalesFunnel funnel) {
+        if (funnel.getSteps() != null) {
+            funnel.getSteps().forEach(step -> step.setFunnel(funnel));
+        }
+        return funnelRepository.save(funnel);
+    }
+
+    public SalesFunnel get(UUID id) {
+        return funnelRepository.findWithStepsById(id).orElseThrow();
+    }
+
+    public SalesFunnel update(UUID id, SalesFunnel funnel) {
+        funnel.setId(id);
         if (funnel.getSteps() != null) {
             funnel.getSteps().forEach(step -> step.setFunnel(funnel));
         }

--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/dto/SalesFunnelDto.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/dto/SalesFunnelDto.java
@@ -1,0 +1,15 @@
+package com.example.marketinghub.funnel.dto;
+
+import java.util.UUID;
+import lombok.Data;
+
+/**
+ * DTO representing a sales funnel summary with experiment count.
+ */
+@Data
+public class SalesFunnelDto {
+    private UUID id;
+    private String name;
+    private String objective;
+    private long experimentCount;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -4,6 +4,7 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.niche.MarketNiche;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Repository for experiments.
@@ -12,4 +13,5 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
     List<Experiment> findByNicheId(Long nicheId);
     boolean existsByNicheAndName(MarketNiche niche, String name);
     List<Experiment> findByStatus(com.marketinghub.experiment.ExperimentStatus status);
+    long countBySalesFunnelId(UUID salesFunnelId);
 }

--- a/backend/ads-service/src/test/java/com/example/marketinghub/funnel/FunnelServiceTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/funnel/FunnelServiceTest.java
@@ -3,6 +3,7 @@ package com.example.marketinghub.funnel;
 import com.example.marketinghub.model.Lead;
 import com.example.marketinghub.model.NurtureStage;
 import com.example.marketinghub.repository.LeadRepository;
+import com.marketinghub.experiment.repository.ExperimentRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -25,6 +26,7 @@ class FunnelServiceTest {
     @Mock private LeadRepository leadRepository;
     @Mock private LeadResponseRepository responseRepository;
     @Mock private StepMetricSnapshotRepository snapshotRepository;
+    @Mock private ExperimentRepository experimentRepository;
 
     @Test
     void registerResponseUpdatesScoreAndStage() {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,7 +36,9 @@ import VisualProofsPage from "./pages/VisualProofsPage";
 import EmotionalTriggersPage from "./pages/EmotionalTriggersPage";
 import LandingPreview from "./pages/landing/LandingPreview";
 import AnalyticsDashboard from "./pages/landing/AnalyticsDashboard";
-import FunnelsPage from "./pages/FunnelsPage";
+import FunnelListPage from "./pages/funnel/FunnelListPage";
+import NewFunnelPage from "./pages/funnel/NewFunnelPage";
+import EditFunnelPage from "./pages/funnel/EditFunnelPage";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
@@ -193,7 +195,9 @@ export default function App() {
         <Route path="/emotional-triggers" element={<EmotionalTriggersPage />} />
         <Route path="/landing/:id" element={<LandingPreview />} />
         <Route path="/analytics" element={<AnalyticsDashboard />} />
-        <Route path="/funnels" element={<FunnelsPage />} />
+        <Route path="/funnels" element={<FunnelListPage />} />
+        <Route path="/funnels/new" element={<NewFunnelPage />} />
+        <Route path="/funnels/:id/edit" element={<EditFunnelPage />} />
         <Route path="*" element={<div>Início</div>} />
       </Routes>
       <ToastContainer position="top-right" />

--- a/frontend/src/__tests__/FunnelNavigation.test.tsx
+++ b/frontend/src/__tests__/FunnelNavigation.test.tsx
@@ -19,11 +19,9 @@ afterEach(() => {
 });
 
 describe("funnels navigation", () => {
-  it("renders FunnelBuilder on /funnels route", async () => {
+  it("renders list on /funnels route", async () => {
     setup(<App />, ["/funnels"]);
-    expect(
-      await screen.findByRole("button", { name: /add step/i }),
-    ).toBeTruthy();
+    expect(await screen.findByText(/carregando/i)).toBeTruthy();
   });
 
   it("has menu link to /funnels", () => {

--- a/frontend/src/api/funnel/useFunnel.ts
+++ b/frontend/src/api/funnel/useFunnel.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface FunnelStep {
+  id: string;
+  stimulusType: string;
+  expectedAction: string;
+  scoreInc: number;
+}
+
+export interface FunnelDetail {
+  id: string;
+  name: string;
+  objective?: string;
+  steps: FunnelStep[];
+}
+
+export function useFunnel(id: string) {
+  return useQuery<FunnelDetail>({
+    queryKey: ["funnels", id],
+    queryFn: async () => {
+      const { data } = await axios.get<FunnelDetail>(`/api/funnels/${id}`);
+      return data;
+    },
+    enabled: !!id,
+  });
+}

--- a/frontend/src/api/funnel/useFunnels.ts
+++ b/frontend/src/api/funnel/useFunnels.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface FunnelSummary {
+  id: string;
+  name: string;
+  objective?: string;
+  experimentCount: number;
+}
+
+export function useFunnels() {
+  return useQuery<FunnelSummary[]>({
+    queryKey: ["funnels"],
+    queryFn: async () => {
+      const { data } = await axios.get<FunnelSummary[]>("/api/funnels");
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/funnel/useSaveFunnel.ts
+++ b/frontend/src/api/funnel/useSaveFunnel.ts
@@ -1,21 +1,23 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 
-export interface CreateFunnelStep {
+export interface SaveFunnelStep {
+  id?: string;
   stimulusType: string;
   expectedAction: string;
   scoreInc: number;
 }
 
-export interface CreateFunnel {
+export interface SaveFunnel {
+  id?: string;
   name: string;
-  steps: CreateFunnelStep[];
+  steps: SaveFunnelStep[];
 }
 
-export function useCreateFunnel() {
+export function useSaveFunnel() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (data: CreateFunnel) => {
+    mutationFn: async (data: SaveFunnel) => {
       const { data: funnel } = await axios.post(`/api/funnels`, data);
       return funnel;
     },

--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -8,23 +8,28 @@ import {
 } from "react-beautiful-dnd";
 import { useForm } from "react-hook-form";
 import { useState } from "react";
-import { useCreateFunnel } from "../api/funnel/useCreateFunnel";
+import { useSaveFunnel } from "../api/funnel/useSaveFunnel";
 
 /**
  * Builder UI for arranging funnel steps.
  */
 interface Step {
   id: string;
+  backendId?: string;
   stimulus_type: string;
   score_inc: number;
   expected_action: string;
 }
 
-export default function FunnelBuilder() {
-  const [steps, setSteps] = useState<Step[]>([]);
-  const [name, setName] = useState("");
+interface FunnelProps {
+  funnel?: { id?: string; name: string; steps: Step[] };
+}
+
+export default function FunnelBuilder({ funnel }: FunnelProps) {
+  const [steps, setSteps] = useState<Step[]>(funnel?.steps ?? []);
+  const [name, setName] = useState(funnel?.name ?? "");
   const { register, handleSubmit } = useForm<Step>();
-  const create = useCreateFunnel();
+  const save = useSaveFunnel();
 
   const stimulusOptions = [
     "DM",
@@ -65,9 +70,11 @@ export default function FunnelBuilder() {
   };
 
   const saveFunnel = () => {
-    create.mutate({
+    save.mutate({
+      id: funnel?.id,
       name,
       steps: steps.map((s) => ({
+        id: s.backendId,
         stimulusType: s.stimulus_type,
         expectedAction: s.expected_action,
         scoreInc: s.score_inc,

--- a/frontend/src/pages/FunnelsPage.tsx
+++ b/frontend/src/pages/FunnelsPage.tsx
@@ -1,5 +1,0 @@
-import FunnelBuilder from "../components/FunnelBuilder";
-
-export default function FunnelsPage() {
-  return <FunnelBuilder />;
-}

--- a/frontend/src/pages/funnel/EditFunnelPage.tsx
+++ b/frontend/src/pages/funnel/EditFunnelPage.tsx
@@ -1,0 +1,17 @@
+import { useParams } from "react-router-dom";
+import FunnelBuilder from "../../components/FunnelBuilder";
+import { useFunnel } from "../../api/funnel/useFunnel";
+
+export default function EditFunnelPage() {
+  const { id } = useParams();
+  const { data, isLoading } = useFunnel(id!);
+  if (isLoading || !data) return <p>Carregando...</p>;
+  const steps = data.steps.map((s) => ({
+    id: s.id,
+    backendId: s.id,
+    stimulus_type: s.stimulusType,
+    expected_action: s.expectedAction,
+    score_inc: s.scoreInc ?? 0,
+  }));
+  return <FunnelBuilder funnel={{ id: data.id, name: data.name, steps }} />;
+}

--- a/frontend/src/pages/funnel/FunnelListPage.tsx
+++ b/frontend/src/pages/funnel/FunnelListPage.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import { useFunnels } from "../../api/funnel/useFunnels";
+import PageTitle from "../../components/PageTitle";
+
+export default function FunnelListPage() {
+  const { data, isLoading } = useFunnels();
+  if (isLoading) return <p>Carregando...</p>;
+  const funnels = data ?? [];
+  return (
+    <div>
+      <PageTitle>Funis</PageTitle>
+      <Link className="btn btn-primary mb-3" to="/funnels/new">
+        Novo Funil
+      </Link>
+      <div className="table-responsive">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Nome</th>
+              <th>Experimentos</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {funnels.map((f) => (
+              <tr key={f.id}>
+                <td>{f.name}</td>
+                <td>{f.experimentCount}</td>
+                <td>
+                  <Link
+                    className="btn btn-secondary btn-sm"
+                    to={`/funnels/${f.id}/edit`}
+                  >
+                    Editar
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/funnel/NewFunnelPage.tsx
+++ b/frontend/src/pages/funnel/NewFunnelPage.tsx
@@ -1,0 +1,5 @@
+import FunnelBuilder from "../../components/FunnelBuilder";
+
+export default function NewFunnelPage() {
+  return <FunnelBuilder />;
+}


### PR DESCRIPTION
## Summary
- include experiment counts in funnel API and support retrieving and updating funnels
- add React pages and hooks to list, create and edit sales funnels
- allow saving funnels and steps with backend IDs

## Testing
- `mvn -s ../settings.xml spotless:apply` *(failed: Non-resolvable parent POM)*
- `mvn -s ../settings.xml test` *(failed: Non-resolvable parent POM)*
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ee8492508321b4bc291fdf1948bd