### PR TITLE
Add platform classification to success products

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/SuccessProduct.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/SuccessProduct.java
@@ -31,6 +31,10 @@ public class SuccessProduct {
     @Builder.Default
     private boolean novo = true;
 
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private SuccessProductPlatform platform = SuccessProductPlatform.COFRE;
+
     private String niche;
     private String avatar;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/SuccessProductPlatform.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/SuccessProductPlatform.java
@@ -1,0 +1,10 @@
+package com.marketinghub.successproduct;
+
+/**
+ * Platform where the successful product is sold.
+ */
+public enum SuccessProductPlatform {
+    COFRE,
+    HOTMART,
+    CLICKBANK
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/CreateSuccessProductRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/CreateSuccessProductRequest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.successproduct.dto;
 
+import com.marketinghub.successproduct.SuccessProductPlatform;
 import lombok.Data;
 
 /**
@@ -8,4 +9,5 @@ import lombok.Data;
 @Data
 public class CreateSuccessProductRequest {
     private String description;
+    private SuccessProductPlatform platform;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/SuccessProductDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/SuccessProductDto.java
@@ -1,5 +1,6 @@
 package com.marketinghub.successproduct.dto;
 
+import com.marketinghub.successproduct.SuccessProductPlatform;
 import java.time.Instant;
 import lombok.Data;
 
@@ -12,6 +13,7 @@ public class SuccessProductDto {
     private String description;
     private String name;
     private boolean novo;
+    private SuccessProductPlatform platform;
     private String niche;
     private String avatar;
     private String audienceType;

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/UpdateSuccessProductRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/UpdateSuccessProductRequest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.successproduct.dto;
 
+import com.marketinghub.successproduct.SuccessProductPlatform;
 import lombok.Data;
 
 /**
@@ -12,6 +13,7 @@ public class UpdateSuccessProductRequest {
     private Boolean novo;
     private String niche;
     private String avatar;
+    private SuccessProductPlatform platform;
     private String audienceType;
     private String salesPageUrl;
     private String instagramUrl;

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/service/SuccessProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/service/SuccessProductService.java
@@ -6,6 +6,7 @@ import com.marketinghub.successproduct.SuccessProduct;
 import com.marketinghub.successproduct.dto.CreateSuccessProductRequest;
 import com.marketinghub.successproduct.dto.UpdateSuccessProductRequest;
 import com.marketinghub.successproduct.repository.SuccessProductRepository;
+import com.marketinghub.successproduct.SuccessProductPlatform;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +32,7 @@ public class SuccessProductService {
         SuccessProduct product = SuccessProduct.builder()
                 .description(request.getDescription())
                 .novo(true)
+                .platform(request.getPlatform() != null ? request.getPlatform() : SuccessProductPlatform.COFRE)
                 .build();
         return repository.save(product);
     }
@@ -54,6 +56,9 @@ public class SuccessProductService {
         }
         product.setNiche(request.getNiche());
         product.setAvatar(request.getAvatar());
+        if (request.getPlatform() != null) {
+            product.setPlatform(request.getPlatform());
+        }
         product.setAudienceType(request.getAudienceType());
         product.setSalesPageUrl(request.getSalesPageUrl());
         product.setInstagramUrl(request.getInstagramUrl());

--- a/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
@@ -2,6 +2,7 @@ package com.marketinghub.successproduct;
 
 import com.marketinghub.ads.AdsServiceApplication;
 import com.marketinghub.successproduct.repository.SuccessProductRepository;
+import com.marketinghub.successproduct.SuccessProductPlatform;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -27,6 +28,7 @@ class SuccessProductRepositoryTest {
         repository.save(product);
         SuccessProduct saved = repository.findById(product.getId()).orElseThrow();
         assertThat(saved.isNovo()).isTrue();
+        assertThat(saved.getPlatform()).isEqualTo(SuccessProductPlatform.COFRE);
         assertThat(saved.getName()).isNull();
         assertThat(saved.getSalesPageUrl()).contains("example.com");
     }
@@ -51,10 +53,12 @@ class SuccessProductRepositoryTest {
         SuccessProduct product = SuccessProduct.builder()
                 .description(description)
                 .salesPageUrl("https://www.taichichenonline.com/PVDTAICHI")
+                .platform(SuccessProductPlatform.HOTMART)
                 .build();
         repository.save(product);
         SuccessProduct saved = repository.findById(product.getId()).orElseThrow();
         assertThat(saved.getDescription()).isEqualTo(description);
+        assertThat(saved.getPlatform()).isEqualTo(SuccessProductPlatform.HOTMART);
         assertThat(saved.getSalesPageUrl()).contains("PVDTAICHI");
     }
 }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -67,6 +67,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `description` LONGTEXT
 - `name` VARCHAR(255)
 - `novo` BOOLEAN DEFAULT TRUE
+- `platform` VARCHAR(20) DEFAULT 'COFRE'
 - `niche` VARCHAR(255)
 - `avatar` VARCHAR(255)
 - `audience_type` VARCHAR(255)

--- a/frontend/src/api/successProduct/useCreateSuccessProduct.ts
+++ b/frontend/src/api/successProduct/useCreateSuccessProduct.ts
@@ -1,9 +1,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
-import { SuccessProduct } from "./useSuccessProducts";
+import { SuccessProduct, SuccessProductPlatform } from "./useSuccessProducts";
 
 export interface CreateSuccessProduct {
   description: string;
+  platform: SuccessProductPlatform;
 }
 
 export function useCreateSuccessProduct() {

--- a/frontend/src/api/successProduct/useSuccessProducts.ts
+++ b/frontend/src/api/successProduct/useSuccessProducts.ts
@@ -1,11 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 
+export type SuccessProductPlatform = "COFRE" | "HOTMART" | "CLICKBANK";
+
 export interface SuccessProduct {
   id: number;
   description: string;
   name?: string;
   novo: boolean;
+  platform: SuccessProductPlatform;
   niche: string;
   avatar: string;
   audienceType: string;

--- a/frontend/src/pages/successProduct/EditSuccessProductPage.tsx
+++ b/frontend/src/pages/successProduct/EditSuccessProductPage.tsx
@@ -68,6 +68,11 @@ export default function EditSuccessProductPage() {
           placeholder="Avatar"
           {...register("avatar")}
         />
+        <select className="form-select mb-2" {...register("platform")}>
+          <option value="COFRE">Cofre</option>
+          <option value="HOTMART">Hotmart</option>
+          <option value="CLICKBANK">Clickbank</option>
+        </select>
         <input
           className="form-control mb-2"
           placeholder="Tipo de Público"

--- a/frontend/src/pages/successProduct/NewSuccessProductPage.tsx
+++ b/frontend/src/pages/successProduct/NewSuccessProductPage.tsx
@@ -1,15 +1,18 @@
 import { useState } from "react";
 import { useCreateSuccessProduct } from "../../api/successProduct/useCreateSuccessProduct";
 import PageTitle from "../../components/PageTitle";
+import { SuccessProductPlatform } from "../../api/successProduct/useSuccessProducts";
 
 export default function NewSuccessProductPage() {
   const create = useCreateSuccessProduct();
   const [description, setDescription] = useState("");
+  const [platform, setPlatform] = useState<SuccessProductPlatform>("COFRE");
 
   const submit = async () => {
     try {
-      await create.mutateAsync({ description });
+      await create.mutateAsync({ description, platform });
       setDescription("");
+      setPlatform("COFRE");
       alert("Produto de Sucesso salvo!");
     } catch (err) {
       alert("Erro ao salvar Produto de Sucesso");
@@ -26,6 +29,15 @@ export default function NewSuccessProductPage() {
         onChange={(e) => setDescription(e.target.value)}
         rows={5}
       />
+      <select
+        className="form-select mb-2"
+        value={platform}
+        onChange={(e) => setPlatform(e.target.value as SuccessProductPlatform)}
+      >
+        <option value="COFRE">Cofre</option>
+        <option value="HOTMART">Hotmart</option>
+        <option value="CLICKBANK">Clickbank</option>
+      </select>
       <button className="btn btn-primary" onClick={submit}>
         Salvar
       </button>

--- a/frontend/src/pages/successProduct/SuccessProductDetailPage.tsx
+++ b/frontend/src/pages/successProduct/SuccessProductDetailPage.tsx
@@ -15,6 +15,7 @@ export default function SuccessProductDetailPage() {
 
   const rows = [
     { label: "Descrição", value: data.description, pre: true },
+    { label: "Plataforma", value: data.platform },
     { label: "Nicho", value: data.niche },
     { label: "Avatar", value: data.avatar },
     { label: "Tipo de Público", value: data.audienceType },

--- a/frontend/src/pages/successProduct/SuccessProductListPage.tsx
+++ b/frontend/src/pages/successProduct/SuccessProductListPage.tsx
@@ -18,6 +18,7 @@ export default function SuccessProductListPage() {
           <tr>
             <th>ID</th>
             <th>Descrição</th>
+            <th>Plataforma</th>
             <th>Novo</th>
             <th>Ações</th>
           </tr>
@@ -27,6 +28,7 @@ export default function SuccessProductListPage() {
             <tr key={p.id}>
               <td>{p.id}</td>
               <td>{p.description}</td>
+              <td>{p.platform}</td>
               <td>{p.novo ? "Yes" : "No"}</td>
               <td>
                 <Link

--- a/schema.sql
+++ b/schema.sql
@@ -60,6 +60,7 @@ CREATE TABLE success_product (
     description LONGTEXT,
     name VARCHAR(255),
     novo BOOLEAN DEFAULT TRUE,
+    platform VARCHAR(20) DEFAULT 'COFRE',
     niche VARCHAR(255),
     avatar VARCHAR(255),
     audience_type VARCHAR(255),

--- a/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProduct.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProduct.java
@@ -27,6 +27,10 @@ public class SuccessProduct {
     @Builder.Default
     private boolean novo = true;
 
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private SuccessProductPlatform platform = SuccessProductPlatform.COFRE;
+
     private String niche;
     private String avatar;
 

--- a/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductPlatform.java
+++ b/success-product-worker/src/main/java/com/marketinghub/worker/SuccessProductPlatform.java
@@ -1,0 +1,10 @@
+package com.marketinghub.worker;
+
+/**
+ * Platform where the successful product is sold.
+ */
+public enum SuccessProductPlatform {
+    COFRE,
+    HOTMART,
+    CLICKBANK
+}

--- a/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
+++ b/success-product-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
@@ -2,6 +2,7 @@ package com.marketinghub.worker;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.marketinghub.worker.SuccessProductPlatform;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -36,11 +37,13 @@ class SuccessProductRepositoryTest {
                 .instagramUrl("https://instagram.com/example")
                 .facebookUrl("https://facebook.com/example")
                 .youtubeUrl("https://youtube.com/example")
+                .platform(SuccessProductPlatform.HOTMART)
                 .build();
         repository.save(product);
         SuccessProduct saved = repository.findById(product.getId()).orElseThrow();
         assertThat(saved.isNovo()).isTrue();
         assertThat(saved.getName()).isEqualTo("Produto");
+        assertThat(saved.getPlatform()).isEqualTo(SuccessProductPlatform.HOTMART);
         assertThat(saved.getSalesPageUrl()).contains("example.com");
     }
 
@@ -65,11 +68,13 @@ class SuccessProductRepositoryTest {
                 .description(description)
                 .name("Produto")
                 .salesPageUrl("https://www.taichichenonline.com/PVDTAICHI")
+                .platform(SuccessProductPlatform.CLICKBANK)
                 .build();
         repository.save(product);
         SuccessProduct saved = repository.findById(product.getId()).orElseThrow();
         assertThat(saved.getDescription()).isEqualTo(description);
         assertThat(saved.getName()).isEqualTo("Produto");
+        assertThat(saved.getPlatform()).isEqualTo(SuccessProductPlatform.CLICKBANK);
         assertThat(saved.getSalesPageUrl()).contains("PVDTAICHI");
     }
 }


### PR DESCRIPTION
## Summary
- allow success products to be tagged with platform (Cofre, Hotmart, Clickbank)
- expose platform in API DTOs and update service logic
- show platform selector and column in success product pages

## Testing
- `mvn -s ../settings.xml test` *(failed: Could not transfer org.springframework.boot:spring-boot-starter-parent: Network is unreachable)*
- `mvn -s settings.xml test` *(failed: Could not transfer org.springframework.boot:spring-boot-starter-parent: Network is unreachable)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f0302ece083219392af324bbea188