### PR TITLE
feat: show related audiences on experiment detail

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -155,7 +155,12 @@ export default function ExperimentDetailPage() {
           </div>
         </Tabs.Content>
         <Tabs.Content value="audiences" asChild>
-          <PublicosTab />
+          <PublicosTab
+            nicheId={data.nicheId}
+            hypothesisId={data.hypothesisId}
+            nicheName={niche?.name}
+            hypothesisTitle={hyp?.title ?? data.hypothesis}
+          />
         </Tabs.Content>
         <Tabs.Content value="creatives" asChild>
           <CriativosTab experimentId={expId} />

--- a/frontend/src/pages/experiment/PublicosTab.tsx
+++ b/frontend/src/pages/experiment/PublicosTab.tsx
@@ -1,137 +1,146 @@
-import { useState } from "react";
-import { useForm } from "react-hook-form";
+import type { Audience } from "../../api/audience/useAudiencesByNiche";
+import { useAudiencesByNiche } from "../../api/audience/useAudiencesByNiche";
 
-interface AdSetForm {
-  geo: string;
-  minAge: number;
-  maxAge: number;
-  gender: string;
-  locale: string;
-  interests: string;
-  customAudiences: string;
-  lookalikeSource: string;
-  lookalikeCountry: string;
-  lookalikePercent: string;
-  placements: string;
+interface PublicosTabProps {
+  nicheId?: number;
+  hypothesisId?: string;
+  nicheName?: string | null;
+  hypothesisTitle?: string | null;
 }
 
-export default function PublicosTab() {
-  const { register, handleSubmit, reset } = useForm<AdSetForm>();
-  const [adSets, setAdSets] = useState<AdSetForm[]>([]);
-  const onSubmit = (data: AdSetForm) => {
-    setAdSets((a) => [...a, data]);
-    reset();
-  };
+export default function PublicosTab({
+  nicheId,
+  hypothesisId,
+  nicheName,
+  hypothesisTitle,
+}: PublicosTabProps) {
+  const nicheIdAsString = nicheId != null ? String(nicheId) : undefined;
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isError,
+  } = useAudiencesByNiche(nicheIdAsString);
+
+  if (nicheIdAsString == null || !hypothesisId) {
+    return (
+      <div className="mt-3">
+        <p className="text-muted">
+          Este experimento não possui nicho ou hipótese associados para exibir públicos.
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="mt-3">
+        <p>Carregando públicos...</p>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="mt-3">
+        <p className="text-danger">Não foi possível carregar os públicos relacionados.</p>
+      </div>
+    );
+  }
+
+  const list = Array.isArray(data) ? data : [];
+  const relatedToHypothesis = list.filter((a) => a.hypothesisId === hypothesisId);
+  const relatedToNiche = list.filter((a) => a.hypothesisId !== hypothesisId);
+  const updating = isFetching && !isLoading;
+
+  const hypothesisTitleSuffix = hypothesisTitle
+    ? ` “${hypothesisTitle}”`
+    : "";
+  const nicheTitleSuffix = nicheName ? ` “${nicheName}”` : "";
+
   return (
     <div className="mt-3">
-      <form>
-        <input
-          className="form-control mb-2"
-          placeholder="Geo (país/estado/cidade)"
-          {...register("geo")}
-        />
-        <div className="d-flex mb-2">
-          <input
-            type="number"
-            className="form-control me-2"
-            placeholder="Idade mínima"
-            {...register("minAge")}
-          />
-          <input
-            type="number"
-            className="form-control"
-            placeholder="Idade máxima"
-            {...register("maxAge")}
-          />
-        </div>
-        <input
-          className="form-control mb-2"
-          placeholder="Gênero"
-          {...register("gender")}
-        />
-        <input
-          className="form-control mb-2"
-          placeholder="Idioma/Locale"
-          {...register("locale")}
-        />
-        <textarea
-          className="form-control mb-2"
-          placeholder="Interesses/comportamentos"
-          {...register("interests")}
-        />
-        <textarea
-          className="form-control mb-2"
-          placeholder="Públicos personalizados e exclusões"
-          {...register("customAudiences")}
-        />
-        <div className="d-flex mb-2">
-          <input
-            className="form-control me-2"
-            placeholder="Fonte Lookalike"
-            {...register("lookalikeSource")}
-          />
-          <input
-            className="form-control me-2"
-            placeholder="País"
-            {...register("lookalikeCountry")}
-          />
-          <input
-            className="form-control"
-            placeholder="%"
-            {...register("lookalikePercent")}
-          />
-        </div>
-        <input
-          className="form-control mb-2"
-          placeholder="Placements"
-          {...register("placements")}
-        />
-        <button
-          type="button"
-          className="btn btn-primary"
-          onClick={handleSubmit(onSubmit, (errors) => {
-            console.log("Validation errors", errors);
-          })}
-        >
-          Salvar Público
-        </button>
-      </form>
-      {adSets.length > 0 && (
-        <div className="table-responsive mt-3">
-          <table className="table">
-            <thead>
-              <tr>
-                <th>Geo</th>
-                <th>Idade</th>
-                <th>Gênero</th>
-                <th>Locale</th>
-                <th>Interesses</th>
-                <th>Custom</th>
-                <th>Lookalike</th>
-                <th>Placements</th>
-              </tr>
-            </thead>
-            <tbody>
-              {adSets.map((a, idx) => (
-                <tr key={idx}>
-                  <td>{a.geo}</td>
-                  <td>
-                    {a.minAge}-{a.maxAge}
-                  </td>
-                  <td>{a.gender}</td>
-                  <td>{a.locale}</td>
-                  <td>{a.interests}</td>
-                  <td>{a.customAudiences}</td>
-                  <td>
-                    {a.lookalikeSource} {a.lookalikeCountry} {a.lookalikePercent}%
-                  </td>
-                  <td>{a.placements}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      {updating && (
+        <p className="text-muted small">Atualizando públicos...</p>
+      )}
+      <AudienceSection
+        title={`Públicos relacionados à hipótese${hypothesisTitleSuffix}`}
+        audiences={relatedToHypothesis}
+        emptyMessage="Nenhum público relacionado diretamente a esta hipótese."
+        badgeLabel="Hipótese"
+      />
+      <AudienceSection
+        title={`Públicos disponíveis no nicho${nicheTitleSuffix}`}
+        audiences={relatedToNiche}
+        emptyMessage="Nenhum outro público cadastrado para este nicho."
+        badgeLabel="Nicho"
+      />
+    </div>
+  );
+}
+
+function AudienceSection({
+  title,
+  audiences,
+  emptyMessage,
+  badgeLabel,
+}: {
+  title: string;
+  audiences: Audience[];
+  emptyMessage: string;
+  badgeLabel: string;
+}) {
+  return (
+    <section className="mb-4">
+      <div className="d-flex align-items-center mb-3">
+        <h5 className="mb-0">{title}</h5>
+        <span className="badge bg-secondary ms-2">{audiences.length}</span>
+      </div>
+      {audiences.length === 0 ? (
+        <p className="text-muted">{emptyMessage}</p>
+      ) : (
+        <div className="row row-cols-1 row-cols-md-2 g-4">
+          {audiences.map((audience) => (
+            <div key={audience.id} className="col">
+              <AudienceCard audience={audience} badgeLabel={badgeLabel} />
+            </div>
+          ))}
         </div>
       )}
+    </section>
+  );
+}
+
+function AudienceCard({
+  audience,
+  badgeLabel,
+}: {
+  audience: Audience;
+  badgeLabel: string;
+}) {
+  return (
+    <div className="card h-100 rounded-3">
+      <div className="card-body">
+        <div className="d-flex justify-content-between align-items-start">
+          <h5 className="card-title mb-0">{audience.name}</h5>
+          <span className="badge bg-primary-subtle text-primary-emphasis border border-primary-subtle">
+            {badgeLabel}
+          </span>
+        </div>
+        <p
+          className="card-text mt-2"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
+          {audience.description || "—"}
+        </p>
+        {audience.model && (
+          <p className="card-text">
+            <small className="text-muted">
+              Gerado pelo modelo {audience.model}
+            </small>
+          </p>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- fetch audiences for the experiment niche and split them between hypothesis and niche related lists
- surface context from the experiment when rendering the audiences tab and show loading/empty feedback
- highlight model information for each audience card to give more context to the user

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ca07eee680832199567af1ed5a35f3