### PR TITLE
Add ad set generation service to AI worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/adset/AdSetPlan.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/adset/AdSetPlan.java
@@ -1,0 +1,19 @@
+package com.marketinghub.worker.adset;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Represents a planned ad set returned by the ChatGPT client.
+ */
+public record AdSetPlan(
+        String location,
+        List<String> interests,
+        List<String> lookalikes,
+        BigDecimal budget,
+        Integer durationDays,
+        String targetingJson,
+        String prompt,
+        String model
+) {
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/adset/AudienceAdSetChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/adset/AudienceAdSetChatGptClient.java
@@ -1,0 +1,318 @@
+package com.marketinghub.worker.adset;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marketinghub.audience.Audience;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.niche.MarketNiche;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * ChatGPT client responsible for translating audience descriptions into
+ * structured ad set plans.
+ */
+@Component
+public class AudienceAdSetChatGptClient {
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+    private final String model;
+    private static final Logger log = LoggerFactory.getLogger(AudienceAdSetChatGptClient.class);
+    private static final Pattern NON_NUMERIC = Pattern.compile("[^0-9,.-]");
+
+    public AudienceAdSetChatGptClient(WebClient.Builder builder,
+                                      ObjectMapper objectMapper,
+                                      @Value("${openai.api-key:}") String apiKey,
+                                      @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
+                                      @Value("${openai.model:gpt-3.5-turbo}") String model) {
+        this.webClient = builder
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .build();
+        this.objectMapper = objectMapper;
+        this.model = model;
+    }
+
+    public AdSetPlan planAdSet(Experiment experiment, Audience audience) {
+        String prompt = buildPrompt(experiment, audience);
+        Map<String, Object> payload = Map.of(
+                "model", model,
+                "messages", List.of(
+                        Map.of("role", "system", "content", "Você é um especialista em mídia paga para Meta Ads."),
+                        Map.of("role", "user", "content", prompt)
+                )
+        );
+        log.info("Sending ad set planning prompt for experiment {} audience {}", experiment.getId(), audience.getId());
+        log.debug("Ad set planning payload: {}", payload);
+        ChatCompletionResponse response = webClient.post()
+                .uri("/chat/completions")
+                .bodyValue(payload)
+                .retrieve()
+                .bodyToMono(ChatCompletionResponse.class)
+                .block();
+        if (response == null || response.choices().isEmpty()) {
+            throw new IllegalStateException("ChatGPT returned no choices for ad set planning");
+        }
+        String content = response.choices().get(0).message().content();
+        log.info("ChatGPT ad set content: {}", content);
+        try {
+            return parseContent(content, prompt);
+        } catch (Exception e) {
+            log.error("Failed to parse ChatGPT ad set response: {}", content, e);
+            String unescaped = content.replace("\\\"", "\"");
+            try {
+                return parseContent(unescaped, prompt);
+            } catch (Exception ex) {
+                log.error("Failed to parse unescaped ChatGPT ad set response: {}", unescaped, ex);
+                throw new RuntimeException("Failed to parse ChatGPT ad set response", ex);
+            }
+        }
+    }
+
+    private AdSetPlan parseContent(String content, String prompt) throws Exception {
+        JsonNode root = objectMapper.readTree(content);
+        if (root.isArray() && root.size() > 0) {
+            root = root.get(0);
+        }
+        if (root.has("adSet")) {
+            root = root.get("adSet");
+        }
+        String location = asText(root, "location");
+        List<String> interests = asStringList(root.get("interests"));
+        List<String> lookalikes = asStringList(root.get("lookalikes"));
+        BigDecimal budget = asBigDecimal(root.get("budget"));
+        Integer durationDays = asInteger(root.get("durationDays"));
+        String targetingJson = extractTargeting(root.get("targeting"), location, interests, lookalikes);
+        return new AdSetPlan(location, interests, lookalikes, budget, durationDays, targetingJson, prompt, model);
+    }
+
+    private String extractTargeting(JsonNode targetingNode,
+                                    String location,
+                                    List<String> interests,
+                                    List<String> lookalikes) throws JsonProcessingException {
+        if (targetingNode != null && targetingNode.isObject()) {
+            return objectMapper.writeValueAsString(targetingNode);
+        }
+        ObjectNode targeting = objectMapper.createObjectNode();
+        ObjectNode geo = targeting.putObject("geo_locations");
+        ArrayNode customLocations = geo.putArray("custom_locations");
+        if (location != null && !location.isBlank()) {
+            ObjectNode entry = objectMapper.createObjectNode();
+            entry.put("name", location);
+            customLocations.add(entry);
+        }
+        ArrayNode interestArray = targeting.putArray("interests");
+        for (String interest : interests) {
+            ObjectNode item = objectMapper.createObjectNode();
+            item.put("name", interest);
+            interestArray.add(item);
+        }
+        ArrayNode lookalikeArray = targeting.putArray("custom_audiences");
+        for (String lookalike : lookalikes) {
+            ObjectNode item = objectMapper.createObjectNode();
+            item.put("name", lookalike);
+            lookalikeArray.add(item);
+        }
+        String description = buildDescription(location, interests, lookalikes);
+        if (description != null) {
+            targeting.put("detailed_targeting_description", description);
+        }
+        return objectMapper.writeValueAsString(targeting);
+    }
+
+    private static String buildDescription(String location, List<String> interests, List<String> lookalikes) {
+        StringBuilder sb = new StringBuilder();
+        if (location != null && !location.isBlank()) {
+            sb.append("Localização: ").append(location.trim());
+        }
+        if (!interests.isEmpty()) {
+            if (sb.length() > 0) {
+                sb.append(" | ");
+            }
+            sb.append("Interesses: ").append(String.join(", ", interests));
+        }
+        if (!lookalikes.isEmpty()) {
+            if (sb.length() > 0) {
+                sb.append(" | ");
+            }
+            sb.append("Públicos semelhantes: ").append(String.join(", ", lookalikes));
+        }
+        return sb.length() == 0 ? null : sb.toString();
+    }
+
+    private static BigDecimal asBigDecimal(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isNumber()) {
+            return node.decimalValue();
+        }
+        String text = node.asText(null);
+        if (text == null) {
+            return null;
+        }
+        String normalized = NON_NUMERIC.matcher(text).replaceAll("");
+        normalized = normalized.replace(',', '.');
+        if (normalized.isBlank()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(normalized);
+        } catch (NumberFormatException e) {
+            log.warn("Unable to parse budget value: {}", text, e);
+            return null;
+        }
+    }
+
+    private static Integer asInteger(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isInt()) {
+            return node.intValue();
+        }
+        if (node.isNumber()) {
+            return node.numberValue().intValue();
+        }
+        String text = node.asText(null);
+        if (text == null) {
+            return null;
+        }
+        String digits = text.replaceAll("[^0-9-]", "");
+        if (digits.isBlank()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(digits);
+        } catch (NumberFormatException e) {
+            log.warn("Unable to parse duration: {}", text, e);
+            return null;
+        }
+    }
+
+    private static List<String> asStringList(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return List.of();
+        }
+        List<String> values = new ArrayList<>();
+        if (node.isArray()) {
+            for (JsonNode element : node) {
+                String value = extractString(element);
+                if (value != null) {
+                    values.add(value);
+                }
+            }
+        } else {
+            String raw = node.asText(null);
+            if (raw != null) {
+                for (String part : raw.split("[,;\\n]")) {
+                    String trimmed = part.trim();
+                    if (!trimmed.isEmpty()) {
+                        values.add(trimmed);
+                    }
+                }
+            }
+        }
+        Set<String> unique = new LinkedHashSet<>();
+        for (String value : values) {
+            if (value != null) {
+                String trimmed = value.trim();
+                if (!trimmed.isEmpty()) {
+                    unique.add(trimmed);
+                }
+            }
+        }
+        return new ArrayList<>(unique);
+    }
+
+    private static String extractString(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        if (node.has("name")) {
+            return node.get("name").asText();
+        }
+        return node.toString();
+    }
+
+    private static String asText(JsonNode node, String field) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        String text = value.asText();
+        return text == null || text.isBlank() ? null : text.trim();
+    }
+
+    private String buildPrompt(Experiment experiment, Audience audience) {
+        MarketNiche niche = experiment.getNiche();
+        Hypothesis hypothesis = experiment.getHypothesisRef();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Planeje um conjunto de anúncios para Meta Ads usando os dados abaixo. ");
+        sb.append("Responda somente com um objeto JSON contendo as chaves ");
+        sb.append("location, interests, lookalikes, budget, durationDays e targeting.\n");
+        sb.append("Regras para o JSON:\n");
+        sb.append("- interests e lookalikes devem ser arrays de strings.\n");
+        sb.append("- budget deve ser um número decimal em reais (BRL), sem texto adicional.\n");
+        sb.append("- durationDays deve ser um número inteiro (quantidade de dias).\n");
+        sb.append("- targeting deve ser um objeto seguindo a estrutura padrão do Meta Ads, com as chaves:\n");
+        sb.append("  geo_locations, age_min, age_max, genders, languages, interests, custom_audiences, ");
+        sb.append("excluded_custom_audiences e detailed_targeting_description. Use arrays vazios quando não houver dados.\n");
+        sb.append("Contexto do experimento:\n");
+        appendField(sb, "Experimento", experiment.getName());
+        if (hypothesis != null) {
+            appendField(sb, "Hipótese", hypothesis.getTitle());
+            appendField(sb, "Promessa", hypothesis.getPromise());
+            appendField(sb, "Persona", hypothesis.getPersona());
+            appendField(sb, "Mecanismo", hypothesis.getMechanism());
+            appendField(sb, "Mecanismo único", hypothesis.getUniqueMechanism());
+        }
+        if (niche != null) {
+            appendField(sb, "Nicho", niche.getName());
+            appendField(sb, "Segmentação base", niche.getBaseSegmentation());
+            appendField(sb, "Interesses do nicho", niche.getInterests());
+            appendField(sb, "Filtros demográficos", niche.getDemographicFilters());
+            appendField(sb, "Dicas extras", niche.getExtraTips());
+        }
+        sb.append("Público a ser segmentado:\n");
+        appendField(sb, "Nome do público", audience.getName());
+        appendField(sb, "Descrição do público", audience.getDescription());
+        sb.append("Considere que a campanha usará dados do Brasil quando não houver indicação explícita.\n");
+        sb.append("Retorne apenas o JSON solicitado.");
+        return sb.toString();
+    }
+
+    private static void appendField(StringBuilder sb, String label, String value) {
+        if (value != null && !value.isBlank()) {
+            sb.append(label).append(": ").append(value.trim()).append('\n');
+        }
+    }
+
+    private record ChatCompletionResponse(List<Choice> choices) {}
+
+    private record Choice(Message message) {}
+
+    private record Message(String content) {}
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/adset/AudienceAdSetScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/adset/AudienceAdSetScheduler.java
@@ -1,0 +1,29 @@
+package com.marketinghub.worker.adset;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduler that periodically generates ad sets from approved audiences.
+ */
+@Component
+public class AudienceAdSetScheduler {
+    private static final Logger log = LoggerFactory.getLogger(AudienceAdSetScheduler.class);
+    private final AudienceAdSetService service;
+
+    public AudienceAdSetScheduler(AudienceAdSetService service) {
+        this.service = service;
+    }
+
+    @Scheduled(cron = "0 */5 * * * *")
+    public void run() {
+        log.info("AudienceAdSetScheduler started");
+        try {
+            service.generate();
+        } finally {
+            log.info("AudienceAdSetScheduler finished");
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/adset/AudienceAdSetService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/adset/AudienceAdSetService.java
@@ -1,0 +1,120 @@
+package com.marketinghub.worker.adset;
+
+import com.marketinghub.audience.Audience;
+import com.marketinghub.audience.repository.AudienceRepository;
+import com.marketinghub.experiment.AdSet;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentPlatform;
+import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.experiment.dto.CreateAdSetRequest;
+import com.marketinghub.experiment.repository.AdSetRepository;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.experiment.service.AdSetService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Service responsible for creating ad set records from approved audiences.
+ */
+@Service
+public class AudienceAdSetService {
+    private static final Logger log = LoggerFactory.getLogger(AudienceAdSetService.class);
+    private final ExperimentRepository experimentRepository;
+    private final AudienceRepository audienceRepository;
+    private final AdSetRepository adSetRepository;
+    private final AdSetService adSetService;
+    private final AudienceAdSetChatGptClient chatGptClient;
+
+    public AudienceAdSetService(ExperimentRepository experimentRepository,
+                                AudienceRepository audienceRepository,
+                                AdSetRepository adSetRepository,
+                                AdSetService adSetService,
+                                AudienceAdSetChatGptClient chatGptClient) {
+        this.experimentRepository = experimentRepository;
+        this.audienceRepository = audienceRepository;
+        this.adSetRepository = adSetRepository;
+        this.adSetService = adSetService;
+        this.chatGptClient = chatGptClient;
+    }
+
+    /**
+     * Generates ad sets for experiments whose audiences were approved by the user.
+     *
+     * @return map keyed by experiment id listing the persisted ad sets
+     */
+    public Map<Long, List<AdSet>> generate() {
+        Map<Long, List<AdSet>> result = new HashMap<>();
+        List<Experiment> experiments = experimentRepository.findAllReadyForAdSets(
+                ExperimentPlatform.FACEBOOK,
+                List.of(ExperimentStatus.PLANNED, ExperimentStatus.RUNNING, ExperimentStatus.PAUSED)
+        );
+        for (Experiment experiment : experiments) {
+            long existing = adSetRepository.countByExperimentId(experiment.getId());
+            if (existing > 0) {
+                log.info("Skipping experiment {} because ad sets already exist", experiment.getId());
+                result.put(experiment.getId(), Collections.emptyList());
+                continue;
+            }
+            List<Audience> audiences = audienceRepository.findDetailedByNicheId(experiment.getNiche().getId());
+            List<Audience> relevantAudiences = filterAudiencesForExperiment(audiences, experiment);
+            if (relevantAudiences.isEmpty()) {
+                log.warn("No audiences found for experiment {} to generate ad sets", experiment.getId());
+                result.put(experiment.getId(), Collections.emptyList());
+                continue;
+            }
+            List<AdSet> saved = new ArrayList<>();
+            for (Audience audience : relevantAudiences) {
+                try {
+                    AdSetPlan plan = chatGptClient.planAdSet(experiment, audience);
+                    CreateAdSetRequest request = new CreateAdSetRequest();
+                    request.setExperimentId(experiment.getId());
+                    request.setLocation(plan.location());
+                    request.setInterests(join(plan.interests()));
+                    request.setLookalikes(join(plan.lookalikes()));
+                    request.setTargetingJson(plan.targetingJson());
+                    request.setBudget(plan.budget());
+                    request.setDurationDays(plan.durationDays());
+                    request.setPrompt(plan.prompt());
+                    request.setModel(plan.model());
+                    AdSet adSet = adSetService.create(request);
+                    saved.add(adSet);
+                } catch (Exception e) {
+                    log.error("Failed to create ad set for experiment {} audience {}", experiment.getId(), audience.getId(), e);
+                }
+            }
+            result.put(experiment.getId(), saved);
+        }
+        return result;
+    }
+
+    private static List<Audience> filterAudiencesForExperiment(List<Audience> audiences, Experiment experiment) {
+        if (audiences.isEmpty()) {
+            return List.of();
+        }
+        UUID hypothesisId = experiment.getHypothesisRef() != null ? experiment.getHypothesisRef().getId() : null;
+        List<Audience> filtered = new ArrayList<>();
+        for (Audience audience : audiences) {
+            if (audience.getHypothesis() == null) {
+                filtered.add(audience);
+            } else if (hypothesisId != null && hypothesisId.equals(audience.getHypothesis().getId())) {
+                filtered.add(audience);
+            }
+        }
+        return filtered;
+    }
+
+    private static String join(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        return String.join("\n", values);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/audience/repository/AudienceRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/audience/repository/AudienceRepository.java
@@ -1,7 +1,9 @@
 package com.marketinghub.audience.repository;
 
 import com.marketinghub.audience.Audience;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 /**
@@ -9,4 +11,11 @@ import java.util.List;
  */
 public interface AudienceRepository extends CrudRepository<Audience, Long> {
     List<Audience> findByNicheId(Long nicheId);
+
+    @Query("""
+            select a from Audience a
+            left join fetch a.hypothesis
+            where a.niche.id = :nicheId
+            """)
+    List<Audience> findDetailedByNicheId(@Param("nicheId") Long nicheId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/AdSet.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/AdSet.java
@@ -3,7 +3,9 @@ package com.marketinghub.experiment;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
 
 import java.time.Instant;
 
@@ -27,13 +29,25 @@ public class AdSet {
     private String location;
 
     @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String interests;
 
     @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
     private String lookalikes;
+
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    private String targetingJson;
 
     private java.math.BigDecimal budget;
     private Integer durationDays;
+
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    private String prompt;
+
+    private String model;
 
     @CreationTimestamp
     private Instant createdAt;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/AdSetDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/AdSetDto.java
@@ -14,8 +14,11 @@ public class AdSetDto {
     private String location;
     private String interests;
     private String lookalikes;
+    private String targetingJson;
     private BigDecimal budget;
     private Integer durationDays;
+    private String prompt;
+    private String model;
     private Instant createdAt;
     private Instant updatedAt;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateAdSetRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateAdSetRequest.java
@@ -12,6 +12,9 @@ public class CreateAdSetRequest {
     private String location;
     private String interests;
     private String lookalikes;
+    private String targetingJson;
     private BigDecimal budget;
     private Integer durationDays;
+    private String prompt;
+    private String model;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/AdSetRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/AdSetRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 /**
  * Repository for ad sets.
  */
-public interface AdSetRepository extends JpaRepository<AdSet, Long> {}
+public interface AdSetRepository extends JpaRepository<AdSet, Long> {
+    long countByExperimentId(Long experimentId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -6,6 +6,7 @@ import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.niche.MarketNiche;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,4 +35,15 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
               and e.creativesToGenerate > 0
             """)
     List<Experiment> findAllToGenerateCreatives();
+
+    @Query("""
+            select distinct e from Experiment e
+            join fetch e.niche n
+            join fetch e.hypothesisRef h
+            where e.audienceApproved = true
+              and e.platform = :platform
+              and e.status in :statuses
+            """)
+    List<Experiment> findAllReadyForAdSets(@Param("platform") ExperimentPlatform platform,
+                                           @Param("statuses") List<ExperimentStatus> statuses);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/AdSetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/AdSetService.java
@@ -36,8 +36,11 @@ public class AdSetService {
                 .location(request.getLocation())
                 .interests(request.getInterests())
                 .lookalikes(request.getLookalikes())
+                .targetingJson(request.getTargetingJson())
                 .budget(request.getBudget())
                 .durationDays(request.getDurationDays())
+                .prompt(request.getPrompt())
+                .model(request.getModel())
                 .build();
         return repository.save(adSet);
     }

--- a/docs/ai-worker/README.md
+++ b/docs/ai-worker/README.md
@@ -47,6 +47,14 @@ de volta no serviço principal.
   `CreativeImageClient` para sugerir imagens, salvando os criativos com `CreativeService`.
 - **Referências:** detalhes e fluxo em [experimento-criativo-service.md](experimento-criativo-service.md).
 
+### Experimento → Conjuntos de anúncios
+- **Disparo:** `AudienceAdSetScheduler` (cron `0 */5 * * * *`).
+- **Fonte dos dados:** experimentos aprovados para Facebook com `audienceApproved = true` e sem ad sets já cadastrados.
+- **O que faz:** `AudienceAdSetService` coleta os públicos do nicho e da hipótese relacionados ao experimento,
+  envia o contexto para o `AudienceAdSetChatGptClient` estruturar localização, interesses, lookalikes e `targetingJson`,
+  e persiste os registros via `AdSetService` preenchendo também `prompt` e `model`.
+- **Referências:** documentação complementar em [experimento-adset-service.md](experimento-adset-service.md).
+
 ## Perguntas frequentes
 
 ### Existe serviço para criar público?

--- a/docs/ai-worker/class-diagram.md
+++ b/docs/ai-worker/class-diagram.md
@@ -30,6 +30,9 @@ classDiagram
     class NicheAudienceService
     class NicheAudienceScheduler
     class AudienceChatGptClient
+    class AudienceAdSetService
+    class AudienceAdSetScheduler
+    class AudienceAdSetChatGptClient
 
     NicheHypothesisScheduler --> NicheHypothesisService
     ExperimentCreativeScheduler --> ExperimentCreativeService
@@ -38,4 +41,6 @@ classDiagram
     ExperimentCreativeService --> CreativeImageClient
     NicheAudienceScheduler --> NicheAudienceService
     NicheAudienceService --> AudienceChatGptClient
+    AudienceAdSetScheduler --> AudienceAdSetService
+    AudienceAdSetService --> AudienceAdSetChatGptClient
 ```

--- a/docs/ai-worker/experimento-adset-service.md
+++ b/docs/ai-worker/experimento-adset-service.md
@@ -1,0 +1,70 @@
+# AI Worker - Serviço EXPERIMENTO para CONJUNTO DE ANÚNCIOS
+
+Este documento descreve o serviço do AI Worker responsável por transformar
+públicos aprovados em **conjuntos de anúncios** no nível de planejamento do
+experimento.
+
+## Visão Geral
+
+O `AudienceAdSetService` executa o fluxo abaixo:
+
+1. Busca experimentos na plataforma Facebook com `audienceApproved = true` e
+   sem registros prévios na tabela `ad_set`.
+2. Carrega os públicos do nicho relacionados ao experimento, priorizando os que
+   pertencem à hipótese associada.
+3. Envia cada público para o `AudienceAdSetChatGptClient`, que estrutura
+   localização, interesses, lookalikes, orçamento sugerido, duração e um objeto
+   `targetingJson` compatível com o Meta Ads.
+4. Persiste o resultado via `AdSetService.create`, preenchendo também os campos
+   `prompt` e `model` exigidos pela governança de IA.
+
+## Diagrama de fluxo
+
+```mermaid
+flowchart LR
+    Experiment -->|dados aprovados| AudienceAdSetService
+    Audience -->|nome + descrição| AudienceAdSetService
+    AudienceAdSetService -->|prompt| AudienceAdSetChatGptClient
+    AudienceAdSetChatGptClient -->|JSON estruturado| AudienceAdSetService
+    AudienceAdSetService -->|CreateAdSetRequest| AdSetService
+    AdSetService -->|salva em ad_set| Banco
+```
+
+## Execução do Serviço
+
+### Pré-requisitos
+- Java 21
+- Maven configurado com `GITHUB_ACTOR` e `GITHUB_TOKEN` para baixar o artefato
+  `ads-service`
+- MySQL compatível com o schema do backend
+- Variável `OPENAI_API_KEY` com o token da API da OpenAI (opcionalmente
+  `OPENAI_BASE_URL` e `OPENAI_MODEL` para personalização)
+
+### Passos para executar
+
+1. Instale as dependências e compile o projeto:
+
+   ```bash
+   cd ai-worker
+   mvn -s settings.xml package
+   ```
+
+2. (Opcional) Execute os testes:
+
+   ```bash
+   mvn -s settings.xml test
+   ```
+
+3. Execute o worker:
+
+   ```bash
+   mvn spring-boot:run
+   ```
+
+   Utilize `-Dspring.profiles.active=dummy` para executar sem chamadas externas
+   à OpenAI.
+
+O agendamento `AudienceAdSetScheduler` roda a cada cinco minutos (`0 */5 * * * *`).
+Quando encontra experimentos elegíveis, gera os conjuntos de anúncios e registra
+os campos `location`, `interests`, `lookalikes`, `targetingJson`, `budget`,
+`durationDays`, `prompt` e `model` em `ad_set`.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -214,8 +214,11 @@ allow variants to be created before an experiment is defined.
 - `location` VARCHAR(255)
 - `interests` LONGTEXT
 - `lookalikes` LONGTEXT
+- `targeting_json` LONGTEXT
 - `budget` DECIMAL(10,2)
 - `duration_days` INT
+- `prompt` LONGTEXT
+- `model` VARCHAR(255)
 - `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 - `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 

--- a/docs/html/data-model.html
+++ b/docs/html/data-model.html
@@ -208,8 +208,11 @@ allow variants to be created before an experiment is defined.</p>
 <li><code>location</code> VARCHAR(255)</li>
 <li><code>interests</code> LONGTEXT</li>
 <li><code>lookalikes</code> LONGTEXT</li>
+<li><code>targeting_json</code> LONGTEXT</li>
 <li><code>budget</code> DECIMAL(10,2)</li>
 <li><code>duration_days</code> INT</li>
+<li><code>prompt</code> LONGTEXT</li>
+<li><code>model</code> VARCHAR(255)</li>
 <li><code>created_at</code> TIMESTAMP DEFAULT CURRENT_TIMESTAMP</li>
 <li><code>updated_at</code> TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP</li>
 </ul>

--- a/schema.sql
+++ b/schema.sql
@@ -179,8 +179,11 @@ CREATE TABLE ad_set (
     location VARCHAR(255),
     interests LONGTEXT,
     lookalikes LONGTEXT,
+    targeting_json LONGTEXT,
     budget DECIMAL(10,2),
     duration_days INT,
+    prompt LONGTEXT,
+    model VARCHAR(255),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- extend the ad set model to persist targeting JSON and IA traceability fields
- implement an AI Worker scheduler, service and ChatGPT client that convert approved audiences into ad set records
- document the new workflow and update the data model references

## Testing
- `mvn -s ../settings.xml test` *(fails: non-resolvable parent POM because https://maven.pkg.github.com is unreachable in the sandbox)*
- `mvn -s settings.xml test` *(fails: non-resolvable parent POM because https://maven.pkg.github.com is unreachable in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cac4410d5c83219986eec348f49e5c