### PR TITLE
feat: add facebook campaign service

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -1,6 +1,8 @@
 package com.marketinghub.experiment.repository;
 
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentPlatform;
+import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.niche.MarketNiche;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +15,8 @@ import java.util.UUID;
 public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
     List<Experiment> findByNicheId(Long nicheId);
     boolean existsByNicheAndName(MarketNiche niche, String name);
-    List<Experiment> findByStatus(com.marketinghub.experiment.ExperimentStatus status);
+    List<Experiment> findByStatus(ExperimentStatus status);
+    List<Experiment> findByStatusAndPlatform(ExperimentStatus status, ExperimentPlatform platform);
     long countBySalesFunnelId(UUID salesFunnelId);
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -132,6 +132,10 @@ public class ExperimentService {
         return repository.findByNicheId(nicheId);
     }
 
+    public java.util.List<Experiment> listReadyForCampaign() {
+        return repository.findByStatusAndPlatform(ExperimentStatus.PLANNED, ExperimentPlatform.FACEBOOK);
+    }
+
     @Transactional
     public Experiment duplicate(Long id) {
         Experiment original = repository.findById(id).orElseThrow();

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
@@ -1,0 +1,43 @@
+package com.marketinghub.facebookads.web;
+
+import com.marketinghub.experiment.service.ExperimentService;
+import com.marketinghub.facebookads.BudgetMode;
+import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.facebookads.FacebookAdsCampaignRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/facebook-campaigns")
+public class FacebookAdsCampaignController {
+    private final ExperimentService experimentService;
+    private final FacebookAdsCampaignRepository campaignRepository;
+
+    public FacebookAdsCampaignController(ExperimentService experimentService,
+                                         FacebookAdsCampaignRepository campaignRepository) {
+        this.experimentService = experimentService;
+        this.campaignRepository = campaignRepository;
+    }
+
+    @GetMapping("/experiments-ready")
+    public List<ExperimentSummary> experimentsReady() {
+        return experimentService.listReadyForCampaign().stream()
+                .map(e -> new ExperimentSummary(e.getId(), e.getName()))
+                .toList();
+    }
+
+    @PostMapping
+    public FacebookAdsCampaign create(@RequestBody CreateCampaignRequest req) {
+        FacebookAdsCampaign campaign = new FacebookAdsCampaign();
+        campaign.setId(req.id());
+        campaign.setAdAccountId(req.adAccountId());
+        campaign.setName(req.name());
+        campaign.setObjective(req.objective());
+        campaign.setBudgetMode(req.budgetMode());
+        return campaignRepository.save(campaign);
+    }
+
+    public record ExperimentSummary(Long id, String name) {}
+    public record CreateCampaignRequest(String id, String adAccountId, String name, String objective, BudgetMode budgetMode) {}
+}

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -33,6 +33,10 @@ public class FacebookAdsService {
         return response.path("id").asText();
     }
 
+    public String createCampaign(String adAccountId, String name) {
+        return createInstagramCampaign(adAccountId, name);
+    }
+
     public JsonNode getCampaignMetrics(String campaignId) {
         return webClient.get()
             .uri("/v20.0/" + campaignId + "/insights?access_token=" + accessToken)

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignScheduler.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignScheduler.java
@@ -1,0 +1,18 @@
+package com.marketinghub.facebookadsworker.facebookcampaign;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FacebookCampaignScheduler {
+    private final FacebookCampaignService service;
+
+    public FacebookCampaignScheduler(FacebookCampaignService service) {
+        this.service = service;
+    }
+
+    @Scheduled(fixedDelayString = "${facebookcampaign.scheduler.delay:60000}")
+    public void schedule() {
+        service.createCampaignsFromExperiments();
+    }
+}

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -1,0 +1,51 @@
+package com.marketinghub.facebookadsworker.facebookcampaign;
+
+import com.marketinghub.facebookadsworker.FacebookAdsService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Service
+public class FacebookCampaignService {
+    private final FacebookAdsService facebookAdsService;
+    private final WebClient backendClient;
+    private final String adAccountId;
+
+    public FacebookCampaignService(FacebookAdsService facebookAdsService,
+                                   WebClient.Builder builder,
+                                   @Value("${backend.base-url:http://localhost:8080}") String backendBaseUrl,
+                                   @Value("${facebook.ad-account-id}") String adAccountId) {
+        this.facebookAdsService = facebookAdsService;
+        this.backendClient = builder.baseUrl(backendBaseUrl).build();
+        this.adAccountId = adAccountId;
+    }
+
+    public void createCampaignsFromExperiments() {
+        List<Experiment> experiments = backendClient.get()
+            .uri("/facebook-campaigns/experiments-ready")
+            .retrieve()
+            .bodyToFlux(Experiment.class)
+            .collectList()
+            .block();
+
+        if (experiments != null) {
+            experiments.forEach(this::processExperiment);
+        }
+    }
+
+    private void processExperiment(Experiment exp) {
+        String campaignId = facebookAdsService.createCampaign(adAccountId, exp.name());
+        CreateCampaignRequest req = new CreateCampaignRequest(campaignId, adAccountId, exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
+        backendClient.post()
+            .uri("/facebook-campaigns")
+            .bodyValue(req)
+            .retrieve()
+            .toBodilessEntity()
+            .block();
+    }
+
+    public record Experiment(long id, String name) {}
+    public record CreateCampaignRequest(String id, String adAccountId, String name, String objective, String budgetMode) {}
+}

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -1,0 +1,59 @@
+package com.marketinghub.facebookadsworker.facebookcampaign;
+
+import com.marketinghub.facebookadsworker.FacebookAdsService;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FacebookCampaignServiceTest {
+    private MockWebServer backend;
+    private MockWebServer facebook;
+    private FacebookCampaignService service;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        backend = new MockWebServer();
+        backend.start();
+        facebook = new MockWebServer();
+        facebook.start();
+
+        String backendUrl = backend.url("/").toString();
+        String facebookUrl = facebook.url("/").toString();
+
+        FacebookAdsService adsService = new FacebookAdsService(WebClient.builder(), facebookUrl, "token");
+        service = new FacebookCampaignService(adsService, WebClient.builder(), backendUrl, "1");
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        backend.shutdown();
+        facebook.shutdown();
+    }
+
+    @Test
+    void createsCampaignForEachExperiment() throws Exception {
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\"}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"10\"}")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setBody("{}")
+            .addHeader("Content-Type", "application/json"));
+
+        service.createCampaignsFromExperiments();
+
+        RecordedRequest get = backend.takeRequest();
+        assertEquals("/facebook-campaigns/experiments-ready", get.getPath());
+        RecordedRequest postFb = facebook.takeRequest();
+        assertEquals("/v20.0/act_1/campaigns", postFb.getPath());
+        RecordedRequest postBackend = backend.takeRequest();
+        assertEquals("/facebook-campaigns", postBackend.getPath());
+    }
+}


### PR DESCRIPTION
## Summary
- expose endpoint to list experiments ready for facebook campaigns and persist new campaigns
- create worker service and scheduler to generate campaigns from experiments via backend APIs

## Testing
- `mvn -s /tmp/maven_settings.xml test` (failed: Non-resolvable parent POM)
- `mvn -s /tmp/maven_settings.xml test` (failed: Non-resolvable parent POM)


------
https://chatgpt.com/codex/tasks/task_e_68be0e4fb6b88321b631eb814d0737bf