### PR TITLE
fix: decode chatgpt escaped json

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -82,8 +82,8 @@ public class ChatGptClient {
         } catch (Exception e) {
             log.error("Failed to parse ChatGPT response: {}", content, e);
             try {
-                // ChatGPT may return JSON with escaped quotes. Attempt to unescape them and parse again.
-                String unescaped = content.replace("\\\"", "\"");
+                // ChatGPT may return JSON encoded as a string. Decode it using ObjectMapper and parse again.
+                String unescaped = objectMapper.readValue("\"" + content + "\"", String.class);
                 List<CreateHypothesisRequest> parsed = parseContent(unescaped, niche, promptData);
                 log.info("Parsed hypotheses after unescaping: {}", parsed);
                 return parsed;


### PR DESCRIPTION
## Summary
- handle ChatGPT responses that return JSON encoded as a string by decoding with `ObjectMapper`

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adc7a8e9448321912944edec8e804e