### PR TITLE
fix: handle escaped JSON from ChatGPT

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -82,9 +82,10 @@ public class ChatGptClient {
         } catch (Exception e) {
             log.error("Failed to parse ChatGPT response: {}", content, e);
             try {
-                String unescaped = objectMapper.readValue("\"" + content + "\"", String.class);
+                // ChatGPT may return JSON with escaped quotes. Attempt to unescape them and parse again.
+                String unescaped = content.replace("\\\"", "\"");
                 List<CreateHypothesisRequest> parsed = parseContent(unescaped, niche, promptData);
-                log.info("Parsed hypotheses: {}", parsed);
+                log.info("Parsed hypotheses after unescaping: {}", parsed);
                 return parsed;
             } catch (Exception ex) {
                 log.error("Failed to parse unescaped ChatGPT response: {}", content, ex);


### PR DESCRIPTION
## Summary
- handle responses where ChatGPT escapes quotes by unescaping before parsing

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68adc1b94d588321a4000eefba85c05e