### PR TITLE
fix: align creative table name

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
@@ -11,7 +11,7 @@ import lombok.*;
  * Creative linked to an experiment.
  */
 @Entity
-@Table(name = "creative_variants")
+@Table(name = "creative_variant")
 @Data
 @Builder
 @NoArgsConstructor

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_creative.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_creative.sql
@@ -1,6 +1,6 @@
 -- liquibase formatted sql
 -- changeset marketinghub:2025-07-01-add-fk-experiment-to-creative
-ALTER TABLE creative_variants
+ALTER TABLE creative_variant
     MODIFY experiment_id BIGINT NOT NULL;
-ALTER TABLE creative_variants
+ALTER TABLE creative_variant
     ADD CONSTRAINT fk_creative_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id);


### PR DESCRIPTION
## Summary
- map Creative entity to correct `creative_variant` table
- fix Liquibase changelog to reference `creative_variant`

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable)*
- `mvn -s settings.xml test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68b86deadd70832194446196b50493e1