### PR TITLE
Allow hypotheses to be created without angle

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -65,7 +65,13 @@ class NicheHypothesisServiceTest {
                 .build();
         nicheRepository.save(ignored);
 
-        String content = "[{\"title\":\"H1\"},{\"title\":\"H2\"}]";
+        String content = "[" +
+                "{\\\"title\\\":\\\"H1\\\",\\\"promise\\\":\\\"p1\\\",\\\"problem\\\":\\\"pr1\\\"," +
+                "\\\"persona\\\":\\\"pe1\\\",\\\"successRule\\\":\\\"sr1\\\"," +
+                "\\\"offerType\\\":\\\"LEAD\\\",\\\"kpiTargetCpl\\\":1}," +
+                "{\\\"title\\\":\\\"H2\\\",\\\"promise\\\":\\\"p2\\\",\\\"problem\\\":\\\"pr2\\\"," +
+                "\\\"persona\\\":\\\"pe2\\\",\\\"successRule\\\":\\\"sr2\\\"," +
+                "\\\"offerType\\\":\\\"LEAD\\\",\\\"kpiTargetCpl\\\":1}]";
         try {
             String body = new ObjectMapper().writeValueAsString(
                     Map.of("choices", List.of(Map.of("message", Map.of("content", content)))));

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -30,8 +30,8 @@ public class Hypothesis {
     @Column(nullable = false)
     private String title;
 
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    @JoinColumn(name = "premise_angle_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "premise_angle_id")
     private Angle premiseAngle;
 
     /** Promessa de valor em até 140 caracteres. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -56,9 +56,6 @@ public class HypothesisService {
         if (req.getMarketNicheId() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "marketNicheId required");
         }
-        if (req.getPremiseAngleId() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "angle required");
-        }
         if (req.getPromise() == null || req.getPromise().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promise required");
         }
@@ -129,9 +126,6 @@ public class HypothesisService {
     private void validate(UpdateHypothesisRequest req) {
         if (req.getTitle() == null || req.getTitle().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "title required");
-        }
-        if (req.getPremiseAngleId() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "angle required");
         }
         if (req.getPromise() == null || req.getPromise().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promise required");

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_22__allow_null_premise_angle.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_22__allow_null_premise_angle.sql
@@ -1,0 +1,4 @@
+-- Allows hypotheses to be created without an angle
+-- liquibase formatted sql
+-- changeset marketinghub:2025-09-22-allow-null-premise-angle
+ALTER TABLE hypothesis MODIFY premise_angle_id BIGINT NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -62,5 +62,8 @@ databaseChangeLog:
       file: V2025_09_21__add_generated_at_to_hypothesis.sql
       relativeToChangelogFile: true
   - include:
+      file: V2025_09_22__allow_null_premise_angle.sql
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2025-08-20-rename-lead-response-value-to-payload.yaml
       relativeToChangelogFile: true

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -121,7 +121,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `id` BINARY(16) PRIMARY KEY
 - `market_niche_id` BIGINT NOT NULL
 - `title` VARCHAR(255) NOT NULL
-- `premise_angle_id` BIGINT NOT NULL
+- `premise_angle_id` BIGINT
 - `promise` VARCHAR(140) NOT NULL
 - `problem` VARCHAR(255) NOT NULL
 - `persona` VARCHAR(255) NOT NULL
@@ -238,7 +238,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `id` BINARY(16) PRIMARY KEY
 - `market_niche_id` BIGINT NOT NULL
 - `title` VARCHAR(255) NOT NULL
-- `premise_angle_id` BIGINT NOT NULL
+- `premise_angle_id` BIGINT
 - `offer_type` VARCHAR(20) NOT NULL
 - `price` DECIMAL(6,2)
 - `mechanism` LONGTEXT

--- a/docs/db/changelog/V2025_09_22__allow_null_premise_angle.sql
+++ b/docs/db/changelog/V2025_09_22__allow_null_premise_angle.sql
@@ -1,0 +1,4 @@
+-- Allows hypotheses to be created without an angle
+-- liquibase formatted sql
+-- changeset marketinghub:2025-09-22-allow-null-premise-angle
+ALTER TABLE hypothesis MODIFY premise_angle_id BIGINT NULL;


### PR DESCRIPTION
## Summary
- make `premiseAngle` relationship optional in hypothesis domain
- add migration and documentation for nullable `premise_angle_id`
- adjust AI worker test data to omit angle while providing required fields

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `cd backend/ads-service && mvn -s ../settings.xml deploy` *(fails: Non-resolvable parent POM)*
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a74e4e3bcc8321b9c6aa81c93d1776