### PR TITLE
docs: document existing AI Worker services

### DIFF
--- a/ai-worker/AGENTS.md
+++ b/ai-worker/AGENTS.md
@@ -2,6 +2,16 @@
 
 - Este projeto utiliza o modelo de dados definido no **backend**.
 - Não duplique ou mantenha modelo de dados aqui; importe-o do backend.
-- Novo serviço: obter dados de **NICHO**, consultar o ChatGPT e retornar dados para **HIPOTESE**.
 - Em produção utilizamos **MySql 5**.
 - Tipos de dados permitidos (MySql 5): `INT`, `BIGINT`, `DECIMAL`, `DOUBLE`, `FLOAT`, `CHAR`, `VARCHAR`, `TEXT`, `LONGTEXT`, `BINARY(16)` para `UUID`, `DATE`, `DATETIME`, `TIMESTAMP`, `BOOLEAN`.
+
+## Serviços existentes
+- **Nicho** (`niche`): gera hipóteses para nichos com `hypothesesToGenerate > 0` usando o ChatGPT. Implementado por `NicheHypothesisService` e agendado por `NicheHypothesisScheduler`.
+- **Criativos** (`creative`): gera criativos para experimentos com `creativesToGenerate > 0` usando o ChatGPT. Implementado por `ExperimentCreativeService` e agendado por `ExperimentCreativeScheduler`.
+
+## Orientação para novos serviços
+- Siga o mesmo padrão do serviço de **nicho**:
+  - criar um pacote com o nome do domínio (ex: `niche`, `creative`);
+  - implementar uma classe `*Service` com a lógica de geração;
+  - criar um `*Scheduler` com `@Scheduled` para executar o serviço periodicamente;
+  - encapsular qualquer cliente do ChatGPT dentro do mesmo pacote.


### PR DESCRIPTION
## Summary
- document `niche` and `creative` services in AI Worker
- add guidance to follow `niche` pattern when adding new services

## Testing
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f8ce18388321833fd3470667a345