### PR TITLE
feat(frontend): mostrar prompt e data de criação na hipótese

### DIFF
--- a/frontend/src/__tests__/NicheFlow.test.tsx
+++ b/frontend/src/__tests__/NicheFlow.test.tsx
@@ -22,6 +22,7 @@ function mockApi() {
             offerType: "LEAD",
             status: "BACKLOG",
             kpiTargetCpl: 5,
+            createdAt: "",
           },
         ],
       });

--- a/frontend/src/api/hypothesis/useHypothesisBoard.ts
+++ b/frontend/src/api/hypothesis/useHypothesisBoard.ts
@@ -18,6 +18,7 @@ export interface Hypothesis {
   price?: number;
   kpiTargetCpl?: number;
   status: string;
+  createdAt?: string;
 }
 
 export function useHypothesisBoard(nicheId: string) {

--- a/frontend/src/pages/hypothesis/EditHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/EditHypothesisPage.test.tsx
@@ -24,6 +24,7 @@ function setup() {
             offerType: "LEAD",
             kpiTargetCpl: 5,
             status: "BACKLOG",
+            createdAt: "",
           },
         ],
       });

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -112,6 +112,18 @@ export default function HypothesisDetailPage() {
           </table>
         </div>
       )}
+      {data.createdAt && (
+        <div className="mt-4">
+          <h5>Data de criação</h5>
+          <p>{new Date(data.createdAt).toLocaleString("pt-BR")}</p>
+        </div>
+      )}
+      {data.prompt && (
+        <div className="mt-4">
+          <h5>Prompt de criação</h5>
+          <pre>{data.prompt}</pre>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- exibe o prompt de criação na tela de detalhes da hipótese
- mostra a data de criação da hipótese

## Testing
- `CI=1 npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae054a7160832195d2ca079dbea819