### PR TITLE
Fix Instagram creative preview in experiments

### DIFF
--- a/frontend/src/pages/experiment/CriativosTab.test.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.test.tsx
@@ -1,26 +1,72 @@
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import CriativosTab from "./CriativosTab";
 import axios from "axios";
 
 vi.mock("axios");
 
 describe("CriativosTab", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
   it("opens modal", async () => {
-    (axios.get as any)
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: { creativesToGenerate: 3 } });
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url.endsWith("/experiments/1/creatives")) {
+        return Promise.resolve({ data: [] });
+      }
+      if (url.endsWith("/experiments/1")) {
+        return Promise.resolve({ data: { creativesToGenerate: 3 } });
+      }
+      return Promise.resolve({ data: [] });
+    });
     const client = new QueryClient();
     render(
       <QueryClientProvider client={client}>
         <CriativosTab experimentId="1" />
       </QueryClientProvider>,
     );
-    expect(
-      await screen.findByText("Solicitados: 3"),
-    ).toBeTruthy();
+    expect(await screen.findByText("Solicitados: 3")).toBeTruthy();
     screen.getByText("Novo Criativo").click();
     expect(await screen.findByText("Novo Criativo")).toBeTruthy();
+  });
+
+  it("shows preview", async () => {
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url.endsWith("/experiments/1/creatives")) {
+        return Promise.resolve({
+          data: [
+            {
+              id: 42,
+              headline: "H1",
+              primaryText: "P1",
+              imageUrl: "img.jpg",
+              status: "READY",
+            },
+          ],
+        });
+      }
+      if (url.endsWith("/experiments/1")) {
+        return Promise.resolve({ data: { creativesToGenerate: 0 } });
+      }
+      if (url.endsWith("/creatives/42/preview")) {
+        return Promise.resolve({ data: "<html>preview</html>" });
+      }
+      return Promise.resolve({ data: [] });
+    });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <CriativosTab experimentId="1" />
+      </QueryClientProvider>,
+    );
+    await screen.findByText("Solicitados: 0");
+    (await screen.findByLabelText("Preview")).click();
+    await screen.findByTitle("preview");
+    expect(
+      (axios.get as any).mock.calls.some((c: any) =>
+        c[0].endsWith("/creatives/42/preview"),
+      ),
+    ).toBe(true);
   });
 });

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -58,11 +58,11 @@ export default function CriativosTab({ experimentId }: Props) {
   const create = useCreateCreative(experimentId);
   const update = useUpdateCreative(experimentId);
   const del = useDeleteCreative(experimentId);
-  const { data: previewHtml, refetch } = usePreviewCreative(
-    editing?.id ?? 0,
-    false,
-  );
   const [showPreview, setShowPreview] = useState(false);
+  const { data: previewHtml } = usePreviewCreative(
+    editing?.id ?? 0,
+    !!editing && showPreview,
+  );
   const requestCreatives = useRequestCreatives(experimentId);
 
   const openNew = () => {
@@ -110,10 +110,9 @@ export default function CriativosTab({ experimentId }: Props) {
     setShowForm(false);
   };
 
-  const startPreview = async (c: Creative) => {
+  const startPreview = (c: Creative) => {
     setEditing(c);
     setShowPreview(true);
-    await refetch();
   };
 
   const remove = async (c: Creative) => {
@@ -275,6 +274,7 @@ export default function CriativosTab({ experimentId }: Props) {
                     type="button"
                     className="btn btn-sm btn-outline-secondary"
                     onClick={() => startPreview(c)}
+                    aria-label="Preview"
                   >
                     👁
                   </button>


### PR DESCRIPTION
## Summary
- trigger creative previews after selecting a creative instead of manual refetch
- ensure preview button is accessible and tested

## Testing
- `npm run build`
- `npm test -- --run`
- `npx vitest run src/pages/experiment/CriativosTab.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bef3097c90832195a0be6b3b089927