### PR TITLE
Add CRUD for prompt entities and attributes

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/CreatePromptEntityRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/CreatePromptEntityRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.prompt.dto;
+
+import lombok.Data;
+
+@Data
+public class CreatePromptEntityRequest {
+    private String name;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/PromptEntityDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/PromptEntityDto.java
@@ -1,0 +1,12 @@
+package com.marketinghub.prompt.dto;
+
+import lombok.Data;
+import java.time.Instant;
+
+@Data
+public class PromptEntityDto {
+    private Long id;
+    private String name;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/UpdatePromptAttributeRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/UpdatePromptAttributeRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.prompt.dto;
+
+import lombok.Data;
+
+@Data
+public class UpdatePromptAttributeRequest {
+    private String description;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/UpdatePromptEntityRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/UpdatePromptEntityRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.prompt.dto;
+
+import lombok.Data;
+
+@Data
+public class UpdatePromptEntityRequest {
+    private String name;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/mapper/PromptEntityMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/mapper/PromptEntityMapper.java
@@ -1,0 +1,10 @@
+package com.marketinghub.prompt.mapper;
+
+import com.marketinghub.prompt.PromptEntity;
+import com.marketinghub.prompt.dto.PromptEntityDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface PromptEntityMapper {
+    PromptEntityDto toDto(PromptEntity entity);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptAttributeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptAttributeRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface PromptAttributeRepository extends JpaRepository<PromptAttribute, Long> {
     List<PromptAttribute> findByEntity_Name(String entityName);
     Optional<PromptAttribute> findTopByEntity_NameAndNameOrderByVersionDesc(String entityName, String name);
+    void deleteByEntity_NameAndName(String entityName, String name);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptAttributeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptAttributeService.java
@@ -4,9 +4,11 @@ import com.marketinghub.prompt.PromptAttribute;
 import com.marketinghub.prompt.PromptEntity;
 import com.marketinghub.prompt.dto.CreatePromptAttributeRequest;
 import com.marketinghub.prompt.dto.PromptAttributeDto;
+import com.marketinghub.prompt.dto.UpdatePromptAttributeRequest;
 import com.marketinghub.prompt.mapper.PromptAttributeMapper;
 import com.marketinghub.prompt.repository.PromptAttributeRepository;
 import com.marketinghub.prompt.repository.PromptEntityRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -49,5 +51,31 @@ public class PromptAttributeService {
                 .build();
         attributeRepository.save(attr);
         return mapper.toDto(attr);
+    }
+
+    public PromptAttributeDto getLatest(String entityName, String attrName) {
+        PromptAttribute attr = attributeRepository.findTopByEntity_NameAndNameOrderByVersionDesc(entityName, attrName)
+                .orElseThrow(() -> new EntityNotFoundException("PromptAttribute not found"));
+        return mapper.toDto(attr);
+    }
+
+    public PromptAttributeDto update(String entityName, String attrName, UpdatePromptAttributeRequest req) {
+        PromptEntity entity = entityRepository.findByName(entityName)
+                .orElseGet(() -> entityRepository.save(PromptEntity.builder().name(entityName).build()));
+        int nextVersion = attributeRepository.findTopByEntity_NameAndNameOrderByVersionDesc(entityName, attrName)
+                .map(PromptAttribute::getVersion)
+                .orElse(0) + 1;
+        PromptAttribute attr = PromptAttribute.builder()
+                .entity(entity)
+                .name(attrName)
+                .description(req.getDescription())
+                .version(nextVersion)
+                .build();
+        attributeRepository.save(attr);
+        return mapper.toDto(attr);
+    }
+
+    public void delete(String entityName, String attrName) {
+        attributeRepository.deleteByEntity_NameAndName(entityName, attrName);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptEntityService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptEntityService.java
@@ -1,7 +1,12 @@
 package com.marketinghub.prompt.service;
 
 import com.marketinghub.prompt.PromptEntity;
+import com.marketinghub.prompt.dto.CreatePromptEntityRequest;
+import com.marketinghub.prompt.dto.PromptEntityDto;
+import com.marketinghub.prompt.dto.UpdatePromptEntityRequest;
+import com.marketinghub.prompt.mapper.PromptEntityMapper;
 import com.marketinghub.prompt.repository.PromptEntityRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -9,14 +14,38 @@ import java.util.List;
 @Service
 public class PromptEntityService {
     private final PromptEntityRepository repository;
+    private final PromptEntityMapper mapper;
 
-    public PromptEntityService(PromptEntityRepository repository) {
+    public PromptEntityService(PromptEntityRepository repository, PromptEntityMapper mapper) {
         this.repository = repository;
+        this.mapper = mapper;
     }
 
-    public List<String> listNames() {
-        return repository.findAll().stream()
-                .map(PromptEntity::getName)
-                .toList();
+    public List<PromptEntityDto> list() {
+        return repository.findAll().stream().map(mapper::toDto).toList();
+    }
+
+    public PromptEntityDto get(Long id) {
+        PromptEntity entity = repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("PromptEntity not found"));
+        return mapper.toDto(entity);
+    }
+
+    public PromptEntityDto create(CreatePromptEntityRequest req) {
+        PromptEntity entity = PromptEntity.builder().name(req.getName()).build();
+        repository.save(entity);
+        return mapper.toDto(entity);
+    }
+
+    public PromptEntityDto update(Long id, UpdatePromptEntityRequest req) {
+        PromptEntity entity = repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("PromptEntity not found"));
+        entity.setName(req.getName());
+        repository.save(entity);
+        return mapper.toDto(entity);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptAttributeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptAttributeController.java
@@ -2,6 +2,7 @@ package com.marketinghub.prompt.web;
 
 import com.marketinghub.prompt.dto.CreatePromptAttributeRequest;
 import com.marketinghub.prompt.dto.PromptAttributeDto;
+import com.marketinghub.prompt.dto.UpdatePromptAttributeRequest;
 import com.marketinghub.prompt.service.PromptAttributeService;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,5 +25,21 @@ public class PromptAttributeController {
     @PostMapping
     public PromptAttributeDto create(@PathVariable String entityName, @RequestBody CreatePromptAttributeRequest req) {
         return service.create(entityName, req);
+    }
+
+    @GetMapping("/{attrName}")
+    public PromptAttributeDto get(@PathVariable String entityName, @PathVariable String attrName) {
+        return service.getLatest(entityName, attrName);
+    }
+
+    @PutMapping("/{attrName}")
+    public PromptAttributeDto update(@PathVariable String entityName, @PathVariable String attrName,
+                                     @RequestBody UpdatePromptAttributeRequest req) {
+        return service.update(entityName, attrName, req);
+    }
+
+    @DeleteMapping("/{attrName}")
+    public void delete(@PathVariable String entityName, @PathVariable String attrName) {
+        service.delete(entityName, attrName);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptEntityController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptEntityController.java
@@ -1,9 +1,10 @@
 package com.marketinghub.prompt.web;
 
+import com.marketinghub.prompt.dto.CreatePromptEntityRequest;
+import com.marketinghub.prompt.dto.PromptEntityDto;
+import com.marketinghub.prompt.dto.UpdatePromptEntityRequest;
 import com.marketinghub.prompt.service.PromptEntityService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -17,7 +18,27 @@ public class PromptEntityController {
     }
 
     @GetMapping
-    public List<String> list() {
-        return service.listNames();
+    public List<PromptEntityDto> list() {
+        return service.list();
+    }
+
+    @GetMapping("/{id}")
+    public PromptEntityDto get(@PathVariable Long id) {
+        return service.get(id);
+    }
+
+    @PostMapping
+    public PromptEntityDto create(@RequestBody CreatePromptEntityRequest req) {
+        return service.create(req);
+    }
+
+    @PutMapping("/{id}")
+    public PromptEntityDto update(@PathVariable Long id, @RequestBody UpdatePromptEntityRequest req) {
+        return service.update(id, req);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long id) {
+        service.delete(id);
     }
 }


### PR DESCRIPTION
## Summary
- implement create, read, update and delete operations for prompt entities
- expose CRUD endpoints for prompt attributes within an entity hierarchy
- add DTOs and MapStruct mappers for new resources

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM due to network/unreachable repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c41451848321b0166f94a051b89f