### PR TITLE
feat: add LANDING stimulus type

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/funnel/StimulusType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/funnel/StimulusType.java
@@ -13,5 +13,6 @@ public enum StimulusType {
     PUSH,
     STORY,
     WEBINAR,
-    CALL
+    CALL,
+    LANDING
 }

--- a/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
+++ b/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
@@ -27,7 +27,7 @@
                 <constraints nullable="false" foreignKeyName="fk_step_funnel" references="sales_funnel(id)"/>
             </column>
             <column name="order_idx" type="INT"/>
-            <column name="stimulus_type" type="ENUM('DM','EMAIL','IG_POST_BOOST','FB_AD','STORY','WHATSAPP','CALL','SMS','WEBINAR','PUSH')"/>
+            <column name="stimulus_type" type="ENUM('DM','EMAIL','IG_POST_BOOST','FB_AD','STORY','WHATSAPP','CALL','SMS','WEBINAR','PUSH','LANDING')"/>
             <column name="channel" type="VARCHAR(50)"/>
             <column name="template_id" type="VARCHAR(50)"/>
             <column name="expected_action" type="ENUM('OPEN','CLICK','REPLY','PURCHASE')"/>

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -244,7 +244,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `id` BINARY(16) PRIMARY KEY
 - `funnel_id` BINARY(16) NOT NULL
 - `order_idx` INT
-- `stimulus_type` ENUM('DM','IG_POST_BOOST','FB_AD','WHATSAPP','EMAIL','SMS','PUSH','STORY','WEBINAR','CALL')
+- `stimulus_type` ENUM('DM','IG_POST_BOOST','FB_AD','WHATSAPP','EMAIL','SMS','PUSH','STORY','WEBINAR','CALL','LANDING')
 - `channel` VARCHAR(50)
 - `template_id` VARCHAR(50)
 - `expected_action` ENUM('OPEN','CLICK','REPLY','VIEW','PURCHASE','REGISTRATION','OPT_IN','OPT_OUT','BOUNCE','SHARE')

--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -47,6 +47,7 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
     "STORY",
     "WEBINAR",
     "CALL",
+    "LANDING",
   ];
 
   const actionOptions = [


### PR DESCRIPTION
## Summary
- support LANDING stimulus in backend enum and DB schema
- expose LANDING option in FunnelBuilder UI
- document LANDING stimulus type

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*
- `cd frontend && npm test`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898e96661d083218a79ee834c02f12f