### PR TITLE
feat: add audience entity for facebook ads

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/audience/Audience.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/Audience.java
@@ -1,0 +1,51 @@
+package com.marketinghub.audience;
+
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.niche.MarketNiche;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+
+/**
+ * Represents a Facebook Ads audience that can be linked to either a market niche or a hypothesis.
+ */
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Audience {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Name of the audience for identification. */
+    private String name;
+
+    /** Optional description or notes about the audience. */
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    private String description;
+
+    /** Associated market niche, if this is a generic audience. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "market_niche_id")
+    private MarketNiche niche;
+
+    /** Associated hypothesis, if this audience is specific to a hypothesis. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hypothesis_id")
+    private Hypothesis hypothesis;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}
+

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/dto/AudienceDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/dto/AudienceDto.java
@@ -1,0 +1,19 @@
+package com.marketinghub.audience.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.UUID;
+
+/**
+ * Data transfer object for {@link com.marketinghub.audience.Audience}.
+ */
+@Data
+@Builder
+public class AudienceDto {
+    private Long id;
+    private String name;
+    private String description;
+    private Long marketNicheId;
+    private UUID hypothesisId;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/dto/CreateAudienceRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/dto/CreateAudienceRequest.java
@@ -1,0 +1,16 @@
+package com.marketinghub.audience.dto;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+/**
+ * Request body for creating an audience.
+ */
+@Data
+public class CreateAudienceRequest {
+    private String name;
+    private String description;
+    private Long marketNicheId;
+    private UUID hypothesisId;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/mapper/AudienceMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/mapper/AudienceMapper.java
@@ -1,0 +1,16 @@
+package com.marketinghub.audience.mapper;
+
+import com.marketinghub.audience.Audience;
+import com.marketinghub.audience.dto.AudienceDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * MapStruct mapper for {@link Audience}.
+ */
+@Mapper(componentModel = "spring")
+public interface AudienceMapper {
+    @Mapping(target = "marketNicheId", source = "niche.id")
+    @Mapping(target = "hypothesisId", source = "hypothesis.id")
+    AudienceDto toDto(Audience audience);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/repository/AudienceRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/repository/AudienceRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.audience.repository;
+
+import com.marketinghub.audience.Audience;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Repository for persisting {@link Audience} entities.
+ */
+public interface AudienceRepository extends CrudRepository<Audience, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/service/AudienceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/service/AudienceService.java
@@ -1,0 +1,55 @@
+package com.marketinghub.audience.service;
+
+import com.marketinghub.audience.Audience;
+import com.marketinghub.audience.dto.CreateAudienceRequest;
+import com.marketinghub.audience.repository.AudienceRepository;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service layer for audiences.
+ */
+@Service
+public class AudienceService {
+    private final AudienceRepository repository;
+    private final MarketNicheRepository nicheRepository;
+    private final HypothesisRepository hypothesisRepository;
+
+    public AudienceService(AudienceRepository repository, MarketNicheRepository nicheRepository, HypothesisRepository hypothesisRepository) {
+        this.repository = repository;
+        this.nicheRepository = nicheRepository;
+        this.hypothesisRepository = hypothesisRepository;
+    }
+
+    /**
+     * Creates an audience associated with a niche or hypothesis.
+     */
+    @Transactional
+    public Audience create(CreateAudienceRequest request) {
+        com.marketinghub.niche.MarketNiche niche = null;
+        if (request.getMarketNicheId() != null) {
+            niche = nicheRepository.findById(request.getMarketNicheId()).orElseThrow();
+        }
+        com.marketinghub.hypothesis.Hypothesis hypothesis = null;
+        if (request.getHypothesisId() != null) {
+            hypothesis = hypothesisRepository.findById(request.getHypothesisId()).orElseThrow();
+        }
+        Audience audience = Audience.builder()
+                .name(request.getName())
+                .description(request.getDescription())
+                .niche(niche)
+                .hypothesis(hypothesis)
+                .build();
+        return repository.save(audience);
+    }
+
+    public Audience get(Long id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    public Iterable<Audience> list() {
+        return repository.findAll();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/web/AudienceController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/web/AudienceController.java
@@ -1,0 +1,42 @@
+package com.marketinghub.audience.web;
+
+import com.marketinghub.audience.dto.AudienceDto;
+import com.marketinghub.audience.dto.CreateAudienceRequest;
+import com.marketinghub.audience.mapper.AudienceMapper;
+import com.marketinghub.audience.service.AudienceService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+/**
+ * REST controller for audiences.
+ */
+@RestController
+@RequestMapping("/api/audiences")
+public class AudienceController {
+    private final AudienceService service;
+    private final AudienceMapper mapper;
+
+    public AudienceController(AudienceService service, AudienceMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @PostMapping
+    public AudienceDto create(@RequestBody CreateAudienceRequest request) {
+        return mapper.toDto(service.create(request));
+    }
+
+    @GetMapping("/{id}")
+    public AudienceDto get(@PathVariable Long id) {
+        return mapper.toDto(service.get(id));
+    }
+
+    @GetMapping
+    public List<AudienceDto> list() {
+        return StreamSupport.stream(service.list().spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -3,6 +3,7 @@ package com.marketinghub.hypothesis;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.creative.label.Angle;
 import com.marketinghub.prompt.PromptAttributeDescription;
+import com.marketinghub.audience.Audience;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -103,4 +104,7 @@ public class Hypothesis {
 
     @UpdateTimestamp
     private Instant updatedAt;
+
+    @OneToMany(mappedBy = "hypothesis")
+    private java.util.List<Audience> audiences;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import com.marketinghub.chat.ChatDialog;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.audience.Audience;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -77,6 +78,9 @@ public class MarketNiche {
 
     @OneToMany(mappedBy = "niche")
     private java.util.List<Experiment> experiments;
+
+    @OneToMany(mappedBy = "niche")
+    private java.util.List<Audience> audiences;
 
     @CreationTimestamp
     private Instant createdAt;

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -133,6 +133,16 @@ for managing campaigns and tracking their performance.
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 
+### audience
+
+- `id` BIGINT AUTO_INCREMENT PRIMARY KEY
+- `name` VARCHAR(255)
+- `description` LONGTEXT
+- `market_niche_id` BIGINT
+- `hypothesis_id` BINARY(16)
+- `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+- `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+
 ### experiment
 
 - `id` BIGINT AUTO_INCREMENT PRIMARY KEY
@@ -410,6 +420,9 @@ erDiagram
     MARKET_NICHE {
         BIGINT id PK
     }
+    AUDIENCE {
+        BIGINT id PK
+    }
     EXPERIMENT {
         BIGINT id PK
     }
@@ -477,7 +490,9 @@ erDiagram
 
     MARKET_NICHE ||--o{ HYPOTHESIS : generates
     MARKET_NICHE ||--o{ EXPERIMENT : contains
+    MARKET_NICHE ||--o{ AUDIENCE : has
     HYPOTHESIS ||--o{ EXPERIMENT : tests
+    HYPOTHESIS ||--o{ AUDIENCE : defines
     EXPERIMENT ||--o{ CREATIVE_VARIANT : has
     EXPERIMENT ||--o{ AD_SET : configures
     EXPERIMENT ||--o{ LANDING_PAGE : uses

--- a/schema.sql
+++ b/schema.sql
@@ -133,6 +133,18 @@ CREATE TABLE experiment (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
+CREATE TABLE audience (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255),
+    description LONGTEXT,
+    market_niche_id BIGINT,
+    hypothesis_id BINARY(16),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_audience_market_niche FOREIGN KEY (market_niche_id) REFERENCES market_niche(id),
+    CONSTRAINT fk_audience_hypothesis FOREIGN KEY (hypothesis_id) REFERENCES hypothesis(id)
+);
+
 CREATE TABLE creative (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     experiment_id BIGINT NOT NULL,


### PR DESCRIPTION
## Summary
- add audience entity to support facebook ad targeting
- connect audiences to market niches and hypotheses
- document schema and update database script

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0320321448321a1304f7a82f3faa6