### PR TITLE
feat: indicate audiences update

### DIFF
--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
@@ -11,7 +11,7 @@ import { useRequestAudiences } from "../../api/niche/useRequestAudiences";
 
 export default function NicheDetailPage() {
   const { nicheId } = useParams();
-  const { data, isLoading } = useNiche(Number(nicheId));
+  const { data, isLoading, isFetching } = useNiche(Number(nicheId));
   const { data: chatDialog } = useChatDialog(data?.chatDialogId);
   const { data: hypotheses } = useHypothesesByNiche(nicheId, "ALL");
   const { data: audiences } = useAudiencesByNiche(nicheId);
@@ -19,6 +19,12 @@ export default function NicheDetailPage() {
   const { register, handleSubmit, reset } = useForm<{ quantity: number }>({
     defaultValues: { quantity: 1 },
   });
+  const [isUpdating, setIsUpdating] = useState(false);
+  useEffect(() => {
+    if (isUpdating && !isFetching) {
+      setIsUpdating(false);
+    }
+  }, [isUpdating, isFetching]);
   useBreadcrumbs([
     { label: "Nichos", to: "/niches" },
     { label: data?.name || "..." },
@@ -135,6 +141,7 @@ export default function NicheDetailPage() {
                 await requestAudiences.mutateAsync(quantity);
                 alert("Solicitação enviada!");
                 reset();
+                setIsUpdating(true);
               } catch {
                 alert("Erro ao solicitar públicos");
               }
@@ -148,7 +155,9 @@ export default function NicheDetailPage() {
           Gerar Públicos
         </button>
         <span className="ms-2">
-          Solicitados: {data.audiencesToGenerate ?? 0}
+          {isUpdating
+            ? "Atualizando..."
+            : `Solicitados: ${data.audiencesToGenerate ?? 0}`}
         </span>
       </div>
       {audienceList.length === 0 ? (


### PR DESCRIPTION
## Summary
- show updating text while niche audience request refreshes

## Testing
- `npm run build`
- `CI=1 npm test` *(fails: Unable to find element "Ver detalhes")*

------
https://chatgpt.com/codex/tasks/task_e_68c228d7000483218f69b4bec9068ea4