### PR TITLE
Log ChatGPT responses and skip invalid hypotheses

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -57,21 +57,25 @@ public class ChatGptClient {
                 .bodyToMono(ChatCompletionResponse.class)
                 .block();
 
-        log.debug("ChatGPT raw response: {}", response);
+        log.info("ChatGPT raw response: {}", response);
 
         if (response == null || response.choices().isEmpty()) {
             log.warn("ChatGPT returned no choices for niche {}", niche.getId());
             return List.of();
         }
         String content = response.choices().get(0).message().content();
-        log.debug("ChatGPT content: {}", content);
+        log.info("ChatGPT content: {}", content);
         try {
-            return parseContent(content, niche, prompt);
+            List<CreateHypothesisRequest> parsed = parseContent(content, niche, prompt);
+            log.info("Parsed hypotheses: {}", parsed);
+            return parsed;
         } catch (Exception e) {
             log.error("Failed to parse ChatGPT response: {}", content, e);
             try {
                 String unescaped = objectMapper.readValue("\"" + content + "\"", String.class);
-                return parseContent(unescaped, niche, prompt);
+                List<CreateHypothesisRequest> parsed = parseContent(unescaped, niche, prompt);
+                log.info("Parsed hypotheses: {}", parsed);
+                return parsed;
             } catch (Exception ex) {
                 log.error("Failed to parse unescaped ChatGPT response: {}", content, ex);
                 throw new RuntimeException("Failed to parse ChatGPT response", ex);

--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
@@ -46,8 +46,14 @@ public class NicheHypothesisService {
             log.info("Generating {} hypotheses for niche {}", qty, niche.getId());
             List<CreateHypothesisRequest> requests = chatGptClient.generateHypotheses(niche, qty);
             log.info("ChatGPT returned {} hypotheses for niche {}", requests.size(), niche.getId());
+            log.info("Hypotheses generated for niche {}: {}", niche.getId(), requests);
             List<Hypothesis> saved = new ArrayList<>();
             for (CreateHypothesisRequest req : requests) {
+                if (req.getTitle() == null || req.getTitle().isBlank()) {
+                    log.error("Skipping hypothesis without title for niche {}: {}", niche.getId(), req);
+                    continue;
+                }
+                log.info("Saving hypothesis for niche {}: {}", niche.getId(), req);
                 saved.add(hypothesisService.create(req));
             }
             result.put(niche.getId(), saved);

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -101,4 +101,37 @@ class NicheHypothesisServiceTest {
         assertThat(hypothesisRepository.count()).isEqualTo(2);
         assertThat(mockWebServer.getRequestCount()).isEqualTo(1);
     }
+
+    @Test
+    void skipHypothesesWithoutTitle() {
+        MarketNiche niche = MarketNiche.builder()
+                .name("Fitness")
+                .hypothesesToGenerate(2)
+                .build();
+        nicheRepository.save(niche);
+
+        String content = "[" +
+                "{\\\"title\\\":\\\"H1\\\",\\\"promise\\\":\\\"p1\\\",\\\"problem\\\":\\\"pr1\\\"," +
+                "\\\"persona\\\":\\\"pe1\\\",\\\"successRule\\\":\\\"sr1\\\"," +
+                "\\\"offerType\\\":\\\"LEAD\\\",\\\"kpiTargetCpl\\\":1}," +
+                "{\\\"promise\\\":\\\"p2\\\",\\\"problem\\\":\\\"pr2\\\"," +
+                "\\\"persona\\\":\\\"pe2\\\",\\\"successRule\\\":\\\"sr2\\\"," +
+                "\\\"offerType\\\":\\\"LEAD\\\",\\\"kpiTargetCpl\\\":1}]";
+        try {
+            String body = new ObjectMapper().writeValueAsString(
+                    Map.of("choices", List.of(Map.of("message", Map.of("content", content)))));
+            mockWebServer.enqueue(new MockResponse()
+                    .addHeader("Content-Type", "application/json")
+                    .setBody(body));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        Map<Long, List<Hypothesis>> result = service.generate();
+        assertThat(result).containsKey(niche.getId());
+        List<Hypothesis> hyps = result.get(niche.getId());
+        assertThat(hyps).hasSize(1);
+        assertThat(hypothesisRepository.count()).isEqualTo(1);
+        assertThat(mockWebServer.getRequestCount()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## Summary
- log full ChatGPT responses and parsed hypotheses for better visibility
- record generated hypotheses, skipping entries missing required title
- add regression test ensuring hypotheses without title are ignored

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM due to missing GitHub packages credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68a783b936b0832192812d32b4285df3