### PR TITLE
fix: update worker path in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -97,8 +97,8 @@ jobs:
             -DremoteRepositories=github::default::https://maven.pkg.github.com/paulofor/marketing-hub
           ls -la ~/.m2/repository/com/marketinghub/ads-service/0.0.1-SNAPSHOT || true
 
-      - name: Build Success Product Worker
-        run: cd ../../success-product-worker && mvn -s settings.xml package
+      - name: Build AI Worker
+        run: cd ../../ai-worker && mvn -s settings.xml package
 
       - name: Publicar artefato
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- adjust CI to build AI worker from its new location

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Network is unreachable for org.springframework.boot:spring-boot-starter-parent)*
- `cd ai-worker && mvn -s settings.xml package` *(fails: Network is unreachable for org.springframework.boot:spring-boot-starter-parent)*
- `cd ai-worker && mvn -s settings.xml test` *(fails: Network is unreachable for org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68a6269607e88321a254e46a3abbd143