### PR TITLE
test: limit entity scan to SuccessProduct

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/SuccessProductRepositoryTest.java
@@ -9,14 +9,12 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ImportAutoConfiguration
-@EntityScan("com.marketinghub")
-@ContextConfiguration(classes = AiWorkerApplication.class)
+@EntityScan(basePackageClasses = SuccessProduct.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 


### PR DESCRIPTION
## Summary
- narrow entity scanning in AI worker repository tests to only success product entities, preventing unrelated tables from being generated

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM due to unreachable GitHub Packages)*
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM due to unreachable GitHub Packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a6166d14fc8321a0d35c4e426cf3c8