### PR TITLE
Add audience generation workflow to AI Worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/audience/AudienceChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/audience/AudienceChatGptClient.java
@@ -1,0 +1,205 @@
+package com.marketinghub.worker.audience;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.audience.dto.CreateAudienceRequest;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.niche.MarketNiche;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Wrapper do ChatGPT para geração de públicos de Meta Ads.
+ */
+@Component
+public class AudienceChatGptClient {
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+    private final String model;
+    private static final Logger log = LoggerFactory.getLogger(AudienceChatGptClient.class);
+
+    public AudienceChatGptClient(WebClient.Builder builder,
+                                 ObjectMapper objectMapper,
+                                 @Value("${openai.api-key:}") String apiKey,
+                                 @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
+                                 @Value("${openai.model:gpt-3.5-turbo}") String model) {
+        this.webClient = builder
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .build();
+        this.objectMapper = objectMapper;
+        this.model = model;
+    }
+
+    public List<CreateAudienceRequest> generateAudiences(MarketNiche niche,
+                                                         List<Hypothesis> hypotheses,
+                                                         int quantity) {
+        PromptData promptData = buildPrompt(niche, hypotheses, quantity);
+        Map<String, Object> payload = Map.of(
+                "model", model,
+                "messages", List.of(
+                        Map.of("role", "system", "content", "Você é um especialista em marketing e segmentação para anúncios da Meta."),
+                        Map.of("role", "user", "content", promptData.prompt())
+                )
+        );
+
+        log.info("Sending prompt to ChatGPT for niche {}: {}", niche.getId(), promptData.prompt());
+        log.debug("ChatGPT payload: {}", payload);
+
+        ChatCompletionResponse response = webClient.post()
+                .uri("/chat/completions")
+                .bodyValue(payload)
+                .retrieve()
+                .bodyToMono(ChatCompletionResponse.class)
+                .block();
+
+        if (response == null || response.choices().isEmpty()) {
+            log.warn("ChatGPT returned no choices for niche {}", niche.getId());
+            return List.of();
+        }
+
+        String content = response.choices().get(0).message().content();
+        log.info("ChatGPT content: {}", content);
+
+        try {
+            return parseContent(content, niche, promptData, quantity);
+        } catch (Exception e) {
+            log.error("Failed to parse ChatGPT response: {}", content, e);
+            try {
+                String unescaped = content.replace("\\\"", "\"");
+                return parseContent(unescaped, niche, promptData, quantity);
+            } catch (Exception ex) {
+                log.error("Failed to parse unescaped ChatGPT response: {}", content, ex);
+                throw new RuntimeException("Failed to parse ChatGPT response", ex);
+            }
+        }
+    }
+
+    private PromptData buildPrompt(MarketNiche niche, List<Hypothesis> hypotheses, int quantity) {
+        Set<UUID> hypothesisIds = hypotheses.stream()
+                .map(Hypothesis::getId)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Gere ").append(quantity).append(" públicos para campanhas de Meta Ads em formato JSON. ");
+        sb.append("Cada objeto deve conter as chaves \"name\", \"description\" e \"hypothesisId\". ");
+        sb.append("Use null em \"hypothesisId\" quando o público for geral do nicho.\n");
+        sb.append("Descreva cada público com interesses, comportamentos ou segmentações sugeridas em até três frases.\n");
+        sb.append("Nicho:\n");
+        appendField(sb, "Nome", niche.getName());
+        appendField(sb, "Descrição", niche.getDescription());
+        appendField(sb, "Segmentação base", niche.getBaseSegmentation());
+        appendField(sb, "Interesses", niche.getInterests());
+        appendField(sb, "Filtros demográficos", niche.getDemographicFilters());
+        appendField(sb, "Dicas extras", niche.getExtraTips());
+
+        if (!hypotheses.isEmpty()) {
+            sb.append("Hipóteses disponíveis com seus identificadores:\n");
+            for (Hypothesis h : hypotheses) {
+                sb.append("- ID: ").append(h.getId()).append(" | Título: ").append(truncate(h.getTitle(), 140)).append("\n");
+                appendIndentedField(sb, "Promessa", h.getPromise());
+                appendIndentedField(sb, "Persona", h.getPersona());
+                appendIndentedField(sb, "Mecanismo", h.getMechanism());
+                appendIndentedField(sb, "Mecanismo único", h.getUniqueMechanism());
+            }
+            sb.append("Use o campo hypothesisId com um dos IDs listados quando o público for específico de uma hipótese.\n");
+        } else {
+            sb.append("Não há hipóteses cadastradas. Gere públicos gerais do nicho e defina hypothesisId como null.\n");
+        }
+        sb.append("Retorne apenas um array JSON com os objetos, sem texto adicional.");
+        return new PromptData(sb.toString(), hypothesisIds);
+    }
+
+    private List<CreateAudienceRequest> parseContent(String content,
+                                                     MarketNiche niche,
+                                                     PromptData data,
+                                                     int quantity) throws Exception {
+        JsonNode root = objectMapper.readTree(content);
+        JsonNode array = root;
+        if (root.isObject()) {
+            if (root.has("audiences")) {
+                array = root.get("audiences");
+            } else if (root.has("items")) {
+                array = root.get("items");
+            }
+        }
+        if (!array.isArray()) {
+            throw new IllegalArgumentException("Expected JSON array with audiences");
+        }
+        List<CreateAudienceRequest> result = new ArrayList<>();
+        for (JsonNode node : array) {
+            CreateAudienceRequest req = new CreateAudienceRequest();
+            req.setName(asText(node, "name"));
+            req.setDescription(asText(node, "description"));
+            String hypothesisIdText = asText(node, "hypothesisId");
+            if (hypothesisIdText != null && !hypothesisIdText.isBlank() && !"null".equalsIgnoreCase(hypothesisIdText)) {
+                try {
+                    UUID hypothesisId = UUID.fromString(hypothesisIdText.trim());
+                    if (data.hypothesisIds().contains(hypothesisId)) {
+                        req.setHypothesisId(hypothesisId);
+                    } else {
+                        log.warn("Ignoring hypothesisId {} not linked to niche {}", hypothesisId, niche.getId());
+                    }
+                } catch (IllegalArgumentException e) {
+                    log.warn("Invalid hypothesisId '{}' for niche {}", hypothesisIdText, niche.getId());
+                }
+            }
+            req.setMarketNicheId(niche.getId());
+            req.setPrompt(data.prompt());
+            req.setModel(model);
+            result.add(req);
+            if (result.size() >= quantity) {
+                break;
+            }
+        }
+        return result;
+    }
+
+    private static String asText(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        return value.asText();
+    }
+
+    private static void appendField(StringBuilder sb, String label, String value) {
+        if (value != null && !value.isBlank()) {
+            sb.append(label).append(": ").append(truncate(value, 500)).append("\n");
+        }
+    }
+
+    private static void appendIndentedField(StringBuilder sb, String label, String value) {
+        if (value != null && !value.isBlank()) {
+            sb.append("  ").append(label).append(": ").append(truncate(value, 300)).append("\n");
+        }
+    }
+
+    private static String truncate(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() <= maxLength) {
+            return trimmed;
+        }
+        return trimmed.substring(0, maxLength);
+    }
+
+    private record ChatCompletionResponse(List<Choice> choices) {}
+    private record Choice(Message message) {}
+    private record Message(String content) {}
+    private record PromptData(String prompt, Set<UUID> hypothesisIds) {}
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/audience/NicheAudienceScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/audience/NicheAudienceScheduler.java
@@ -1,0 +1,29 @@
+package com.marketinghub.worker.audience;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduler que dispara a geração automática de públicos.
+ */
+@Component
+public class NicheAudienceScheduler {
+    private static final Logger log = LoggerFactory.getLogger(NicheAudienceScheduler.class);
+    private final NicheAudienceService service;
+
+    public NicheAudienceScheduler(NicheAudienceService service) {
+        this.service = service;
+    }
+
+    @Scheduled(cron = "0 */5 * * * *")
+    public void run() {
+        log.info("NicheAudienceScheduler started");
+        try {
+            service.generate();
+        } finally {
+            log.info("NicheAudienceScheduler finished");
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/audience/NicheAudienceService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/audience/NicheAudienceService.java
@@ -1,0 +1,92 @@
+package com.marketinghub.worker.audience;
+
+import com.marketinghub.audience.Audience;
+import com.marketinghub.audience.dto.CreateAudienceRequest;
+import com.marketinghub.audience.service.AudienceService;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Serviço responsável por acionar o ChatGPT e salvar públicos para nichos marcados.
+ */
+@Service
+public class NicheAudienceService {
+    private final MarketNicheRepository nicheRepository;
+    private final AudienceChatGptClient chatGptClient;
+    private final AudienceService audienceService;
+    private final HypothesisRepository hypothesisRepository;
+    private static final Logger log = LoggerFactory.getLogger(NicheAudienceService.class);
+
+    public NicheAudienceService(MarketNicheRepository nicheRepository,
+                                AudienceChatGptClient chatGptClient,
+                                AudienceService audienceService,
+                                HypothesisRepository hypothesisRepository) {
+        this.nicheRepository = nicheRepository;
+        this.chatGptClient = chatGptClient;
+        this.audienceService = audienceService;
+        this.hypothesisRepository = hypothesisRepository;
+    }
+
+    /**
+     * Gera públicos para todos os nichos com audiencesToGenerate &gt; 0.
+     *
+     * @return mapa com os públicos criados por nicho
+     */
+    public Map<Long, List<Audience>> generate() {
+        Map<Long, List<Audience>> result = new HashMap<>();
+        List<MarketNiche> niches = nicheRepository.findAllToGenerateAudiences();
+        for (MarketNiche niche : niches) {
+            Integer qty = niche.getAudiencesToGenerate();
+            if (qty == null || qty <= 0) {
+                log.info("Skipping niche {} because audiencesToGenerate={} is not positive", niche.getId(), qty);
+                niche.setAudiencesToGenerate(0);
+                nicheRepository.save(niche);
+                result.put(niche.getId(), Collections.emptyList());
+                continue;
+            }
+
+            log.info("Generating {} audiences for niche {}", qty, niche.getId());
+            List<Audience> savedAudiences = new ArrayList<>();
+            try {
+                List<Hypothesis> hypotheses = hypothesisRepository.findByMarketNicheId(niche.getId());
+                List<CreateAudienceRequest> requests = chatGptClient.generateAudiences(niche, hypotheses, qty);
+                log.info("ChatGPT returned {} audience candidates for niche {}", requests.size(), niche.getId());
+
+                for (CreateAudienceRequest req : requests) {
+                    if (req.getName() == null || req.getName().isBlank()) {
+                        log.warn("Skipping audience without name for niche {}: {}", niche.getId(), req);
+                        continue;
+                    }
+                    if (req.getMarketNicheId() == null) {
+                        req.setMarketNicheId(niche.getId());
+                    }
+                    try {
+                        Audience audience = audienceService.create(req);
+                        savedAudiences.add(audience);
+                    } catch (Exception e) {
+                        log.error("Failed to persist audience for niche {}: {}", niche.getId(), req, e);
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Unexpected error while generating audiences for niche {}", niche.getId(), e);
+            } finally {
+                log.info("Resetting audiencesToGenerate for niche {} to 0", niche.getId());
+                niche.setAudiencesToGenerate(0);
+                nicheRepository.save(niche);
+            }
+            result.put(niche.getId(), savedAudiences);
+        }
+        return result;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/Audience.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/Audience.java
@@ -32,6 +32,14 @@ public class Audience {
     @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String description;
 
+    /** Prompt utilizado para gerar o público via IA. */
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    private String prompt;
+
+    /** Modelo responsável pela criação automática. */
+    private String model;
+
     /** Associated market niche, if this is a generic audience. */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "market_niche_id")

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/dto/AudienceDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/dto/AudienceDto.java
@@ -16,4 +16,6 @@ public class AudienceDto {
     private String description;
     private Long marketNicheId;
     private UUID hypothesisId;
+    private String prompt;
+    private String model;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/dto/CreateAudienceRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/dto/CreateAudienceRequest.java
@@ -13,4 +13,6 @@ public class CreateAudienceRequest {
     private String description;
     private Long marketNicheId;
     private UUID hypothesisId;
+    private String prompt;
+    private String model;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/service/AudienceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/service/AudienceService.java
@@ -39,6 +39,8 @@ public class AudienceService {
         Audience audience = Audience.builder()
                 .name(request.getName())
                 .description(request.getDescription())
+                .prompt(request.getPrompt())
+                .model(request.getModel())
                 .niche(niche)
                 .hypothesis(hypothesis)
                 .build();

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/repository/MarketNicheRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/repository/MarketNicheRepository.java
@@ -22,4 +22,14 @@ public interface MarketNicheRepository extends JpaRepository<MarketNiche, Long> 
               and n.hypothesesToGenerate > 0
             """)
     List<MarketNiche> findAllToGenerateHypotheses();
+
+    /**
+     * Retrieves niches configured to generate audiences.
+     */
+    @Query("""
+            select n from MarketNiche n
+            where n.audiencesToGenerate is not null
+              and n.audiencesToGenerate > 0
+            """)
+    List<MarketNiche> findAllToGenerateAudiences();
 }

--- a/docs/ai-worker/README.md
+++ b/docs/ai-worker/README.md
@@ -32,6 +32,14 @@ de volta no serviço principal.
   `ChatGptClient` específico do domínio, valida os dados e zera o contador após salvar os registros.
 - **Referências:** documentação complementar em [nicho-hypotese-service.md](nicho-hypotese-service.md).
 
+### Nicho → Públicos
+- **Disparo:** `NicheAudienceScheduler` (cron `0 */5 * * * *`).
+- **Fonte dos dados:** nichos com `audiencesToGenerate > 0`.
+- **O que faz:** `NicheAudienceService` coleta informações do nicho e de suas hipóteses relacionadas,
+  envia o contexto para o `AudienceChatGptClient` gerar públicos via ChatGPT e persiste os registros
+  através do `AudienceService`, preenchendo os campos `model` e `prompt` exigidos pela plataforma.
+- **Referências:** detalhes adicionais em [nicho-publico-service.md](nicho-publico-service.md).
+
 ### Experimento → Criativos
 - **Disparo:** `ExperimentCreativeScheduler` (cron `0 */5 * * * *`).
 - **Fonte dos dados:** experimentos com `creativesToGenerate > 0`.
@@ -42,6 +50,6 @@ de volta no serviço principal.
 ## Perguntas frequentes
 
 ### Existe serviço para criar público?
-Ainda não. O campo `audiencesToGenerate` pode ser marcado via backend (ver
-`backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java`), mas o Worker
-não possui rotina que consuma esse valor para gerar públicos automaticamente.
+Sim. Basta solicitar públicos para um nicho (`audiencesToGenerate`) e aguardar a execução do
+`NicheAudienceScheduler`. O serviço usa ChatGPT para gerar os registros em `audience`, mantendo o
+histórico do `prompt` e do `model` utilizado.

--- a/docs/ai-worker/class-diagram.md
+++ b/docs/ai-worker/class-diagram.md
@@ -27,10 +27,15 @@ classDiagram
     class NicheHypothesisScheduler
     class ExperimentCreativeService
     class ExperimentCreativeScheduler
+    class NicheAudienceService
+    class NicheAudienceScheduler
+    class AudienceChatGptClient
 
     NicheHypothesisScheduler --> NicheHypothesisService
     ExperimentCreativeScheduler --> ExperimentCreativeService
     NicheHypothesisService --> NicheChatGptClient
     ExperimentCreativeService --> CreativeChatGptClient
     ExperimentCreativeService --> CreativeImageClient
+    NicheAudienceScheduler --> NicheAudienceService
+    NicheAudienceService --> AudienceChatGptClient
 ```

--- a/docs/ai-worker/nicho-publico-service.md
+++ b/docs/ai-worker/nicho-publico-service.md
@@ -1,0 +1,68 @@
+# AI Worker - Serviço NICHO para PÚBLICO
+
+Este documento descreve o serviço do AI Worker responsável por gerar **públicos**
+a partir de dados de **nicho** (e, quando disponíveis, de suas **hipóteses**).
+
+## Visão Geral
+
+O fluxo executado pelo `NicheAudienceService` segue os passos abaixo:
+
+1. Busca nichos com `audiencesToGenerate > 0` usando o `MarketNicheRepository`.
+2. Carrega as hipóteses do nicho para enriquecer o contexto enviado ao ChatGPT.
+3. Monta o prompt no `AudienceChatGptClient`, instruindo o modelo a informar `name`,
+   `description` e `hypothesisId` (quando o público estiver ligado a uma hipótese específica).
+4. Persiste cada público retornado através do `AudienceService`, preenchendo os
+   campos `prompt` e `model` exigidos para rastreabilidade.
+5. Zera o contador `audiencesToGenerate` do nicho para evitar duplicidades.
+
+## Diagrama de fluxo
+
+```mermaid
+flowchart LR
+    Nicho -->|dados + hipóteses| NicheAudienceService
+    NicheAudienceService -->|prompt| AudienceChatGptClient
+    AudienceChatGptClient -->|resposta JSON| NicheAudienceService
+    NicheAudienceService -->|CreateAudienceRequest| AudienceService
+    AudienceService -->|salva| Banco
+```
+
+## Execução do Serviço
+
+### Pré-requisitos
+- Java 21
+- Maven configurado com as variáveis `GITHUB_ACTOR` e `GITHUB_TOKEN`
+  para acessar os artefatos publicados no GitHub Packages
+- MySQL em execução conforme `application.properties`
+- Variável de ambiente `OPENAI_API_KEY` apontando para o token da API do OpenAI
+
+### Passos para executar
+
+1. Instale as dependências e compile o projeto:
+
+   ```bash
+   cd ai-worker
+   mvn -s settings.xml package
+   ```
+
+2. (Opcional) Execute os testes:
+
+   ```bash
+   mvn -s settings.xml test
+   ```
+
+3. Execute o worker:
+
+   ```bash
+   mvn spring-boot:run
+   ```
+
+   Para executar sem chamadas externas ao ChatGPT, utilize o perfil `dummy`:
+
+   ```bash
+   mvn spring-boot:run -Dspring.profiles.active=dummy
+   ```
+
+O worker agenda a tarefa `NicheAudienceScheduler` a cada cinco minutos (`0 */5 * * * *`).
+Quando encontrar nichos com `audiencesToGenerate > 0`, ele solicitará a criação de
+novos públicos, salvará os resultados (incluindo `prompt` e `model`) e registrará os
+logs no console.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -142,6 +142,8 @@ For a mapping between frontend screens and these entities, see [Frontend Screens
 - `id` BIGINT AUTO_INCREMENT PRIMARY KEY
 - `name` VARCHAR(255)
 - `description` LONGTEXT
+- `prompt` LONGTEXT
+- `model` VARCHAR(255)
 - `market_niche_id` BIGINT
 - `hypothesis_id` BINARY(16)
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/docs/html/data-model.html
+++ b/docs/html/data-model.html
@@ -121,6 +121,18 @@
 <li><code>created_at</code> TIMESTAMP DEFAULT CURRENT_TIMESTAMP</li>
 <li><code>updated_at</code> TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP</li>
 </ul>
+<h3>audience</h3>
+<ul>
+<li><code>id</code> BIGINT AUTO_INCREMENT PRIMARY KEY</li>
+<li><code>name</code> VARCHAR(255)</li>
+<li><code>description</code> LONGTEXT</li>
+<li><code>prompt</code> LONGTEXT</li>
+<li><code>model</code> VARCHAR(255)</li>
+<li><code>market_niche_id</code> BIGINT</li>
+<li><code>hypothesis_id</code> BINARY(16)</li>
+<li><code>created_at</code> TIMESTAMP DEFAULT CURRENT_TIMESTAMP</li>
+<li><code>updated_at</code> TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP</li>
+</ul>
 <h3>hypothesis</h3>
 <ul>
 <li><code>id</code> BINARY(16) PRIMARY KEY</li>

--- a/frontend/src/api/audience/useAudiencesByNiche.ts
+++ b/frontend/src/api/audience/useAudiencesByNiche.ts
@@ -7,6 +7,8 @@ export interface Audience {
   description: string;
   marketNicheId?: number;
   hypothesisId?: string;
+  prompt?: string;
+  model?: string;
 }
 
 export function useAudiencesByNiche(nicheId?: string) {

--- a/schema.sql
+++ b/schema.sql
@@ -139,6 +139,8 @@ CREATE TABLE audience (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255),
     description LONGTEXT,
+    prompt LONGTEXT,
+    model VARCHAR(255),
     market_niche_id BIGINT,
     hypothesis_id BINARY(16),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- add prompt/model metadata to the audience entity and creation flow
- implement ChatGPT-backed niche audience generation service and scheduler in the AI Worker
- document the new routine and expose metadata to the frontend type definitions

## Testing
- npm run build
- mvn -s ../settings.xml test *(fails: network unreachable for Spring Boot parent POM)*
- mvn -s settings.xml test *(fails: network unreachable for Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c9eb23585c8321846b444865a559a2