### PR TITLE
feat: allow renaming chat dialogs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/chat/dto/UpdateChatDialogRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/chat/dto/UpdateChatDialogRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.chat.dto;
+
+import lombok.Data;
+
+/**
+ * Request to update a ChatDialog.
+ */
+@Data
+public class UpdateChatDialogRequest {
+    private String description;
+}
+

--- a/backend/ads-service/src/main/java/com/marketinghub/chat/service/ChatDialogService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/chat/service/ChatDialogService.java
@@ -2,11 +2,13 @@ package com.marketinghub.chat.service;
 
 import com.marketinghub.chat.ChatDialog;
 import com.marketinghub.chat.dto.CreateChatDialogRequest;
+import com.marketinghub.chat.dto.UpdateChatDialogRequest;
 import com.marketinghub.chat.repository.ChatDialogRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import jakarta.persistence.EntityNotFoundException;
 
 /** Service layer for ChatDialog. */
 @Service
@@ -28,6 +30,14 @@ public class ChatDialogService {
                 .description(request.getDescription())
                 .theme(request.getTheme())
                 .build();
+        return repository.save(dialog);
+    }
+
+    @Transactional
+    public ChatDialog update(Long id, UpdateChatDialogRequest request) {
+        ChatDialog dialog = repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("ChatDialog not found"));
+        dialog.setDescription(request.getDescription());
         return repository.save(dialog);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/chat/web/ChatDialogController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/chat/web/ChatDialogController.java
@@ -2,6 +2,7 @@ package com.marketinghub.chat.web;
 
 import com.marketinghub.chat.dto.ChatDialogDto;
 import com.marketinghub.chat.dto.CreateChatDialogRequest;
+import com.marketinghub.chat.dto.UpdateChatDialogRequest;
 import com.marketinghub.chat.mapper.ChatDialogMapper;
 import com.marketinghub.chat.service.ChatDialogService;
 import org.springframework.web.bind.annotation.*;
@@ -28,6 +29,12 @@ public class ChatDialogController {
     @PostMapping
     public ChatDialogDto create(@RequestBody CreateChatDialogRequest request) {
         return mapper.toDto(service.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public ChatDialogDto update(
+            @PathVariable Long id, @RequestBody UpdateChatDialogRequest request) {
+        return mapper.toDto(service.update(id, request));
     }
 }
 

--- a/frontend/src/api/chatDialog/useUpdateChatDialog.ts
+++ b/frontend/src/api/chatDialog/useUpdateChatDialog.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { ChatDialog } from "./useChatDialogs";
+
+export interface UpdateChatDialog {
+  id: number;
+  description: string;
+}
+
+export function useUpdateChatDialog() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, ...data }: UpdateChatDialog) => {
+      const { data: dialog } = await axios.put<ChatDialog>(
+        `/api/chat-dialogs/${id}`,
+        data,
+      );
+      return dialog;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["chatDialogs"] });
+    },
+  });
+}

--- a/frontend/src/pages/chatDialog/ChatDialogListPage.tsx
+++ b/frontend/src/pages/chatDialog/ChatDialogListPage.tsx
@@ -1,9 +1,11 @@
 import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import { useChatDialogs } from "../../api/chatDialog/useChatDialogs";
+import { useUpdateChatDialog } from "../../api/chatDialog/useUpdateChatDialog";
 
 export default function ChatDialogListPage() {
   const { data, isLoading } = useChatDialogs();
+  const update = useUpdateChatDialog();
   const dialogs = Array.isArray(data)
     ? [...data].sort(
         (a, b) =>
@@ -25,6 +27,7 @@ export default function ChatDialogListPage() {
               <th>Descrição</th>
               <th>Tema</th>
               <th>URL</th>
+              <th>Ações</th>
             </tr>
           </thead>
           <tbody>
@@ -37,6 +40,19 @@ export default function ChatDialogListPage() {
                   <a href={d.url} target="_blank" rel="noopener noreferrer">
                     Abrir
                   </a>
+                </td>
+                <td>
+                  <button
+                    className="btn btn-sm btn-secondary"
+                    onClick={() => {
+                      const description = prompt("Novo nome", d.description);
+                      if (description) {
+                        update.mutate({ id: d.id, description });
+                      }
+                    }}
+                  >
+                    Editar
+                  </button>
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary
- allow updating chat dialog description
- add edit button to chat dialog list

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Network is unreachable: Could not transfer artifact)*
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bba6c03c8321a3b693dc61a5af62