### PR TITLE
feat: gerar criativos com imagens da OpenAI

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
@@ -102,7 +102,7 @@ public class CreativeChatGptClient {
             if (h.getOfferType() != null) sb.append("Tipo de oferta: ").append(h.getOfferType()).append("\n");
             if (h.getPrice() != null) sb.append("Preço: ").append(h.getPrice()).append("\n");
         }
-        sb.append("Cada objeto deve conter as chaves: \"headline\", \"primaryText\", \"imageUrl\". ");
+        sb.append("Cada objeto deve conter as chaves: \"headline\", \"primaryText\". ");
         sb.append("Retorne apenas um array JSON com esses objetos, sem texto adicional.");
         return sb.toString();
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
@@ -1,0 +1,57 @@
+package com.marketinghub.worker.creative;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple wrapper around the OpenAI images API for creative image generation.
+ */
+@Component
+public class CreativeImageClient {
+    private final WebClient webClient;
+    private final String model;
+    private static final Logger log = LoggerFactory.getLogger(CreativeImageClient.class);
+
+    public CreativeImageClient(WebClient.Builder builder,
+                               @Value("${openai.api-key:}") String apiKey,
+                               @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
+                               @Value("${openai.image-model:dall-e-3}") String model) {
+        this.webClient = builder
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .build();
+        this.model = model;
+    }
+
+    public String generateImage(String prompt) {
+        Map<String, Object> payload = Map.of(
+                "model", model,
+                "prompt", prompt
+        );
+
+        log.info("Sending image generation prompt to OpenAI: {}", prompt);
+        ImageResponse response = webClient.post()
+                .uri("/images/generations")
+                .bodyValue(payload)
+                .retrieve()
+                .bodyToMono(ImageResponse.class)
+                .block();
+
+        log.info("OpenAI image response: {}", response);
+
+        if (response == null || response.data().isEmpty()) {
+            throw new RuntimeException("No image returned from OpenAI");
+        }
+        return response.data().get(0).url();
+    }
+
+    private record ImageResponse(List<ImageData> data) {}
+    private record ImageData(String url) {}
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
@@ -23,14 +23,17 @@ import java.util.Map;
 public class ExperimentCreativeService {
     private final ExperimentRepository experimentRepository;
     private final CreativeChatGptClient chatGptClient;
+    private final CreativeImageClient imageClient;
     private final CreativeService creativeService;
     private static final Logger log = LoggerFactory.getLogger(ExperimentCreativeService.class);
 
     public ExperimentCreativeService(ExperimentRepository experimentRepository,
                                      CreativeChatGptClient chatGptClient,
+                                     CreativeImageClient imageClient,
                                      CreativeService creativeService) {
         this.experimentRepository = experimentRepository;
         this.chatGptClient = chatGptClient;
+        this.imageClient = imageClient;
         this.creativeService = creativeService;
     }
 
@@ -53,6 +56,12 @@ public class ExperimentCreativeService {
                 if (req.getHeadline() == null || req.getHeadline().isBlank()) {
                     log.error("Skipping creative without headline for experiment {}: {}", exp.getId(), req);
                     continue;
+                }
+                try {
+                    String imageUrl = imageClient.generateImage(req.getHeadline());
+                    req.setImageUrl(imageUrl);
+                } catch (Exception e) {
+                    log.error("Failed to generate image for experiment {}: {}", exp.getId(), req.getHeadline(), e);
                 }
                 log.info("Saving creative for experiment {}: {}", exp.getId(), req);
                 saved.add(creativeService.create(exp.getId(), req));

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
@@ -26,6 +26,8 @@ class ExperimentCreativeServiceTest {
     @Mock
     CreativeChatGptClient chatGptClient;
     @Mock
+    CreativeImageClient imageClient;
+    @Mock
     CreativeService creativeService;
     @InjectMocks
     ExperimentCreativeService service;
@@ -48,13 +50,15 @@ class ExperimentCreativeServiceTest {
         CreateCreativeRequest req = new CreateCreativeRequest();
         req.setHeadline("h1");
         req.setPrimaryText("p1");
-        req.setImageUrl("img");
         when(chatGptClient.generateCreatives(experiment, 1)).thenReturn(List.of(req));
+        when(imageClient.generateImage("h1")).thenReturn("img");
         Creative saved = new Creative();
         when(creativeService.create(1L, req)).thenReturn(saved);
 
         Map<Long, List<Creative>> result = service.generate();
 
+        verify(imageClient).generateImage("h1");
+        assertThat(req.getImageUrl()).isEqualTo("img");
         verify(creativeService).create(1L, req);
         verify(experimentRepository).save(experiment);
         assertThat(experiment.getCreativesToGenerate()).isZero();


### PR DESCRIPTION
## Summary
- adicionar cliente para gerar imagens via OpenAI
- integrar geração de imagens ao serviço de criativos
- ajustar prompt do ChatGPT e testes

## Testing
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker)*
- `mvn -s settings.xml package` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d89696b08321b1d856e423fd7e6d