### PR TITLE
fix: accept previous checksum for Liquibase changeset

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_creative.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_07_01__add_fk_experiment_to_creative.sql
@@ -1,5 +1,5 @@
 -- liquibase formatted sql
--- changeset marketinghub:2025-07-01-add-fk-experiment-to-creative
+-- changeset marketinghub:2025-07-01-add-fk-experiment-to-creative validCheckSum:9:76ab8ad9dcb8ea995bd7a11be567c553
 ALTER TABLE creative_variant
     MODIFY experiment_id BIGINT NOT NULL;
 ALTER TABLE creative_variant


### PR DESCRIPTION
## Summary
- allow migration `V2025_07_01__add_fk_experiment_to_creative` to accept previous checksum

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8acdb2b148321add649da5c06565a