### PR TITLE
Display and edit descriptions for all prompt entity attributes

### DIFF
--- a/frontend/src/pages/prompt/PromptAttributesPage.tsx
+++ b/frontend/src/pages/prompt/PromptAttributesPage.tsx
@@ -1,16 +1,11 @@
 import { useForm } from "react-hook-form";
 import { useParams } from "react-router-dom";
 import { usePromptAttributes } from "../../api/prompt/usePromptAttributes";
-import { useCreatePromptAttribute } from "../../api/prompt/useCreatePromptAttribute";
 import { useEntityAttributes } from "../../api/prompt/useEntityAttributes";
 import { useUpdatePromptAttribute } from "../../api/prompt/useUpdatePromptAttribute";
 import { usePromptEntity } from "../../api/prompt/usePromptEntity";
 import { useState } from "react";
 import PageTitle from "../../components/PageTitle";
-
-interface FormData {
-  name: string;
-}
 
 interface EditFormData {
   description: string;
@@ -20,10 +15,9 @@ export default function PromptAttributesPage() {
   const { entityId = "" } = useParams<{ entityId: string }>();
   const { data: entity } = usePromptEntity(entityId);
   const entityName = entity?.name ?? "";
-  const { data, isLoading } = usePromptAttributes(entityName);
-  const create = useCreatePromptAttribute(entityName);
-  const { data: entityAttrs } = useEntityAttributes(entityName);
-  const { register, handleSubmit, reset } = useForm<FormData>();
+  const { data: promptAttrs, isLoading } = usePromptAttributes(entityName);
+  const { data: entityAttrs, isLoading: loadingAttrs } =
+    useEntityAttributes(entityName);
   const {
     register: registerEdit,
     handleSubmit: handleEdit,
@@ -31,15 +25,6 @@ export default function PromptAttributesPage() {
   } = useForm<EditFormData>();
   const update = useUpdatePromptAttribute(entityName);
   const [editing, setEditing] = useState<string | null>(null);
-
-  const onSubmit = async (values: FormData) => {
-    try {
-      await create.mutateAsync({ name: values.name });
-      reset({ name: "" });
-    } catch {
-      alert("Erro ao salvar atributo");
-    }
-  };
 
   const onEdit = async (values: EditFormData) => {
     if (!editing) return;
@@ -50,79 +35,60 @@ export default function PromptAttributesPage() {
     setEditing(null);
   };
 
-  if (!entityName || isLoading) return <p>Carregando...</p>;
+  if (!entityName || isLoading || loadingAttrs) return <p>Carregando...</p>;
+
+  const attributes = (entityAttrs ?? []).map((attr) => ({
+    name: attr,
+    description: promptAttrs?.find((a) => a.name === attr)?.description || "",
+  }));
 
   return (
     <div style={{ maxWidth: 480 }}>
       <PageTitle>{`Atributos de ${entity?.name || ""}`}</PageTitle>
       <ul>
-        {Array.isArray(data) &&
-          data.map((a) => (
-            <li key={a.name} className="mb-3">
-              <strong>{a.name}</strong>
-              {editing === a.name ? (
-                <form onSubmit={handleEdit(onEdit)} noValidate className="mt-2">
-                  <textarea
-                    className="form-control mb-2"
-                    {...registerEdit("description")}
-                  />
-                  <div className="d-flex justify-content-end">
-                    <button
-                      type="button"
-                      className="btn btn-primary btn-sm"
-                      onClick={handleEdit(onEdit, (errors) => {
-                        console.log("Validation errors", errors);
-                      })}
-                    >
-                      Salvar
-                    </button>
-                  </div>
-                </form>
-              ) : (
-                <>
-                  {a.description && (
-                    <div className="text-muted small">{a.description}</div>
-                  )}
+        {attributes.map((a) => (
+          <li key={a.name} className="mb-3">
+            <strong>{a.name}</strong>
+            {editing === a.name ? (
+              <form onSubmit={handleEdit(onEdit)} noValidate className="mt-2">
+                <textarea
+                  className="form-control mb-2"
+                  {...registerEdit("description")}
+                />
+                <div className="d-flex justify-content-end">
                   <button
                     type="button"
-                    className="btn btn-link btn-sm"
-                    onClick={() => {
-                      setEditing(a.name);
-                      resetEdit({ description: a.description || "" });
-                    }}
+                    className="btn btn-primary btn-sm"
+                    onClick={handleEdit(onEdit, (errors) => {
+                      console.log("Validation errors", errors);
+                    })}
                   >
-                    Editar
+                    Salvar
                   </button>
-                </>
-              )}
-            </li>
-          ))}
+                </div>
+              </form>
+            ) : (
+              <>
+                {a.description ? (
+                  <div className="text-muted small">{a.description}</div>
+                ) : (
+                  <div className="text-muted small">Sem descrição</div>
+                )}
+                <button
+                  type="button"
+                  className="btn btn-link btn-sm"
+                  onClick={() => {
+                    setEditing(a.name);
+                    resetEdit({ description: a.description || "" });
+                  }}
+                >
+                  {a.description ? "Editar" : "Adicionar"}
+                </button>
+              </>
+            )}
+          </li>
+        ))}
       </ul>
-      <form onSubmit={handleSubmit(onSubmit)} noValidate className="mt-3">
-        <label className="form-label" htmlFor="name">
-          Nome
-        </label>
-        <select id="name" className="form-control mb-2" {...register("name")}>
-          <option value="">Selecione o atributo</option>
-          {entityAttrs?.map((attr) => (
-            <option key={attr} value={attr}>
-              {attr}
-            </option>
-          ))}
-        </select>
-        <div className="mt-3 d-flex justify-content-end">
-          <button
-            type="button"
-            className="btn btn-primary"
-            disabled={create.isPending}
-            onClick={handleSubmit(onSubmit, (errors) => {
-              console.log("Validation errors", errors);
-            })}
-          >
-            Salvar
-          </button>
-        </div>
-      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- list all entity attributes with their current prompt descriptions
- allow adding or editing each attribute's description

## Testing
- `cd frontend && npm run test -- --run`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acc684cca0832184eb73388ec11e23