### PR TITLE
feat: manage prompt objects

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,8 @@ import NewFunnelPage from "./pages/funnel/NewFunnelPage";
 import EditFunnelPage from "./pages/funnel/EditFunnelPage";
 import ChatDialogListPage from "./pages/chatDialog/ChatDialogListPage";
 import NewChatDialogPage from "./pages/chatDialog/NewChatDialogPage";
+import PromptEntitiesPage from "./pages/prompt/PromptEntitiesPage";
+import PromptAttributesPage from "./pages/prompt/PromptAttributesPage";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
@@ -98,6 +100,9 @@ export default function App() {
             </Link>
             <Link className="nav-link" to="/funnels">
               Funil de Vendas
+            </Link>
+            <Link className="nav-link" to="/prompt-entities">
+              Objetos de Prompt
             </Link>
             <div className="nav-item dropdown">
               <span
@@ -210,6 +215,11 @@ export default function App() {
         <Route path="/funnels/:id/edit" element={<EditFunnelPage />} />
         <Route path="/chat-dialogs" element={<ChatDialogListPage />} />
         <Route path="/chat-dialogs/new" element={<NewChatDialogPage />} />
+        <Route path="/prompt-entities" element={<PromptEntitiesPage />} />
+        <Route
+          path="/prompt-entities/:entityName/attributes"
+          element={<PromptAttributesPage />}
+        />
         <Route path="*" element={<div>Início</div>} />
       </Routes>
       <ToastContainer position="top-right" />

--- a/frontend/src/api/prompt/useCreatePromptAttribute.ts
+++ b/frontend/src/api/prompt/useCreatePromptAttribute.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { PromptAttribute } from "./usePromptAttributes";
+
+export interface CreatePromptAttribute {
+  name: string;
+  description: string;
+}
+
+export function useCreatePromptAttribute(entityName: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreatePromptAttribute) => {
+      const { data: attr } = await axios.post<PromptAttribute>(
+        `/api/prompt-entities/${entityName}/attributes`,
+        data,
+      );
+      return attr;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["promptAttributes", entityName],
+      });
+      queryClient.invalidateQueries({ queryKey: ["promptEntities"] });
+    },
+  });
+}

--- a/frontend/src/api/prompt/usePromptAttributes.ts
+++ b/frontend/src/api/prompt/usePromptAttributes.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface PromptAttribute {
+  name: string;
+  description: string;
+  version: number;
+}
+
+export function usePromptAttributes(entityName: string) {
+  return useQuery({
+    queryKey: ["promptAttributes", entityName],
+    queryFn: async () => {
+      const { data } = await axios.get<PromptAttribute[]>(
+        `/api/prompt-entities/${entityName}/attributes`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/prompt/usePromptEntities.ts
+++ b/frontend/src/api/prompt/usePromptEntities.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export function usePromptEntities() {
+  return useQuery({
+    queryKey: ["promptEntities"],
+    queryFn: async () => {
+      const { data } = await axios.get<string[]>("/api/prompt-entities");
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/prompt/PromptAttributesPage.tsx
+++ b/frontend/src/pages/prompt/PromptAttributesPage.tsx
@@ -1,0 +1,68 @@
+import { useForm } from "react-hook-form";
+import { useParams } from "react-router-dom";
+import { usePromptAttributes } from "../../api/prompt/usePromptAttributes";
+import { useCreatePromptAttribute } from "../../api/prompt/useCreatePromptAttribute";
+import PageTitle from "../../components/PageTitle";
+
+interface FormData {
+  name: string;
+  description: string;
+}
+
+export default function PromptAttributesPage() {
+  const { entityName = "" } = useParams<{ entityName: string }>();
+  const { data, isLoading } = usePromptAttributes(entityName);
+  const create = useCreatePromptAttribute(entityName);
+  const { register, handleSubmit, reset } = useForm<FormData>();
+
+  const onSubmit = async (values: FormData) => {
+    try {
+      await create.mutateAsync(values);
+      reset({ name: "", description: "" });
+    } catch {
+      alert("Erro ao salvar atributo");
+    }
+  };
+
+  if (isLoading) return <p>Carregando...</p>;
+
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <PageTitle>{`Atributos de ${entityName}`}</PageTitle>
+      <ul>
+        {Array.isArray(data) &&
+          data.map((a) => (
+            <li key={`${a.name}-${a.version}`}>
+              <strong>{a.name}</strong>: {a.description}
+            </li>
+          ))}
+      </ul>
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="mt-3">
+        <label className="form-label" htmlFor="name">
+          Nome
+        </label>
+        <input id="name" className="form-control mb-2" {...register("name")} />
+        <label className="form-label" htmlFor="description">
+          Descrição
+        </label>
+        <textarea
+          id="description"
+          className="form-control mb-2"
+          {...register("description")}
+        />
+        <div className="mt-3 d-flex justify-content-end">
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={create.isPending}
+            onClick={handleSubmit(onSubmit, (errors) => {
+              console.log("Validation errors", errors);
+            })}
+          >
+            Salvar
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/prompt/PromptEntitiesPage.tsx
+++ b/frontend/src/pages/prompt/PromptEntitiesPage.tsx
@@ -1,0 +1,52 @@
+import { useForm } from "react-hook-form";
+import { Link, useNavigate } from "react-router-dom";
+import { usePromptEntities } from "../../api/prompt/usePromptEntities";
+import PageTitle from "../../components/PageTitle";
+
+interface FormData {
+  name: string;
+}
+
+export default function PromptEntitiesPage() {
+  const { data, isLoading } = usePromptEntities();
+  const navigate = useNavigate();
+  const { register, handleSubmit, reset } = useForm<FormData>();
+
+  const onSubmit = (values: FormData) => {
+    const n = values.name.trim();
+    if (!n) return;
+    reset();
+    navigate(`/prompt-entities/${n}/attributes`);
+  };
+
+  if (isLoading) return <p>Carregando...</p>;
+
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <PageTitle>Objetos de Prompt</PageTitle>
+      <ul>
+        {Array.isArray(data) &&
+          data.map((n) => (
+            <li key={n}>
+              <Link to={`/prompt-entities/${n}/attributes`}>{n}</Link>
+            </li>
+          ))}
+      </ul>
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="mt-3">
+        <label className="form-label" htmlFor="name">
+          Nova Entidade
+        </label>
+        <input id="name" className="form-control mb-2" {...register("name")} />
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={handleSubmit(onSubmit, (errors) => {
+            console.log("Validation errors", errors);
+          })}
+        >
+          Abrir
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add prompt object management pages
- allow listing prompt entities and attributes
- expose hooks for prompt entities and attributes

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8a050ff6483218f3c594e18035af3