### PR TITLE
feat: add niche hypothesis generation service

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/AiWorkerApplication.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/AiWorkerApplication.java
@@ -5,8 +5,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
-@EntityScan({"com.marketinghub.worker", "com.marketinghub.ads"})
+@SpringBootApplication(scanBasePackages = "com.marketinghub")
+@EntityScan("com.marketinghub")
 @EnableScheduling
 public class AiWorkerApplication {
     public static void main(String[] args) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -1,0 +1,93 @@
+package com.marketinghub.worker.niche;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
+import com.marketinghub.niche.MarketNiche;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple wrapper around the OpenAI chat completions API.
+ */
+@Component
+public class ChatGptClient {
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+    private final String model;
+
+    public ChatGptClient(WebClient.Builder builder,
+                         ObjectMapper objectMapper,
+                         @Value("${openai.api-key:}") String apiKey,
+                         @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
+                         @Value("${openai.model:gpt-3.5-turbo}") String model) {
+        this.webClient = builder
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .build();
+        this.objectMapper = objectMapper;
+        this.model = model;
+    }
+
+    public List<CreateHypothesisRequest> generateHypotheses(MarketNiche niche, int quantity) {
+        String prompt = buildPrompt(niche, quantity);
+        Map<String, Object> payload = Map.of(
+                "model", model,
+                "messages", List.of(
+                        Map.of("role", "system", "content", "Você é um especialista em marketing."),
+                        Map.of("role", "user", "content", prompt)
+                )
+        );
+
+        ChatCompletionResponse response = webClient.post()
+                .uri("/chat/completions")
+                .bodyValue(payload)
+                .retrieve()
+                .bodyToMono(ChatCompletionResponse.class)
+                .block();
+
+        if (response == null || response.choices().isEmpty()) {
+            return List.of();
+        }
+        String content = response.choices().get(0).message().content();
+        try {
+            CreateHypothesisRequest[] arr = objectMapper.readValue(content, CreateHypothesisRequest[].class);
+            return Arrays.asList(arr);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse ChatGPT response", e);
+        }
+    }
+
+    private String buildPrompt(MarketNiche niche, int quantity) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Gere ").append(quantity).append(" hipóteses em formato JSON. ");
+        sb.append("Use o seguinte nicho como contexto:\n");
+        sb.append("Nome: ").append(niche.getName()).append("\n");
+        if (niche.getDescription() != null) {
+            sb.append("Descrição: ").append(niche.getDescription()).append("\n");
+        }
+        if (niche.getBaseSegmentation() != null) {
+            sb.append("Segmentação base: ").append(niche.getBaseSegmentation()).append("\n");
+        }
+        if (niche.getInterests() != null) {
+            sb.append("Interesses: ").append(niche.getInterests()).append("\n");
+        }
+        if (niche.getDemographicFilters() != null) {
+            sb.append("Filtros demográficos: ").append(niche.getDemographicFilters()).append("\n");
+        }
+        if (niche.getExtraTips() != null) {
+            sb.append("Dicas extras: ").append(niche.getExtraTips()).append("\n");
+        }
+        sb.append("Retorne apenas o JSON com uma lista de objetos compatíveis com CreateHypothesisRequest.");
+        return sb.toString();
+    }
+
+    private record ChatCompletionResponse(List<Choice> choices) {}
+    private record Choice(Message message) {}
+    private record Message(String content) {}
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
@@ -1,0 +1,43 @@
+package com.marketinghub.worker.niche;
+
+import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service that loops through all niches with {@code hypothesesToGenerate > 0}
+ * and asks ChatGPT to generate hypotheses for each one.
+ */
+@Service
+public class NicheHypothesisService {
+    private final MarketNicheRepository nicheRepository;
+    private final ChatGptClient chatGptClient;
+
+    public NicheHypothesisService(MarketNicheRepository nicheRepository, ChatGptClient chatGptClient) {
+        this.nicheRepository = nicheRepository;
+        this.chatGptClient = chatGptClient;
+    }
+
+    /**
+     * Generates hypotheses for all configured niches.
+     *
+     * @return map keyed by niche id containing the generated hypotheses
+     */
+    public Map<Long, List<CreateHypothesisRequest>> generate() {
+        Map<Long, List<CreateHypothesisRequest>> result = new HashMap<>();
+        Iterable<MarketNiche> niches = nicheRepository.findAll();
+        for (MarketNiche niche : niches) {
+            Integer qty = niche.getHypothesesToGenerate();
+            if (qty != null && qty > 0) {
+                List<CreateHypothesisRequest> hyps = chatGptClient.generateHypotheses(niche, qty);
+                result.put(niche.getId(), hyps);
+            }
+        }
+        return result;
+    }
+}

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -6,6 +6,7 @@ spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.format_sql=true
 openai.api-key=${OPENAI_API_KEY:}
 openai.model=${OPENAI_MODEL:o3}
+openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 google.api-key=${GOOGLE_API_KEY:}
 google.search-id=${GOOGLE_SEARCH_ID:}
 server.port=4567

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -1,0 +1,76 @@
+package com.marketinghub.worker.niche;
+
+import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NicheHypothesisServiceTest {
+    static MockWebServer mockWebServer;
+
+    @Autowired
+    MarketNicheRepository nicheRepository;
+
+    @Autowired
+    NicheHypothesisService service;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("openai.base-url", () -> mockWebServer.url("/").toString());
+        registry.add("openai.api-key", () -> "test-key");
+    }
+
+    @BeforeAll
+    void setup() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterAll
+    void shutdown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void generateHypothesesForNiches() {
+        MarketNiche niche = MarketNiche.builder()
+                .name("Saúde")
+                .hypothesesToGenerate(2)
+                .build();
+        nicheRepository.save(niche);
+        MarketNiche ignored = MarketNiche.builder()
+                .name("Ignored")
+                .hypothesesToGenerate(0)
+                .build();
+        nicheRepository.save(ignored);
+
+        String content = "[{\"title\":\"H1\"},{\"title\":\"H2\"}]";
+        mockWebServer.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("{\"choices\":[{\"message\":{\"content\":\"" + content + "\"}}]}"));
+
+        Map<Long, List<CreateHypothesisRequest>> result = service.generate();
+        assertThat(result).containsKey(niche.getId());
+        List<CreateHypothesisRequest> hyps = result.get(niche.getId());
+        assertThat(hyps).hasSize(2);
+        assertThat(hyps.get(0).getTitle()).isEqualTo("H1");
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary
- expand AI worker scanning to all marketing hub packages
- integrate with OpenAI to generate hypotheses per niche
- add service and tests for looping niches with pending hypothesis generation

## Testing
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to github: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a520db61b883219a37398c87b99fc1