### PR TITLE
Fix text block delimiter in test

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -201,9 +201,11 @@ class NicheHypothesisServiceTest {
                 .build();
         nicheRepository.save(niche);
 
-        String content = """[
-          {"promise":"p1","problem":"pr1","persona":"pe1","successRule":"sr1","offerType":"LEAD","kpiTargetCpl":1}
-        ]""";
+        String content = """
+                [
+                  {"promise":"p1","problem":"pr1","persona":"pe1","successRule":"sr1","offerType":"LEAD","kpiTargetCpl":1}
+                ]
+                """;
         try {
             String body = new ObjectMapper().writeValueAsString(
                     Map.of("choices", List.of(Map.of("message", Map.of("content", content)))));


### PR DESCRIPTION
## Summary
- fix text block delimiter in NicheHypothesisServiceTest

## Testing
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b060d473588321a140c4f685f435a1