### PR TITLE
Enable editing prompt attribute descriptions

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/metadata/EntityMetadataController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/metadata/EntityMetadataController.java
@@ -1,0 +1,23 @@
+package com.marketinghub.metadata;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/entities/{entityName}/attributes")
+public class EntityMetadataController {
+    private final EntityMetadataService service;
+
+    public EntityMetadataController(EntityMetadataService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<String> list(@PathVariable String entityName) {
+        return service.listAttributes(entityName);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/metadata/EntityMetadataService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/metadata/EntityMetadataService.java
@@ -1,0 +1,20 @@
+package com.marketinghub.metadata;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class EntityMetadataService {
+    private final JdbcTemplate jdbcTemplate;
+
+    public EntityMetadataService(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<String> listAttributes(String entityName) {
+        String sql = "SELECT column_name FROM information_schema.columns WHERE table_name = ?";
+        return jdbcTemplate.queryForList(sql, String.class, entityName);
+    }
+}

--- a/frontend/src/api/prompt/useEntityAttributes.ts
+++ b/frontend/src/api/prompt/useEntityAttributes.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export function useEntityAttributes(entityName: string) {
+  return useQuery({
+    queryKey: ["entityAttributes", entityName],
+    queryFn: async () => {
+      const { data } = await axios.get<string[]>(`/api/entities/${entityName}/attributes`);
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/prompt/useUpdatePromptAttribute.ts
+++ b/frontend/src/api/prompt/useUpdatePromptAttribute.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+
+interface UpdateRequest {
+  name: string;
+  description: string;
+}
+
+export function useUpdatePromptAttribute(entityName: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ name, description }: UpdateRequest) => {
+      const { data } = await axios.put(
+        `/api/prompt-entities/${entityName}/attributes/${name}`,
+        { description },
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["promptAttributes", entityName] });
+    },
+  });
+}

--- a/frontend/src/pages/prompt/PromptAttributesPage.tsx
+++ b/frontend/src/pages/prompt/PromptAttributesPage.tsx
@@ -2,6 +2,8 @@ import { useForm } from "react-hook-form";
 import { useParams } from "react-router-dom";
 import { usePromptAttributes } from "../../api/prompt/usePromptAttributes";
 import { useCreatePromptAttribute } from "../../api/prompt/useCreatePromptAttribute";
+import { useEntityAttributes } from "../../api/prompt/useEntityAttributes";
+import { useUpdatePromptAttribute } from "../../api/prompt/useUpdatePromptAttribute";
 import PageTitle from "../../components/PageTitle";
 
 interface FormData {
@@ -13,6 +15,8 @@ export default function PromptAttributesPage() {
   const { entityName = "" } = useParams<{ entityName: string }>();
   const { data, isLoading } = usePromptAttributes(entityName);
   const create = useCreatePromptAttribute(entityName);
+  const { data: entityAttrs } = useEntityAttributes(entityName);
+  const update = useUpdatePromptAttribute(entityName);
   const { register, handleSubmit, reset } = useForm<FormData>();
 
   const onSubmit = async (values: FormData) => {
@@ -33,7 +37,22 @@ export default function PromptAttributesPage() {
         {Array.isArray(data) &&
           data.map((a) => (
             <li key={`${a.name}-${a.version}`}>
-              <strong>{a.name}</strong>: {a.description}
+              <strong>{a.name}</strong>: {a.description}{" "}
+              <button
+                type="button"
+                className="btn btn-link btn-sm"
+                onClick={() => {
+                  const description = window.prompt(
+                    "Nova descrição",
+                    a.description,
+                  );
+                  if (description) {
+                    update.mutate({ name: a.name, description });
+                  }
+                }}
+              >
+                Editar
+              </button>
             </li>
           ))}
       </ul>
@@ -41,7 +60,14 @@ export default function PromptAttributesPage() {
         <label className="form-label" htmlFor="name">
           Nome
         </label>
-        <input id="name" className="form-control mb-2" {...register("name")} />
+        <select id="name" className="form-control mb-2" {...register("name")}> 
+          <option value="">Selecione o atributo</option>
+          {entityAttrs?.map((attr) => (
+            <option key={attr} value={attr}>
+              {attr}
+            </option>
+          ))}
+        </select>
         <label className="form-label" htmlFor="description">
           Descrição
         </label>


### PR DESCRIPTION
## Summary
- expose entity metadata endpoint to list real attributes
- allow selecting real attributes from combo box and editing descriptions

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9097383e4832191c07068d0925a60