### PR TITLE
Permite editar passos do funil

### DIFF
--- a/frontend/src/__tests__/FunnelBuilder.test.tsx
+++ b/frontend/src/__tests__/FunnelBuilder.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import FunnelBuilder from "../components/FunnelBuilder";
@@ -24,6 +24,9 @@ describe("FunnelBuilder", () => {
     await userEvent.click(
       screen.getAllByRole("button", { name: /add step/i })[0],
     );
-    expect(await screen.findByText(/DM - OPEN/i)).toBeTruthy();
+    const list = screen.getAllByRole("list")[0];
+    const item = (await within(list).findAllByRole("button"))[0];
+    expect(within(item).getByDisplayValue("DM")).toBeTruthy();
+    expect(within(item).getByDisplayValue("OPEN")).toBeTruthy();
   });
 });

--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -33,7 +33,7 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
     setSteps(funnel?.steps ?? []);
     setName(funnel?.name ?? "");
   }, [funnel]);
-  const { register, handleSubmit } = useForm<Step>();
+  const { register, handleSubmit, reset } = useForm<Step>();
   const save = useSaveFunnel();
 
   const stimulusOptions = [
@@ -71,7 +71,23 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
   };
 
   const onSubmit = (data: Step) => {
-    setSteps([...steps, { ...data, id: Date.now().toString() }]);
+    setSteps([
+      ...steps,
+      {
+        ...data,
+        score_inc: data.score_inc ?? 0,
+        id: Date.now().toString(),
+      },
+    ]);
+    reset();
+  };
+
+  const updateStep = (index: number, updates: Partial<Step>) => {
+    setSteps((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], ...updates };
+      return next;
+    });
   };
 
   const saveFunnel = () => {
@@ -140,8 +156,39 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
                       {...prov.draggableProps}
                       {...prov.dragHandleProps}
                     >
-                      {step.stimulus_type} - {step.expected_action} (+
-                      {step.score_inc})
+                      <select
+                        value={step.stimulus_type}
+                        onChange={(e) =>
+                          updateStep(index, { stimulus_type: e.target.value })
+                        }
+                      >
+                        {stimulusOptions.map((opt) => (
+                          <option key={opt} value={opt}>
+                            {opt}
+                          </option>
+                        ))}
+                      </select>
+                      <input
+                        type="number"
+                        value={step.score_inc}
+                        onChange={(e) =>
+                          updateStep(index, {
+                            score_inc: parseInt(e.target.value, 10) || 0,
+                          })
+                        }
+                      />
+                      <select
+                        value={step.expected_action}
+                        onChange={(e) =>
+                          updateStep(index, { expected_action: e.target.value })
+                        }
+                      >
+                        {actionOptions.map((opt) => (
+                          <option key={opt} value={opt}>
+                            {opt}
+                          </option>
+                        ))}
+                      </select>
                     </li>
                   )}
                 </Draggable>

--- a/frontend/src/pages/funnel/EditFunnelPage.test.tsx
+++ b/frontend/src/pages/funnel/EditFunnelPage.test.tsx
@@ -10,7 +10,7 @@ afterEach(() => {
 });
 
 describe("EditFunnelPage", () => {
-  it("renders steps sorted by orderIdx", () => {
+  it("renders steps sorted by orderIdx", async () => {
     vi.spyOn(funnelApi, "useFunnel").mockReturnValue({
       data: {
         id: "1",
@@ -46,9 +46,11 @@ describe("EditFunnelPage", () => {
       </QueryClientProvider>,
     );
 
-    const list = screen.getByRole("list");
-    const items = within(list).getAllByRole("button");
-    expect(items[0].textContent).toMatch(/DM - OPEN/);
-    expect(items[1].textContent).toMatch(/EMAIL - CLICK/);
+    const list = screen.getAllByRole("list")[0];
+    const items = await within(list).findAllByRole("button");
+    expect(within(items[0]).getByDisplayValue("DM")).toBeTruthy();
+    expect(within(items[0]).getByDisplayValue("OPEN")).toBeTruthy();
+    expect(within(items[1]).getByDisplayValue("EMAIL")).toBeTruthy();
+    expect(within(items[1]).getByDisplayValue("CLICK")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- permitir alterar estímulos, ações e pontuação de cada passo do funil
- cobrir casos de edição e ordenação no teste da tela de edição do funil
- ajustar testes do construtor de funil para trabalhar com campos editáveis

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689632cfbc8c8321812bb8ebc4bb0bdc