### PR TITLE
fix: sync funnel builder with prop changes

### DIFF
--- a/frontend/src/__tests__/FunnelBuilder.test.tsx
+++ b/frontend/src/__tests__/FunnelBuilder.test.tsx
@@ -26,4 +26,47 @@ describe("FunnelBuilder", () => {
     );
     expect(await screen.findByText(/DM - OPEN/i)).toBeTruthy();
   });
+
+  it("updates when funnel prop changes", () => {
+    const client = new QueryClient();
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <FunnelBuilder
+          funnel={{
+            id: "1",
+            name: "F1",
+            steps: [
+              {
+                id: "a",
+                stimulus_type: "EMAIL",
+                expected_action: "OPEN",
+                score_inc: 5,
+              },
+            ],
+          }}
+        />
+      </QueryClientProvider>,
+    );
+    expect(screen.getByText(/EMAIL - OPEN \(\+5\)/)).toBeTruthy();
+    rerender(
+      <QueryClientProvider client={client}>
+        <FunnelBuilder
+          funnel={{
+            id: "2",
+            name: "F2",
+            steps: [
+              {
+                id: "b",
+                stimulus_type: "SMS",
+                expected_action: "CLICK",
+                score_inc: 7,
+              },
+            ],
+          }}
+        />
+      </QueryClientProvider>,
+    );
+    expect(screen.getByText(/SMS - CLICK \(\+7\)/)).toBeTruthy();
+    expect(screen.queryByText(/EMAIL - OPEN \(\+5\)/)).toBeNull();
+  });
 });

--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -7,7 +7,7 @@ import {
   DraggableProvided,
 } from "react-beautiful-dnd";
 import { useForm } from "react-hook-form";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSaveFunnel } from "../api/funnel/useSaveFunnel";
 
 /**
@@ -28,6 +28,11 @@ interface FunnelProps {
 export default function FunnelBuilder({ funnel }: FunnelProps) {
   const [steps, setSteps] = useState<Step[]>(funnel?.steps ?? []);
   const [name, setName] = useState(funnel?.name ?? "");
+
+  useEffect(() => {
+    setSteps(funnel?.steps ?? []);
+    setName(funnel?.name ?? "");
+  }, [funnel]);
   const { register, handleSubmit } = useForm<Step>();
   const save = useSaveFunnel();
 


### PR DESCRIPTION
## Summary
- refresh funnel builder fields when loading existing funnel
- add regression test covering funnel prop updates

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689618bc3b4083219fa1695cadac3430