### PR TITLE
fix: sanitize ChatGPT JSON before parsing

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -82,13 +82,16 @@ public class ChatGptClient {
         } catch (Exception e) {
             log.error("Failed to parse ChatGPT response: {}", content, e);
             try {
-                // ChatGPT may return JSON with escaped quotes. Attempt to unescape them and parse again.
-                String unescaped = content.replace("\\\"", "\"");
-                List<CreateHypothesisRequest> parsed = parseContent(unescaped, niche, promptData);
-                log.info("Parsed hypotheses after unescaping: {}", parsed);
+                // ChatGPT sometimes returns JSON wrapped in quotes with escaped characters.
+                String sanitized = content.trim().replace("\\\"", "\"");
+                if (sanitized.startsWith("\"") && sanitized.endsWith("\"")) {
+                    sanitized = sanitized.substring(1, sanitized.length() - 1);
+                }
+                List<CreateHypothesisRequest> parsed = parseContent(sanitized, niche, promptData);
+                log.info("Parsed hypotheses after sanitizing: {}", parsed);
                 return parsed;
             } catch (Exception ex) {
-                log.error("Failed to parse unescaped ChatGPT response: {}", content, ex);
+                log.error("Failed to parse sanitized ChatGPT response: {}", content, ex);
                 throw new RuntimeException("Failed to parse ChatGPT response", ex);
             }
         }


### PR DESCRIPTION
## Summary
- sanitize ChatGPT responses by trimming, unescaping quotes, and removing wrapping quotes before JSON parsing

## Testing
- `cd ai-worker && mvn -s settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to github: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adc48385688321be243fc99bf069c6