### PR TITLE
Ensure default hypothesis fields in AI worker prompts

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -116,26 +116,27 @@ public class ChatGptClient {
         }
         var attrs = attributeRepository.findByEntity_Name("hypothesis");
         var descriptionIds = new java.util.ArrayList<Long>();
+        var fields = new java.util.LinkedHashSet<>(
+                java.util.List.of("title", "promise", "problem", "persona",
+                        "mechanism", "uniqueMechanism", "successRule",
+                        "offerType", "price"));
         var descriptions = attrs.stream()
                 .map(attr -> {
                     var opt = descriptionRepository.findByAttribute_IdAndActiveTrue(attr.getId());
                     return opt.map(d -> {
                         descriptionIds.add(d.getId());
+                        fields.add(attr.getName());
                         return Map.entry(attr.getName(), d.getDescription());
                     });
                 })
                 .flatMap(java.util.Optional::stream)
                 .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        if (!descriptions.isEmpty()) {
-            sb.append("Cada objeto deve conter as chaves: ")
-                    .append(descriptions.keySet().stream().map(n -> "\\\"" + n + "\\\"")
-                            .collect(java.util.stream.Collectors.joining(", ")))
-                    .append(". ");
-            descriptions.forEach((name, desc) ->
-                    sb.append("Campo \\\"" + name + "\\\": " + desc + ". "));
-        } else {
-            sb.append("Cada objeto deve conter as chaves: \"title\", \"promise\", \"problem\", \"persona\", \"mechanism\", \"uniqueMechanism\", \"successRule\", \"offerType\", \"price\". ");
-        }
+        sb.append("Cada objeto deve conter as chaves: ")
+                .append(fields.stream().map(n -> "\\\"" + n + "\\\"")
+                        .collect(java.util.stream.Collectors.joining(", ")))
+                .append(". ");
+        descriptions.forEach((name, desc) ->
+                sb.append("Campo \\\"" + name + "\\\": " + desc + ". "));
         sb.append("O campo \"offerType\" deve ser \"LEAD\" ou \"TRIPWIRE\". ");
         sb.append("O campo \"price\" deve ser um número. ");
         sb.append("Retorne apenas um array JSON com esses objetos, sem texto adicional.");

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -189,4 +189,40 @@ class NicheHypothesisServiceTest {
         assertThat(hyps).hasSize(1);
         assertThat(hyps.get(0).getOfferType()).isNull();
     }
+
+    @Test
+    void promptIncludesDefaultFields() throws Exception {
+        PromptEntity entity = entityRepository.save(PromptEntity.builder().name("hypothesis").build());
+        PromptAttribute attr = attributeRepository.save(PromptAttribute.builder().entity(entity).name("title").build());
+        descriptionRepository.save(PromptAttributeDescription.builder().attribute(attr).description("d").build());
+
+        MarketNiche niche = MarketNiche.builder()
+                .name("Tech")
+                .hypothesesToGenerate(1)
+                .build();
+        nicheRepository.save(niche);
+
+        String content = "[" +
+                "{\\\"title\\\":\\\"H1\\\",\\\"promise\\\":\\\"p1\\\",\\\"problem\\\":\\\"pr1\\\"," +
+                "\\\"persona\\\":\\\"pe1\\\",\\\"mechanism\\\":\\\"m\\\",\\\"uniqueMechanism\\\":\\\"um\\\"," +
+                "\\\"successRule\\\":\\\"sr\\\",\\\"offerType\\\":\\\"LEAD\\\",\\\"price\\\":1}]";
+        String body = new ObjectMapper().writeValueAsString(
+                Map.of("choices", List.of(Map.of("message", Map.of("content", content)))));
+        mockWebServer.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody(body));
+
+        service.generate();
+
+        var request = mockWebServer.takeRequest();
+        String requestBody = request.getBody().readUtf8();
+        Map<String, Object> json = new ObjectMapper().readValue(requestBody, Map.class);
+        List<Map<String, String>> messages = (List<Map<String, String>>) json.get("messages");
+        String prompt = messages.get(1).get("content");
+
+        assertThat(prompt).contains(
+                "\"title\"", "\"promise\"", "\"problem\"", "\"persona\"",
+                "\"mechanism\"", "\"uniqueMechanism\"", "\"successRule\"",
+                "\"offerType\"", "\"price\"");
+    }
 }


### PR DESCRIPTION
## Summary
- Always include required hypothesis fields when building ChatGPT prompts
- Add regression test to verify prompt lists default fields

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adc7a8e9448321912944edec8e804e