### PR TITLE
feat: allow requesting niche audiences

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
@@ -73,6 +73,16 @@ public class MarketNicheService {
         return repository.save(niche);
     }
 
+    /**
+     * Requests generation of new audiences by setting the pending quantity.
+     */
+    @Transactional
+    public MarketNiche requestAudiences(Long id, int quantity) {
+        MarketNiche niche = repository.findById(id).orElseThrow();
+        niche.setAudiencesToGenerate(quantity);
+        return niche;
+    }
+
     public Iterable<MarketNiche> list() {
         return repository.findAll();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/web/MarketNicheController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/web/MarketNicheController.java
@@ -38,6 +38,11 @@ public class MarketNicheController {
         return mapper.toDto(service.update(id, request));
     }
 
+    @PatchMapping("/{id}/audiences-to-generate")
+    public MarketNicheDto requestAudiences(@PathVariable Long id, @RequestParam("quantity") int quantity) {
+        return mapper.toDto(service.requestAudiences(id, quantity));
+    }
+
     @GetMapping
     public List<MarketNicheDto> list() {
         return StreamSupport.stream(service.list().spliterator(), false)

--- a/backend/ads-service/src/test/java/com/marketinghub/niche/web/MarketNicheControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/niche/web/MarketNicheControllerTest.java
@@ -1,0 +1,44 @@
+package com.marketinghub.niche.web;
+
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.FixtureUtils;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = AdsServiceApplication.class)
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
+})
+class MarketNicheControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    FixtureUtils fixtures;
+    @Autowired
+    MarketNicheRepository repository;
+
+    @Test
+    void requestAudiencesEndpointUpdatesQuantity() throws Exception {
+        var niche = fixtures.createAndSaveNiche();
+        mockMvc.perform(
+                        patch("/api/niches/" + niche.getId() + "/audiences-to-generate")
+                                .param("quantity", "3"))
+                .andExpect(status().isOk());
+        var updated = repository.findById(niche.getId()).orElseThrow();
+        assertThat(updated.getAudiencesToGenerate()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
## Summary
- add service method to request new niche audiences
- expose PATCH `/api/niches/{id}/audiences-to-generate`
- cover audience request with integration test

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f0dc5c1883218676bf3ab2459969