### PR TITLE
feat: manage versioned prompt descriptions

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -116,7 +116,7 @@ public class ChatGptClient {
         var attrs = attributeRepository.findByEntity_Name("hypothesis");
         var descriptions = attrs.stream()
                 .map(attr -> Map.entry(attr.getName(),
-                        descriptionRepository.findTopByAttribute_IdOrderByVersionDesc(attr.getId())
+                        descriptionRepository.findTopByAttribute_IdAndActiveTrueOrderByVersionDesc(attr.getId())
                                 .map(PromptAttributeDescription::getDescription)
                                 .orElse(null)))
                 .filter(e -> e.getValue() != null)

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptAttributeDescription.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptAttributeDescription.java
@@ -30,6 +30,9 @@ public class PromptAttributeDescription {
     @Column(nullable = false)
     private int version;
 
+    @Column(nullable = false)
+    private boolean active = true;
+
     @CreationTimestamp
     private Instant createdAt;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptEntityDescription.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptEntityDescription.java
@@ -30,6 +30,9 @@ public class PromptEntityDescription {
     @Column(nullable = false)
     private int version;
 
+    @Column(nullable = false)
+    private boolean active = true;
+
     @CreationTimestamp
     private Instant createdAt;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptAttributeDescriptionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptAttributeDescriptionRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface PromptAttributeDescriptionRepository extends JpaRepository<PromptAttributeDescription, Long> {
     Optional<PromptAttributeDescription> findTopByAttribute_IdOrderByVersionDesc(Long attributeId);
+
+    Optional<PromptAttributeDescription> findTopByAttribute_IdAndActiveTrueOrderByVersionDesc(Long attributeId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptEntityDescriptionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptEntityDescriptionRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface PromptEntityDescriptionRepository extends JpaRepository<PromptEntityDescription, Long> {
     Optional<PromptEntityDescription> findTopByEntity_NameOrderByVersionDesc(String entityName);
+
+    Optional<PromptEntityDescription> findTopByEntity_NameAndActiveTrueOrderByVersionDesc(String entityName);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptAttributeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptAttributeService.java
@@ -36,7 +36,7 @@ public class PromptAttributeService {
         List<PromptAttribute> attrs = attributeRepository.findByEntity_Name(entityName);
         return attrs.stream().map(attr -> {
             PromptAttributeDescription desc = descriptionRepository
-                    .findTopByAttribute_IdOrderByVersionDesc(attr.getId())
+                    .findTopByAttribute_IdAndActiveTrueOrderByVersionDesc(attr.getId())
                     .orElse(null);
             return mapper.toDto(attr, desc);
         }).toList();
@@ -51,6 +51,11 @@ public class PromptAttributeService {
                         .entity(entity)
                         .name(req.getName())
                         .build()));
+        descriptionRepository.findTopByAttribute_IdAndActiveTrueOrderByVersionDesc(attribute.getId())
+                .ifPresent(prev -> {
+                    prev.setActive(false);
+                    descriptionRepository.save(prev);
+                });
         int nextVersion = descriptionRepository
                 .findTopByAttribute_IdOrderByVersionDesc(attribute.getId())
                 .map(PromptAttributeDescription::getVersion)
@@ -59,6 +64,7 @@ public class PromptAttributeService {
                 .attribute(attribute)
                 .description(req.getDescription())
                 .version(nextVersion)
+                .active(true)
                 .build();
         descriptionRepository.save(desc);
         return mapper.toDto(attribute, desc);
@@ -69,7 +75,7 @@ public class PromptAttributeService {
                 .findByEntity_NameAndName(entityName, attrName)
                 .orElseThrow(() -> new EntityNotFoundException("PromptAttribute not found"));
         PromptAttributeDescription desc = descriptionRepository
-                .findTopByAttribute_IdOrderByVersionDesc(attribute.getId())
+                .findTopByAttribute_IdAndActiveTrueOrderByVersionDesc(attribute.getId())
                 .orElseThrow(() -> new EntityNotFoundException("PromptAttributeDescription not found"));
         return mapper.toDto(attribute, desc);
     }
@@ -83,6 +89,11 @@ public class PromptAttributeService {
                         .entity(entity)
                         .name(attrName)
                         .build()));
+        descriptionRepository.findTopByAttribute_IdAndActiveTrueOrderByVersionDesc(attribute.getId())
+                .ifPresent(prev -> {
+                    prev.setActive(false);
+                    descriptionRepository.save(prev);
+                });
         int nextVersion = descriptionRepository
                 .findTopByAttribute_IdOrderByVersionDesc(attribute.getId())
                 .map(PromptAttributeDescription::getVersion)
@@ -91,6 +102,7 @@ public class PromptAttributeService {
                 .attribute(attribute)
                 .description(req.getDescription())
                 .version(nextVersion)
+                .active(true)
                 .build();
         descriptionRepository.save(desc);
         return mapper.toDto(attribute, desc);

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptEntityDescriptionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptEntityDescriptionService.java
@@ -20,7 +20,7 @@ public class PromptEntityDescriptionService {
     }
 
     public PromptEntityDescriptionDto getLatest(String entityName) {
-        return descriptionRepository.findTopByEntity_NameOrderByVersionDesc(entityName)
+        return descriptionRepository.findTopByEntity_NameAndActiveTrueOrderByVersionDesc(entityName)
                 .map(desc -> {
                     PromptEntityDescriptionDto dto = new PromptEntityDescriptionDto();
                     dto.setDescription(desc.getDescription());
@@ -33,6 +33,11 @@ public class PromptEntityDescriptionService {
     public PromptEntityDescriptionDto update(String entityName, UpdatePromptEntityDescriptionRequest req) {
         PromptEntity entity = entityRepository.findByName(entityName)
                 .orElseGet(() -> entityRepository.save(PromptEntity.builder().name(entityName).build()));
+        descriptionRepository.findTopByEntity_NameAndActiveTrueOrderByVersionDesc(entityName)
+                .ifPresent(prev -> {
+                    prev.setActive(false);
+                    descriptionRepository.save(prev);
+                });
         int nextVersion = descriptionRepository.findTopByEntity_NameOrderByVersionDesc(entityName)
                 .map(PromptEntityDescription::getVersion)
                 .orElse(0) + 1;
@@ -40,6 +45,7 @@ public class PromptEntityDescriptionService {
                 .entity(entity)
                 .description(req.getDescription())
                 .version(nextVersion)
+                .active(true)
                 .build();
         descriptionRepository.save(desc);
         PromptEntityDescriptionDto dto = new PromptEntityDescriptionDto();

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_27__add_active_to_prompt_descriptions.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_27__add_active_to_prompt_descriptions.sql
@@ -1,0 +1,4 @@
+ALTER TABLE prompt_entity_description ADD COLUMN active BOOLEAN DEFAULT TRUE;
+ALTER TABLE prompt_attribute_description ADD COLUMN active BOOLEAN DEFAULT TRUE;
+UPDATE prompt_entity_description SET active = TRUE WHERE active IS NULL;
+UPDATE prompt_attribute_description SET active = TRUE WHERE active IS NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -70,3 +70,6 @@ databaseChangeLog:
   - include:
       file: V2025_09_26__relax_hypothesis_constraints.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_09_27__add_active_to_prompt_descriptions.sql
+      relativeToChangelogFile: true

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -230,6 +230,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `prompt_entity_id` BIGINT
 - `description` LONGTEXT
 - `version` INT
+- `active` BOOLEAN
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 
@@ -239,6 +240,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `prompt_attribute_id` BIGINT
 - `description` LONGTEXT
 - `version` INT
+- `active` BOOLEAN
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,7 @@ import NewChatDialogPage from "./pages/chatDialog/NewChatDialogPage";
 import PromptEntitiesPage from "./pages/prompt/PromptEntitiesPage";
 import PromptAttributesPage from "./pages/prompt/PromptAttributesPage";
 import NewPromptEntityPage from "./pages/prompt/NewPromptEntityPage";
+import PromptEntityDescriptionPage from "./pages/prompt/PromptEntityDescriptionPage";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
@@ -218,6 +219,10 @@ export default function App() {
         <Route path="/chat-dialogs/new" element={<NewChatDialogPage />} />
         <Route path="/prompt-entities" element={<PromptEntitiesPage />} />
         <Route path="/prompt-entities/new" element={<NewPromptEntityPage />} />
+        <Route
+          path="/prompt-entities/:entityName"
+          element={<PromptEntityDescriptionPage />}
+        />
         <Route
           path="/prompt-entities/:entityName/attributes"
           element={<PromptAttributesPage />}

--- a/frontend/src/pages/prompt/PromptAttributesPage.tsx
+++ b/frontend/src/pages/prompt/PromptAttributesPage.tsx
@@ -3,10 +3,16 @@ import { useParams } from "react-router-dom";
 import { usePromptAttributes } from "../../api/prompt/usePromptAttributes";
 import { useCreatePromptAttribute } from "../../api/prompt/useCreatePromptAttribute";
 import { useEntityAttributes } from "../../api/prompt/useEntityAttributes";
+import { useUpdatePromptAttribute } from "../../api/prompt/useUpdatePromptAttribute";
+import { useState } from "react";
 import PageTitle from "../../components/PageTitle";
 
 interface FormData {
   name: string;
+}
+
+interface EditFormData {
+  description: string;
 }
 
 export default function PromptAttributesPage() {
@@ -15,6 +21,10 @@ export default function PromptAttributesPage() {
   const create = useCreatePromptAttribute(entityName);
   const { data: entityAttrs } = useEntityAttributes(entityName);
   const { register, handleSubmit, reset } = useForm<FormData>();
+  const { register: registerEdit, handleSubmit: handleEdit, reset: resetEdit } =
+    useForm<EditFormData>();
+  const update = useUpdatePromptAttribute(entityName);
+  const [editing, setEditing] = useState<string | null>(null);
 
   const onSubmit = async (values: FormData) => {
     try {
@@ -25,6 +35,12 @@ export default function PromptAttributesPage() {
     }
   };
 
+  const onEdit = async (values: EditFormData) => {
+    if (!editing) return;
+    await update.mutateAsync({ name: editing, description: values.description });
+    setEditing(null);
+  };
+
   if (isLoading) return <p>Carregando...</p>;
 
   return (
@@ -33,8 +49,47 @@ export default function PromptAttributesPage() {
       <ul>
         {Array.isArray(data) &&
           data.map((a) => (
-            <li key={`${a.name}-${a.version}`}>
+            <li key={a.name} className="mb-3">
               <strong>{a.name}</strong>
+              {editing === a.name ? (
+                <form
+                  onSubmit={handleEdit(onEdit)}
+                  noValidate
+                  className="mt-2"
+                >
+                  <textarea
+                    className="form-control mb-2"
+                    {...registerEdit("description")}
+                  />
+                  <div className="d-flex justify-content-end">
+                    <button
+                      type="button"
+                      className="btn btn-primary btn-sm"
+                      onClick={handleEdit(onEdit, (errors) => {
+                        console.log("Validation errors", errors);
+                      })}
+                    >
+                      Salvar
+                    </button>
+                  </div>
+                </form>
+              ) : (
+                <>
+                  {a.description && (
+                    <div className="text-muted small">{a.description}</div>
+                  )}
+                  <button
+                    type="button"
+                    className="btn btn-link btn-sm"
+                    onClick={() => {
+                      setEditing(a.name);
+                      resetEdit({ description: a.description || "" });
+                    }}
+                  >
+                    Editar
+                  </button>
+                </>
+              )}
             </li>
           ))}
       </ul>

--- a/frontend/src/pages/prompt/PromptEntitiesPage.tsx
+++ b/frontend/src/pages/prompt/PromptEntitiesPage.tsx
@@ -1,21 +1,10 @@
 import { Link } from "react-router-dom";
-import axios from "axios";
 import { usePromptEntities } from "../../api/prompt/usePromptEntities";
-import { useUpdatePromptEntityDescription } from "../../api/prompt/useUpdatePromptEntityDescription";
 import PageTitle from "../../components/PageTitle";
 
 export default function PromptEntitiesPage() {
   const { data, isLoading } = usePromptEntities();
   const entities = Array.isArray(data) ? data : [];
-  const updateDesc = useUpdatePromptEntityDescription();
-
-  const handleEdit = async (name: string) => {
-    const { data } = await axios.get(`/api/prompt-entities/${name}/description`);
-    const description = window.prompt("Nova descrição", data?.description || "");
-    if (description) {
-      updateDesc.mutate({ entityName: name, description });
-    }
-  };
 
   if (isLoading) return <p>Carregando...</p>;
 
@@ -31,14 +20,13 @@ export default function PromptEntitiesPage() {
         <ul>
           {entities.map((e) => (
             <li key={e.id}>
-              <Link to={`/prompt-entities/${e.name}/attributes`}>{e.name}</Link>{" "}
-              <button
-                type="button"
+              <Link to={`/prompt-entities/${e.name}`}>{e.name}</Link>{" "}
+              <Link
+                to={`/prompt-entities/${e.name}/attributes`}
                 className="btn btn-link btn-sm"
-                onClick={() => handleEdit(e.name)}
               >
-                Descrição
-              </button>
+                Atributos
+              </Link>
             </li>
           ))}
         </ul>

--- a/frontend/src/pages/prompt/PromptEntityDescriptionPage.tsx
+++ b/frontend/src/pages/prompt/PromptEntityDescriptionPage.tsx
@@ -1,0 +1,61 @@
+import { Link, useParams } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { usePromptEntityDescription } from "../../api/prompt/usePromptEntityDescription";
+import { useUpdatePromptEntityDescription } from "../../api/prompt/useUpdatePromptEntityDescription";
+import PageTitle from "../../components/PageTitle";
+import { useEffect } from "react";
+
+interface FormData {
+  description: string;
+}
+
+export default function PromptEntityDescriptionPage() {
+  const { entityName = "" } = useParams<{ entityName: string }>();
+  const { data, isLoading } = usePromptEntityDescription(entityName);
+  const update = useUpdatePromptEntityDescription();
+  const { register, handleSubmit, reset } = useForm<FormData>({
+    defaultValues: { description: "" },
+  });
+
+  useEffect(() => {
+    reset({ description: data?.description || "" });
+  }, [data, reset]);
+
+  const onSubmit = async (values: FormData) => {
+    await update.mutateAsync({ entityName, description: values.description });
+  };
+
+  if (isLoading) return <p>Carregando...</p>;
+
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <PageTitle>{`Descrição de ${entityName}`}</PageTitle>
+      <p>{data?.description || "Sem descrição"}</p>
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="mt-3">
+        <label className="form-label" htmlFor="description">
+          Nova descrição
+        </label>
+        <textarea
+          id="description"
+          className="form-control mb-2"
+          {...register("description")}
+        />
+        <div className="mt-3 d-flex justify-content-end">
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={update.isPending}
+            onClick={handleSubmit(onSubmit, (errors) => {
+              console.log("Validation errors", errors);
+            })}
+          >
+            Salvar
+          </button>
+        </div>
+      </form>
+      <Link className="btn btn-link mt-3" to={`/prompt-entities/${entityName}/attributes`}>
+        Atributos
+      </Link>
+    </div>
+  );
+}

--- a/schema.sql
+++ b/schema.sql
@@ -224,6 +224,7 @@ CREATE TABLE prompt_entity_description (
     prompt_entity_id BIGINT,
     description LONGTEXT,
     version INT,
+    active BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_prompt_entity_description_entity FOREIGN KEY (prompt_entity_id) REFERENCES prompt_entity(id)
@@ -234,6 +235,7 @@ CREATE TABLE prompt_attribute_description (
     prompt_attribute_id BIGINT,
     description LONGTEXT,
     version INT,
+    active BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_prompt_attribute_description_attr FOREIGN KEY (prompt_attribute_id) REFERENCES prompt_attribute(id)


### PR DESCRIPTION
## Summary
- add active flag to prompt description tables and services
- allow updating entity and attribute descriptions via new UI
- update ChatGPT client to use active attribute descriptions

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml install` (fails: Non-resolvable parent POM)
- `cd ai-worker && mvn -s settings.xml package` (fails: Non-resolvable parent POM)
- `cd frontend && npm test`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac939e68208321b805b1b763ceaf8b