### PR TITLE
Pass selected prompt entity code to attributes screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -220,11 +220,11 @@ export default function App() {
         <Route path="/prompt-entities" element={<PromptEntitiesPage />} />
         <Route path="/prompt-entities/new" element={<NewPromptEntityPage />} />
         <Route
-          path="/prompt-entities/:entityName"
+          path="/prompt-entities/:entityId"
           element={<PromptEntityDescriptionPage />}
         />
         <Route
-          path="/prompt-entities/:entityName/attributes"
+          path="/prompt-entities/:entityId/attributes"
           element={<PromptAttributesPage />}
         />
         <Route path="*" element={<div>Início</div>} />

--- a/frontend/src/api/prompt/useCreatePromptAttribute.ts
+++ b/frontend/src/api/prompt/useCreatePromptAttribute.ts
@@ -6,19 +6,19 @@ export interface CreatePromptAttribute {
   name: string;
 }
 
-export function useCreatePromptAttribute(entityName: string) {
+export function useCreatePromptAttribute(entityId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (data: CreatePromptAttribute) => {
       const { data: attr } = await axios.post<PromptAttribute>(
-        `/api/prompt-entities/${entityName}/attributes`,
+        `/api/prompt-entities/${entityId}/attributes`,
         data,
       );
       return attr;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["promptAttributes", entityName],
+        queryKey: ["promptAttributes", entityId],
       });
       queryClient.invalidateQueries({ queryKey: ["promptEntities"] });
     },

--- a/frontend/src/api/prompt/useEntityAttributes.ts
+++ b/frontend/src/api/prompt/useEntityAttributes.ts
@@ -1,11 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 
-export function useEntityAttributes(entityName: string) {
+export function useEntityAttributes(entityId: string) {
   return useQuery({
-    queryKey: ["entityAttributes", entityName],
+    queryKey: ["entityAttributes", entityId],
     queryFn: async () => {
-      const { data } = await axios.get<string[]>(`/api/entities/${entityName}/attributes`);
+      const { data } = await axios.get<string[]>(`/api/entities/${entityId}/attributes`);
       return data;
     },
   });

--- a/frontend/src/api/prompt/usePromptAttributes.ts
+++ b/frontend/src/api/prompt/usePromptAttributes.ts
@@ -7,12 +7,12 @@ export interface PromptAttribute {
   version: number;
 }
 
-export function usePromptAttributes(entityName: string) {
+export function usePromptAttributes(entityId: string) {
   return useQuery({
-    queryKey: ["promptAttributes", entityName],
+    queryKey: ["promptAttributes", entityId],
     queryFn: async () => {
       const { data } = await axios.get<PromptAttribute[]>(
-        `/api/prompt-entities/${entityName}/attributes`,
+        `/api/prompt-entities/${entityId}/attributes`,
       );
       return data;
     },

--- a/frontend/src/api/prompt/usePromptEntity.ts
+++ b/frontend/src/api/prompt/usePromptEntity.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { PromptEntity } from "./usePromptEntities";
+
+export function usePromptEntity(entityId: string) {
+  return useQuery({
+    queryKey: ["promptEntity", entityId],
+    queryFn: async () => {
+      const { data } = await axios.get<PromptEntity>(
+        `/api/prompt-entities/${entityId}`,
+      );
+      return data;
+    },
+    enabled: !!entityId,
+  });
+}

--- a/frontend/src/api/prompt/usePromptEntityDescription.ts
+++ b/frontend/src/api/prompt/usePromptEntityDescription.ts
@@ -6,12 +6,12 @@ export interface PromptEntityDescription {
   version: number;
 }
 
-export function usePromptEntityDescription(entityName: string) {
+export function usePromptEntityDescription(entityId: string) {
   return useQuery({
-    queryKey: ["promptEntityDescription", entityName],
+    queryKey: ["promptEntityDescription", entityId],
     queryFn: async () => {
       const { data } = await axios.get<PromptEntityDescription>(
-        `/api/prompt-entities/${entityName}/description`,
+        `/api/prompt-entities/${entityId}/description`,
       );
       return data;
     },

--- a/frontend/src/api/prompt/useUpdatePromptAttribute.ts
+++ b/frontend/src/api/prompt/useUpdatePromptAttribute.ts
@@ -6,18 +6,18 @@ interface UpdateRequest {
   description: string;
 }
 
-export function useUpdatePromptAttribute(entityName: string) {
+export function useUpdatePromptAttribute(entityId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({ name, description }: UpdateRequest) => {
       const { data } = await axios.put(
-        `/api/prompt-entities/${entityName}/attributes/${name}`,
+        `/api/prompt-entities/${entityId}/attributes/${name}`,
         { description },
       );
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["promptAttributes", entityName] });
+      queryClient.invalidateQueries({ queryKey: ["promptAttributes", entityId] });
     },
   });
 }

--- a/frontend/src/api/prompt/useUpdatePromptEntityDescription.ts
+++ b/frontend/src/api/prompt/useUpdatePromptEntityDescription.ts
@@ -2,16 +2,16 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 
 interface UpdateRequest {
-  entityName: string;
+  entityId: string;
   description: string;
 }
 
 export function useUpdatePromptEntityDescription() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ entityName, description }: UpdateRequest) => {
+    mutationFn: async ({ entityId, description }: UpdateRequest) => {
       const { data } = await axios.put(
-        `/api/prompt-entities/${entityName}/description`,
+        `/api/prompt-entities/${entityId}/description`,
         { description },
       );
       return data;
@@ -19,7 +19,7 @@ export function useUpdatePromptEntityDescription() {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ["promptEntities"] });
       queryClient.invalidateQueries({
-        queryKey: ["promptEntityDescription", variables.entityName],
+        queryKey: ["promptEntityDescription", variables.entityId],
       });
     },
   });

--- a/frontend/src/pages/prompt/NewPromptEntityPage.tsx
+++ b/frontend/src/pages/prompt/NewPromptEntityPage.tsx
@@ -18,7 +18,7 @@ export default function NewPromptEntityPage() {
     try {
       const entity = await create.mutateAsync(values);
       reset();
-      navigate(`/prompt-entities/${entity.name}/attributes`);
+      navigate(`/prompt-entities/${entity.id}/attributes`);
     } catch {
       alert("Erro ao criar entidade");
     }

--- a/frontend/src/pages/prompt/PromptAttributesPage.tsx
+++ b/frontend/src/pages/prompt/PromptAttributesPage.tsx
@@ -4,6 +4,7 @@ import { usePromptAttributes } from "../../api/prompt/usePromptAttributes";
 import { useCreatePromptAttribute } from "../../api/prompt/useCreatePromptAttribute";
 import { useEntityAttributes } from "../../api/prompt/useEntityAttributes";
 import { useUpdatePromptAttribute } from "../../api/prompt/useUpdatePromptAttribute";
+import { usePromptEntity } from "../../api/prompt/usePromptEntity";
 import { useState } from "react";
 import PageTitle from "../../components/PageTitle";
 
@@ -16,14 +17,15 @@ interface EditFormData {
 }
 
 export default function PromptAttributesPage() {
-  const { entityName = "" } = useParams<{ entityName: string }>();
-  const { data, isLoading } = usePromptAttributes(entityName);
-  const create = useCreatePromptAttribute(entityName);
-  const { data: entityAttrs } = useEntityAttributes(entityName);
+  const { entityId = "" } = useParams<{ entityId: string }>();
+  const { data: entity } = usePromptEntity(entityId);
+  const { data, isLoading } = usePromptAttributes(entityId);
+  const create = useCreatePromptAttribute(entityId);
+  const { data: entityAttrs } = useEntityAttributes(entityId);
   const { register, handleSubmit, reset } = useForm<FormData>();
   const { register: registerEdit, handleSubmit: handleEdit, reset: resetEdit } =
     useForm<EditFormData>();
-  const update = useUpdatePromptAttribute(entityName);
+  const update = useUpdatePromptAttribute(entityId);
   const [editing, setEditing] = useState<string | null>(null);
 
   const onSubmit = async (values: FormData) => {
@@ -45,7 +47,7 @@ export default function PromptAttributesPage() {
 
   return (
     <div style={{ maxWidth: 480 }}>
-      <PageTitle>{`Atributos de ${entityName}`}</PageTitle>
+      <PageTitle>{`Atributos de ${entity?.name || ""}`}</PageTitle>
       <ul>
         {Array.isArray(data) &&
           data.map((a) => (

--- a/frontend/src/pages/prompt/PromptEntitiesPage.tsx
+++ b/frontend/src/pages/prompt/PromptEntitiesPage.tsx
@@ -20,9 +20,12 @@ export default function PromptEntitiesPage() {
         <ul>
           {entities.map((e) => (
             <li key={e.id}>
-              <Link to={`/prompt-entities/${e.name}`}>{e.name}</Link>{" "}
+              <Link to={`/prompt-entities/${e.id}`} state={{ name: e.name }}>
+                {e.name}
+              </Link>{" "}
               <Link
-                to={`/prompt-entities/${e.name}/attributes`}
+                to={`/prompt-entities/${e.id}/attributes`}
+                state={{ name: e.name }}
                 className="btn btn-link btn-sm"
               >
                 Atributos

--- a/frontend/src/pages/prompt/PromptEntityDescriptionPage.tsx
+++ b/frontend/src/pages/prompt/PromptEntityDescriptionPage.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { usePromptEntityDescription } from "../../api/prompt/usePromptEntityDescription";
 import { useUpdatePromptEntityDescription } from "../../api/prompt/useUpdatePromptEntityDescription";
+import { usePromptEntity } from "../../api/prompt/usePromptEntity";
 import PageTitle from "../../components/PageTitle";
 import { useEffect } from "react";
 
@@ -10,8 +11,9 @@ interface FormData {
 }
 
 export default function PromptEntityDescriptionPage() {
-  const { entityName = "" } = useParams<{ entityName: string }>();
-  const { data, isLoading } = usePromptEntityDescription(entityName);
+  const { entityId = "" } = useParams<{ entityId: string }>();
+  const { data: entity } = usePromptEntity(entityId);
+  const { data, isLoading } = usePromptEntityDescription(entityId);
   const update = useUpdatePromptEntityDescription();
   const { register, handleSubmit, reset } = useForm<FormData>({
     defaultValues: { description: "" },
@@ -22,14 +24,14 @@ export default function PromptEntityDescriptionPage() {
   }, [data, reset]);
 
   const onSubmit = async (values: FormData) => {
-    await update.mutateAsync({ entityName, description: values.description });
+    await update.mutateAsync({ entityId, description: values.description });
   };
 
   if (isLoading) return <p>Carregando...</p>;
 
   return (
     <div style={{ maxWidth: 480 }}>
-      <PageTitle>{`Descrição de ${entityName}`}</PageTitle>
+      <PageTitle>{`Descrição de ${entity?.name || ""}`}</PageTitle>
       <p>{data?.description || "Sem descrição"}</p>
       <form onSubmit={handleSubmit(onSubmit)} noValidate className="mt-3">
         <label className="form-label" htmlFor="description">
@@ -53,7 +55,10 @@ export default function PromptEntityDescriptionPage() {
           </button>
         </div>
       </form>
-      <Link className="btn btn-link mt-3" to={`/prompt-entities/${entityName}/attributes`}>
+      <Link
+        className="btn btn-link mt-3"
+        to={`/prompt-entities/${entityId}/attributes`}
+      >
         Atributos
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- use entity IDs in prompt entity routes
- load prompt entity details by ID and show related attributes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac9ec8380c83218307131be6dc3346