### PR TITLE
Reset niche hypothesis generation count after processing

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
@@ -66,6 +66,9 @@ public class NicheHypothesisService {
                 log.info("Saving hypothesis for niche {}: {}", niche.getId(), req);
                 saved.add(hypothesisService.create(req));
             }
+            // Reset the amount of hypotheses to generate so this niche isn't processed again
+            niche.setHypothesesToGenerate(0);
+            nicheRepository.save(niche);
             result.put(niche.getId(), saved);
         }
         return result;

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -124,6 +124,9 @@ class NicheHypothesisServiceTest {
         assertThat(first.getPromptAttributeDescriptions()).extracting(PromptAttributeDescription::getId).contains(desc.getId());
         assertThat(hypothesisRepository.count()).isEqualTo(2);
         assertThat(mockWebServer.getRequestCount() - initialCount).isEqualTo(1);
+
+        MarketNiche updated = nicheRepository.findById(niche.getId()).orElseThrow();
+        assertThat(updated.getHypothesesToGenerate()).isZero();
     }
 
     @Test
@@ -157,6 +160,9 @@ class NicheHypothesisServiceTest {
         assertThat(hyps).hasSize(1);
         assertThat(hypothesisRepository.count()).isEqualTo(1);
         assertThat(mockWebServer.getRequestCount() - initialCount).isEqualTo(1);
+
+        MarketNiche updated = nicheRepository.findById(niche.getId()).orElseThrow();
+        assertThat(updated.getHypothesesToGenerate()).isZero();
     }
 
     @Test
@@ -188,5 +194,8 @@ class NicheHypothesisServiceTest {
         List<Hypothesis> hyps = result.get(niche.getId());
         assertThat(hyps).hasSize(1);
         assertThat(hyps.get(0).getOfferType()).isNull();
+
+        MarketNiche updated = nicheRepository.findById(niche.getId()).orElseThrow();
+        assertThat(updated.getHypothesesToGenerate()).isZero();
     }
 }


### PR DESCRIPTION
## Summary
- Reset `hypothesesToGenerate` to 0 after the AI worker generates hypotheses for a niche
- Cover resetting behavior with new assertions in `NicheHypothesisServiceTest`

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afbe88d1148321b61b9aa43cf7c92a