### PR TITLE
Enable Swagger UI access at /swagger-ui.html

### DIFF
--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -26,3 +26,7 @@ spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 # Enable detailed Liquibase logging
 logging.level.liquibase=DEBUG
 spring.config.import=optional:metrics.yml
+
+# Expose Swagger UI at /swagger-ui.html for quick API inspection
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
## Summary
- enable springdoc's Swagger UI so the API can be inspected at /swagger-ui.html on the VPS

## Testing
- mvn -s ../settings.xml test *(fails: unable to reach https://maven.pkg.github.com to download Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2661389c83219089beab9e04d59b