### PR TITLE
chore: drop prompt table version columns

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_28__drop_version_from_prompt_tables.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_28__drop_version_from_prompt_tables.sql
@@ -1,0 +1,20 @@
+-- liquibase formatted sql
+-- changeset marketinghub:2025-09-28-drop-version-prompt_entity
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prompt_entity' AND COLUMN_NAME = 'version';
+ALTER TABLE prompt_entity DROP COLUMN version;
+
+-- changeset marketinghub:2025-09-28-drop-version-prompt_attribute
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prompt_attribute' AND COLUMN_NAME = 'version';
+ALTER TABLE prompt_attribute DROP COLUMN version;
+
+-- changeset marketinghub:2025-09-28-drop-version-prompt_entity_description
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prompt_entity_description' AND COLUMN_NAME = 'version';
+ALTER TABLE prompt_entity_description DROP COLUMN version;
+
+-- changeset marketinghub:2025-09-28-drop-version-prompt_attribute_description
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prompt_attribute_description' AND COLUMN_NAME = 'version';
+ALTER TABLE prompt_attribute_description DROP COLUMN version;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -73,3 +73,7 @@ databaseChangeLog:
   - include:
       file: V2025_09_27__add_active_to_prompt_descriptions.sql
       relativeToChangelogFile: true
+
+  - include:
+      file: V2025_09_28__drop_version_from_prompt_tables.sql
+      relativeToChangelogFile: true


### PR DESCRIPTION
## Summary
- drop legacy version columns from prompt-related tables to prevent insert failures
- register migration in Liquibase changelog

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acbd98abe48321930f0f1dcff0d9c8