### PR TITLE
Handle 404 from experiments endpoint in Facebook Ads worker

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -6,7 +6,8 @@ Marketing do Facebook. O serviço reutiliza o modelo de
 dados definido no projeto `backend`, evitando duplicação de entidades.
 
 As chamadas ao backend utilizam o prefixo `/api`. Atualmente o worker consome
-`/api/facebook-campaigns/experiments-ready`. O endpoint
+`/api/facebook-campaigns/experiments-ready`, tratando respostas `404` como
+"nenhum experimento disponível" para evitar falhas no agendamento. O endpoint
 `/api/instagram-creatives/approved` permanece documentado para uso futuro.
 
 Os acessos são configurados pelas propriedades:

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -3,8 +3,11 @@ package com.marketinghub.facebookadsworker.facebookcampaign;
 import com.marketinghub.facebookadsworker.FacebookAdsService;
 import com.marketinghub.facebookadsworker.util.UrlUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -31,14 +34,25 @@ public class FacebookCampaignService {
     public void createCampaignsFromExperiments() {
         List<Experiment> experiments = backendClient.get()
             .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/experiments-ready"))
-            .retrieve()
-            .bodyToFlux(Experiment.class)
+            .exchangeToFlux(response -> {
+                if (response.statusCode().value() == HttpStatus.NOT_FOUND.value()) {
+                    return Flux.empty();
+                }
+
+                if (response.statusCode().isError()) {
+                    return response.createException().flatMapMany(Mono::error);
+                }
+
+                return response.bodyToFlux(Experiment.class);
+            })
             .collectList()
             .block();
 
-        if (experiments != null) {
-            experiments.forEach(this::processExperiment);
+        if (experiments == null || experiments.isEmpty()) {
+            return;
         }
+
+        experiments.forEach(this::processExperiment);
     }
 
     private void processExperiment(Experiment exp) {


### PR DESCRIPTION
## Summary
- avoid failing scheduled job when backend responds 404 for experiments-ready by treating it as an empty set
- document the new 404 handling in the Facebook Ads worker README

## Testing
- `mvn -s settings.xml test` *(fails: Network is unreachable while downloading org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from GitHub Packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c8454b85fc83219f36f9314ed73f48