### PR TITLE
fix: add valid checksum for funnel step changeset

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
+++ b/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
@@ -19,6 +19,7 @@
     </changeSet>
 
     <changeSet id="20250825-2" author="codex">
+        <validCheckSum>9:4cd87201ff6020297a7db39108a0147a</validCheckSum>
         <createTable tableName="funnel_step">
             <column name="id" type="BINARY(16)">
                 <constraints primaryKey="true" nullable="false"/>


### PR DESCRIPTION
## Summary
- add validCheckSum to funnel_step changeset to avoid Liquibase checksum mismatch

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central-all: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68995a4684a4832189b4b796fda0a964