### PR TITLE
Fix funnel edit screen step rendering

### DIFF
--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -7,7 +7,7 @@ import {
   DraggableProvided,
 } from "react-beautiful-dnd";
 import { useForm } from "react-hook-form";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSaveFunnel } from "../api/funnel/useSaveFunnel";
 
 /**
@@ -28,6 +28,11 @@ interface FunnelProps {
 export default function FunnelBuilder({ funnel }: FunnelProps) {
   const [steps, setSteps] = useState<Step[]>(funnel?.steps ?? []);
   const [name, setName] = useState(funnel?.name ?? "");
+
+  useEffect(() => {
+    setSteps(funnel?.steps ?? []);
+    setName(funnel?.name ?? "");
+  }, [funnel]);
   const { register, handleSubmit } = useForm<Step>();
   const save = useSaveFunnel();
 

--- a/frontend/src/pages/funnel/EditFunnelPage.tsx
+++ b/frontend/src/pages/funnel/EditFunnelPage.tsx
@@ -8,8 +8,8 @@ export default function EditFunnelPage() {
   if (isLoading || !data) return <p>Carregando...</p>;
   const steps =
     data.steps?.map((s) => ({
-      id: s.id,
-      backendId: s.id,
+      id: s.id.toString(),
+      backendId: s.id.toString(),
       stimulus_type: s.stimulusType,
       expected_action: s.expectedAction,
       score_inc: s.scoreInc ?? 0,


### PR DESCRIPTION
## Summary
- ensure funnel step IDs are strings when editing
- reset funnel builder state when switching funnels

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689618bc3b4083219fa1695cadac3430