### PR TITLE
feat: add entrega field to hypothesis

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -134,7 +134,7 @@ public class ChatGptClient {
             descriptions.forEach((name, desc) ->
                     sb.append("Campo \\\"" + name + "\\\": " + desc + ". "));
         } else {
-            sb.append("Cada objeto deve conter as chaves: \"title\", \"promise\", \"problem\", \"persona\", \"mechanism\", \"uniqueMechanism\", \"successRule\", \"offerType\", \"price\". ");
+            sb.append("Cada objeto deve conter as chaves: \"title\", \"promise\", \"problem\", \"persona\", \"mechanism\", \"uniqueMechanism\", \"entrega\", \"successRule\", \"offerType\", \"price\". ");
         }
         sb.append("O campo \"offerType\" deve ser \"LEAD\" ou \"TRIPWIRE\". ");
         sb.append("O campo \"price\" deve ser um número. ");

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -57,6 +57,11 @@ public class Hypothesis {
     @Lob
     private String uniqueMechanism;
 
+    /** Entrega ou deliverable associado à hipótese. */
+    @Lob
+    @Column(columnDefinition = "LONGTEXT")
+    private String entrega;
+
     /** Prompt usado quando a hipótese é gerada por IA. */
     @Lob
     @Column(columnDefinition = "LONGTEXT")

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/CreateHypothesisRequest.java
@@ -16,6 +16,7 @@ public class CreateHypothesisRequest {
 
     @JsonAlias("unique_mechanism")
     private String uniqueMechanism;
+    private String entrega;
     private String successRule;
     private String prompt;
     private String model;
@@ -41,6 +42,8 @@ public class CreateHypothesisRequest {
     public void setMechanism(String mechanism) { this.mechanism = mechanism; }
     public String getUniqueMechanism() { return uniqueMechanism; }
     public void setUniqueMechanism(String uniqueMechanism) { this.uniqueMechanism = uniqueMechanism; }
+    public String getEntrega() { return entrega; }
+    public void setEntrega(String entrega) { this.entrega = entrega; }
     public String getSuccessRule() { return successRule; }
     public void setSuccessRule(String successRule) { this.successRule = successRule; }
     public String getPrompt() { return prompt; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/HypothesisDto.java
@@ -20,6 +20,7 @@ public class HypothesisDto {
     private String persona;
     private String mechanism;
     private String uniqueMechanism;
+    private String entrega;
     private String successRule;
     private String prompt;
     private String model;

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/dto/UpdateHypothesisRequest.java
@@ -10,6 +10,7 @@ public class UpdateHypothesisRequest {
     private String persona;
     private String mechanism;
     private String uniqueMechanism;
+    private String entrega;
     private String successRule;
     private String prompt;
     private String model;
@@ -37,6 +38,9 @@ public class UpdateHypothesisRequest {
 
     public String getUniqueMechanism() { return uniqueMechanism; }
     public void setUniqueMechanism(String uniqueMechanism) { this.uniqueMechanism = uniqueMechanism; }
+
+    public String getEntrega() { return entrega; }
+    public void setEntrega(String entrega) { this.entrega = entrega; }
 
     public String getSuccessRule() { return successRule; }
     public void setSuccessRule(String successRule) { this.successRule = successRule; }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -89,6 +89,7 @@ public class HypothesisService {
                 .persona(req.getPersona())
                 .mechanism(req.getMechanism())
                 .uniqueMechanism(req.getUniqueMechanism())
+                .entrega(req.getEntrega())
                 .successRule(req.getSuccessRule())
                 .prompt(req.getPrompt())
                 .model(req.getModel())
@@ -142,6 +143,7 @@ public class HypothesisService {
         h.setPersona(req.getPersona());
         h.setMechanism(req.getMechanism());
         h.setUniqueMechanism(req.getUniqueMechanism());
+        h.setEntrega(req.getEntrega());
         h.setSuccessRule(req.getSuccessRule());
         h.setOfferType(req.getOfferType() == null ? null : OfferType.valueOf(req.getOfferType()));
         h.setPrice(req.getPrice());

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -124,6 +124,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `title` VARCHAR(255) NOT NULL
 - `premise_angle_id` BIGINT NOT NULL
 - `offer_type` VARCHAR(20) NOT NULL
+- `entrega` LONGTEXT
 - `price` DECIMAL(6,2)
 - `kpi_target_cpl` DECIMAL(7,2) NOT NULL
 - `status` VARCHAR(20) DEFAULT 'BACKLOG' NOT NULL

--- a/docs/db/changelog/V2025_09_23__add_entrega_to_hypothesis.sql
+++ b/docs/db/changelog/V2025_09_23__add_entrega_to_hypothesis.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hypothesis ADD COLUMN entrega LONGTEXT;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -410,12 +410,14 @@ components:
           type: string
         problem:
           type: string
-        persona:
-          type: string
-        mechanism:
-          type: string
-        uniqueMechanism:
-          type: string
+          persona:
+            type: string
+          entrega:
+            type: string
+          mechanism:
+            type: string
+          uniqueMechanism:
+            type: string
         successRule:
           type: string
         prompt:

--- a/frontend/src/api/hypothesis/useCreateHypothesis.ts
+++ b/frontend/src/api/hypothesis/useCreateHypothesis.ts
@@ -12,6 +12,7 @@ export interface CreateHypothesis {
   persona: string;
   mechanism?: string;
   uniqueMechanism?: string;
+  entrega?: string;
   successRule: string;
   prompt?: string;
   model?: string;

--- a/frontend/src/api/hypothesis/useHypothesisBoard.ts
+++ b/frontend/src/api/hypothesis/useHypothesisBoard.ts
@@ -10,6 +10,7 @@ export interface Hypothesis {
   persona?: string;
   mechanism?: string;
   uniqueMechanism?: string;
+  entrega?: string;
   successRule?: string;
   prompt?: string;
   model?: string;

--- a/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
@@ -17,6 +17,7 @@ const schema = z
     persona: z.string().min(1),
     mechanism: z.string().optional(),
     uniqueMechanism: z.string().optional(),
+    entrega: z.string().optional(),
     successRule: z.string().min(1),
     premiseAngleId: z.string().optional(),
     offerType: z.enum(["LEAD", "TRIPWIRE"]),
@@ -63,6 +64,7 @@ export default function EditHypothesisPage() {
         persona: data.persona || "",
         mechanism: data.mechanism || "",
         uniqueMechanism: data.uniqueMechanism || "",
+        entrega: data.entrega || "",
         successRule: data.successRule || "",
         premiseAngleId: String(data.premiseAngleId ?? ""),
         offerType: (data.offerType as "LEAD" | "TRIPWIRE") || "LEAD",
@@ -84,6 +86,7 @@ export default function EditHypothesisPage() {
       persona: values.persona,
       mechanism: values.mechanism,
       uniqueMechanism: values.uniqueMechanism,
+      entrega: values.entrega,
       successRule: values.successRule,
       premiseAngleId: values.premiseAngleId
         ? Number(values.premiseAngleId)
@@ -194,6 +197,22 @@ export default function EditHypothesisPage() {
         {errors.uniqueMechanism && (
           <div id="uniqueMechanism-error" className="invalid-feedback d-block">
             {errors.uniqueMechanism.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="entrega">
+          Entrega
+        </label>
+        <textarea
+          id="entrega"
+          rows={2}
+          {...register("entrega")}
+          className={`form-control mb-2 ${errors.entrega ? "is-invalid" : ""}`}
+          aria-describedby="entrega-error"
+        />
+        {errors.entrega && (
+          <div id="entrega-error" className="invalid-feedback d-block">
+            {errors.entrega.message}
           </div>
         )}
 

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -32,6 +32,7 @@ export default function HypothesisDetailPage() {
     { label: "Persona", value: data.persona },
     { label: "Mecanismo", value: data.mechanism },
     { label: "Mecanismo único", value: data.uniqueMechanism },
+    { label: "Entrega", value: data.entrega },
     { label: "Regra de sucesso", value: data.successRule },
     { label: "Ângulo", value: angleName },
     {

--- a/frontend/src/pages/hypothesis/NewHypothesisModal.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisModal.tsx
@@ -14,6 +14,7 @@ const schema = z
     promise: z.string().min(1, "obrigatório").max(140, "máx. 140"),
     problem: z.string().min(1, "obrigatório"),
     persona: z.string().min(1, "obrigatório"),
+    entrega: z.string().optional(),
     successRule: z.string().min(1, "obrigatório"),
     premiseAngleId: z.string().optional(),
     offerType: z.enum(["LEAD", "TRIPWIRE"]),
@@ -67,6 +68,7 @@ export default function NewHypothesisModal({
       promise: values.promise,
       problem: values.problem,
       persona: values.persona,
+      entrega: values.entrega,
       successRule: values.successRule,
       premiseAngleId: values.premiseAngleId
         ? Number(values.premiseAngleId)
@@ -153,6 +155,20 @@ export default function NewHypothesisModal({
                 {errors.persona && (
                   <div id="persona-error" className="invalid-feedback d-block">
                     {errors.persona.message}
+                  </div>
+                )}
+
+                <label className="form-label" htmlFor="entrega">Entrega</label>
+                <textarea
+                  id="entrega"
+                  rows={2}
+                  {...register("entrega")}
+                  className={`form-control mb-2 ${errors.entrega ? "is-invalid" : ""}`}
+                  aria-describedby="entrega-error"
+                />
+                {errors.entrega && (
+                  <div id="entrega-error" className="invalid-feedback d-block">
+                    {errors.entrega.message}
                   </div>
                 )}
 

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -18,6 +18,7 @@ const schema = z
     persona: z.string().min(1, "obrigatório"),
     mechanism: z.string().optional(),
     uniqueMechanism: z.string().optional(),
+    entrega: z.string().optional(),
     successRule: z.string().min(1, "obrigatório"),
     premiseAngleId: z.string().optional(),
     offerType: z.enum(["LEAD", "TRIPWIRE"]),
@@ -67,6 +68,7 @@ export default function NewHypothesisPage() {
       persona: values.persona,
       mechanism: values.mechanism,
       uniqueMechanism: values.uniqueMechanism,
+      entrega: values.entrega,
       successRule: values.successRule,
       premiseAngleId: values.premiseAngleId
         ? Number(values.premiseAngleId)
@@ -219,6 +221,22 @@ export default function NewHypothesisPage() {
         {errors.uniqueMechanism && (
           <div id="uniqueMechanism-error" className="invalid-feedback d-block">
             {errors.uniqueMechanism.message}
+          </div>
+        )}
+
+        <label className="form-label" htmlFor="entrega">
+          Entrega
+        </label>
+        <textarea
+          id="entrega"
+          rows={2}
+          {...register("entrega")}
+          className={`form-control mb-2 ${errors.entrega ? "is-invalid" : ""}`}
+          aria-describedby="entrega-error"
+        />
+        {errors.entrega && (
+          <div id="entrega-error" className="invalid-feedback d-block">
+            {errors.entrega.message}
           </div>
         )}
 

--- a/schema.sql
+++ b/schema.sql
@@ -246,3 +246,5 @@ CREATE TABLE hypothesis_prompt_attribute_description (
     CONSTRAINT fk_hpah_hypothesis FOREIGN KEY (hypothesis_id) REFERENCES hypothesis(id),
     CONSTRAINT fk_hpah_description FOREIGN KEY (prompt_attribute_description_id) REFERENCES prompt_attribute_description(id)
 );
+
+ALTER TABLE hypothesis ADD COLUMN entrega LONGTEXT;


### PR DESCRIPTION
## Summary
- add entrega field to Hypothesis entity and DTOs
- support entrega in hypothesis forms and API
- extend worker prompt and database schema for entrega

## Testing
- `mvn -s ../settings.xml test` *(backend, failed: Network is unreachable)*
- `mvn -s ../settings.xml deploy` *(backend, failed: Network is unreachable)*
- `mvn -s settings.xml test` *(ai-worker, failed: Network is unreachable)*
- `mvn -s settings.xml package` *(ai-worker, failed: Network is unreachable)*
- `npm run test` *(frontend, failed: Minified React error #310)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b44c434e388321a56ef7f149bc8b1d