### PR TITLE
feat: add unique mechanism to hypothesis

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -46,6 +46,10 @@ public class Hypothesis {
     @Column(nullable = false)
     private String persona;
 
+    /** Mecanismo único que sustenta a promessa. */
+    @Lob
+    private String uniqueMechanism;
+
     /** Regra de sucesso que define se a hipótese será validada. */
     @Lob
     private String successRule;

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
@@ -9,6 +9,7 @@ public class CreateHypothesisRequest {
     private String promise;
     private String problem;
     private String persona;
+    private String uniqueMechanism;
     private String successRule;
     private String offerType;
     private BigDecimal price;
@@ -27,6 +28,8 @@ public class CreateHypothesisRequest {
     public void setProblem(String problem) { this.problem = problem; }
     public String getPersona() { return persona; }
     public void setPersona(String persona) { this.persona = persona; }
+    public String getUniqueMechanism() { return uniqueMechanism; }
+    public void setUniqueMechanism(String uniqueMechanism) { this.uniqueMechanism = uniqueMechanism; }
     public String getSuccessRule() { return successRule; }
     public void setSuccessRule(String successRule) { this.successRule = successRule; }
     public String getOfferType() { return offerType; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
@@ -16,6 +16,7 @@ public class HypothesisDto {
     private String promise;
     private String problem;
     private String persona;
+    private String uniqueMechanism;
     private String successRule;
     private OfferType offerType;
     private BigDecimal price;

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
@@ -8,6 +8,7 @@ public class UpdateHypothesisRequest {
     private String promise;
     private String problem;
     private String persona;
+    private String uniqueMechanism;
     private String successRule;
     private String offerType;
     private BigDecimal price;
@@ -27,6 +28,9 @@ public class UpdateHypothesisRequest {
 
     public String getPersona() { return persona; }
     public void setPersona(String persona) { this.persona = persona; }
+
+    public String getUniqueMechanism() { return uniqueMechanism; }
+    public void setUniqueMechanism(String uniqueMechanism) { this.uniqueMechanism = uniqueMechanism; }
 
     public String getSuccessRule() { return successRule; }
     public void setSuccessRule(String successRule) { this.successRule = successRule; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -91,6 +91,7 @@ public class HypothesisService {
                 .promise(req.getPromise())
                 .problem(req.getProblem())
                 .persona(req.getPersona())
+                .uniqueMechanism(req.getUniqueMechanism())
                 .successRule(req.getSuccessRule())
                 .offerType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()))
                 .price(req.getPrice())
@@ -162,6 +163,7 @@ public class HypothesisService {
         h.setPromise(req.getPromise());
         h.setProblem(req.getProblem());
         h.setPersona(req.getPersona());
+        h.setUniqueMechanism(req.getUniqueMechanism());
         h.setSuccessRule(req.getSuccessRule());
         h.setOfferType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()));
         h.setPrice(req.getPrice());

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_08_14__add_unique_mechanism_to_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_08_14__add_unique_mechanism_to_hypothesis.sql
@@ -1,0 +1,5 @@
+-- liquibase formatted sql
+-- changeset marketinghub:2025-08-14-add-unique-mechanism-to-hypothesis
+--preconditions onFail:MARK_RAN onError:HALT
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'hypothesis' AND COLUMN_NAME = 'unique_mechanism';
+ALTER TABLE hypothesis ADD COLUMN unique_mechanism LONGTEXT;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -47,5 +47,8 @@ databaseChangeLog:
       file: V2025_08_06__create_chat_tables.sql
       relativeToChangelogFile: true
   - include:
+      file: V2025_08_14__add_unique_mechanism_to_hypothesis.sql
+      relativeToChangelogFile: true
+  - include:
       file: V2025_09_15__create_chat_dialog_table.sql
       relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
@@ -43,6 +43,7 @@ public class FixtureUtils {
                 .promise("Promessa")
                 .problem("Problema")
                 .persona("Persona")
+                .uniqueMechanism("Mecanismo")
                 .successRule("Regra")
                 .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
                 .kpiTargetCpl(java.math.BigDecimal.ONE)

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -214,6 +214,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `premise_angle_id` BIGINT NOT NULL
 - `offer_type` VARCHAR(20) NOT NULL
 - `price` DECIMAL(6,2)
+- `unique_mechanism` LONGTEXT
 - `kpi_target_cpl` DECIMAL(7,2) NOT NULL
 - `status` VARCHAR(20) DEFAULT 'BACKLOG' NOT NULL
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -412,6 +412,8 @@ components:
           type: string
         persona:
           type: string
+        uniqueMechanism:
+          type: string
         successRule:
           type: string
         offerType:

--- a/frontend/src/api/hypothesis/useCreateHypothesis.ts
+++ b/frontend/src/api/hypothesis/useCreateHypothesis.ts
@@ -10,6 +10,7 @@ export interface CreateHypothesis {
   promise: string;
   problem: string;
   persona: string;
+  uniqueMechanism?: string;
   successRule: string;
   offerType?: string;
   kpiTargetCpl?: number;

--- a/frontend/src/api/hypothesis/useHypothesisBoard.ts
+++ b/frontend/src/api/hypothesis/useHypothesisBoard.ts
@@ -8,6 +8,7 @@ export interface Hypothesis {
   promise?: string;
   problem?: string;
   persona?: string;
+  uniqueMechanism?: string;
   successRule?: string;
   premiseAngleId?: number;
   offerType?: string;

--- a/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
@@ -15,6 +15,7 @@ const schema = z
     promise: z.string().min(1).max(140),
     problem: z.string().min(1),
     persona: z.string().min(1),
+    uniqueMechanism: z.string().optional(),
     successRule: z.string().min(1),
     premiseAngleId: z.string().min(1),
     offerType: z.enum(["LEAD", "TRIPWIRE"]),
@@ -59,6 +60,7 @@ export default function EditHypothesisPage() {
         promise: data.promise || "",
         problem: data.problem || "",
         persona: data.persona || "",
+        uniqueMechanism: data.uniqueMechanism || "",
         successRule: data.successRule || "",
         premiseAngleId: String(data.premiseAngleId ?? ""),
         offerType: (data.offerType as "LEAD" | "TRIPWIRE") || "LEAD",
@@ -78,6 +80,7 @@ export default function EditHypothesisPage() {
       promise: values.promise,
       problem: values.problem,
       persona: values.persona,
+      uniqueMechanism: values.uniqueMechanism,
       successRule: values.successRule,
       premiseAngleId: Number(values.premiseAngleId),
       offerType: values.offerType,
@@ -146,14 +149,30 @@ export default function EditHypothesisPage() {
           Persona
         </label>
         <input
-          id="persona"
-          {...register("persona")}
+        id="persona"
+        {...register("persona")}
           className={`form-control mb-2 ${errors.persona ? "is-invalid" : ""}`}
           aria-describedby="persona-error"
         />
         {errors.persona && (
           <div id="persona-error" className="invalid-feedback d-block">
             {errors.persona.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="uniqueMechanism">
+          Mecanismo único
+        </label>
+        <textarea
+          id="uniqueMechanism"
+          rows={2}
+          {...register("uniqueMechanism")}
+          className={`form-control mb-2 ${errors.uniqueMechanism ? "is-invalid" : ""}`}
+          aria-describedby="uniqueMechanism-error"
+        />
+        {errors.uniqueMechanism && (
+          <div id="uniqueMechanism-error" className="invalid-feedback d-block">
+            {errors.uniqueMechanism.message}
           </div>
         )}
 

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -30,6 +30,7 @@ export default function HypothesisDetailPage() {
     { label: "Promessa", value: data.promise },
     { label: "Problema", value: data.problem },
     { label: "Persona", value: data.persona },
+    { label: "Mecanismo único", value: data.uniqueMechanism },
     { label: "Regra de sucesso", value: data.successRule },
     { label: "Ângulo", value: angleName },
     {

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -15,6 +15,7 @@ const schema = z
     promise: z.string().min(1, "obrigatório").max(140, "máx. 140"),
     problem: z.string().min(1, "obrigatório"),
     persona: z.string().min(1, "obrigatório"),
+    uniqueMechanism: z.string().optional(),
     successRule: z.string().min(1, "obrigatório"),
     premiseAngleId: z.string().min(1, "obrigatório"),
     offerType: z.enum(["LEAD", "TRIPWIRE"]),
@@ -62,6 +63,7 @@ export default function NewHypothesisPage() {
       promise: values.promise,
       problem: values.problem,
       persona: values.persona,
+      uniqueMechanism: values.uniqueMechanism,
       successRule: values.successRule,
       premiseAngleId: Number(values.premiseAngleId),
       offerType: values.offerType,
@@ -123,14 +125,30 @@ export default function NewHypothesisPage() {
 
         <label className="form-label" htmlFor="persona">Persona</label>
         <input
-          id="persona"
-          {...register("persona")}
+        id="persona"
+        {...register("persona")}
           className={`form-control mb-2 ${errors.persona ? "is-invalid" : ""}`}
           aria-describedby="persona-error"
         />
         {errors.persona && (
           <div id="persona-error" className="invalid-feedback d-block">
             {errors.persona.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="uniqueMechanism">
+          Mecanismo único
+        </label>
+        <textarea
+          id="uniqueMechanism"
+          rows={2}
+          {...register("uniqueMechanism")}
+          className={`form-control mb-2 ${errors.uniqueMechanism ? "is-invalid" : ""}`}
+          aria-describedby="uniqueMechanism-error"
+        />
+        {errors.uniqueMechanism && (
+          <div id="uniqueMechanism-error" className="invalid-feedback d-block">
+            {errors.uniqueMechanism.message}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- add uniqueMechanism field to hypothesis entity and DTOs
- include unique mechanism in UI forms and detail view
- document and migrate unique mechanism column

## Testing
- `npm test`
- `npm run build`
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e82d457348321878e042433029e3f