### PR TITLE
feat: link niches to ChatGPT dialogs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
@@ -3,6 +3,7 @@ package com.marketinghub.niche;
 import jakarta.persistence.*;
 import lombok.*;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.chat.ChatDialog;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -54,6 +55,11 @@ public class MarketNiche {
     /** Extra tips for advertising this niche. */
     @Lob
     private String extraTips;
+
+    /** ChatGPT dialog that originated this niche, if any. */
+    @ManyToOne
+    @JoinColumn(name = "chat_dialog_id")
+    private ChatDialog chatDialog;
 
     @OneToMany(mappedBy = "niche")
     private java.util.List<Experiment> experiments;

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/dto/CreateMarketNicheRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/dto/CreateMarketNicheRequest.java
@@ -17,4 +17,5 @@ public class CreateMarketNicheRequest {
     private String interests;
     private String demographicFilters;
     private String extraTips;
+    private Long chatDialogId;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/dto/MarketNicheDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/dto/MarketNicheDto.java
@@ -18,6 +18,7 @@ public class MarketNicheDto {
     private String interests;
     private String demographicFilters;
     private String extraTips;
+    private Long chatDialogId;
     private Instant createdAt;
     private Instant updatedAt;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/mapper/MarketNicheMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/mapper/MarketNicheMapper.java
@@ -3,11 +3,13 @@ package com.marketinghub.niche.mapper;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.dto.MarketNicheDto;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /**
  * MapStruct mapper for {@link MarketNiche}.
  */
 @Mapper(componentModel = "spring")
 public interface MarketNicheMapper {
+    @Mapping(target = "chatDialogId", source = "chatDialog.id")
     MarketNicheDto toDto(MarketNiche niche);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
@@ -3,6 +3,8 @@ package com.marketinghub.niche.service;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.dto.CreateMarketNicheRequest;
 import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.chat.ChatDialog;
+import com.marketinghub.chat.repository.ChatDialogRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,9 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class MarketNicheService {
     private final MarketNicheRepository repository;
+    private final ChatDialogRepository chatDialogRepository;
 
-    public MarketNicheService(MarketNicheRepository repository) {
+    public MarketNicheService(MarketNicheRepository repository, ChatDialogRepository chatDialogRepository) {
         this.repository = repository;
+        this.chatDialogRepository = chatDialogRepository;
     }
 
     /**
@@ -32,6 +36,7 @@ public class MarketNicheService {
                 .interests(request.getInterests())
                 .demographicFilters(request.getDemographicFilters())
                 .extraTips(request.getExtraTips())
+                .chatDialog(attachChatDialog(request.getChatDialogId()))
                 .build();
         return repository.save(niche);
     }
@@ -52,10 +57,19 @@ public class MarketNicheService {
         niche.setInterests(request.getInterests());
         niche.setDemographicFilters(request.getDemographicFilters());
         niche.setExtraTips(request.getExtraTips());
+        niche.setChatDialog(attachChatDialog(request.getChatDialogId()));
         return repository.save(niche);
     }
 
     public Iterable<MarketNiche> list() {
         return repository.findAll();
+    }
+
+    private ChatDialog attachChatDialog(Long id) {
+        if (id == null) {
+            return null;
+        }
+        return chatDialogRepository.findById(id)
+                .orElseThrow(() -> new jakarta.persistence.EntityNotFoundException("ChatDialog not found: " + id));
     }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_20__link_niche_to_chat_dialog.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_20__link_niche_to_chat_dialog.sql
@@ -1,0 +1,12 @@
+-- liquibase formatted sql
+-- changeset marketinghub:2025-09-20-link-niche-to-chat-dialog
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <columnExists tableName="market_niche" columnName="chat_dialog_id"/>
+--    </not>
+ALTER TABLE market_niche ADD COLUMN chat_dialog_id BIGINT;
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'market_niche' AND CONSTRAINT_NAME = 'fk_market_niche_chat_dialog' AND CONSTRAINT_TYPE = 'FOREIGN KEY';
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'market_niche' AND INDEX_NAME = 'fk_market_niche_chat_dialog';
+ALTER TABLE market_niche
+    ADD CONSTRAINT fk_market_niche_chat_dialog FOREIGN KEY (chat_dialog_id) REFERENCES chat_dialog(id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -55,3 +55,6 @@ databaseChangeLog:
   - include:
       file: V2025_09_16__add_mechanism_to_hypothesis.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_09_20__link_niche_to_chat_dialog.sql
+      relativeToChangelogFile: true

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -111,6 +111,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `interests` LONGTEXT
 - `demographic_filters` LONGTEXT
 - `extra_tips` LONGTEXT
+- `chat_dialog_id` BIGINT
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 
@@ -404,4 +405,5 @@ erDiagram
     AD_SET ||--o{ METRIC_SNAPSHOT : tracks
     METRIC_PRESET ||--o{ EXPERIMENT : configures
     CHAT_SESSION ||--o{ CHAT_MESSAGE : includes
+    CHAT_DIALOG ||--o{ MARKET_NICHE : generates
 ```

--- a/frontend/src/api/niche/useCreateNiche.ts
+++ b/frontend/src/api/niche/useCreateNiche.ts
@@ -12,6 +12,7 @@ export interface CreateNiche {
   interests: string;
   demographicFilters: string;
   extraTips: string;
+  chatDialogId?: number;
 }
 
 export function useCreateNiche() {

--- a/frontend/src/api/niche/useNiches.ts
+++ b/frontend/src/api/niche/useNiches.ts
@@ -12,6 +12,7 @@ export interface MarketNiche {
   interests: string;
   demographicFilters: string;
   extraTips: string;
+  chatDialogId?: number;
 }
 
 export function useNiches() {

--- a/frontend/src/pages/niche/EditNichePage.tsx
+++ b/frontend/src/pages/niche/EditNichePage.tsx
@@ -5,6 +5,7 @@ import { useUpdateNiche } from "../../api/niche/useUpdateNiche";
 import { useNiche } from "../../api/niche/useNiche";
 import PageTitle from "../../components/PageTitle";
 import { MarketNiche } from "../../api/niche/useNiches";
+import { useChatDialogs } from "../../api/chatDialog/useChatDialogs";
 
 export default function EditNichePage() {
   const { nicheId } = useParams<{ nicheId: string }>();
@@ -13,6 +14,7 @@ export default function EditNichePage() {
   const update = useUpdateNiche();
   const navigate = useNavigate();
   const { handleSubmit } = useForm<MarketNiche>();
+  const { data: dialogs } = useChatDialogs();
   const [form, setForm] = useState<MarketNiche>({
     id,
     name: "",
@@ -24,6 +26,7 @@ export default function EditNichePage() {
     interests: "",
     demographicFilters: "",
     extraTips: "",
+    chatDialogId: undefined,
   });
 
   useEffect(() => {
@@ -110,6 +113,24 @@ export default function EditNichePage() {
         onChange={(e) => setForm({ ...form, extraTips: e.target.value })}
         rows={3}
       />
+      <label className="form-label">Diálogo do ChatGPT</label>
+      <select
+        className="form-select mb-2"
+        value={form.chatDialogId ?? ""}
+        onChange={(e) =>
+          setForm({
+            ...form,
+            chatDialogId: e.target.value ? Number(e.target.value) : undefined,
+          })
+        }
+      >
+        <option value="">Nenhum</option>
+        {dialogs?.map((d) => (
+          <option key={d.id} value={d.id}>
+            {d.theme || d.id}
+          </option>
+        ))}
+      </select>
       <button
         className="btn btn-primary"
         onClick={handleSubmit(

--- a/frontend/src/pages/niche/NewNichePage.tsx
+++ b/frontend/src/pages/niche/NewNichePage.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
-import { useCreateNiche } from "../../api/niche/useCreateNiche";
+import { useCreateNiche, CreateNiche } from "../../api/niche/useCreateNiche";
 import PageTitle from "../../components/PageTitle";
+import { useChatDialogs } from "../../api/chatDialog/useChatDialogs";
 
 export default function NewNichePage() {
   const create = useCreateNiche();
-  const [form, setForm] = useState({
+  const [form, setForm] = useState<CreateNiche>({
     name: "",
     description: "",
     demandVolume: "",
@@ -14,7 +15,9 @@ export default function NewNichePage() {
     interests: "",
     demographicFilters: "",
     extraTips: "",
+    chatDialogId: undefined,
   });
+  const { data: dialogs } = useChatDialogs();
 
   const submit = () => {
     create.mutate(form);
@@ -61,9 +64,7 @@ export default function NewNichePage() {
         className="form-control mb-2"
         placeholder="Segmentação-base (Brasil)"
         value={form.baseSegmentation}
-        onChange={(e) =>
-          setForm({ ...form, baseSegmentation: e.target.value })
-        }
+        onChange={(e) => setForm({ ...form, baseSegmentation: e.target.value })}
         rows={3}
       />
       <textarea
@@ -89,6 +90,23 @@ export default function NewNichePage() {
         onChange={(e) => setForm({ ...form, extraTips: e.target.value })}
         rows={3}
       />
+      <select
+        className="form-select mb-2"
+        value={form.chatDialogId ?? ""}
+        onChange={(e) =>
+          setForm({
+            ...form,
+            chatDialogId: e.target.value ? Number(e.target.value) : undefined,
+          })
+        }
+      >
+        <option value="">Diálogo do ChatGPT (opcional)</option>
+        {dialogs?.map((d) => (
+          <option key={d.id} value={d.id}>
+            {d.theme || d.id}
+          </option>
+        ))}
+      </select>
       <button className="btn btn-primary" onClick={submit}>
         Salvar
       </button>

--- a/schema.sql
+++ b/schema.sql
@@ -104,6 +104,7 @@ CREATE TABLE market_niche (
     interests LONGTEXT,
     demographic_filters LONGTEXT,
     extra_tips LONGTEXT,
+    chat_dialog_id BIGINT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- allow each MarketNiche to reference its source ChatGPT dialog
- expose chatDialogId in niche APIs and UI
- document niche-chat dialog relationship and database schema

## Testing
- `mvn -s ../settings.xml spotless:apply` *(fails: Network is unreachable)*
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a3261fcf54832191950bb7d1c745bc