### PR TITLE
feat: add AI metadata to hypothesis and niche

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -54,6 +54,13 @@ public class Hypothesis {
     @Lob
     private String uniqueMechanism;
 
+    /** Prompt usado quando a hipótese é gerada por IA. */
+    @Lob
+    private String prompt;
+
+    /** Modelo de IA responsável pela geração desta hipótese. */
+    private String model;
+
     /** Regra de sucesso que define se a hipótese será validada. */
     @Lob
     private String successRule;

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
@@ -12,6 +12,8 @@ public class CreateHypothesisRequest {
     private String mechanism;
     private String uniqueMechanism;
     private String successRule;
+    private String prompt;
+    private String model;
     private String offerType;
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;
@@ -35,6 +37,10 @@ public class CreateHypothesisRequest {
     public void setUniqueMechanism(String uniqueMechanism) { this.uniqueMechanism = uniqueMechanism; }
     public String getSuccessRule() { return successRule; }
     public void setSuccessRule(String successRule) { this.successRule = successRule; }
+    public String getPrompt() { return prompt; }
+    public void setPrompt(String prompt) { this.prompt = prompt; }
+    public String getModel() { return model; }
+    public void setModel(String model) { this.model = model; }
     public String getOfferType() { return offerType; }
     public void setOfferType(String offerType) { this.offerType = offerType; }
     public BigDecimal getPrice() { return price; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
@@ -19,6 +19,8 @@ public class HypothesisDto {
     private String mechanism;
     private String uniqueMechanism;
     private String successRule;
+    private String prompt;
+    private String model;
     private OfferType offerType;
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
@@ -11,6 +11,8 @@ public class UpdateHypothesisRequest {
     private String mechanism;
     private String uniqueMechanism;
     private String successRule;
+    private String prompt;
+    private String model;
     private String offerType;
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;
@@ -38,6 +40,12 @@ public class UpdateHypothesisRequest {
 
     public String getSuccessRule() { return successRule; }
     public void setSuccessRule(String successRule) { this.successRule = successRule; }
+
+    public String getPrompt() { return prompt; }
+    public void setPrompt(String prompt) { this.prompt = prompt; }
+
+    public String getModel() { return model; }
+    public void setModel(String model) { this.model = model; }
 
     public String getOfferType() { return offerType; }
     public void setOfferType(String offerType) { this.offerType = offerType; }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
@@ -44,6 +44,9 @@ public class MarketNiche {
     @Column(columnDefinition = "LONGTEXT")
     private String offers;
 
+    /** Quantidade de hipóteses a serem geradas para este nicho. */
+    private Integer hypothesesToGenerate;
+
     /** Base segmentation for the Brazilian market. */
     @Lob
     @Column(columnDefinition = "LONGTEXT")

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/dto/CreateMarketNicheRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/dto/CreateMarketNicheRequest.java
@@ -17,5 +17,6 @@ public class CreateMarketNicheRequest {
     private String interests;
     private String demographicFilters;
     private String extraTips;
+    private Integer hypothesesToGenerate;
     private Long chatDialogId;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/dto/MarketNicheDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/dto/MarketNicheDto.java
@@ -18,6 +18,7 @@ public class MarketNicheDto {
     private String interests;
     private String demographicFilters;
     private String extraTips;
+    private Integer hypothesesToGenerate;
     private Long chatDialogId;
     private Instant createdAt;
     private Instant updatedAt;

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -107,6 +107,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `demand_volume` LONGTEXT
 - `promises` LONGTEXT
 - `offers` LONGTEXT
+- `hypotheses_to_generate` INT
 - `base_segmentation` LONGTEXT
 - `interests` LONGTEXT
 - `demographic_filters` LONGTEXT
@@ -220,6 +221,8 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `price` DECIMAL(6,2)
 - `mechanism` LONGTEXT
 - `unique_mechanism` LONGTEXT
+- `prompt` LONGTEXT
+- `model` VARCHAR(255)
 - `kpi_target_cpl` DECIMAL(7,2) NOT NULL
 - `status` VARCHAR(20) DEFAULT 'BACKLOG' NOT NULL
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -418,6 +418,10 @@ components:
           type: string
         successRule:
           type: string
+        prompt:
+          type: string
+        model:
+          type: string
         offerType:
           type: string
         price:

--- a/frontend/src/api/hypothesis/useCreateHypothesis.ts
+++ b/frontend/src/api/hypothesis/useCreateHypothesis.ts
@@ -13,6 +13,8 @@ export interface CreateHypothesis {
   mechanism?: string;
   uniqueMechanism?: string;
   successRule: string;
+  prompt?: string;
+  model?: string;
   offerType?: string;
   kpiTargetCpl?: number;
 }

--- a/frontend/src/api/hypothesis/useHypothesisBoard.ts
+++ b/frontend/src/api/hypothesis/useHypothesisBoard.ts
@@ -11,6 +11,8 @@ export interface Hypothesis {
   mechanism?: string;
   uniqueMechanism?: string;
   successRule?: string;
+  prompt?: string;
+  model?: string;
   premiseAngleId?: number;
   offerType?: string;
   price?: number;

--- a/frontend/src/api/niche/useCreateNiche.ts
+++ b/frontend/src/api/niche/useCreateNiche.ts
@@ -13,6 +13,7 @@ export interface CreateNiche {
   demographicFilters: string;
   extraTips: string;
   chatDialogId?: number;
+  hypothesesToGenerate?: number;
 }
 
 export function useCreateNiche() {

--- a/frontend/src/api/niche/useNiches.ts
+++ b/frontend/src/api/niche/useNiches.ts
@@ -12,6 +12,7 @@ export interface MarketNiche {
   interests: string;
   demographicFilters: string;
   extraTips: string;
+  hypothesesToGenerate?: number;
   chatDialogId?: number;
 }
 

--- a/frontend/src/pages/niche/EditNichePage.tsx
+++ b/frontend/src/pages/niche/EditNichePage.tsx
@@ -27,6 +27,7 @@ export default function EditNichePage() {
     demographicFilters: "",
     extraTips: "",
     chatDialogId: undefined,
+    hypothesesToGenerate: 0,
   });
 
   useEffect(() => {
@@ -71,6 +72,15 @@ export default function EditNichePage() {
           </option>
         ))}
       </select>
+      <label className="form-label">Qtd. de hipóteses para gerar</label>
+      <input
+        type="number"
+        className="form-control mb-2"
+        value={form.hypothesesToGenerate}
+        onChange={(e) =>
+          setForm({ ...form, hypothesesToGenerate: Number(e.target.value) })
+        }
+      />
       <label className="form-label">Descrição</label>
       <textarea
         className="form-control mb-2"

--- a/frontend/src/pages/niche/NewNichePage.tsx
+++ b/frontend/src/pages/niche/NewNichePage.tsx
@@ -17,6 +17,7 @@ export default function NewNichePage() {
     demographicFilters: "",
     extraTips: "",
     chatDialogId: undefined as number | undefined,
+    hypothesesToGenerate: 0,
   });
 
   const submit = () => {
@@ -78,6 +79,15 @@ export default function NewNichePage() {
           </option>
         ))}
       </select>
+      <input
+        type="number"
+        className="form-control mb-2"
+        placeholder="Qtd. de hipóteses para gerar"
+        value={form.hypothesesToGenerate}
+        onChange={(e) =>
+          setForm({ ...form, hypothesesToGenerate: Number(e.target.value) })
+        }
+      />
       <textarea
         className="form-control mb-2"
         placeholder="Segmentação-base (Brasil)"

--- a/schema.sql
+++ b/schema.sql
@@ -100,6 +100,7 @@ CREATE TABLE market_niche (
     demand_volume LONGTEXT,
     promises LONGTEXT,
     offers LONGTEXT,
+    hypotheses_to_generate INT,
     base_segmentation LONGTEXT,
     interests LONGTEXT,
     demographic_filters LONGTEXT,


### PR DESCRIPTION
## Summary
- store AI prompt and model for each Hypothesis
- allow Niche to specify how many hypotheses to generate
- document new fields and update frontend forms

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4c3cc83c08321bf25615096df30c4