### PR TITLE
refactor: remove legacy facebook ads client

### DIFF
--- a/facebook-ads-worker/pom.xml
+++ b/facebook-ads-worker/pom.xml
@@ -48,13 +48,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.marketinghub</groupId>
-            <artifactId>facebook-ads-client</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -1,20 +1,43 @@
 package com.marketinghub.facebookadsworker;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.marketinghub.facebookads.FacebookAdsClient;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
 
 @Service
-@RequiredArgsConstructor
 public class FacebookAdsService {
-    private final FacebookAdsClient client;
+    private final WebClient webClient;
+    private final String accessToken;
+
+    public FacebookAdsService(WebClient.Builder builder,
+                              @Value("${facebook.graph-api.base-url:https://graph.facebook.com}") String baseUrl,
+                              @Value("${facebook.access-token}") String accessToken) {
+        this.webClient = builder.baseUrl(baseUrl).build();
+        this.accessToken = accessToken;
+    }
 
     public String createInstagramCampaign(String adAccountId, String name) {
-        return client.createCampaign(adAccountId, name, "OUTCOME_TRAFFIC").path("id").asText();
+        JsonNode response = webClient.post()
+            .uri("/v20.0/act_" + adAccountId + "/campaigns")
+            .bodyValue(Map.of(
+                "name", name,
+                "objective", "OUTCOME_TRAFFIC",
+                "access_token", accessToken
+            ))
+            .retrieve()
+            .bodyToMono(JsonNode.class)
+            .block();
+        return response.path("id").asText();
     }
 
     public JsonNode getCampaignMetrics(String campaignId) {
-        return client.getCampaignInsights(campaignId);
+        return webClient.get()
+            .uri("/v20.0/" + campaignId + "/insights?access_token=" + accessToken)
+            .retrieve()
+            .bodyToMono(JsonNode.class)
+            .block();
     }
 }

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -1,42 +1,52 @@
 package com.marketinghub.facebookadsworker;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.marketinghub.facebookads.FacebookAdsClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
 
-@SpringBootTest
 class FacebookAdsServiceTest {
-
-    @Autowired
+    private MockWebServer server;
     private FacebookAdsService service;
 
-    @MockBean
-    private FacebookAdsClient client;
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        String baseUrl = server.url("/").toString();
+        service = new FacebookAdsService(WebClient.builder(), baseUrl, "token");
+    }
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
 
     @Test
-    void createCampaignDelegatesToClient() {
-        ObjectNode node = mapper.createObjectNode();
-        node.put("id", "123");
-        given(client.createCampaign(anyString(), anyString(), anyString())).willReturn(node);
+    void createCampaignPostsCorrectRequest() throws Exception {
+        server.enqueue(new MockResponse().setBody("{\"id\":\"123\"}")
+            .addHeader("Content-Type", "application/json"));
         String id = service.createInstagramCampaign("1", "Camp");
+        RecordedRequest request = server.takeRequest();
+        assertEquals("/v20.0/act_1/campaigns", request.getPath());
         assertEquals("123", id);
     }
 
     @Test
-    void metricsDelegatesToClient() {
-        ObjectNode node = mapper.createObjectNode();
-        given(client.getCampaignInsights(anyString())).willReturn(node);
-        ObjectNode result = service.getCampaignMetrics("77");
-        assertEquals(node, result);
+    void metricsRequestsCampaignInsights() throws Exception {
+        server.enqueue(new MockResponse().setBody("{\"data\":[{\"impressions\":\"10\"}]}")
+            .addHeader("Content-Type", "application/json"));
+        JsonNode node = service.getCampaignMetrics("77");
+        RecordedRequest request = server.takeRequest();
+        assertEquals("/v20.0/77/insights?access_token=token", request.getPath());
+        assertEquals("10", node.get("data").get(0).path("impressions").asText());
     }
 }


### PR DESCRIPTION
## Summary
- use WebClient to call Facebook Graph API
- drop facebook-ads-client dependency
- test requests with MockWebServer

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM for com.marketinghub:facebook-ads-worker)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ea59a2588321a4d915706535d75a