### PR TITLE
feat(worker): truncate long creative texts

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
@@ -102,7 +102,8 @@ public class CreativeChatGptClient {
             if (h.getOfferType() != null) sb.append("Tipo de oferta: ").append(h.getOfferType()).append("\n");
             if (h.getPrice() != null) sb.append("Preço: ").append(h.getPrice()).append("\n");
         }
-        sb.append("Cada objeto deve conter as chaves: \"headline\" (máximo 255 caracteres), \"primaryText\" (máximo 255 caracteres). ");
+        sb.append("Cada objeto deve conter as chaves: \"headline\" (máximo 40 caracteres), ");
+        sb.append("\"primaryText\" (máximo 125 caracteres e até 30 hashtags). ");
         sb.append("Retorne apenas um array JSON com esses objetos, sem texto adicional.");
         return sb.toString();
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
@@ -26,7 +26,9 @@ public class ExperimentCreativeService {
     private final CreativeImageClient imageClient;
     private final CreativeService creativeService;
     private static final Logger log = LoggerFactory.getLogger(ExperimentCreativeService.class);
-    private static final int MAX_LENGTH = 255;
+    private static final int HEADLINE_MAX = 40;
+    private static final int PRIMARY_TEXT_MAX = 125;
+    private static final int MAX_HASHTAGS = 30;
 
     public ExperimentCreativeService(ExperimentRepository experimentRepository,
                                      CreativeChatGptClient chatGptClient,
@@ -58,8 +60,8 @@ public class ExperimentCreativeService {
                     log.error("Skipping creative without headline for experiment {}: {}", exp.getId(), req);
                     continue;
                 }
-                req.setHeadline(truncate(req.getHeadline(), MAX_LENGTH));
-                req.setPrimaryText(truncate(req.getPrimaryText(), MAX_LENGTH));
+                req.setHeadline(truncate(req.getHeadline(), HEADLINE_MAX));
+                req.setPrimaryText(truncate(limitHashtags(req.getPrimaryText(), MAX_HASHTAGS), PRIMARY_TEXT_MAX));
                 try {
                     String imageUrl = imageClient.generateImage(req.getHeadline());
                     req.setImageUrl(imageUrl);
@@ -82,5 +84,27 @@ public class ExperimentCreativeService {
             return null;
         }
         return value.length() > max ? value.substring(0, max) : value;
+    }
+
+    private static String limitHashtags(String text, int maxHashtags) {
+        if (text == null) {
+            return null;
+        }
+        String[] parts = text.split("\\s+");
+        StringBuilder sb = new StringBuilder();
+        int count = 0;
+        for (String part : parts) {
+            if (part.startsWith("#")) {
+                count++;
+                if (count > maxHashtags) {
+                    continue;
+                }
+            }
+            if (sb.length() > 0) {
+                sb.append(' ');
+            }
+            sb.append(part);
+        }
+        return sb.toString();
     }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
@@ -16,6 +16,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -84,7 +87,29 @@ class ExperimentCreativeServiceTest {
         ArgumentCaptor<CreateCreativeRequest> captor = ArgumentCaptor.forClass(CreateCreativeRequest.class);
         verify(creativeService).create(eq(1L), captor.capture());
         CreateCreativeRequest captured = captor.getValue();
-        assertThat(captured.getHeadline().length()).isEqualTo(255);
-        assertThat(captured.getPrimaryText().length()).isEqualTo(255);
+        assertThat(captured.getHeadline().length()).isEqualTo(40);
+        assertThat(captured.getPrimaryText().length()).isEqualTo(125);
+    }
+
+    @Test
+    void limitHashtagsToThirty() {
+        when(experimentRepository.findAllToGenerateCreatives()).thenReturn(List.of(experiment));
+        String hashtags = IntStream.rangeClosed(1, 35)
+                .mapToObj(i -> "#t" + i)
+                .collect(Collectors.joining(" "));
+        CreateCreativeRequest req = new CreateCreativeRequest();
+        req.setHeadline("headline");
+        req.setPrimaryText(hashtags);
+        when(chatGptClient.generateCreatives(experiment, 1)).thenReturn(List.of(req));
+        when(imageClient.generateImage(anyString())).thenReturn("img");
+        when(creativeService.create(eq(1L), any(CreateCreativeRequest.class))).thenReturn(new Creative());
+
+        service.generate();
+
+        ArgumentCaptor<CreateCreativeRequest> captor = ArgumentCaptor.forClass(CreateCreativeRequest.class);
+        verify(creativeService).create(eq(1L), captor.capture());
+        String savedText = captor.getValue().getPrimaryText();
+        long count = Arrays.stream(savedText.split("\\s+")).filter(p -> p.startsWith("#")).count();
+        assertThat(count).isEqualTo(30);
     }
 }


### PR DESCRIPTION
## Summary
- avoid DB errors by truncating headline and primary text before persisting
- instruct ChatGPT to generate shorter creative fields
- test long text truncation logic in ExperimentCreativeService

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e50247188321821e21c57fc2fe1d