### PR TITLE
Fix creative image preview paths

### DIFF
--- a/frontend/src/components/InstagramAdPreview.tsx
+++ b/frontend/src/components/InstagramAdPreview.tsx
@@ -1,4 +1,5 @@
 import { Creative } from "../api/creative/useCreatives";
+import { resolveAssetUrl } from "../utils/resolveAssetUrl";
 
 interface Props {
   creative: Creative;
@@ -39,7 +40,7 @@ export default function InstagramAdPreview({ creative }: Props) {
         </div>
       </div>
       <img
-        src={creative.imageUrl}
+        src={resolveAssetUrl(creative.imageUrl)}
         alt="creative"
         style={{ width: "100%", display: "block" }}
       />

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,0 +1,4 @@
+const defaultApiBaseUrl = `${window.location.protocol}//${window.location.hostname}:8000`;
+const envApiUrl = import.meta.env.VITE_API_URL;
+
+export const apiBaseUrl = envApiUrl && envApiUrl.length > 0 ? envApiUrl : defaultApiBaseUrl;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,9 +6,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { io } from "socket.io-client";
 import App from "./App";
 import axios from "axios";
+import { apiBaseUrl } from "./config/api";
 
-const defaultBaseURL = `${window.location.protocol}//${window.location.hostname}:8000`;
-axios.defaults.baseURL = import.meta.env.VITE_API_URL || defaultBaseURL;
+axios.defaults.baseURL = apiBaseUrl;
 
 const queryClient = new QueryClient();
 const socket = io({ path: "/ws" });

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -11,6 +11,7 @@ import { useUpdateCreativeLabels } from "../../api/creative/useUpdateCreativeLab
 import { useRequestCreatives } from "../../api/experiment/useRequestCreatives";
 import { useExperiment } from "../../api/experiment/useExperiment";
 import InstagramAdPreview from "../../components/InstagramAdPreview";
+import { resolveAssetUrl } from "../../utils/resolveAssetUrl";
 
 interface Props {
   experimentId: string;
@@ -205,7 +206,11 @@ export default function CriativosTab({ experimentId }: Props) {
             {creatives.map((c) => (
               <tr key={c.id}>
                 <td>
-                  <img src={c.imageUrl} style={{ width: 80 }} />
+                  <img
+                    src={resolveAssetUrl(c.imageUrl)}
+                    alt={c.headline || "Criativo"}
+                    style={{ width: 80 }}
+                  />
                 </td>
                 <td>{c.headline}</td>
                 <td>{c.primaryText.slice(0, 60)}</td>

--- a/frontend/src/utils/resolveAssetUrl.ts
+++ b/frontend/src/utils/resolveAssetUrl.ts
@@ -1,0 +1,18 @@
+import { apiBaseUrl } from "../config/api";
+
+const ABSOLUTE_URL_PATTERN = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i;
+
+export function resolveAssetUrl(path?: string | null): string {
+  if (!path) {
+    return "";
+  }
+  if (path.startsWith("data:")) {
+    return path;
+  }
+  if (ABSOLUTE_URL_PATTERN.test(path)) {
+    return path;
+  }
+  const normalizedBase = apiBaseUrl.replace(/\/$/, "");
+  const normalizedPath = path.replace(/^\/+/, "");
+  return `${normalizedBase}/${normalizedPath}`;
+}


### PR DESCRIPTION
## Summary
- centralize API base URL configuration for reuse in the frontend
- resolve creative asset URLs so relative paths include the backend host
- use the resolved URLs in the creatives list and Instagram preview to load images correctly

## Testing
- npm run test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc188f0ef88321bb1d7468e5f1a3b6