### PR TITLE
docs: guide to run nicho-hypotese worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisScheduler.java
@@ -1,0 +1,29 @@
+package com.marketinghub.worker.niche;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduler that periodically triggers hypothesis generation for niches.
+ */
+@Component
+public class NicheHypothesisScheduler {
+    private static final Logger log = LoggerFactory.getLogger(NicheHypothesisScheduler.class);
+    private final NicheHypothesisService service;
+
+    public NicheHypothesisScheduler(NicheHypothesisService service) {
+        this.service = service;
+    }
+
+    @Scheduled(cron = "0 */5 * * * *")
+    public void run() {
+        log.info("NicheHypothesisScheduler started");
+        try {
+            service.generate();
+        } finally {
+            log.info("NicheHypothesisScheduler finished");
+        }
+    }
+}

--- a/docs/nicho-hypotese-service.md
+++ b/docs/nicho-hypotese-service.md
@@ -18,3 +18,40 @@ flowchart LR
     ChatGPT -->|resposta| AIWorker
     AIWorker -->|dados processados| Hipotese
 ```
+
+## Execução do Serviço
+
+### Pré-requisitos
+- Java 21
+- Maven configurado com as variáveis `GITHUB_ACTOR` e `GITHUB_TOKEN` para acessar os artefatos do GitHub Packages
+- MySQL em execução conforme `application.properties`
+- Variáveis de ambiente `OPENAI_API_KEY` (e opcionalmente `GOOGLE_API_KEY` e `GOOGLE_SEARCH_ID` para permitir buscas externas)
+
+### Passos para executar
+
+1. Instale as dependências e compile o projeto:
+
+   ```bash
+   cd ai-worker
+   mvn -s settings.xml package
+   ```
+
+2. (Opcional) Execute os testes:
+
+   ```bash
+   mvn -s settings.xml test
+   ```
+
+3. Execute o worker:
+
+   ```bash
+   mvn spring-boot:run
+   ```
+
+   Para executar sem chamadas externas ao ChatGPT, utilize o perfil `dummy`:
+
+   ```bash
+   mvn spring-boot:run -Dspring.profiles.active=dummy
+   ```
+
+O worker agenda a tarefa `NicheHypothesisScheduler` a cada cinco minutos (`0 */5 * * * *`) para analisar nichos configurados, consultar o ChatGPT e gerar as hipóteses. Os logs do processo são exibidos no console.


### PR DESCRIPTION
## Summary
- document prerequisite configuration and steps to run the AI worker service for generating hypotheses from niches
- schedule periodic niche hypothesis generation with a new scheduler

## Testing
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM due to missing GitHub Packages credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68a6606d63fc8321b1cb0b5a22fed8b0