### PR TITLE
fix: avoid quoting binary type in tests

### DIFF
--- a/ai-worker/src/test/resources/application-test.yml
+++ b/ai-worker/src/test/resources/application-test.yml
@@ -9,6 +9,6 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
-        globally_quoted_identifiers: true
+        globally_quoted_identifiers: false
   liquibase:
     enabled: false


### PR DESCRIPTION
## Summary
- disable globally quoted identifiers in ai-worker test config so BINARY(16) columns are not quoted

## Testing
- `mvn -s settings.xml package` *(fails: Network is unreachable for spring-boot-starter-parent)*
- `mvn -s settings.xml test` *(fails: Network is unreachable for spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68a604c5fda08321843cada3417f970a