### PR TITLE
Add audience management to niche pages

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/audience/repository/AudienceRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/repository/AudienceRepository.java
@@ -2,9 +2,11 @@ package com.marketinghub.audience.repository;
 
 import com.marketinghub.audience.Audience;
 import org.springframework.data.repository.CrudRepository;
+import java.util.List;
 
 /**
  * Repository for persisting {@link Audience} entities.
  */
 public interface AudienceRepository extends CrudRepository<Audience, Long> {
+    List<Audience> findByNicheId(Long nicheId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/service/AudienceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/service/AudienceService.java
@@ -52,4 +52,8 @@ public class AudienceService {
     public Iterable<Audience> list() {
         return repository.findAll();
     }
+
+    public Iterable<Audience> listByMarketNiche(Long nicheId) {
+        return repository.findByNicheId(nicheId);
+    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/web/AudienceController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/web/AudienceController.java
@@ -13,7 +13,7 @@ import java.util.stream.StreamSupport;
  * REST controller for audiences.
  */
 @RestController
-@RequestMapping("/api/audiences")
+@RequestMapping("/api")
 public class AudienceController {
     private final AudienceService service;
     private final AudienceMapper mapper;
@@ -23,19 +23,26 @@ public class AudienceController {
         this.mapper = mapper;
     }
 
-    @PostMapping
+    @PostMapping("/audiences")
     public AudienceDto create(@RequestBody CreateAudienceRequest request) {
         return mapper.toDto(service.create(request));
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/audiences/{id}")
     public AudienceDto get(@PathVariable Long id) {
         return mapper.toDto(service.get(id));
     }
 
-    @GetMapping
+    @GetMapping("/audiences")
     public List<AudienceDto> list() {
         return StreamSupport.stream(service.list().spliterator(), false)
+                .map(mapper::toDto)
+                .toList();
+    }
+
+    @GetMapping("/niches/{nicheId}/audiences")
+    public List<AudienceDto> listByNiche(@PathVariable Long nicheId) {
+        return StreamSupport.stream(service.listByMarketNiche(nicheId).spliterator(), false)
                 .map(mapper::toDto)
                 .toList();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
@@ -50,6 +50,9 @@ public class MarketNiche {
     /** Quantidade de hipóteses a serem geradas para este nicho. */
     private Integer hypothesesToGenerate;
 
+    /** Quantidade de públicos a serem gerados para este nicho. */
+    private Integer audiencesToGenerate;
+
     /** Base segmentation for the Brazilian market. */
     @Lob
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/dto/CreateMarketNicheRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/dto/CreateMarketNicheRequest.java
@@ -18,5 +18,6 @@ public class CreateMarketNicheRequest {
     private String demographicFilters;
     private String extraTips;
     private Integer hypothesesToGenerate;
+    private Integer audiencesToGenerate;
     private Long chatDialogId;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/dto/MarketNicheDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/dto/MarketNicheDto.java
@@ -19,6 +19,7 @@ public class MarketNicheDto {
     private String demographicFilters;
     private String extraTips;
     private Integer hypothesesToGenerate;
+    private Integer audiencesToGenerate;
     private Long chatDialogId;
     private Instant createdAt;
     private Instant updatedAt;

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
@@ -41,6 +41,7 @@ public class MarketNicheService {
                 .demographicFilters(request.getDemographicFilters())
                 .extraTips(request.getExtraTips())
                 .hypothesesToGenerate(request.getHypothesesToGenerate())
+                .audiencesToGenerate(request.getAudiencesToGenerate())
                 .chatDialog(chat)
                 .build();
         return repository.save(niche);
@@ -63,6 +64,7 @@ public class MarketNicheService {
         niche.setDemographicFilters(request.getDemographicFilters());
         niche.setExtraTips(request.getExtraTips());
         niche.setHypothesesToGenerate(request.getHypothesesToGenerate());
+        niche.setAudiencesToGenerate(request.getAudiencesToGenerate());
         ChatDialog chat = null;
         if (request.getChatDialogId() != null) {
             chat = chatDialogRepository.findById(request.getChatDialogId()).orElseThrow();

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_06__add_audiences_to_generate_to_niche.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_06__add_audiences_to_generate_to_niche.sql
@@ -1,0 +1,1 @@
+ALTER TABLE market_niche ADD COLUMN audiences_to_generate INT;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -86,3 +86,6 @@ databaseChangeLog:
   - include:
       file: V2025_10_05__create_facebook_ads_tables.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_10_06__add_audiences_to_generate_to_niche.sql
+      relativeToChangelogFile: true

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -110,6 +110,7 @@ for managing campaigns and tracking their performance.
 - `promises` LONGTEXT
 - `offers` LONGTEXT
 - `hypotheses_to_generate` INT
+- `audiences_to_generate` INT
 - `base_segmentation` LONGTEXT
 - `interests` LONGTEXT
 - `demographic_filters` LONGTEXT

--- a/docs/html/data-model.html
+++ b/docs/html/data-model.html
@@ -112,6 +112,7 @@
 <li><code>promises</code> LONGTEXT</li>
 <li><code>offers</code> LONGTEXT</li>
 <li><code>hypotheses_to_generate</code> INT</li>
+<li><code>audiences_to_generate</code> INT</li>
 <li><code>base_segmentation</code> LONGTEXT</li>
 <li><code>interests</code> LONGTEXT</li>
 <li><code>demographic_filters</code> LONGTEXT</li>

--- a/frontend/src/api/audience/useAudiencesByNiche.ts
+++ b/frontend/src/api/audience/useAudiencesByNiche.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface Audience {
+  id: number;
+  name: string;
+  description: string;
+  marketNicheId?: number;
+  hypothesisId?: string;
+}
+
+export function useAudiencesByNiche(nicheId?: string) {
+  return useQuery({
+    queryKey: ["niche-audiences", nicheId],
+    queryFn: async () => {
+      if (!nicheId) return [] as Audience[];
+      const { data } = await axios.get<Audience[]>(
+        `/api/niches/${nicheId}/audiences`
+      );
+      return data;
+    },
+    enabled: !!nicheId,
+  });
+}

--- a/frontend/src/api/niche/useCreateNiche.ts
+++ b/frontend/src/api/niche/useCreateNiche.ts
@@ -14,6 +14,7 @@ export interface CreateNiche {
   extraTips: string;
   chatDialogId?: number;
   hypothesesToGenerate?: number;
+  audiencesToGenerate?: number;
 }
 
 export function useCreateNiche() {

--- a/frontend/src/api/niche/useNiches.ts
+++ b/frontend/src/api/niche/useNiches.ts
@@ -13,6 +13,7 @@ export interface MarketNiche {
   demographicFilters: string;
   extraTips: string;
   hypothesesToGenerate?: number;
+  audiencesToGenerate?: number;
   chatDialogId?: number;
   createdAt?: string;
   updatedAt?: string;

--- a/frontend/src/pages/niche/EditNichePage.tsx
+++ b/frontend/src/pages/niche/EditNichePage.tsx
@@ -28,6 +28,7 @@ export default function EditNichePage() {
     extraTips: "",
     chatDialogId: undefined,
     hypothesesToGenerate: 0,
+    audiencesToGenerate: 0,
   });
 
   useEffect(() => {
@@ -79,6 +80,15 @@ export default function EditNichePage() {
         value={form.hypothesesToGenerate}
         onChange={(e) =>
           setForm({ ...form, hypothesesToGenerate: Number(e.target.value) })
+        }
+      />
+      <label className="form-label">Qtd. de públicos para gerar</label>
+      <input
+        type="number"
+        className="form-control mb-2"
+        value={form.audiencesToGenerate}
+        onChange={(e) =>
+          setForm({ ...form, audiencesToGenerate: Number(e.target.value) })
         }
       />
       <label className="form-label">Descrição</label>

--- a/frontend/src/pages/niche/NewNichePage.tsx
+++ b/frontend/src/pages/niche/NewNichePage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useForm } from "react-hook-form";
 import { useCreateNiche } from "../../api/niche/useCreateNiche";
 import { useChatDialogs } from "../../api/chatDialog/useChatDialogs";
 import PageTitle from "../../components/PageTitle";
@@ -6,6 +7,7 @@ import PageTitle from "../../components/PageTitle";
 export default function NewNichePage() {
   const create = useCreateNiche();
   const { data: chatDialogs } = useChatDialogs();
+  const { handleSubmit } = useForm();
   const [form, setForm] = useState({
     name: "",
     description: "",
@@ -18,6 +20,7 @@ export default function NewNichePage() {
     extraTips: "",
     chatDialogId: undefined as number | undefined,
     hypothesesToGenerate: 0,
+    audiencesToGenerate: 0,
   });
 
   const submit = () => {
@@ -88,6 +91,15 @@ export default function NewNichePage() {
           setForm({ ...form, hypothesesToGenerate: Number(e.target.value) })
         }
       />
+      <input
+        type="number"
+        className="form-control mb-2"
+        placeholder="Qtd. de públicos para gerar"
+        value={form.audiencesToGenerate}
+        onChange={(e) =>
+          setForm({ ...form, audiencesToGenerate: Number(e.target.value) })
+        }
+      />
       <textarea
         className="form-control mb-2"
         placeholder="Segmentação-base (Brasil)"
@@ -120,7 +132,12 @@ export default function NewNichePage() {
         onChange={(e) => setForm({ ...form, extraTips: e.target.value })}
         rows={3}
       />
-      <button className="btn btn-primary" onClick={submit}>
+      <button
+        className="btn btn-primary"
+        onClick={handleSubmit(() => submit(), (errors) => {
+          console.log("Validation errors", errors);
+        })}
+      >
         Salvar
       </button>
     </div>

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -2,6 +2,7 @@ import { Fragment } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
+import { useAudiencesByNiche } from "../../api/audience/useAudiencesByNiche";
 import PageTitle from "../../components/PageTitle";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 import { useChatDialog } from "../../api/chatDialog/useChatDialog";
@@ -11,6 +12,7 @@ export default function NicheDetailPage() {
   const { data, isLoading } = useNiche(Number(nicheId));
   const { data: chatDialog } = useChatDialog(data?.chatDialogId);
   const { data: hypotheses } = useHypothesesByNiche(nicheId, "ALL");
+  const { data: audiences } = useAudiencesByNiche(nicheId);
   useBreadcrumbs([
     { label: "Nichos", to: "/niches" },
     { label: data?.name || "..." },
@@ -47,12 +49,14 @@ export default function NicheDetailPage() {
         return bDate - aDate;
       })
     : [];
+  const audienceList = Array.isArray(audiences) ? audiences : [];
   const rows = [
     { label: "Descrição", value: data.description },
     { label: "Volume de demanda", value: data.demandVolume },
     { label: "Promessas", value: data.promises },
     { label: "Ofertas", value: data.offers },
     { label: "Hipóteses a gerar", value: data.hypothesesToGenerate },
+    { label: "Públicos a gerar", value: data.audiencesToGenerate },
     { label: "Segmentação base", value: data.baseSegmentation },
     { label: "Interesses", value: data.interests },
     { label: "Filtros demográficos", value: data.demographicFilters },
@@ -105,6 +109,24 @@ export default function NicheDetailPage() {
           </Fragment>
         ))}
       </dl>
+      <h4 className="mt-4">Públicos</h4>
+      {audienceList.length === 0 ? (
+        <p>Nenhum público ainda.</p>
+      ) : (
+        <div className="row row-cols-1 row-cols-md-2 g-4 mb-4">
+          {audienceList.map((a) => (
+            <div key={a.id} className="col">
+              <div className="card h-100 rounded-3">
+                <div className="card-body">
+                  <h5 className="card-title">{a.name}</h5>
+                  <p className="card-text">{a.description || "-"}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      <h4 className="mt-4">Hipóteses</h4>
       {list.length === 0 ? (
         <p>Nenhuma hipótese ainda.</p>
       ) : (

--- a/schema.sql
+++ b/schema.sql
@@ -101,6 +101,7 @@ CREATE TABLE market_niche (
     promises LONGTEXT,
     offers LONGTEXT,
     hypotheses_to_generate INT,
+    audiences_to_generate INT,
     base_segmentation LONGTEXT,
     interests LONGTEXT,
     demographic_filters LONGTEXT,


### PR DESCRIPTION
## Summary
- list niche audiences on detail page
- allow setting audiences to generate when creating or editing niches
- support audience lookup by niche in backend and schema

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to github)*
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ac3dcf4c83218782144487c6aaab