### PR TITLE
fix: wrap prompt text to avoid horizontal scroll

### DIFF
--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -121,7 +121,9 @@ export default function HypothesisDetailPage() {
       {data.prompt && (
         <div className="mt-4">
           <h5>Prompt de criação</h5>
-          <pre>{data.prompt}</pre>
+          <pre className="text-break" style={{ whiteSpace: "pre-wrap" }}>
+            {data.prompt}
+          </pre>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- wrap hypothesis prompt text for better readability

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae32edd5c08321852522fc5278695e