### PR TITLE
Handle hashtags before truncating creative primary text

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
@@ -61,7 +61,11 @@ public class ExperimentCreativeService {
                     continue;
                 }
                 req.setHeadline(truncate(req.getHeadline(), HEADLINE_MAX));
-                req.setPrimaryText(truncate(limitHashtags(req.getPrimaryText(), MAX_HASHTAGS), PRIMARY_TEXT_MAX));
+                String primary = limitHashtags(req.getPrimaryText(), MAX_HASHTAGS);
+                if (primary != null && !primary.contains("#")) {
+                    primary = truncate(primary, PRIMARY_TEXT_MAX);
+                }
+                req.setPrimaryText(primary);
                 try {
                     String imageUrl = imageClient.generateImage(req.getHeadline());
                     req.setImageUrl(imageUrl);


### PR DESCRIPTION
## Summary
- ensure hashtags are limited to 30 before other processing
- skip character truncation when hashtags are present to avoid cutting them off

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker)*
- `mvn -s settings.xml package` *(fails: Non-resolvable parent POM for com.marketinghub:ai-worker)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ec2ea49083219d81d91fa860a01b