### PR TITLE
feat: add instagram-style creative preview

### DIFF
--- a/frontend/src/components/InstagramAdPreview.tsx
+++ b/frontend/src/components/InstagramAdPreview.tsx
@@ -1,0 +1,65 @@
+import { Creative } from "../api/creative/useCreatives";
+
+interface Props {
+  creative: Creative;
+}
+
+export default function InstagramAdPreview({ creative }: Props) {
+  const cta = creative.cta?.replace(/_/g, " ") || "SAIBA MAIS";
+  return (
+    <div
+      style={{
+        maxWidth: 360,
+        margin: "0 auto",
+        border: "1px solid #dbdbdb",
+        borderRadius: 8,
+        fontFamily: "Arial, sans-serif",
+        backgroundColor: "#fff",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          padding: "8px",
+        }}
+      >
+        <div
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: "50%",
+            background: "#eee",
+            marginRight: 8,
+          }}
+        />
+        <div>
+          <div style={{ fontWeight: 600 }}>Página</div>
+          <div style={{ fontSize: 12, color: "#8e8e8e" }}>Patrocinado</div>
+        </div>
+      </div>
+      <img
+        src={creative.imageUrl}
+        alt="creative"
+        style={{ width: "100%", display: "block" }}
+      />
+      <div style={{ padding: 8 }}>
+        <p style={{ marginBottom: 8 }}>
+          <strong>{creative.headline}</strong> {creative.primaryText}
+        </p>
+        <button
+          style={{
+            width: "100%",
+            padding: "8px",
+            background: "#fff",
+            border: "1px solid #dbdbdb",
+            borderRadius: 4,
+            fontWeight: 600,
+          }}
+        >
+          {cta}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/experiment/CriativosTab.test.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.test.tsx
@@ -59,7 +59,6 @@ describe("CriativosTab", () => {
     );
     await screen.findByText("Solicitados: 0");
     (await screen.findByLabelText("Preview")).click();
-    const iframe = await screen.findByTitle("preview");
-    expect(iframe.getAttribute("src")).toBe("/api/creatives/42/preview");
+    await screen.findByText("Patrocinado");
   });
 });

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -10,6 +10,7 @@ import { useEmotionalTriggers } from "../../api/emotionalTrigger/useEmotionalTri
 import { useUpdateCreativeLabels } from "../../api/creative/useUpdateCreativeLabels";
 import { useRequestCreatives } from "../../api/experiment/useRequestCreatives";
 import { useExperiment } from "../../api/experiment/useExperiment";
+import InstagramAdPreview from "../../components/InstagramAdPreview";
 
 interface Props {
   experimentId: string;
@@ -58,7 +59,6 @@ export default function CriativosTab({ experimentId }: Props) {
   const update = useUpdateCreative(experimentId);
   const del = useDeleteCreative(experimentId);
   const [showPreview, setShowPreview] = useState(false);
-  const previewUrl = editing ? `/api/creatives/${editing.id}/preview` : "";
   const requestCreatives = useRequestCreatives(experimentId);
 
   const openNew = () => {
@@ -449,9 +449,9 @@ export default function CriativosTab({ experimentId }: Props) {
         </div>
       )}
 
-      {showPreview && (
+      {showPreview && editing && (
         <div className="modal d-block" tabIndex={-1}>
-          <div className="modal-dialog modal-xl">
+          <div className="modal-dialog">
             <div className="modal-content">
               <div className="modal-header">
                 <h5 className="modal-title">Preview</h5>
@@ -462,11 +462,7 @@ export default function CriativosTab({ experimentId }: Props) {
                 />
               </div>
               <div className="modal-body">
-                <iframe
-                  title="preview"
-                  style={{ width: "100%", height: "80vh" }}
-                  src={previewUrl}
-                />
+                <InstagramAdPreview creative={editing} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- show creative previews in Instagram-like card layout
- swap iframe preview for InstagramAdPreview component
- update tests for new creative preview behavior

## Testing
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf4b9a4a90832190cee9b3ab470e69