### PR TITLE
feat: show requested creatives count

### DIFF
--- a/frontend/src/pages/experiment/CriativosTab.test.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.test.tsx
@@ -8,13 +8,18 @@ vi.mock("axios");
 
 describe("CriativosTab", () => {
   it("opens modal", async () => {
-    (axios.get as any).mockResolvedValue({ data: [] });
+    (axios.get as any)
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: { creativesToGenerate: 3 } });
     const client = new QueryClient();
     render(
       <QueryClientProvider client={client}>
         <CriativosTab experimentId="1" />
       </QueryClientProvider>,
     );
+    expect(
+      await screen.findByText("Solicitados: 3"),
+    ).toBeTruthy();
     screen.getByText("Novo Criativo").click();
     expect(await screen.findByText("Novo Criativo")).toBeTruthy();
   });

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -9,6 +9,7 @@ import { useVisualProofs } from "../../api/visualProof/useVisualProofs";
 import { useEmotionalTriggers } from "../../api/emotionalTrigger/useEmotionalTriggers";
 import { useUpdateCreativeLabels } from "../../api/creative/useUpdateCreativeLabels";
 import { useRequestCreatives } from "../../api/experiment/useRequestCreatives";
+import { useExperiment } from "../../api/experiment/useExperiment";
 
 interface Props {
   experimentId: string;
@@ -17,6 +18,7 @@ interface Props {
 export default function CriativosTab({ experimentId }: Props) {
   const { data } = useCreatives(experimentId);
   const creatives = Array.isArray(data) ? data : [];
+  const { data: experiment } = useExperiment(experimentId);
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<Creative | null>(null);
   const [form, setForm] = useState({
@@ -124,6 +126,9 @@ export default function CriativosTab({ experimentId }: Props) {
       >
         Gerar Criativos
       </button>
+      <span className="ms-2">
+        Solicitados: {experiment?.creativesToGenerate ?? 0}
+      </span>
       <div className="table-responsive">
         <table className="table">
           <thead>


### PR DESCRIPTION
## Summary
- show current creative request count next to generator button
- cover new counter display with tests

## Testing
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b73dc5b83483219af077bef56937af