### PR TITLE
fix: keep session open while generating creatives

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
@@ -8,6 +8,7 @@ import com.marketinghub.experiment.repository.ExperimentRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,6 +39,7 @@ public class ExperimentCreativeService {
      *
      * @return map keyed by experiment id containing the generated creatives
      */
+    @Transactional
     public Map<Long, List<Creative>> generate() {
         Map<Long, List<Creative>> result = new HashMap<>();
         Iterable<Experiment> experiments = experimentRepository.findAllToGenerateCreatives();


### PR DESCRIPTION
## Summary
- keep ExperimentCreativeService transactional to avoid lazy initialization errors

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker)*
- `mvn -s settings.xml package` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker)*

------
https://chatgpt.com/codex/tasks/task_e_68b85df23378832193ddd73705b48320