### PR TITLE
docs: document instagram creative and facebook campaign endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md — Contract for Codex agent
 
+> Sempre consulte este arquivo antes de realizar qualquer alteração no repositório.
+
 ## Build & Test
 
 - **Backend**

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -395,6 +395,30 @@ components:
       responses:
         '200':
           description: OK
+  /api/instagram-creatives/approved:
+    get:
+      summary: Listar criativos do Instagram aprovados
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InstagramCreative'
+  /api/facebook-campaigns/experiments-ready:
+    get:
+      summary: Listar experimentos prontos para campanhas no Facebook
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Experiment'
 components:
   schemas:
     CreateHypothesisRequest:
@@ -434,3 +458,19 @@ components:
           type: array
           items:
             type: integer
+    InstagramCreative:
+      type: object
+      properties:
+        id:
+          type: integer
+        instagramUserId:
+          type: string
+        content:
+          type: string
+    Experiment:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string


### PR DESCRIPTION
## Summary
- document approved Instagram creatives and Facebook campaign endpoints in Swagger
- clarify that AGENTS.md must always be consulted

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` (fails: Non-resolvable parent POM)
- `cd ai-worker && mvn -s settings.xml test` (fails: Non-resolvable parent POM)
- `cd frontend && npm test` (fails: Minified React error #310)
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7b4dda0c88321a05f46536b10887c