### PR TITLE
fix: split prompt description Liquibase SQL

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_27__add_active_to_prompt_descriptions.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_27__add_active_to_prompt_descriptions.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+--changeset raw:includeAll splitStatements:true
 ALTER TABLE prompt_entity_description ADD COLUMN active BOOLEAN DEFAULT TRUE;
 ALTER TABLE prompt_attribute_description ADD COLUMN active BOOLEAN DEFAULT TRUE;
 UPDATE prompt_entity_description SET active = TRUE WHERE active IS NULL;


### PR DESCRIPTION
## Summary
- ensure Liquibase treats prompt description migration as formatted SQL with explicit changeset

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac997901b88321aedc94880ac59ca4