### PR TITLE
feat: add experimental CMS Pages landing project

### DIFF
--- a/experimental/cms-pages-landing/README.md
+++ b/experimental/cms-pages-landing/README.md
@@ -1,0 +1,11 @@
+# CMS Pages Landing Experiment
+
+Projeto experimental em Java com Spring Boot para criar landing pages via API de CMS Pages.
+
+## Execução
+
+```bash
+mvn spring-boot:run
+```
+
+A aplicação cria uma landing page de exemplo ao iniciar.

--- a/experimental/cms-pages-landing/pom.xml
+++ b/experimental/cms-pages-landing/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+    <groupId>com.marketinghub.experimental</groupId>
+    <artifactId>cms-pages-landing</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>cms-pages-landing</name>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/experimental/cms-pages-landing/src/main/java/com/marketinghub/experimental/cmspages/CmsPagesApplication.java
+++ b/experimental/cms-pages-landing/src/main/java/com/marketinghub/experimental/cmspages/CmsPagesApplication.java
@@ -1,0 +1,32 @@
+package com.marketinghub.experimental.cmspages;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
+
+@SpringBootApplication
+public class CmsPagesApplication implements CommandLineRunner {
+
+    private final CmsPagesClient client;
+
+    public CmsPagesApplication(CmsPagesClient client) {
+        this.client = client;
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(CmsPagesApplication.class, args);
+    }
+
+    @Override
+    public void run(String... args) {
+        LandingPage page = new LandingPage("Sample Landing Page", "<h1>Hello!</h1>");
+        client.createLandingPage(page);
+    }
+
+    @Bean
+    RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/experimental/cms-pages-landing/src/main/java/com/marketinghub/experimental/cmspages/CmsPagesClient.java
+++ b/experimental/cms-pages-landing/src/main/java/com/marketinghub/experimental/cmspages/CmsPagesClient.java
@@ -1,0 +1,27 @@
+package com.marketinghub.experimental.cmspages;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class CmsPagesClient {
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+
+    public CmsPagesClient(RestTemplate restTemplate, @Value("${cms.base-url}") String baseUrl) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+    }
+
+    public void createLandingPage(LandingPage page) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<LandingPage> request = new HttpEntity<>(page, headers);
+        restTemplate.postForEntity(baseUrl + "/pages", request, Void.class);
+    }
+}

--- a/experimental/cms-pages-landing/src/main/java/com/marketinghub/experimental/cmspages/LandingPage.java
+++ b/experimental/cms-pages-landing/src/main/java/com/marketinghub/experimental/cmspages/LandingPage.java
@@ -1,0 +1,3 @@
+package com.marketinghub.experimental.cmspages;
+
+public record LandingPage(String title, String content) {}

--- a/experimental/cms-pages-landing/src/main/resources/application.properties
+++ b/experimental/cms-pages-landing/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+cms.base-url=https://api.example.com

--- a/experimental/cms-pages-landing/src/test/java/com/marketinghub/experimental/cmspages/CmsPagesClientTest.java
+++ b/experimental/cms-pages-landing/src/test/java/com/marketinghub/experimental/cmspages/CmsPagesClientTest.java
@@ -1,0 +1,28 @@
+package com.marketinghub.experimental.cmspages;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class CmsPagesClientTest {
+
+    @Test
+    void createsLandingPage() {
+        RestTemplate template = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.createServer(template);
+        CmsPagesClient client = new CmsPagesClient(template, "http://localhost:8080");
+
+        server.expect(requestTo("http://localhost:8080/pages"))
+              .andExpect(method(HttpMethod.POST))
+              .andRespond(withSuccess());
+
+        client.createLandingPage(new LandingPage("Title", "<p>Body</p>"));
+
+        server.verify();
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold experimental CMS Pages landing project with Spring Boot
- add REST client for creating landing pages via CMS Pages API

## Testing
- `mvn -q package` *(fails: Non-resolvable parent POM)*
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `cd backend/ads-service && mvn -s ../settings.xml deploy` *(fails: Network is unreachable)*
- `cd success-product-worker && mvn -s settings.xml test` *(fails: Network is unreachable)*
- `cd success-product-worker && mvn -s settings.xml package` *(fails: Network is unreachable)*
- `cd frontend && npm run build` *(passes)*
- `cd frontend && npm test` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e174bc97083219ac5855f9a30d808