### PR TITLE
test: fix funnel controller test configuration

### DIFF
--- a/backend/ads-service/src/test/java/com/example/marketinghub/funnel/FunnelControllerTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/funnel/FunnelControllerTest.java
@@ -4,10 +4,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 import java.util.UUID;
+
+import com.marketinghub.ads.AdsServiceApplication;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -15,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(FunnelController.class)
+@ContextConfiguration(classes = AdsServiceApplication.class)
 class FunnelControllerTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- fix WebMvcTest configuration for FunnelControllerTest by referencing AdsServiceApplication

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896424f912083219ff98546dac74c14