### PR TITLE
Relacionar nichos a diálogos do ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ O overlay de erros fica acessível em `/__vite__` e os sourcemaps são gerados e
 \nSwagger UI disponível em /swagger-ui.html quando o backend estiver rodando.
 
 \n## Niches e Experiments\nCada Experiment pertence a um Market Niche. Use as rotas /api/niches/{nicheId}/experiments para criar e listar por nicho.
+Cada Niche pode opcionalmente referenciar um ChatGPT Dialog que originou a ideia.
 
 ## Criativos
 Os criativos representam variações de anúncios vinculados a um experimento. Utilize a rota `/api/experiments/{id}/creatives` para cadastrar e listar. A visualização de um criativo usa `/api/creatives/{id}/preview` que consulta a Marketing API do Facebook.

--- a/backend/ads-service/src/main/java/com/marketinghub/chat/ChatDialog.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/chat/ChatDialog.java
@@ -5,6 +5,9 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.util.List;
+import com.marketinghub.niche.MarketNiche;
+
 import java.time.Instant;
 
 /**
@@ -32,5 +35,9 @@ public class ChatDialog {
 
     @UpdateTimestamp
     private Instant updatedAt;
+
+    @OneToMany(mappedBy = "chatDialog")
+    @ToString.Exclude
+    private List<MarketNiche> niches;
 }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
@@ -2,6 +2,7 @@ package com.marketinghub.niche;
 
 import jakarta.persistence.*;
 import lombok.*;
+import com.marketinghub.chat.ChatDialog;
 import com.marketinghub.experiment.Experiment;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -54,6 +55,12 @@ public class MarketNiche {
     /** Extra tips for advertising this niche. */
     @Lob
     private String extraTips;
+
+    /** ChatGPT dialog that originated this niche, if any. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_dialog_id")
+    @ToString.Exclude
+    private ChatDialog chatDialog;
 
     @OneToMany(mappedBy = "niche")
     private java.util.List<Experiment> experiments;

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/dto/CreateMarketNicheRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/dto/CreateMarketNicheRequest.java
@@ -17,4 +17,5 @@ public class CreateMarketNicheRequest {
     private String interests;
     private String demographicFilters;
     private String extraTips;
+    private Long chatDialogId;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/dto/MarketNicheDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/dto/MarketNicheDto.java
@@ -18,6 +18,7 @@ public class MarketNicheDto {
     private String interests;
     private String demographicFilters;
     private String extraTips;
+    private Long chatDialogId;
     private Instant createdAt;
     private Instant updatedAt;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/mapper/MarketNicheMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/mapper/MarketNicheMapper.java
@@ -3,11 +3,13 @@ package com.marketinghub.niche.mapper;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.dto.MarketNicheDto;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /**
  * MapStruct mapper for {@link MarketNiche}.
  */
 @Mapper(componentModel = "spring")
 public interface MarketNicheMapper {
+    @Mapping(target = "chatDialogId", source = "chatDialog.id")
     MarketNicheDto toDto(MarketNiche niche);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
@@ -1,5 +1,7 @@
 package com.marketinghub.niche.service;
 
+import com.marketinghub.chat.ChatDialog;
+import com.marketinghub.chat.repository.ChatDialogRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.dto.CreateMarketNicheRequest;
 import com.marketinghub.niche.repository.MarketNicheRepository;
@@ -12,9 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class MarketNicheService {
     private final MarketNicheRepository repository;
+    private final ChatDialogRepository chatDialogRepository;
 
-    public MarketNicheService(MarketNicheRepository repository) {
+    public MarketNicheService(MarketNicheRepository repository, ChatDialogRepository chatDialogRepository) {
         this.repository = repository;
+        this.chatDialogRepository = chatDialogRepository;
     }
 
     /**
@@ -22,6 +26,10 @@ public class MarketNicheService {
      */
     @Transactional
     public MarketNiche create(CreateMarketNicheRequest request) {
+        ChatDialog chat = null;
+        if (request.getChatDialogId() != null) {
+            chat = chatDialogRepository.findById(request.getChatDialogId()).orElseThrow();
+        }
         MarketNiche niche = MarketNiche.builder()
                 .name(request.getName())
                 .description(request.getDescription())
@@ -32,6 +40,7 @@ public class MarketNicheService {
                 .interests(request.getInterests())
                 .demographicFilters(request.getDemographicFilters())
                 .extraTips(request.getExtraTips())
+                .chatDialog(chat)
                 .build();
         return repository.save(niche);
     }
@@ -52,6 +61,11 @@ public class MarketNicheService {
         niche.setInterests(request.getInterests());
         niche.setDemographicFilters(request.getDemographicFilters());
         niche.setExtraTips(request.getExtraTips());
+        ChatDialog chat = null;
+        if (request.getChatDialogId() != null) {
+            chat = chatDialogRepository.findById(request.getChatDialogId()).orElseThrow();
+        }
+        niche.setChatDialog(chat);
         return repository.save(niche);
     }
 

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_20__add_chat_dialog_fk_to_market_niche.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_20__add_chat_dialog_fk_to_market_niche.sql
@@ -1,0 +1,5 @@
+-- liquibase formatted sql
+-- changeset marketinghub:2025-09-20-add-chat-dialog-fk-to-market-niche
+ALTER TABLE market_niche ADD COLUMN chat_dialog_id BIGINT;
+ALTER TABLE market_niche
+    ADD CONSTRAINT fk_market_niche_chat_dialog FOREIGN KEY (chat_dialog_id) REFERENCES chat_dialog(id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -55,3 +55,6 @@ databaseChangeLog:
   - include:
       file: V2025_09_16__add_mechanism_to_hypothesis.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_09_20__add_chat_dialog_fk_to_market_niche.sql
+      relativeToChangelogFile: true

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -111,6 +111,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `interests` LONGTEXT
 - `demographic_filters` LONGTEXT
 - `extra_tips` LONGTEXT
+- `chat_dialog_id` BIGINT
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 

--- a/frontend/src/api/niche/useCreateNiche.ts
+++ b/frontend/src/api/niche/useCreateNiche.ts
@@ -12,6 +12,7 @@ export interface CreateNiche {
   interests: string;
   demographicFilters: string;
   extraTips: string;
+  chatDialogId?: number;
 }
 
 export function useCreateNiche() {

--- a/frontend/src/api/niche/useNiches.ts
+++ b/frontend/src/api/niche/useNiches.ts
@@ -12,6 +12,7 @@ export interface MarketNiche {
   interests: string;
   demographicFilters: string;
   extraTips: string;
+  chatDialogId?: number;
 }
 
 export function useNiches() {

--- a/frontend/src/pages/niche/EditNichePage.tsx
+++ b/frontend/src/pages/niche/EditNichePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useUpdateNiche } from "../../api/niche/useUpdateNiche";
 import { useNiche } from "../../api/niche/useNiche";
+import { useChatDialogs } from "../../api/chatDialog/useChatDialogs";
 import PageTitle from "../../components/PageTitle";
 import { MarketNiche } from "../../api/niche/useNiches";
 
@@ -13,6 +14,7 @@ export default function EditNichePage() {
   const update = useUpdateNiche();
   const navigate = useNavigate();
   const { handleSubmit } = useForm<MarketNiche>();
+  const { data: chatDialogs } = useChatDialogs();
   const [form, setForm] = useState<MarketNiche>({
     id,
     name: "",
@@ -24,6 +26,7 @@ export default function EditNichePage() {
     interests: "",
     demographicFilters: "",
     extraTips: "",
+    chatDialogId: undefined,
   });
 
   useEffect(() => {
@@ -50,6 +53,24 @@ export default function EditNichePage() {
         value={form.name}
         onChange={(e) => setForm({ ...form, name: e.target.value })}
       />
+      <label className="form-label">Chat GPT Dialog</label>
+      <select
+        className="form-select mb-2"
+        value={form.chatDialogId ?? ""}
+        onChange={(e) =>
+          setForm({
+            ...form,
+            chatDialogId: e.target.value ? Number(e.target.value) : undefined,
+          })
+        }
+      >
+        <option value="">Nenhum</option>
+        {chatDialogs?.map((d) => (
+          <option key={d.id} value={d.id}>
+            {d.theme}
+          </option>
+        ))}
+      </select>
       <label className="form-label">Descrição</label>
       <textarea
         className="form-control mb-2"

--- a/frontend/src/pages/niche/NewNichePage.tsx
+++ b/frontend/src/pages/niche/NewNichePage.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { useCreateNiche } from "../../api/niche/useCreateNiche";
+import { useChatDialogs } from "../../api/chatDialog/useChatDialogs";
 import PageTitle from "../../components/PageTitle";
 
 export default function NewNichePage() {
   const create = useCreateNiche();
+  const { data: chatDialogs } = useChatDialogs();
   const [form, setForm] = useState({
     name: "",
     description: "",
@@ -14,6 +16,7 @@ export default function NewNichePage() {
     interests: "",
     demographicFilters: "",
     extraTips: "",
+    chatDialogId: undefined as number | undefined,
   });
 
   const submit = () => {
@@ -57,6 +60,24 @@ export default function NewNichePage() {
         onChange={(e) => setForm({ ...form, offers: e.target.value })}
         rows={3}
       />
+      <label className="form-label">Chat GPT Dialog</label>
+      <select
+        className="form-select mb-2"
+        value={form.chatDialogId ?? ""}
+        onChange={(e) =>
+          setForm({
+            ...form,
+            chatDialogId: e.target.value ? Number(e.target.value) : undefined,
+          })
+        }
+      >
+        <option value="">Nenhum</option>
+        {chatDialogs?.map((d) => (
+          <option key={d.id} value={d.id}>
+            {d.theme}
+          </option>
+        ))}
+      </select>
       <textarea
         className="form-control mb-2"
         placeholder="Segmentação-base (Brasil)"

--- a/schema.sql
+++ b/schema.sql
@@ -104,6 +104,7 @@ CREATE TABLE market_niche (
     interests LONGTEXT,
     demographic_filters LONGTEXT,
     extra_tips LONGTEXT,
+    chat_dialog_id BIGINT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- Permite associar Niches a um ChatDialog de origem
- Exibe seleção de ChatDialog ao criar ou editar um Niche
- Documenta e migra banco para armazenar vínculo com chat_dialog

## Testing
- `mvn -s ../settings.xml test` *(falhou: Network is unreachable)*
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3261fcf54832191950bb7d1c745bc