### PR TITLE
Handle double encoded JSON responses

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/JsonUtils.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/JsonUtils.java
@@ -1,0 +1,37 @@
+package com.marketinghub.worker;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utility to parse JSON responses from LLMs that may be wrapped in markdown
+ * code fences or double-encoded as a JSON string.
+ */
+final class JsonUtils {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** Remove cercas ``` e ```json caso a resposta venha em Markdown. */
+  static String stripCodeFences(String s) {
+    if (s == null) return null;
+    String t = s.trim();
+    if (t.startsWith("```")) {
+      t = t.replaceAll("(?s)^```(?:json)?\\s*", "");
+      t = t.replaceAll("(?s)\\s*```$", "");
+    }
+    return t.trim();
+  }
+
+  /** Faz parse resiliente, inclusive para JSON duplamente codificado. */
+  static <T> T parsePossiblyDoubleEncoded(String raw, TypeReference<T> type) throws JsonProcessingException {
+    String cleaned = stripCodeFences(raw);
+    try {
+      return MAPPER.readValue(cleaned, type);
+    } catch (JsonParseException ignored) {
+      // Plano B: a resposta está como STRING contendo JSON
+      String inner = MAPPER.readValue(cleaned, String.class);
+      return MAPPER.readValue(inner, type);
+    }
+  }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
@@ -1,5 +1,7 @@
 package com.marketinghub.worker;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.successproduct.SuccessProduct;
@@ -83,11 +85,16 @@ public class OpenAiChatGptClient implements ChatGptClient {
         try {
             // ===== 3. Loop principal (tool calling)
             while (true) {
-                String requestBody = MAPPER.writeValueAsString(Map.of(
-                        "model", model,
-                        "messages", messages,
-                        "tools", tools,
-                        "tool_choice", "auto"));
+                boolean structuredOutputs = false; // TODO ativar para usar Structured Outputs e evitar cercas
+                Map<String, Object> body = new java.util.HashMap<>();
+                body.put("model", model);
+                body.put("messages", messages);
+                body.put("tools", tools);
+                body.put("tool_choice", "auto");
+                if (structuredOutputs) {
+                    body.put("response_format", buildResponseFormat());
+                }
+                String requestBody = MAPPER.writeValueAsString(body);
 
                 log.info("Sending ChatGPT request with {} messages", messages.size());
                 log.info("ChatGPT request body: {}", requestBody);
@@ -154,8 +161,14 @@ public class OpenAiChatGptClient implements ChatGptClient {
 
                 // ===== 3b. Resposta final do modelo
                 String content = choice.path("message").path("content").asText();
-                content = stripCodeFence(content);
-                JsonNode data = MAPPER.readTree(content);
+                JsonNode data;
+                try {
+                    data = JsonUtils.parsePossiblyDoubleEncoded(content, new TypeReference<JsonNode>() {});
+                } catch (JsonProcessingException e) {
+                    String preview = content == null ? "null" : content.substring(0, Math.min(200, content.length()));
+                    log.error("Failed to parse ChatGPT response: {}", preview, e);
+                    return product;
+                }
 
                 product.setName(asText(data, "name"));
                 product.setExplicitPain(asText(data, "explicitPain"));
@@ -181,6 +194,28 @@ public class OpenAiChatGptClient implements ChatGptClient {
             log.error("Failed to call OpenAI API", e);
             return product;
         }
+    }
+
+    // TODO usar Structured Outputs para forçar o modelo a seguir o schema e evitar Markdown
+    private Map<String, Object> buildResponseFormat() {
+        Map<String, Object> properties = Map.of(
+                "title", Map.of("type", "string"),
+                "promise", Map.of("type", "string"),
+                "problem", Map.of("type", "string"),
+                "persona", Map.of("type", "string"),
+                "successRule", Map.of("type", "string"),
+                "offerType", Map.of("type", "string"),
+                "kpiTargetCpl", Map.of("type", "number"));
+        Map<String, Object> itemSchema = Map.of(
+                "type", "object",
+                "properties", properties);
+        Map<String, Object> jsonSchema = Map.of(
+                "type", "array",
+                "items", itemSchema,
+                "strict", true);
+        return Map.of(
+                "type", "json_schema",
+                "json_schema", jsonSchema);
     }
 
     /**
@@ -212,17 +247,6 @@ public class OpenAiChatGptClient implements ChatGptClient {
             }
         }
         return list;
-    }
-
-    private static String stripCodeFence(String text) {
-        if (text == null) return null;
-        String t = text.trim();
-        if (t.startsWith("```") && t.contains("```")) {
-            int start = t.indexOf('\n');
-            int end = t.lastIndexOf("```");
-            if (start >= 0 && end > start) return t.substring(start + 1, end).trim();
-        }
-        return t;
     }
 
     private static String asText(JsonNode node, String field) {

--- a/ai-worker/src/test/java/com/marketinghub/worker/JsonUtilsTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/JsonUtilsTest.java
@@ -1,0 +1,51 @@
+package com.marketinghub.worker;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class JsonUtilsTest {
+
+  @Test
+  void parseRawJson() throws Exception {
+    String raw = "[{\"title\":\"H1\"}]";
+    List<Map<String, Object>> list =
+        JsonUtils.parsePossiblyDoubleEncoded(raw, new TypeReference<List<Map<String, Object>>>() {});
+    assertEquals(1, list.size());
+    assertEquals("H1", list.get(0).get("title"));
+  }
+
+  @Test
+  void parseJsonWithFences() throws Exception {
+    String raw = "```json\n[{\"title\":\"H1\"}]\n```";
+    List<Map<String, Object>> list =
+        JsonUtils.parsePossiblyDoubleEncoded(raw, new TypeReference<List<Map<String, Object>>>() {});
+    assertEquals(1, list.size());
+    assertEquals("H1", list.get(0).get("title"));
+  }
+
+  @Test
+  void parseDoubleEncodedJson() throws Exception {
+    String doubleEncoded =
+        "\"[{\\\"title\\\":\\\"H1\\\",\\\"promise\\\":\\\"p1\\\",\\\"problem\\\":\\\"pr1\\\",\\\"persona\\\":\\\"pe1\\\",\\\"successRule\\\":\\\"sr1\\\",\\\"offerType\\\":\\\"LEAD\\\",\\\"kpiTargetCpl\\\":1},{\\\"promise\\\":\\\"p2\\\",\\\"problem\\\":\\\"pr2\\\",\\\"persona\\\":\\\"pe2\\\",\\\"successRule\\\":\\\"sr2\\\",\\\"offerType\\\":\\\"LEAD\\\",\\\"kpiTargetCpl\\\":1}]\"";
+    List<Map<String, Object>> list =
+        JsonUtils.parsePossiblyDoubleEncoded(doubleEncoded, new TypeReference<List<Map<String, Object>>>() {});
+    assertEquals(2, list.size());
+    assertEquals("H1", list.get(0).get("title"));
+    assertEquals("p2", list.get(1).get("promise"));
+  }
+
+  @Test
+  void invalidJsonThrowsAndTruncates() {
+    String invalid = "a".repeat(250);
+    assertThrows(
+        JsonProcessingException.class,
+        () -> JsonUtils.parsePossiblyDoubleEncoded(invalid, new TypeReference<List<Map<String, Object>>>() {}));
+    String preview = invalid.substring(0, Math.min(200, invalid.length()));
+    assertEquals(200, preview.length());
+  }
+}


### PR DESCRIPTION
## Summary
- strip markdown fences and parse JSON that may be double-encoded
- use resilient JSON parsing in OpenAI client and log truncated previews on failure
- document optional Structured Outputs path for OpenAI responses and add unit tests

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68adcf3f8a0083218261ea0919017c80