### PR TITLE
Ensure prompt attribute descriptions are active by default

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptAttributeDescription.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/PromptAttributeDescription.java
@@ -30,6 +30,7 @@ public class PromptAttributeDescription {
     private String description;
 
     @Column(nullable = false)
+    @Builder.Default
     private boolean active = true;
 
     @CreationTimestamp
@@ -39,5 +40,6 @@ public class PromptAttributeDescription {
     private Instant updatedAt;
 
     @ManyToMany(mappedBy = "promptAttributeDescriptions")
+    @Builder.Default
     private Set<com.marketinghub.hypothesis.Hypothesis> hypotheses = new HashSet<>();
 }


### PR DESCRIPTION
## Summary
- Ensure `PromptAttributeDescription` builder defaults to `active=true` and initializes hypothesis set

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68add6607e9083219a3ae686aada3ea3