### PR TITLE
feat: allow requesting niche hypothesis for success products

### DIFF
--- a/ai-worker/AGENTS.md
+++ b/ai-worker/AGENTS.md
@@ -8,7 +8,7 @@
 ## Serviços existentes
 - **Nicho** (`niche`): gera hipóteses para nichos com `hypothesesToGenerate > 0` usando o ChatGPT. Implementado por `NicheHypothesisService` e agendado por `NicheHypothesisScheduler`.
 - **Criativos** (`creative`): gera criativos para experimentos com `creativesToGenerate > 0` usando o ChatGPT. Implementado por `ExperimentCreativeService` e agendado por `ExperimentCreativeScheduler`.
-- **Produto de Sucesso** (`successproduct`): gera nicho e hipótese a partir de produtos com `novo=false` usando o ChatGPT. Implementado por `SuccessProductNicheHypothesisService` e agendado por `SuccessProductNicheHypothesisScheduler`.
+- **Produto de Sucesso** (`successproduct`): gera nicho e hipótese a partir de produtos com `generate_niche_hypothesis=true` usando o ChatGPT. Implementado por `SuccessProductNicheHypothesisService` e agendado por `SuccessProductNicheHypothesisScheduler`.
 
 ## Orientação para novos serviços
 - Siga o mesmo padrão do serviço de **nicho**:

--- a/ai-worker/src/main/java/com/marketinghub/worker/WorkerSuccessProductRepository.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/WorkerSuccessProductRepository.java
@@ -25,4 +25,9 @@ public interface WorkerSuccessProductRepository extends SuccessProductRepository
      * Retrieves products already processed (novo = false).
      */
     List<SuccessProduct> findByNovoFalse();
+
+    /**
+     * Retrieves products flagged for niche/hypothesis generation.
+     */
+    List<SuccessProduct> findByGenerateNicheHypothesisTrue();
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/successproduct/SuccessProductNicheHypothesisService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/successproduct/SuccessProductNicheHypothesisService.java
@@ -41,12 +41,12 @@ public class SuccessProductNicheHypothesisService {
     }
 
     /**
-     * Process all success products marked as not new and create corresponding
+     * Process all success products flagged for generation and create corresponding
      * niche and hypothesis entries.
      */
     @Transactional
     public void generate() {
-        List<SuccessProduct> products = productRepository.findByNovoFalse();
+        List<SuccessProduct> products = productRepository.findByGenerateNicheHypothesisTrue();
         log.info("Processing {} success products for niche/hypothesis generation", products.size());
         for (SuccessProduct product : products) {
             if (product.getDescription() == null || product.getDescription().isBlank()) {
@@ -73,6 +73,10 @@ public class SuccessProductNicheHypothesisService {
             hypReq.setPromise(data.promise());
             hypReq.setUniqueMechanism(data.uniqueMechanism());
             hypothesisService.create(hypReq);
+
+            log.info("Resetting generateNicheHypothesis for product {}", product.getId());
+            product.setGenerateNicheHypothesis(false);
+            productRepository.save(product);
         }
     }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/successproduct/SuccessProductNicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/successproduct/SuccessProductNicheHypothesisServiceTest.java
@@ -32,7 +32,7 @@ class SuccessProductNicheHypothesisServiceTest {
         SuccessProduct product = SuccessProduct.builder()
                 .description("Produto de sucesso")
                 .name("Produto Original")
-                .novo(false)
+                .generateNicheHypothesis(true)
                 .build();
         productRepository.save(product);
 
@@ -40,6 +40,9 @@ class SuccessProductNicheHypothesisServiceTest {
 
         assertThat(marketNicheRepository.count()).isEqualTo(1);
         assertThat(hypothesisRepository.count()).isEqualTo(1);
+
+        assertThat(productRepository.findById(product.getId()).orElseThrow().isGenerateNicheHypothesis())
+                .isFalse();
 
         var niche = marketNicheRepository.findAll().get(0);
         var hypothesis = hypothesisRepository.findAll().get(0);

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/SuccessProduct.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/SuccessProduct.java
@@ -38,6 +38,10 @@ public class SuccessProduct {
     @Builder.Default
     private SuccessProductPlatform platform = SuccessProductPlatform.COFRE;
 
+    /** Indicates if the AI worker should generate niche and hypothesis. */
+    @Builder.Default
+    private boolean generateNicheHypothesis = false;
+
     private String niche;
     private String avatar;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/CreateSuccessProductRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/CreateSuccessProductRequest.java
@@ -10,4 +10,5 @@ import lombok.Data;
 public class CreateSuccessProductRequest {
     private String description;
     private SuccessProductPlatform platform;
+    private Boolean generateNicheHypothesis;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/SuccessProductDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/SuccessProductDto.java
@@ -14,6 +14,7 @@ public class SuccessProductDto {
     private String name;
     private boolean novo;
     private SuccessProductPlatform platform;
+    private boolean generateNicheHypothesis;
     private String niche;
     private String avatar;
     private String audienceType;

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/UpdateSuccessProductRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/dto/UpdateSuccessProductRequest.java
@@ -11,6 +11,7 @@ public class UpdateSuccessProductRequest {
     private String description;
     private String name;
     private Boolean novo;
+    private Boolean generateNicheHypothesis;
     private String niche;
     private String avatar;
     private SuccessProductPlatform platform;

--- a/backend/ads-service/src/main/java/com/marketinghub/successproduct/service/SuccessProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/successproduct/service/SuccessProductService.java
@@ -33,6 +33,7 @@ public class SuccessProductService {
                 .description(request.getDescription())
                 .novo(true)
                 .platform(request.getPlatform() != null ? request.getPlatform() : SuccessProductPlatform.COFRE)
+                .generateNicheHypothesis(Boolean.TRUE.equals(request.getGenerateNicheHypothesis()))
                 .build();
         return repository.save(product);
     }
@@ -53,6 +54,9 @@ public class SuccessProductService {
         product.setName(request.getName());
         if (request.getNovo() != null) {
             product.setNovo(request.getNovo());
+        }
+        if (request.getGenerateNicheHypothesis() != null) {
+            product.setGenerateNicheHypothesis(request.getGenerateNicheHypothesis());
         }
         product.setNiche(request.getNiche());
         product.setAvatar(request.getAvatar());

--- a/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/successproduct/SuccessProductRepositoryTest.java
@@ -28,6 +28,7 @@ class SuccessProductRepositoryTest {
         repository.save(product);
         SuccessProduct saved = repository.findById(product.getId()).orElseThrow();
         assertThat(saved.isNovo()).isTrue();
+        assertThat(saved.isGenerateNicheHypothesis()).isFalse();
         assertThat(saved.getPlatform()).isEqualTo(SuccessProductPlatform.COFRE);
         assertThat(saved.getName()).isNull();
         assertThat(saved.getSalesPageUrl()).contains("example.com");

--- a/docs/ai-worker/produto-sucesso-nicho-hypotese-service.md
+++ b/docs/ai-worker/produto-sucesso-nicho-hypotese-service.md
@@ -5,7 +5,7 @@ Este documento descreve o serviço do AI Worker que gera **NICHO** e **HIPOTESE*
 ## Visão Geral
 
 O serviço realiza as seguintes etapas:
-1. Busca produtos de sucesso com `novo=false` e descrição preenchida.
+1. Busca produtos de sucesso com `generate_niche_hypothesis=true` e descrição preenchida.
 2. Consulta o ChatGPT para extrair dados de nicho e hipótese.
 3. Cria os registros de `MarketNiche` e `Hypothesis` correspondentes.
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -71,6 +71,7 @@ for managing campaigns and tracking their performance.
 - `name` VARCHAR(255)
 - `novo` BOOLEAN DEFAULT TRUE
 - `platform` VARCHAR(20) NOT NULL DEFAULT 'COFRE'
+- `generate_niche_hypothesis` BOOLEAN DEFAULT FALSE
 - `niche` VARCHAR(255)
 - `avatar` VARCHAR(255)
 - `audience_type` VARCHAR(255)

--- a/frontend/src/api/successProduct/useCreateSuccessProduct.ts
+++ b/frontend/src/api/successProduct/useCreateSuccessProduct.ts
@@ -5,6 +5,7 @@ import { SuccessProduct, SuccessProductPlatform } from "./useSuccessProducts";
 export interface CreateSuccessProduct {
   description: string;
   platform: SuccessProductPlatform;
+  generateNicheHypothesis?: boolean;
 }
 
 export function useCreateSuccessProduct() {

--- a/frontend/src/api/successProduct/useSuccessProducts.ts
+++ b/frontend/src/api/successProduct/useSuccessProducts.ts
@@ -9,6 +9,7 @@ export interface SuccessProduct {
   name?: string;
   novo: boolean;
   platform: SuccessProductPlatform;
+  generateNicheHypothesis: boolean;
   niche: string;
   avatar: string;
   audienceType: string;

--- a/frontend/src/pages/successProduct/EditSuccessProductPage.tsx
+++ b/frontend/src/pages/successProduct/EditSuccessProductPage.tsx
@@ -47,6 +47,17 @@ export default function EditSuccessProductPage() {
             Novo
           </label>
         </div>
+        <div className="form-check form-switch mb-2">
+          <input
+            className="form-check-input"
+            type="checkbox"
+            id="generateNicheHypothesis"
+            {...register("generateNicheHypothesis")}
+          />
+          <label className="form-check-label" htmlFor="generateNicheHypothesis">
+            Gerar Nicho e Hipótese
+          </label>
+        </div>
         <input
           className="form-control mb-2"
           placeholder="Nome"

--- a/frontend/src/pages/successProduct/NewSuccessProductPage.tsx
+++ b/frontend/src/pages/successProduct/NewSuccessProductPage.tsx
@@ -1,18 +1,34 @@
-import { useState } from "react";
-import { useCreateSuccessProduct } from "../../api/successProduct/useCreateSuccessProduct";
+import { useForm } from "react-hook-form";
+import {
+  useCreateSuccessProduct,
+  CreateSuccessProduct,
+} from "../../api/successProduct/useCreateSuccessProduct";
 import PageTitle from "../../components/PageTitle";
 import { SuccessProductPlatform } from "../../api/successProduct/useSuccessProducts";
 
 export default function NewSuccessProductPage() {
   const create = useCreateSuccessProduct();
-  const [description, setDescription] = useState("");
-  const [platform, setPlatform] = useState<SuccessProductPlatform>("COFRE");
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<CreateSuccessProduct>({
+    defaultValues: {
+      description: "",
+      platform: "COFRE" as SuccessProductPlatform,
+      generateNicheHypothesis: false,
+    },
+  });
 
-  const submit = async () => {
+  const onSubmit = async (values: CreateSuccessProduct) => {
     try {
-      await create.mutateAsync({ description, platform });
-      setDescription("");
-      setPlatform("COFRE");
+      await create.mutateAsync(values);
+      reset({
+        description: "",
+        platform: "COFRE",
+        generateNicheHypothesis: false,
+      });
       alert("Produto de Sucesso salvo!");
     } catch (err) {
       alert("Erro ao salvar Produto de Sucesso");
@@ -22,25 +38,40 @@ export default function NewSuccessProductPage() {
   return (
     <div>
       <PageTitle>Novo Produto de Sucesso</PageTitle>
-      <textarea
-        className="form-control mb-2"
-        placeholder="Descrição"
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        rows={5}
-      />
-      <select
-        className="form-select mb-2"
-        value={platform}
-        onChange={(e) => setPlatform(e.target.value as SuccessProductPlatform)}
-      >
-        <option value="COFRE">Cofre</option>
-        <option value="HOTMART">Hotmart</option>
-        <option value="CLICKBANK">Clickbank</option>
-      </select>
-      <button className="btn btn-primary" onClick={submit}>
-        Salvar
-      </button>
+      <form noValidate>
+        <textarea
+          className="form-control mb-2"
+          placeholder="Descrição"
+          rows={5}
+          {...register("description")}
+        />
+        <select className="form-select mb-2" {...register("platform")}>
+          <option value="COFRE">Cofre</option>
+          <option value="HOTMART">Hotmart</option>
+          <option value="CLICKBANK">Clickbank</option>
+        </select>
+        <div className="form-check form-switch mb-3">
+          <input
+            className="form-check-input"
+            type="checkbox"
+            id="generateNicheHypothesis"
+            {...register("generateNicheHypothesis")}
+          />
+          <label className="form-check-label" htmlFor="generateNicheHypothesis">
+            Gerar Nicho e Hipótese
+          </label>
+        </div>
+        <button
+          type="button"
+          className="btn btn-primary"
+          disabled={isSubmitting}
+          onClick={handleSubmit(onSubmit, (errors) => {
+            console.log("Validation errors", errors);
+          })}
+        >
+          Salvar
+        </button>
+      </form>
     </div>
   );
 }

--- a/schema.sql
+++ b/schema.sql
@@ -62,6 +62,7 @@ CREATE TABLE success_product (
     name VARCHAR(255),
     novo BOOLEAN DEFAULT TRUE,
     platform VARCHAR(20) NOT NULL DEFAULT 'COFRE',
+    generate_niche_hypothesis BOOLEAN DEFAULT FALSE,
     niche VARCHAR(255),
     avatar VARCHAR(255),
     audience_type VARCHAR(255),


### PR DESCRIPTION
## Summary
- add `generateNicheHypothesis` flag to SuccessProduct
- expose niche/hypothesis generation option in Success Product forms
- process only flagged success products in AI worker

## Testing
- `npm run build`
- `npm test`
- `mvn -s ../settings.xml test` *(failed: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to github)*
- `mvn -s settings.xml test` *(failed: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to github)*


------
https://chatgpt.com/codex/tasks/task_e_68c2dd89f01083219703262894e13407