### PR TITLE
Expand market niche text fields

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
@@ -25,34 +25,42 @@ public class MarketNiche {
 
     /** Optional description or notes about this niche. */
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String description;
 
     /** Results of demand volume tests. */
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String demandVolume;
 
     /** Promises validated for this niche. */
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String promises;
 
     /** Offers validated for this niche. */
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String offers;
 
     /** Base segmentation for the Brazilian market. */
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String baseSegmentation;
 
     /** Main interests or behaviors for this niche. */
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String interests;
 
     /** Demographic filters and job roles. */
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String demographicFilters;
 
     /** Extra tips for advertising this niche. */
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String extraTips;
 
     @OneToMany(mappedBy = "niche")


### PR DESCRIPTION
## Summary
- ensure market niche textual attributes are stored as LONGTEXT in the database

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a34b0a844883218f4f5a79819397e9