### PR TITLE
Add API prefix for prompt entity endpoints

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptAttributeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptAttributeController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/prompt-entities/{entityName}/attributes")
+@RequestMapping("/api/prompt-entities/{entityName}/attributes")
 public class PromptAttributeController {
     private final PromptAttributeService service;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptEntityController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptEntityController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/prompt-entities")
+@RequestMapping("/api/prompt-entities")
 public class PromptEntityController {
     private final PromptEntityService service;
 


### PR DESCRIPTION
## Summary
- align prompt entity and attribute controllers with `/api` URL prefix

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a9040aa1e4832184a4a189b75b804e