### PR TITLE
fix: create prompt attribute when missing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptAttributeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/prompt/service/PromptAttributeService.java
@@ -2,12 +2,14 @@ package com.marketinghub.prompt.service;
 
 import com.marketinghub.prompt.PromptAttribute;
 import com.marketinghub.prompt.PromptAttributeDescription;
+import com.marketinghub.prompt.PromptEntity;
 import com.marketinghub.prompt.dto.CreatePromptAttributeRequest;
 import com.marketinghub.prompt.dto.PromptAttributeDto;
 import com.marketinghub.prompt.dto.UpdatePromptAttributeRequest;
 import com.marketinghub.prompt.mapper.PromptAttributeMapper;
 import com.marketinghub.prompt.repository.PromptAttributeDescriptionRepository;
 import com.marketinghub.prompt.repository.PromptAttributeRepository;
+import com.marketinghub.prompt.repository.PromptEntityRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
@@ -17,13 +19,16 @@ import java.util.List;
 public class PromptAttributeService {
     private final PromptAttributeRepository attributeRepository;
     private final PromptAttributeDescriptionRepository descriptionRepository;
+    private final PromptEntityRepository entityRepository;
     private final PromptAttributeMapper mapper;
 
     public PromptAttributeService(PromptAttributeRepository attributeRepository,
                                   PromptAttributeDescriptionRepository descriptionRepository,
+                                  PromptEntityRepository entityRepository,
                                   PromptAttributeMapper mapper) {
         this.attributeRepository = attributeRepository;
         this.descriptionRepository = descriptionRepository;
+        this.entityRepository = entityRepository;
         this.mapper = mapper;
     }
 
@@ -40,7 +45,15 @@ public class PromptAttributeService {
     public PromptAttributeDto create(String entityName, CreatePromptAttributeRequest req) {
         PromptAttribute attribute = attributeRepository
                 .findByEntity_NameAndName(entityName, req.getName())
-                .orElseThrow(() -> new EntityNotFoundException("PromptAttribute not found"));
+                .orElseGet(() -> {
+                    PromptEntity entity = entityRepository.findByName(entityName)
+                            .orElseThrow(() -> new EntityNotFoundException("PromptEntity not found"));
+                    PromptAttribute newAttr = PromptAttribute.builder()
+                            .entity(entity)
+                            .name(req.getName())
+                            .build();
+                    return attributeRepository.save(newAttr);
+                });
         descriptionRepository.findByAttribute_IdAndActiveTrue(attribute.getId())
                 .ifPresent(prev -> {
                     prev.setActive(false);

--- a/backend/ads-service/src/test/java/com/marketinghub/prompt/PromptAttributeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/prompt/PromptAttributeServiceTest.java
@@ -1,0 +1,55 @@
+package com.marketinghub.prompt;
+
+import com.marketinghub.prompt.dto.CreatePromptAttributeRequest;
+import com.marketinghub.prompt.dto.PromptAttributeDto;
+import com.marketinghub.prompt.repository.PromptAttributeDescriptionRepository;
+import com.marketinghub.prompt.repository.PromptAttributeRepository;
+import com.marketinghub.prompt.repository.PromptEntityRepository;
+import com.marketinghub.prompt.service.PromptAttributeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
+})
+@org.springframework.transaction.annotation.Transactional
+class PromptAttributeServiceTest {
+    @Autowired
+    PromptAttributeService service;
+    @Autowired
+    PromptEntityRepository entityRepository;
+    @Autowired
+    PromptAttributeRepository attributeRepository;
+    @Autowired
+    PromptAttributeDescriptionRepository descriptionRepository;
+
+    @Test
+    void createNewAttribute() {
+        PromptEntity entity = entityRepository.save(PromptEntity.builder().name("hypothesis").build());
+        CreatePromptAttributeRequest req = new CreatePromptAttributeRequest();
+        req.setName("entrega");
+        req.setDescription("d");
+
+        PromptAttributeDto dto = service.create(entity.getName(), req);
+
+        assertThat(dto.getName()).isEqualTo("entrega");
+        assertThat(dto.getDescription()).isEqualTo("d");
+        PromptAttribute attr = attributeRepository
+                .findByEntity_NameAndName(entity.getName(), "entrega")
+                .orElse(null);
+        assertThat(attr).isNotNull();
+        assertThat(descriptionRepository.findByAttribute_IdAndActiveTrue(attr.getId()))
+                .map(PromptAttributeDescription::getDescription)
+                .contains("d");
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow creating new prompt attributes with automatic entity association
- add unit test for creating new prompt attributes

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bad6f3848321b4af06a7c794f194