### PR TITLE
Handle duplicate sales funnel names when resolving

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -62,7 +62,8 @@ public class ExperimentService {
     }
 
     private SalesFunnel resolveSalesFunnel(String name) {
-        return salesFunnelRepository.findByNameIgnoreCase(name)
+        return salesFunnelRepository.findFirstByNameIgnoreCaseOrderByCreatedAtDesc(name)
+                .or(() -> salesFunnelRepository.findByNameIgnoreCase(name))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         "salesFunnelName not found: " + name));
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/funnel/SalesFunnelRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/funnel/SalesFunnelRepository.java
@@ -12,4 +12,6 @@ public interface SalesFunnelRepository extends JpaRepository<SalesFunnel, UUID> 
     Optional<SalesFunnel> findWithStepsById(UUID id);
 
     Optional<SalesFunnel> findByNameIgnoreCase(String name);
+
+    Optional<SalesFunnel> findFirstByNameIgnoreCaseOrderByCreatedAtDesc(String name);
 }


### PR DESCRIPTION
## Summary
- resolve sales funnels by name using the most recently created record to avoid duplicate lookups
- expose a repository method that fetches the latest sales funnel by case-insensitive name

## Testing
- mvn -s ../settings.xml test *(fails: cannot reach https://maven.pkg.github.com to download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a22f61f48321b6fb4ef4fcd4cdec