### PR TITLE
feat(ai-worker): schedule experiment creatives every 5 minutes

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeScheduler.java
@@ -11,13 +11,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class ExperimentCreativeScheduler {
     private static final Logger log = LoggerFactory.getLogger(ExperimentCreativeScheduler.class);
+    private static final String CRON_EVERY_FIVE_MINUTES = "0 */5 * * * *";
+
     private final ExperimentCreativeService service;
 
     public ExperimentCreativeScheduler(ExperimentCreativeService service) {
         this.service = service;
     }
 
-    @Scheduled(cron = "0 */5 * * * *")
+    /**
+     * Executes creative generation every five minutes.
+     */
+    @Scheduled(cron = CRON_EVERY_FIVE_MINUTES)
     public void run() {
         log.info("ExperimentCreativeScheduler started");
         try {


### PR DESCRIPTION
## Summary
- run creative generation for experiments every 5 minutes via scheduler constant

## Testing
- `cd ai-worker && mvn -s settings.xml package` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f875a628832199d213b2a53a5be0