### PR TITLE
fix: rename lead_response value column

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
+++ b/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
@@ -51,7 +51,7 @@
                 <constraints nullable="false" foreignKeyName="fk_response_step" references="funnel_step(id)"/>
             </column>
             <column name="action" type="ENUM('OPEN','CLICK','REPLY','PURCHASE')"/>
-            <column name="value" type="JSON"/>
+            <column name="payload" type="LONGTEXT"/>
             <column name="revenue" type="DECIMAL(10,2)"/>
             <column name="occurred_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP"/>
         </createTable>

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2025-08-20-rename-lead-response-value-to-payload.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2025-08-20-rename-lead-response-value-to-payload.yaml
@@ -2,6 +2,11 @@ databaseChangeLog:
   - changeSet:
       id: rename-lead-response-value-to-payload
       author: codemod
+      preConditions:
+        onFail: MARK_RAN
+        columnExists:
+          tableName: lead_response
+          columnName: value
       changes:
         - renameColumn:
             tableName: lead_response


### PR DESCRIPTION
## Summary
- rename lead_response value column to payload
- guard migration to skip rename when column already renamed

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to github)*
- `mvn -s ../settings.xml spotless:apply` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to github)*

------
https://chatgpt.com/codex/tasks/task_e_68a624a587748321a223d276acfb10a7