### PR TITLE
test: isolate FunnelController web slice

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/funnel/FunnelControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/funnel/FunnelControllerTest.java
@@ -2,9 +2,9 @@ package com.marketinghub.funnel;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -15,11 +15,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.marketinghub.ads.AdsServiceApplication;
-
 @WebMvcTest(FunnelController.class)
-@ContextConfiguration(classes = AdsServiceApplication.class)
 class FunnelControllerTest {
+
+    @SpringBootApplication
+    static class TestConfig {}
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- avoid loading full AdsServiceApplication in FunnelControllerTest by adding minimal @SpringBootApplication config

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent 3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68965833c13883218443b47792acd0d9