### PR TITLE
feat(frontend): add niche detail view

### DIFF
--- a/frontend/src/api/niche/useNiches.ts
+++ b/frontend/src/api/niche/useNiches.ts
@@ -14,6 +14,8 @@ export interface MarketNiche {
   extraTips: string;
   hypothesesToGenerate?: number;
   chatDialogId?: number;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export function useNiches() {

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
@@ -15,10 +16,50 @@ export default function NicheDetailPage() {
 
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;
+
   const list = Array.isArray(hypotheses) ? hypotheses : [];
+  const rows = [
+    { label: "Descrição", value: data.description },
+    { label: "Volume de demanda", value: data.demandVolume },
+    { label: "Promessas", value: data.promises },
+    { label: "Ofertas", value: data.offers },
+    { label: "Hipóteses a gerar", value: data.hypothesesToGenerate },
+    { label: "Segmentação base", value: data.baseSegmentation },
+    { label: "Interesses", value: data.interests },
+    { label: "Filtros demográficos", value: data.demographicFilters },
+    { label: "Dicas extras", value: data.extraTips },
+    { label: "Chat Dialog", value: data.chatDialogId },
+    {
+      label: "Criado em",
+      value: data.createdAt
+        ? new Date(data.createdAt).toLocaleString("pt-BR")
+        : undefined,
+    },
+    {
+      label: "Atualizado em",
+      value: data.updatedAt
+        ? new Date(data.updatedAt).toLocaleString("pt-BR")
+        : undefined,
+    },
+  ];
+
   return (
     <div>
       <PageTitle>{data.name}</PageTitle>
+      <dl className="row mb-4">
+        {rows.map((r, idx) => (
+          <Fragment key={r.label}>
+            <dt className={`col-sm-3 py-2${idx % 2 === 0 ? " bg-light" : ""}`}>
+              {r.label}
+            </dt>
+            <dd className={`col-sm-9 py-2${idx % 2 === 0 ? " bg-light" : ""}`}>
+              <span className="text-break" style={{ whiteSpace: "pre-wrap" }}>
+                {r.value ?? "-"}
+              </span>
+            </dd>
+          </Fragment>
+        ))}
+      </dl>
       {list.length === 0 ? (
         <p>Nenhuma hipótese ainda.</p>
       ) : (

--- a/frontend/src/pages/niche/NicheListPage.test.tsx
+++ b/frontend/src/pages/niche/NicheListPage.test.tsx
@@ -20,4 +20,31 @@ describe("NicheListPage", () => {
     );
     expect(await screen.findByText(/Novo Nicho/)).toBeTruthy();
   });
+
+  it("shows detail button", async () => {
+    const niche = {
+      id: 1,
+      name: "Teste",
+      description: "",
+      demandVolume: "",
+      promises: "",
+      offers: "",
+      baseSegmentation: "",
+      interests: "",
+      demographicFilters: "",
+      extraTips: "",
+    };
+    (axios.get as any)
+      .mockResolvedValueOnce({ data: [niche] })
+      .mockResolvedValue({ data: [] });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <BrowserRouter>
+          <NicheListPage />
+        </BrowserRouter>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByText("Detalhes")).toBeTruthy();
+  });
 });

--- a/frontend/src/pages/niche/NicheListPage.tsx
+++ b/frontend/src/pages/niche/NicheListPage.tsx
@@ -19,8 +19,7 @@ export default function NicheListPage() {
       </Link>
       {niches.length === 0 ? (
         <p>
-          Nenhum nicho encontrado.{' '}
-          <Link to="/niches/new">Crie um agora</Link>.
+          Nenhum nicho encontrado. <Link to="/niches/new">Crie um agora</Link>.
         </p>
       ) : (
         <div className="table-responsive">
@@ -57,7 +56,13 @@ function NicheRow({ niche }: { niche: { id: number; name: string } }) {
       <td>{Array.isArray(exps) ? exps.length : 0}</td>
       <td>
         <Link
-          className="btn btn-sm btn-outline-secondary me-1"
+          className="btn btn-sm btn-outline-primary me-1"
+          to={`/niches/${niche.id}`}
+        >
+          Detalhes
+        </Link>
+        <Link
+          className="btn btn-sm btn-outline-secondary"
           to={`/niches/${niche.id}/edit`}
         >
           Editar


### PR DESCRIPTION
## Summary
- add detail button in niche list
- show full niche fields in detail page
- cover list with detail button test

## Testing
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae4ebfcf148321906c831ede8b98a9