### PR TITLE
Fix ExperimentControllerTest database cleanup order

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.audience.repository.AudienceRepository;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.repository.ExperimentRepository;
@@ -63,6 +64,8 @@ class ExperimentControllerTest {
     private FixtureUtils fixtures;
     @Autowired
     private SalesFunnelRepository salesFunnelRepository;
+    @Autowired
+    private AudienceRepository audienceRepository;
 
     Long nicheId;
 
@@ -71,6 +74,7 @@ class ExperimentControllerTest {
         creativeRepo.deleteAll();
         repository.deleteAll();
         salesFunnelRepository.deleteAll();
+        audienceRepository.deleteAll();
         hypothesisRepository.deleteAll();
         angleRepository.deleteAll();
         nicheRepo.deleteAll();


### PR DESCRIPTION
## Summary
- autowire the AudienceRepository in ExperimentControllerTest and delete all audiences before hypotheses
- prevent foreign key violations during database cleanup in integration tests

## Testing
- `mvn -s ../settings.xml test` *(fails: unable to resolve parent POM because https://maven.pkg.github.com/paulofor/marketing-hub is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb092ccaa483218f334f06702f1fd6