### PR TITLE
feat: robust JSON parsing for ChatGPT output

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/JsonUtils.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/JsonUtils.java
@@ -1,0 +1,37 @@
+package com.marketinghub.worker;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utilitário para lidar com respostas do modelo que podem vir embrulhadas em
+ * cercas Markdown ou duplamente codificadas como string JSON.
+ */
+public final class JsonUtils {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** Remove cercas ``` e ```json caso a resposta venha em Markdown. */
+  public static String stripCodeFences(String s) {
+    if (s == null) return null;
+    String t = s.trim();
+    if (t.startsWith("```") ) {
+      t = t.replaceAll("(?s)^```(?:json)?\\s*", "");
+      t = t.replaceAll("(?s)\\s*```$", "");
+    }
+    return t.trim();
+  }
+
+  /** Faz parse resiliente, inclusive para JSON duplamente codificado. */
+  public static <T> T parsePossiblyDoubleEncoded(String raw, TypeReference<T> type) throws JsonProcessingException {
+    String cleaned = stripCodeFences(raw);
+    try {
+      return MAPPER.readValue(cleaned, type);
+    } catch (JsonParseException ignored) {
+      // Plano B: a resposta está como STRING contendo JSON
+      String inner = MAPPER.readValue(cleaned, String.class);
+      return MAPPER.readValue(inner, type);
+    }
+  }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
@@ -1,5 +1,7 @@
 package com.marketinghub.worker;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.successproduct.SuccessProduct;
@@ -154,28 +156,34 @@ public class OpenAiChatGptClient implements ChatGptClient {
 
                 // ===== 3b. Resposta final do modelo
                 String content = choice.path("message").path("content").asText();
-                content = stripCodeFence(content);
-                JsonNode data = MAPPER.readTree(content);
+                try {
+                    JsonNode data = JsonUtils.parsePossiblyDoubleEncoded(
+                            content, new TypeReference<JsonNode>() {});
 
-                product.setName(asText(data, "name"));
-                product.setExplicitPain(asText(data, "explicitPain"));
-                product.setPromise(asText(data, "promise"));
-                product.setUniqueMechanism(asText(data, "uniqueMechanism"));
-                product.setTripwire(asText(data, "tripwire"));
-                product.setRiskReversal(asText(data, "riskReversal"));
-                product.setSocialProof(asText(data, "socialProof"));
-                product.setCheckoutMonetization(asText(data, "checkoutMonetization"));
-                product.setSalesFunnel(asText(data, "salesFunnel"));
-                product.setAudienceType(asText(data, "audienceType"));
-                product.setCreativeVolume(asText(data, "creativeVolume"));
-                product.setStorytelling(asText(data, "storytelling"));
-                product.setSalesPageUrl(asText(data, "salesPageUrl"));
-                product.setInstagramUrl(asText(data, "instagramUrl"));
-                product.setFacebookUrl(asText(data, "facebookUrl"));
-                product.setYoutubeUrl(asText(data, "youtubeUrl"));
-                product.setNovo(false);
-                log.info("OpenAI enrichment completed for product {}", product.getId());
-                return product;
+                    product.setName(asText(data, "name"));
+                    product.setExplicitPain(asText(data, "explicitPain"));
+                    product.setPromise(asText(data, "promise"));
+                    product.setUniqueMechanism(asText(data, "uniqueMechanism"));
+                    product.setTripwire(asText(data, "tripwire"));
+                    product.setRiskReversal(asText(data, "riskReversal"));
+                    product.setSocialProof(asText(data, "socialProof"));
+                    product.setCheckoutMonetization(asText(data, "checkoutMonetization"));
+                    product.setSalesFunnel(asText(data, "salesFunnel"));
+                    product.setAudienceType(asText(data, "audienceType"));
+                    product.setCreativeVolume(asText(data, "creativeVolume"));
+                    product.setStorytelling(asText(data, "storytelling"));
+                    product.setSalesPageUrl(asText(data, "salesPageUrl"));
+                    product.setInstagramUrl(asText(data, "instagramUrl"));
+                    product.setFacebookUrl(asText(data, "facebookUrl"));
+                    product.setYoutubeUrl(asText(data, "youtubeUrl"));
+                    product.setNovo(false);
+                    log.info("OpenAI enrichment completed for product {}", product.getId());
+                    return product;
+                } catch (JsonProcessingException e) {
+                    log.error("Failed to parse ChatGPT response: {}",
+                            truncate(content), e);
+                    return product;
+                }
             }
         } catch (Exception e) {
             log.error("Failed to call OpenAI API", e);
@@ -214,20 +222,14 @@ public class OpenAiChatGptClient implements ChatGptClient {
         return list;
     }
 
-    private static String stripCodeFence(String text) {
-        if (text == null) return null;
-        String t = text.trim();
-        if (t.startsWith("```") && t.contains("```")) {
-            int start = t.indexOf('\n');
-            int end = t.lastIndexOf("```");
-            if (start >= 0 && end > start) return t.substring(start + 1, end).trim();
-        }
-        return t;
-    }
-
     private static String asText(JsonNode node, String field) {
         JsonNode v = node.get(field);
         return (v != null && !v.isNull()) ? v.asText() : null;
+    }
+
+    private static String truncate(String s) {
+        if (s == null) return null;
+        return s.length() > 200 ? s.substring(0, 200) : s;
     }
 
     /** Resultado simplificado de busca. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -1,10 +1,10 @@
 package com.marketinghub.worker.niche;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.marketinghub.worker.JsonUtils;
 import com.marketinghub.hypothesis.dto.CreateHypothesisRequest;
 import com.marketinghub.niche.MarketNiche;
-import com.marketinghub.prompt.PromptAttribute;
-import com.marketinghub.prompt.PromptAttributeDescription;
 import com.marketinghub.prompt.repository.PromptAttributeDescriptionRepository;
 import com.marketinghub.prompt.repository.PromptAttributeRepository;
 import org.slf4j.Logger;
@@ -24,14 +24,12 @@ import java.util.Map;
 @Component
 public class ChatGptClient {
     private final WebClient webClient;
-    private final ObjectMapper objectMapper;
     private final String model;
     private final PromptAttributeRepository attributeRepository;
     private final PromptAttributeDescriptionRepository descriptionRepository;
     private static final Logger log = LoggerFactory.getLogger(ChatGptClient.class);
 
     public ChatGptClient(WebClient.Builder builder,
-                         ObjectMapper objectMapper,
                          @Value("${openai.api-key:}") String apiKey,
                          @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
                          @Value("${openai.model:gpt-3.5-turbo}") String model,
@@ -41,7 +39,6 @@ public class ChatGptClient {
                 .baseUrl(baseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
                 .build();
-        this.objectMapper = objectMapper;
         this.model = model;
         this.attributeRepository = attributeRepository;
         this.descriptionRepository = descriptionRepository;
@@ -49,13 +46,37 @@ public class ChatGptClient {
 
     public List<CreateHypothesisRequest> generateHypotheses(MarketNiche niche, int quantity) {
         PromptData promptData = buildPrompt(niche, quantity);
-        Map<String, Object> payload = Map.of(
-                "model", model,
-                "messages", List.of(
-                        Map.of("role", "system", "content", "Você é um especialista em marketing."),
-                        Map.of("role", "user", "content", promptData.prompt())
-                )
-        );
+        Map<String, Object> payload = new java.util.HashMap<>();
+        payload.put("model", model);
+        payload.put("messages", List.of(
+                Map.of("role", "system", "content", "Você é um especialista em marketing."),
+                Map.of("role", "user", "content", promptData.prompt())
+        ));
+        // TODO: para evitar respostas com cercas, use a OpenAI Responses API e
+        // habilite Structured Outputs adicionando o campo abaixo.
+        // payload.put("response_format", Map.of(
+        //         "type", "json_schema",
+        //         "json_schema", Map.of(
+        //                 "name", "hypotheses",
+        //                 "strict", true,
+        //                 "schema", Map.of(
+        //                         "type", "array",
+        //                         "items", Map.of(
+        //                                 "type", "object",
+        //                                 "properties", Map.of(
+        //                                         "title", Map.of("type", "string"),
+        //                                         "promise", Map.of("type", "string"),
+        //                                         "problem", Map.of("type", "string"),
+        //                                         "persona", Map.of("type", "string"),
+        //                                         "successRule", Map.of("type", "string"),
+        //                                         "offerType", Map.of("type", "string"),
+        //                                         "kpiTargetCpl", Map.of("type", "number")
+        //                                 ),
+        //                                 "required", List.of("title", "promise", "problem", "persona", "successRule", "offerType", "kpiTargetCpl")
+        //                         )
+        //                 )
+        //         )
+        // ));
 
         log.info("Sending prompt to ChatGPT for niche {}: {}", niche.getId(), promptData.prompt());
         log.debug("ChatGPT payload: {}", payload);
@@ -79,18 +100,9 @@ public class ChatGptClient {
             List<CreateHypothesisRequest> parsed = parseContent(content, niche, promptData);
             log.info("Parsed hypotheses: {}", parsed);
             return parsed;
-        } catch (Exception e) {
-            log.error("Failed to parse ChatGPT response: {}", content, e);
-            try {
-                // ChatGPT may return JSON with escaped quotes. Attempt to unescape them and parse again.
-                String unescaped = content.replace("\\\"", "\"");
-                List<CreateHypothesisRequest> parsed = parseContent(unescaped, niche, promptData);
-                log.info("Parsed hypotheses after unescaping: {}", parsed);
-                return parsed;
-            } catch (Exception ex) {
-                log.error("Failed to parse unescaped ChatGPT response: {}", content, ex);
-                throw new RuntimeException("Failed to parse ChatGPT response", ex);
-            }
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse ChatGPT response: {}", truncate(content), e);
+            throw new RuntimeException("Failed to parse ChatGPT response", e);
         }
     }
 
@@ -146,8 +158,10 @@ public class ChatGptClient {
     private record Choice(Message message) {}
     private record Message(String content) {}
 
-    private List<CreateHypothesisRequest> parseContent(String content, MarketNiche niche, PromptData data) throws Exception {
-        CreateHypothesisRequest[] arr = objectMapper.readValue(content, CreateHypothesisRequest[].class);
+    private List<CreateHypothesisRequest> parseContent(String content, MarketNiche niche, PromptData data)
+            throws JsonProcessingException {
+        CreateHypothesisRequest[] arr = JsonUtils.parsePossiblyDoubleEncoded(
+                content, new TypeReference<CreateHypothesisRequest[]>() {});
         for (CreateHypothesisRequest req : arr) {
             req.setMarketNicheId(niche.getId());
             req.setPrompt(data.prompt());
@@ -155,6 +169,11 @@ public class ChatGptClient {
             req.setPromptAttributeDescriptionIds(data.descriptionIds());
         }
         return Arrays.asList(arr);
+    }
+
+    private static String truncate(String s) {
+        if (s == null) return null;
+        return s.length() > 200 ? s.substring(0, 200) : s;
     }
 
     private record PromptData(String prompt, List<Long> descriptionIds) {}

--- a/ai-worker/src/test/java/com/marketinghub/worker/JsonUtilsTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/JsonUtilsTest.java
@@ -1,0 +1,50 @@
+package com.marketinghub.worker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonUtilsTest {
+
+    @Test
+    void parseRawJson() throws Exception {
+        String raw = "[{\"title\":\"H1\"}]";
+        List<Map<String, Object>> list = JsonUtils.parsePossiblyDoubleEncoded(raw,
+                new TypeReference<List<Map<String, Object>>>() {});
+        assertEquals(1, list.size());
+        assertEquals("H1", list.get(0).get("title"));
+    }
+
+    @Test
+    void parseJsonWithFences() throws Exception {
+        String raw = "```json\n[{\"title\":\"H1\"}]\n```";
+        List<Map<String, Object>> list = JsonUtils.parsePossiblyDoubleEncoded(raw,
+                new TypeReference<List<Map<String, Object>>>() {});
+        assertEquals(1, list.size());
+        assertEquals("H1", list.get(0).get("title"));
+    }
+
+    @Test
+    void parseDoubleEncodedJson() throws Exception {
+        String raw = "\"[{\\\"title\\\":\\\"H1\\\",\\\"promise\\\":\\\"p1\\\",\\\"problem\\\":\\\"pr1\\\",\\\"persona\\\":\\\"pe1\\\",\\\"successRule\\\":\\\"sr1\\\",\\\"offerType\\\":\\\"LEAD\\\",\\\"kpiTargetCpl\\\":1},{\\\"promise\\\":\\\"p2\\\",\\\"problem\\\":\\\"pr2\\\",\\\"persona\\\":\\\"pe2\\\",\\\"successRule\\\":\\\"sr2\\\",\\\"offerType\\\":\\\"LEAD\\\",\\\"kpiTargetCpl\\\":1}]\"";
+        List<Map<String, Object>> list = JsonUtils.parsePossiblyDoubleEncoded(raw,
+                new TypeReference<List<Map<String, Object>>>() {});
+        assertEquals(2, list.size());
+        assertEquals("H1", list.get(0).get("title"));
+        assertEquals("p2", list.get(1).get("promise"));
+    }
+
+    @Test
+    void invalidJsonThrows() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 250; i++) sb.append('a');
+        String raw = sb.toString();
+        assertThrows(JsonProcessingException.class, () ->
+                JsonUtils.parsePossiblyDoubleEncoded(raw, new TypeReference<List<Map<String, Object>>>() {}));
+        String truncated = raw.substring(0, 200);
+        assertEquals(200, truncated.length());
+    }
+}


### PR DESCRIPTION
## Summary
- add utility to strip code fences and parse double-encoded JSON
- use resilient parsing in ChatGPT clients with concise error logging
- document schema option for future OpenAI structured outputs
- cover JSON parsing edge cases with unit tests

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adcf3f8a0083218261ea0919017c80