### PR TITLE
docs: reforçar atualização de docs do facebook-ads-worker

### DIFF
--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -1,5 +1,6 @@
 # AGENTS.md — Facebook Ads Worker
 
+- 🚨 **Muito importante:** qualquer alteração neste módulo deve ser refletida em todos os arquivos `.md` deste diretório. Mantenha a documentação atualizada.
 - Este projeto utiliza o modelo de dados definido no **backend**.
 - Não duplique ou mantenha modelo de dados aqui; importe-o do backend.
 - Em produção utilizamos **MySql 5**.


### PR DESCRIPTION
## Summary
- enfatiza que alterações no facebook-ads-worker devem atualizar os arquivos .md do módulo

## Testing
- `cd facebook-ads-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4905e04e88321a2eec2c8d1b5e4dd