### PR TITLE
Fix duplicate creative_variant entity

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
@@ -11,7 +11,7 @@ import lombok.*;
  * Creative linked to an experiment.
  */
 @Entity
-@Table(name = "creative_variant")
+@Table(name = "creative")
 @Data
 @Builder
 @NoArgsConstructor

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -153,6 +153,17 @@ This document summarizes the current database schema defined in `schema.sql`.
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 
+### creative
+
+- `id` BIGINT AUTO_INCREMENT PRIMARY KEY
+- `experiment_id` BIGINT NOT NULL
+- `headline` VARCHAR(255)
+- `primary_text` VARCHAR(255)
+- `image_url` VARCHAR(500)
+- `image_hash` VARCHAR(255)
+- `video_id` VARCHAR(255)
+- `status` VARCHAR(20)
+
 ### creative_variant
 
 - `id` BIGINT AUTO_INCREMENT PRIMARY KEY

--- a/schema.sql
+++ b/schema.sql
@@ -131,6 +131,17 @@ CREATE TABLE experiment (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
+CREATE TABLE creative (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    experiment_id BIGINT NOT NULL,
+    headline VARCHAR(255),
+    primary_text VARCHAR(255),
+    image_url VARCHAR(500),
+    image_hash VARCHAR(255),
+    video_id VARCHAR(255),
+    status VARCHAR(20)
+);
+
 CREATE TABLE creative_variant (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     experiment_id BIGINT,


### PR DESCRIPTION
## Summary
- rename Creative entity table to `creative` to avoid clashes with CreativeVariant
- document `creative` table in data model and schema

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b895a9fe98832191f08e1ef518b8af