### PR TITLE
Fetch hypothesis to avoid lazy initialization in creative generation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -24,6 +24,7 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
      */
     @Query("""
             select e from Experiment e
+            join fetch e.hypothesisRef
             where e.creativesToGenerate is not null
               and e.creativesToGenerate > 0
             """)

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
@@ -1,0 +1,63 @@
+package com.marketinghub.experiment;
+
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ContextConfiguration(classes = AdsServiceApplication.class)
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
+class ExperimentRepositoryTest {
+
+    @Autowired
+    ExperimentRepository repository;
+
+    @Autowired
+    MarketNicheRepository nicheRepository;
+
+    @Autowired
+    HypothesisRepository hypothesisRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Test
+    void findAllToGenerateCreativesFetchesHypothesis() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("N1").build());
+        Hypothesis hyp = hypothesisRepository.save(Hypothesis.builder()
+                .marketNiche(niche)
+                .title("T")
+                .build());
+        Experiment exp = repository.save(Experiment.builder()
+                .niche(niche)
+                .hypothesisRef(hyp)
+                .name("E1")
+                .creativesToGenerate(1)
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Experiment> result = repository.findAllToGenerateCreatives();
+        assertThat(result).hasSize(1);
+        Experiment fetched = result.get(0);
+
+        entityManager.clear();
+
+        assertThat(fetched.getHypothesisRef().getTitle()).isEqualTo("T");
+    }
+}
+


### PR DESCRIPTION
## Summary
- fetch hypothesis eagerly when loading experiments for creative generation
- add test ensuring hypothesis is initialized after repository fetch

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -s ../settings.xml deploy` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8437a7e9c8321b39a9a9e1d2785c4