### PR TITLE
feat: schedule instagram campaigns

### DIFF
--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsWorkerApplication.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsWorkerApplication.java
@@ -2,8 +2,10 @@ package com.marketinghub.facebookadsworker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class FacebookAdsWorkerApplication {
     public static void main(String[] args) {
         SpringApplication.run(FacebookAdsWorkerApplication.class, args);

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/instagramcampaign/InstagramCampaignScheduler.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/instagramcampaign/InstagramCampaignScheduler.java
@@ -1,0 +1,19 @@
+package com.marketinghub.facebookadsworker.instagramcampaign;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InstagramCampaignScheduler {
+    private final InstagramCampaignService service;
+
+    public InstagramCampaignScheduler(InstagramCampaignService service) {
+        this.service = service;
+    }
+
+    @Scheduled(fixedDelayString = "${instagramcampaign.scheduler.delay:60000}")
+    public void schedule() {
+        service.createCampaignsFromAuthorizedCreatives();
+    }
+}
+

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/instagramcampaign/InstagramCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/instagramcampaign/InstagramCampaignService.java
@@ -1,0 +1,47 @@
+package com.marketinghub.facebookadsworker.instagramcampaign;
+
+import com.marketinghub.facebookadsworker.FacebookAdsService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class InstagramCampaignService {
+    private final FacebookAdsService facebookAdsService;
+    private final WebClient backendClient;
+
+    public InstagramCampaignService(FacebookAdsService facebookAdsService,
+                                    WebClient.Builder builder,
+                                    @Value("${backend.base-url:http://localhost:8080}") String backendBaseUrl) {
+        this.facebookAdsService = facebookAdsService;
+        this.backendClient = builder.baseUrl(backendBaseUrl).build();
+    }
+
+    public void createCampaignsFromAuthorizedCreatives() {
+        List<Creative> creatives = backendClient.get()
+            .uri("/instagram-creatives/approved")
+            .retrieve()
+            .bodyToFlux(Creative.class)
+            .collectList()
+            .block();
+
+        if (creatives != null) {
+            creatives.forEach(this::processCreative);
+        }
+    }
+
+    private void processCreative(Creative creative) {
+        String campaignId = facebookAdsService.createInstagramCampaign(creative.adAccountId(), creative.name());
+        backendClient.post()
+            .uri("/instagram-creatives/" + creative.id() + "/campaign")
+            .bodyValue(Map.of("campaignId", campaignId))
+            .retrieve()
+            .toBodilessEntity()
+            .block();
+    }
+
+    public record Creative(long id, String adAccountId, String name) {}
+}
+

--- a/facebook-ads-worker/src/main/resources/application.properties
+++ b/facebook-ads-worker/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=facebook-ads-worker
+backend.base-url=http://localhost:8080
+instagramcampaign.scheduler.delay=60000

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/instagramcampaign/InstagramCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/instagramcampaign/InstagramCampaignServiceTest.java
@@ -1,0 +1,60 @@
+package com.marketinghub.facebookadsworker.instagramcampaign;
+
+import com.marketinghub.facebookadsworker.FacebookAdsService;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InstagramCampaignServiceTest {
+    private MockWebServer backend;
+    private MockWebServer facebook;
+    private InstagramCampaignService service;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        backend = new MockWebServer();
+        backend.start();
+        facebook = new MockWebServer();
+        facebook.start();
+
+        String backendUrl = backend.url("/").toString();
+        String facebookUrl = facebook.url("/").toString();
+
+        FacebookAdsService adsService = new FacebookAdsService(WebClient.builder(), facebookUrl, "token");
+        service = new InstagramCampaignService(adsService, WebClient.builder(), backendUrl);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        backend.shutdown();
+        facebook.shutdown();
+    }
+
+    @Test
+    void createsCampaignForEachAuthorizedCreative() throws Exception {
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"adAccountId\":\"1\",\"name\":\"Camp\"}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"10\"}")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setBody("{}")
+            .addHeader("Content-Type", "application/json"));
+
+        service.createCampaignsFromAuthorizedCreatives();
+
+        RecordedRequest get = backend.takeRequest();
+        assertEquals("/instagram-creatives/approved", get.getPath());
+        RecordedRequest postFb = facebook.takeRequest();
+        assertEquals("/v20.0/act_1/campaigns", postFb.getPath());
+        RecordedRequest postBackend = backend.takeRequest();
+        assertEquals("/instagram-creatives/1/campaign", postBackend.getPath());
+    }
+}
+


### PR DESCRIPTION
## Summary
- schedule Instagram campaign creation for authorized creatives
- enable Spring scheduling in worker
- record campaign ids back to backend

## Testing
- `mvn -s settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:3.2.5 from/to github)*

------
https://chatgpt.com/codex/tasks/task_e_68bb21db575c83219f2e2662db3ac62a