### PR TITLE
Renomeia tela de campanhas do Facebook para Experimentos para Campanha

### DIFF
--- a/docs/facebook-ads-worker/input-output-mapping.md
+++ b/docs/facebook-ads-worker/input-output-mapping.md
@@ -7,6 +7,10 @@ os dados necessários para registrar a campanha criada; o enriquecimento com
 informações de conjuntos de anúncios, criativos e UTM permanece listado em
 [pendencias.md](./pendencias.md).
 
+Os experimentos que alimentam esse fluxo são apresentados ao time na tela
+"Experimentos para Campanha" do frontend, garantindo o alinhamento entre a visão
+operacional e a automação do worker.
+
 ## Visão Geral do Fluxo
 
 ```mermaid

--- a/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
+++ b/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
@@ -4,6 +4,10 @@ Este documento descreve como o MarketingHub converte experimentos aprovados em
 campanhas no Facebook Ads e os próximos passos para incluir entidades
 relacionadas (conjuntos de anúncios, criativos e rastreamento).
 
+A fila de trabalho usada aqui é a mesma exibida na tela "Experimentos para
+Campanha" do frontend, que lista os experimentos aprovados e prontos para serem
+transformados em campanhas.
+
 ## Visão geral do fluxo
 
 ```mermaid

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -105,7 +105,7 @@ export default function App() {
               Funil de Vendas
             </Link>
             <Link className="nav-link" to="/facebook-campaigns">
-              Campanhas Facebook
+              Experimentos para Campanha
             </Link>
             <Link className="nav-link" to="/prompt-entities">
               Objetos de Prompt

--- a/frontend/src/__tests__/FacebookCampaignNavigation.test.tsx
+++ b/frontend/src/__tests__/FacebookCampaignNavigation.test.tsx
@@ -21,7 +21,7 @@ afterEach(() => {
 describe("facebook campaigns navigation", () => {
   it("has menu link to /facebook-campaigns", () => {
     setup(<App />, ["/"]); 
-    const link = screen.getByRole("link", { name: /campanhas facebook/i });
+    const link = screen.getByRole("link", { name: /experimentos para campanha/i });
     expect(link).toBeTruthy();
     expect(link.getAttribute("href")).toBe("/facebook-campaigns");
   });

--- a/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
+++ b/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
@@ -8,7 +8,7 @@ export default function FacebookCampaignExperimentsPage() {
   const experiments = Array.isArray(data) ? data : [];
   return (
     <div>
-      <PageTitle>Campanhas do Facebook</PageTitle>
+      <PageTitle>Experimentos para Campanha</PageTitle>
       <div className="btn-group mb-3">
         <button
           className={`btn btn-outline-primary${status === "PLANNED" ? " active" : ""}`}


### PR DESCRIPTION
## Summary
- atualiza o título da página e o item de navegação para exibir "Experimentos para Campanha"
- ajusta o teste de navegação associado e referencia a nova denominação na documentação do Facebook Ads Worker

## Testing
- npm run test -- --run --reporter=basic


------
https://chatgpt.com/codex/tasks/task_e_68c8ac4dc36c8321b983063ce587af1d