### PR TITLE
feat: add facebook campaign experiment view

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -132,6 +132,11 @@ public class ExperimentService {
         return repository.findByNicheId(nicheId);
     }
 
+    public java.util.List<Experiment> listByStatusAndPlatform(
+            ExperimentStatus status, ExperimentPlatform platform) {
+        return repository.findByStatusAndPlatform(status, platform);
+    }
+
     public java.util.List<Experiment> listReadyForCampaign() {
         return repository.findByStatusAndPlatformAndAudienceApprovedTrueAndCreativeApprovedTrue(
                 ExperimentStatus.PLANNED, ExperimentPlatform.FACEBOOK);

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
@@ -27,6 +27,16 @@ public class FacebookAdsCampaignController {
                 .toList();
     }
 
+    @GetMapping("/experiments")
+    public List<ExperimentSummary> experiments(@RequestParam("status")
+            com.marketinghub.experiment.ExperimentStatus status) {
+        return experimentService
+                .listByStatusAndPlatform(status, com.marketinghub.experiment.ExperimentPlatform.FACEBOOK)
+                .stream()
+                .map(e -> new ExperimentSummary(e.getId(), e.getName()))
+                .toList();
+    }
+
     @PostMapping
     public FacebookAdsCampaign create(@RequestBody CreateCampaignRequest req) {
         FacebookAdsCampaign campaign = new FacebookAdsCampaign();

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -196,4 +196,30 @@ class ExperimentServiceTest {
         var result = service.listReadyForCampaign();
         assertThat(result).extracting(Experiment::getId).containsExactly(expApproved.getId());
     }
+
+    @Test
+    void listByStatusAndPlatform() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche2").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A2").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("T2")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("ExpRun");
+        var exp = service.create(req);
+        exp.setStatus(ExperimentStatus.RUNNING);
+        experimentRepository.save(exp);
+
+        var result = service.listByStatusAndPlatform(ExperimentStatus.RUNNING, ExperimentPlatform.FACEBOOK);
+        assertThat(result).extracting(Experiment::getId).containsExactly(exp.getId());
+    }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -1,0 +1,38 @@
+package com.marketinghub.facebookads.web;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.service.ExperimentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(FacebookAdsCampaignController.class)
+class FacebookAdsCampaignControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+    @MockBean
+    ExperimentService experimentService;
+    @MockBean
+    com.marketinghub.facebookads.FacebookAdsCampaignRepository campaignRepository;
+
+    @Test
+    void listExperimentsByStatus() throws Exception {
+        var exp = Experiment.builder().id(1L).name("Exp").build();
+        when(experimentService.listByStatusAndPlatform(
+                com.marketinghub.experiment.ExperimentStatus.PLANNED,
+                com.marketinghub.experiment.ExperimentPlatform.FACEBOOK))
+                .thenReturn(List.of(exp));
+        mockMvc.perform(get("/facebook-campaigns/experiments").param("status", "PLANNED"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("Exp"));
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ import NewPromptEntityPage from "./pages/prompt/NewPromptEntityPage";
 import PromptEntityDescriptionPage from "./pages/prompt/PromptEntityDescriptionPage";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import FacebookCampaignExperimentsPage from "./pages/facebook/FacebookCampaignExperimentsPage";
 
 export default function App() {
   return (
@@ -102,6 +103,9 @@ export default function App() {
             </Link>
             <Link className="nav-link" to="/funnels">
               Funil de Vendas
+            </Link>
+            <Link className="nav-link" to="/facebook-campaigns">
+              Campanhas Facebook
             </Link>
             <Link className="nav-link" to="/prompt-entities">
               Objetos de Prompt
@@ -227,6 +231,7 @@ export default function App() {
           path="/prompt-entities/:entityId/attributes"
           element={<PromptAttributesPage />}
         />
+        <Route path="/facebook-campaigns" element={<FacebookCampaignExperimentsPage />} />
         <Route path="*" element={<div>Início</div>} />
       </Routes>
       <ToastContainer position="top-right" />

--- a/frontend/src/__tests__/FacebookCampaignNavigation.test.tsx
+++ b/frontend/src/__tests__/FacebookCampaignNavigation.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, afterEach } from "vitest";
+import React from "react";
+import App from "../App";
+
+function setup(ui: React.ReactNode, initialEntries: string[]) {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("facebook campaigns navigation", () => {
+  it("has menu link to /facebook-campaigns", () => {
+    setup(<App />, ["/"]); 
+    const link = screen.getByRole("link", { name: /campanhas facebook/i });
+    expect(link).toBeTruthy();
+    expect(link.getAttribute("href")).toBe("/facebook-campaigns");
+  });
+});

--- a/frontend/src/api/useFacebookCampaignExperiments.ts
+++ b/frontend/src/api/useFacebookCampaignExperiments.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface ExperimentSummary {
+  id: number;
+  name: string;
+}
+
+export function useFacebookCampaignExperiments(status: string) {
+  return useQuery({
+    queryKey: ["facebook-campaign-experiments", status],
+    queryFn: async () => {
+      const { data } = await axios.get<ExperimentSummary[]>(
+        "/api/facebook-campaigns/experiments",
+        { params: { status } },
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
+++ b/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { useFacebookCampaignExperiments } from "../../api/useFacebookCampaignExperiments";
+import PageTitle from "../../components/PageTitle";
+
+export default function FacebookCampaignExperimentsPage() {
+  const [status, setStatus] = useState("PLANNED");
+  const { data, isLoading } = useFacebookCampaignExperiments(status);
+  const experiments = Array.isArray(data) ? data : [];
+  return (
+    <div>
+      <PageTitle>Campanhas do Facebook</PageTitle>
+      <div className="btn-group mb-3">
+        <button
+          className={`btn btn-outline-primary${status === "PLANNED" ? " active" : ""}`}
+          onClick={() => setStatus("PLANNED")}
+        >
+          Planejadas
+        </button>
+        <button
+          className={`btn btn-outline-primary${status === "RUNNING" ? " active" : ""}`}
+          onClick={() => setStatus("RUNNING")}
+        >
+          Ativas
+        </button>
+        <button
+          className={`btn btn-outline-primary${status === "FINISHED" ? " active" : ""}`}
+          onClick={() => setStatus("FINISHED")}
+        >
+          Encerradas
+        </button>
+      </div>
+      {isLoading ? (
+        <p>Carregando...</p>
+      ) : (
+        <ul>
+          {experiments.map((e) => (
+            <li key={e.id}>{e.name}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose experiments filtered by status and platform
- show Facebook campaigns grouped by status in UI
- add navigation link for Facebook campaigns

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c493a70ad483218d9bb4b77ae46b22