### PR TITLE
fix: prioritize worker success product repository

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/WorkerSuccessProductRepository.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/WorkerSuccessProductRepository.java
@@ -2,6 +2,8 @@ package com.marketinghub.worker;
 
 import com.marketinghub.successproduct.SuccessProduct;
 import com.marketinghub.successproduct.repository.SuccessProductRepository;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
@@ -11,6 +13,8 @@ import java.util.List;
  * <p>Extends the shared {@link SuccessProductRepository} from the backend and
  * adds convenience methods used only by the AI Worker.</p>
  */
+@Primary
+@Repository
 public interface WorkerSuccessProductRepository extends SuccessProductRepository {
     /**
      * Retrieves products marked as new in the database.


### PR DESCRIPTION
## Summary
- mark WorkerSuccessProductRepository as the primary Spring Data bean to avoid duplicate repository beans

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a62911c34c83219da6410b824918f2