### PR TITLE
Show funnel preview modal on experiment detail

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -9,6 +9,7 @@ import CriativosTab from "./CriativosTab";
 import PublicosTab from "./PublicosTab";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 import * as Tabs from "@radix-ui/react-tabs";
+import FunnelPreviewModal from "./FunnelPreviewModal";
 
 export default function ExperimentDetailPage() {
   const { id } = useParams();
@@ -21,6 +22,7 @@ export default function ExperimentDetailPage() {
   );
   const { data: presets } = useMetricPresets();
   const [tab, setTab] = useState("overview");
+  const [isFunnelPreviewOpen, setFunnelPreviewOpen] = useState(false);
   useBreadcrumbs([
     { label: "Nichos", to: "/niches" },
     { label: niche?.name || "...", to: `/niches/${data?.nicheId}` },
@@ -66,9 +68,13 @@ export default function ExperimentDetailPage() {
           {
             label: "Funil de Vendas",
             value: data.salesFunnelId ? (
-              <Link to={`/funnels/${data.salesFunnelId}/edit`}>
+              <button
+                type="button"
+                className="btn btn-link p-0 align-baseline"
+                onClick={() => setFunnelPreviewOpen(true)}
+              >
                 {data.salesFunnelName}
-              </Link>
+              </button>
             ) : (
               data.salesFunnelName
             ),
@@ -155,6 +161,13 @@ export default function ExperimentDetailPage() {
           <CriativosTab experimentId={expId} />
         </Tabs.Content>
       </Tabs.Root>
+      {isFunnelPreviewOpen && data.salesFunnelId && (
+        <FunnelPreviewModal
+          funnelId={data.salesFunnelId}
+          fallbackName={data.salesFunnelName}
+          onClose={() => setFunnelPreviewOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/experiment/FunnelPreviewModal.tsx
+++ b/frontend/src/pages/experiment/FunnelPreviewModal.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from "react";
+import { useFunnel } from "../../api/funnel/useFunnel";
+
+interface FunnelPreviewModalProps {
+  funnelId: string;
+  fallbackName?: string | null;
+  onClose: () => void;
+}
+
+function formatLabel(value?: string | null) {
+  if (!value) return "";
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+    .join(" ");
+}
+
+export default function FunnelPreviewModal({
+  funnelId,
+  fallbackName,
+  onClose,
+}: FunnelPreviewModalProps) {
+  const { data, isLoading } = useFunnel(funnelId);
+  const steps = useMemo(() => {
+    if (!data?.steps) return [];
+    return [...data.steps].sort((a, b) => a.orderIdx - b.orderIdx);
+  }, [data?.steps]);
+
+  return (
+    <>
+      <div className="modal d-block" tabIndex={-1} role="dialog">
+        <div className="modal-dialog modal-lg modal-dialog-centered" role="document">
+          <div className="modal-content shadow-lg border-0">
+            <div className="modal-header border-0 pb-0">
+              <div>
+                <h5 className="modal-title mb-1">Funil de Vendas</h5>
+                <p className="text-muted mb-0 small">
+                  {data?.name || fallbackName || "Visualização do funil"}
+                </p>
+              </div>
+              <button
+                type="button"
+                className="btn-close"
+                aria-label="Fechar"
+                onClick={onClose}
+              />
+            </div>
+            <div className="modal-body">
+              {data?.objective && (
+                <p className="text-muted small mb-4">{data.objective}</p>
+              )}
+              {isLoading ? (
+                <p className="text-center text-muted my-5">Carregando funil...</p>
+              ) : steps.length === 0 ? (
+                <div className="alert alert-info mb-0">
+                  Este funil ainda não possui etapas cadastradas.
+                </div>
+              ) : (
+                <ol className="list-group list-group-numbered">
+                  {steps.map((step) => (
+                    <li
+                      key={step.id}
+                      className="list-group-item border-0 mb-3 shadow-sm rounded-3"
+                    >
+                      <div className="d-flex flex-wrap justify-content-between gap-3">
+                        <div>
+                          <span className="badge bg-primary bg-opacity-10 text-primary fw-semibold text-uppercase small">
+                            {formatLabel(step.stimulusType)}
+                          </span>
+                          <div className="fs-5 fw-semibold text-dark mt-2">
+                            {formatLabel(step.expectedAction)}
+                          </div>
+                        </div>
+                        <div className="d-flex flex-column align-items-end gap-2">
+                          {step.scoreInc != null && step.scoreInc !== 0 && (
+                            <span className="badge bg-success rounded-pill">
+                              +{step.scoreInc}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      {step.note && (
+                        <p className="text-muted small mb-0 mt-3">{step.note}</p>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+            <div className="modal-footer border-0 pt-0">
+              <button type="button" className="btn btn-outline-secondary" onClick={onClose}>
+                Fechar
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="modal-backdrop fade show" />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a funnel preview modal to display funnel steps in a styled Bootstrap dialog
- update the experiment detail page to open the modal instead of navigating to the funnel editor

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9e0598d4083219ee6630b48d2892a