### PR TITLE
feat(chat): show newest dialogs first

### DIFF
--- a/frontend/src/api/chatDialog/useChatDialogs.ts
+++ b/frontend/src/api/chatDialog/useChatDialogs.ts
@@ -6,6 +6,8 @@ export interface ChatDialog {
   url: string;
   description: string;
   theme: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export function useChatDialogs() {
@@ -17,4 +19,3 @@ export function useChatDialogs() {
     },
   });
 }
-

--- a/frontend/src/pages/chatDialog/ChatDialogListPage.tsx
+++ b/frontend/src/pages/chatDialog/ChatDialogListPage.tsx
@@ -4,7 +4,12 @@ import { useChatDialogs } from "../../api/chatDialog/useChatDialogs";
 
 export default function ChatDialogListPage() {
   const { data, isLoading } = useChatDialogs();
-  const dialogs = Array.isArray(data) ? data : [];
+  const dialogs = Array.isArray(data)
+    ? [...data].sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      )
+    : [];
   if (isLoading) return <p>Carregando...</p>;
   return (
     <div>
@@ -41,4 +46,3 @@ export default function ChatDialogListPage() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- sort ChatGPT dialog list by creation time, showing newest first
- expose creation metadata in chat dialog client hook

## Testing
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689efc7d5ed083218d04b809f30f838a