### PR TITLE
Fix incorrect niche edit backend call

### DIFF
--- a/frontend/src/pages/niche/EditNichePage.tsx
+++ b/frontend/src/pages/niche/EditNichePage.tsx
@@ -1,18 +1,20 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useForm } from "react-hook-form";
 import { useUpdateNiche } from "../../api/niche/useUpdateNiche";
 import { useNiche } from "../../api/niche/useNiche";
 import PageTitle from "../../components/PageTitle";
 import { MarketNiche } from "../../api/niche/useNiches";
 
 export default function EditNichePage() {
-  const { id } = useParams<{ id: string }>();
-  const nicheId = Number(id);
-  const { data, isLoading } = useNiche(nicheId);
+  const { nicheId } = useParams<{ nicheId: string }>();
+  const id = Number(nicheId);
+  const { data, isLoading } = useNiche(id);
   const update = useUpdateNiche();
   const navigate = useNavigate();
+  const { handleSubmit } = useForm<MarketNiche>();
   const [form, setForm] = useState<MarketNiche>({
-    id: nicheId,
+    id,
     name: "",
     description: "",
     demandVolume: "",
@@ -110,7 +112,12 @@ export default function EditNichePage() {
       />
       <button
         className="btn btn-primary"
-        onClick={submit}
+        onClick={handleSubmit(
+          () => submit(),
+          (errors) => {
+            console.log("Validation errors", errors);
+          },
+        )}
         disabled={update.isPending}
       >
         {update.isPending ? (


### PR DESCRIPTION
## Summary
- ensure edit niche page uses `nicheId` route param
- log validation errors during niche editing

## Testing
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bb81b7ac83219b1c1d52bc40ea0f