### PR TITLE
feat: allow editing success product

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/UpdateSuccessProductRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/UpdateSuccessProductRequest.java
@@ -1,0 +1,31 @@
+package com.marketinghub.successproduct.dto;
+
+import lombok.Data;
+
+/**
+ * Request body for updating a success product.
+ */
+@Data
+public class UpdateSuccessProductRequest {
+    private String description;
+    private String name;
+    private Boolean novo;
+    private String niche;
+    private String avatar;
+    private String audienceType;
+    private String salesPageUrl;
+    private String instagramUrl;
+    private String facebookUrl;
+    private String youtubeUrl;
+    private Long instagramAccountId;
+    private String explicitPain;
+    private String promise;
+    private String uniqueMechanism;
+    private String tripwire;
+    private String riskReversal;
+    private String socialProof;
+    private String checkoutMonetization;
+    private String salesFunnel;
+    private String creativeVolume;
+    private String storytelling;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/service/SuccessProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/service/SuccessProductService.java
@@ -1,7 +1,10 @@
 package com.marketinghub.successproduct.service;
 
+import com.marketinghub.ads.InstagramAccount;
+import com.marketinghub.ads.InstagramAccountRepository;
 import com.marketinghub.successproduct.SuccessProduct;
 import com.marketinghub.successproduct.dto.CreateSuccessProductRequest;
+import com.marketinghub.successproduct.dto.UpdateSuccessProductRequest;
 import com.marketinghub.successproduct.repository.SuccessProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,9 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class SuccessProductService {
     private final SuccessProductRepository repository;
+    private final InstagramAccountRepository instagramAccountRepository;
 
-    public SuccessProductService(SuccessProductRepository repository) {
+    public SuccessProductService(SuccessProductRepository repository,
+                                 InstagramAccountRepository instagramAccountRepository) {
         this.repository = repository;
+        this.instagramAccountRepository = instagramAccountRepository;
     }
 
     /**
@@ -35,5 +41,42 @@ public class SuccessProductService {
 
     public Iterable<SuccessProduct> list() {
         return repository.findAll();
+    }
+
+    /** Update an existing success product. */
+    @Transactional
+    public SuccessProduct update(Long id, UpdateSuccessProductRequest request) {
+        SuccessProduct product = repository.findById(id).orElseThrow();
+        product.setDescription(request.getDescription());
+        product.setName(request.getName());
+        if (request.getNovo() != null) {
+            product.setNovo(request.getNovo());
+        }
+        product.setNiche(request.getNiche());
+        product.setAvatar(request.getAvatar());
+        product.setAudienceType(request.getAudienceType());
+        product.setSalesPageUrl(request.getSalesPageUrl());
+        product.setInstagramUrl(request.getInstagramUrl());
+        product.setFacebookUrl(request.getFacebookUrl());
+        product.setYoutubeUrl(request.getYoutubeUrl());
+        if (request.getInstagramAccountId() != null) {
+            InstagramAccount account = instagramAccountRepository
+                    .findById(request.getInstagramAccountId())
+                    .orElse(null);
+            product.setInstagramAccount(account);
+        } else {
+            product.setInstagramAccount(null);
+        }
+        product.setExplicitPain(request.getExplicitPain());
+        product.setPromise(request.getPromise());
+        product.setUniqueMechanism(request.getUniqueMechanism());
+        product.setTripwire(request.getTripwire());
+        product.setRiskReversal(request.getRiskReversal());
+        product.setSocialProof(request.getSocialProof());
+        product.setCheckoutMonetization(request.getCheckoutMonetization());
+        product.setSalesFunnel(request.getSalesFunnel());
+        product.setCreativeVolume(request.getCreativeVolume());
+        product.setStorytelling(request.getStorytelling());
+        return repository.save(product);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/web/SuccessProductController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/web/SuccessProductController.java
@@ -2,6 +2,7 @@ package com.marketinghub.successproduct.web;
 
 import com.marketinghub.successproduct.dto.CreateSuccessProductRequest;
 import com.marketinghub.successproduct.dto.SuccessProductDto;
+import com.marketinghub.successproduct.dto.UpdateSuccessProductRequest;
 import com.marketinghub.successproduct.mapper.SuccessProductMapper;
 import com.marketinghub.successproduct.service.SuccessProductService;
 import org.springframework.web.bind.annotation.*;
@@ -38,5 +39,10 @@ public class SuccessProductController {
         return StreamSupport.stream(service.list().spliterator(), false)
                 .map(mapper::toDto)
                 .toList();
+    }
+
+    @PutMapping("/{id}")
+    public SuccessProductDto update(@PathVariable Long id, @RequestBody UpdateSuccessProductRequest request) {
+        return mapper.toDto(service.update(id, request));
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import NewProductPage from "./pages/product/NewProductPage";
 import SuccessProductListPage from "./pages/successProduct/SuccessProductListPage";
 import NewSuccessProductPage from "./pages/successProduct/NewSuccessProductPage";
 import SuccessProductDetailPage from "./pages/successProduct/SuccessProductDetailPage";
+import EditSuccessProductPage from "./pages/successProduct/EditSuccessProductPage";
 import InstagramPostsPage from "./pages/post/InstagramPostsPage";
 import NicheListPage from "./pages/niche/NicheListPage";
 import NewNichePage from "./pages/niche/NewNichePage";
@@ -165,6 +166,10 @@ export default function App() {
         <Route
           path="/success-products/:id"
           element={<SuccessProductDetailPage />}
+        />
+        <Route
+          path="/success-products/:id/edit"
+          element={<EditSuccessProductPage />}
         />
         <Route path="/niches" element={<AppLayout />}>
           <Route index element={<NicheListPage />} />

--- a/frontend/src/api/successProduct/useUpdateSuccessProduct.ts
+++ b/frontend/src/api/successProduct/useUpdateSuccessProduct.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { SuccessProduct } from "./useSuccessProducts";
+
+export function useUpdateSuccessProduct() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (p: SuccessProduct) => {
+      const { id, ...body } = p;
+      const { data } = await axios.put<SuccessProduct>(
+        `/api/success-products/${id}`,
+        body,
+      );
+      return data;
+    },
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ["successProducts"] });
+      qc.invalidateQueries({ queryKey: ["successProduct", data.id] });
+    },
+  });
+}

--- a/frontend/src/pages/successProduct/EditSuccessProductPage.tsx
+++ b/frontend/src/pages/successProduct/EditSuccessProductPage.tsx
@@ -1,0 +1,175 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useSuccessProduct } from "../../api/successProduct/useSuccessProduct";
+import { useUpdateSuccessProduct } from "../../api/successProduct/useUpdateSuccessProduct";
+import { SuccessProduct } from "../../api/successProduct/useSuccessProducts";
+
+export default function EditSuccessProductPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const productId = Number(id);
+  const { data, isLoading } = useSuccessProduct(productId);
+  const update = useUpdateSuccessProduct();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<SuccessProduct>();
+
+  useEffect(() => {
+    if (data) {
+      reset(data);
+    }
+  }, [data, reset]);
+
+  const onSubmit = async (values: SuccessProduct) => {
+    await update.mutateAsync(values);
+    navigate(-1);
+  };
+
+  if (isLoading || !data) return <p>Carregando...</p>;
+
+  return (
+    <div style={{ maxWidth: 600 }}>
+      <PageTitle>Editar Produto de Sucesso</PageTitle>
+      <form noValidate>
+        <div className="form-check form-switch mb-2">
+          <input
+            className="form-check-input"
+            type="checkbox"
+            id="novo"
+            {...register("novo")}
+          />
+          <label className="form-check-label" htmlFor="novo">
+            Novo
+          </label>
+        </div>
+        <input
+          className="form-control mb-2"
+          placeholder="Nome"
+          {...register("name")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Descrição"
+          rows={3}
+          {...register("description")}
+        />
+        <input
+          className="form-control mb-2"
+          placeholder="Nicho"
+          {...register("niche")}
+        />
+        <input
+          className="form-control mb-2"
+          placeholder="Avatar"
+          {...register("avatar")}
+        />
+        <input
+          className="form-control mb-2"
+          placeholder="Tipo de Público"
+          {...register("audienceType")}
+        />
+        <input
+          className="form-control mb-2"
+          placeholder="URL da Página de Vendas"
+          {...register("salesPageUrl")}
+        />
+        <input
+          className="form-control mb-2"
+          placeholder="Instagram"
+          {...register("instagramUrl")}
+        />
+        <input
+          className="form-control mb-2"
+          placeholder="Facebook"
+          {...register("facebookUrl")}
+        />
+        <input
+          className="form-control mb-2"
+          placeholder="YouTube"
+          {...register("youtubeUrl")}
+        />
+        <input
+          type="number"
+          className="form-control mb-2"
+          placeholder="Instagram Account ID"
+          {...register("instagramAccountId", { valueAsNumber: true })}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Dor Explícita"
+          rows={2}
+          {...register("explicitPain")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Promessa"
+          rows={2}
+          {...register("promise")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Mecanismo Único"
+          rows={2}
+          {...register("uniqueMechanism")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Tripwire"
+          rows={2}
+          {...register("tripwire")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Reversão de Risco"
+          rows={2}
+          {...register("riskReversal")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Prova Social"
+          rows={2}
+          {...register("socialProof")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Monetização do Checkout"
+          rows={2}
+          {...register("checkoutMonetization")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Funil de Vendas"
+          rows={2}
+          {...register("salesFunnel")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Volume Criativo"
+          rows={2}
+          {...register("creativeVolume")}
+        />
+        <textarea
+          className="form-control mb-3"
+          placeholder="Storytelling"
+          rows={2}
+          {...register("storytelling")}
+        />
+        <button
+          type="button"
+          className="btn btn-primary"
+          disabled={isSubmitting}
+          onClick={handleSubmit(onSubmit, (errors) => {
+            console.log("Validation errors", errors);
+          })}
+        >
+          Salvar
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/successProduct/SuccessProductListPage.tsx
+++ b/frontend/src/pages/successProduct/SuccessProductListPage.tsx
@@ -30,6 +30,12 @@ export default function SuccessProductListPage() {
               <td>{p.novo ? "Yes" : "No"}</td>
               <td>
                 <Link
+                  className="btn btn-sm btn-outline-secondary me-2"
+                  to={`/success-products/${p.id}/edit`}
+                >
+                  Editar
+                </Link>
+                <Link
                   className="btn btn-sm btn-outline-primary"
                   to={`/success-products/${p.id}`}
                 >


### PR DESCRIPTION
## Summary
- add backend update support for success products
- enable editing success product on frontend list and new edit page

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `cd success-product-worker && mvn -s settings.xml test` *(fails: Network is unreachable)*
- `cd frontend && npm run build`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689efd74bff48321baf803d8f7712aaf