### PR TITLE
fix: avoid recursive funnel serialization

### DIFF
--- a/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelStep.java
+++ b/backend/ads-service/src/main/java/com/example/marketinghub/funnel/FunnelStep.java
@@ -1,5 +1,6 @@
 package com.example.marketinghub.funnel;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -24,6 +25,7 @@ public class FunnelStep {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "funnel_id")
+    @JsonIgnore
     private SalesFunnel funnel;
 
     private Integer orderIdx;

--- a/backend/ads-service/src/test/java/com/example/marketinghub/funnel/FunnelControllerTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/funnel/FunnelControllerTest.java
@@ -1,0 +1,39 @@
+package com.example.marketinghub.funnel;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FunnelController.class)
+class FunnelControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FunnelService funnelService;
+
+    @Test
+    void getFunnelDoesNotReturnNestedFunnel() throws Exception {
+        UUID id = UUID.randomUUID();
+        SalesFunnel funnel = SalesFunnel.builder().id(id).name("test").build();
+        FunnelStep step = FunnelStep.builder().id(UUID.randomUUID()).funnel(funnel).build();
+        funnel.setSteps(List.of(step));
+        when(funnelService.get(id)).thenReturn(funnel);
+
+        mockMvc.perform(get("/api/funnels/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.steps[0].funnel").doesNotExist());
+    }
+}
+


### PR DESCRIPTION
## Summary
- avoid recursive serialization of `SalesFunnel` in `FunnelStep`
- cover `/api/funnels/{id}` response with controller test

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68963b0908488321952dacee7ec41fcd