### PR TITLE
Add mechanism field to hypotheses

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -46,6 +46,10 @@ public class Hypothesis {
     @Column(nullable = false)
     private String persona;
 
+    /** Mecanismo que sustenta a promessa. */
+    @Lob
+    private String mechanism;
+
     /** Mecanismo único que sustenta a promessa. */
     @Lob
     private String uniqueMechanism;

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
@@ -9,6 +9,7 @@ public class CreateHypothesisRequest {
     private String promise;
     private String problem;
     private String persona;
+    private String mechanism;
     private String uniqueMechanism;
     private String successRule;
     private String offerType;
@@ -28,6 +29,8 @@ public class CreateHypothesisRequest {
     public void setProblem(String problem) { this.problem = problem; }
     public String getPersona() { return persona; }
     public void setPersona(String persona) { this.persona = persona; }
+    public String getMechanism() { return mechanism; }
+    public void setMechanism(String mechanism) { this.mechanism = mechanism; }
     public String getUniqueMechanism() { return uniqueMechanism; }
     public void setUniqueMechanism(String uniqueMechanism) { this.uniqueMechanism = uniqueMechanism; }
     public String getSuccessRule() { return successRule; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
@@ -16,6 +16,7 @@ public class HypothesisDto {
     private String promise;
     private String problem;
     private String persona;
+    private String mechanism;
     private String uniqueMechanism;
     private String successRule;
     private OfferType offerType;

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
@@ -8,6 +8,7 @@ public class UpdateHypothesisRequest {
     private String promise;
     private String problem;
     private String persona;
+    private String mechanism;
     private String uniqueMechanism;
     private String successRule;
     private String offerType;
@@ -28,6 +29,9 @@ public class UpdateHypothesisRequest {
 
     public String getPersona() { return persona; }
     public void setPersona(String persona) { this.persona = persona; }
+
+    public String getMechanism() { return mechanism; }
+    public void setMechanism(String mechanism) { this.mechanism = mechanism; }
 
     public String getUniqueMechanism() { return uniqueMechanism; }
     public void setUniqueMechanism(String uniqueMechanism) { this.uniqueMechanism = uniqueMechanism; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -91,6 +91,7 @@ public class HypothesisService {
                 .promise(req.getPromise())
                 .problem(req.getProblem())
                 .persona(req.getPersona())
+                .mechanism(req.getMechanism())
                 .uniqueMechanism(req.getUniqueMechanism())
                 .successRule(req.getSuccessRule())
                 .offerType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()))
@@ -163,6 +164,7 @@ public class HypothesisService {
         h.setPromise(req.getPromise());
         h.setProblem(req.getProblem());
         h.setPersona(req.getPersona());
+        h.setMechanism(req.getMechanism());
         h.setUniqueMechanism(req.getUniqueMechanism());
         h.setSuccessRule(req.getSuccessRule());
         h.setOfferType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()));

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_16__add_mechanism_to_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_16__add_mechanism_to_hypothesis.sql
@@ -1,0 +1,5 @@
+-- liquibase formatted sql
+-- changeset marketinghub:2025-09-16-add-mechanism-to-hypothesis
+--preconditions onFail:MARK_RAN onError:HALT
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'hypothesis' AND COLUMN_NAME = 'mechanism';
+ALTER TABLE hypothesis ADD COLUMN mechanism LONGTEXT;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -52,3 +52,6 @@ databaseChangeLog:
   - include:
       file: V2025_09_15__create_chat_dialog_table.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_09_16__add_mechanism_to_hypothesis.sql
+      relativeToChangelogFile: true

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -216,6 +216,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `premise_angle_id` BIGINT NOT NULL
 - `offer_type` VARCHAR(20) NOT NULL
 - `price` DECIMAL(6,2)
+- `mechanism` LONGTEXT
 - `unique_mechanism` LONGTEXT
 - `kpi_target_cpl` DECIMAL(7,2) NOT NULL
 - `status` VARCHAR(20) DEFAULT 'BACKLOG' NOT NULL

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -412,6 +412,8 @@ components:
           type: string
         persona:
           type: string
+        mechanism:
+          type: string
         uniqueMechanism:
           type: string
         successRule:

--- a/frontend/src/api/hypothesis/useCreateHypothesis.ts
+++ b/frontend/src/api/hypothesis/useCreateHypothesis.ts
@@ -10,6 +10,7 @@ export interface CreateHypothesis {
   promise: string;
   problem: string;
   persona: string;
+  mechanism?: string;
   uniqueMechanism?: string;
   successRule: string;
   offerType?: string;

--- a/frontend/src/api/hypothesis/useHypothesisBoard.ts
+++ b/frontend/src/api/hypothesis/useHypothesisBoard.ts
@@ -8,6 +8,7 @@ export interface Hypothesis {
   promise?: string;
   problem?: string;
   persona?: string;
+  mechanism?: string;
   uniqueMechanism?: string;
   successRule?: string;
   premiseAngleId?: number;

--- a/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
@@ -15,6 +15,7 @@ const schema = z
     promise: z.string().min(1).max(140),
     problem: z.string().min(1),
     persona: z.string().min(1),
+    mechanism: z.string().optional(),
     uniqueMechanism: z.string().optional(),
     successRule: z.string().min(1),
     premiseAngleId: z.string().min(1),
@@ -60,6 +61,7 @@ export default function EditHypothesisPage() {
         promise: data.promise || "",
         problem: data.problem || "",
         persona: data.persona || "",
+        mechanism: data.mechanism || "",
         uniqueMechanism: data.uniqueMechanism || "",
         successRule: data.successRule || "",
         premiseAngleId: String(data.premiseAngleId ?? ""),
@@ -80,6 +82,7 @@ export default function EditHypothesisPage() {
       promise: values.promise,
       problem: values.problem,
       persona: values.persona,
+      mechanism: values.mechanism,
       uniqueMechanism: values.uniqueMechanism,
       successRule: values.successRule,
       premiseAngleId: Number(values.premiseAngleId),
@@ -157,6 +160,22 @@ export default function EditHypothesisPage() {
         {errors.persona && (
           <div id="persona-error" className="invalid-feedback d-block">
             {errors.persona.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="mechanism">
+          Mecanismo
+        </label>
+        <textarea
+          id="mechanism"
+          rows={2}
+          {...register("mechanism")}
+          className={`form-control mb-2 ${errors.mechanism ? "is-invalid" : ""}`}
+          aria-describedby="mechanism-error"
+        />
+        {errors.mechanism && (
+          <div id="mechanism-error" className="invalid-feedback d-block">
+            {errors.mechanism.message}
           </div>
         )}
 

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -30,6 +30,7 @@ export default function HypothesisDetailPage() {
     { label: "Promessa", value: data.promise },
     { label: "Problema", value: data.problem },
     { label: "Persona", value: data.persona },
+    { label: "Mecanismo", value: data.mechanism },
     { label: "Mecanismo único", value: data.uniqueMechanism },
     { label: "Regra de sucesso", value: data.successRule },
     { label: "Ângulo", value: angleName },

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -15,6 +15,7 @@ const schema = z
     promise: z.string().min(1, "obrigatório").max(140, "máx. 140"),
     problem: z.string().min(1, "obrigatório"),
     persona: z.string().min(1, "obrigatório"),
+    mechanism: z.string().optional(),
     uniqueMechanism: z.string().optional(),
     successRule: z.string().min(1, "obrigatório"),
     premiseAngleId: z.string().min(1, "obrigatório"),
@@ -63,6 +64,7 @@ export default function NewHypothesisPage() {
       promise: values.promise,
       problem: values.problem,
       persona: values.persona,
+      mechanism: values.mechanism,
       uniqueMechanism: values.uniqueMechanism,
       successRule: values.successRule,
       premiseAngleId: Number(values.premiseAngleId),
@@ -133,6 +135,22 @@ export default function NewHypothesisPage() {
         {errors.persona && (
           <div id="persona-error" className="invalid-feedback d-block">
             {errors.persona.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="mechanism">
+          Mecanismo
+        </label>
+        <textarea
+          id="mechanism"
+          rows={2}
+          {...register("mechanism")}
+          className={`form-control mb-2 ${errors.mechanism ? "is-invalid" : ""}`}
+          aria-describedby="mechanism-error"
+        />
+        {errors.mechanism && (
+          <div id="mechanism-error" className="invalid-feedback d-block">
+            {errors.mechanism.message}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- add missing `mechanism` column for hypotheses and wire through backend DTOs and service
- expose new field in OpenAPI and data model docs
- surface mechanism on hypothesis forms and details in the frontend

## Testing
- `mvn -s ../settings.xml test` *(failed: Could not resolve dependencies)*
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f07d4a5b48321b4fc2ce13eb414e1