### PR TITLE
fix: allow long hypothesis prompts

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -56,6 +56,7 @@ public class Hypothesis {
 
     /** Prompt usado quando a hipótese é gerada por IA. */
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String prompt;
 
     /** Modelo de IA responsável pela geração desta hipótese. */

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -127,7 +127,8 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `persona` VARCHAR(255)
 - `mechanism` LONGTEXT
 - `unique_mechanism` LONGTEXT
-- `prompt` LONGTEXT
+- `prompt` LONGTEXT  
+  Texto do prompt usado pela IA; pode ser bem longo
 - `model` VARCHAR(255)
 - `success_rule` LONGTEXT
 - `offer_type` VARCHAR(20)
@@ -243,7 +244,8 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `price` DECIMAL(6,2)
 - `mechanism` LONGTEXT
 - `unique_mechanism` LONGTEXT
-- `prompt` LONGTEXT
+- `prompt` LONGTEXT  
+  Texto do prompt usado pela IA; pode ser bem longo
 - `model` VARCHAR(255)
 - `success_rule` LONGTEXT
 - `kpi_target_cpl` DECIMAL(7,2)


### PR DESCRIPTION
## Summary
- allow storing very long prompts in hypothesis by using LONGTEXT
- document that hypothesis prompt can be very long

## Testing
- `mvn -s ../settings.xml -q spotless:apply` *(fails: Non-resolvable parent POM due to network unreachable)*
- `mvn -s ../settings.xml -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a87e4c59488321a24b2a66536aa70b