### PR TITLE
docs: open manual links in new tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 
 ## Conventions
 
+- Na pasta `manual do usuario`, todos os links devem abrir em uma nova aba utilizando `target="_blank"` para manter o usuário no documento.
 - DataBase: MySql 5
 - Modelo de Dados atualizado: docs/data-model.md
   - Todo o modelo de dados deve permanecer no projeto **backend**. O projeto

--- a/manual do usuario/facebook-ad-account-id.md
+++ b/manual do usuario/facebook-ad-account-id.md
@@ -2,7 +2,7 @@
 
 O **Ad Account ID** é o identificador da sua conta de anúncios no Facebook. Siga os passos abaixo para encontrá-lo:
 
-1. Acesse [https://www.facebook.com/adsmanager](https://www.facebook.com/adsmanager) e faça login com a sua conta do Facebook.
+1. Acesse <a href="https://www.facebook.com/adsmanager" target="_blank">https://www.facebook.com/adsmanager</a> e faça login com a sua conta do Facebook.
 2. Caso possua mais de uma conta de anúncios, selecione a conta desejada no canto superior esquerdo da página.
 3. Observe a barra de endereços do navegador: o número após `act=` na URL é o seu **Ad Account ID**.
    - Exemplo de URL: `https://www.facebook.com/adsmanager/manage/campaigns?act=1234567890`.


### PR DESCRIPTION
## Summary
- ensure user manual links open in a new tab
- document new link policy in AGENTS.md

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM)*
- `cd ai-worker && mvn -s settings.xml package` *(fails: Non-resolvable parent POM)*
- `cd ai-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM)*
- `cd frontend && npm ci`
- `cd frontend && npm run build`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6d4d2c3708321a6eb6ac6f0634f98