### PR TITLE
docs: add success product service documentation

### DIFF
--- a/ai-worker/AGENTS.md
+++ b/ai-worker/AGENTS.md
@@ -8,6 +8,7 @@
 ## Serviços existentes
 - **Nicho** (`niche`): gera hipóteses para nichos com `hypothesesToGenerate > 0` usando o ChatGPT. Implementado por `NicheHypothesisService` e agendado por `NicheHypothesisScheduler`.
 - **Criativos** (`creative`): gera criativos para experimentos com `creativesToGenerate > 0` usando o ChatGPT. Implementado por `ExperimentCreativeService` e agendado por `ExperimentCreativeScheduler`.
+- **Produto de Sucesso** (`successproduct`): gera nicho e hipótese a partir de produtos com `novo=false` usando o ChatGPT. Implementado por `SuccessProductNicheHypothesisService` e agendado por `SuccessProductNicheHypothesisScheduler`.
 
 ## Orientação para novos serviços
 - Siga o mesmo padrão do serviço de **nicho**:

--- a/docs/ai-worker/class-diagram.md
+++ b/docs/ai-worker/class-diagram.md
@@ -14,6 +14,15 @@ classDiagram
     WorkerSuccessProductRepository --> SuccessProductAnalyzer
     SuccessProductScheduler --> SuccessProductAnalyzer
 
+    class SuccessProductNicheHypothesisService
+    class SuccessProductNicheHypothesisScheduler
+    class SPChatGptClient {
+        +extract(SuccessProduct) NicheHypothesis
+    }
+    SuccessProductNicheHypothesisService --> SPChatGptClient
+    WorkerSuccessProductRepository --> SuccessProductNicheHypothesisService
+    SuccessProductNicheHypothesisScheduler --> SuccessProductNicheHypothesisService
+
     class NicheHypothesisService
     class NicheHypothesisScheduler
     class ExperimentCreativeService

--- a/docs/ai-worker/produto-sucesso-nicho-hypotese-service.md
+++ b/docs/ai-worker/produto-sucesso-nicho-hypotese-service.md
@@ -1,0 +1,58 @@
+# AI Worker - Serviço PRODUTO DE SUCESSO para NICHO e HIPOTESE
+
+Este documento descreve o serviço do AI Worker que gera **NICHO** e **HIPOTESE** a partir de registros de **PRODUTO DE SUCESSO** usando o ChatGPT.
+
+## Visão Geral
+
+O serviço realiza as seguintes etapas:
+1. Busca produtos de sucesso com `novo=false` e descrição preenchida.
+2. Consulta o ChatGPT para extrair dados de nicho e hipótese.
+3. Cria os registros de `MarketNiche` e `Hypothesis` correspondentes.
+
+## Diagrama de fluxo
+
+```mermaid
+flowchart LR
+    SuccessProduct -->|descrição| AIWorker
+    AIWorker -->|prompts| ChatGPT
+    ChatGPT -->|nicho e hipótese| AIWorker
+    AIWorker -->|cria| MarketNiche
+    AIWorker -->|cria| Hypothesis
+```
+
+## Execução do Serviço
+
+### Pré-requisitos
+- Java 21
+- Maven configurado com as variáveis `GITHUB_ACTOR` e `GITHUB_TOKEN` para acessar os artefatos do GitHub Packages
+- MySQL em execução conforme `application.properties`
+- Variável de ambiente `OPENAI_API_KEY` (e opcionalmente `GOOGLE_API_KEY` e `GOOGLE_SEARCH_ID` para permitir buscas externas)
+
+### Passos para executar
+
+1. Instale as dependências e compile o projeto:
+
+   ```bash
+   cd ai-worker
+   mvn -s settings.xml package
+   ```
+
+2. (Opcional) Execute os testes:
+
+   ```bash
+   mvn -s settings.xml test
+   ```
+
+3. Execute o worker:
+
+   ```bash
+   mvn spring-boot:run
+   ```
+
+   Para executar sem chamadas externas ao ChatGPT, utilize o perfil `dummy`:
+
+   ```bash
+   mvn spring-boot:run -Dspring.profiles.active=dummy
+   ```
+
+O worker agenda a tarefa `SuccessProductNicheHypothesisScheduler` a cada cinco minutos (`0 */5 * * * *`) para processar os produtos de sucesso e gerar os nichos e hipóteses. Os logs do processo são exibidos no console.


### PR DESCRIPTION
## Summary
- document SuccessProductNicheHypothesisService in ai-worker agent contract
- describe Success Product service and scheduler in docs
- update AI Worker class diagram for success product niche & hypothesis flow

## Testing
- `mvn -s settings.xml test` *(fails: Could not transfer artifact spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d96a30a8832181bf0b5e4089ec9a