### PR TITLE
docs: simplify facebook ads worker class diagram

### DIFF
--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -1,17 +1,13 @@
 # Facebook Ads Worker Class Diagram
 
+Only the classes that contain campaign data sent to the Facebook API are represented.
+
 ```mermaid
 classDiagram
-    class FacebookAdsWorkerApplication
     class FacebookAdsService
     class InstagramCampaignService
-    class InstagramCampaignScheduler
     class FacebookCampaignService
-    class FacebookCampaignScheduler
 
-    FacebookAdsWorkerApplication --> FacebookAdsService
     InstagramCampaignService --> FacebookAdsService
-    InstagramCampaignScheduler --> InstagramCampaignService
     FacebookCampaignService --> FacebookAdsService
-    FacebookCampaignScheduler --> FacebookCampaignService
 ```


### PR DESCRIPTION
## Summary
- simplify Facebook Ads Worker class diagram to show only campaign data classes

## Testing
- `cd facebook-ads-worker && mvn -s settings.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c48c7dae7483219d4f0fdda89c4c83