### PR TITLE
Restrict prompt attribute descriptions to registered attributes

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptAttributeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptAttributeService.java
@@ -2,14 +2,12 @@ package com.marketinghub.prompt.service;
 
 import com.marketinghub.prompt.PromptAttribute;
 import com.marketinghub.prompt.PromptAttributeDescription;
-import com.marketinghub.prompt.PromptEntity;
 import com.marketinghub.prompt.dto.CreatePromptAttributeRequest;
 import com.marketinghub.prompt.dto.PromptAttributeDto;
 import com.marketinghub.prompt.dto.UpdatePromptAttributeRequest;
 import com.marketinghub.prompt.mapper.PromptAttributeMapper;
 import com.marketinghub.prompt.repository.PromptAttributeDescriptionRepository;
 import com.marketinghub.prompt.repository.PromptAttributeRepository;
-import com.marketinghub.prompt.repository.PromptEntityRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
@@ -19,16 +17,13 @@ import java.util.List;
 public class PromptAttributeService {
     private final PromptAttributeRepository attributeRepository;
     private final PromptAttributeDescriptionRepository descriptionRepository;
-    private final PromptEntityRepository entityRepository;
     private final PromptAttributeMapper mapper;
 
     public PromptAttributeService(PromptAttributeRepository attributeRepository,
                                   PromptAttributeDescriptionRepository descriptionRepository,
-                                  PromptEntityRepository entityRepository,
                                   PromptAttributeMapper mapper) {
         this.attributeRepository = attributeRepository;
         this.descriptionRepository = descriptionRepository;
-        this.entityRepository = entityRepository;
         this.mapper = mapper;
     }
 
@@ -43,14 +38,9 @@ public class PromptAttributeService {
     }
 
     public PromptAttributeDto create(String entityName, CreatePromptAttributeRequest req) {
-        PromptEntity entity = entityRepository.findByName(entityName)
-                .orElseGet(() -> entityRepository.save(PromptEntity.builder().name(entityName).build()));
         PromptAttribute attribute = attributeRepository
                 .findByEntity_NameAndName(entityName, req.getName())
-                .orElseGet(() -> attributeRepository.save(PromptAttribute.builder()
-                        .entity(entity)
-                        .name(req.getName())
-                        .build()));
+                .orElseThrow(() -> new EntityNotFoundException("PromptAttribute not found"));
         descriptionRepository.findByAttribute_IdAndActiveTrue(attribute.getId())
                 .ifPresent(prev -> {
                     prev.setActive(false);
@@ -76,14 +66,9 @@ public class PromptAttributeService {
     }
 
     public PromptAttributeDto update(String entityName, String attrName, UpdatePromptAttributeRequest req) {
-        PromptEntity entity = entityRepository.findByName(entityName)
-                .orElseGet(() -> entityRepository.save(PromptEntity.builder().name(entityName).build()));
         PromptAttribute attribute = attributeRepository
                 .findByEntity_NameAndName(entityName, attrName)
-                .orElseGet(() -> attributeRepository.save(PromptAttribute.builder()
-                        .entity(entity)
-                        .name(attrName)
-                        .build()));
+                .orElseThrow(() -> new EntityNotFoundException("PromptAttribute not found"));
         descriptionRepository.findByAttribute_IdAndActiveTrue(attribute.getId())
                 .ifPresent(prev -> {
                     prev.setActive(false);

--- a/frontend/src/pages/prompt/PromptAttributesPage.tsx
+++ b/frontend/src/pages/prompt/PromptAttributesPage.tsx
@@ -1,7 +1,6 @@
 import { useForm } from "react-hook-form";
 import { useParams } from "react-router-dom";
 import { usePromptAttributes } from "../../api/prompt/usePromptAttributes";
-import { useEntityAttributes } from "../../api/prompt/useEntityAttributes";
 import { useUpdatePromptAttribute } from "../../api/prompt/useUpdatePromptAttribute";
 import { usePromptEntity } from "../../api/prompt/usePromptEntity";
 import { useState } from "react";
@@ -16,8 +15,6 @@ export default function PromptAttributesPage() {
   const { data: entity } = usePromptEntity(entityId);
   const entityName = entity?.name ?? "";
   const { data: promptAttrs, isLoading } = usePromptAttributes(entityName);
-  const { data: entityAttrs, isLoading: loadingAttrs } =
-    useEntityAttributes(entityName);
   const {
     register: registerEdit,
     handleSubmit: handleEdit,
@@ -35,12 +32,9 @@ export default function PromptAttributesPage() {
     setEditing(null);
   };
 
-  if (!entityName || isLoading || loadingAttrs) return <p>Carregando...</p>;
+  if (!entityName || isLoading) return <p>Carregando...</p>;
 
-  const attributes = (entityAttrs ?? []).map((attr) => ({
-    name: attr,
-    description: promptAttrs?.find((a) => a.name === attr)?.description || "",
-  }));
+  const attributes = promptAttrs ?? [];
 
   return (
     <div style={{ maxWidth: 480 }}>


### PR DESCRIPTION
## Summary
- Disallow creation of prompt attribute descriptions for unregistered attributes in backend service
- Show only registered prompt attributes on attribute description page

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to github: Network is unreachable)*
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acf16dea2c83218d84af3a00c38bcd