### PR TITLE
Handle null audiences when generating ad sets

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/adset/AudienceAdSetService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/adset/AudienceAdSetService.java
@@ -70,6 +70,15 @@ public class AudienceAdSetService {
             }
             List<AdSetDto> saved = new ArrayList<>();
             for (Audience audience : audiences) {
+                if (audience == null) {
+                    log.warn("Skipping null audience entry for experiment {}", experimentId);
+                    continue;
+                }
+                Long audienceId = audience.getId();
+                if (audienceId == null) {
+                    log.warn("Skipping audience without identifier for experiment {}", experimentId);
+                    continue;
+                }
                 try {
                     AdSetPlan plan = chatGptClient.planAdSet(experiment, audience);
                     CreateAdSetRequest request = new CreateAdSetRequest();
@@ -86,12 +95,12 @@ public class AudienceAdSetService {
                     if (adSet != null) {
                         saved.add(adSet);
                     } else {
-                        log.warn("Backend returned null ad set for experiment {} audience {}", experimentId, audience.getId());
+                        log.warn("Backend returned null ad set for experiment {} audience {}", experimentId, audienceId);
                     }
                 } catch (BackendClientException e) {
-                    log.error("Backend rejected ad set for experiment {} audience {}: {}", experimentId, audience.getId(), e.getMessage());
+                    log.error("Backend rejected ad set for experiment {} audience {}: {}", experimentId, audienceId, e.getMessage());
                 } catch (Exception e) {
-                    log.error("Failed to create ad set for experiment {} audience {}", experimentId, audience.getId(), e);
+                    log.error("Failed to create ad set for experiment {} audience {}", experimentId, audienceId, e);
                 }
             }
             result.put(experimentId, saved);


### PR DESCRIPTION
## Summary
- skip null or identifier-less audiences when generating ad sets to avoid passing invalid data to the ChatGPT planner
- reuse the captured audience identifier when logging backend failures

## Testing
- `mvn -s settings.xml -Dtest=AudienceAdSetServiceTest test` *(fails: Network is unreachable while downloading org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2b52b14c8321b49a3b837eb2206a