### PR TITLE
feat: show audience generation count on detail pages

### DIFF
--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from "react-router-dom";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useExperimentsByHypothesis } from "../../api/experiment/useExperimentsByHypothesis";
+import { useAudiencesByNiche } from "../../api/audience/useAudiencesByNiche";
 import PageTitle from "../../components/PageTitle";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 
@@ -14,6 +15,7 @@ export default function HypothesisDetailPage() {
     nicheId,
     hypothesisId,
   );
+  const { data: audiences } = useAudiencesByNiche(nicheId);
   useBreadcrumbs([
     { label: "Nichos", to: "/niches" },
     { label: niche?.name || "...", to: `/niches/${nicheId}` },
@@ -23,6 +25,7 @@ export default function HypothesisDetailPage() {
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;
   const list = Array.isArray(experiments) ? experiments : [];
+  const audienceList = Array.isArray(audiences) ? audiences : [];
   const rows = [
     { label: "Promessa", value: data.promise },
     { label: "Problema", value: data.problem },
@@ -89,6 +92,11 @@ export default function HypothesisDetailPage() {
           </button>
         </div>
       </div>
+
+      <p className="mb-4">
+        Públicos gerados: {audienceList.length}/
+        {niche?.audiencesToGenerate ?? 0}
+      </p>
 
       <div className="card mb-4">
         <div className="card-header">

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -109,7 +109,9 @@ export default function NicheDetailPage() {
           </Fragment>
         ))}
       </dl>
-      <h4 className="mt-4">Públicos</h4>
+      <h4 className="mt-4">
+        Públicos ({audienceList.length}/{data.audiencesToGenerate ?? 0})
+      </h4>
       {audienceList.length === 0 ? (
         <p>Nenhum público ainda.</p>
       ) : (


### PR DESCRIPTION
## Summary
- display current/target audience counts in niche details
- show same audience progress on hypothesis details

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1dc014eb483219d1e5125db65d867