### PR TITLE
fix: simplify funnel controller test

### DIFF
--- a/backend/ads-service/src/test/java/com/example/marketinghub/funnel/FunnelControllerTest.java
+++ b/backend/ads-service/src/test/java/com/example/marketinghub/funnel/FunnelControllerTest.java
@@ -4,13 +4,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 import java.util.UUID;
-
-import com.marketinghub.ads.AdsServiceApplication;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,7 +15,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(FunnelController.class)
-@ContextConfiguration(classes = AdsServiceApplication.class)
 class FunnelControllerTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- avoid loading full application context in `FunnelControllerTest`

## Testing
- `mvn -s ../settings.xml -Dtest=FunnelControllerTest test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689647b3f9f48321838e4fc475e3a14a