### PR TITLE
Unify campaign handling for Facebook and Instagram

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/CampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/CampaignController.java
@@ -19,29 +19,26 @@ public class CampaignController {
         this.campaignRepo = campaignRepo;
     }
 
-    @GetMapping("/accounts/facebook/{id}/campaigns")
-    public List<Campaign> listFbCampaigns(@PathVariable Long id) {
-        return campaignRepo.findByFacebookAccountId(id);
+    @GetMapping("/accounts/{id}/campaigns")
+    public List<Campaign> listCampaigns(@PathVariable Long id) {
+        return campaignRepo.findByFacebookAccountIdOrInstagramAccountId(id, id);
     }
 
-    @PostMapping("/accounts/facebook/{id}/campaigns")
-    public Campaign createFbCampaign(@PathVariable Long id, @RequestBody Campaign campaign) {
-        FacebookAccount account = fbRepo.findById(id).orElseThrow();
-        campaign.setFacebookAccount(account);
-        campaign.setInstagramAccount(null);
-        return campaignRepo.save(campaign);
-    }
-
-    @GetMapping("/accounts/instagram/{id}/campaigns")
-    public List<Campaign> listIgCampaigns(@PathVariable Long id) {
-        return campaignRepo.findByInstagramAccountId(id);
-    }
-
-    @PostMapping("/accounts/instagram/{id}/campaigns")
-    public Campaign createIgCampaign(@PathVariable Long id, @RequestBody Campaign campaign) {
-        InstagramAccount account = igRepo.findById(id).orElseThrow();
-        campaign.setInstagramAccount(account);
-        campaign.setFacebookAccount(null);
+    @PostMapping("/accounts/{id}/campaigns")
+    public Campaign createCampaign(@PathVariable Long id,
+                                  @RequestParam("platform") String platform,
+                                  @RequestBody Campaign campaign) {
+        if ("facebook".equalsIgnoreCase(platform)) {
+            FacebookAccount account = fbRepo.findById(id).orElseThrow();
+            campaign.setFacebookAccount(account);
+            campaign.setInstagramAccount(null);
+        } else if ("instagram".equalsIgnoreCase(platform)) {
+            InstagramAccount account = igRepo.findById(id).orElseThrow();
+            campaign.setInstagramAccount(account);
+            campaign.setFacebookAccount(null);
+        } else {
+            throw new IllegalArgumentException("platform must be facebook or instagram");
+        }
         return campaignRepo.save(campaign);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/CampaignRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/CampaignRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CampaignRepository extends JpaRepository<Campaign, Long> {
-    List<Campaign> findByFacebookAccountId(Long accountId);
-    List<Campaign> findByInstagramAccountId(Long accountId);
+    List<Campaign> findByFacebookAccountIdOrInstagramAccountId(Long facebookAccountId, Long instagramAccountId);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/CampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/CampaignControllerTest.java
@@ -1,0 +1,61 @@
+package com.marketinghub.ads;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
+})
+public class CampaignControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    FacebookAccountRepository fbRepo;
+
+    @Autowired
+    InstagramAccountRepository igRepo;
+
+    @Test
+    void shouldJoinFacebookAndInstagramCampaigns() throws Exception {
+        FacebookAccount fb = fbRepo.save(FacebookAccount.builder()
+                .name("FB Account")
+                .currency("USD")
+                .build());
+
+        InstagramAccount ig = igRepo.save(InstagramAccount.builder()
+                .username("iguser")
+                .build());
+
+        mockMvc.perform(post("/accounts/" + fb.getId() + "/campaigns?platform=facebook")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"FB Campaign\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists());
+
+        mockMvc.perform(post("/accounts/" + ig.getId() + "/campaigns?platform=instagram")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"IG Campaign\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists());
+
+        mockMvc.perform(get("/accounts/" + fb.getId() + "/campaigns"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+}

--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -10,11 +10,11 @@
 - Endpoints do backend devem ser acessados com o prefixo `/api`.
 
 ## Serviços existentes
-- **Campanhas de Instagram** (`instagram-campaign`): cria campanhas de Instagram utilizando o `facebook-ads-worker` com criativos gerados pelo **AI Worker** e aprovados pelo usuário no frontend.
+- **Campanhas de Facebook Ads** (`campaign`): cria campanhas para Facebook e Instagram utilizando o `facebook-ads-worker` com criativos gerados pelo **AI Worker** e aprovados pelo usuário no frontend.
 
 ## Orientação para novos serviços
-- Siga o mesmo padrão do serviço de **campanhas de Instagram**:
-  - criar um pacote com o nome do domínio (ex: `instagramcampaign`);
+- Siga o mesmo padrão do serviço de **campanhas de Facebook Ads**:
+  - criar um pacote com o nome do domínio (ex: `campaign`);
   - implementar uma classe `*Service` com a lógica de integração com a API do Facebook;
   - criar um `*Scheduler` com `@Scheduled` para executar o serviço periodicamente;
   - encapsular qualquer cliente do Facebook dentro do mesmo pacote.

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -1,10 +1,11 @@
 # Facebook Ads Worker
 
-Worker responsável por criar campanhas no Facebook e Instagram e coletar
-métricas usando a API de Marketing do Facebook. O serviço reutiliza o modelo de
+Worker responsável por criar campanhas no Facebook Ads, incluindo
+posicionamentos no Facebook e no Instagram, e coletar métricas usando a API de
+Marketing do Facebook. O serviço reutiliza o modelo de
 dados definido no projeto `backend`, evitando duplicação de entidades.
 
-As chamadas ao backend utilizam o prefixo `/api` (por exemplo, `/api/facebook-campaigns`).
+As chamadas ao backend utilizam o prefixo `/api` (por exemplo, `/api/accounts/{id}/campaigns`).
 
 ## Data Model
 


### PR DESCRIPTION
## Summary
- expose a single campaign endpoint that accepts Facebook or Instagram accounts
- document Facebook Ads worker as managing campaigns for both Facebook and Instagram
- test joining campaigns from both platforms

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `cd facebook-ads-worker && mvn -s settings.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dcb5af488321a57ee8c4429b7c39