### PR TITLE
chore: remove workflow artifacts after deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -138,3 +138,7 @@ jobs:
           JAR=target/app.jar
           rsync -az --delete "$JAR" marketinghub@${VPS_IP}:${APP_DIR}/
           ssh marketinghub@${VPS_IP} "sudo -n systemctl restart marketinghub-backend.service"
+      - name: Cleanup artifact
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: backend-jar

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -76,3 +76,7 @@ jobs:
         run: |
           rsync -az --delete dist/ marketinghub@${VPS_IP}:${FRONTEND_DIR}/
           ssh marketinghub@${VPS_IP} "sudo -n systemctl restart marketinghub-frontend.service"
+      - name: Cleanup artifact
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: frontend-build


### PR DESCRIPTION
## Summary
- remove frontend build artifact after deployment
- remove backend jar artifact after deployment

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` (fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)
- `cd success-product-worker && mvn -s settings.xml test` (fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)
- `cd frontend && npm test`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3427e4d2c8321bad4c0e1bf97d942