### PR TITLE
Handle null audiences when building ad set context

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/adset/BackendExperimentClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/adset/BackendExperimentClient.java
@@ -184,6 +184,15 @@ public class BackendExperimentClient {
         UUID hypothesisId = hypothesis != null ? hypothesis.getId() : null;
         List<Audience> result = new ArrayList<>();
         for (AudienceDto dto : dtos) {
+            if (dto == null) {
+                log.warn("Backend returned null audience entry when listing experiment audiences");
+                continue;
+            }
+            Long dtoId = dto.getId();
+            if (dtoId == null) {
+                log.warn("Skipping audience without identifier when listing experiment audiences");
+                continue;
+            }
             if (!dto.isApproved()) {
                 continue;
             }
@@ -192,7 +201,7 @@ public class BackendExperimentClient {
                 continue;
             }
             Audience audience = new Audience();
-            audience.setId(dto.getId());
+            audience.setId(dtoId);
             audience.setName(dto.getName());
             audience.setDescription(dto.getDescription());
             audience.setPrompt(dto.getPrompt());


### PR DESCRIPTION
## Summary
- guard against null or identifier-less audience payload entries when mapping ready experiments
- log skipped audience entries before building the audience model used by the ad-set generator

## Testing
- unable to run `mvn -s settings.xml test` (fails to resolve spring-boot-starter-parent from the configured GitHub repository in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb30a92e748321b3f9d4422b394278