### PR TITLE
Limit hypothesis fields in ChatGPT prompt

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -103,7 +103,9 @@ public class ChatGptClient {
         if (niche.getExtraTips() != null) {
             sb.append("Dicas extras: ").append(niche.getExtraTips()).append("\n");
         }
-        sb.append("Retorne apenas o JSON com uma lista de objetos compatíveis com CreateHypothesisRequest.");
+        sb.append("Cada objeto deve conter as chaves: \"title\", \"promise\", \"problem\", \"persona\", \"mechanism\", \"uniqueMechanism\", \"successRule\", \"offerType\", \"price\". ");
+        sb.append("O campo \"price\" deve ser um número. ");
+        sb.append("Retorne apenas um array JSON com esses objetos, sem texto adicional.");
         return sb.toString();
     }
 


### PR DESCRIPTION
## Summary
- restrict ChatGPT instructions to generate hypotheses with only `title`, `promise`, `problem`, `persona`, `mechanism`, `uniqueMechanism`, `successRule`, `offerType`, and numeric `price`

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM – Network is unreachable)*
- `mvn -s settings.xml package` *(fails: Non-resolvable parent POM – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a79f4e2ea8832192a1c68cb53103c3