### PR TITLE
docs: orientar registro de saida do worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
 - Zustand for state, TanStack Query for data fetching
 - Prettier (frontend) and Spotless (backend) for formatting
 - Campos de formulário que acionam serviços do Worker IA devem incluir um tooltip explicativo
+- Todo registro de entidade produzido por um processo do **Worker IA** deve possuir os atributos `modelo` e `prompt`, que devem ser preenchidos no momento da criação do registro.
 
 ## Secrets
 


### PR DESCRIPTION
## Summary
- orientar que registros gerados pelo Worker IA salvem `modelo` e `prompt`

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*
- `cd ai-worker && mvn -s settings.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*
- `cd frontend && npm run test` *(fails: test run cancelled; watching for file changes)*

------
https://chatgpt.com/codex/tasks/task_e_68c41fb682e08321947e31f2f0533acb