### PR TITLE
fix: handle missing funnel steps

### DIFF
--- a/frontend/src/pages/funnel/EditFunnelPage.tsx
+++ b/frontend/src/pages/funnel/EditFunnelPage.tsx
@@ -6,12 +6,13 @@ export default function EditFunnelPage() {
   const { id } = useParams();
   const { data, isLoading } = useFunnel(id!);
   if (isLoading || !data) return <p>Carregando...</p>;
-  const steps = data.steps.map((s) => ({
-    id: s.id,
-    backendId: s.id,
-    stimulus_type: s.stimulusType,
-    expected_action: s.expectedAction,
-    score_inc: s.scoreInc ?? 0,
-  }));
+  const steps =
+    data.steps?.map((s) => ({
+      id: s.id,
+      backendId: s.id,
+      stimulus_type: s.stimulusType,
+      expected_action: s.expectedAction,
+      score_inc: s.scoreInc ?? 0,
+    })) ?? [];
   return <FunnelBuilder funnel={{ id: data.id, name: data.name, steps }} />;
 }


### PR DESCRIPTION
## Summary
- avoid mapping undefined steps when editing funnels

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6895fbb3dc5c8321867d61cad75c1a66