### PR TITLE
Rename success product OpenAI client bean to avoid conflicts

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/successproduct/SuccessProductOpenAiChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/successproduct/SuccessProductOpenAiChatGptClient.java
@@ -19,14 +19,14 @@ import org.springframework.web.reactive.function.client.WebClient;
  */
 @Component
 @Profile("!test & !dummy")
-public class OpenAiChatGptClient implements ChatGptClient {
-    private static final Logger log = LoggerFactory.getLogger(OpenAiChatGptClient.class);
+public class SuccessProductOpenAiChatGptClient implements ChatGptClient {
+    private static final Logger log = LoggerFactory.getLogger(SuccessProductOpenAiChatGptClient.class);
 
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
     private final String model;
 
-    public OpenAiChatGptClient(
+    public SuccessProductOpenAiChatGptClient(
             WebClient.Builder builder,
             ObjectMapper objectMapper,
             @Value("${openai.api-key:}") String apiKey,


### PR DESCRIPTION
## Summary
- rename the success product OpenAI ChatGPT client component to give it a distinct bean name
- keep constructor and logger in sync with the new class name to prevent duplicate bean registration errors

## Testing
- `mvn -s settings.xml test` *(fails: missing access to org.springframework.boot:spring-boot-starter-parent due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e3e133f883218ed67c308155779c