### PR TITLE
fix: refresh niche audience request

### DIFF
--- a/frontend/src/api/niche/useRequestAudiences.ts
+++ b/frontend/src/api/niche/useRequestAudiences.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { MarketNiche } from "./useNiches";
 
-export function useRequestAudiences(id: string) {
+export function useRequestAudiences(id: number) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (quantity: number) => {
@@ -13,11 +13,13 @@ export function useRequestAudiences(id: string) {
       );
       return data;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["niche", id] });
+    onSuccess: (data) => {
+      // Update niche detail immediately and refetch related queries
+      queryClient.setQueryData(["niche", id], data);
       queryClient.invalidateQueries({ queryKey: ["niches"] });
-      queryClient.invalidateQueries({ queryKey: ["niche-audiences", id] });
+      queryClient.invalidateQueries({
+        queryKey: ["niche-audiences", String(id)],
+      });
     },
   });
 }
-

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -11,11 +11,12 @@ import { useRequestAudiences } from "../../api/niche/useRequestAudiences";
 
 export default function NicheDetailPage() {
   const { nicheId } = useParams();
-  const { data, isLoading, isFetching } = useNiche(Number(nicheId));
+  const id = Number(nicheId);
+  const { data, isLoading, isFetching } = useNiche(id);
   const { data: chatDialog } = useChatDialog(data?.chatDialogId);
   const { data: hypotheses } = useHypothesesByNiche(nicheId, "ALL");
   const { data: audiences } = useAudiencesByNiche(nicheId);
-  const requestAudiences = useRequestAudiences(nicheId ?? "");
+  const requestAudiences = useRequestAudiences(id);
   const { register, handleSubmit, reset } = useForm<{ quantity: number }>({
     defaultValues: { quantity: 1 },
   });


### PR DESCRIPTION
## Summary
- refresh niche details after requesting audiences
- use numeric niche id for audience requests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c41f13681c8321a09f1c7b0125207a