### PR TITLE
feat: display generated audiences on niche list

### DIFF
--- a/frontend/src/pages/niche/NicheListPage.tsx
+++ b/frontend/src/pages/niche/NicheListPage.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { useNiches } from "../../api/niche/useNiches";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
 import { useExperimentsByNiche } from "../../api/experiment/useExperimentsByNiche";
+import { useAudiencesByNiche } from "../../api/audience/useAudiencesByNiche";
 import PageTitle from "../../components/PageTitle";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 
@@ -27,6 +28,7 @@ export default function NicheListPage() {
             <thead>
               <tr>
                 <th>Nome</th>
+                <th>Públicos gerados</th>
                 <th>Hipóteses</th>
                 <th>Experimentos</th>
                 <th>Ações</th>
@@ -47,11 +49,13 @@ export default function NicheListPage() {
 function NicheRow({ niche }: { niche: { id: number; name: string } }) {
   const { data: hyps } = useHypothesesByNiche(String(niche.id), "ALL");
   const { data: exps } = useExperimentsByNiche(String(niche.id));
+  const { data: audiences } = useAudiencesByNiche(String(niche.id));
   return (
     <tr>
       <td>
         <Link to={`/niches/${niche.id}`}>{niche.name}</Link>
       </td>
+      <td>{Array.isArray(audiences) ? audiences.length : 0}</td>
       <td>{Array.isArray(hyps) ? hyps.length : 0}</td>
       <td>{Array.isArray(exps) ? exps.length : 0}</td>
       <td>


### PR DESCRIPTION
## Summary
- add audiences query to the niche list
- show generated audience count in the niches table

## Testing
- npm run test -- NicheListPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ca0773e77483218b18993db217a03b