### PR TITLE
feat(ai-worker): generate experiment creatives via ChatGPT

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
@@ -1,0 +1,123 @@
+package com.marketinghub.worker.creative;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.creative.CreativeStatus;
+import com.marketinghub.creative.dto.CreateCreativeRequest;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.hypothesis.Hypothesis;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple wrapper around the OpenAI chat completions API for creative generation.
+ */
+@Component
+public class CreativeChatGptClient {
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+    private final String model;
+    private static final Logger log = LoggerFactory.getLogger(CreativeChatGptClient.class);
+
+    public CreativeChatGptClient(WebClient.Builder builder,
+                                 ObjectMapper objectMapper,
+                                 @Value("${openai.api-key:}") String apiKey,
+                                 @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
+                                 @Value("${openai.model:gpt-3.5-turbo}") String model) {
+        this.webClient = builder
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .build();
+        this.objectMapper = objectMapper;
+        this.model = model;
+    }
+
+    public List<CreateCreativeRequest> generateCreatives(Experiment experiment, int quantity) {
+        String prompt = buildPrompt(experiment, quantity);
+        Map<String, Object> payload = Map.of(
+                "model", model,
+                "messages", List.of(
+                        Map.of("role", "system", "content", "Você é um especialista em marketing."),
+                        Map.of("role", "user", "content", prompt)
+                )
+        );
+
+        log.info("Sending prompt to ChatGPT for experiment {}: {}", experiment.getId(), prompt);
+        log.debug("ChatGPT payload: {}", payload);
+
+        ChatCompletionResponse response = webClient.post()
+                .uri("/chat/completions")
+                .bodyValue(payload)
+                .retrieve()
+                .bodyToMono(ChatCompletionResponse.class)
+                .block();
+
+        log.info("ChatGPT raw response: {}", response);
+
+        if (response == null || response.choices().isEmpty()) {
+            log.warn("ChatGPT returned no choices for experiment {}", experiment.getId());
+            return List.of();
+        }
+        String content = response.choices().get(0).message().content();
+        log.info("ChatGPT content: {}", content);
+        try {
+            List<CreateCreativeRequest> parsed = parseContent(content);
+            log.info("Parsed creatives: {}", parsed);
+            return parsed;
+        } catch (Exception e) {
+            log.error("Failed to parse ChatGPT response: {}", content, e);
+            try {
+                String unescaped = content.replace("\\\"", "\"");
+                List<CreateCreativeRequest> parsed = parseContent(unescaped);
+                log.info("Parsed creatives after unescaping: {}", parsed);
+                return parsed;
+            } catch (Exception ex) {
+                log.error("Failed to parse unescaped ChatGPT response: {}", content, ex);
+                throw new RuntimeException("Failed to parse ChatGPT response", ex);
+            }
+        }
+    }
+
+    private String buildPrompt(Experiment experiment, int quantity) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Gere ").append(quantity).append(" criativos em formato JSON. ");
+        Hypothesis h = experiment.getHypothesisRef();
+        if (h != null) {
+            sb.append("Use a seguinte hipótese como contexto:\n");
+            sb.append("Título: ").append(h.getTitle()).append("\n");
+            if (h.getPromise() != null) sb.append("Promessa: ").append(h.getPromise()).append("\n");
+            if (h.getProblem() != null) sb.append("Problema: ").append(h.getProblem()).append("\n");
+            if (h.getPersona() != null) sb.append("Persona: ").append(h.getPersona()).append("\n");
+            if (h.getMechanism() != null) sb.append("Mecanismo: ").append(h.getMechanism()).append("\n");
+            if (h.getUniqueMechanism() != null) sb.append("Mecanismo único: ").append(h.getUniqueMechanism()).append("\n");
+            if (h.getEntrega() != null) sb.append("Entrega: ").append(h.getEntrega()).append("\n");
+            if (h.getSuccessRule() != null) sb.append("Regra de sucesso: ").append(h.getSuccessRule()).append("\n");
+            if (h.getOfferType() != null) sb.append("Tipo de oferta: ").append(h.getOfferType()).append("\n");
+            if (h.getPrice() != null) sb.append("Preço: ").append(h.getPrice()).append("\n");
+        }
+        sb.append("Cada objeto deve conter as chaves: \"headline\", \"primaryText\", \"imageUrl\". ");
+        sb.append("Retorne apenas um array JSON com esses objetos, sem texto adicional.");
+        return sb.toString();
+    }
+
+    private List<CreateCreativeRequest> parseContent(String content) throws Exception {
+        CreateCreativeRequest[] arr = objectMapper.readValue(content, CreateCreativeRequest[].class);
+        for (CreateCreativeRequest req : arr) {
+            if (req.getStatus() == null) {
+                req.setStatus(CreativeStatus.DRAFT);
+            }
+        }
+        return Arrays.asList(arr);
+    }
+
+    private record ChatCompletionResponse(List<Choice> choices) {}
+    private record Choice(Message message) {}
+    private record Message(String content) {}
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeScheduler.java
@@ -1,0 +1,29 @@
+package com.marketinghub.worker.creative;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduler that periodically triggers creative generation for experiments.
+ */
+@Component
+public class ExperimentCreativeScheduler {
+    private static final Logger log = LoggerFactory.getLogger(ExperimentCreativeScheduler.class);
+    private final ExperimentCreativeService service;
+
+    public ExperimentCreativeScheduler(ExperimentCreativeService service) {
+        this.service = service;
+    }
+
+    @Scheduled(cron = "0 */5 * * * *")
+    public void run() {
+        log.info("ExperimentCreativeScheduler started");
+        try {
+            service.generate();
+        } finally {
+            log.info("ExperimentCreativeScheduler finished");
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
@@ -1,0 +1,65 @@
+package com.marketinghub.worker.creative;
+
+import com.marketinghub.creative.Creative;
+import com.marketinghub.creative.dto.CreateCreativeRequest;
+import com.marketinghub.creative.service.CreativeService;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service that loops through experiments with {@code creativesToGenerate > 0}
+ * and asks ChatGPT to generate creatives for each one.
+ */
+@Service
+public class ExperimentCreativeService {
+    private final ExperimentRepository experimentRepository;
+    private final CreativeChatGptClient chatGptClient;
+    private final CreativeService creativeService;
+    private static final Logger log = LoggerFactory.getLogger(ExperimentCreativeService.class);
+
+    public ExperimentCreativeService(ExperimentRepository experimentRepository,
+                                     CreativeChatGptClient chatGptClient,
+                                     CreativeService creativeService) {
+        this.experimentRepository = experimentRepository;
+        this.chatGptClient = chatGptClient;
+        this.creativeService = creativeService;
+    }
+
+    /**
+     * Generates creatives for all configured experiments.
+     *
+     * @return map keyed by experiment id containing the generated creatives
+     */
+    public Map<Long, List<Creative>> generate() {
+        Map<Long, List<Creative>> result = new HashMap<>();
+        Iterable<Experiment> experiments = experimentRepository.findAllToGenerateCreatives();
+        for (Experiment exp : experiments) {
+            Integer qty = exp.getCreativesToGenerate();
+            log.info("Generating {} creatives for experiment {}", qty, exp.getId());
+            List<CreateCreativeRequest> requests = chatGptClient.generateCreatives(exp, qty);
+            log.info("ChatGPT returned {} creatives for experiment {}", requests.size(), exp.getId());
+            List<Creative> saved = new ArrayList<>();
+            for (CreateCreativeRequest req : requests) {
+                if (req.getHeadline() == null || req.getHeadline().isBlank()) {
+                    log.error("Skipping creative without headline for experiment {}: {}", exp.getId(), req);
+                    continue;
+                }
+                log.info("Saving creative for experiment {}: {}", exp.getId(), req);
+                saved.add(creativeService.create(exp.getId(), req));
+            }
+            log.info("Resetting creativesToGenerate for experiment {} to 0", exp.getId());
+            exp.setCreativesToGenerate(0);
+            experimentRepository.save(exp);
+            result.put(exp.getId(), saved);
+        }
+        return result;
+    }
+}

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
@@ -1,0 +1,63 @@
+package com.marketinghub.worker.creative;
+
+import com.marketinghub.creative.Creative;
+import com.marketinghub.creative.dto.CreateCreativeRequest;
+import com.marketinghub.creative.service.CreativeService;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.hypothesis.Hypothesis;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ExperimentCreativeServiceTest {
+    @Mock
+    ExperimentRepository experimentRepository;
+    @Mock
+    CreativeChatGptClient chatGptClient;
+    @Mock
+    CreativeService creativeService;
+    @InjectMocks
+    ExperimentCreativeService service;
+
+    Experiment experiment;
+
+    @BeforeEach
+    void setup() {
+        experiment = new Experiment();
+        experiment.setId(1L);
+        experiment.setCreativesToGenerate(1);
+        Hypothesis h = new Hypothesis();
+        h.setTitle("title");
+        experiment.setHypothesisRef(h);
+    }
+
+    @Test
+    void generateCreatesCreativesAndResetsFlag() {
+        when(experimentRepository.findAllToGenerateCreatives()).thenReturn(List.of(experiment));
+        CreateCreativeRequest req = new CreateCreativeRequest();
+        req.setHeadline("h1");
+        req.setPrimaryText("p1");
+        req.setImageUrl("img");
+        when(chatGptClient.generateCreatives(experiment, 1)).thenReturn(List.of(req));
+        Creative saved = new Creative();
+        when(creativeService.create(1L, req)).thenReturn(saved);
+
+        Map<Long, List<Creative>> result = service.generate();
+
+        verify(creativeService).create(1L, req);
+        verify(experimentRepository).save(experiment);
+        assertThat(experiment.getCreativesToGenerate()).isZero();
+        assertThat(result.get(1L)).containsExactly(saved);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -3,6 +3,7 @@ package com.marketinghub.experiment.repository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.niche.MarketNiche;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 import java.util.UUID;
 
@@ -14,4 +15,17 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
     boolean existsByNicheAndName(MarketNiche niche, String name);
     List<Experiment> findByStatus(com.marketinghub.experiment.ExperimentStatus status);
     long countBySalesFunnelId(UUID salesFunnelId);
+
+    /**
+     * Retrieves experiments configured to generate creatives.
+     *
+     * <p>Filters are handled in the query so we only fetch the records we
+     * actually need.</p>
+     */
+    @Query("""
+            select e from Experiment e
+            where e.creativesToGenerate is not null
+              and e.creativesToGenerate > 0
+            """)
+    List<Experiment> findAllToGenerateCreatives();
 }


### PR DESCRIPTION
## Summary
- allow backend to fetch experiments needing creative generation
- generate experiment creatives via ChatGPT in AI worker
- schedule periodic creative generation
- cover creative generation with unit test

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `cd ai-worker && mvn -s settings.xml test` *(fails: Network is unreachable)*
- `cd ai-worker && mvn -s settings.xml package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b74d5b8e3c8321a385dad5ed411b8b