### PR TITLE
Handle double-encoded JSON responses

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/JsonUtils.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/JsonUtils.java
@@ -1,0 +1,52 @@
+package com.marketinghub.worker;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utilidades para lidar com JSON retornado por LLMs que pode vir
+ * embrulhado em cercas Markdown ou duplamente codificado.
+ */
+final class JsonUtils {
+  private static final Logger log = LoggerFactory.getLogger(JsonUtils.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** Remove cercas ``` e ```json caso a resposta venha em Markdown. */
+  static String stripCodeFences(String s) {
+    if (s == null) return null;
+    String t = s.trim();
+    if (t.startsWith("```")) {
+      t = t.replaceAll("(?s)^```(?:json)?\\s*", "");
+      t = t.replaceAll("(?s)\\s*```$", "");
+    }
+    return t.trim();
+  }
+
+  /** Faz parse resiliente, inclusive para JSON duplamente codificado. */
+  static <T> T parsePossiblyDoubleEncoded(String raw, TypeReference<T> type) throws JsonProcessingException {
+    String cleaned = stripCodeFences(raw);
+    try {
+      try {
+        return MAPPER.readValue(cleaned, type);
+      } catch (JsonParseException ignored) {
+        // Plano B: a resposta está como STRING contendo JSON
+        String inner = MAPPER.readValue(cleaned, String.class);
+        return MAPPER.readValue(inner, type);
+      }
+    } catch (JsonProcessingException e) {
+      String preview = preview(raw);
+      log.error("Failed to parse JSON: {}", preview, e);
+      throw e;
+    }
+  }
+
+  private static String preview(String s) {
+    if (s == null) return null;
+    String t = s.trim();
+    return t.length() > 200 ? t.substring(0, 200) + "..." : t;
+  }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
@@ -1,5 +1,7 @@
 package com.marketinghub.worker;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.successproduct.SuccessProduct;
@@ -154,28 +156,32 @@ public class OpenAiChatGptClient implements ChatGptClient {
 
                 // ===== 3b. Resposta final do modelo
                 String content = choice.path("message").path("content").asText();
-                content = stripCodeFence(content);
-                JsonNode data = MAPPER.readTree(content);
+                try {
+                    JsonNode data = JsonUtils.parsePossiblyDoubleEncoded(content, new TypeReference<JsonNode>() {});
 
-                product.setName(asText(data, "name"));
-                product.setExplicitPain(asText(data, "explicitPain"));
-                product.setPromise(asText(data, "promise"));
-                product.setUniqueMechanism(asText(data, "uniqueMechanism"));
-                product.setTripwire(asText(data, "tripwire"));
-                product.setRiskReversal(asText(data, "riskReversal"));
-                product.setSocialProof(asText(data, "socialProof"));
-                product.setCheckoutMonetization(asText(data, "checkoutMonetization"));
-                product.setSalesFunnel(asText(data, "salesFunnel"));
-                product.setAudienceType(asText(data, "audienceType"));
-                product.setCreativeVolume(asText(data, "creativeVolume"));
-                product.setStorytelling(asText(data, "storytelling"));
-                product.setSalesPageUrl(asText(data, "salesPageUrl"));
-                product.setInstagramUrl(asText(data, "instagramUrl"));
-                product.setFacebookUrl(asText(data, "facebookUrl"));
-                product.setYoutubeUrl(asText(data, "youtubeUrl"));
-                product.setNovo(false);
-                log.info("OpenAI enrichment completed for product {}", product.getId());
-                return product;
+                    product.setName(asText(data, "name"));
+                    product.setExplicitPain(asText(data, "explicitPain"));
+                    product.setPromise(asText(data, "promise"));
+                    product.setUniqueMechanism(asText(data, "uniqueMechanism"));
+                    product.setTripwire(asText(data, "tripwire"));
+                    product.setRiskReversal(asText(data, "riskReversal"));
+                    product.setSocialProof(asText(data, "socialProof"));
+                    product.setCheckoutMonetization(asText(data, "checkoutMonetization"));
+                    product.setSalesFunnel(asText(data, "salesFunnel"));
+                    product.setAudienceType(asText(data, "audienceType"));
+                    product.setCreativeVolume(asText(data, "creativeVolume"));
+                    product.setStorytelling(asText(data, "storytelling"));
+                    product.setSalesPageUrl(asText(data, "salesPageUrl"));
+                    product.setInstagramUrl(asText(data, "instagramUrl"));
+                    product.setFacebookUrl(asText(data, "facebookUrl"));
+                    product.setYoutubeUrl(asText(data, "youtubeUrl"));
+                    product.setNovo(false);
+                    log.info("OpenAI enrichment completed for product {}", product.getId());
+                    return product;
+                } catch (JsonProcessingException e) {
+                    // JsonUtils já logou a resposta; apenas retornamos o produto sem alterações
+                    return product;
+                }
             }
         } catch (Exception e) {
             log.error("Failed to call OpenAI API", e);
@@ -214,20 +220,54 @@ public class OpenAiChatGptClient implements ChatGptClient {
         return list;
     }
 
-    private static String stripCodeFence(String text) {
-        if (text == null) return null;
-        String t = text.trim();
-        if (t.startsWith("```") && t.contains("```")) {
-            int start = t.indexOf('\n');
-            int end = t.lastIndexOf("```");
-            if (start >= 0 && end > start) return t.substring(start + 1, end).trim();
-        }
-        return t;
-    }
-
     private static String asText(JsonNode node, String field) {
         JsonNode v = node.get(field);
         return (v != null && !v.isNull()) ? v.asText() : null;
+    }
+
+    /**
+     * Exemplo de como usar Structured Outputs da OpenAI Responses API para forçar
+     * a conformidade JSON e evitar cercas Markdown.
+     * TODO: Alternar para este modo quando o backend migrar para a Responses API.
+     */
+    @SuppressWarnings("unused")
+    private HttpRequest buildStructuredOutputRequest(List<Map<String, Object>> messages) throws JsonProcessingException {
+        Map<String, Object> schema = Map.of(
+                "type", "json_schema",
+                "json_schema",
+                Map.of(
+                        "name", "offer_items",
+                        "schema",
+                        Map.of(
+                                "type", "array",
+                                "items",
+                                Map.of(
+                                        "type", "object",
+                                        "properties",
+                                        Map.of(
+                                                "title", Map.of("type", "string"),
+                                                "promise", Map.of("type", "string"),
+                                                "problem", Map.of("type", "string"),
+                                                "persona", Map.of("type", "string"),
+                                                "successRule", Map.of("type", "string"),
+                                                "offerType", Map.of("type", "string"),
+                                                "kpiTargetCpl", Map.of("type", "number")),
+                                        "required",
+                                        List.of("title", "promise", "problem", "persona", "successRule", "offerType", "kpiTargetCpl"))),
+                        "strict", true));
+
+        Map<String, Object> body = Map.of(
+                "model", model,
+                "messages", messages,
+                "response_format", schema);
+
+        return HttpRequest.newBuilder()
+                .uri(URI.create("https://api.openai.com/v1/responses"))
+                .timeout(Duration.ofMinutes(2))
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body), StandardCharsets.UTF_8))
+                .build();
     }
 
     /** Resultado simplificado de busca. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/JsonUtilsTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/JsonUtilsTest.java
@@ -1,0 +1,59 @@
+package com.marketinghub.worker;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.Test;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonUtilsTest {
+
+    @Test
+    void parsesPlainJson() throws Exception {
+        String raw = "[{\"title\":\"H1\"}]";
+        List<Map<String, Object>> list = JsonUtils.parsePossiblyDoubleEncoded(raw,
+                new TypeReference<List<Map<String, Object>>>() {});
+        assertEquals(1, list.size());
+        assertEquals("H1", list.get(0).get("title"));
+    }
+
+    @Test
+    void parsesJsonWithFences() throws Exception {
+        String raw = "```json\n[{\"title\":\"H1\"}]\n```";
+        List<Map<String, Object>> list = JsonUtils.parsePossiblyDoubleEncoded(raw,
+                new TypeReference<List<Map<String, Object>>>() {});
+        assertEquals(1, list.size());
+    }
+
+    @Test
+    void parsesDoubleEncodedJson() throws Exception {
+        String raw = "[{\\\"title\\\":\\\"H1\\\",\\\"promise\\\":\\\"p1\\\",\\\"problem\\\":\\\"pr1\\\",\\\"persona\\\":\\\"pe1\\\",\\\"successRule\\\":\\\"sr1\\\",\\\"offerType\\\":\\\"LEAD\\\",\\\"kpiTargetCpl\\\":1},{\\\"promise\\\":\\\"p2\\\",\\\"problem\\\":\\\"pr2\\\",\\\"persona\\\":\\\"pe2\\\",\\\"successRule\\\":\\\"sr2\\\",\\\"offerType\\\":\\\"LEAD\\\",\\\"kpiTargetCpl\\\":1}]";
+        List<Map<String, Object>> list = JsonUtils.parsePossiblyDoubleEncoded(raw,
+                new TypeReference<List<Map<String, Object>>>() {});
+        assertEquals(2, list.size());
+        assertEquals("H1", list.get(0).get("title"));
+        assertEquals("p1", list.get(0).get("promise"));
+    }
+
+    @Test
+    void logsPreviewOnParseFailure() {
+        String invalid = "[" + "x".repeat(250);
+        Logger logger = (Logger) LoggerFactory.getLogger(JsonUtils.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        assertThrows(JsonProcessingException.class, () ->
+                JsonUtils.parsePossiblyDoubleEncoded(invalid, new TypeReference<Map<String, Object>>() {}));
+        assertFalse(appender.list.isEmpty());
+        String msg = appender.list.get(0).getFormattedMessage();
+        String expected = invalid.trim().substring(0, 200) + "...";
+        assertTrue(msg.contains(expected));
+    }
+}


### PR DESCRIPTION
## Summary
- Add JsonUtils to strip code fences and parse double-encoded JSON, logging a 200-char preview on failure
- Use JsonUtils in OpenAiChatGptClient and sketch Responses API structured output flow
- Cover plain, fenced and double-encoded payloads plus failure logging in JsonUtilsTest

## Testing
- `mvn -s settings.xml test` *(failed: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adcf3f8a0083218261ea0919017c80