### PR TITLE
fix: add valid checksum for lead response changeset

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
+++ b/backend/ads-service/src/main/resources/db/changelog/V20250825__sales_funnel_multichannel.xml
@@ -40,6 +40,7 @@
     </changeSet>
 
     <changeSet id="20250825-3" author="codex">
+        <validCheckSum>9:9986258bcabed2f43b3579b4faefb482</validCheckSum>
         <createTable tableName="lead_response">
             <column name="id" type="BIGINT" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>


### PR DESCRIPTION
## Summary
- add valid checksum for lead_response change set

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to github)*

------
https://chatgpt.com/codex/tasks/task_e_68a6310b5a188321b7b2f5309fa68d62