### PR TITLE
Link chat dialog from niche details

### DIFF
--- a/frontend/src/api/chatDialog/useChatDialog.ts
+++ b/frontend/src/api/chatDialog/useChatDialog.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { ChatDialog } from "./useChatDialogs";
+
+export function useChatDialog(id?: number) {
+  return useQuery({
+    queryKey: ["chatDialog", id],
+    queryFn: async () => {
+      const { data } = await axios.get<ChatDialog>(`/api/chat-dialogs/${id}`);
+      return data;
+    },
+    enabled: !!id,
+  });
+}

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -4,10 +4,12 @@ import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
 import PageTitle from "../../components/PageTitle";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
+import { useChatDialog } from "../../api/chatDialog/useChatDialog";
 
 export default function NicheDetailPage() {
   const { nicheId } = useParams();
   const { data, isLoading } = useNiche(Number(nicheId));
+  const { data: chatDialog } = useChatDialog(data?.chatDialogId);
   const { data: hypotheses } = useHypothesesByNiche(nicheId, "ALL");
   useBreadcrumbs([
     { label: "Nichos", to: "/niches" },
@@ -28,7 +30,14 @@ export default function NicheDetailPage() {
     { label: "Interesses", value: data.interests },
     { label: "Filtros demográficos", value: data.demographicFilters },
     { label: "Dicas extras", value: data.extraTips },
-    { label: "Chat Dialog", value: data.chatDialogId },
+    {
+      label: "Chat Dialog",
+      value: chatDialog ? (
+        <a href={chatDialog.url} target="_blank" rel="noopener noreferrer">
+          {chatDialog.description}
+        </a>
+      ) : undefined,
+    },
     {
       label: "Criado em",
       value: data.createdAt


### PR DESCRIPTION
## Summary
- Load chat dialog by ID on Niche detail page and render link to open the dialog
- Add `useChatDialog` hook for fetching a single chat dialog

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af3b6c095c832194c616b4722f1738