### PR TITLE
Refactor prompt entities with description tables

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/metadata/EntityMetadataController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/metadata/EntityMetadataController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/entities/{entityName}/attributes")
+@RequestMapping("/api/entities")
 public class EntityMetadataController {
     private final EntityMetadataService service;
 
@@ -17,6 +17,11 @@ public class EntityMetadataController {
     }
 
     @GetMapping
+    public List<String> listEntities() {
+        return service.listEntities();
+    }
+
+    @GetMapping("/{entityName}/attributes")
     public List<String> list(@PathVariable String entityName) {
         return service.listAttributes(entityName);
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/metadata/EntityMetadataService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/metadata/EntityMetadataService.java
@@ -13,6 +13,11 @@ public class EntityMetadataService {
         this.jdbcTemplate = jdbcTemplate;
     }
 
+    public List<String> listEntities() {
+        String sql = "SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE()";
+        return jdbcTemplate.queryForList(sql, String.class);
+    }
+
     public List<String> listAttributes(String entityName) {
         String sql = "SELECT column_name FROM information_schema.columns WHERE table_name = ?";
         return jdbcTemplate.queryForList(sql, String.class, entityName);

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptAttributeDescription.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptAttributeDescription.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+
 import java.time.Instant;
 
 @Entity
@@ -12,17 +13,22 @@ import java.time.Instant;
 @NoArgsConstructor
 @AllArgsConstructor
 @EntityListeners(org.springframework.data.jpa.domain.support.AuditingEntityListener.class)
-public class PromptAttribute {
+@Table(name = "prompt_attribute_description")
+public class PromptAttributeDescription {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "prompt_entity_id")
-    private PromptEntity entity;
+    @JoinColumn(name = "prompt_attribute_id")
+    private PromptAttribute attribute;
+
+    @Lob
+    @Column(columnDefinition = "LONGTEXT")
+    private String description;
 
     @Column(nullable = false)
-    private String name;
+    private int version;
 
     @CreationTimestamp
     private Instant createdAt;

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptEntityDescription.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptEntityDescription.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+
 import java.time.Instant;
 
 @Entity
@@ -12,7 +13,8 @@ import java.time.Instant;
 @NoArgsConstructor
 @AllArgsConstructor
 @EntityListeners(org.springframework.data.jpa.domain.support.AuditingEntityListener.class)
-public class PromptAttribute {
+@Table(name = "prompt_entity_description")
+public class PromptEntityDescription {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -21,8 +23,12 @@ public class PromptAttribute {
     @JoinColumn(name = "prompt_entity_id")
     private PromptEntity entity;
 
+    @Lob
+    @Column(columnDefinition = "LONGTEXT")
+    private String description;
+
     @Column(nullable = false)
-    private String name;
+    private int version;
 
     @CreationTimestamp
     private Instant createdAt;

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/PromptEntityDescriptionDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/PromptEntityDescriptionDto.java
@@ -1,0 +1,9 @@
+package com.marketinghub.prompt.dto;
+
+import lombok.Data;
+
+@Data
+public class PromptEntityDescriptionDto {
+    private String description;
+    private int version;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/UpdatePromptEntityDescriptionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/dto/UpdatePromptEntityDescriptionRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.prompt.dto;
+
+import lombok.Data;
+
+@Data
+public class UpdatePromptEntityDescriptionRequest {
+    private String description;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/mapper/PromptAttributeMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/mapper/PromptAttributeMapper.java
@@ -1,12 +1,15 @@
 package com.marketinghub.prompt.mapper;
 
 import com.marketinghub.prompt.PromptAttribute;
+import com.marketinghub.prompt.PromptAttributeDescription;
 import com.marketinghub.prompt.dto.PromptAttributeDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface PromptAttributeMapper {
-    @Mapping(target = "name", source = "name")
-    PromptAttributeDto toDto(PromptAttribute attr);
+    @Mapping(target = "name", source = "attr.name")
+    @Mapping(target = "description", source = "desc.description")
+    @Mapping(target = "version", source = "desc.version")
+    PromptAttributeDto toDto(PromptAttribute attr, PromptAttributeDescription desc);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptAttributeDescriptionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptAttributeDescriptionRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.prompt.repository;
+
+import com.marketinghub.prompt.PromptAttributeDescription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PromptAttributeDescriptionRepository extends JpaRepository<PromptAttributeDescription, Long> {
+    Optional<PromptAttributeDescription> findTopByAttribute_IdOrderByVersionDesc(Long attributeId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptAttributeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptAttributeRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 public interface PromptAttributeRepository extends JpaRepository<PromptAttribute, Long> {
     List<PromptAttribute> findByEntity_Name(String entityName);
-    Optional<PromptAttribute> findTopByEntity_NameAndNameOrderByVersionDesc(String entityName, String name);
+    Optional<PromptAttribute> findByEntity_NameAndName(String entityName, String name);
     void deleteByEntity_NameAndName(String entityName, String name);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptEntityDescriptionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptEntityDescriptionRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.prompt.repository;
+
+import com.marketinghub.prompt.PromptEntityDescription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PromptEntityDescriptionRepository extends JpaRepository<PromptEntityDescription, Long> {
+    Optional<PromptEntityDescription> findTopByEntity_NameOrderByVersionDesc(String entityName);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptAttributeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptAttributeService.java
@@ -1,81 +1,105 @@
 package com.marketinghub.prompt.service;
 
 import com.marketinghub.prompt.PromptAttribute;
+import com.marketinghub.prompt.PromptAttributeDescription;
 import com.marketinghub.prompt.PromptEntity;
 import com.marketinghub.prompt.dto.CreatePromptAttributeRequest;
 import com.marketinghub.prompt.dto.PromptAttributeDto;
 import com.marketinghub.prompt.dto.UpdatePromptAttributeRequest;
 import com.marketinghub.prompt.mapper.PromptAttributeMapper;
+import com.marketinghub.prompt.repository.PromptAttributeDescriptionRepository;
 import com.marketinghub.prompt.repository.PromptAttributeRepository;
 import com.marketinghub.prompt.repository.PromptEntityRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Service
 public class PromptAttributeService {
     private final PromptAttributeRepository attributeRepository;
+    private final PromptAttributeDescriptionRepository descriptionRepository;
     private final PromptEntityRepository entityRepository;
     private final PromptAttributeMapper mapper;
 
     public PromptAttributeService(PromptAttributeRepository attributeRepository,
+                                  PromptAttributeDescriptionRepository descriptionRepository,
                                   PromptEntityRepository entityRepository,
                                   PromptAttributeMapper mapper) {
         this.attributeRepository = attributeRepository;
+        this.descriptionRepository = descriptionRepository;
         this.entityRepository = entityRepository;
         this.mapper = mapper;
     }
 
     public List<PromptAttributeDto> listLatest(String entityName) {
         List<PromptAttribute> attrs = attributeRepository.findByEntity_Name(entityName);
-        Map<String, PromptAttribute> latest = attrs.stream()
-                .collect(Collectors.toMap(PromptAttribute::getName, Function.identity(),
-                        (a, b) -> a.getVersion() > b.getVersion() ? a : b));
-        return latest.values().stream().map(mapper::toDto).toList();
+        return attrs.stream().map(attr -> {
+            PromptAttributeDescription desc = descriptionRepository
+                    .findTopByAttribute_IdOrderByVersionDesc(attr.getId())
+                    .orElse(null);
+            return mapper.toDto(attr, desc);
+        }).toList();
     }
 
     public PromptAttributeDto create(String entityName, CreatePromptAttributeRequest req) {
         PromptEntity entity = entityRepository.findByName(entityName)
                 .orElseGet(() -> entityRepository.save(PromptEntity.builder().name(entityName).build()));
-        int nextVersion = attributeRepository.findTopByEntity_NameAndNameOrderByVersionDesc(entityName, req.getName())
-                .map(PromptAttribute::getVersion)
+        PromptAttribute attribute = attributeRepository
+                .findByEntity_NameAndName(entityName, req.getName())
+                .orElseGet(() -> attributeRepository.save(PromptAttribute.builder()
+                        .entity(entity)
+                        .name(req.getName())
+                        .build()));
+        int nextVersion = descriptionRepository
+                .findTopByAttribute_IdOrderByVersionDesc(attribute.getId())
+                .map(PromptAttributeDescription::getVersion)
                 .orElse(0) + 1;
-        PromptAttribute attr = PromptAttribute.builder()
-                .entity(entity)
-                .name(req.getName())
+        PromptAttributeDescription desc = PromptAttributeDescription.builder()
+                .attribute(attribute)
                 .description(req.getDescription())
                 .version(nextVersion)
                 .build();
-        attributeRepository.save(attr);
-        return mapper.toDto(attr);
+        descriptionRepository.save(desc);
+        return mapper.toDto(attribute, desc);
     }
 
     public PromptAttributeDto getLatest(String entityName, String attrName) {
-        PromptAttribute attr = attributeRepository.findTopByEntity_NameAndNameOrderByVersionDesc(entityName, attrName)
+        PromptAttribute attribute = attributeRepository
+                .findByEntity_NameAndName(entityName, attrName)
                 .orElseThrow(() -> new EntityNotFoundException("PromptAttribute not found"));
-        return mapper.toDto(attr);
+        PromptAttributeDescription desc = descriptionRepository
+                .findTopByAttribute_IdOrderByVersionDesc(attribute.getId())
+                .orElseThrow(() -> new EntityNotFoundException("PromptAttributeDescription not found"));
+        return mapper.toDto(attribute, desc);
     }
 
     public PromptAttributeDto update(String entityName, String attrName, UpdatePromptAttributeRequest req) {
         PromptEntity entity = entityRepository.findByName(entityName)
                 .orElseGet(() -> entityRepository.save(PromptEntity.builder().name(entityName).build()));
-        int nextVersion = attributeRepository.findTopByEntity_NameAndNameOrderByVersionDesc(entityName, attrName)
-                .map(PromptAttribute::getVersion)
+        PromptAttribute attribute = attributeRepository
+                .findByEntity_NameAndName(entityName, attrName)
+                .orElseGet(() -> attributeRepository.save(PromptAttribute.builder()
+                        .entity(entity)
+                        .name(attrName)
+                        .build()));
+        int nextVersion = descriptionRepository
+                .findTopByAttribute_IdOrderByVersionDesc(attribute.getId())
+                .map(PromptAttributeDescription::getVersion)
                 .orElse(0) + 1;
-        PromptAttribute attr = PromptAttribute.builder()
-                .entity(entity)
-                .name(attrName)
+        PromptAttributeDescription desc = PromptAttributeDescription.builder()
+                .attribute(attribute)
                 .description(req.getDescription())
                 .version(nextVersion)
                 .build();
-        attributeRepository.save(attr);
-        return mapper.toDto(attr);
+        descriptionRepository.save(desc);
+        return mapper.toDto(attribute, desc);
     }
 
     public void delete(String entityName, String attrName) {
-        attributeRepository.deleteByEntity_NameAndName(entityName, attrName);
+        attributeRepository.findByEntity_NameAndName(entityName, attrName)
+                .ifPresent(attribute -> {
+                    attributeRepository.delete(attribute);
+                });
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptEntityDescriptionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptEntityDescriptionService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.prompt.service;
+
+import com.marketinghub.prompt.PromptEntity;
+import com.marketinghub.prompt.PromptEntityDescription;
+import com.marketinghub.prompt.dto.PromptEntityDescriptionDto;
+import com.marketinghub.prompt.dto.UpdatePromptEntityDescriptionRequest;
+import com.marketinghub.prompt.repository.PromptEntityDescriptionRepository;
+import com.marketinghub.prompt.repository.PromptEntityRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PromptEntityDescriptionService {
+    private final PromptEntityDescriptionRepository descriptionRepository;
+    private final PromptEntityRepository entityRepository;
+
+    public PromptEntityDescriptionService(PromptEntityDescriptionRepository descriptionRepository,
+                                          PromptEntityRepository entityRepository) {
+        this.descriptionRepository = descriptionRepository;
+        this.entityRepository = entityRepository;
+    }
+
+    public PromptEntityDescriptionDto getLatest(String entityName) {
+        return descriptionRepository.findTopByEntity_NameOrderByVersionDesc(entityName)
+                .map(desc -> {
+                    PromptEntityDescriptionDto dto = new PromptEntityDescriptionDto();
+                    dto.setDescription(desc.getDescription());
+                    dto.setVersion(desc.getVersion());
+                    return dto;
+                })
+                .orElse(null);
+    }
+
+    public PromptEntityDescriptionDto update(String entityName, UpdatePromptEntityDescriptionRequest req) {
+        PromptEntity entity = entityRepository.findByName(entityName)
+                .orElseGet(() -> entityRepository.save(PromptEntity.builder().name(entityName).build()));
+        int nextVersion = descriptionRepository.findTopByEntity_NameOrderByVersionDesc(entityName)
+                .map(PromptEntityDescription::getVersion)
+                .orElse(0) + 1;
+        PromptEntityDescription desc = PromptEntityDescription.builder()
+                .entity(entity)
+                .description(req.getDescription())
+                .version(nextVersion)
+                .build();
+        descriptionRepository.save(desc);
+        PromptEntityDescriptionDto dto = new PromptEntityDescriptionDto();
+        dto.setDescription(desc.getDescription());
+        dto.setVersion(desc.getVersion());
+        return dto;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptEntityDescriptionController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptEntityDescriptionController.java
@@ -1,0 +1,27 @@
+package com.marketinghub.prompt.web;
+
+import com.marketinghub.prompt.dto.PromptEntityDescriptionDto;
+import com.marketinghub.prompt.dto.UpdatePromptEntityDescriptionRequest;
+import com.marketinghub.prompt.service.PromptEntityDescriptionService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/prompt-entities/{entityName}/description")
+public class PromptEntityDescriptionController {
+    private final PromptEntityDescriptionService service;
+
+    public PromptEntityDescriptionController(PromptEntityDescriptionService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public PromptEntityDescriptionDto get(@PathVariable String entityName) {
+        return service.getLatest(entityName);
+    }
+
+    @PutMapping
+    public PromptEntityDescriptionDto update(@PathVariable String entityName,
+                                             @RequestBody UpdatePromptEntityDescriptionRequest req) {
+        return service.update(entityName, req);
+    }
+}

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -327,6 +327,39 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `stop_loss_factor` DECIMAL(5,2)
 - `default_mde_pp` DECIMAL(5,2)
 
+### prompt_entity
+
+- `id` BIGINT AUTO_INCREMENT PRIMARY KEY
+- `name` VARCHAR(255) UNIQUE
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+- `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+
+### prompt_attribute
+
+- `id` BIGINT AUTO_INCREMENT PRIMARY KEY
+- `prompt_entity_id` BIGINT
+- `name` VARCHAR(255)
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+- `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+
+### prompt_entity_description
+
+- `id` BIGINT AUTO_INCREMENT PRIMARY KEY
+- `prompt_entity_id` BIGINT
+- `description` LONGTEXT
+- `version` INT
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+- `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+
+### prompt_attribute_description
+
+- `id` BIGINT AUTO_INCREMENT PRIMARY KEY
+- `prompt_attribute_id` BIGINT
+- `description` LONGTEXT
+- `version` INT
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+- `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+
 ## Diagram
 
 ```mermaid

--- a/frontend/src/api/prompt/useEntities.ts
+++ b/frontend/src/api/prompt/useEntities.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export function useEntities() {
+  return useQuery({
+    queryKey: ["entities"],
+    queryFn: async () => {
+      const { data } = await axios.get<string[]>("/api/entities");
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/prompt/usePromptEntityDescription.ts
+++ b/frontend/src/api/prompt/usePromptEntityDescription.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface PromptEntityDescription {
+  description: string;
+  version: number;
+}
+
+export function usePromptEntityDescription(entityName: string) {
+  return useQuery({
+    queryKey: ["promptEntityDescription", entityName],
+    queryFn: async () => {
+      const { data } = await axios.get<PromptEntityDescription>(
+        `/api/prompt-entities/${entityName}/description`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/prompt/useUpdatePromptEntityDescription.ts
+++ b/frontend/src/api/prompt/useUpdatePromptEntityDescription.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+
+interface UpdateRequest {
+  entityName: string;
+  description: string;
+}
+
+export function useUpdatePromptEntityDescription() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ entityName, description }: UpdateRequest) => {
+      const { data } = await axios.put(
+        `/api/prompt-entities/${entityName}/description`,
+        { description },
+      );
+      return data;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["promptEntities"] });
+      queryClient.invalidateQueries({
+        queryKey: ["promptEntityDescription", variables.entityName],
+      });
+    },
+  });
+}

--- a/frontend/src/pages/prompt/NewPromptEntityPage.tsx
+++ b/frontend/src/pages/prompt/NewPromptEntityPage.tsx
@@ -2,6 +2,7 @@ import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import { useCreatePromptEntity } from "../../api/prompt/useCreatePromptEntity";
+import { useEntities } from "../../api/prompt/useEntities";
 
 interface FormData {
   name: string;
@@ -11,6 +12,7 @@ export default function NewPromptEntityPage() {
   const { register, handleSubmit, reset } = useForm<FormData>();
   const navigate = useNavigate();
   const create = useCreatePromptEntity();
+  const { data: entities } = useEntities();
 
   const onSubmit = async (values: FormData) => {
     try {
@@ -29,7 +31,14 @@ export default function NewPromptEntityPage() {
         <label className="form-label" htmlFor="name">
           Nome
         </label>
-        <input id="name" className="form-control mb-2" {...register("name")} />
+        <select id="name" className="form-control mb-2" {...register("name")}>
+          <option value="">Selecione a entidade</option>
+          {entities?.map((e) => (
+            <option key={e} value={e}>
+              {e}
+            </option>
+          ))}
+        </select>
         <div className="mt-3 d-flex justify-content-end">
           <button
             type="button"

--- a/frontend/src/pages/prompt/PromptEntitiesPage.tsx
+++ b/frontend/src/pages/prompt/PromptEntitiesPage.tsx
@@ -1,10 +1,21 @@
 import { Link } from "react-router-dom";
+import axios from "axios";
 import { usePromptEntities } from "../../api/prompt/usePromptEntities";
+import { useUpdatePromptEntityDescription } from "../../api/prompt/useUpdatePromptEntityDescription";
 import PageTitle from "../../components/PageTitle";
 
 export default function PromptEntitiesPage() {
   const { data, isLoading } = usePromptEntities();
   const entities = Array.isArray(data) ? data : [];
+  const updateDesc = useUpdatePromptEntityDescription();
+
+  const handleEdit = async (name: string) => {
+    const { data } = await axios.get(`/api/prompt-entities/${name}/description`);
+    const description = window.prompt("Nova descrição", data?.description || "");
+    if (description) {
+      updateDesc.mutate({ entityName: name, description });
+    }
+  };
 
   if (isLoading) return <p>Carregando...</p>;
 
@@ -20,7 +31,14 @@ export default function PromptEntitiesPage() {
         <ul>
           {entities.map((e) => (
             <li key={e.id}>
-              <Link to={`/prompt-entities/${e.name}/attributes`}>{e.name}</Link>
+              <Link to={`/prompt-entities/${e.name}/attributes`}>{e.name}</Link>{" "}
+              <button
+                type="button"
+                className="btn btn-link btn-sm"
+                onClick={() => handleEdit(e.name)}
+              >
+                Descrição
+              </button>
             </li>
           ))}
         </ul>

--- a/schema.sql
+++ b/schema.sql
@@ -214,9 +214,27 @@ CREATE TABLE prompt_attribute (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     prompt_entity_id BIGINT,
     name VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_prompt_attribute_entity FOREIGN KEY (prompt_entity_id) REFERENCES prompt_entity(id)
+);
+
+CREATE TABLE prompt_entity_description (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    prompt_entity_id BIGINT,
     description LONGTEXT,
     version INT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    CONSTRAINT fk_prompt_attribute_entity FOREIGN KEY (prompt_entity_id) REFERENCES prompt_entity(id)
+    CONSTRAINT fk_prompt_entity_description_entity FOREIGN KEY (prompt_entity_id) REFERENCES prompt_entity(id)
+);
+
+CREATE TABLE prompt_attribute_description (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    prompt_attribute_id BIGINT,
+    description LONGTEXT,
+    version INT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_prompt_attribute_description_attr FOREIGN KEY (prompt_attribute_id) REFERENCES prompt_attribute(id)
 );


### PR DESCRIPTION
## Summary
- split prompt attributes and entities into separate description tables
- expose system entities and prompt descriptions via new backend controllers
- add frontend flows for choosing entities and editing descriptions

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` (failed: Non-resolvable parent POM)
- `cd frontend && npm test` (failed: Minified React error #310)


------
https://chatgpt.com/codex/tasks/task_e_68aad493ebbc83218c19f599b11a4466