### PR TITLE
Relax hypothesis field requirements

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -23,8 +23,8 @@ public class Hypothesis {
     @UuidGenerator
     private UUID id;
 
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    @JoinColumn(name = "market_niche_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "market_niche_id")
     private MarketNiche marketNiche;
 
     @Column(nullable = false)
@@ -35,15 +35,15 @@ public class Hypothesis {
     private Angle premiseAngle;
 
     /** Promessa de valor em até 140 caracteres. */
-    @Column(nullable = false, length = 140)
+    @Column(length = 140)
     private String promise;
 
     /** Problema ou insight do cliente em uma frase. */
-    @Column(nullable = false)
+    @Column
     private String problem;
 
     /** Persona alvo dentro do nicho. */
-    @Column(nullable = false)
+    @Column
     private String persona;
 
     /** Mecanismo que sustenta a promessa. */
@@ -66,17 +66,17 @@ public class Hypothesis {
     private String successRule;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column
     private OfferType offerType;
 
     @Column(precision = 6, scale = 2)
     private BigDecimal price;
-    @Column(precision = 7, scale = 2, nullable = false)
+    @Column(precision = 7, scale = 2)
     private BigDecimal kpiTargetCpl;
 
     @Enumerated(EnumType.STRING)
     @Builder.Default
-    @Column(nullable = false)
+    @Column
     private HypothesisStatus status = HypothesisStatus.BACKLOG;
 
     /** Data em que a hipótese foi gerada pela IA. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -35,6 +35,7 @@ public class HypothesisService {
     }
 
     private MarketNiche attachNiche(Long id) {
+        if (id == null) return null;
         if (!nicheRepository.existsById(id)) {
             throw new EntityNotFoundException("MarketNiche not found: " + id);
         }
@@ -53,31 +54,7 @@ public class HypothesisService {
         if (req.getTitle() == null || req.getTitle().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "title required");
         }
-        if (req.getMarketNicheId() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "marketNicheId required");
-        }
-        if (req.getPromise() == null || req.getPromise().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promise required");
-        }
-        if (req.getPromise().length() > 140) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promise too long");
-        }
-        if (req.getProblem() == null || req.getProblem().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "problem required");
-        }
-        if (req.getPersona() == null || req.getPersona().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "persona required");
-        }
-        if (req.getSuccessRule() == null || req.getSuccessRule().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "successRule required");
-        }
-        if (req.getKpiTargetCpl() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "kpiTargetCpl required");
-        }
-        // premiseAngleId is optional and validated only when present
-        if ("TRIPWIRE".equals(req.getOfferType()) && req.getPrice() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "price required for TRIPWIRE");
-        }
+        // only title is required
     }
 
     @Transactional
@@ -127,27 +104,6 @@ public class HypothesisService {
     private void validate(UpdateHypothesisRequest req) {
         if (req.getTitle() == null || req.getTitle().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "title required");
-        }
-        if (req.getPromise() == null || req.getPromise().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promise required");
-        }
-        if (req.getPromise().length() > 140) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "promise too long");
-        }
-        if (req.getProblem() == null || req.getProblem().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "problem required");
-        }
-        if (req.getPersona() == null || req.getPersona().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "persona required");
-        }
-        if (req.getSuccessRule() == null || req.getSuccessRule().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "successRule required");
-        }
-        if (req.getKpiTargetCpl() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "kpiTargetCpl required");
-        }
-        if ("TRIPWIRE".equals(req.getOfferType()) && req.getPrice() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "price required for TRIPWIRE");
         }
     }
 

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_26__relax_hypothesis_constraints.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_26__relax_hypothesis_constraints.sql
@@ -1,0 +1,5 @@
+-- changeset marketinghub:2025-09-26-relax-hypothesis-constraints
+ALTER TABLE hypothesis MODIFY kpi_target_cpl DECIMAL(7,2) NULL;
+ALTER TABLE hypothesis MODIFY offer_type VARCHAR(20) NULL;
+ALTER TABLE hypothesis MODIFY status VARCHAR(20) NULL DEFAULT 'BACKLOG';
+ALTER TABLE hypothesis MODIFY market_niche_id BIGINT NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -67,3 +67,6 @@ databaseChangeLog:
   - include:
       file: changesets/2025-08-20-rename-lead-response-value-to-payload.yaml
       relativeToChangelogFile: true
+  - include:
+      file: V2025_09_26__relax_hypothesis_constraints.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -1,17 +1,13 @@
 package com.marketinghub.hypothesis;
 
 import com.marketinghub.FixtureUtils;
-import com.marketinghub.creative.label.repository.AngleRepository;
 import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
 import com.marketinghub.hypothesis.service.HypothesisService;
 import com.marketinghub.niche.MarketNiche;
-import com.marketinghub.niche.repository.MarketNicheRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-
-import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -29,26 +25,12 @@ class HypothesisServiceTest {
     @Autowired
     HypothesisService service;
     @Autowired
-    MarketNicheRepository nicheRepository;
-    @Autowired
-    AngleRepository angleRepository;
-    @Autowired
     FixtureUtils fixtures;
 
     @Test
     void createValidHypothesis() {
-        MarketNiche niche = fixtures.createAndSaveNiche();
-        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
         CreateHypothesisRequest req = new CreateHypothesisRequest();
-        req.setMarketNicheId(niche.getId());
         req.setTitle("Teste");
-        req.setPremiseAngleId(angle.getId());
-        req.setPromise("Promessa");
-        req.setProblem("Problema");
-        req.setPersona("Persona");
-        req.setSuccessRule("Regra");
-        req.setOfferType("LEAD");
-        req.setKpiTargetCpl(new BigDecimal("5"));
         Hypothesis h = service.create(req);
         assertThat(h.getId()).isNotNull();
         assertThat(h.getStatus()).isEqualTo(HypothesisStatus.BACKLOG);
@@ -57,80 +39,16 @@ class HypothesisServiceTest {
 
     @Test
     void createHypothesisWithoutAngle() {
-        MarketNiche niche = fixtures.createAndSaveNiche();
         CreateHypothesisRequest req = new CreateHypothesisRequest();
-        req.setMarketNicheId(niche.getId());
         req.setTitle("Sem ângulo");
-        req.setPromise("Promessa");
-        req.setProblem("Problema");
-        req.setPersona("Persona");
-        req.setSuccessRule("Regra");
-        req.setOfferType("LEAD");
-        req.setKpiTargetCpl(BigDecimal.ONE);
-
         Hypothesis h = service.create(req);
         assertThat(h.getPremiseAngle()).isNull();
     }
 
     @Test
     void validateTitle() {
-        MarketNiche niche = fixtures.createAndSaveNiche();
         CreateHypothesisRequest req = new CreateHypothesisRequest();
-        req.setMarketNicheId(niche.getId());
         req.setTitle("   ");
-        req.setPromise("p");
-        req.setProblem("pr");
-        req.setPersona("pe");
-        req.setSuccessRule("sr");
-        assertThatThrownBy(() -> service.create(req))
-                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
-    }
-
-    @Test
-    void kpiTargetCplRequired() {
-        MarketNiche niche = fixtures.createAndSaveNiche();
-        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
-        CreateHypothesisRequest req = new CreateHypothesisRequest();
-        req.setMarketNicheId(niche.getId());
-        req.setTitle("T");
-        req.setPremiseAngleId(angle.getId());
-        req.setPromise("p");
-        req.setProblem("pr");
-        req.setPersona("pe");
-        req.setSuccessRule("sr");
-        assertThatThrownBy(() -> service.create(req))
-                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
-    }
-
-    @Test
-    void priceRequiredForTripwire() {
-        MarketNiche niche = fixtures.createAndSaveNiche();
-        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
-        CreateHypothesisRequest req = new CreateHypothesisRequest();
-        req.setMarketNicheId(niche.getId());
-        req.setTitle("T");
-        req.setPremiseAngleId(angle.getId());
-        req.setPromise("p");
-        req.setProblem("pr");
-        req.setPersona("pe");
-        req.setSuccessRule("sr");
-        req.setOfferType("TRIPWIRE");
-        req.setKpiTargetCpl(new BigDecimal("5"));
-        assertThatThrownBy(() -> service.create(req))
-                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
-    }
-
-    @Test
-    void marketNicheIdRequired() {
-        CreateHypothesisRequest req = new CreateHypothesisRequest();
-        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
-        req.setTitle("T");
-        req.setPremiseAngleId(angle.getId());
-        req.setPromise("p");
-        req.setProblem("pr");
-        req.setPersona("pe");
-        req.setSuccessRule("sr");
-        req.setKpiTargetCpl(new BigDecimal("5"));
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
@@ -138,18 +56,10 @@ class HypothesisServiceTest {
     @Test
     void listByMarketNicheWithNullStatusReturnsAll() {
         MarketNiche niche = fixtures.createAndSaveNiche();
-        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
 
         CreateHypothesisRequest req = new CreateHypothesisRequest();
         req.setMarketNicheId(niche.getId());
         req.setTitle("H1");
-        req.setPremiseAngleId(angle.getId());
-        req.setPromise("p");
-        req.setProblem("pr");
-        req.setPersona("pe");
-        req.setSuccessRule("sr");
-        req.setOfferType("LEAD");
-        req.setKpiTargetCpl(BigDecimal.ONE);
 
         Hypothesis h1 = service.create(req);
         Hypothesis h2 = service.create(req);
@@ -166,29 +76,14 @@ class HypothesisServiceTest {
     @Test
     void updateHypothesisOnlyWhenBacklog() {
         MarketNiche niche = fixtures.createAndSaveNiche();
-        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
         CreateHypothesisRequest req = new CreateHypothesisRequest();
         req.setMarketNicheId(niche.getId());
         req.setTitle("H1");
-        req.setPremiseAngleId(angle.getId());
-        req.setPromise("p");
-        req.setProblem("pr");
-        req.setPersona("pe");
-        req.setSuccessRule("sr");
-        req.setOfferType("LEAD");
-        req.setKpiTargetCpl(BigDecimal.ONE);
 
         Hypothesis h = service.create(req);
 
         com.marketinghub.hypothesis.dto.UpdateHypothesisRequest u = new com.marketinghub.hypothesis.dto.UpdateHypothesisRequest();
         u.setTitle("H2");
-        u.setPremiseAngleId(angle.getId());
-        u.setPromise("p2");
-        u.setProblem("pr2");
-        u.setPersona("pe2");
-        u.setSuccessRule("sr2");
-        u.setOfferType("LEAD");
-        u.setKpiTargetCpl(BigDecimal.TEN);
 
         Hypothesis updated = service.update(h.getId(), u);
         assertThat(updated.getTitle()).isEqualTo("H2");

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -119,21 +119,21 @@ This document summarizes the current database schema defined in `schema.sql`.
 ### hypothesis
 
 - `id` BINARY(16) PRIMARY KEY
-- `market_niche_id` BIGINT NOT NULL
+- `market_niche_id` BIGINT
 - `title` VARCHAR(255) NOT NULL
 - `premise_angle_id` BIGINT
-- `promise` VARCHAR(140) NOT NULL
-- `problem` VARCHAR(255) NOT NULL
-- `persona` VARCHAR(255) NOT NULL
+- `promise` VARCHAR(140)
+- `problem` VARCHAR(255)
+- `persona` VARCHAR(255)
 - `mechanism` LONGTEXT
 - `unique_mechanism` LONGTEXT
 - `prompt` LONGTEXT
 - `model` VARCHAR(255)
 - `success_rule` LONGTEXT
-- `offer_type` VARCHAR(20) NOT NULL
+- `offer_type` VARCHAR(20)
 - `price` DECIMAL(6,2)
-- `kpi_target_cpl` DECIMAL(7,2) NOT NULL
-- `status` VARCHAR(20) DEFAULT 'BACKLOG' NOT NULL
+- `kpi_target_cpl` DECIMAL(7,2)
+- `status` VARCHAR(20) DEFAULT 'BACKLOG'
 - `generated_at` TIMESTAMP
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
@@ -236,17 +236,18 @@ This document summarizes the current database schema defined in `schema.sql`.
 ### hypothesis
 
 - `id` BINARY(16) PRIMARY KEY
-- `market_niche_id` BIGINT NOT NULL
+- `market_niche_id` BIGINT
 - `title` VARCHAR(255) NOT NULL
 - `premise_angle_id` BIGINT
-- `offer_type` VARCHAR(20) NOT NULL
+- `offer_type` VARCHAR(20)
 - `price` DECIMAL(6,2)
 - `mechanism` LONGTEXT
 - `unique_mechanism` LONGTEXT
 - `prompt` LONGTEXT
 - `model` VARCHAR(255)
-- `kpi_target_cpl` DECIMAL(7,2) NOT NULL
-- `status` VARCHAR(20) DEFAULT 'BACKLOG' NOT NULL
+- `success_rule` LONGTEXT
+- `kpi_target_cpl` DECIMAL(7,2)
+- `status` VARCHAR(20) DEFAULT 'BACKLOG'
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 


### PR DESCRIPTION
## Summary
- allow Hypothesis fields like kpiTargetCpl, offerType, and marketNiche to be nullable
- validate only title on Hypothesis service
- document and migrate schema to reflect optional Hypothesis fields

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to github: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b02807e88321976eb2dd3ef2604c