### PR TITLE
Fix Hotmart client injection and enable quoted identifiers for H2 tests

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/hotmart/HotmartClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/hotmart/HotmartClient.java
@@ -1,5 +1,6 @@
 package com.marketinghub.worker.hotmart;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunctions;
@@ -15,6 +16,7 @@ public class HotmartClient {
 
     private final WebClient webClient;
 
+    @Autowired
     public HotmartClient(
             @Value("${hotmart.base-url:https://api.hotmart.com}") String baseUrl,
             @Value("${hotmart.username:}") String username,

--- a/ai-worker/src/test/resources/application-test.yml
+++ b/ai-worker/src/test/resources/application-test.yml
@@ -7,5 +7,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+    properties:
+      hibernate:
+        globally_quoted_identifiers: true
   liquibase:
     enabled: false


### PR DESCRIPTION
## Summary
- fix HotmartClient bean instantiation by autowiring constructor
- quote identifiers in tests to handle reserved keywords in H2

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM; cannot access github packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f6b80ef48321aa41e79c93340874