### PR TITLE
Fix niche hypothesis count persistence

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
@@ -40,6 +40,7 @@ public class MarketNicheService {
                 .interests(request.getInterests())
                 .demographicFilters(request.getDemographicFilters())
                 .extraTips(request.getExtraTips())
+                .hypothesesToGenerate(request.getHypothesesToGenerate())
                 .chatDialog(chat)
                 .build();
         return repository.save(niche);
@@ -61,6 +62,7 @@ public class MarketNicheService {
         niche.setInterests(request.getInterests());
         niche.setDemographicFilters(request.getDemographicFilters());
         niche.setExtraTips(request.getExtraTips());
+        niche.setHypothesesToGenerate(request.getHypothesesToGenerate());
         ChatDialog chat = null;
         if (request.getChatDialogId() != null) {
             chat = chatDialogRepository.findById(request.getChatDialogId()).orElseThrow();

--- a/backend/ads-service/src/test/java/com/marketinghub/niche/MarketNicheServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/niche/MarketNicheServiceTest.java
@@ -1,0 +1,51 @@
+package com.marketinghub.niche;
+
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.niche.dto.CreateMarketNicheRequest;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.niche.service.MarketNicheService;
+import com.marketinghub.chat.repository.ChatDialogRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DataJpaTest
+@ContextConfiguration(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
+class MarketNicheServiceTest {
+
+    @Autowired
+    MarketNicheRepository repository;
+
+    MarketNicheService service;
+
+    @BeforeEach
+    void setup() {
+        ChatDialogRepository chatRepo = mock(ChatDialogRepository.class);
+        service = new MarketNicheService(repository, chatRepo);
+    }
+
+    @Test
+    void updatePersistsHypothesesToGenerate() {
+        MarketNiche niche = MarketNiche.builder()
+                .name("Fitness")
+                .hypothesesToGenerate(1)
+                .build();
+        repository.save(niche);
+
+        CreateMarketNicheRequest req = new CreateMarketNicheRequest();
+        req.setName("Fitness");
+        req.setHypothesesToGenerate(5);
+
+        service.update(niche.getId(), req);
+
+        MarketNiche updated = repository.findById(niche.getId()).orElseThrow();
+        assertThat(updated.getHypothesesToGenerate()).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
## Summary
- persist `hypothesesToGenerate` when creating and updating a niche
- add service test ensuring hypotheses quantity persists

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*
- `mvn -s ../settings.xml deploy` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68a7324ede0c8321b0108200dbabb6e1