### PR TITLE
Reset niche quantity after hypothesis generation

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/NicheHypothesisService.java
@@ -66,11 +66,9 @@ public class NicheHypothesisService {
                 log.info("Saving hypothesis for niche {}: {}", niche.getId(), req);
                 saved.add(hypothesisService.create(req));
             }
-            if (!saved.isEmpty()) {
-                log.info("Resetting hypothesesToGenerate for niche {} to 0", niche.getId());
-                niche.setHypothesesToGenerate(0);
-                nicheRepository.save(niche);
-            }
+            log.info("Resetting hypothesesToGenerate for niche {} to 0", niche.getId());
+            niche.setHypothesesToGenerate(0);
+            nicheRepository.save(niche);
             result.put(niche.getId(), saved);
         }
         return result;

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -194,7 +194,7 @@ class NicheHypothesisServiceTest {
     }
 
     @Test
-    void keepQuantityWhenNoHypothesisCreated() {
+    void resetQuantityWhenNoHypothesisCreated() {
         MarketNiche niche = MarketNiche.builder()
                 .name("Health")
                 .hypothesesToGenerate(1)
@@ -218,6 +218,6 @@ class NicheHypothesisServiceTest {
         assertThat(result).containsKey(niche.getId());
         assertThat(result.get(niche.getId())).isEmpty();
         assertThat(hypothesisRepository.count()).isZero();
-        assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isEqualTo(1);
+        assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isZero();
     }
 }


### PR DESCRIPTION
## Summary
- Always reset `hypothesesToGenerate` to 0 after processing each niche
- Update test to assert quantity reset even when no hypotheses were saved

## Testing
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker:0.0.1-SNAPSHOT)*
- `mvn -s settings.xml package` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68b05834240c83219e8fcd4d0d7d47ce