### PR TITLE
Initialize mock server in tests and fix LeadResponse column type

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -4,7 +4,6 @@ import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +28,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 class NicheHypothesisServiceTest {
     static MockWebServer mockWebServer;
 
+    static {
+        mockWebServer = new MockWebServer();
+        try {
+            mockWebServer.start();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Autowired
     MarketNicheRepository nicheRepository;
 
@@ -39,12 +47,6 @@ class NicheHypothesisServiceTest {
     static void registerProperties(DynamicPropertyRegistry registry) {
         registry.add("openai.base-url", () -> mockWebServer.url("/").toString());
         registry.add("openai.api-key", () -> "test-key");
-    }
-
-    @BeforeAll
-    void setup() throws IOException {
-        mockWebServer = new MockWebServer();
-        mockWebServer.start();
     }
 
     @AfterAll

--- a/backend/ads-service/src/main/java/com/marketinghub/funnel/LeadResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/funnel/LeadResponse.java
@@ -3,8 +3,6 @@ package com.marketinghub.funnel;
 import com.marketinghub.model.Lead;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -33,8 +31,8 @@ public class LeadResponse {
     @Enumerated(EnumType.STRING)
     private ActionType action;
 
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "payload", columnDefinition = "json")
+    @Lob
+    @Column(name = "payload", columnDefinition = "LONGTEXT")
     private String payload;
 
     private BigDecimal revenue;


### PR DESCRIPTION
## Summary
- start MockWebServer before dynamic property registration
- store LeadResponse payload as LONGTEXT to avoid JSON type/reserved word issues

## Testing
- `mvn -s ../settings.xml test` *(backend/ads-service: failed – Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(ai-worker: failed – Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a6197a04cc83219162df7d77e94c4b