### PR TITLE
feat: list prompt entities

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,6 +44,7 @@ import ChatDialogListPage from "./pages/chatDialog/ChatDialogListPage";
 import NewChatDialogPage from "./pages/chatDialog/NewChatDialogPage";
 import PromptEntitiesPage from "./pages/prompt/PromptEntitiesPage";
 import PromptAttributesPage from "./pages/prompt/PromptAttributesPage";
+import NewPromptEntityPage from "./pages/prompt/NewPromptEntityPage";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
@@ -216,6 +217,7 @@ export default function App() {
         <Route path="/chat-dialogs" element={<ChatDialogListPage />} />
         <Route path="/chat-dialogs/new" element={<NewChatDialogPage />} />
         <Route path="/prompt-entities" element={<PromptEntitiesPage />} />
+        <Route path="/prompt-entities/new" element={<NewPromptEntityPage />} />
         <Route
           path="/prompt-entities/:entityName/attributes"
           element={<PromptAttributesPage />}

--- a/frontend/src/api/prompt/useCreatePromptEntity.ts
+++ b/frontend/src/api/prompt/useCreatePromptEntity.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { PromptEntity } from "./usePromptEntities";
+
+export interface CreatePromptEntity {
+  name: string;
+}
+
+export function useCreatePromptEntity() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CreatePromptEntity) => {
+      const { data: entity } = await axios.post<PromptEntity>(
+        "/api/prompt-entities",
+        data,
+      );
+      return entity;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["promptEntities"] });
+    },
+  });
+}

--- a/frontend/src/api/prompt/usePromptEntities.ts
+++ b/frontend/src/api/prompt/usePromptEntities.ts
@@ -1,11 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 
+export interface PromptEntity {
+  id: number;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export function usePromptEntities() {
   return useQuery({
     queryKey: ["promptEntities"],
     queryFn: async () => {
-      const { data } = await axios.get<string[]>("/api/prompt-entities");
+      const { data } = await axios.get<PromptEntity[]>("/api/prompt-entities");
       return data;
     },
   });

--- a/frontend/src/pages/prompt/NewPromptEntityPage.tsx
+++ b/frontend/src/pages/prompt/NewPromptEntityPage.tsx
@@ -1,0 +1,48 @@
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useCreatePromptEntity } from "../../api/prompt/useCreatePromptEntity";
+
+interface FormData {
+  name: string;
+}
+
+export default function NewPromptEntityPage() {
+  const { register, handleSubmit, reset } = useForm<FormData>();
+  const navigate = useNavigate();
+  const create = useCreatePromptEntity();
+
+  const onSubmit = async (values: FormData) => {
+    try {
+      const entity = await create.mutateAsync(values);
+      reset();
+      navigate(`/prompt-entities/${entity.name}/attributes`);
+    } catch {
+      alert("Erro ao criar entidade");
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <PageTitle>Nova Entidade de Prompt</PageTitle>
+      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+        <label className="form-label" htmlFor="name">
+          Nome
+        </label>
+        <input id="name" className="form-control mb-2" {...register("name")} />
+        <div className="mt-3 d-flex justify-content-end">
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={create.isPending}
+            onClick={handleSubmit(onSubmit, (errors) => {
+              console.log("Validation errors", errors);
+            })}
+          >
+            Salvar
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/prompt/PromptEntitiesPage.tsx
+++ b/frontend/src/pages/prompt/PromptEntitiesPage.tsx
@@ -1,52 +1,30 @@
-import { useForm } from "react-hook-form";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { usePromptEntities } from "../../api/prompt/usePromptEntities";
 import PageTitle from "../../components/PageTitle";
 
-interface FormData {
-  name: string;
-}
-
 export default function PromptEntitiesPage() {
   const { data, isLoading } = usePromptEntities();
-  const navigate = useNavigate();
-  const { register, handleSubmit, reset } = useForm<FormData>();
-
-  const onSubmit = (values: FormData) => {
-    const n = values.name.trim();
-    if (!n) return;
-    reset();
-    navigate(`/prompt-entities/${n}/attributes`);
-  };
+  const entities = Array.isArray(data) ? data : [];
 
   if (isLoading) return <p>Carregando...</p>;
 
   return (
     <div style={{ maxWidth: 480 }}>
       <PageTitle>Objetos de Prompt</PageTitle>
-      <ul>
-        {Array.isArray(data) &&
-          data.map((n) => (
-            <li key={n}>
-              <Link to={`/prompt-entities/${n}/attributes`}>{n}</Link>
+      <Link className="btn btn-primary mb-3" to="/prompt-entities/new">
+        Nova Entidade
+      </Link>
+      {entities.length === 0 ? (
+        <p>Nenhuma entidade encontrada.</p>
+      ) : (
+        <ul>
+          {entities.map((e) => (
+            <li key={e.id}>
+              <Link to={`/prompt-entities/${e.name}/attributes`}>{e.name}</Link>
             </li>
           ))}
-      </ul>
-      <form onSubmit={handleSubmit(onSubmit)} noValidate className="mt-3">
-        <label className="form-label" htmlFor="name">
-          Nova Entidade
-        </label>
-        <input id="name" className="form-control mb-2" {...register("name")} />
-        <button
-          type="button"
-          className="btn btn-primary"
-          onClick={handleSubmit(onSubmit, (errors) => {
-            console.log("Validation errors", errors);
-          })}
-        >
-          Abrir
-        </button>
-      </form>
+        </ul>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show existing prompt entities with links
- support creating new prompt entity

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a8fec1a8b0832198947ef8f82bfe4c