### PR TITLE
Fix Mockito matchers in audience ad set service test

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/adset/AudienceAdSetServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/adset/AudienceAdSetServiceTest.java
@@ -128,9 +128,13 @@ class AudienceAdSetServiceTest {
                         """)
                 .setHeader("Content-Type", "application/json"));
 
-        when(chatGptClient.planAdSet(org.mockito.Mockito.any(), org.mockito.Mockito.argThat(a -> a.getId().equals(1L))))
+        when(chatGptClient.planAdSet(
+                        org.mockito.Mockito.any(),
+                        org.mockito.Mockito.argThat(a -> a != null && a.getId().equals(1L))))
                 .thenReturn(new AdSetPlan("BR", List.of("Interest"), List.of(), BigDecimal.TEN, 7, "{}", "prompt1", "gpt-4"));
-        when(chatGptClient.planAdSet(org.mockito.Mockito.any(), org.mockito.Mockito.argThat(a -> a.getId().equals(3L))))
+        when(chatGptClient.planAdSet(
+                        org.mockito.Mockito.any(),
+                        org.mockito.Mockito.argThat(a -> a != null && a.getId().equals(3L))))
                 .thenReturn(new AdSetPlan("US", List.of("Another"), List.of("Look"), BigDecimal.valueOf(5), 5,
                         "{\"key\":\"value\"}", "prompt2", "gpt-4"));
 


### PR DESCRIPTION
## Summary
- guard the mock argument matchers in AudienceAdSetServiceTest against null values so stubbing no longer throws a NullPointerException when the test runs

## Testing
- mvn -s settings.xml -q -Dtest=AudienceAdSetServiceTest test *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cb30a92e748321b3f9d4422b394278