### PR TITLE
Reset niche hypothesis quantity after generation

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
@@ -67,6 +67,10 @@ public class NicheHypothesisService {
                 saved.add(hypothesisService.create(req));
             }
             result.put(niche.getId(), saved);
+
+            // Reset quantity after generating hypotheses for this niche
+            niche.setHypothesesToGenerate(0);
+            nicheRepository.save(niche);
         }
         return result;
     }

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -124,6 +124,7 @@ class NicheHypothesisServiceTest {
         assertThat(first.getPromptAttributeDescriptions()).extracting(PromptAttributeDescription::getId).contains(desc.getId());
         assertThat(hypothesisRepository.count()).isEqualTo(2);
         assertThat(mockWebServer.getRequestCount() - initialCount).isEqualTo(1);
+        assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isZero();
     }
 
     @Test
@@ -157,6 +158,7 @@ class NicheHypothesisServiceTest {
         assertThat(hyps).hasSize(1);
         assertThat(hypothesisRepository.count()).isEqualTo(1);
         assertThat(mockWebServer.getRequestCount() - initialCount).isEqualTo(1);
+        assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isZero();
     }
 
     @Test
@@ -188,5 +190,6 @@ class NicheHypothesisServiceTest {
         List<Hypothesis> hyps = result.get(niche.getId());
         assertThat(hyps).hasSize(1);
         assertThat(hyps.get(0).getOfferType()).isNull();
+        assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isZero();
     }
 }


### PR DESCRIPTION
## Summary
- reset `hypothesesToGenerate` to 0 for niches after AI generation
- test that hypothesis generation clears remaining quantity

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker:0.0.1-SNAPSHOT)*
- `mvn -s settings.xml package` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker:0.0.1-SNAPSHOT)*
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service:0.0.1-SNAPSHOT)*
- `mvn -s ../settings.xml deploy` *(fails: Non-resolvable parent POM for com.marketinghub:ads-service:0.0.1-SNAPSHOT)*
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afbe88d1148321b61b9aa43cf7c92a