### PR TITLE
feat: allow requesting creative generation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -75,6 +75,10 @@ public class Experiment {
     @Enumerated(EnumType.STRING)
     private ExperimentPlatform platform;
 
+    /** Quantidade de criativos a serem gerados pelo worker. */
+    @Column(name = "creatives_to_generate")
+    private Integer creativesToGenerate;
+
     @CreationTimestamp
     private Instant createdAt;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
@@ -27,4 +27,5 @@ public class CreateExperimentRequest {
     private BigDecimal mdePercent;
     private LocalDate startDate;
     private LocalDate endDate;
+    private Integer creativesToGenerate;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -33,4 +33,5 @@ public class ExperimentDto {
     private Instant createdAt;
     private Instant updatedAt;
     private String metricPresetId;
+    private Integer creativesToGenerate;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
@@ -20,5 +20,6 @@ public class UpdateExperimentRequest {
     private BigDecimal mdePercent;
     private LocalDate startDate;
     private LocalDate endDate;
+    private Integer creativesToGenerate;
 }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -107,6 +107,7 @@ public class ExperimentService {
                 .endDate(request.getEndDate())
                 .status(ExperimentStatus.PLANNED)
                 .platform(ExperimentPlatform.FACEBOOK)
+                .creativesToGenerate(request.getCreativesToGenerate())
                 .build();
         return repository.save(exp);
     }
@@ -150,6 +151,7 @@ public class ExperimentService {
                 .endDate(original.getEndDate())
                 .status(ExperimentStatus.PLANNED)
                 .platform(original.getPlatform())
+                .creativesToGenerate(original.getCreativesToGenerate())
                 .build();
         return repository.save(copy);
     }
@@ -216,6 +218,19 @@ public class ExperimentService {
         }
         exp.setStartDate(request.getStartDate());
         exp.setEndDate(request.getEndDate());
+        if (request.getCreativesToGenerate() != null) {
+            exp.setCreativesToGenerate(request.getCreativesToGenerate());
+        }
+        return exp;
+    }
+
+    /**
+     * Requests generation of new creatives by setting the pending quantity.
+     */
+    @Transactional
+    public Experiment requestCreatives(Long id, int quantity) {
+        Experiment exp = repository.findById(id).orElseThrow();
+        exp.setCreativesToGenerate(quantity);
         return exp;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -61,4 +61,9 @@ public class ExperimentController {
         return mapper.toDto(service.update(id, request));
     }
 
+    @PatchMapping("/{id}/creatives-to-generate")
+    public ExperimentDto requestCreatives(@PathVariable Long id, @RequestParam("quantity") int quantity) {
+        return mapper.toDto(service.requestCreatives(id, quantity));
+    }
+
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
@@ -73,6 +73,7 @@ public class FixtureUtils {
                 .targetCvr(java.math.BigDecimal.valueOf(5))
                 .status(ExperimentStatus.PLANNED)
                 .platform(ExperimentPlatform.FACEBOOK)
+                .creativesToGenerate(0)
                 .build();
         return experimentRepository.save(exp);
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -138,4 +138,16 @@ class ExperimentControllerTest {
         assertThat(updated.getSampleSize()).isEqualTo(200);
         assertThat(updated.getMdePercent()).isEqualByComparingTo("30");
     }
+
+    @Test
+    void requestCreativesEndpointUpdatesQuantity() throws Exception {
+        var niche = nicheRepo.findById(nicheId).orElseThrow();
+        var exp = fixtures.createAndSaveExperiment(niche);
+        mockMvc.perform(
+                        patch("/api/experiments/" + exp.getId() + "/creatives-to-generate")
+                                .param("quantity", "3"))
+                .andExpect(status().isOk());
+        var updated = repository.findById(exp.getId()).orElseThrow();
+        assertThat(updated.getCreativesToGenerate()).isEqualTo(3);
+    }
 }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -144,6 +144,7 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `baseline_cvr` DECIMAL(5,2) DEFAULT 3.00
 - `target_cvr` DECIMAL(5,2) DEFAULT 5.00
 - `mde_percent` DECIMAL(5,2) DEFAULT 40.0
+- `creatives_to_generate` INT
 - `start_date` DATE
 - `end_date` DATE
 - `status` VARCHAR(20)

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -13,6 +13,7 @@ export interface CreateExperiment {
   mde?: number;
   startDate?: string;
   endDate?: string;
+  creativesToGenerate?: number;
 }
 
 export function useCreateExperiment() {

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -21,6 +21,7 @@ export interface Experiment {
   startDate: string | null;
   endDate: string | null;
   metricPresetId?: string | null;
+  creativesToGenerate?: number | null;
   status: string;
   platform: string;
   createdAt: string;

--- a/frontend/src/api/experiment/useRequestCreatives.ts
+++ b/frontend/src/api/experiment/useRequestCreatives.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Experiment } from "./useExperiments";
+
+export function useRequestCreatives(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (quantity: number) => {
+      const { data } = await axios.patch<Experiment>(
+        `/api/experiments/${id}/creatives-to-generate`,
+        undefined,
+        { params: { quantity } },
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["experiment", id] });
+      queryClient.invalidateQueries({ queryKey: ["experiments"] });
+    },
+  });
+}

--- a/frontend/src/api/experiment/useUpdateExperiment.ts
+++ b/frontend/src/api/experiment/useUpdateExperiment.ts
@@ -11,6 +11,7 @@ export interface UpdateExperiment {
   mde?: number;
   startDate?: string;
   endDate?: string;
+  creativesToGenerate?: number;
 }
 
 export function useUpdateExperiment(id: string) {

--- a/frontend/src/pages/experiment/CriativosTab.test.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.test.tsx
@@ -16,6 +16,6 @@ describe("CriativosTab", () => {
       </QueryClientProvider>,
     );
     screen.getByText("Novo Criativo").click();
-    expect(await screen.findByText(/Criativo/)).toBeTruthy();
+    expect(await screen.findByText("Novo Criativo")).toBeTruthy();
   });
 });

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -8,6 +8,7 @@ import { useAngles } from "../../api/angle/useAngles";
 import { useVisualProofs } from "../../api/visualProof/useVisualProofs";
 import { useEmotionalTriggers } from "../../api/emotionalTrigger/useEmotionalTriggers";
 import { useUpdateCreativeLabels } from "../../api/creative/useUpdateCreativeLabels";
+import { useRequestCreatives } from "../../api/experiment/useRequestCreatives";
 
 interface Props {
   experimentId: string;
@@ -39,6 +40,7 @@ export default function CriativosTab({ experimentId }: Props) {
     false,
   );
   const [showPreview, setShowPreview] = useState(false);
+  const requestCreatives = useRequestCreatives(experimentId);
 
   const openNew = () => {
     setEditing(null);
@@ -97,10 +99,30 @@ export default function CriativosTab({ experimentId }: Props) {
     img.src = URL.createObjectURL(file);
   };
 
+  const generateCreatives = async () => {
+    const qtyStr = prompt("Quantos criativos gerar?");
+    if (!qtyStr) return;
+    const qty = Number(qtyStr);
+    if (!qty || qty <= 0) return;
+    try {
+      await requestCreatives.mutateAsync(qty);
+      alert("Solicitação enviada!");
+    } catch {
+      alert("Erro ao solicitar criativos");
+    }
+  };
+
   return (
     <div className="mt-3">
       <button className="btn btn-primary mb-2" onClick={openNew}>
         Novo Criativo
+      </button>
+      <button
+        className="btn btn-secondary mb-2 ms-2"
+        onClick={generateCreatives}
+        disabled={requestCreatives.isPending}
+      >
+        Gerar Criativos
       </button>
       <div className="table-responsive">
         <table className="table">

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -65,6 +65,7 @@ export default function ExperimentDetailPage() {
       label: "Sample size",
       value: data.sampleSize ?? preset?.sampleSize ?? "—",
     },
+    { label: "Criativos a gerar", value: data.creativesToGenerate ?? "—" },
     {
       label: "MDE (p.p.)",
       value: data.mdePercent ?? preset?.defaultMdePp ?? "—",

--- a/schema.sql
+++ b/schema.sql
@@ -121,6 +121,7 @@ CREATE TABLE experiment (
     baseline_cvr DECIMAL(5,2) DEFAULT 3.00,
     target_cvr DECIMAL(5,2) DEFAULT 5.00,
     mde_percent DECIMAL(5,2) DEFAULT 40.0,
+    creatives_to_generate INT,
     start_date DATE,
     end_date DATE,
     status VARCHAR(20),


### PR DESCRIPTION
## Summary
- add creatives_to_generate field to experiments and endpoint to request generation
- expose API hook and UI button to trigger creative generation

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.2.5)*
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b72cf465d483219dff377701c73fcf