### PR TITLE
Fix prompt attribute lookup by entity name

### DIFF
--- a/frontend/src/api/prompt/useCreatePromptAttribute.ts
+++ b/frontend/src/api/prompt/useCreatePromptAttribute.ts
@@ -6,19 +6,19 @@ export interface CreatePromptAttribute {
   name: string;
 }
 
-export function useCreatePromptAttribute(entityId: string) {
+export function useCreatePromptAttribute(entityName: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (data: CreatePromptAttribute) => {
       const { data: attr } = await axios.post<PromptAttribute>(
-        `/api/prompt-entities/${entityId}/attributes`,
+        `/api/prompt-entities/${entityName}/attributes`,
         data,
       );
       return attr;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["promptAttributes", entityId],
+        queryKey: ["promptAttributes", entityName],
       });
       queryClient.invalidateQueries({ queryKey: ["promptEntities"] });
     },

--- a/frontend/src/api/prompt/useEntityAttributes.ts
+++ b/frontend/src/api/prompt/useEntityAttributes.ts
@@ -1,12 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 
-export function useEntityAttributes(entityId: string) {
+export function useEntityAttributes(entityName: string) {
   return useQuery({
-    queryKey: ["entityAttributes", entityId],
+    queryKey: ["entityAttributes", entityName],
     queryFn: async () => {
-      const { data } = await axios.get<string[]>(`/api/entities/${entityId}/attributes`);
+      const { data } = await axios.get<string[]>(
+        `/api/entities/${entityName}/attributes`,
+      );
       return data;
     },
+    enabled: !!entityName,
   });
 }

--- a/frontend/src/api/prompt/usePromptAttributes.ts
+++ b/frontend/src/api/prompt/usePromptAttributes.ts
@@ -7,14 +7,15 @@ export interface PromptAttribute {
   version: number;
 }
 
-export function usePromptAttributes(entityId: string) {
+export function usePromptAttributes(entityName: string) {
   return useQuery({
-    queryKey: ["promptAttributes", entityId],
+    queryKey: ["promptAttributes", entityName],
     queryFn: async () => {
       const { data } = await axios.get<PromptAttribute[]>(
-        `/api/prompt-entities/${entityId}/attributes`,
+        `/api/prompt-entities/${entityName}/attributes`,
       );
       return data;
     },
+    enabled: !!entityName,
   });
 }

--- a/frontend/src/api/prompt/useUpdatePromptAttribute.ts
+++ b/frontend/src/api/prompt/useUpdatePromptAttribute.ts
@@ -6,18 +6,20 @@ interface UpdateRequest {
   description: string;
 }
 
-export function useUpdatePromptAttribute(entityId: string) {
+export function useUpdatePromptAttribute(entityName: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({ name, description }: UpdateRequest) => {
       const { data } = await axios.put(
-        `/api/prompt-entities/${entityId}/attributes/${name}`,
+        `/api/prompt-entities/${entityName}/attributes/${name}`,
         { description },
       );
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["promptAttributes", entityId] });
+      queryClient.invalidateQueries({
+        queryKey: ["promptAttributes", entityName],
+      });
     },
   });
 }

--- a/frontend/src/pages/prompt/PromptAttributesPage.tsx
+++ b/frontend/src/pages/prompt/PromptAttributesPage.tsx
@@ -19,13 +19,17 @@ interface EditFormData {
 export default function PromptAttributesPage() {
   const { entityId = "" } = useParams<{ entityId: string }>();
   const { data: entity } = usePromptEntity(entityId);
-  const { data, isLoading } = usePromptAttributes(entityId);
-  const create = useCreatePromptAttribute(entityId);
-  const { data: entityAttrs } = useEntityAttributes(entityId);
+  const entityName = entity?.name ?? "";
+  const { data, isLoading } = usePromptAttributes(entityName);
+  const create = useCreatePromptAttribute(entityName);
+  const { data: entityAttrs } = useEntityAttributes(entityName);
   const { register, handleSubmit, reset } = useForm<FormData>();
-  const { register: registerEdit, handleSubmit: handleEdit, reset: resetEdit } =
-    useForm<EditFormData>();
-  const update = useUpdatePromptAttribute(entityId);
+  const {
+    register: registerEdit,
+    handleSubmit: handleEdit,
+    reset: resetEdit,
+  } = useForm<EditFormData>();
+  const update = useUpdatePromptAttribute(entityName);
   const [editing, setEditing] = useState<string | null>(null);
 
   const onSubmit = async (values: FormData) => {
@@ -39,11 +43,14 @@ export default function PromptAttributesPage() {
 
   const onEdit = async (values: EditFormData) => {
     if (!editing) return;
-    await update.mutateAsync({ name: editing, description: values.description });
+    await update.mutateAsync({
+      name: editing,
+      description: values.description,
+    });
     setEditing(null);
   };
 
-  if (isLoading) return <p>Carregando...</p>;
+  if (!entityName || isLoading) return <p>Carregando...</p>;
 
   return (
     <div style={{ maxWidth: 480 }}>
@@ -54,11 +61,7 @@ export default function PromptAttributesPage() {
             <li key={a.name} className="mb-3">
               <strong>{a.name}</strong>
               {editing === a.name ? (
-                <form
-                  onSubmit={handleEdit(onEdit)}
-                  noValidate
-                  className="mt-2"
-                >
+                <form onSubmit={handleEdit(onEdit)} noValidate className="mt-2">
                   <textarea
                     className="form-control mb-2"
                     {...registerEdit("description")}
@@ -99,7 +102,7 @@ export default function PromptAttributesPage() {
         <label className="form-label" htmlFor="name">
           Nome
         </label>
-        <select id="name" className="form-control mb-2" {...register("name")}> 
+        <select id="name" className="form-control mb-2" {...register("name")}>
           <option value="">Selecione o atributo</option>
           {entityAttrs?.map((attr) => (
             <option key={attr} value={attr}>


### PR DESCRIPTION
## Summary
- retrieve prompt attributes using entity name instead of id
- populate new attribute list with table column names

## Testing
- `npm run build`
- `npm run test` *(fails: watch mode cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68aca7e6ab688321b645a619b8e1a22d