### PR TITLE
feat: add tooltips for worker ia triggers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md — Contract for Codex agent
 
 ## Build & Test
+
 - **Backend**
   - Build & publish: `cd backend/ads-service && mvn -s ../settings.xml deploy`
   - Publicar o pacote para ser usado pelo **AI Worker** no GitHub Packages repository.
@@ -14,12 +15,13 @@
   - Tests: `npm run test`
 
 ## Conventions
+
 - DataBase: MySql 5
 - Modelo de Dados atualizado: docs/data-model.md
   - Todo o modelo de dados deve permanecer no projeto **backend**. O projeto
     **ai-worker** deve reutilizar esse modelo e não manter uma cópia
     própria.
-  - Todos os métodos de consulta e manipulação de banco de dados deve ser códificado 
+  - Todos os métodos de consulta e manipulação de banco de dados deve ser códificado
     no projeto **backend** e pode ser utilizado no projeto **ai-worker**
   - Sempre prefira fazer filtros na consulta ao banco de dados, evite buscar muitos registros
     para tratamento em memória.
@@ -27,6 +29,8 @@
 - React 18 + Vite + TypeScript
 - Zustand for state, TanStack Query for data fetching
 - Prettier (frontend) and Spotless (backend) for formatting
+- Campos de formulário que acionam serviços do Worker IA devem incluir um tooltip explicativo
 
 ## Secrets
+
 - Do **NOT** commit `.env`. Use GitHub Actions secrets for tokens.

--- a/frontend/agents.md
+++ b/frontend/agents.md
@@ -1,4 +1,6 @@
 toda tela de edição/inserção de dados por formulário deve ter esse tipo de log:
-            onClick={handleSubmit(onSubmit, (errors) => {
-              console.log('Validation errors', errors);
-            })}
+onClick={handleSubmit(onSubmit, (errors) => {
+console.log('Validation errors', errors);
+})}
+
+além disso, todo campo que aciona serviços do Worker IA deve possuir um tooltip explicando seu funcionamento.

--- a/frontend/src/pages/niche/EditNichePage.tsx
+++ b/frontend/src/pages/niche/EditNichePage.tsx
@@ -78,6 +78,7 @@ export default function EditNichePage() {
         type="number"
         className="form-control mb-2"
         value={form.hypothesesToGenerate}
+        title="Quantidade de hipóteses que o Worker IA irá gerar"
         onChange={(e) =>
           setForm({ ...form, hypothesesToGenerate: Number(e.target.value) })
         }
@@ -87,6 +88,7 @@ export default function EditNichePage() {
         type="number"
         className="form-control mb-2"
         value={form.audiencesToGenerate}
+        title="Quantidade de públicos que o Worker IA irá gerar"
         onChange={(e) =>
           setForm({ ...form, audiencesToGenerate: Number(e.target.value) })
         }

--- a/frontend/src/pages/niche/NewNichePage.tsx
+++ b/frontend/src/pages/niche/NewNichePage.tsx
@@ -87,6 +87,7 @@ export default function NewNichePage() {
         className="form-control mb-2"
         placeholder="Qtd. de hipóteses para gerar"
         value={form.hypothesesToGenerate}
+        title="Quantidade de hipóteses que o Worker IA irá gerar"
         onChange={(e) =>
           setForm({ ...form, hypothesesToGenerate: Number(e.target.value) })
         }
@@ -96,6 +97,7 @@ export default function NewNichePage() {
         className="form-control mb-2"
         placeholder="Qtd. de públicos para gerar"
         value={form.audiencesToGenerate}
+        title="Quantidade de públicos que o Worker IA irá gerar"
         onChange={(e) =>
           setForm({ ...form, audiencesToGenerate: Number(e.target.value) })
         }
@@ -104,9 +106,7 @@ export default function NewNichePage() {
         className="form-control mb-2"
         placeholder="Segmentação-base (Brasil)"
         value={form.baseSegmentation}
-        onChange={(e) =>
-          setForm({ ...form, baseSegmentation: e.target.value })
-        }
+        onChange={(e) => setForm({ ...form, baseSegmentation: e.target.value })}
         rows={3}
       />
       <textarea
@@ -134,9 +134,12 @@ export default function NewNichePage() {
       />
       <button
         className="btn btn-primary"
-        onClick={handleSubmit(() => submit(), (errors) => {
-          console.log("Validation errors", errors);
-        })}
+        onClick={handleSubmit(
+          () => submit(),
+          (errors) => {
+            console.log("Validation errors", errors);
+          },
+        )}
       >
         Salvar
       </button>

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -123,6 +123,7 @@ export default function NicheDetailPage() {
           type="number"
           min={1}
           className="form-control w-auto me-2"
+          title="Quantidade de públicos que o Worker IA irá gerar"
           {...register("quantity", { valueAsNumber: true })}
         />
         <button

--- a/frontend/src/pages/successProduct/EditSuccessProductPage.tsx
+++ b/frontend/src/pages/successProduct/EditSuccessProductPage.tsx
@@ -41,6 +41,7 @@ export default function EditSuccessProductPage() {
             className="form-check-input"
             type="checkbox"
             id="novo"
+            title="Quando marcado, o Worker IA analisará este produto."
             {...register("novo")}
           />
           <label className="form-check-label" htmlFor="novo">
@@ -52,6 +53,7 @@ export default function EditSuccessProductPage() {
             className="form-check-input"
             type="checkbox"
             id="generateNicheHypothesis"
+            title="Gera nicho e hipótese automaticamente usando o Worker IA."
             {...register("generateNicheHypothesis")}
           />
           <label className="form-check-label" htmlFor="generateNicheHypothesis">


### PR DESCRIPTION
## Summary
- add explanatory tooltips to Worker IA-related inputs
- document tooltip requirement in AGENTS files

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c33b5f5dbc8321b7d448ed19aa33b5