### PR TITLE
Fix ChatGPT response parsing for escaped quotes

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -83,7 +83,7 @@ public class ChatGptClient {
             log.error("Failed to parse ChatGPT response: {}", content, e);
             try {
                 // ChatGPT may return JSON with escaped quotes. Attempt to unescape them and parse again.
-                String unescaped = content.replace("\\\"", "\"");
+                String unescaped = content.replaceAll("\\\\(?=\")", "");
                 List<CreateHypothesisRequest> parsed = parseContent(unescaped, niche, promptData);
                 log.info("Parsed hypotheses after unescaping: {}", parsed);
                 return parsed;


### PR DESCRIPTION
## Summary
- Avoid JSON parsing failures in niche ChatGptClient by stripping backslashes before quotes

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM for ai-worker)*

------
https://chatgpt.com/codex/tasks/task_e_68adc48385688321be243fc99bf069c6