### PR TITLE
Persist AI generation details for hypotheses

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -57,6 +57,11 @@ public class ChatGptClient {
         String content = response.choices().get(0).message().content();
         try {
             CreateHypothesisRequest[] arr = objectMapper.readValue(content, CreateHypothesisRequest[].class);
+            for (CreateHypothesisRequest req : arr) {
+                req.setMarketNicheId(niche.getId());
+                req.setPrompt(prompt);
+                req.setModel(model);
+            }
             return Arrays.asList(arr);
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse ChatGPT response", e);

--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
@@ -1,6 +1,8 @@
 package com.marketinghub.worker.niche;
 
 import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.service.HypothesisService;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import org.springframework.stereotype.Service;
@@ -8,6 +10,7 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ArrayList;
 
 /**
  * Service that loops through all niches with {@code hypothesesToGenerate > 0}
@@ -17,10 +20,14 @@ import java.util.Map;
 public class NicheHypothesisService {
     private final MarketNicheRepository nicheRepository;
     private final ChatGptClient chatGptClient;
+    private final HypothesisService hypothesisService;
 
-    public NicheHypothesisService(MarketNicheRepository nicheRepository, ChatGptClient chatGptClient) {
+    public NicheHypothesisService(MarketNicheRepository nicheRepository,
+                                  ChatGptClient chatGptClient,
+                                  HypothesisService hypothesisService) {
         this.nicheRepository = nicheRepository;
         this.chatGptClient = chatGptClient;
+        this.hypothesisService = hypothesisService;
     }
 
     /**
@@ -28,13 +35,17 @@ public class NicheHypothesisService {
      *
      * @return map keyed by niche id containing the generated hypotheses
      */
-    public Map<Long, List<CreateHypothesisRequest>> generate() {
-        Map<Long, List<CreateHypothesisRequest>> result = new HashMap<>();
+    public Map<Long, List<Hypothesis>> generate() {
+        Map<Long, List<Hypothesis>> result = new HashMap<>();
         Iterable<MarketNiche> niches = nicheRepository.findAllToGenerateHypotheses();
         for (MarketNiche niche : niches) {
             Integer qty = niche.getHypothesesToGenerate();
-            List<CreateHypothesisRequest> hyps = chatGptClient.generateHypotheses(niche, qty);
-            result.put(niche.getId(), hyps);
+            List<CreateHypothesisRequest> requests = chatGptClient.generateHypotheses(niche, qty);
+            List<Hypothesis> saved = new ArrayList<>();
+            for (CreateHypothesisRequest req : requests) {
+                saved.add(hypothesisService.create(req));
+            }
+            result.put(niche.getId(), saved);
         }
         return result;
     }

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.worker.niche;
 
-import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import org.junit.jupiter.api.AfterAll;
@@ -34,6 +35,9 @@ class NicheHypothesisServiceTest {
 
     @Autowired
     NicheHypothesisService service;
+
+    @Autowired
+    HypothesisRepository hypothesisRepository;
 
     @DynamicPropertySource
     static void registerProperties(DynamicPropertyRegistry registry) throws IOException {
@@ -72,11 +76,17 @@ class NicheHypothesisServiceTest {
             throw new RuntimeException(e);
         }
 
-        Map<Long, List<CreateHypothesisRequest>> result = service.generate();
+        Map<Long, List<Hypothesis>> result = service.generate();
         assertThat(result).containsKey(niche.getId());
-        List<CreateHypothesisRequest> hyps = result.get(niche.getId());
+        List<Hypothesis> hyps = result.get(niche.getId());
         assertThat(hyps).hasSize(2);
-        assertThat(hyps.get(0).getTitle()).isEqualTo("H1");
+        Hypothesis first = hyps.get(0);
+        assertThat(first.getTitle()).isEqualTo("H1");
+        assertThat(first.getMarketNiche().getId()).isEqualTo(niche.getId());
+        assertThat(first.getModel()).isEqualTo("gpt-3.5-turbo");
+        assertThat(first.getPrompt()).isNotBlank();
+        assertThat(first.getGeneratedAt()).isNotNull();
+        assertThat(hypothesisRepository.count()).isEqualTo(2);
         assertThat(mockWebServer.getRequestCount()).isEqualTo(1);
     }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -85,7 +85,9 @@ class NicheHypothesisServiceTest {
         assertThat(first.getMarketNiche().getId()).isEqualTo(niche.getId());
         assertThat(first.getModel()).isEqualTo("gpt-3.5-turbo");
         assertThat(first.getPrompt()).isNotBlank();
-        assertThat(first.getGeneratedAt()).isNotNull();
+        // Access the field via reflection since older ads-service builds may lack the getter
+        assertThat(org.springframework.test.util.ReflectionTestUtils.getField(first, "generatedAt"))
+                .isNotNull();
         assertThat(hypothesisRepository.count()).isEqualTo(2);
         assertThat(mockWebServer.getRequestCount()).isEqualTo(1);
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -79,6 +79,9 @@ public class Hypothesis {
     @Column(nullable = false)
     private HypothesisStatus status = HypothesisStatus.BACKLOG;
 
+    /** Data em que a hipótese foi gerada pela IA. */
+    private Instant generatedAt;
+
     @CreationTimestamp
     private Instant createdAt;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
@@ -5,6 +5,7 @@ import com.marketinghub.hypothesis.OfferType;
 import lombok.Data;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 
 @Data
@@ -25,4 +26,5 @@ public class HypothesisDto {
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;
     private HypothesisStatus status;
+    private Instant generatedAt;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -9,6 +9,7 @@ import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
 import com.marketinghub.hypothesis.dto.UpdateHypothesisRequest;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import java.util.UUID;
+import java.time.Instant;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -94,6 +95,9 @@ public class HypothesisService {
                 .mechanism(req.getMechanism())
                 .uniqueMechanism(req.getUniqueMechanism())
                 .successRule(req.getSuccessRule())
+                .prompt(req.getPrompt())
+                .model(req.getModel())
+                .generatedAt(Instant.now())
                 .offerType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()))
                 .price(req.getPrice())
                 .kpiTargetCpl(req.getKpiTargetCpl())

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_21__add_generated_at_to_hypothesis.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_21__add_generated_at_to_hypothesis.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hypothesis ADD COLUMN generated_at TIMESTAMP;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -59,5 +59,8 @@ databaseChangeLog:
       file: V2025_09_20__add_chat_dialog_fk_to_market_niche.sql
       relativeToChangelogFile: true
   - include:
+      file: V2025_09_21__add_generated_at_to_hypothesis.sql
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2025-08-20-rename-lead-response-value-to-payload.yaml
       relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -52,6 +52,7 @@ class HypothesisServiceTest {
         Hypothesis h = service.create(req);
         assertThat(h.getId()).isNotNull();
         assertThat(h.getStatus()).isEqualTo(HypothesisStatus.BACKLOG);
+        assertThat(h.getGeneratedAt()).isNotNull();
     }
 
     @Test

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -116,6 +116,28 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 
+### hypothesis
+
+- `id` BINARY(16) PRIMARY KEY
+- `market_niche_id` BIGINT NOT NULL
+- `title` VARCHAR(255) NOT NULL
+- `premise_angle_id` BIGINT NOT NULL
+- `promise` VARCHAR(140) NOT NULL
+- `problem` VARCHAR(255) NOT NULL
+- `persona` VARCHAR(255) NOT NULL
+- `mechanism` LONGTEXT
+- `unique_mechanism` LONGTEXT
+- `prompt` LONGTEXT
+- `model` VARCHAR(255)
+- `success_rule` LONGTEXT
+- `offer_type` VARCHAR(20) NOT NULL
+- `price` DECIMAL(6,2)
+- `kpi_target_cpl` DECIMAL(7,2) NOT NULL
+- `status` VARCHAR(20) DEFAULT 'BACKLOG' NOT NULL
+- `generated_at` TIMESTAMP
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+- `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+
 ### experiment
 
 - `id` BIGINT AUTO_INCREMENT PRIMARY KEY
@@ -330,6 +352,9 @@ erDiagram
     HYPOTHESIS {
         BINARY id PK
         BIGINT market_niche_id FK
+        VARCHAR model
+        TEXT prompt
+        TIMESTAMP generated_at
     }
     EXPERIMENT {
         BIGINT id PK


### PR DESCRIPTION
## Summary
- Record model, prompt, niche, and generation timestamp for AI-created hypotheses
- Persist generated hypotheses directly in the worker using backend services
- Document new `hypothesis` fields and add DB migration

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `mvn -s ../settings.xml deploy` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `cd ../../ai-worker && mvn -s settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `mvn -s settings.xml package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68a736ec7a84832184b803d7ae2ae410