### PR TITLE
fix(worker): padroniza chamadas ao backend com prefixo /api e centraliza configuração

### DIFF
--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -7,7 +7,7 @@
 - Tipos de dados permitidos (MySql 5): `INT`, `BIGINT`, `DECIMAL`, `DOUBLE`, `FLOAT`, `CHAR`, `VARCHAR`, `TEXT`, `LONGTEXT`, `BINARY(16)` para `UUID`, `DATE`, `DATETIME`, `TIMESTAMP`, `BOOLEAN`.
 - Utilize o `facebook-ads-worker` para todas as chamadas à API do Facebook.
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.
-- Endpoints do backend devem ser acessados com o prefixo `/api`.
+- Endpoints do backend devem ser acessados com o prefixo configurado em `backend.api-prefix` (default `/api`).
 
 ## Serviços existentes
 - **Campanhas de Facebook Ads** (`campaign`): cria campanhas para Facebook e Instagram utilizando o `facebook-ads-worker` com criativos gerados pelo **AI Worker** e aprovados pelo usuário no frontend.

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -9,6 +9,11 @@ As chamadas ao backend utilizam o prefixo `/api`. Atualmente o worker consome
 `/api/facebook-campaigns/experiments-ready`. O endpoint
 `/api/instagram-creatives/approved` permanece documentado para uso futuro.
 
+Os acessos são configurados pelas propriedades:
+
+- `backend.base-url` (default: `http://localhost:8000`)
+- `backend.api-prefix` (default: `/api`)
+
 ## Data Model
 
 As tabelas prefixadas com `facebook_ads_` descritas em

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.facebookadsworker.facebookcampaign;
 
 import com.marketinghub.facebookadsworker.FacebookAdsService;
+import com.marketinghub.facebookadsworker.util.UrlUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -11,20 +12,25 @@ import java.util.List;
 public class FacebookCampaignService {
     private final FacebookAdsService facebookAdsService;
     private final WebClient backendClient;
+    private final String backendBaseUrl;
+    private final String apiPrefix;
     private final String adAccountId;
 
     public FacebookCampaignService(FacebookAdsService facebookAdsService,
                                    WebClient.Builder builder,
-                                   @Value("${backend.base-url:http://localhost:8080}") String backendBaseUrl,
+                                   @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
+                                   @Value("${backend.api-prefix:/api}") String apiPrefix,
                                    @Value("${facebook.ad-account-id}") String adAccountId) {
         this.facebookAdsService = facebookAdsService;
-        this.backendClient = builder.baseUrl(backendBaseUrl).build();
+        this.backendClient = builder.build();
+        this.backendBaseUrl = backendBaseUrl;
+        this.apiPrefix = apiPrefix;
         this.adAccountId = adAccountId;
     }
 
     public void createCampaignsFromExperiments() {
         List<Experiment> experiments = backendClient.get()
-            .uri("/api/facebook-campaigns/experiments-ready")
+            .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/experiments-ready"))
             .retrieve()
             .bodyToFlux(Experiment.class)
             .collectList()
@@ -39,7 +45,7 @@ public class FacebookCampaignService {
         String campaignId = facebookAdsService.createCampaign(adAccountId, exp.name());
         CreateCampaignRequest req = new CreateCampaignRequest(campaignId, adAccountId, exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
         backendClient.post()
-            .uri("/api/facebook-campaigns")
+            .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns"))
             .bodyValue(req)
             .retrieve()
             .toBodilessEntity()

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/util/UrlUtils.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/util/UrlUtils.java
@@ -1,0 +1,19 @@
+package com.marketinghub.facebookadsworker.util;
+
+/** Utility methods for composing URLs. */
+public final class UrlUtils {
+    private UrlUtils() {
+    }
+
+    /**
+     * Joins a base URL, a prefix and a path ensuring no duplicated slashes are generated.
+     */
+    public static String joinPath(String base, String prefix, String path) {
+        String b = base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+        String p = prefix.startsWith("/") ? prefix : "/" + prefix;
+        p = p.endsWith("/") ? p.substring(0, p.length() - 1) : p;
+        String r = path.startsWith("/") ? path : "/" + path;
+        return b + p + r;
+    }
+}
+

--- a/facebook-ads-worker/src/main/resources/application.properties
+++ b/facebook-ads-worker/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=facebook-ads-worker
-backend.base-url=http://localhost:8080
+backend.base-url=http://localhost:8000
+backend.api-prefix=/api

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -29,7 +29,7 @@ class FacebookCampaignServiceTest {
         String facebookUrl = facebook.url("/").toString();
 
         FacebookAdsService adsService = new FacebookAdsService(WebClient.builder(), facebookUrl, "token");
-        service = new FacebookCampaignService(adsService, WebClient.builder(), backendUrl, "1");
+        service = new FacebookCampaignService(adsService, WebClient.builder(), backendUrl, "/api", "1");
     }
 
     @AfterEach

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/util/UrlUtilsTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/util/UrlUtilsTest.java
@@ -1,0 +1,15 @@
+package com.marketinghub.facebookadsworker.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UrlUtilsTest {
+
+    @Test
+    void joinsPathsAvoidingDuplicateSlashes() {
+        assertEquals("http://host/api/creatives", UrlUtils.joinPath("http://host/", "/api/", "creatives"));
+        assertEquals("http://host/api/creatives", UrlUtils.joinPath("http://host", "api", "/creatives"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- centralize backend base URL and API prefix
- add UrlUtils.joinPath to compose backend paths safely
- route FacebookCampaignService calls through the configured `/api` prefix

## Testing
- `mvn -s settings.xml -q -DskipTests package` *(fails: Network is unreachable)*
- `mvn -s settings.xml -q test` *(fails: Network is unreachable)*
- `jshell --class-path facebook-ads-worker/src/main/java` (GET/POST via HttpClient)


------
https://chatgpt.com/codex/tasks/task_e_68c82e0839b08321b53daf6351c2f571