### PR TITLE
Link hypotheses to prompt attribute descriptions

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -48,16 +48,16 @@ public class ChatGptClient {
     }
 
     public List<CreateHypothesisRequest> generateHypotheses(MarketNiche niche, int quantity) {
-        String prompt = buildPrompt(niche, quantity);
+        PromptData promptData = buildPrompt(niche, quantity);
         Map<String, Object> payload = Map.of(
                 "model", model,
                 "messages", List.of(
                         Map.of("role", "system", "content", "Você é um especialista em marketing."),
-                        Map.of("role", "user", "content", prompt)
+                        Map.of("role", "user", "content", promptData.prompt())
                 )
         );
 
-        log.info("Sending prompt to ChatGPT for niche {}: {}", niche.getId(), prompt);
+        log.info("Sending prompt to ChatGPT for niche {}: {}", niche.getId(), promptData.prompt());
         log.debug("ChatGPT payload: {}", payload);
 
         ChatCompletionResponse response = webClient.post()
@@ -76,14 +76,14 @@ public class ChatGptClient {
         String content = response.choices().get(0).message().content();
         log.info("ChatGPT content: {}", content);
         try {
-            List<CreateHypothesisRequest> parsed = parseContent(content, niche, prompt);
+            List<CreateHypothesisRequest> parsed = parseContent(content, niche, promptData);
             log.info("Parsed hypotheses: {}", parsed);
             return parsed;
         } catch (Exception e) {
             log.error("Failed to parse ChatGPT response: {}", content, e);
             try {
                 String unescaped = objectMapper.readValue("\"" + content + "\"", String.class);
-                List<CreateHypothesisRequest> parsed = parseContent(unescaped, niche, prompt);
+                List<CreateHypothesisRequest> parsed = parseContent(unescaped, niche, promptData);
                 log.info("Parsed hypotheses: {}", parsed);
                 return parsed;
             } catch (Exception ex) {
@@ -93,7 +93,7 @@ public class ChatGptClient {
         }
     }
 
-    private String buildPrompt(MarketNiche niche, int quantity) {
+    private PromptData buildPrompt(MarketNiche niche, int quantity) {
         StringBuilder sb = new StringBuilder();
         sb.append("Gere ").append(quantity).append(" hipóteses em formato JSON. ");
         sb.append("Use o seguinte nicho como contexto:\n");
@@ -114,11 +114,13 @@ public class ChatGptClient {
             sb.append("Dicas extras: ").append(niche.getExtraTips()).append("\n");
         }
         var attrs = attributeRepository.findByEntity_Name("hypothesis");
+        var descriptionIds = new java.util.ArrayList<Long>();
         var descriptions = attrs.stream()
-                .map(attr -> Map.entry(attr.getName(),
-                        descriptionRepository.findByAttribute_IdAndActiveTrue(attr.getId())
-                                .map(PromptAttributeDescription::getDescription)
-                                .orElse(null)))
+                .map(attr -> {
+                    var opt = descriptionRepository.findByAttribute_IdAndActiveTrue(attr.getId());
+                    opt.ifPresent(d -> descriptionIds.add(d.getId()));
+                    return Map.entry(attr.getName(), opt.map(PromptAttributeDescription::getDescription).orElse(null));
+                })
                 .filter(e -> e.getValue() != null)
                 .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         if (!descriptions.isEmpty()) {
@@ -134,20 +136,23 @@ public class ChatGptClient {
         sb.append("O campo \"offerType\" deve ser \"LEAD\" ou \"TRIPWIRE\". ");
         sb.append("O campo \"price\" deve ser um número. ");
         sb.append("Retorne apenas um array JSON com esses objetos, sem texto adicional.");
-        return sb.toString();
+        return new PromptData(sb.toString(), descriptionIds);
     }
 
     private record ChatCompletionResponse(List<Choice> choices) {}
     private record Choice(Message message) {}
     private record Message(String content) {}
 
-    private List<CreateHypothesisRequest> parseContent(String content, MarketNiche niche, String prompt) throws Exception {
+    private List<CreateHypothesisRequest> parseContent(String content, MarketNiche niche, PromptData data) throws Exception {
         CreateHypothesisRequest[] arr = objectMapper.readValue(content, CreateHypothesisRequest[].class);
         for (CreateHypothesisRequest req : arr) {
             req.setMarketNicheId(niche.getId());
-            req.setPrompt(prompt);
+            req.setPrompt(data.prompt());
             req.setModel(model);
+            req.setPromptAttributeDescriptionIds(data.descriptionIds());
         }
         return Arrays.asList(arr);
     }
+
+    private record PromptData(String prompt, List<Long> descriptionIds) {}
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -4,6 +4,12 @@ import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.prompt.PromptAttribute;
+import com.marketinghub.prompt.PromptAttributeDescription;
+import com.marketinghub.prompt.PromptEntity;
+import com.marketinghub.prompt.repository.PromptAttributeDescriptionRepository;
+import com.marketinghub.prompt.repository.PromptAttributeRepository;
+import com.marketinghub.prompt.repository.PromptEntityRepository;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +46,12 @@ class NicheHypothesisServiceTest {
 
     @Autowired
     HypothesisRepository hypothesisRepository;
+    @Autowired
+    PromptEntityRepository entityRepository;
+    @Autowired
+    PromptAttributeRepository attributeRepository;
+    @Autowired
+    PromptAttributeDescriptionRepository descriptionRepository;
 
     @Value("${openai.model}")
     String model;
@@ -64,7 +76,11 @@ class NicheHypothesisServiceTest {
     }
 
     @Test
+    @org.springframework.transaction.annotation.Transactional
     void generateHypothesesForNiches() {
+        PromptEntity entity = entityRepository.save(PromptEntity.builder().name("hypothesis").build());
+        PromptAttribute attr = attributeRepository.save(PromptAttribute.builder().entity(entity).name("title").build());
+        PromptAttributeDescription desc = descriptionRepository.save(PromptAttributeDescription.builder().attribute(attr).description("d").build());
         MarketNiche niche = MarketNiche.builder()
                 .name("Saúde")
                 .hypothesesToGenerate(2)
@@ -106,6 +122,7 @@ class NicheHypothesisServiceTest {
         // Access the field via reflection since older ads-service builds may lack the getter
         assertThat(org.springframework.test.util.ReflectionTestUtils.getField(first, "generatedAt"))
                 .isNotNull();
+        assertThat(first.getPromptAttributeDescriptions()).extracting(PromptAttributeDescription::getId).contains(desc.getId());
         assertThat(hypothesisRepository.count()).isEqualTo(2);
         assertThat(mockWebServer.getRequestCount() - initialCount).isEqualTo(1);
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -2,6 +2,7 @@ package com.marketinghub.hypothesis;
 
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.creative.label.Angle;
+import com.marketinghub.prompt.PromptAttributeDescription;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -9,6 +10,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -61,6 +64,13 @@ public class Hypothesis {
 
     /** Modelo de IA responsável pela geração desta hipótese. */
     private String model;
+
+    @ManyToMany
+    @JoinTable(name = "hypothesis_prompt_attribute_description",
+            joinColumns = @JoinColumn(name = "hypothesis_id"),
+            inverseJoinColumns = @JoinColumn(name = "prompt_attribute_description_id"))
+    @Builder.Default
+    private Set<PromptAttributeDescription> promptAttributeDescriptions = new HashSet<>();
 
     /** Regra de sucesso que define se a hipótese será validada. */
     @Lob

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.hypothesis.dto;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 public class CreateHypothesisRequest {
     private Long marketNicheId;
@@ -17,6 +18,7 @@ public class CreateHypothesisRequest {
     private String offerType;
     private BigDecimal price;
     private BigDecimal kpiTargetCpl;
+    private List<Long> promptAttributeDescriptionIds;
 
     public Long getMarketNicheId() { return marketNicheId; }
     public void setMarketNicheId(Long marketNicheId) { this.marketNicheId = marketNicheId; }
@@ -47,4 +49,7 @@ public class CreateHypothesisRequest {
     public void setPrice(BigDecimal price) { this.price = price; }
     public BigDecimal getKpiTargetCpl() { return kpiTargetCpl; }
     public void setKpiTargetCpl(BigDecimal kpiTargetCpl) { this.kpiTargetCpl = kpiTargetCpl; }
+
+    public List<Long> getPromptAttributeDescriptionIds() { return promptAttributeDescriptionIds; }
+    public void setPromptAttributeDescriptionIds(List<Long> promptAttributeDescriptionIds) { this.promptAttributeDescriptionIds = promptAttributeDescriptionIds; }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
+import java.util.List;
 
 @Data
 public class HypothesisDto {
@@ -27,4 +28,5 @@ public class HypothesisDto {
     private BigDecimal kpiTargetCpl;
     private HypothesisStatus status;
     private Instant generatedAt;
+    private List<Long> promptAttributeDescriptionIds;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/mapper/HypothesisMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/mapper/HypothesisMapper.java
@@ -9,5 +9,6 @@ import org.mapstruct.Mapping;
 public interface HypothesisMapper {
     @Mapping(target = "marketNicheId", source = "marketNiche.id")
     @Mapping(target = "premiseAngleId", source = "premiseAngle.id")
+    @Mapping(target = "promptAttributeDescriptionIds", expression = "java(hypothesis.getPromptAttributeDescriptions().stream().map(com.marketinghub.prompt.PromptAttributeDescription::getId).toList())")
     HypothesisDto toDto(Hypothesis hypothesis);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -8,8 +8,13 @@ import com.marketinghub.hypothesis.*;
 import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
 import com.marketinghub.hypothesis.dto.UpdateHypothesisRequest;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
+import com.marketinghub.prompt.PromptAttributeDescription;
+import com.marketinghub.prompt.repository.PromptAttributeDescriptionRepository;
 import java.util.UUID;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -22,15 +27,18 @@ public class HypothesisService {
     private final HypothesisRepository repository;
     private final MarketNicheRepository nicheRepository;
     private final AngleRepository angleRepository;
+    private final PromptAttributeDescriptionRepository descriptionRepository;
     private final EntityManager em;
 
     public HypothesisService(HypothesisRepository repository,
                              MarketNicheRepository nicheRepository,
                              AngleRepository angleRepository,
+                             PromptAttributeDescriptionRepository descriptionRepository,
                              EntityManager em) {
         this.repository = repository;
         this.nicheRepository = nicheRepository;
         this.angleRepository = angleRepository;
+        this.descriptionRepository = descriptionRepository;
         this.em = em;
     }
 
@@ -57,6 +65,18 @@ public class HypothesisService {
         // only title is required
     }
 
+    private Set<PromptAttributeDescription> attachPromptAttributeDescriptions(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) return new HashSet<>();
+        Set<PromptAttributeDescription> set = new HashSet<>();
+        for (Long id : ids) {
+            if (!descriptionRepository.existsById(id)) {
+                throw new EntityNotFoundException("PromptAttributeDescription not found: " + id);
+            }
+            set.add(em.getReference(PromptAttributeDescription.class, id));
+        }
+        return set;
+    }
+
     @Transactional
     public Hypothesis create(CreateHypothesisRequest req) {
         validate(req);
@@ -72,6 +92,7 @@ public class HypothesisService {
                 .successRule(req.getSuccessRule())
                 .prompt(req.getPrompt())
                 .model(req.getModel())
+                .promptAttributeDescriptions(attachPromptAttributeDescriptions(req.getPromptAttributeDescriptionIds()))
                 .generatedAt(Instant.now())
                 .offerType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()))
                 .price(req.getPrice())

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptAttributeDescription.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptAttributeDescription.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import java.util.HashSet;
+import java.util.Set;
 
 import java.time.Instant;
 
@@ -35,4 +37,7 @@ public class PromptAttributeDescription {
 
     @UpdateTimestamp
     private Instant updatedAt;
+
+    @ManyToMany(mappedBy = "promptAttributeDescriptions")
+    private Set<com.marketinghub.hypothesis.Hypothesis> hypotheses = new HashSet<>();
 }

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_09_29__link_hypothesis_prompt_attribute_description.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_09_29__link_hypothesis_prompt_attribute_description.sql
@@ -1,0 +1,9 @@
+-- liquibase formatted sql
+-- changeset marketinghub:2025-09-29-link-hypothesis-prompt-attr-desc
+CREATE TABLE IF NOT EXISTS hypothesis_prompt_attribute_description (
+    hypothesis_id BINARY(16) NOT NULL,
+    prompt_attribute_description_id BIGINT NOT NULL,
+    PRIMARY KEY (hypothesis_id, prompt_attribute_description_id),
+    CONSTRAINT fk_hpah_hypothesis FOREIGN KEY (hypothesis_id) REFERENCES hypothesis(id),
+    CONSTRAINT fk_hpah_description FOREIGN KEY (prompt_attribute_description_id) REFERENCES prompt_attribute_description(id)
+);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -77,3 +77,6 @@ databaseChangeLog:
   - include:
       file: V2025_09_28__drop_version_from_prompt_tables.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_09_29__link_hypothesis_prompt_attribute_description.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -4,6 +4,12 @@ import com.marketinghub.FixtureUtils;
 import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
 import com.marketinghub.hypothesis.service.HypothesisService;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.prompt.PromptAttribute;
+import com.marketinghub.prompt.PromptAttributeDescription;
+import com.marketinghub.prompt.PromptEntity;
+import com.marketinghub.prompt.repository.PromptAttributeDescriptionRepository;
+import com.marketinghub.prompt.repository.PromptAttributeRepository;
+import com.marketinghub.prompt.repository.PromptEntityRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,6 +32,12 @@ class HypothesisServiceTest {
     HypothesisService service;
     @Autowired
     FixtureUtils fixtures;
+    @Autowired
+    PromptEntityRepository entityRepository;
+    @Autowired
+    PromptAttributeRepository attributeRepository;
+    @Autowired
+    PromptAttributeDescriptionRepository descriptionRepository;
 
     @Test
     void createValidHypothesis() {
@@ -91,5 +103,17 @@ class HypothesisServiceTest {
         service.updateStatus(h.getId(), HypothesisStatus.TESTING);
         assertThatThrownBy(() -> service.update(h.getId(), u))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+    }
+
+    @Test
+    void linkPromptAttributeDescriptionsOnCreate() {
+        PromptEntity entity = entityRepository.save(PromptEntity.builder().name("hypothesis").build());
+        PromptAttribute attr = attributeRepository.save(PromptAttribute.builder().entity(entity).name("title").build());
+        PromptAttributeDescription desc = descriptionRepository.save(PromptAttributeDescription.builder().attribute(attr).description("d").build());
+        CreateHypothesisRequest req = new CreateHypothesisRequest();
+        req.setTitle("Teste");
+        req.setPromptAttributeDescriptionIds(java.util.List.of(desc.getId()));
+        Hypothesis h = service.create(req);
+        assertThat(h.getPromptAttributeDescriptions()).extracting(PromptAttributeDescription::getId).contains(desc.getId());
     }
 }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -242,6 +242,11 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 
+### hypothesis_prompt_attribute_description
+
+- `hypothesis_id` BINARY(16)
+- `prompt_attribute_description_id` BIGINT
+
 ## Diagram
 
 ```mermaid
@@ -303,6 +308,13 @@ erDiagram
     PROMPT_ATTRIBUTE_DESCRIPTION {
         BIGINT id PK
     }
+    HYPOTHESIS {
+        BINARY(16) id PK
+    }
+    HYPOTHESIS_PROMPT_ATTRIBUTE_DESCRIPTION {
+        BINARY(16) hypothesis_id PK
+        BIGINT prompt_attribute_description_id PK
+    }
 
     MARKET_NICHE ||--o{ EXPERIMENT : contains
     EXPERIMENT ||--o{ CREATIVE_VARIANT : has
@@ -314,4 +326,6 @@ erDiagram
     PROMPT_ENTITY ||--o{ PROMPT_ATTRIBUTE : defines
     PROMPT_ENTITY ||--o{ PROMPT_ENTITY_DESCRIPTION : described_by
     PROMPT_ATTRIBUTE ||--o{ PROMPT_ATTRIBUTE_DESCRIPTION : described_by
+    HYPOTHESIS ||--o{ HYPOTHESIS_PROMPT_ATTRIBUTE_DESCRIPTION : uses
+    PROMPT_ATTRIBUTE_DESCRIPTION ||--o{ HYPOTHESIS_PROMPT_ATTRIBUTE_DESCRIPTION : referenced_by
 ```

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -428,3 +428,7 @@ components:
           type: number
         kpiTargetCpl:
           type: number
+        promptAttributeDescriptionIds:
+          type: array
+          items:
+            type: integer

--- a/schema.sql
+++ b/schema.sql
@@ -238,3 +238,11 @@ CREATE TABLE prompt_attribute_description (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_prompt_attribute_description_attr FOREIGN KEY (prompt_attribute_id) REFERENCES prompt_attribute(id)
 );
+
+CREATE TABLE hypothesis_prompt_attribute_description (
+    hypothesis_id BINARY(16) NOT NULL,
+    prompt_attribute_description_id BIGINT NOT NULL,
+    PRIMARY KEY (hypothesis_id, prompt_attribute_description_id),
+    CONSTRAINT fk_hpah_hypothesis FOREIGN KEY (hypothesis_id) REFERENCES hypothesis(id),
+    CONSTRAINT fk_hpah_description FOREIGN KEY (prompt_attribute_description_id) REFERENCES prompt_attribute_description(id)
+);


### PR DESCRIPTION
## Summary
- establish many-to-many relationship between hypotheses and prompt attribute descriptions
- ensure AI worker saves description links when generating hypotheses
- document new join table and request field

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acfdb9a4fc8321b3ed910906c9c748