### PR TITLE
Fix LeadResponse payload mapping and stabilize niche test

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -4,7 +4,6 @@ import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,15 +35,11 @@ class NicheHypothesisServiceTest {
     NicheHypothesisService service;
 
     @DynamicPropertySource
-    static void registerProperties(DynamicPropertyRegistry registry) {
-        registry.add("openai.base-url", () -> mockWebServer.url("/").toString());
-        registry.add("openai.api-key", () -> "test-key");
-    }
-
-    @BeforeAll
-    void setup() throws IOException {
+    static void registerProperties(DynamicPropertyRegistry registry) throws IOException {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
+        registry.add("openai.base-url", () -> mockWebServer.url("/").toString());
+        registry.add("openai.api-key", () -> "test-key");
     }
 
     @AfterAll

--- a/backend/ads-service/src/main/java/com/marketinghub/funnel/LeadResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/funnel/LeadResponse.java
@@ -3,8 +3,6 @@ package com.marketinghub.funnel;
 import com.marketinghub.model.Lead;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -33,8 +31,8 @@ public class LeadResponse {
     @Enumerated(EnumType.STRING)
     private ActionType action;
 
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "payload", columnDefinition = "json")
+    @Lob
+    @Column(name = "payload", columnDefinition = "longtext")
     private String payload;
 
     private BigDecimal revenue;

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2025-08-20-rename-lead-response-value-to-payload.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2025-08-20-rename-lead-response-value-to-payload.yaml
@@ -7,4 +7,4 @@ databaseChangeLog:
             tableName: lead_response
             oldColumnName: value
             newColumnName: payload
-            columnDataType: JSON
+            columnDataType: LONGTEXT


### PR DESCRIPTION
## Summary
- Store `LeadResponse` payload as `LONGTEXT` instead of JSON
- Update Liquibase change set for the payload column
- Initialize MockWebServer within `NicheHypothesisServiceTest`'s dynamic properties

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68a6197a04cc83219162df7d77e94c4b