### PR TITLE
fix: handle escaped JSON from ChatGPT

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -55,17 +55,29 @@ public class ChatGptClient {
             return List.of();
         }
         String content = response.choices().get(0).message().content();
+        // Algumas respostas do ChatGPT podem escapar as aspas do JSON gerado.
+        // Tentamos analisar o conteúdo diretamente e, em caso de falha,
+        // removemos os caracteres de escape antes de tentar novamente.
         try {
-            CreateHypothesisRequest[] arr = objectMapper.readValue(content, CreateHypothesisRequest[].class);
-            for (CreateHypothesisRequest req : arr) {
-                req.setMarketNicheId(niche.getId());
-                req.setPrompt(prompt);
-                req.setModel(model);
+            return parseAndPopulate(content, prompt, niche);
+        } catch (Exception first) {
+            try {
+                String sanitized = content.replace("\\\"", "\"");
+                return parseAndPopulate(sanitized, prompt, niche);
+            } catch (Exception second) {
+                throw new RuntimeException("Failed to parse ChatGPT response", second);
             }
-            return Arrays.asList(arr);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to parse ChatGPT response", e);
         }
+    }
+
+    private List<CreateHypothesisRequest> parseAndPopulate(String json, String prompt, MarketNiche niche) throws Exception {
+        CreateHypothesisRequest[] arr = objectMapper.readValue(json, CreateHypothesisRequest[].class);
+        for (CreateHypothesisRequest req : arr) {
+            req.setMarketNicheId(niche.getId());
+            req.setPrompt(prompt);
+            req.setModel(model);
+        }
+        return Arrays.asList(arr);
     }
 
     private String buildPrompt(MarketNiche niche, int quantity) {


### PR DESCRIPTION
## Summary
- retry parsing ChatGPT responses with escaped quotes
- populate hypothesis fields in a helper method

## Testing
- `mvn -s settings.xml -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7521322748321b6e86bd6bd8f50ea