### PR TITLE
Expose hypothesis creation date

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
@@ -28,5 +28,6 @@ public class HypothesisDto {
     private BigDecimal kpiTargetCpl;
     private HypothesisStatus status;
     private Instant generatedAt;
+    private Instant createdAt;
     private List<Long> promptAttributeDescriptionIds;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/mapper/HypothesisMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/mapper/HypothesisMapper.java
@@ -10,5 +10,6 @@ public interface HypothesisMapper {
     @Mapping(target = "marketNicheId", source = "marketNiche.id")
     @Mapping(target = "premiseAngleId", source = "premiseAngle.id")
     @Mapping(target = "promptAttributeDescriptionIds", expression = "java(hypothesis.getPromptAttributeDescriptions().stream().map(com.marketinghub.prompt.PromptAttributeDescription::getId).toList())")
+    @Mapping(target = "createdAt", source = "createdAt")
     HypothesisDto toDto(Hypothesis hypothesis);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/web/HypothesisControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/web/HypothesisControllerTest.java
@@ -43,6 +43,7 @@ class HypothesisControllerTest {
         mockMvc.perform(get("/api/niches/" + niche.getId() + "/hypotheses")
                         .param("status", "ALL"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(2));
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].createdAt").exists());
     }
 }


### PR DESCRIPTION
## Summary
- include `createdAt` field in `HypothesisDto` and map it from the entity
- verify hypothesis endpoints return creation date

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3b48b03008321aa92c6459d326219