### PR TITLE
Expand observation field for funnel steps

### DIFF
--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -139,7 +139,12 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
           ))}
         </select>
         <label htmlFor="note">Observation</label>
-        <input id="note" {...register("note")} />
+        <textarea
+          id="note"
+          rows={3}
+          style={{ width: "100%" }}
+          {...register("note")}
+        />
         <button
           type="button"
           onClick={handleSubmit(onSubmit, (errors) => {
@@ -194,8 +199,9 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
                           </option>
                         ))}
                       </select>
-                      <input
-                        type="text"
+                      <textarea
+                        rows={3}
+                        style={{ width: "100%" }}
                         value={step.note ?? ""}
                         onChange={(e) =>
                           updateStep(index, { note: e.target.value })


### PR DESCRIPTION
## Summary
- enlarge observation field in funnel step editor using multi-line textarea

## Testing
- `npm run build`
- `npm run test` *(fails: Unable to find an element with the text: Hip 1)*

------
https://chatgpt.com/codex/tasks/task_e_689a04812ed48321b7d9e755df662efd