### PR TITLE
feat: add approvals for facebook campaigns

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -75,6 +75,14 @@ public class Experiment {
     @Enumerated(EnumType.STRING)
     private ExperimentPlatform platform;
 
+    /** Indica se o público está aprovado pelo usuário. */
+    @Column(nullable = false)
+    private boolean audienceApproved;
+
+    /** Indica se o criativo está aprovado pelo usuário. */
+    @Column(nullable = false)
+    private boolean creativeApproved;
+
     /** Quantidade de criativos a serem gerados pelo worker. */
     @Column(name = "creatives_to_generate")
     private Integer creativesToGenerate;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -30,6 +30,8 @@ public class ExperimentDto {
     private LocalDate endDate;
     private ExperimentStatus status;
     private ExperimentPlatform platform;
+    private boolean audienceApproved;
+    private boolean creativeApproved;
     private Instant createdAt;
     private Instant updatedAt;
     private String metricPresetId;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
@@ -21,5 +21,7 @@ public class UpdateExperimentRequest {
     private LocalDate startDate;
     private LocalDate endDate;
     private Integer creativesToGenerate;
+    private Boolean audienceApproved;
+    private Boolean creativeApproved;
 }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -17,6 +17,8 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
     boolean existsByNicheAndName(MarketNiche niche, String name);
     List<Experiment> findByStatus(ExperimentStatus status);
     List<Experiment> findByStatusAndPlatform(ExperimentStatus status, ExperimentPlatform platform);
+    List<Experiment> findByStatusAndPlatformAndAudienceApprovedTrueAndCreativeApprovedTrue(
+            ExperimentStatus status, ExperimentPlatform platform);
     long countBySalesFunnelId(UUID salesFunnelId);
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -133,7 +133,8 @@ public class ExperimentService {
     }
 
     public java.util.List<Experiment> listReadyForCampaign() {
-        return repository.findByStatusAndPlatform(ExperimentStatus.PLANNED, ExperimentPlatform.FACEBOOK);
+        return repository.findByStatusAndPlatformAndAudienceApprovedTrueAndCreativeApprovedTrue(
+                ExperimentStatus.PLANNED, ExperimentPlatform.FACEBOOK);
     }
 
     @Transactional
@@ -224,6 +225,12 @@ public class ExperimentService {
         exp.setEndDate(request.getEndDate());
         if (request.getCreativesToGenerate() != null) {
             exp.setCreativesToGenerate(request.getCreativesToGenerate());
+        }
+        if (request.getAudienceApproved() != null) {
+            exp.setAudienceApproved(request.getAudienceApproved());
+        }
+        if (request.getCreativeApproved() != null) {
+            exp.setCreativeApproved(request.getCreativeApproved());
         }
         return exp;
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -7,6 +7,7 @@ import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import com.marketinghub.creative.label.repository.AngleRepository;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
+import com.marketinghub.experiment.repository.ExperimentRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,6 +37,8 @@ class ExperimentServiceTest {
     com.marketinghub.creative.label.repository.AngleRepository angleRepository;
     @Autowired
     com.marketinghub.experiment.repository.MetricPresetRepository metricPresetRepository;
+    @Autowired
+    ExperimentRepository experimentRepository;
 
     @Test
     void createNewExperimentWithExistingNiche() {
@@ -143,5 +146,54 @@ class ExperimentServiceTest {
         req.setMdePercent(new BigDecimal("40"));
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+    }
+
+    @Test
+    void listReadyForCampaignRequiresApprovals() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("H1")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+
+        CreateExperimentRequest req1 = new CreateExperimentRequest();
+        req1.setMarketNicheId(niche.getId());
+        req1.setHypothesisId(hyp.getId());
+        req1.setName("ExpA");
+        req1.setHypothesis("H");
+        req1.setKpiTargetCpl(new BigDecimal("45"));
+        req1.setMetricPresetId("LEAN_150");
+        var expApproved = service.create(req1);
+        expApproved.setAudienceApproved(true);
+        expApproved.setCreativeApproved(true);
+        experimentRepository.save(expApproved);
+
+        CreateExperimentRequest req2 = new CreateExperimentRequest();
+        req2.setMarketNicheId(niche.getId());
+        req2.setHypothesisId(hyp.getId());
+        req2.setName("ExpB");
+        req2.setHypothesis("H");
+        req2.setKpiTargetCpl(new BigDecimal("45"));
+        req2.setMetricPresetId("LEAN_150");
+        var expNotApproved = service.create(req2);
+        expNotApproved.setAudienceApproved(true);
+        experimentRepository.save(expNotApproved);
+
+        var result = service.listReadyForCampaign();
+        assertThat(result).extracting(Experiment::getId).containsExactly(expApproved.getId());
     }
 }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -151,6 +151,8 @@ for managing campaigns and tracking their performance.
 - `end_date` DATE
 - `status` VARCHAR(20)
 - `platform` VARCHAR(50)
+- `audience_approved` BOOLEAN DEFAULT FALSE
+- `creative_approved` BOOLEAN DEFAULT FALSE
 - `sales_funnel_id` BINARY(16)
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP

--- a/schema.sql
+++ b/schema.sql
@@ -126,6 +126,8 @@ CREATE TABLE experiment (
     end_date DATE,
     status VARCHAR(20),
     platform VARCHAR(50),
+    audience_approved BOOLEAN DEFAULT FALSE,
+    creative_approved BOOLEAN DEFAULT FALSE,
     sales_funnel_id BINARY(16),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP


### PR DESCRIPTION
## Summary
- track audience and creative approval on experiments
- create Facebook campaigns only when both approvals are set
- document new experiment fields in schema and data model

## Testing
- `mvn -s ../settings.xml test` *(failed: Network is unreachable)*
- `mvn -s settings.xml test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4c1a309c83219b543e9076aea3be