### PR TITLE
feat(ai-worker): implement niche hypothesis service

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/AiWorkerApplication.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/AiWorkerApplication.java
@@ -5,8 +5,20 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
-@EntityScan({"com.marketinghub.worker", "com.marketinghub.ads"})
+@SpringBootApplication(
+        scanBasePackages = {
+                "com.marketinghub.worker",
+                "com.marketinghub.niche",
+                "com.marketinghub.hypothesis",
+                "com.marketinghub.creative"
+        })
+@EntityScan({
+        "com.marketinghub.worker",
+        "com.marketinghub.ads",
+        "com.marketinghub.niche",
+        "com.marketinghub.hypothesis",
+        "com.marketinghub.creative"
+})
 @EnableScheduling
 public class AiWorkerApplication {
     public static void main(String[] args) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/DummyHypothesisChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/DummyHypothesisChatGptClient.java
@@ -1,0 +1,36 @@
+package com.marketinghub.worker;
+
+import com.marketinghub.creative.label.Angle;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.OfferType;
+import com.marketinghub.niche.MarketNiche;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Profile("dummy")
+public class DummyHypothesisChatGptClient implements HypothesisChatGptClient {
+    @Override
+    public List<Hypothesis> generate(MarketNiche niche, int quantity) {
+        List<Hypothesis> results = new ArrayList<>();
+        for (int i = 1; i <= quantity; i++) {
+            results.add(
+                    Hypothesis.builder()
+                            .title("Hipotese " + i + " for " + niche.getName())
+                            .premiseAngle(Angle.builder().id(1L).name("Default Angle").build())
+                            .promise("Promise " + i)
+                            .problem("Problem " + i)
+                            .persona("Persona " + i)
+                            .offerType(OfferType.LEAD)
+                            .kpiTargetCpl(BigDecimal.ONE)
+                            .build()
+            );
+        }
+        return results;
+    }
+}
+

--- a/ai-worker/src/main/java/com/marketinghub/worker/HypothesisChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/HypothesisChatGptClient.java
@@ -1,0 +1,10 @@
+package com.marketinghub.worker;
+
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.niche.MarketNiche;
+
+import java.util.List;
+
+public interface HypothesisChatGptClient {
+    List<Hypothesis> generate(MarketNiche niche, int quantity);
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/NicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/NicheHypothesisService.java
@@ -1,0 +1,45 @@
+package com.marketinghub.worker;
+
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class NicheHypothesisService {
+    private static final Logger log = LoggerFactory.getLogger(NicheHypothesisService.class);
+    private final MarketNicheRepository nicheRepository;
+    private final HypothesisRepository hypothesisRepository;
+    private final HypothesisChatGptClient chatGptClient;
+
+    public NicheHypothesisService(MarketNicheRepository nicheRepository,
+                                  HypothesisRepository hypothesisRepository,
+                                  HypothesisChatGptClient chatGptClient) {
+        this.nicheRepository = nicheRepository;
+        this.hypothesisRepository = hypothesisRepository;
+        this.chatGptClient = chatGptClient;
+    }
+
+    @Transactional
+    public void generateHypotheses() {
+        List<MarketNiche> niches = nicheRepository.findAll();
+        for (MarketNiche niche : niches) {
+            Integer quantity = niche.getHypothesesToGenerate();
+            if (quantity != null && quantity > 0) {
+                log.info("Generating {} hypotheses for niche {}", quantity, niche.getId());
+                List<Hypothesis> generated = chatGptClient.generate(niche, quantity);
+                for (Hypothesis hypothesis : generated) {
+                    hypothesis.setMarketNiche(niche);
+                    hypothesisRepository.save(hypothesis);
+                }
+            }
+        }
+    }
+}
+

--- a/ai-worker/src/test/java/com/marketinghub/worker/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/NicheHypothesisServiceTest.java
@@ -1,0 +1,65 @@
+package com.marketinghub.worker;
+
+import com.marketinghub.creative.label.Angle;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.OfferType;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NicheHypothesisServiceTest {
+
+    @Mock
+    MarketNicheRepository nicheRepository;
+    @Mock
+    HypothesisRepository hypothesisRepository;
+    @Mock
+    HypothesisChatGptClient chatGptClient;
+
+    @InjectMocks
+    NicheHypothesisService service;
+
+    @Test
+    void generateHypothesesSavesResults() {
+        MarketNiche niche = MarketNiche.builder().id(1L).name("Niche").hypothesesToGenerate(2).build();
+        when(nicheRepository.findAll()).thenReturn(List.of(niche));
+
+        Hypothesis h1 = baseHypothesis("h1");
+        Hypothesis h2 = baseHypothesis("h2");
+        when(chatGptClient.generate(niche, 2)).thenReturn(List.of(h1, h2));
+
+        service.generateHypotheses();
+
+        ArgumentCaptor<Hypothesis> captor = ArgumentCaptor.forClass(Hypothesis.class);
+        verify(hypothesisRepository, times(2)).save(captor.capture());
+        List<Hypothesis> saved = captor.getAllValues();
+        assertThat(saved).hasSize(2);
+        assertThat(saved).allMatch(h -> h.getMarketNiche().equals(niche));
+    }
+
+    private Hypothesis baseHypothesis(String title) {
+        return Hypothesis.builder()
+                .title(title)
+                .premiseAngle(Angle.builder().id(1L).name("a").build())
+                .promise("p")
+                .problem("pr")
+                .persona("pe")
+                .offerType(OfferType.LEAD)
+                .kpiTargetCpl(BigDecimal.ONE)
+                .build();
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend entity scanning to include niche and hypothesis packages
- add ChatGPT client and service to generate hypotheses for niches
- cover service with unit test

## Testing
- `mvn -s settings.xml package` *(fails: Network is unreachable for GitHub packages)*
- `mvn -s settings.xml test` *(fails: Network is unreachable for GitHub packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a520db61b883219a37398c87b99fc1