### PR TITLE
Fix missing configuration in FunnelControllerTest

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/funnel/FunnelControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/funnel/FunnelControllerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -14,7 +15,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.marketinghub.ads.AdsServiceApplication;
+
 @WebMvcTest(FunnelController.class)
+@ContextConfiguration(classes = AdsServiceApplication.class)
 class FunnelControllerTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- wire FunnelControllerTest to AdsServiceApplication so that WebMvc tests can load Spring context

## Testing
- `mvn -o -s ../settings.xml test` *(fails: Non-resolvable parent POM for org.springframework.boot:spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896561261d88321be8994320893a347