### PR TITLE
Allow hypotheses without angle

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -74,6 +74,7 @@ public class HypothesisService {
         if (req.getKpiTargetCpl() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "kpiTargetCpl required");
         }
+        // premiseAngleId is optional and validated only when present
         if ("TRIPWIRE".equals(req.getOfferType()) && req.getPrice() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "price required for TRIPWIRE");
         }

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -56,6 +56,23 @@ class HypothesisServiceTest {
     }
 
     @Test
+    void createHypothesisWithoutAngle() {
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        CreateHypothesisRequest req = new CreateHypothesisRequest();
+        req.setMarketNicheId(niche.getId());
+        req.setTitle("Sem ângulo");
+        req.setPromise("Promessa");
+        req.setProblem("Problema");
+        req.setPersona("Persona");
+        req.setSuccessRule("Regra");
+        req.setOfferType("LEAD");
+        req.setKpiTargetCpl(BigDecimal.ONE);
+
+        Hypothesis h = service.create(req);
+        assertThat(h.getPremiseAngle()).isNull();
+    }
+
+    @Test
     void validateTitle() {
         MarketNiche niche = fixtures.createAndSaveNiche();
         CreateHypothesisRequest req = new CreateHypothesisRequest();
@@ -70,11 +87,13 @@ class HypothesisServiceTest {
     }
 
     @Test
-    void validateAngleAndKpi() {
+    void kpiTargetCplRequired() {
         MarketNiche niche = fixtures.createAndSaveNiche();
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
         CreateHypothesisRequest req = new CreateHypothesisRequest();
         req.setMarketNicheId(niche.getId());
         req.setTitle("T");
+        req.setPremiseAngleId(angle.getId());
         req.setPromise("p");
         req.setProblem("pr");
         req.setPersona("pe");


### PR DESCRIPTION
## Summary
- Allow hypotheses to be created without an associated angle
- Clarify validation that angle is optional
- Add tests covering creation without angle and require KPI

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68a770c1d94883218a997ba50a3f8a59