### PR TITLE
Handle invalid offerType in AI worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -104,6 +104,7 @@ public class ChatGptClient {
             sb.append("Dicas extras: ").append(niche.getExtraTips()).append("\n");
         }
         sb.append("Cada objeto deve conter as chaves: \"title\", \"promise\", \"problem\", \"persona\", \"mechanism\", \"uniqueMechanism\", \"successRule\", \"offerType\", \"price\". ");
+        sb.append("O campo \"offerType\" deve ser \"LEAD\" ou \"TRIPWIRE\". ");
         sb.append("O campo \"price\" deve ser um número. ");
         sb.append("Retorne apenas um array JSON com esses objetos, sem texto adicional.");
         return sb.toString();

--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
@@ -2,6 +2,7 @@ package com.marketinghub.worker.niche;
 
 import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
 import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.OfferType;
 import com.marketinghub.hypothesis.service.HypothesisService;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
@@ -52,6 +53,15 @@ public class NicheHypothesisService {
                 if (req.getTitle() == null || req.getTitle().isBlank()) {
                     log.error("Skipping hypothesis without title for niche {}: {}", niche.getId(), req);
                     continue;
+                }
+                String offerType = req.getOfferType();
+                if (offerType != null) {
+                    try {
+                        OfferType.valueOf(offerType);
+                    } catch (IllegalArgumentException e) {
+                        log.error("Invalid offerType '{}' for niche {}: {}", offerType, niche.getId(), req);
+                        req.setOfferType(null);
+                    }
                 }
                 log.info("Saving hypothesis for niche {}: {}", niche.getId(), req);
                 saved.add(hypothesisService.create(req));

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -143,4 +143,33 @@ class NicheHypothesisServiceTest {
         assertThat(hypothesisRepository.count()).isEqualTo(1);
         assertThat(mockWebServer.getRequestCount() - initialCount).isEqualTo(1);
     }
+
+    @Test
+    void nullOfferTypeOnInvalidValue() {
+        MarketNiche niche = MarketNiche.builder()
+                .name("Tech")
+                .hypothesesToGenerate(1)
+                .build();
+        nicheRepository.save(niche);
+
+        String content = "[" +
+                "{\\\"title\\\":\\\"H1\\\",\\\"promise\\\":\\\"p1\\\",\\\"problem\\\":\\\"pr1\\\"," +
+                "\\\"persona\\\":\\\"pe1\\\",\\\"successRule\\\":\\\"sr1\\\"," +
+                "\\\"offerType\\\":\\\"Teste grátis 14 dias de plataforma SaaS\\\",\\\"kpiTargetCpl\\\":1}]";
+        try {
+            String body = new ObjectMapper().writeValueAsString(
+                    Map.of("choices", List.of(Map.of("message", Map.of("content", content)))));
+            mockWebServer.enqueue(new MockResponse()
+                    .addHeader("Content-Type", "application/json")
+                    .setBody(body));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        Map<Long, List<Hypothesis>> result = service.generate();
+        assertThat(result).containsKey(niche.getId());
+        List<Hypothesis> hyps = result.get(niche.getId());
+        assertThat(hyps).hasSize(1);
+        assertThat(hyps.get(0).getOfferType()).isNull();
+    }
 }


### PR DESCRIPTION
## Summary
- Validate incoming offerType values from ChatGPT and clear invalid ones before saving hypotheses
- Instruct ChatGPT to use only `LEAD` or `TRIPWIRE` for the offerType field
- Add unit test covering hypotheses returned with unknown offerType values

## Testing
- `mvn -s settings.xml package` *(failed: Non-resolvable parent POM for com.marketinghub:ai-worker:0.0.1-SNAPSHOT)*
- `mvn -s settings.xml test` *(failed: Non-resolvable parent POM for com.marketinghub:ai-worker:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68a86fdbc0448321bf7a7d1fd2026456