### PR TITLE
Remove hypothesis creation from niche detail page

### DIFF
--- a/frontend/src/__tests__/NicheFlow.test.tsx
+++ b/frontend/src/__tests__/NicheFlow.test.tsx
@@ -86,7 +86,7 @@ describe("niche navigation", () => {
 
     await screen.findByText("Fitness");
     userEvent.click(screen.getByText("Fitness"));
-    await screen.findByText("Nova Hipótese");
+    await screen.findByText("Ver detalhes");
     userEvent.click(screen.getByText("Ver detalhes"));
     await screen.findByText("Criar Experimento");
     userEvent.click(screen.getByText("Abrir"));

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -18,20 +18,9 @@ export default function NicheDetailPage() {
   const list = Array.isArray(hypotheses) ? hypotheses : [];
   return (
     <div>
-      <div className="d-flex justify-content-between align-items-center">
-        <PageTitle>{data.name}</PageTitle>
-        <Link
-          className="btn btn-primary"
-          to={`/niches/${nicheId}/hypotheses/new`}
-        >
-          Nova Hipótese
-        </Link>
-      </div>
+      <PageTitle>{data.name}</PageTitle>
       {list.length === 0 ? (
-        <p>
-          Nenhuma hipótese ainda.{" "}
-          <Link to={`/niches/${nicheId}/hypotheses/new`}>Crie uma agora</Link>.
-        </p>
+        <p>Nenhuma hipótese ainda.</p>
       ) : (
         <div className="table-responsive">
           <table className="table">
@@ -56,14 +45,6 @@ export default function NicheDetailPage() {
                   <td>{h.status}</td>
                   <td>{h.kpiTargetCpl}</td>
                   <td>
-                    {h.status === "BACKLOG" && (
-                      <Link
-                        className="btn btn-sm btn-outline-secondary me-1"
-                        to={`hypotheses/${h.id}/edit`}
-                      >
-                        Editar
-                      </Link>
-                    )}
                     <Link
                       className="btn btn-sm btn-outline-primary"
                       to={`hypotheses/${h.id}`}


### PR DESCRIPTION
## Summary
- Make niche detail page read-only by removing hypothesis creation and editing UI
- Update navigation test to match new read-only niche detail view

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c41b89483218775b844df215b7f