### PR TITLE
Log backend requests from AI worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/adset/BackendExperimentClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/adset/BackendExperimentClient.java
@@ -43,7 +43,7 @@ public class BackendExperimentClient {
                                    @Value("${backend.bae-urls:http://191.252.92.222:8080}") String backendBaseUrl,
                                    @Value("${backend.api-prefix:/api}") String apiPrefix) {
         this.webClient = builder.build();
-        this.backendBaseUrlAudienceAdSetScheduler = backendBaseUrl;
+        this.backendBaseUrl = backendBaseUrl;
         this.apiPrefix = apiPrefix;
     }
 
@@ -52,6 +52,7 @@ public class BackendExperimentClient {
      */
     public List<ReadyExperiment> listExperimentsReadyForAdSets() {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-adsets/experiments-ready");
+        logBackendRequest("GET", url);
         List<ExperimentReadyForAdSetDto> payload = webClient.get()
                 .uri(url)
                 .exchangeToFlux(response -> {
@@ -86,6 +87,7 @@ public class BackendExperimentClient {
         String uri = UriComponentsBuilder.fromHttpUrl(base)
                 .queryParam("experimentId", experimentId)
                 .toUriString();
+        logBackendRequest("GET", uri);
         Boolean result = webClient.get()
                 .uri(uri)
                 .exchangeToMono(response -> {
@@ -110,6 +112,7 @@ public class BackendExperimentClient {
      */
     public AdSetDto createAdSet(CreateAdSetRequest request) {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/adsets");
+        logBackendRequest("POST", url);
         return webClient.post()
                 .uri(url)
                 .bodyValue(request)
@@ -124,6 +127,12 @@ public class BackendExperimentClient {
                     return response.bodyToMono(AdSetDto.class);
                 })
                 .block();
+    }
+
+    private void logBackendRequest(String method, String url) {
+        if (log.isInfoEnabled()) {
+            log.info("Calling backend {} {}", method, url);
+        }
     }
 
     private ReadyExperiment toReadyExperiment(ExperimentReadyForAdSetDto dto) {


### PR DESCRIPTION
## Summary
- log the HTTP method and URL before each backend request in `BackendExperimentClient`
- fix the assignment of the backend base URL field in the client constructor

## Testing
- mvn -s settings.xml test *(fails: unable to download parent POM from GitHub Packages in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb62b49e9883219dcb6c27ea1a895c