### PR TITLE
Atualiza diagrama do Facebook Ads Worker com modelo de campanha

### DIFF
--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -28,6 +28,56 @@ classDiagram
         +getCampaignMetrics(campaignId) JsonNode
     }
 
+    class CreateCampaignRequest {
+        <<record>>
+        +id : String
+        +adAccountId : String
+        +name : String
+        +objective : String
+        +budgetMode : BudgetMode
+    }
+
+    class FacebookAdsCampaign {
+        <<entity>>
+        +id : String
+        +externalId : String
+        +adAccountId : String
+        +name : String
+        +objective : String
+        +status : FacebookAdStatus
+        +budgetMode : BudgetMode
+        +dailyBudgetMinor : Long
+        +lifetimeBudgetMinor : Long
+        +apiVersion : String
+        +specialAdCategories : Set<SpecialAdCategory>
+        +specialAdCountries : Set<String>
+        +createdAt : Instant
+        +updatedAt : Instant
+    }
+
+    class FacebookAdStatus {
+        <<enum>>
+        PAUSED
+        ACTIVE
+        ARCHIVED
+        DELETED
+    }
+
+    class BudgetMode {
+        <<enum>>
+        CAMPAIGN
+        ADSET
+    }
+
+    class SpecialAdCategory {
+        <<enum>>
+        NONE
+        CREDIT
+        EMPLOYMENT
+        HOUSING
+        ISSUES_ELECTIONS_POLITICS
+    }
+
     class UrlUtils {
         <<utility>>
         +joinPath(base, prefix, path) String
@@ -35,6 +85,11 @@ classDiagram
 
     FacebookCampaignScheduler --> FacebookCampaignService : dispara ciclo
     FacebookCampaignService --> FacebookAdsService : cria campanhas
+    FacebookCampaignService --> CreateCampaignRequest : monta payload do backend
+    CreateCampaignRequest ..> FacebookAdsCampaign : persiste entidade
+    FacebookAdsCampaign --> FacebookAdStatus
+    FacebookAdsCampaign --> BudgetMode
+    FacebookAdsCampaign --> SpecialAdCategory
     FacebookCampaignService ..> UrlUtils : compõe URLs do backend
 ```
 
@@ -44,5 +99,20 @@ classDiagram
   campanha na Graph API e registra o resultado de volta no backend.
 * `FacebookAdsService` encapsula as chamadas à Graph API (criação de campanhas e
   consulta de métricas).
+* `CreateCampaignRequest` representa o payload enviado ao backend contendo os
+  campos mínimos para materializar a entidade de campanha.
+* `FacebookAdsCampaign` é a entidade JPA do backend responsável por armazenar a
+  campanha criada com seus metadados básicos e enums auxiliares.
 * `UrlUtils` garante a composição correta das URLs ao concatenar `base-url`,
   `api-prefix` e o caminho dos endpoints do backend.
+
+## Modelo de Dados de Campanha
+
+O backend persiste os dados das campanhas na entidade `FacebookAdsCampaign`,
+que reflete a tabela `facebook_ads_campaign`. Além dos atributos básicos
+utilizados hoje (`id`, `adAccountId`, `name`, `objective` e `budgetMode`), o
+modelo inclui campos para controle de status (`FacebookAdStatus`), valores de
+orçamento (`dailyBudgetMinor`, `lifetimeBudgetMinor`), versão da API utilizada e
+listas para categorias e países especiais (`specialAdCategories` e
+`specialAdCountries`). Esses dados são enriquecidos conforme novas informações
+forem fornecidas pelo worker e pelo backend.


### PR DESCRIPTION
## Summary
- adiciona CreateCampaignRequest, FacebookAdsCampaign e enums ao diagrama de classes do worker
- documenta como o backend materializa o modelo de campanhas na entidade `FacebookAdsCampaign`

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c8a42d06588321b599a6b2ec885922