### PR TITLE
Fix Liquibase header for hypothesis constraints change

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_26__relax_hypothesis_constraints.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_26__relax_hypothesis_constraints.sql
@@ -1,3 +1,4 @@
+-- liquibase formatted sql
 -- changeset marketinghub:2025-09-26-relax-hypothesis-constraints
 ALTER TABLE hypothesis MODIFY kpi_target_cpl DECIMAL(7,2) NULL;
 ALTER TABLE hypothesis MODIFY offer_type VARCHAR(20) NULL;


### PR DESCRIPTION
## Summary
- add missing `-- liquibase formatted sql` header so relax_hypothesis_constraints runs correctly

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bc48afb08321b161c852d4cbebc5