### PR TITLE
feat: associate experiments with sales funnels

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
@@ -28,4 +28,5 @@ public class CreateExperimentRequest {
     private LocalDate startDate;
     private LocalDate endDate;
     private Integer creativesToGenerate;
+    private String salesFunnelName;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -36,4 +36,6 @@ public class ExperimentDto {
     private Instant updatedAt;
     private String metricPresetId;
     private Integer creativesToGenerate;
+    private java.util.UUID salesFunnelId;
+    private String salesFunnelName;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
@@ -23,5 +23,6 @@ public class UpdateExperimentRequest {
     private Integer creativesToGenerate;
     private Boolean audienceApproved;
     private Boolean creativeApproved;
+    private String salesFunnelName;
 }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/mapper/ExperimentMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/mapper/ExperimentMapper.java
@@ -12,5 +12,7 @@ public interface ExperimentMapper {
     @org.mapstruct.Mapping(target = "nicheId", source = "niche.id")
     @org.mapstruct.Mapping(target = "hypothesisId", source = "hypothesisRef.id")
     @org.mapstruct.Mapping(target = "metricPresetId", source = "metricPreset.id")
+    @org.mapstruct.Mapping(target = "salesFunnelId", source = "salesFunnel.id")
+    @org.mapstruct.Mapping(target = "salesFunnelName", source = "salesFunnel.name")
     ExperimentDto toDto(Experiment experiment);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -4,6 +4,8 @@ import com.marketinghub.experiment.*;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.funnel.SalesFunnel;
+import com.marketinghub.funnel.SalesFunnelRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import jakarta.persistence.EntityManager;
@@ -23,16 +25,19 @@ public class ExperimentService {
     private final com.marketinghub.hypothesis.repository.HypothesisRepository hypothesisRepository;
     private final MetricPresetService metricPresetService;
     private final EntityManager entityManager;
+    private final SalesFunnelRepository salesFunnelRepository;
 
     public ExperimentService(ExperimentRepository repository, MarketNicheRepository nicheRepository,
                              com.marketinghub.hypothesis.repository.HypothesisRepository hypothesisRepository,
                              MetricPresetService metricPresetService,
-                             EntityManager entityManager) {
+                             EntityManager entityManager,
+                             SalesFunnelRepository salesFunnelRepository) {
         this.repository = repository;
         this.nicheRepository = nicheRepository;
         this.hypothesisRepository = hypothesisRepository;
         this.metricPresetService = metricPresetService;
         this.entityManager = entityManager;
+        this.salesFunnelRepository = salesFunnelRepository;
     }
 
     /**
@@ -54,6 +59,12 @@ public class ExperimentService {
             throw new EntityNotFoundException("Hypothesis not found: " + id);
         }
         return entityManager.getReference(com.marketinghub.hypothesis.Hypothesis.class, id);
+    }
+
+    private SalesFunnel resolveSalesFunnel(String name) {
+        return salesFunnelRepository.findByNameIgnoreCase(name)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "salesFunnelName not found: " + name));
     }
 
     /**
@@ -91,6 +102,10 @@ public class ExperimentService {
                 request.getBaselineCvr().compareTo(request.getTargetCvr()) >= 0) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "baselineCvr must be < targetCvr");
         }
+        SalesFunnel salesFunnel = null;
+        if (request.getSalesFunnelName() != null && !request.getSalesFunnelName().isBlank()) {
+            salesFunnel = resolveSalesFunnel(request.getSalesFunnelName());
+        }
         Experiment exp = Experiment.builder()
                 .niche(niche)
                 .name(request.getName())
@@ -108,6 +123,7 @@ public class ExperimentService {
                 .status(ExperimentStatus.PLANNED)
                 .platform(ExperimentPlatform.FACEBOOK)
                 .creativesToGenerate(request.getCreativesToGenerate())
+                .salesFunnel(salesFunnel)
                 .build();
         return repository.save(exp);
     }
@@ -162,6 +178,7 @@ public class ExperimentService {
                 .status(ExperimentStatus.PLANNED)
                 .platform(original.getPlatform())
                 .creativesToGenerate(original.getCreativesToGenerate())
+                .salesFunnel(original.getSalesFunnel())
                 .build();
         return repository.save(copy);
     }
@@ -236,6 +253,13 @@ public class ExperimentService {
         }
         if (request.getCreativeApproved() != null) {
             exp.setCreativeApproved(request.getCreativeApproved());
+        }
+        if (request.getSalesFunnelName() != null) {
+            if (request.getSalesFunnelName().isBlank()) {
+                exp.setSalesFunnel(null);
+            } else {
+                exp.setSalesFunnel(resolveSalesFunnel(request.getSalesFunnelName()));
+            }
         }
         return exp;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/funnel/SalesFunnelRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/funnel/SalesFunnelRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 public interface SalesFunnelRepository extends JpaRepository<SalesFunnel, UUID> {
     @EntityGraph(attributePaths = "steps")
     Optional<SalesFunnel> findWithStepsById(UUID id);
+
+    Optional<SalesFunnel> findByNameIgnoreCase(String name);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -2,12 +2,15 @@ package com.marketinghub.experiment;
 
 import com.marketinghub.experiment.MetricPreset;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
+import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import com.marketinghub.creative.label.repository.AngleRepository;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.funnel.SalesFunnel;
+import com.marketinghub.funnel.SalesFunnelRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,6 +42,8 @@ class ExperimentServiceTest {
     com.marketinghub.experiment.repository.MetricPresetRepository metricPresetRepository;
     @Autowired
     ExperimentRepository experimentRepository;
+    @Autowired
+    SalesFunnelRepository salesFunnelRepository;
 
     @Test
     void createNewExperimentWithExistingNiche() {
@@ -235,5 +240,132 @@ class ExperimentServiceTest {
 
         var result = service.listByStatusAndPlatform(ExperimentStatus.RUNNING, ExperimentPlatform.FACEBOOK);
         assertThat(result).extracting(Experiment::getId).containsExactly(exp.getId());
+    }
+
+    @Test
+    void createAssociatesSalesFunnelByName() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("T")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+        SalesFunnel funnel = salesFunnelRepository.save(SalesFunnel.builder().name("Topo").build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("Exp1");
+        req.setHypothesis("Teste");
+        req.setKpiTargetCpl(new BigDecimal("45"));
+        req.setMetricPresetId("LEAN_150");
+        req.setSalesFunnelName("Topo");
+
+        Experiment exp = service.create(req);
+
+        assertThat(exp.getSalesFunnel()).isNotNull();
+        assertThat(exp.getSalesFunnel().getId()).isEqualTo(funnel.getId());
+    }
+
+    @Test
+    void updateChangesSalesFunnelWhenProvided() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("T")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+        SalesFunnel first = salesFunnelRepository.save(SalesFunnel.builder().name("Topo").build());
+        SalesFunnel second = salesFunnelRepository.save(SalesFunnel.builder().name("Meio").build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("Exp1");
+        req.setHypothesis("Teste");
+        req.setKpiTargetCpl(new BigDecimal("45"));
+        req.setMetricPresetId("LEAN_150");
+        req.setSalesFunnelName(first.getName());
+        Experiment exp = service.create(req);
+
+        UpdateExperimentRequest updateReq = new UpdateExperimentRequest();
+        updateReq.setName("Exp1");
+        updateReq.setHypothesis("Teste");
+        updateReq.setKpiTargetCpl(new BigDecimal("45"));
+        updateReq.setMetricPresetId("LEAN_150");
+        updateReq.setSalesFunnelName(second.getName());
+
+        Experiment updated = service.update(exp.getId(), updateReq);
+
+        assertThat(updated.getSalesFunnel()).isNotNull();
+        assertThat(updated.getSalesFunnel().getId()).isEqualTo(second.getId());
+    }
+
+    @Test
+    void updateClearsSalesFunnelWhenBlank() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("T")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+        SalesFunnel funnel = salesFunnelRepository.save(SalesFunnel.builder().name("Topo").build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("Exp1");
+        req.setHypothesis("Teste");
+        req.setKpiTargetCpl(new BigDecimal("45"));
+        req.setMetricPresetId("LEAN_150");
+        req.setSalesFunnelName(funnel.getName());
+        Experiment exp = service.create(req);
+
+        UpdateExperimentRequest updateReq = new UpdateExperimentRequest();
+        updateReq.setName("Exp1");
+        updateReq.setHypothesis("Teste");
+        updateReq.setKpiTargetCpl(new BigDecimal("45"));
+        updateReq.setMetricPresetId("LEAN_150");
+        updateReq.setSalesFunnelName("");
+
+        Experiment updated = service.update(exp.getId(), updateReq);
+
+        assertThat(updated.getSalesFunnel()).isNull();
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -10,6 +10,8 @@ import com.marketinghub.niche.repository.MarketNicheRepository;
 import com.marketinghub.creative.label.repository.AngleRepository;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import com.marketinghub.FixtureUtils;
+import com.marketinghub.funnel.SalesFunnel;
+import com.marketinghub.funnel.SalesFunnelRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,6 +61,8 @@ class ExperimentControllerTest {
     private com.marketinghub.creative.repository.CreativeRepository creativeRepo;
     @Autowired
     private FixtureUtils fixtures;
+    @Autowired
+    private SalesFunnelRepository salesFunnelRepository;
 
     Long nicheId;
 
@@ -66,6 +70,7 @@ class ExperimentControllerTest {
     void cleanDb() {
         creativeRepo.deleteAll();
         repository.deleteAll();
+        salesFunnelRepository.deleteAll();
         hypothesisRepository.deleteAll();
         angleRepository.deleteAll();
         nicheRepo.deleteAll();
@@ -93,6 +98,7 @@ class ExperimentControllerTest {
                 .stopLossFactor(new BigDecimal("2"))
                 .defaultMdePp(new BigDecimal("12"))
                 .build());
+        SalesFunnel funnel = salesFunnelRepository.save(SalesFunnel.builder().name("Topo").build());
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setName("Exp1");
         req.setHypothesisId(hyp.getId());
@@ -105,19 +111,27 @@ class ExperimentControllerTest {
         req.setMdePercent(new BigDecimal("40"));
         req.setStartDate(LocalDate.now());
         req.setEndDate(LocalDate.now().plusDays(5));
+        req.setSalesFunnelName(funnel.getName());
 
         mockMvc.perform(post("/api/niches/" + nicheId + "/experiments")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(req)))
                 .andExpect(status().isOk());
 
-        assertThat(repository.count()).isEqualTo(1);
+        var saved = repository.findAll();
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getSalesFunnel()).isNotNull();
+        assertThat(saved.get(0).getSalesFunnel().getId()).isEqualTo(funnel.getId());
     }
 
     @Test
     void updateEndpointUpdatesFields() throws Exception {
         var niche = nicheRepo.findById(nicheId).orElseThrow();
         var exp = fixtures.createAndSaveExperiment(niche);
+        SalesFunnel startFunnel = salesFunnelRepository.save(SalesFunnel.builder().name("Topo").build());
+        SalesFunnel newFunnel = salesFunnelRepository.save(SalesFunnel.builder().name("Meio").build());
+        exp.setSalesFunnel(startFunnel);
+        repository.save(exp);
         UpdateExperimentRequest req = new UpdateExperimentRequest();
         req.setName("Updated");
         req.setHypothesis("Hyp");
@@ -127,6 +141,7 @@ class ExperimentControllerTest {
         req.setMdePercent(new BigDecimal("30"));
         req.setStartDate(LocalDate.now());
         req.setEndDate(LocalDate.now().plusDays(2));
+        req.setSalesFunnelName(newFunnel.getName());
 
         mockMvc.perform(patch("/api/experiments/" + exp.getId())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -137,6 +152,8 @@ class ExperimentControllerTest {
         assertThat(updated.getName()).isEqualTo("Updated");
         assertThat(updated.getSampleSize()).isEqualTo(200);
         assertThat(updated.getMdePercent()).isEqualByComparingTo("30");
+        assertThat(updated.getSalesFunnel()).isNotNull();
+        assertThat(updated.getSalesFunnel().getId()).isEqualTo(newFunnel.getId());
     }
 
     @Test

--- a/docs/frontend-screens-entities.md
+++ b/docs/frontend-screens-entities.md
@@ -29,9 +29,9 @@ Consulte também o [Diagrama de Navegação do Frontend](./frontend-navigation.m
 | `/niches/:nicheId/hypotheses/:hypothesisId` | Detalhe da Hipótese | Hypothesis | - |
 | `/niches/:nicheId/hypotheses/:hypothesisId/edit` | Editar Hipótese | Hypothesis | Hypothesis |
 | `/experiments` | Lista de Experimentos | Experiment | - |
-| `/experiments/new` | Novo Experimento | - | Experiment |
-| `/experiments/:id` | Detalhe do Experimento | Experiment, Creative, AdSet, MetricSnapshot, LandingPage | - |
-| `/experiments/:id/edit` | Editar Experimento | Experiment | Experiment |
+| `/experiments/new` | Novo Experimento | MarketNiche, Hypothesis, MetricPreset, SalesFunnel | Experiment |
+| `/experiments/:id` | Detalhe do Experimento | Experiment, SalesFunnel, Creative, AdSet, MetricSnapshot, LandingPage | - |
+| `/experiments/:id/edit` | Editar Experimento | Experiment, SalesFunnel | Experiment |
 | `/hypotheses` | Lista de Hipóteses | Hypothesis | - |
 | `/hypotheses/board` | Quadro de Hipóteses | Hypothesis | Hypothesis |
 | `/ai-services` | Serviços de IA | AiService | - |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -80,6 +80,8 @@ components:
         endDate:
           type: string
           format: date
+        salesFunnelName:
+          type: string
   /api/experiments/{id}/creatives:
     post:
       summary: Criar criativo
@@ -263,6 +265,11 @@ components:
       type: object
       properties:
         name:
+          type: string
+        salesFunnelId:
+          type: string
+          format: uuid
+        salesFunnelName:
           type: string
         description:
           type: string
@@ -473,4 +480,9 @@ components:
         id:
           type: integer
         name:
+          type: string
+        salesFunnelId:
+          type: string
+          format: uuid
+        salesFunnelName:
           type: string

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -14,6 +14,7 @@ export interface CreateExperiment {
   startDate?: string;
   endDate?: string;
   creativesToGenerate?: number;
+  salesFunnelName?: string;
 }
 
 export function useCreateExperiment() {

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -26,6 +26,8 @@ export interface Experiment {
   platform: string;
   createdAt: string;
   updatedAt: string;
+  salesFunnelId?: string | null;
+  salesFunnelName?: string | null;
 }
 
 export function useExperiments() {

--- a/frontend/src/api/experiment/useUpdateExperiment.ts
+++ b/frontend/src/api/experiment/useUpdateExperiment.ts
@@ -12,6 +12,7 @@ export interface UpdateExperiment {
   startDate?: string;
   endDate?: string;
   creativesToGenerate?: number;
+  salesFunnelName?: string | null;
 }
 
 export function useUpdateExperiment(id: string) {

--- a/frontend/src/pages/experiment/EditExperimentPage.tsx
+++ b/frontend/src/pages/experiment/EditExperimentPage.tsx
@@ -4,12 +4,14 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useExperiment } from "../../api/experiment/useExperiment";
 import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
 import { useMetricPresets } from "../../api/experiment/useMetricPresets";
+import { useFunnels } from "../../api/funnel/useFunnels";
 import PageTitle from "../../components/PageTitle";
 
 interface FormData {
   name: string;
   kpiTarget: string;
   metricPresetId: string;
+  salesFunnelName: string;
 }
 
 export default function EditExperimentPage() {
@@ -18,6 +20,7 @@ export default function EditExperimentPage() {
   const navigate = useNavigate();
   const { data, isLoading } = useExperiment(expId);
   const { data: presets } = useMetricPresets();
+  const { data: funnels } = useFunnels();
   const update = useUpdateExperiment(expId);
   const { register, handleSubmit, reset } = useForm<FormData>();
 
@@ -27,6 +30,7 @@ export default function EditExperimentPage() {
         name: data.name || "",
         kpiTarget: data.kpiTarget ? String(data.kpiTarget) : "",
         metricPresetId: data.metricPresetId || "",
+        salesFunnelName: data.salesFunnelName || "",
       });
     }
   }, [data, reset]);
@@ -43,6 +47,7 @@ export default function EditExperimentPage() {
         mde: data.mdePercent ?? undefined,
         startDate: data.startDate ?? undefined,
         endDate: data.endDate ?? undefined,
+        salesFunnelName: values.salesFunnelName,
       });
       navigate(-1);
     } catch {
@@ -84,6 +89,22 @@ export default function EditExperimentPage() {
             presets.map((p) => (
               <option key={p.id} value={p.id}>
                 {p.name}
+              </option>
+            ))}
+        </select>
+        <label className="form-label" htmlFor="salesFunnel">
+          Funil de Vendas
+        </label>
+        <select
+          id="salesFunnel"
+          className="form-select mb-2"
+          {...register("salesFunnelName")}
+        >
+          <option value="">Nenhum</option>
+          {Array.isArray(funnels) &&
+            funnels.map((f) => (
+              <option key={f.id} value={f.name}>
+                {f.name}
               </option>
             ))}
         </select>

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -61,6 +61,20 @@ export default function ExperimentDetailPage() {
         </Link>
       ),
     },
+    ...(data.salesFunnelName
+      ? [
+          {
+            label: "Funil de Vendas",
+            value: data.salesFunnelId ? (
+              <Link to={`/funnels/${data.salesFunnelId}/edit`}>
+                {data.salesFunnelName}
+              </Link>
+            ) : (
+              data.salesFunnelName
+            ),
+          },
+        ]
+      : []),
     { label: "Preset de Métricas", value: preset?.name || "—" },
     {
       label: "Sample size",

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -5,6 +5,7 @@ import { useNiches } from "../../api/niche/useNiches";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useMetricPresets } from "../../api/experiment/useMetricPresets";
+import { useFunnels } from "../../api/funnel/useFunnels";
 import PageTitle from "../../components/PageTitle";
 
 export default function NewExperimentPage() {
@@ -24,6 +25,7 @@ export default function NewExperimentPage() {
     mde: "",
     startDate: "",
     endDate: "",
+    salesFunnelName: "",
   });
   const { data: hypotheses } = useHypothesesByNiche(form.nicheId);
   const { data: selectedHypothesis } = useHypothesis(
@@ -34,6 +36,7 @@ export default function NewExperimentPage() {
     (n) => n.id === Number(form.nicheId),
   );
   const { data: presets } = useMetricPresets();
+  const { data: funnels } = useFunnels();
   const showNicheSelect = nicheIdParam === "";
   const showHypSelect = hypothesisIdParam === "";
 
@@ -56,6 +59,7 @@ export default function NewExperimentPage() {
         mde: form.mde ? Number(form.mde) : undefined,
         startDate: form.startDate || undefined,
         endDate: form.endDate || undefined,
+        salesFunnelName: form.salesFunnelName || undefined,
       });
       setForm({
         nicheId: nicheIdParam,
@@ -68,6 +72,7 @@ export default function NewExperimentPage() {
         mde: "",
         startDate: "",
         endDate: "",
+        salesFunnelName: "",
       });
       alert("Teste salvo!");
     } catch (errors) {
@@ -162,6 +167,23 @@ export default function NewExperimentPage() {
           presets.map((p) => (
             <option key={p.id} value={p.id}>
               {p.name}
+            </option>
+          ))}
+      </select>
+      <label className="form-label" htmlFor="salesFunnel">
+        Funil de Vendas
+      </label>
+      <select
+        id="salesFunnel"
+        className="form-select mb-2"
+        value={form.salesFunnelName}
+        onChange={(e) => setForm({ ...form, salesFunnelName: e.target.value })}
+      >
+        <option value="">Selecione Funil de Vendas (opcional)</option>
+        {Array.isArray(funnels) &&
+          funnels.map((f) => (
+            <option key={f.id} value={f.name}>
+              {f.name}
             </option>
           ))}
       </select>


### PR DESCRIPTION
## Summary
- allow experiments to store a selected sales funnel by name on create and update
- expose the funnel choice in API DTOs and surface it on the experiment detail screen with a link to the funnel
- update experiment forms to pick funnels by name and refresh documentation for the new contract

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable while downloading spring-boot-starter-parent from GitHub Packages)*
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c99719db288321a1638bfe690839c3