### PR TITLE
Use PromptEntity id for description FK

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptEntityDescriptionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/repository/PromptEntityDescriptionRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PromptEntityDescriptionRepository extends JpaRepository<PromptEntityDescription, Long> {
-    Optional<PromptEntityDescription> findByEntity_NameAndActiveTrue(String entityName);
+    Optional<PromptEntityDescription> findByEntity_IdAndActiveTrue(Long entityId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptEntityDescriptionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptEntityDescriptionService.java
@@ -6,6 +6,7 @@ import com.marketinghub.prompt.dto.PromptEntityDescriptionDto;
 import com.marketinghub.prompt.dto.UpdatePromptEntityDescriptionRequest;
 import com.marketinghub.prompt.repository.PromptEntityDescriptionRepository;
 import com.marketinghub.prompt.repository.PromptEntityRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,8 +20,8 @@ public class PromptEntityDescriptionService {
         this.entityRepository = entityRepository;
     }
 
-    public PromptEntityDescriptionDto getLatest(String entityName) {
-        return descriptionRepository.findByEntity_NameAndActiveTrue(entityName)
+    public PromptEntityDescriptionDto getLatest(Long entityId) {
+        return descriptionRepository.findByEntity_IdAndActiveTrue(entityId)
                 .map(desc -> {
                     PromptEntityDescriptionDto dto = new PromptEntityDescriptionDto();
                     dto.setDescription(desc.getDescription());
@@ -29,10 +30,10 @@ public class PromptEntityDescriptionService {
                 .orElse(null);
     }
 
-    public PromptEntityDescriptionDto update(String entityName, UpdatePromptEntityDescriptionRequest req) {
-        PromptEntity entity = entityRepository.findByName(entityName)
-                .orElseGet(() -> entityRepository.save(PromptEntity.builder().name(entityName).build()));
-        descriptionRepository.findByEntity_NameAndActiveTrue(entityName)
+    public PromptEntityDescriptionDto update(Long entityId, UpdatePromptEntityDescriptionRequest req) {
+        PromptEntity entity = entityRepository.findById(entityId)
+                .orElseThrow(() -> new EntityNotFoundException("PromptEntity not found"));
+        descriptionRepository.findByEntity_IdAndActiveTrue(entityId)
                 .ifPresent(prev -> {
                     prev.setActive(false);
                     descriptionRepository.save(prev);

--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptEntityDescriptionController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/web/PromptEntityDescriptionController.java
@@ -6,7 +6,7 @@ import com.marketinghub.prompt.service.PromptEntityDescriptionService;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/prompt-entities/{entityName}/description")
+@RequestMapping("/api/prompt-entities/{entityId}/description")
 public class PromptEntityDescriptionController {
     private final PromptEntityDescriptionService service;
 
@@ -15,13 +15,13 @@ public class PromptEntityDescriptionController {
     }
 
     @GetMapping
-    public PromptEntityDescriptionDto get(@PathVariable String entityName) {
-        return service.getLatest(entityName);
+    public PromptEntityDescriptionDto get(@PathVariable Long entityId) {
+        return service.getLatest(entityId);
     }
 
     @PutMapping
-    public PromptEntityDescriptionDto update(@PathVariable String entityName,
+    public PromptEntityDescriptionDto update(@PathVariable Long entityId,
                                              @RequestBody UpdatePromptEntityDescriptionRequest req) {
-        return service.update(entityName, req);
+        return service.update(entityId, req);
     }
 }


### PR DESCRIPTION
## Summary
- look up prompt entity description by entity id instead of name
- validate prompt entity existence before updating descriptions
- expose description endpoints by entity id

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68acffefb18483219480c851c3cebe56