### PR TITLE
feat(frontend): show hypothesis delivery field

### DIFF
--- a/frontend/src/__tests__/NicheFlow.test.tsx
+++ b/frontend/src/__tests__/NicheFlow.test.tsx
@@ -87,6 +87,7 @@ describe("niche navigation", () => {
     await screen.findByText("Fitness");
     userEvent.click(screen.getByText("Fitness"));
     await screen.findByText("Ver detalhes");
+    await screen.findByText(/Entrega:/);
     await screen.findByRole("button", { name: /salvar em markdown/i });
     userEvent.click(screen.getByText("Ver detalhes"));
     await screen.findByText("Criar Experimento");

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -20,7 +20,8 @@ export default function NicheDetailPage() {
   if (!data) return <p>Não encontrado</p>;
 
   const handleSaveMarkdown = () => {
-    const md = `# Nicho: ${data.name}\n\n` +
+    const md =
+      `# Nicho: ${data.name}\n\n` +
       `**ID:** ${data.id}\n\n` +
       `**Descrição:**\n${data.description}\n\n` +
       `**Volume de Demanda:**\n${data.demandVolume}\n\n` +
@@ -127,6 +128,9 @@ export default function NicheDetailPage() {
                   </p>
                   <p className="card-text">
                     <strong>Persona:</strong> {h.persona || "-"}
+                  </p>
+                  <p className="card-text">
+                    <strong>Entrega:</strong> {h.entrega || "-"}
                   </p>
                   <Link
                     className="btn btn-sm btn-outline-primary mt-2"


### PR DESCRIPTION
## Summary
- display delivery info for each hypothesis on niche detail view
- cover delivery field with a navigation test

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5cb1d868083218417054759cf0f1c