### PR TITLE
Reset niche hypothesis quantity after generation

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
@@ -66,6 +66,11 @@ public class NicheHypothesisService {
                 log.info("Saving hypothesis for niche {}: {}", niche.getId(), req);
                 saved.add(hypothesisService.create(req));
             }
+            if (!saved.isEmpty()) {
+                log.info("Resetting hypothesesToGenerate for niche {} to 0", niche.getId());
+                niche.setHypothesesToGenerate(0);
+                nicheRepository.save(niche);
+            }
             result.put(niche.getId(), saved);
         }
         return result;

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -124,6 +124,7 @@ class NicheHypothesisServiceTest {
         assertThat(first.getPromptAttributeDescriptions()).extracting(PromptAttributeDescription::getId).contains(desc.getId());
         assertThat(hypothesisRepository.count()).isEqualTo(2);
         assertThat(mockWebServer.getRequestCount() - initialCount).isEqualTo(1);
+        assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isZero();
     }
 
     @Test
@@ -157,6 +158,7 @@ class NicheHypothesisServiceTest {
         assertThat(hyps).hasSize(1);
         assertThat(hypothesisRepository.count()).isEqualTo(1);
         assertThat(mockWebServer.getRequestCount() - initialCount).isEqualTo(1);
+        assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isZero();
     }
 
     @Test
@@ -188,5 +190,34 @@ class NicheHypothesisServiceTest {
         List<Hypothesis> hyps = result.get(niche.getId());
         assertThat(hyps).hasSize(1);
         assertThat(hyps.get(0).getOfferType()).isNull();
+        assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isZero();
+    }
+
+    @Test
+    void keepQuantityWhenNoHypothesisCreated() {
+        MarketNiche niche = MarketNiche.builder()
+                .name("Health")
+                .hypothesesToGenerate(1)
+                .build();
+        nicheRepository.save(niche);
+
+        String content = """[
+          {"promise":"p1","problem":"pr1","persona":"pe1","successRule":"sr1","offerType":"LEAD","kpiTargetCpl":1}
+        ]""";
+        try {
+            String body = new ObjectMapper().writeValueAsString(
+                    Map.of("choices", List.of(Map.of("message", Map.of("content", content)))));
+            mockWebServer.enqueue(new MockResponse()
+                    .addHeader("Content-Type", "application/json")
+                    .setBody(body));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        Map<Long, List<Hypothesis>> result = service.generate();
+        assertThat(result).containsKey(niche.getId());
+        assertThat(result.get(niche.getId())).isEmpty();
+        assertThat(hypothesisRepository.count()).isZero();
+        assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## Summary
- Clear `hypothesesToGenerate` after AI Worker creates hypotheses for a niche
- Add tests verifying the quantity is reset only when hypotheses are saved

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afbe88d1148321b61b9aa43cf7c92a