### PR TITLE
feat: support legacy experiment payload fields

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
@@ -1,7 +1,9 @@
 package com.marketinghub.experiment.dto;
 
-import java.time.LocalDate;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import lombok.Data;
 
 /**
@@ -13,11 +15,15 @@ public class CreateExperimentRequest {
     private java.util.UUID hypothesisId;
     private String name;
     private String hypothesis;
+    @JsonProperty("kpiTarget")
+    @JsonAlias("kpiTargetCpl")
     private BigDecimal kpiTargetCpl;
     private String metricPresetId;
     private Integer sampleSize;
     private BigDecimal baselineCvr;
     private BigDecimal targetCvr;
+    @JsonProperty("mde")
+    @JsonAlias("mdePercent")
     private BigDecimal mdePercent;
     private LocalDate startDate;
     private LocalDate endDate;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -1,7 +1,8 @@
 package com.marketinghub.experiment.dto;
 
-import com.marketinghub.experiment.ExperimentStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.marketinghub.experiment.ExperimentPlatform;
+import com.marketinghub.experiment.ExperimentStatus;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -17,11 +18,13 @@ public class ExperimentDto {
     private java.util.UUID hypothesisId;
     private String name;
     private String hypothesis;
+    @JsonProperty("kpiTarget")
     private BigDecimal kpiTargetCpl;
     private BigDecimal stopLossCpl;
     private Integer sampleSize;
     private BigDecimal baselineCvr;
     private BigDecimal targetCvr;
+    @JsonProperty("mde")
     private BigDecimal mdePercent;
     private LocalDate startDate;
     private LocalDate endDate;


### PR DESCRIPTION
## Summary
- map `kpiTarget` and `mde` payload fields to existing experiment fields
- expose matching property names in experiment DTO

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b71edc0bf88321bb161bde2563d703