### PR TITLE
Prevent Hibernate from altering Facebook Ads CHAR identifiers

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAd.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAd.java
@@ -16,21 +16,21 @@ import java.time.Instant;
 @NoArgsConstructor
 public class FacebookAdsAd {
     @Id
-    @Column(length = 36)
+    @Column(length = 36, columnDefinition = "CHAR(36)")
     private String id;
 
     @Column(name = "external_id")
     private String externalId;
 
     @ManyToOne
-    @JoinColumn(name = "adset_id", nullable = false)
+    @JoinColumn(name = "adset_id", nullable = false, columnDefinition = "CHAR(36)")
     private FacebookAdsAdSet adSet;
 
     @Column(nullable = false)
     private String name;
 
     @ManyToOne
-    @JoinColumn(name = "creative_id", nullable = false)
+    @JoinColumn(name = "creative_id", nullable = false, columnDefinition = "CHAR(36)")
     private FacebookAdsAdCreative creative;
 
     @Enumerated(EnumType.STRING)

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdCreative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdCreative.java
@@ -16,7 +16,7 @@ import java.time.Instant;
 @NoArgsConstructor
 public class FacebookAdsAdCreative {
     @Id
-    @Column(length = 36)
+    @Column(length = 36, columnDefinition = "CHAR(36)")
     private String id;
 
     @Column(name = "external_id")

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdSet.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdSet.java
@@ -17,14 +17,14 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class FacebookAdsAdSet {
     @Id
-    @Column(length = 36)
+    @Column(length = 36, columnDefinition = "CHAR(36)")
     private String id;
 
     @Column(name = "external_id")
     private String externalId;
 
     @ManyToOne
-    @JoinColumn(name = "campaign_id", nullable = false)
+    @JoinColumn(name = "campaign_id", nullable = false, columnDefinition = "CHAR(36)")
     private FacebookAdsCampaign campaign;
 
     @Column(nullable = false)

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdTrackingUtm.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsAdTrackingUtm.java
@@ -12,12 +12,12 @@ import lombok.Setter;
 @NoArgsConstructor
 public class FacebookAdsAdTrackingUtm {
     @Id
-    @Column(name = "ad_id", length = 36)
+    @Column(name = "ad_id", length = 36, columnDefinition = "CHAR(36)")
     private String adId;
 
     @OneToOne
     @MapsId
-    @JoinColumn(name = "ad_id")
+    @JoinColumn(name = "ad_id", columnDefinition = "CHAR(36)")
     private FacebookAdsAd ad;
 
     @Column(name = "utm_source")

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsCampaign.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsCampaign.java
@@ -18,7 +18,7 @@ import java.util.Set;
 @NoArgsConstructor
 public class FacebookAdsCampaign {
     @Id
-    @Column(length = 36)
+    @Column(length = 36, columnDefinition = "CHAR(36)")
     private String id;
 
     @Column(name = "external_id")
@@ -51,13 +51,19 @@ public class FacebookAdsCampaign {
     private String apiVersion;
 
     @ElementCollection(targetClass = SpecialAdCategory.class)
-    @CollectionTable(name = "facebook_ads_campaign_special_ad_category", joinColumns = @JoinColumn(name = "campaign_id"))
+    @CollectionTable(
+            name = "facebook_ads_campaign_special_ad_category",
+            joinColumns = @JoinColumn(name = "campaign_id", columnDefinition = "CHAR(36)")
+    )
     @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false)
     private Set<SpecialAdCategory> specialAdCategories = new HashSet<>();
 
     @ElementCollection
-    @CollectionTable(name = "facebook_ads_campaign_special_ad_country", joinColumns = @JoinColumn(name = "campaign_id"))
+    @CollectionTable(
+            name = "facebook_ads_campaign_special_ad_country",
+            joinColumns = @JoinColumn(name = "campaign_id", columnDefinition = "CHAR(36)")
+    )
     @Column(name = "country_iso2", length = 2, nullable = false)
     private Set<String> specialAdCountries = new HashSet<>();
 

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsMediaAsset.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsMediaAsset.java
@@ -15,7 +15,7 @@ import java.time.Instant;
 @NoArgsConstructor
 public class FacebookAdsMediaAsset {
     @Id
-    @Column(length = 36)
+    @Column(length = 36, columnDefinition = "CHAR(36)")
     private String id;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## Summary
- ensure all Facebook Ads entity identifiers map to CHAR(36) so Hibernate matches the Liquibase schema
- update join and collection columns to keep CHAR(36) foreign keys and avoid unintended DDL changes

## Testing
- mvn -s ../settings.xml test *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cae742a10c8321ae8eb9c482ff5be9