### PR TITLE
Handle missing prompt attribute descriptions

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -118,10 +118,12 @@ public class ChatGptClient {
         var descriptions = attrs.stream()
                 .map(attr -> {
                     var opt = descriptionRepository.findByAttribute_IdAndActiveTrue(attr.getId());
-                    opt.ifPresent(d -> descriptionIds.add(d.getId()));
-                    return Map.entry(attr.getName(), opt.map(PromptAttributeDescription::getDescription).orElse(null));
+                    return opt.map(d -> {
+                        descriptionIds.add(d.getId());
+                        return Map.entry(attr.getName(), d.getDescription());
+                    });
                 })
-                .filter(e -> e.getValue() != null)
+                .flatMap(java.util.Optional::stream)
                 .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         if (!descriptions.isEmpty()) {
             sb.append("Cada objeto deve conter as chaves: ")


### PR DESCRIPTION
## Summary
- Avoid NullPointerException when building prompts without active attribute descriptions

## Testing
- `mvn -q -s settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68adb4e304108321ba777f7fada38e36