### PR TITLE
refactor: query niches for hypothesis generation

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
@@ -30,13 +30,11 @@ public class NicheHypothesisService {
      */
     public Map<Long, List<CreateHypothesisRequest>> generate() {
         Map<Long, List<CreateHypothesisRequest>> result = new HashMap<>();
-        Iterable<MarketNiche> niches = nicheRepository.findAll();
+        Iterable<MarketNiche> niches = nicheRepository.findAllToGenerateHypotheses();
         for (MarketNiche niche : niches) {
             Integer qty = niche.getHypothesesToGenerate();
-            if (qty != null && qty > 0) {
-                List<CreateHypothesisRequest> hyps = chatGptClient.generateHypotheses(niche, qty);
-                result.put(niche.getId(), hyps);
-            }
+            List<CreateHypothesisRequest> hyps = chatGptClient.generateHypotheses(niche, qty);
+            result.put(niche.getId(), hyps);
         }
         return result;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/repository/MarketNicheRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/repository/MarketNicheRepository.java
@@ -2,8 +2,20 @@ package com.marketinghub.niche.repository;
 
 import com.marketinghub.niche.MarketNiche;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 /**
  * JPA repository for {@link MarketNiche} entities.
  */
-public interface MarketNicheRepository extends JpaRepository<MarketNiche, Long> {}
+public interface MarketNicheRepository extends JpaRepository<MarketNiche, Long> {
+    /**
+     * Retrieves niches configured to generate hypotheses.
+     *
+     * <p>Filters are handled in the query so we only fetch the records we
+     * actually need.</p>
+     */
+    @Query("select n from MarketNiche n where n.hypothesesToGenerate is not null and n.hypothesesToGenerate > 0")
+    List<MarketNiche> findAllToGenerateHypotheses();
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/niche/MarketNicheRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/niche/MarketNicheRepositoryTest.java
@@ -29,4 +29,24 @@ class MarketNicheRepositoryTest {
         repository.save(niche);
         assertThat(repository.findById(niche.getId())).isPresent();
     }
+
+    @Test
+    void findAllToGenerateHypothesesReturnsOnlyConfiguredNiches() {
+        MarketNiche withHyps = MarketNiche.builder()
+                .name("Saúde")
+                .hypothesesToGenerate(2)
+                .build();
+        repository.save(withHyps);
+
+        MarketNiche withoutHyps = MarketNiche.builder()
+                .name("Ignored")
+                .hypothesesToGenerate(0)
+                .build();
+        repository.save(withoutHyps);
+
+        var result = repository.findAllToGenerateHypotheses();
+        assertThat(result)
+                .extracting(MarketNiche::getName)
+                .containsExactly("Saúde");
+    }
 }


### PR DESCRIPTION
## Summary
- fetch only niches that require hypothesis generation
- query repository with dedicated method
- test repository filtering logic

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a6678241cc8321b916b37db691b034