### PR TITLE
fix: add api prefix to facebook campaigns

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/facebook-campaigns")
+@RequestMapping("/api/facebook-campaigns")
 public class FacebookAdsCampaignController {
     private final ExperimentService experimentService;
     private final FacebookAdsCampaignRepository campaignRepository;

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -41,7 +41,7 @@ class FacebookAdsCampaignControllerTest {
                 com.marketinghub.experiment.ExperimentStatus.PLANNED,
                 com.marketinghub.experiment.ExperimentPlatform.FACEBOOK))
                 .thenReturn(List.of(exp));
-        mockMvc.perform(get("/facebook-campaigns/experiments").param("status", "PLANNED"))
+        mockMvc.perform(get("/api/facebook-campaigns/experiments").param("status", "PLANNED"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1))
                 .andExpect(jsonPath("$[0].name").value("Exp"));

--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -7,6 +7,7 @@
 - Tipos de dados permitidos (MySql 5): `INT`, `BIGINT`, `DECIMAL`, `DOUBLE`, `FLOAT`, `CHAR`, `VARCHAR`, `TEXT`, `LONGTEXT`, `BINARY(16)` para `UUID`, `DATE`, `DATETIME`, `TIMESTAMP`, `BOOLEAN`.
 - Utilize o `facebook-ads-worker` para todas as chamadas à API do Facebook.
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.
+- Endpoints do backend devem ser acessados com o prefixo `/api`.
 
 ## Serviços existentes
 - **Campanhas de Instagram** (`instagram-campaign`): cria campanhas de Instagram utilizando o `facebook-ads-worker` com criativos gerados pelo **AI Worker** e aprovados pelo usuário no frontend.

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -4,6 +4,8 @@ Worker responsável por criar campanhas no Facebook e Instagram e coletar
 métricas usando a API de Marketing do Facebook. O serviço reutiliza o modelo de
 dados definido no projeto `backend`, evitando duplicação de entidades.
 
+As chamadas ao backend utilizam o prefixo `/api` (por exemplo, `/api/facebook-campaigns`).
+
 ## Data Model
 
 As tabelas prefixadas com `facebook_ads_` descritas em

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -24,7 +24,7 @@ public class FacebookCampaignService {
 
     public void createCampaignsFromExperiments() {
         List<Experiment> experiments = backendClient.get()
-            .uri("/facebook-campaigns/experiments-ready")
+            .uri("/api/facebook-campaigns/experiments-ready")
             .retrieve()
             .bodyToFlux(Experiment.class)
             .collectList()
@@ -39,7 +39,7 @@ public class FacebookCampaignService {
         String campaignId = facebookAdsService.createCampaign(adAccountId, exp.name());
         CreateCampaignRequest req = new CreateCampaignRequest(campaignId, adAccountId, exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
         backendClient.post()
-            .uri("/facebook-campaigns")
+            .uri("/api/facebook-campaigns")
             .bodyValue(req)
             .retrieve()
             .toBodilessEntity()

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -50,10 +50,10 @@ class FacebookCampaignServiceTest {
         service.createCampaignsFromExperiments();
 
         RecordedRequest get = backend.takeRequest();
-        assertEquals("/facebook-campaigns/experiments-ready", get.getPath());
+        assertEquals("/api/facebook-campaigns/experiments-ready", get.getPath());
         RecordedRequest postFb = facebook.takeRequest();
         assertEquals("/v20.0/act_1/campaigns", postFb.getPath());
         RecordedRequest postBackend = backend.takeRequest();
-        assertEquals("/facebook-campaigns", postBackend.getPath());
+        assertEquals("/api/facebook-campaigns", postBackend.getPath());
     }
 }


### PR DESCRIPTION
## Summary
- prefix facebook campaign endpoints with `/api`
- adjust worker service to call updated paths
- document backend api prefix usage

## Testing
- `mvn -s ../settings.xml test` *(failed: Non-resolvable parent POM: could not transfer artifact)*
- `mvn -s settings.xml test` *(failed: Non-resolvable parent POM: could not transfer artifact)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6d00e146c8321bb16aef514811e4a