### PR TITLE
Add audience approval toggle for experiments

### DIFF
--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -22,6 +22,8 @@ export interface Experiment {
   endDate: string | null;
   metricPresetId?: string | null;
   creativesToGenerate?: number | null;
+  audienceApproved: boolean;
+  creativeApproved: boolean;
   status: string;
   platform: string;
   createdAt: string;

--- a/frontend/src/api/experiment/useUpdateExperiment.ts
+++ b/frontend/src/api/experiment/useUpdateExperiment.ts
@@ -13,6 +13,7 @@ export interface UpdateExperiment {
   endDate?: string;
   creativesToGenerate?: number;
   salesFunnelName?: string | null;
+  audienceApproved?: boolean;
 }
 
 export function useUpdateExperiment(id: string) {

--- a/frontend/src/pages/experiment/EditExperimentPage.tsx
+++ b/frontend/src/pages/experiment/EditExperimentPage.tsx
@@ -12,6 +12,7 @@ interface FormData {
   kpiTarget: string;
   metricPresetId: string;
   salesFunnelName: string;
+  audienceApproved: boolean;
 }
 
 export default function EditExperimentPage() {
@@ -22,7 +23,9 @@ export default function EditExperimentPage() {
   const { data: presets } = useMetricPresets();
   const { data: funnels } = useFunnels();
   const update = useUpdateExperiment(expId);
-  const { register, handleSubmit, reset } = useForm<FormData>();
+  const { register, handleSubmit, reset } = useForm<FormData>({
+    defaultValues: { audienceApproved: false },
+  });
 
   useEffect(() => {
     if (data) {
@@ -31,6 +34,7 @@ export default function EditExperimentPage() {
         kpiTarget: data.kpiTarget ? String(data.kpiTarget) : "",
         metricPresetId: data.metricPresetId || "",
         salesFunnelName: data.salesFunnelName || "",
+        audienceApproved: data.audienceApproved,
       });
     }
   }, [data, reset]);
@@ -48,6 +52,7 @@ export default function EditExperimentPage() {
         startDate: data.startDate ?? undefined,
         endDate: data.endDate ?? undefined,
         salesFunnelName: values.salesFunnelName,
+        audienceApproved: values.audienceApproved,
       });
       navigate(-1);
     } catch {
@@ -108,6 +113,21 @@ export default function EditExperimentPage() {
               </option>
             ))}
         </select>
+        <div className="form-check form-switch mb-3">
+          <input
+            id="audienceApproved"
+            type="checkbox"
+            className="form-check-input"
+            {...register("audienceApproved")}
+            title="Quando ativado, o Worker IA criará conjuntos de anúncios com os públicos aprovados."
+          />
+          <label className="form-check-label" htmlFor="audienceApproved">
+            Aprovar públicos para mídia
+          </label>
+          <div className="form-text">
+            Marque após revisar os públicos gerados e autorizar o uso em campanhas.
+          </div>
+        </div>
         <div className="mt-3 d-flex justify-content-end">
           <button
             type="button"

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -88,6 +88,10 @@ export default function ExperimentDetailPage() {
     },
     { label: "Criativos a gerar", value: data.creativesToGenerate ?? "—" },
     {
+      label: "Públicos aprovados",
+      value: data.audienceApproved ? "Sim" : "Não",
+    },
+    {
       label: "MDE (p.p.)",
       value: data.mdePercent ?? preset?.defaultMdePp ?? "—",
     },


### PR DESCRIPTION
## Summary
- expose the audience approval status in experiment details and editing
- add a switch with tooltip so operators can approve audiences for worker processing
- extend experiment update payloads to send the approval flag

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cae0e6f2a88321839e93f24a1b9714