### PR TITLE
Show experiment details for Facebook campaigns

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
@@ -6,6 +6,8 @@ import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.FacebookAdsCampaignRepository;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -23,7 +25,13 @@ public class FacebookAdsCampaignController {
     @GetMapping("/experiments-ready")
     public List<ExperimentSummary> experimentsReady() {
         return experimentService.listReadyForCampaign().stream()
-                .map(e -> new ExperimentSummary(e.getId(), e.getName()))
+                .map(e -> new ExperimentSummary(
+                        e.getId(),
+                        e.getName(),
+                        e.getHypothesis(),
+                        e.getKpiTargetCpl(),
+                        e.getStartDate(),
+                        e.getEndDate()))
                 .toList();
     }
 
@@ -33,7 +41,13 @@ public class FacebookAdsCampaignController {
         return experimentService
                 .listByStatusAndPlatform(status, com.marketinghub.experiment.ExperimentPlatform.FACEBOOK)
                 .stream()
-                .map(e -> new ExperimentSummary(e.getId(), e.getName()))
+                .map(e -> new ExperimentSummary(
+                        e.getId(),
+                        e.getName(),
+                        e.getHypothesis(),
+                        e.getKpiTargetCpl(),
+                        e.getStartDate(),
+                        e.getEndDate()))
                 .toList();
     }
 
@@ -48,6 +62,18 @@ public class FacebookAdsCampaignController {
         return campaignRepository.save(campaign);
     }
 
-    public record ExperimentSummary(Long id, String name) {}
-    public record CreateCampaignRequest(String id, String adAccountId, String name, String objective, BudgetMode budgetMode) {}
+    public record ExperimentSummary(
+            Long id,
+            String name,
+            String hypothesis,
+            BigDecimal kpiTargetCpl,
+            LocalDate startDate,
+            LocalDate endDate) {}
+
+    public record CreateCampaignRequest(
+            String id,
+            String adAccountId,
+            String name,
+            String objective,
+            BudgetMode budgetMode) {}
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -11,6 +11,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -36,7 +38,14 @@ class FacebookAdsCampaignControllerTest {
 
     @Test
     void listExperimentsByStatus() throws Exception {
-        var exp = Experiment.builder().id(1L).name("Exp").build();
+        var exp = Experiment.builder()
+                .id(1L)
+                .name("Exp")
+                .hypothesis("Hipótese")
+                .kpiTargetCpl(BigDecimal.TEN)
+                .startDate(LocalDate.of(2024, 1, 1))
+                .endDate(LocalDate.of(2024, 1, 31))
+                .build();
         when(experimentService.listByStatusAndPlatform(
                 com.marketinghub.experiment.ExperimentStatus.PLANNED,
                 com.marketinghub.experiment.ExperimentPlatform.FACEBOOK))
@@ -44,6 +53,10 @@ class FacebookAdsCampaignControllerTest {
         mockMvc.perform(get("/api/facebook-campaigns/experiments").param("status", "PLANNED"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1))
-                .andExpect(jsonPath("$[0].name").value("Exp"));
+                .andExpect(jsonPath("$[0].name").value("Exp"))
+                .andExpect(jsonPath("$[0].hypothesis").value("Hipótese"))
+                .andExpect(jsonPath("$[0].kpiTargetCpl").value(10))
+                .andExpect(jsonPath("$[0].startDate").value("2024-01-01"))
+                .andExpect(jsonPath("$[0].endDate").value("2024-01-31"));
     }
 }

--- a/frontend/src/api/useFacebookCampaignExperiments.ts
+++ b/frontend/src/api/useFacebookCampaignExperiments.ts
@@ -4,6 +4,10 @@ import axios from "axios";
 export interface ExperimentSummary {
   id: number;
   name: string;
+  hypothesis: string;
+  kpiTargetCpl: number | null;
+  startDate: string | null;
+  endDate: string | null;
 }
 
 export function useFacebookCampaignExperiments(status: string) {

--- a/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
+++ b/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
@@ -32,11 +32,30 @@ export default function FacebookCampaignExperimentsPage() {
       {isLoading ? (
         <p>Carregando...</p>
       ) : (
-        <ul>
-          {experiments.map((e) => (
-            <li key={e.id}>{e.name}</li>
-          ))}
-        </ul>
+        <div className="table-responsive">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Nome</th>
+                <th>Hipótese</th>
+                <th>KPI alvo</th>
+                <th>Início</th>
+                <th>Término</th>
+              </tr>
+            </thead>
+            <tbody>
+              {experiments.map((e) => (
+                <tr key={e.id}>
+                  <td>{e.name}</td>
+                  <td>{e.hypothesis}</td>
+                  <td>{e.kpiTargetCpl}</td>
+                  <td>{e.startDate}</td>
+                  <td>{e.endDate}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- include hypothesis, KPI target and dates in Facebook campaign experiment summaries
- render table with key experiment fields on Facebook campaigns page

## Testing
- `mvn -s ../settings.xml test` *(fails: Could not resolve parent POM)*
- `npm test` *(fails: Expected +0 to be 1)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6dafdd0e88321a83553393633788c