### PR TITLE
Fix funnel step ordering on edit screen

### DIFF
--- a/frontend/src/api/funnel/useFunnel.ts
+++ b/frontend/src/api/funnel/useFunnel.ts
@@ -6,6 +6,7 @@ export interface FunnelStep {
   stimulusType: string;
   expectedAction: string;
   scoreInc: number;
+  orderIdx: number;
 }
 
 export interface FunnelDetail {

--- a/frontend/src/api/funnel/useSaveFunnel.ts
+++ b/frontend/src/api/funnel/useSaveFunnel.ts
@@ -6,6 +6,7 @@ export interface SaveFunnelStep {
   stimulusType: string;
   expectedAction: string;
   scoreInc: number;
+  orderIdx: number;
 }
 
 export interface SaveFunnel {

--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -78,11 +78,12 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
     save.mutate({
       id: funnel?.id,
       name,
-      steps: steps.map((s) => ({
+      steps: steps.map((s, index) => ({
         id: s.backendId,
         stimulusType: s.stimulus_type,
         expectedAction: s.expected_action,
         scoreInc: s.score_inc,
+        orderIdx: index,
       })),
     });
   };

--- a/frontend/src/pages/funnel/EditFunnelPage.test.tsx
+++ b/frontend/src/pages/funnel/EditFunnelPage.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import EditFunnelPage from "./EditFunnelPage";
+import * as funnelApi from "../../api/funnel/useFunnel";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("EditFunnelPage", () => {
+  it("renders steps sorted by orderIdx", () => {
+    vi.spyOn(funnelApi, "useFunnel").mockReturnValue({
+      data: {
+        id: "1",
+        name: "Test",
+        steps: [
+          {
+            id: "b",
+            stimulusType: "EMAIL",
+            expectedAction: "CLICK",
+            scoreInc: 2,
+            orderIdx: 2,
+          },
+          {
+            id: "a",
+            stimulusType: "DM",
+            expectedAction: "OPEN",
+            scoreInc: 1,
+            orderIdx: 1,
+          },
+        ],
+      },
+      isLoading: false,
+    } as any);
+
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={["/funnels/1/edit"]}>
+          <Routes>
+            <Route path="/funnels/:id/edit" element={<EditFunnelPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const list = screen.getByRole("list");
+    const items = within(list).getAllByRole("button");
+    expect(items[0].textContent).toMatch(/DM - OPEN/);
+    expect(items[1].textContent).toMatch(/EMAIL - CLICK/);
+  });
+});

--- a/frontend/src/pages/funnel/EditFunnelPage.tsx
+++ b/frontend/src/pages/funnel/EditFunnelPage.tsx
@@ -7,12 +7,14 @@ export default function EditFunnelPage() {
   const { data, isLoading } = useFunnel(id!);
   if (isLoading || !data) return <p>Carregando...</p>;
   const steps =
-    data.steps?.map((s) => ({
-      id: s.id.toString(),
-      backendId: s.id.toString(),
-      stimulus_type: s.stimulusType,
-      expected_action: s.expectedAction,
-      score_inc: s.scoreInc ?? 0,
-    })) ?? [];
+    [...(data.steps ?? [])]
+      .sort((a, b) => a.orderIdx - b.orderIdx)
+      .map((s) => ({
+        id: s.id.toString(),
+        backendId: s.id.toString(),
+        stimulus_type: s.stimulusType,
+        expected_action: s.expectedAction,
+        score_inc: s.scoreInc ?? 0,
+      }));
   return <FunnelBuilder funnel={{ id: data.id, name: data.name, steps }} />;
 }


### PR DESCRIPTION
## Summary
- ensure funnel steps are sorted by `orderIdx` on edit screen
- persist step ordering when saving funnels
- add regression test for funnel step order

## Testing
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689627695ab48321b17ebaba70c495ee