### PR TITLE
Fix CampaignControllerTest InstagramAccount builder usage

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/ads/CampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/CampaignControllerTest.java
@@ -39,7 +39,7 @@ public class CampaignControllerTest {
                 .build());
 
         InstagramAccount ig = igRepo.save(InstagramAccount.builder()
-                .username("iguser")
+                .name("IG Account")
                 .build());
 
         mockMvc.perform(post("/accounts/" + fb.getId() + "/campaigns?platform=facebook")


### PR DESCRIPTION
## Summary
- use `name` field when building InstagramAccount in CampaignControllerTest

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM ... Network is unreachable)*
- `mvn -s ../settings.xml -q spotless:apply` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ec914f5883218284a5e6f44da83d