### PR TITLE
Handle escaped ChatGPT responses in AI Worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -56,15 +56,14 @@ public class ChatGptClient {
         }
         String content = response.choices().get(0).message().content();
         try {
-            CreateHypothesisRequest[] arr = objectMapper.readValue(content, CreateHypothesisRequest[].class);
-            for (CreateHypothesisRequest req : arr) {
-                req.setMarketNicheId(niche.getId());
-                req.setPrompt(prompt);
-                req.setModel(model);
-            }
-            return Arrays.asList(arr);
+            return parseContent(content, niche, prompt);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to parse ChatGPT response", e);
+            try {
+                String unescaped = objectMapper.readValue("\"" + content + "\"", String.class);
+                return parseContent(unescaped, niche, prompt);
+            } catch (Exception ex) {
+                throw new RuntimeException("Failed to parse ChatGPT response", ex);
+            }
         }
     }
 
@@ -95,4 +94,14 @@ public class ChatGptClient {
     private record ChatCompletionResponse(List<Choice> choices) {}
     private record Choice(Message message) {}
     private record Message(String content) {}
+
+    private List<CreateHypothesisRequest> parseContent(String content, MarketNiche niche, String prompt) throws Exception {
+        CreateHypothesisRequest[] arr = objectMapper.readValue(content, CreateHypothesisRequest[].class);
+        for (CreateHypothesisRequest req : arr) {
+            req.setMarketNicheId(niche.getId());
+            req.setPrompt(prompt);
+            req.setModel(model);
+        }
+        return Arrays.asList(arr);
+    }
 }


### PR DESCRIPTION
## Summary
- Add fallback logic to parse ChatGPT responses that return JSON as an escaped string
- Extract content parsing into helper for reuse and clarity

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7521322748321b6e86bd6bd8f50ea