### PR TITLE
feat: add Facebook Ads data model

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/AdCreativeKind.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/AdCreativeKind.java
@@ -1,0 +1,7 @@
+package com.marketinghub.facebookads;
+
+public enum AdCreativeKind {
+    LINK,
+    VIDEO,
+    CAROUSEL
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/BudgetMode.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/BudgetMode.java
@@ -1,0 +1,6 @@
+package com.marketinghub.facebookads;
+
+public enum BudgetMode {
+    CAMPAIGN,
+    ADSET
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdStatus.java
@@ -1,0 +1,8 @@
+package com.marketinghub.facebookads;
+
+public enum FacebookAdStatus {
+    PAUSED,
+    ACTIVE,
+    ARCHIVED,
+    DELETED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAd.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAd.java
@@ -1,0 +1,50 @@
+package com.marketinghub.facebookads;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "facebook_ads_ad")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FacebookAdsAd {
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    @ManyToOne
+    @JoinColumn(name = "adset_id", nullable = false)
+    private FacebookAdsAdSet adSet;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "creative_id", nullable = false)
+    private FacebookAdsAdCreative creative;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FacebookAdStatus status = FacebookAdStatus.PAUSED;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @OneToOne(mappedBy = "ad", cascade = CascadeType.ALL)
+    private FacebookAdsAdTrackingUtm trackingUtm;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdCreative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdCreative.java
@@ -1,0 +1,54 @@
+package com.marketinghub.facebookads;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "facebook_ads_ad_creative")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FacebookAdsAdCreative {
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    @Column(name = "page_id", nullable = false)
+    private String pageId;
+
+    @Column(name = "instagram_user_id")
+    private String instagramUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AdCreativeKind kind;
+
+    @Column(name = "link_data_json", columnDefinition = "LONGTEXT")
+    private String linkDataJson;
+
+    @Column(name = "video_data_json", columnDefinition = "LONGTEXT")
+    private String videoDataJson;
+
+    @Column(name = "carousel_data_json", columnDefinition = "LONGTEXT")
+    private String carouselDataJson;
+
+    @Column(name = "last_preview_url")
+    private String lastPreviewUrl;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdCreativeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdCreativeRepository.java
@@ -1,0 +1,6 @@
+package com.marketinghub.facebookads;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FacebookAdsAdCreativeRepository extends JpaRepository<FacebookAdsAdCreative, String> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdRepository.java
@@ -1,0 +1,6 @@
+package com.marketinghub.facebookads;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FacebookAdsAdRepository extends JpaRepository<FacebookAdsAd, String> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdSet.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdSet.java
@@ -1,0 +1,74 @@
+package com.marketinghub.facebookads;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "facebook_ads_ad_set")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FacebookAdsAdSet {
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    @ManyToOne
+    @JoinColumn(name = "campaign_id", nullable = false)
+    private FacebookAdsCampaign campaign;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FacebookAdStatus status = FacebookAdStatus.PAUSED;
+
+    @Column(name = "daily_budget_minor")
+    private Long dailyBudgetMinor;
+
+    @Column(name = "lifetime_budget_minor")
+    private Long lifetimeBudgetMinor;
+
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
+
+    @Column(name = "billing_event", nullable = false)
+    private String billingEvent;
+
+    @Column(name = "optimization_goal", nullable = false)
+    private String optimizationGoal;
+
+    @Column(name = "bid_strategy", nullable = false)
+    private String bidStrategy;
+
+    @Column(name = "bid_amount_minor")
+    private Long bidAmountMinor;
+
+    @Column(name = "promoted_object_json", columnDefinition = "LONGTEXT")
+    private String promotedObjectJson;
+
+    @Column(name = "targeting_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String targetingJson;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdSetRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdSetRepository.java
@@ -1,0 +1,6 @@
+package com.marketinghub.facebookads;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FacebookAdsAdSetRepository extends JpaRepository<FacebookAdsAdSet, String> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdTrackingUtm.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdTrackingUtm.java
@@ -1,0 +1,37 @@
+package com.marketinghub.facebookads;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "facebook_ads_ad_tracking_utm")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FacebookAdsAdTrackingUtm {
+    @Id
+    @Column(name = "ad_id", length = 36)
+    private String adId;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "ad_id")
+    private FacebookAdsAd ad;
+
+    @Column(name = "utm_source")
+    private String utmSource;
+
+    @Column(name = "utm_medium")
+    private String utmMedium;
+
+    @Column(name = "utm_campaign")
+    private String utmCampaign;
+
+    @Column(name = "utm_content")
+    private String utmContent;
+
+    @Column(name = "utm_term")
+    private String utmTerm;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdTrackingUtmRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdTrackingUtmRepository.java
@@ -1,0 +1,6 @@
+package com.marketinghub.facebookads;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FacebookAdsAdTrackingUtmRepository extends JpaRepository<FacebookAdsAdTrackingUtm, String> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsCampaign.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsCampaign.java
@@ -1,0 +1,71 @@
+package com.marketinghub.facebookads;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "facebook_ads_campaign")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FacebookAdsCampaign {
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    @Column(name = "ad_account_id", nullable = false)
+    private String adAccountId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String objective;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FacebookAdStatus status = FacebookAdStatus.PAUSED;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "budget_mode", nullable = false)
+    private BudgetMode budgetMode;
+
+    @Column(name = "daily_budget_minor")
+    private Long dailyBudgetMinor;
+
+    @Column(name = "lifetime_budget_minor")
+    private Long lifetimeBudgetMinor;
+
+    @Column(name = "api_version")
+    private String apiVersion;
+
+    @ElementCollection(targetClass = SpecialAdCategory.class)
+    @CollectionTable(name = "facebook_ads_campaign_special_ad_category", joinColumns = @JoinColumn(name = "campaign_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private Set<SpecialAdCategory> specialAdCategories = new HashSet<>();
+
+    @ElementCollection
+    @CollectionTable(name = "facebook_ads_campaign_special_ad_country", joinColumns = @JoinColumn(name = "campaign_id"))
+    @Column(name = "country_iso2", length = 2, nullable = false)
+    private Set<String> specialAdCountries = new HashSet<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsCampaignRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsCampaignRepository.java
@@ -1,0 +1,6 @@
+package com.marketinghub.facebookads;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FacebookAdsCampaignRepository extends JpaRepository<FacebookAdsCampaign, String> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsMediaAsset.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsMediaAsset.java
@@ -1,0 +1,49 @@
+package com.marketinghub.facebookads;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "facebook_ads_media_asset")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FacebookAdsMediaAsset {
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MediaAssetKind kind;
+
+    @Column(name = "source_uri")
+    private String sourceUri;
+
+    @Column(name = "image_hash")
+    private String imageHash;
+
+    @Column(name = "video_id")
+    private String videoId;
+
+    @Column
+    private Integer width;
+
+    @Column
+    private Integer height;
+
+    @Column(name = "duration_ms")
+    private Integer durationMs;
+
+    @Column
+    private String checksum;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsMediaAssetRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsMediaAssetRepository.java
@@ -1,0 +1,6 @@
+package com.marketinghub.facebookads;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FacebookAdsMediaAssetRepository extends JpaRepository<FacebookAdsMediaAsset, String> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/MediaAssetKind.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/MediaAssetKind.java
@@ -1,0 +1,6 @@
+package com.marketinghub.facebookads;
+
+public enum MediaAssetKind {
+    IMAGE,
+    VIDEO
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/SpecialAdCategory.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/SpecialAdCategory.java
@@ -1,0 +1,9 @@
+package com.marketinghub.facebookads;
+
+public enum SpecialAdCategory {
+    NONE,
+    CREDIT,
+    EMPLOYMENT,
+    HOUSING,
+    ISSUES_ELECTIONS_POLITICS
+}

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_05__create_facebook_ads_tables.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_05__create_facebook_ads_tables.sql
@@ -1,0 +1,159 @@
+-- liquibase formatted sql
+
+-- changeset marketinghub:2025-10-05-create-facebook-ads-campaign
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <tableExists tableName="facebook_ads_campaign"/>
+--    </not>
+CREATE TABLE facebook_ads_campaign (
+  id                   CHAR(36)      NOT NULL,
+  external_id          VARCHAR(64)   NULL,
+  ad_account_id        VARCHAR(64)   NOT NULL,
+  name                 VARCHAR(255)  NOT NULL,
+  objective            VARCHAR(64)   NOT NULL,
+  status               ENUM('PAUSED','ACTIVE','ARCHIVED','DELETED') NOT NULL DEFAULT 'PAUSED',
+  budget_mode          ENUM('CAMPAIGN','ADSET') NOT NULL,
+  daily_budget_minor   BIGINT UNSIGNED NULL,
+  lifetime_budget_minor BIGINT UNSIGNED NULL,
+  api_version          VARCHAR(16)   NULL,
+  created_at           TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at           TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+);
+
+-- changeset marketinghub:2025-10-05-create-facebook-ads-campaign-special-ad-category
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <tableExists tableName="facebook_ads_campaign_special_ad_category"/>
+--    </not>
+CREATE TABLE facebook_ads_campaign_special_ad_category (
+  campaign_id   CHAR(36)    NOT NULL,
+  category      ENUM('NONE','CREDIT','EMPLOYMENT','HOUSING','ISSUES_ELECTIONS_POLITICS') NOT NULL,
+  PRIMARY KEY (campaign_id, category),
+  CONSTRAINT fk_facebook_ads_csac_campaign
+    FOREIGN KEY (campaign_id) REFERENCES facebook_ads_campaign(id)
+    ON DELETE CASCADE ON UPDATE RESTRICT
+);
+
+-- changeset marketinghub:2025-10-05-create-facebook-ads-campaign-special-ad-country
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <tableExists tableName="facebook_ads_campaign_special_ad_country"/>
+--    </not>
+CREATE TABLE facebook_ads_campaign_special_ad_country (
+  campaign_id   CHAR(36) NOT NULL,
+  country_iso2  CHAR(2)  NOT NULL,
+  PRIMARY KEY (campaign_id, country_iso2),
+  CONSTRAINT fk_facebook_ads_csacountry_campaign
+    FOREIGN KEY (campaign_id) REFERENCES facebook_ads_campaign(id)
+    ON DELETE CASCADE ON UPDATE RESTRICT
+);
+
+-- changeset marketinghub:2025-10-05-create-facebook-ads-ad-set
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <tableExists tableName="facebook_ads_ad_set"/>
+--    </not>
+CREATE TABLE facebook_ads_ad_set (
+  id                       CHAR(36)    NOT NULL,
+  external_id              VARCHAR(64) NULL,
+  campaign_id              CHAR(36)    NOT NULL,
+  name                     VARCHAR(255) NOT NULL,
+  status                   ENUM('PAUSED','ACTIVE','ARCHIVED','DELETED') NOT NULL DEFAULT 'PAUSED',
+  daily_budget_minor       BIGINT UNSIGNED NULL,
+  lifetime_budget_minor    BIGINT UNSIGNED NULL,
+  start_time               DATETIME   NULL,
+  end_time                 DATETIME   NULL,
+  billing_event            VARCHAR(32) NOT NULL,
+  optimization_goal        VARCHAR(64) NOT NULL,
+  bid_strategy             VARCHAR(64) NOT NULL,
+  bid_amount_minor         BIGINT UNSIGNED NULL,
+  promoted_object_json     LONGTEXT   NULL,
+  targeting_json           LONGTEXT   NOT NULL,
+  created_at               TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at               TIMESTAMP  NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT fk_facebook_ads_adset_campaign
+    FOREIGN KEY (campaign_id) REFERENCES facebook_ads_campaign(id)
+    ON DELETE CASCADE ON UPDATE RESTRICT
+);
+
+-- changeset marketinghub:2025-10-05-create-facebook-ads-media-asset
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <tableExists tableName="facebook_ads_media_asset"/>
+--    </not>
+CREATE TABLE facebook_ads_media_asset (
+  id            CHAR(36)     NOT NULL,
+  kind          ENUM('IMAGE','VIDEO') NOT NULL,
+  source_uri    VARCHAR(1024) NULL,
+  image_hash    VARCHAR(128)  NULL,
+  video_id      VARCHAR(64)   NULL,
+  width         INT UNSIGNED  NULL,
+  height        INT UNSIGNED  NULL,
+  duration_ms   INT UNSIGNED  NULL,
+  checksum      VARCHAR(128)  NULL,
+  created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+);
+
+-- changeset marketinghub:2025-10-05-create-facebook-ads-ad-creative
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <tableExists tableName="facebook_ads_ad_creative"/>
+--    </not>
+CREATE TABLE facebook_ads_ad_creative (
+  id                  CHAR(36)    NOT NULL,
+  external_id         VARCHAR(64) NULL,
+  page_id             VARCHAR(64) NOT NULL,
+  instagram_user_id   VARCHAR(64) NULL,
+  kind                ENUM('LINK','VIDEO','CAROUSEL') NOT NULL,
+  link_data_json      LONGTEXT NULL,
+  video_data_json     LONGTEXT NULL,
+  carousel_data_json  LONGTEXT NULL,
+  last_preview_url    VARCHAR(1024) NULL,
+  created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+);
+
+-- changeset marketinghub:2025-10-05-create-facebook-ads-ad
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <tableExists tableName="facebook_ads_ad"/>
+--    </not>
+CREATE TABLE facebook_ads_ad (
+  id            CHAR(36)   NOT NULL,
+  external_id   VARCHAR(64) NULL,
+  adset_id      CHAR(36)   NOT NULL,
+  name          VARCHAR(255) NOT NULL,
+  creative_id   CHAR(36)   NOT NULL,
+  status        ENUM('PAUSED','ACTIVE','ARCHIVED','DELETED') NOT NULL DEFAULT 'PAUSED',
+  created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT fk_facebook_ads_ad_adset
+    FOREIGN KEY (adset_id) REFERENCES facebook_ads_ad_set(id)
+    ON DELETE CASCADE ON UPDATE RESTRICT,
+  CONSTRAINT fk_facebook_ads_ad_creative
+    FOREIGN KEY (creative_id) REFERENCES facebook_ads_ad_creative(id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT
+);
+
+-- changeset marketinghub:2025-10-05-create-facebook-ads-ad-tracking-utm
+-- preconditions onFail:MARK_RAN
+--    <not>
+--        <tableExists tableName="facebook_ads_ad_tracking_utm"/>
+--    </not>
+CREATE TABLE facebook_ads_ad_tracking_utm (
+  ad_id        CHAR(36)    NOT NULL,
+  utm_source   VARCHAR(64)  NULL,
+  utm_medium   VARCHAR(64)  NULL,
+  utm_campaign VARCHAR(128) NULL,
+  utm_content  VARCHAR(128) NULL,
+  utm_term     VARCHAR(128) NULL,
+  PRIMARY KEY (ad_id),
+  CONSTRAINT fk_facebook_ads_utm_ad
+    FOREIGN KEY (ad_id) REFERENCES facebook_ads_ad(id)
+    ON DELETE CASCADE ON UPDATE RESTRICT
+);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -83,3 +83,6 @@ databaseChangeLog:
   - include:
       file: V2025_09_30__create_creative_table.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_10_05__create_facebook_ads_tables.sql
+      relativeToChangelogFile: true

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -287,6 +287,100 @@ allow variants to be created before an experiment is defined.
 - `hypothesis_id` BINARY(16)
 - `prompt_attribute_description_id` BIGINT
 
+### facebook_ads_campaign
+
+- `id` CHAR(36) PRIMARY KEY
+- `external_id` VARCHAR(64)
+- `ad_account_id` VARCHAR(64) NOT NULL
+- `name` VARCHAR(255) NOT NULL
+- `objective` VARCHAR(64) NOT NULL
+- `status` ENUM(PAUSED,ACTIVE,ARCHIVED,DELETED) DEFAULT "PAUSED"
+- `budget_mode` ENUM("CAMPAIGN","ADSET") NOT NULL
+- `daily_budget_minor` BIGINT
+- `lifetime_budget_minor` BIGINT
+- `api_version` VARCHAR(16)
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+- `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+
+### facebook_ads_campaign_special_ad_category
+
+- `campaign_id` CHAR(36)
+- `category` ENUM(NONE,CREDIT,EMPLOYMENT,HOUSING,ISSUES_ELECTIONS_POLITICS)
+- `PRIMARY KEY` (`campaign_id`, `category`)
+
+### facebook_ads_campaign_special_ad_country
+
+- `campaign_id` CHAR(36)
+- `country_iso2` CHAR(2)
+- `PRIMARY KEY` (`campaign_id`, `country_iso2`)
+
+### facebook_ads_ad_set
+
+- `id` CHAR(36) PRIMARY KEY
+- `external_id` VARCHAR(64)
+- `campaign_id` CHAR(36)
+- `name` VARCHAR(255)
+- `status` ENUM(PAUSED,ACTIVE,ARCHIVED,DELETED) DEFAULT "PAUSED"
+- `daily_budget_minor` BIGINT
+- `lifetime_budget_minor` BIGINT
+- `start_time` DATETIME
+- `end_time` DATETIME
+- `billing_event` VARCHAR(32)
+- `optimization_goal` VARCHAR(64)
+- `bid_strategy` VARCHAR(64)
+- `bid_amount_minor` BIGINT
+- `promoted_object_json` LONGTEXT
+- `targeting_json` LONGTEXT
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+- `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+
+### facebook_ads_media_asset
+
+- `id` CHAR(36) PRIMARY KEY
+- `kind` ENUM(IMAGE,VIDEO)
+- `source_uri` VARCHAR(1024)
+- `image_hash` VARCHAR(128)
+- `video_id` VARCHAR(64)
+- `width` INT
+- `height` INT
+- `duration_ms` INT
+- `checksum` VARCHAR(128)
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+
+### facebook_ads_ad_creative
+
+- `id` CHAR(36) PRIMARY KEY
+- `external_id` VARCHAR(64)
+- `page_id` VARCHAR(64)
+- `instagram_user_id` VARCHAR(64)
+- `kind` ENUM(LINK,VIDEO,CAROUSEL)
+- `link_data_json` LONGTEXT
+- `video_data_json` LONGTEXT
+- `carousel_data_json` LONGTEXT
+- `last_preview_url` VARCHAR(1024)
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+- `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+
+### facebook_ads_ad
+
+- `id` CHAR(36) PRIMARY KEY
+- `external_id` VARCHAR(64)
+- `adset_id` CHAR(36)
+- `name` VARCHAR(255)
+- `creative_id` CHAR(36)
+- `status` ENUM(PAUSED,ACTIVE,ARCHIVED,DELETED) DEFAULT "PAUSED"
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+- `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+
+### facebook_ads_ad_tracking_utm
+
+- `ad_id` CHAR(36) PRIMARY KEY
+- `utm_source` VARCHAR(64)
+- `utm_medium` VARCHAR(64)
+- `utm_campaign` VARCHAR(128)
+- `utm_content` VARCHAR(128)
+- `utm_term` VARCHAR(128)
+
 ## Diagram
 
 ```mermaid
@@ -355,6 +449,27 @@ erDiagram
         BINARY(16) hypothesis_id PK
         BIGINT prompt_attribute_description_id PK
     }
+
+    FACEBOOK_ADS_CAMPAIGN {
+        CHAR(36) id PK
+    }
+    FACEBOOK_ADS_AD_SET {
+        CHAR(36) id PK
+    }
+    FACEBOOK_ADS_AD_CREATIVE {
+        CHAR(36) id PK
+    }
+    FACEBOOK_ADS_AD {
+        CHAR(36) id PK
+    }
+    FACEBOOK_ADS_AD_TRACKING_UTM {
+        CHAR(36) ad_id PK
+    }
+
+    FACEBOOK_ADS_CAMPAIGN ||--o{ FACEBOOK_ADS_AD_SET : contains
+    FACEBOOK_ADS_AD_SET ||--o{ FACEBOOK_ADS_AD : includes
+    FACEBOOK_ADS_AD }o--|| FACEBOOK_ADS_AD_CREATIVE : uses
+    FACEBOOK_ADS_AD ||--|| FACEBOOK_ADS_AD_TRACKING_UTM : tracks
 
     MARKET_NICHE ||--o{ HYPOTHESIS : generates
     MARKET_NICHE ||--o{ EXPERIMENT : contains

--- a/schema.sql
+++ b/schema.sql
@@ -262,3 +262,109 @@ CREATE TABLE hypothesis_prompt_attribute_description (
 );
 
 ALTER TABLE hypothesis ADD COLUMN entrega LONGTEXT;
+
+CREATE TABLE facebook_ads_campaign (
+  id CHAR(36) NOT NULL,
+  external_id VARCHAR(64),
+  ad_account_id VARCHAR(64) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  objective VARCHAR(64) NOT NULL,
+  status ENUM('PAUSED','ACTIVE','ARCHIVED','DELETED') NOT NULL DEFAULT 'PAUSED',
+  budget_mode ENUM('CAMPAIGN','ADSET') NOT NULL,
+  daily_budget_minor BIGINT UNSIGNED,
+  lifetime_budget_minor BIGINT UNSIGNED,
+  api_version VARCHAR(16),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE facebook_ads_campaign_special_ad_category (
+  campaign_id CHAR(36) NOT NULL,
+  category ENUM('NONE','CREDIT','EMPLOYMENT','HOUSING','ISSUES_ELECTIONS_POLITICS') NOT NULL,
+  PRIMARY KEY (campaign_id, category),
+  CONSTRAINT fk_facebook_ads_csac_campaign FOREIGN KEY (campaign_id) REFERENCES facebook_ads_campaign(id) ON DELETE CASCADE ON UPDATE RESTRICT
+);
+
+CREATE TABLE facebook_ads_campaign_special_ad_country (
+  campaign_id CHAR(36) NOT NULL,
+  country_iso2 CHAR(2) NOT NULL,
+  PRIMARY KEY (campaign_id, country_iso2),
+  CONSTRAINT fk_facebook_ads_csacountry_campaign FOREIGN KEY (campaign_id) REFERENCES facebook_ads_campaign(id) ON DELETE CASCADE ON UPDATE RESTRICT
+);
+
+CREATE TABLE facebook_ads_ad_set (
+  id CHAR(36) NOT NULL,
+  external_id VARCHAR(64),
+  campaign_id CHAR(36) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  status ENUM('PAUSED','ACTIVE','ARCHIVED','DELETED') NOT NULL DEFAULT 'PAUSED',
+  daily_budget_minor BIGINT UNSIGNED,
+  lifetime_budget_minor BIGINT UNSIGNED,
+  start_time DATETIME,
+  end_time DATETIME,
+  billing_event VARCHAR(32) NOT NULL,
+  optimization_goal VARCHAR(64) NOT NULL,
+  bid_strategy VARCHAR(64) NOT NULL,
+  bid_amount_minor BIGINT UNSIGNED,
+  promoted_object_json LONGTEXT,
+  targeting_json LONGTEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT fk_facebook_ads_adset_campaign FOREIGN KEY (campaign_id) REFERENCES facebook_ads_campaign(id) ON DELETE CASCADE ON UPDATE RESTRICT
+);
+
+CREATE TABLE facebook_ads_media_asset (
+  id CHAR(36) NOT NULL,
+  kind ENUM('IMAGE','VIDEO') NOT NULL,
+  source_uri VARCHAR(1024),
+  image_hash VARCHAR(128),
+  video_id VARCHAR(64),
+  width INT UNSIGNED,
+  height INT UNSIGNED,
+  duration_ms INT UNSIGNED,
+  checksum VARCHAR(128),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE facebook_ads_ad_creative (
+  id CHAR(36) NOT NULL,
+  external_id VARCHAR(64),
+  page_id VARCHAR(64) NOT NULL,
+  instagram_user_id VARCHAR(64),
+  kind ENUM('LINK','VIDEO','CAROUSEL') NOT NULL,
+  link_data_json LONGTEXT,
+  video_data_json LONGTEXT,
+  carousel_data_json LONGTEXT,
+  last_preview_url VARCHAR(1024),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE facebook_ads_ad (
+  id CHAR(36) NOT NULL,
+  external_id VARCHAR(64),
+  adset_id CHAR(36) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  creative_id CHAR(36) NOT NULL,
+  status ENUM('PAUSED','ACTIVE','ARCHIVED','DELETED') NOT NULL DEFAULT 'PAUSED',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT fk_facebook_ads_ad_adset FOREIGN KEY (adset_id) REFERENCES facebook_ads_ad_set(id) ON DELETE CASCADE ON UPDATE RESTRICT,
+  CONSTRAINT fk_facebook_ads_ad_creative FOREIGN KEY (creative_id) REFERENCES facebook_ads_ad_creative(id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);
+
+CREATE TABLE facebook_ads_ad_tracking_utm (
+  ad_id CHAR(36) NOT NULL,
+  utm_source VARCHAR(64),
+  utm_medium VARCHAR(64),
+  utm_campaign VARCHAR(128),
+  utm_content VARCHAR(128),
+  utm_term VARCHAR(128),
+  PRIMARY KEY (ad_id),
+  CONSTRAINT fk_facebook_ads_utm_ad FOREIGN KEY (ad_id) REFERENCES facebook_ads_ad(id) ON DELETE CASCADE ON UPDATE RESTRICT
+);


### PR DESCRIPTION
## Summary
- add entities and repositories for Facebook Ads objects
- create Liquibase migration for Facebook Ads tables
- document Facebook Ads tables in data model

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bda82e32208321983521dc8cc8cb7d