### PR TITLE
fix: add api prefix to instagram creatives

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -5,7 +5,7 @@ posicionamentos no Facebook e no Instagram, e coletar métricas usando a API de
 Marketing do Facebook. O serviço reutiliza o modelo de
 dados definido no projeto `backend`, evitando duplicação de entidades.
 
-As chamadas ao backend utilizam o prefixo `/api` (por exemplo, `/api/accounts/{id}/campaigns`).
+As chamadas ao backend utilizam o prefixo `/api` (por exemplo, `/api/facebook-campaigns/experiments-ready` e `/api/instagram-creatives/approved`).
 
 ## Data Model
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/instagramcampaign/InstagramCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/instagramcampaign/InstagramCampaignService.java
@@ -21,7 +21,7 @@ public class InstagramCampaignService {
 
     public void createCampaignsFromAuthorizedCreatives() {
         List<Creative> creatives = backendClient.get()
-            .uri("/instagram-creatives/approved")
+            .uri("/api/instagram-creatives/approved")
             .retrieve()
             .bodyToFlux(Creative.class)
             .collectList()
@@ -35,7 +35,7 @@ public class InstagramCampaignService {
     private void processCreative(Creative creative) {
         String campaignId = facebookAdsService.createInstagramCampaign(creative.adAccountId(), creative.name());
         backendClient.post()
-            .uri("/instagram-creatives/" + creative.id() + "/campaign")
+            .uri("/api/instagram-creatives/" + creative.id() + "/campaign")
             .bodyValue(Map.of("campaignId", campaignId))
             .retrieve()
             .toBodilessEntity()

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/instagramcampaign/InstagramCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/instagramcampaign/InstagramCampaignServiceTest.java
@@ -50,11 +50,11 @@ class InstagramCampaignServiceTest {
         service.createCampaignsFromAuthorizedCreatives();
 
         RecordedRequest get = backend.takeRequest();
-        assertEquals("/instagram-creatives/approved", get.getPath());
+        assertEquals("/api/instagram-creatives/approved", get.getPath());
         RecordedRequest postFb = facebook.takeRequest();
         assertEquals("/v20.0/act_1/campaigns", postFb.getPath());
         RecordedRequest postBackend = backend.takeRequest();
-        assertEquals("/instagram-creatives/1/campaign", postBackend.getPath());
+        assertEquals("/api/instagram-creatives/1/campaign", postBackend.getPath());
     }
 }
 


### PR DESCRIPTION
## Summary
- prefix instagram creatives requests with `/api`
- update docs and tests

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f6379b408321be7eaec3dbca6bdd