### PR TITLE
chore(ci): limit frontend artifact retention

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           name: frontend-build
           path: frontend/dist
-          retention-days: 14
+          retention-days: 7
 
 
   build-debug:


### PR DESCRIPTION
## Summary
- reduce artifact retention to 7 days in frontend workflow to respect repo quota

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm run build`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68a4770904248321980ba2541a43f3ad