### PR TITLE
feat: add prompt entity listing endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptEntityService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptEntityService.java
@@ -1,0 +1,22 @@
+package com.marketinghub.prompt.service;
+
+import com.marketinghub.prompt.PromptEntity;
+import com.marketinghub.prompt.repository.PromptEntityRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PromptEntityService {
+    private final PromptEntityRepository repository;
+
+    public PromptEntityService(PromptEntityRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<String> listNames() {
+        return repository.findAll().stream()
+                .map(PromptEntity::getName)
+                .toList();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptEntityController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptEntityController.java
@@ -1,0 +1,23 @@
+package com.marketinghub.prompt.web;
+
+import com.marketinghub.prompt.service.PromptEntityService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/prompt-entities")
+public class PromptEntityController {
+    private final PromptEntityService service;
+
+    public PromptEntityController(PromptEntityService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<String> list() {
+        return service.listNames();
+    }
+}


### PR DESCRIPTION
## Summary
- expose GET /prompt-entities to list prompt entity names
- add service to retrieve prompt entity names

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM, network is unreachable)*
- `npm run build`
- `npm test` *(all tests passed, exited watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bd4e82d4832180e17da56c0e21c1