### PR TITLE
feat: add targeting and creative fields

### DIFF
--- a/frontend/src/api/creative/useCreatives.ts
+++ b/frontend/src/api/creative/useCreatives.ts
@@ -8,6 +8,12 @@ export interface Creative {
   primaryText: string;
   imageUrl: string;
   status: string;
+  format?: string;
+  description?: string;
+  cta?: string;
+  destinationUrl?: string;
+  pageId?: string;
+  instagramUserId?: string;
 }
 
 export function useCreatives(expId: string) {

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useForm } from "react-hook-form";
 import { Creative, useCreatives } from "../../api/creative/useCreatives";
 import { useCreateCreative } from "../../api/creative/useCreateCreative";
 import { useUpdateCreative } from "../../api/creative/useUpdateCreative";
@@ -15,18 +16,38 @@ interface Props {
   experimentId: string;
 }
 
+interface CreativeForm {
+  format: string;
+  primaryText: string;
+  headline: string;
+  description: string;
+  cta: string;
+  destinationUrl: string;
+  imageUrl: string;
+  pageId: string;
+  instagramUserId: string;
+  status: string;
+}
+
 export default function CriativosTab({ experimentId }: Props) {
   const { data } = useCreatives(experimentId);
   const creatives = Array.isArray(data) ? data : [];
   const { data: experiment } = useExperiment(experimentId);
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<Creative | null>(null);
-  const [form, setForm] = useState({
+  const [form, setForm] = useState<CreativeForm>({
+    format: "LINK",
     headline: "",
     primaryText: "",
+    description: "",
+    cta: "LEARN_MORE",
+    destinationUrl: "",
     imageUrl: "",
+    pageId: "",
+    instagramUserId: "",
     status: "DRAFT",
   });
+  const { handleSubmit: handleFormSubmit } = useForm<CreativeForm>();
   const { data: angles } = useAngles();
   const { data: proofs } = useVisualProofs();
   const { data: triggers } = useEmotionalTriggers();
@@ -46,7 +67,18 @@ export default function CriativosTab({ experimentId }: Props) {
 
   const openNew = () => {
     setEditing(null);
-    setForm({ headline: "", primaryText: "", imageUrl: "", status: "DRAFT" });
+    setForm({
+      format: "LINK",
+      headline: "",
+      primaryText: "",
+      description: "",
+      cta: "LEARN_MORE",
+      destinationUrl: "",
+      imageUrl: "",
+      pageId: "",
+      instagramUserId: "",
+      status: "DRAFT",
+    });
     setSelectedAngle("");
     setSelectedProof("");
     setSelectedTrigger("");
@@ -54,10 +86,16 @@ export default function CriativosTab({ experimentId }: Props) {
   };
 
   const submit = async () => {
+    const payload = {
+      headline: form.headline,
+      primaryText: form.primaryText,
+      imageUrl: form.imageUrl,
+      status: form.status,
+    };
     if (editing) {
-      await update?.mutateAsync(form);
+      await update?.mutateAsync(payload);
     } else {
-      const created = await create.mutateAsync(form);
+      const created = await create.mutateAsync(payload);
       await patchLabels.mutateAsync({
         id: created.id,
         labels: {
@@ -81,6 +119,23 @@ export default function CriativosTab({ experimentId }: Props) {
   const remove = async (c: Creative) => {
     if (!confirm("Excluir criativo?")) return;
     await useDeleteCreative(c.id, experimentId).mutateAsync();
+  };
+
+  const duplicate = (c: Creative) => {
+    setEditing(null);
+    setForm({
+      format: c.format || "LINK",
+      headline: c.headline,
+      primaryText: c.primaryText,
+      description: c.description || "",
+      cta: c.cta || "LEARN_MORE",
+      destinationUrl: c.destinationUrl || "",
+      imageUrl: c.imageUrl,
+      pageId: c.pageId || "",
+      instagramUserId: c.instagramUserId || "",
+      status: c.status,
+    });
+    setShowForm(true);
   };
 
   const upload = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -165,15 +220,27 @@ export default function CriativosTab({ experimentId }: Props) {
                     onClick={() => {
                       setEditing(c);
                       setForm({
+                        format: c.format || "LINK",
                         headline: c.headline,
                         primaryText: c.primaryText,
+                        description: c.description || "",
+                        cta: c.cta || "LEARN_MORE",
+                        destinationUrl: c.destinationUrl || "",
                         imageUrl: c.imageUrl,
+                        pageId: c.pageId || "",
+                        instagramUserId: c.instagramUserId || "",
                         status: c.status,
                       });
                       setShowForm(true);
                     }}
                   >
                     🖊
+                  </button>
+                  <button
+                    className="btn btn-sm btn-outline-secondary me-1"
+                    onClick={() => duplicate(c)}
+                  >
+                    Duplicar
                   </button>
                   <button
                     className="btn btn-sm btn-outline-danger me-1"
@@ -208,10 +275,24 @@ export default function CriativosTab({ experimentId }: Props) {
                 />
               </div>
               <div className="modal-body">
-                <input
-                  type="file"
+                <select
+                  className="form-select mb-2"
+                  value={form.format}
+                  onChange={(e) => setForm({ ...form, format: e.target.value })}
+                >
+                  <option value="LINK">LINK</option>
+                  <option value="VIDEO">VIDEO</option>
+                  <option value="CAROUSEL">CAROUSEL</option>
+                </select>
+                <textarea
                   className="form-control mb-2"
-                  onChange={upload}
+                  placeholder="Primary Text"
+                  maxLength={125}
+                  value={form.primaryText}
+                  title="máx. 125 caracteres"
+                  onChange={(e) =>
+                    setForm({ ...form, primaryText: e.target.value })
+                  }
                 />
                 <input
                   className="form-control mb-2"
@@ -223,16 +304,53 @@ export default function CriativosTab({ experimentId }: Props) {
                     setForm({ ...form, headline: e.target.value })
                   }
                 />
-                <textarea
+                <input
                   className="form-control mb-2"
-                  placeholder="Primary Text"
-                  maxLength={125}
-                  value={form.primaryText}
-                  title="máx. 125 caracteres"
+                  placeholder="Descrição (opcional)"
+                  value={form.description}
                   onChange={(e) =>
-                    setForm({ ...form, primaryText: e.target.value })
+                    setForm({ ...form, description: e.target.value })
                   }
                 />
+                <select
+                  className="form-select mb-2"
+                  value={form.cta}
+                  onChange={(e) => setForm({ ...form, cta: e.target.value })}
+                >
+                  <option value="LEARN_MORE">LEARN_MORE</option>
+                  <option value="SHOP_NOW">SHOP_NOW</option>
+                </select>
+                <input
+                  className="form-control mb-2"
+                  placeholder="URL de destino"
+                  value={form.destinationUrl}
+                  onChange={(e) =>
+                    setForm({ ...form, destinationUrl: e.target.value })
+                  }
+                />
+                <input
+                  type="file"
+                  className="form-control mb-2"
+                  onChange={upload}
+                />
+                <div className="d-flex mb-2">
+                  <input
+                    className="form-control me-2"
+                    placeholder="page_id"
+                    value={form.pageId}
+                    onChange={(e) =>
+                      setForm({ ...form, pageId: e.target.value })
+                    }
+                  />
+                  <input
+                    className="form-control"
+                    placeholder="instagram_user_id"
+                    value={form.instagramUserId}
+                    onChange={(e) =>
+                      setForm({ ...form, instagramUserId: e.target.value })
+                    }
+                  />
+                </div>
                 {!editing && (
                   <>
                     <select
@@ -289,7 +407,14 @@ export default function CriativosTab({ experimentId }: Props) {
                 >
                   Cancelar
                 </button>
-                <button className="btn btn-primary" onClick={submit}>
+                <button
+                  className="btn btn-primary"
+                  onClick={handleFormSubmit(async () => {
+                    await submit();
+                  }, (errors) => {
+                    console.log('Validation errors', errors);
+                  })}
+                >
                   Salvar
                 </button>
               </div>

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -6,6 +6,7 @@ import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import PageTitle from "../../components/PageTitle";
 import CriativosTab from "./CriativosTab";
+import PublicosTab from "./PublicosTab";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 import * as Tabs from "@radix-ui/react-tabs";
 
@@ -104,9 +105,6 @@ export default function ExperimentDetailPage() {
           <Tabs.Trigger value="overview" className="nav-link">
             Overview
           </Tabs.Trigger>
-          <Tabs.Trigger value="landings" className="nav-link">
-            Landings
-          </Tabs.Trigger>
           <Tabs.Trigger value="audiences" className="nav-link">
             Públicos
           </Tabs.Trigger>
@@ -136,11 +134,8 @@ export default function ExperimentDetailPage() {
             </div>
           </div>
         </Tabs.Content>
-        <Tabs.Content value="landings">
-          <p>Landings aqui</p>
-        </Tabs.Content>
-        <Tabs.Content value="audiences">
-          <p>Públicos aqui</p>
+        <Tabs.Content value="audiences" asChild>
+          <PublicosTab />
         </Tabs.Content>
         <Tabs.Content value="creatives" asChild>
           <CriativosTab experimentId={expId} />

--- a/frontend/src/pages/experiment/PublicosTab.tsx
+++ b/frontend/src/pages/experiment/PublicosTab.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+interface AdSetForm {
+  geo: string;
+  minAge: number;
+  maxAge: number;
+  gender: string;
+  locale: string;
+  interests: string;
+  customAudiences: string;
+  lookalikeSource: string;
+  lookalikeCountry: string;
+  lookalikePercent: string;
+  placements: string;
+}
+
+export default function PublicosTab() {
+  const { register, handleSubmit, reset } = useForm<AdSetForm>();
+  const [adSets, setAdSets] = useState<AdSetForm[]>([]);
+  const onSubmit = (data: AdSetForm) => {
+    setAdSets((a) => [...a, data]);
+    reset();
+  };
+  return (
+    <div className="mt-3">
+      <form>
+        <input
+          className="form-control mb-2"
+          placeholder="Geo (país/estado/cidade)"
+          {...register("geo")}
+        />
+        <div className="d-flex mb-2">
+          <input
+            type="number"
+            className="form-control me-2"
+            placeholder="Idade mínima"
+            {...register("minAge")}
+          />
+          <input
+            type="number"
+            className="form-control"
+            placeholder="Idade máxima"
+            {...register("maxAge")}
+          />
+        </div>
+        <input
+          className="form-control mb-2"
+          placeholder="Gênero"
+          {...register("gender")}
+        />
+        <input
+          className="form-control mb-2"
+          placeholder="Idioma/Locale"
+          {...register("locale")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Interesses/comportamentos"
+          {...register("interests")}
+        />
+        <textarea
+          className="form-control mb-2"
+          placeholder="Públicos personalizados e exclusões"
+          {...register("customAudiences")}
+        />
+        <div className="d-flex mb-2">
+          <input
+            className="form-control me-2"
+            placeholder="Fonte Lookalike"
+            {...register("lookalikeSource")}
+          />
+          <input
+            className="form-control me-2"
+            placeholder="País"
+            {...register("lookalikeCountry")}
+          />
+          <input
+            className="form-control"
+            placeholder="%"
+            {...register("lookalikePercent")}
+          />
+        </div>
+        <input
+          className="form-control mb-2"
+          placeholder="Placements"
+          {...register("placements")}
+        />
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={handleSubmit(onSubmit, (errors) => {
+            console.log("Validation errors", errors);
+          })}
+        >
+          Salvar Público
+        </button>
+      </form>
+      {adSets.length > 0 && (
+        <div className="table-responsive mt-3">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Geo</th>
+                <th>Idade</th>
+                <th>Gênero</th>
+                <th>Locale</th>
+                <th>Interesses</th>
+                <th>Custom</th>
+                <th>Lookalike</th>
+                <th>Placements</th>
+              </tr>
+            </thead>
+            <tbody>
+              {adSets.map((a, idx) => (
+                <tr key={idx}>
+                  <td>{a.geo}</td>
+                  <td>
+                    {a.minAge}-{a.maxAge}
+                  </td>
+                  <td>{a.gender}</td>
+                  <td>{a.locale}</td>
+                  <td>{a.interests}</td>
+                  <td>{a.customAudiences}</td>
+                  <td>
+                    {a.lookalikeSource} {a.lookalikeCountry} {a.lookalikePercent}%
+                  </td>
+                  <td>{a.placements}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- drop Landings tab from experiment detail
- add Publicos tab with audience targeting form
- expand creatives modal with format, CTA, URL and duplicate option

## Testing
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdaeee422083218b205626dd57fe73