### PR TITLE
feat: add journey orchestration domain and api

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/EventLogRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/EventLogRequest.java
@@ -1,0 +1,24 @@
+package com.marketinghub.journey.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Unified ingest payload for external events.
+ */
+public record EventLogRequest(
+        UUID actorId,
+        @NotBlank String eventType,
+        Long journeyId,
+        Long journeyStepId,
+        String source,
+        String campaignId,
+        Map<String, Object> metadata,
+        BigDecimal value,
+        Instant occurredAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/EventLogResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/EventLogResponse.java
@@ -1,0 +1,24 @@
+package com.marketinghub.journey.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Representation of an ingested event.
+ */
+public record EventLogResponse(
+        Long id,
+        UUID actorId,
+        String eventType,
+        Long journeyId,
+        Long journeyStepId,
+        String source,
+        String campaignId,
+        Map<String, Object> metadata,
+        BigDecimal value,
+        Instant occurredAt,
+        Instant receivedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyAssignmentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyAssignmentRequest.java
@@ -1,0 +1,19 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyAssignmentStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Batch assignment payload for linking leads or segments to a journey.
+ */
+public record JourneyAssignmentRequest(
+        List<UUID> leadIds,
+        List<String> segmentIdentifiers,
+        JourneyAssignmentStatus status,
+        Long currentStepId,
+        Long nextStepId,
+        String contextPayload
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyAssignmentResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyAssignmentResponse.java
@@ -1,0 +1,26 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyAssignmentStatus;
+import com.marketinghub.journey.model.JourneyAssignmentType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Representation of a journey assignment.
+ */
+public record JourneyAssignmentResponse(
+        Long id,
+        Long journeyId,
+        JourneyAssignmentType type,
+        JourneyAssignmentStatus status,
+        UUID leadId,
+        String segmentIdentifier,
+        Long currentStepId,
+        Long nextStepId,
+        Instant lastEventAt,
+        String contextPayload,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyRequest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Payload for creating a journey instance.
+ */
+public record JourneyRequest(
+        @NotNull Long templateId,
+        @NotBlank String name,
+        String description,
+        JourneyStatus status,
+        Long marketNicheId,
+        Long experimentId,
+        String segmentReference,
+        String segmentFilter,
+        Instant startAt,
+        Instant endAt,
+        Map<String, String> metadata
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyResponse.java
@@ -1,0 +1,28 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyStatus;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Representation of a journey instance returned by the API.
+ */
+public record JourneyResponse(
+        Long id,
+        Long templateId,
+        String templateName,
+        String name,
+        String description,
+        JourneyStatus status,
+        Long marketNicheId,
+        Long experimentId,
+        String segmentReference,
+        String segmentFilter,
+        Map<String, String> metadata,
+        Instant startAt,
+        Instant endAt,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyStepRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyStepRequest.java
@@ -1,0 +1,27 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyPhase;
+import com.marketinghub.journey.model.JourneyStimulusType;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Map;
+
+/**
+ * Payload used to create steps inside a template.
+ */
+public record JourneyStepRequest(
+        String name,
+        String description,
+        @NotNull JourneyPhase phase,
+        @NotNull JourneyStimulusType stimulusType,
+        Integer position,
+        Long creativeId,
+        Long angleId,
+        Long visualProofId,
+        Long emotionalTriggerId,
+        String entryCondition,
+        String exitCondition,
+        Integer delayMinutes,
+        Map<String, String> metadata
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyStepResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyStepResponse.java
@@ -1,0 +1,28 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyPhase;
+import com.marketinghub.journey.model.JourneyStimulusType;
+
+import java.util.Map;
+
+/**
+ * Representation of a journey step exposed via the API.
+ */
+public record JourneyStepResponse(
+        Long id,
+        Long templateId,
+        Integer position,
+        String name,
+        String description,
+        JourneyPhase phase,
+        JourneyStimulusType stimulusType,
+        Long creativeId,
+        Long angleId,
+        Long visualProofId,
+        Long emotionalTriggerId,
+        String entryCondition,
+        String exitCondition,
+        Integer delayMinutes,
+        Map<String, String> metadata
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyStepUpdateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyStepUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyPhase;
+import com.marketinghub.journey.model.JourneyStimulusType;
+
+import java.util.Map;
+
+/**
+ * Partial update payload for journey steps.
+ */
+public record JourneyStepUpdateRequest(
+        String name,
+        String description,
+        JourneyPhase phase,
+        JourneyStimulusType stimulusType,
+        Integer position,
+        Long creativeId,
+        Long angleId,
+        Long visualProofId,
+        Long emotionalTriggerId,
+        String entryCondition,
+        String exitCondition,
+        Integer delayMinutes,
+        Map<String, String> metadata
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyTemplateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyTemplateRequest.java
@@ -1,0 +1,22 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyPhase;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Payload used to create journey templates.
+ */
+public record JourneyTemplateRequest(
+        @NotBlank String name,
+        String description,
+        String objective,
+        List<JourneyPhase> phases,
+        String preferredChannel,
+        Set<String> tags,
+        Map<String, String> metadata
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyTemplateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyTemplateResponse.java
@@ -1,0 +1,26 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyPhase;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Full representation of a journey template.
+ */
+public record JourneyTemplateResponse(
+        Long id,
+        String name,
+        String description,
+        String objective,
+        List<JourneyPhase> phases,
+        String preferredChannel,
+        Set<String> tags,
+        Map<String, String> metadata,
+        List<JourneyStepResponse> steps,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyTemplateSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyTemplateSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyPhase;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Lightweight representation of a {@link com.marketinghub.journey.model.JourneyTemplate}.
+ */
+public record JourneyTemplateSummaryResponse(
+        Long id,
+        String name,
+        String objective,
+        List<JourneyPhase> phases,
+        String preferredChannel,
+        Set<String> tags,
+        Map<String, String> metadata,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyTemplateUpdateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyTemplateUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyPhase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Partial update payload for {@link com.marketinghub.journey.model.JourneyTemplate}.
+ */
+public record JourneyTemplateUpdateRequest(
+        String name,
+        String description,
+        String objective,
+        List<JourneyPhase> phases,
+        String preferredChannel,
+        Set<String> tags,
+        Map<String, String> metadata
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyUpdateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyStatus;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Partial update payload for journey instances.
+ */
+public record JourneyUpdateRequest(
+        Long templateId,
+        String name,
+        String description,
+        JourneyStatus status,
+        Long marketNicheId,
+        Long experimentId,
+        String segmentReference,
+        String segmentFilter,
+        Instant startAt,
+        Instant endAt,
+        Map<String, String> metadata
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/mapper/JourneyMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/mapper/JourneyMapper.java
@@ -1,0 +1,141 @@
+package com.marketinghub.journey.mapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.journey.dto.*;
+import com.marketinghub.journey.model.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.*;
+
+/**
+ * Mapper centralizing conversions between domain entities and API DTOs.
+ */
+@Component
+public class JourneyMapper {
+    private final ObjectMapper objectMapper;
+
+    public JourneyMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public JourneyTemplateSummaryResponse toSummary(JourneyTemplate template) {
+        return new JourneyTemplateSummaryResponse(
+                template.getId(),
+                template.getName(),
+                template.getObjective(),
+                List.copyOf(template.getPhases()),
+                template.getPreferredChannel(),
+                new LinkedHashSet<>(template.getTags()),
+                new LinkedHashMap<>(template.getMetadata()),
+                template.getCreatedAt(),
+                template.getUpdatedAt()
+        );
+    }
+
+    public JourneyTemplateResponse toResponse(JourneyTemplate template) {
+        List<JourneyStepResponse> steps = template.getSteps().stream()
+                .sorted(Comparator.comparing(JourneyStep::getPosition, Comparator.nullsLast(Integer::compareTo)))
+                .map(this::toStepResponse)
+                .toList();
+        return new JourneyTemplateResponse(
+                template.getId(),
+                template.getName(),
+                template.getDescription(),
+                template.getObjective(),
+                List.copyOf(template.getPhases()),
+                template.getPreferredChannel(),
+                new LinkedHashSet<>(template.getTags()),
+                new LinkedHashMap<>(template.getMetadata()),
+                steps,
+                template.getCreatedAt(),
+                template.getUpdatedAt()
+        );
+    }
+
+    public JourneyStepResponse toStepResponse(JourneyStep step) {
+        return new JourneyStepResponse(
+                step.getId(),
+                step.getTemplate().getId(),
+                step.getPosition(),
+                step.getName(),
+                step.getDescription(),
+                step.getPhase(),
+                step.getStimulusType(),
+                step.getCreative() != null ? step.getCreative().getId() : null,
+                step.getAngle() != null ? step.getAngle().getId() : null,
+                step.getVisualProof() != null ? step.getVisualProof().getId() : null,
+                step.getEmotionalTrigger() != null ? step.getEmotionalTrigger().getId() : null,
+                step.getEntryCondition(),
+                step.getExitCondition(),
+                step.getDelayMinutes(),
+                new LinkedHashMap<>(step.getMetadata())
+        );
+    }
+
+    public JourneyResponse toJourneyResponse(Journey journey) {
+        return new JourneyResponse(
+                journey.getId(),
+                journey.getTemplate().getId(),
+                journey.getTemplate().getName(),
+                journey.getName(),
+                journey.getDescription(),
+                journey.getStatus(),
+                journey.getMarketNiche() != null ? journey.getMarketNiche().getId() : null,
+                journey.getExperiment() != null ? journey.getExperiment().getId() : null,
+                journey.getSegmentReference(),
+                journey.getSegmentFilter(),
+                new LinkedHashMap<>(journey.getMetadata()),
+                journey.getStartAt(),
+                journey.getEndAt(),
+                journey.getCreatedAt(),
+                journey.getUpdatedAt()
+        );
+    }
+
+    public JourneyAssignmentResponse toAssignmentResponse(JourneyAssignment assignment) {
+        return new JourneyAssignmentResponse(
+                assignment.getId(),
+                assignment.getJourney().getId(),
+                assignment.getType(),
+                assignment.getStatus(),
+                assignment.getLead() != null ? assignment.getLead().getId() : null,
+                assignment.getSegmentIdentifier(),
+                assignment.getCurrentStep() != null ? assignment.getCurrentStep().getId() : null,
+                assignment.getNextStep() != null ? assignment.getNextStep().getId() : null,
+                assignment.getLastEventAt(),
+                assignment.getContextPayload(),
+                assignment.getCreatedAt(),
+                assignment.getUpdatedAt()
+        );
+    }
+
+    public EventLogResponse toEventLogResponse(EventLog log) {
+        return new EventLogResponse(
+                log.getId(),
+                log.getActorId(),
+                log.getEventType(),
+                log.getJourney() != null ? log.getJourney().getId() : null,
+                log.getJourneyStep() != null ? log.getJourneyStep().getId() : null,
+                log.getSource(),
+                log.getCampaignId(),
+                deserializeMetadata(log.getMetadata()),
+                log.getValue(),
+                log.getOccurredAt(),
+                log.getReceivedAt()
+        );
+    }
+
+    private Map<String, Object> deserializeMetadata(String metadata) {
+        if (metadata == null || metadata.isBlank()) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(metadata, Map.class);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to parse event metadata", e);
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/EventLog.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/EventLog.java
@@ -1,0 +1,59 @@
+package com.marketinghub.journey.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Canonical storage for multi-channel events.
+ */
+@Entity
+@Table(name = "journey_event_log")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JdbcTypeCode(SqlTypes.BINARY)
+    @Column(name = "actor_id", columnDefinition = "BINARY(16)")
+    private UUID actorId;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "journey_id")
+    private Journey journey;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "journey_step_id")
+    private JourneyStep journeyStep;
+
+    private String source;
+
+    @Column(name = "campaign_id")
+    private String campaignId;
+
+    @Lob
+    private String metadata;
+
+    @Column(precision = 12, scale = 2)
+    private BigDecimal value;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    @CreationTimestamp
+    @Column(name = "received_at", updatable = false)
+    private Instant receivedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/Journey.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/Journey.java
@@ -1,0 +1,79 @@
+package com.marketinghub.journey.model;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.niche.MarketNiche;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * Operational instance of a {@link JourneyTemplate} targeting a concrete audience.
+ */
+@Entity
+@Table(name = "journey")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Journey {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "template_id", nullable = false)
+    private JourneyTemplate template;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Lob
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private JourneyStatus status = JourneyStatus.DRAFT;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "niche_id")
+    private MarketNiche marketNiche;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_id")
+    private Experiment experiment;
+
+    /** Optional external segment identifier or CRM list reference. */
+    @Column(name = "segment_reference")
+    private String segmentReference;
+
+    @Lob
+    @Column(name = "segment_filter")
+    private String segmentFilter;
+
+    private Instant startAt;
+
+    private Instant endAt;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "journey_metadata", joinColumns = @JoinColumn(name = "journey_id"))
+    @MapKeyColumn(name = "meta_key")
+    @Column(name = "meta_value")
+    @Builder.Default
+    private Map<String, String> metadata = new LinkedHashMap<>();
+
+    @OneToMany(mappedBy = "journey", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<JourneyAssignment> assignments = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyAssignment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyAssignment.java
@@ -1,0 +1,66 @@
+package com.marketinghub.journey.model;
+
+import com.marketinghub.model.Lead;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Links a lead or segment to a specific {@link Journey} execution.
+ */
+@Entity
+@Table(name = "journey_assignment")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JourneyAssignment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "journey_id", nullable = false)
+    private Journey journey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private JourneyAssignmentType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lead_id")
+    private Lead lead;
+
+    @Column(name = "segment_identifier")
+    private String segmentIdentifier;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private JourneyAssignmentStatus status = JourneyAssignmentStatus.PENDING;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_step_id")
+    private JourneyStep currentStep;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "next_step_id")
+    private JourneyStep nextStep;
+
+    @Column(name = "last_event_at")
+    private Instant lastEventAt;
+
+    @Lob
+    @Column(name = "context_payload")
+    private String contextPayload;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyAssignmentStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyAssignmentStatus.java
@@ -1,0 +1,11 @@
+package com.marketinghub.journey.model;
+
+/**
+ * Execution state for a journey assignment.
+ */
+public enum JourneyAssignmentStatus {
+    PENDING,
+    IN_PROGRESS,
+    COMPLETED,
+    STOPPED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyAssignmentType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyAssignmentType.java
@@ -1,0 +1,9 @@
+package com.marketinghub.journey.model;
+
+/**
+ * Distinguishes between assignments for individual leads and broader segments.
+ */
+public enum JourneyAssignmentType {
+    LEAD,
+    SEGMENT
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyPhase.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyPhase.java
@@ -1,0 +1,50 @@
+package com.marketinghub.journey.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Four classic phases of the AIDA framework used to structure journeys.
+ */
+public enum JourneyPhase {
+    ATTENTION("A"),
+    INTEREST("I"),
+    DESIRE("D"),
+    ACTION("A");
+
+    private final String code;
+
+    JourneyPhase(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    @JsonCreator
+    public static JourneyPhase fromValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        return switch (value.trim().toUpperCase()) {
+            case "A", "ATTENTION", "ATENCAO" -> ATTENTION;
+            case "I", "INTEREST", "INTERESSE" -> INTEREST;
+            case "D", "DESIRE", "DESEJO" -> DESIRE;
+            case "ACTION", "ACAO", "A2", "ACAO_FINAL" -> ACTION;
+            default -> {
+                for (JourneyPhase phase : JourneyPhase.values()) {
+                    if (phase.name().equalsIgnoreCase(value)) {
+                        yield phase;
+                    }
+                }
+                throw new IllegalArgumentException("Unknown journey phase: " + value);
+            }
+        };
+    }
+
+    @JsonValue
+    public String toJson() {
+        return name();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyStatus.java
@@ -1,0 +1,12 @@
+package com.marketinghub.journey.model;
+
+/**
+ * Operational status for a journey instance.
+ */
+public enum JourneyStatus {
+    DRAFT,
+    ACTIVE,
+    PAUSED,
+    COMPLETED,
+    ARCHIVED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyStep.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyStep.java
@@ -1,0 +1,80 @@
+package com.marketinghub.journey.model;
+
+import com.marketinghub.creative.Creative;
+import com.marketinghub.creative.label.Angle;
+import com.marketinghub.creative.label.EmotionalTrigger;
+import com.marketinghub.creative.label.VisualProof;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Defines a concrete touchpoint inside a {@link JourneyTemplate}.
+ */
+@Entity
+@Table(name = "journey_step")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JourneyStep {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "template_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private JourneyTemplate template;
+
+    @Column(nullable = false)
+    private Integer position;
+
+    private String name;
+
+    @Lob
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private JourneyPhase phase;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "stimulus_type", nullable = false)
+    private JourneyStimulusType stimulusType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creative_id")
+    private Creative creative;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "angle_id")
+    private Angle angle;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "visual_proof_id")
+    private VisualProof visualProof;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "emotional_trigger_id")
+    private EmotionalTrigger emotionalTrigger;
+
+    @Column(name = "entry_condition")
+    private String entryCondition;
+
+    @Column(name = "exit_condition")
+    private String exitCondition;
+
+    @Column(name = "delay_minutes")
+    private Integer delayMinutes;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "journey_step_metadata", joinColumns = @JoinColumn(name = "step_id"))
+    @MapKeyColumn(name = "meta_key")
+    @Column(name = "meta_value")
+    @Builder.Default
+    private Map<String, String> metadata = new LinkedHashMap<>();
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyStimulusType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyStimulusType.java
@@ -1,0 +1,11 @@
+package com.marketinghub.journey.model;
+
+/**
+ * Types of stimuli supported by the orchestration engine.
+ */
+public enum JourneyStimulusType {
+    AD,
+    EMAIL,
+    WHATSAPP,
+    LANDING_PAGE
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyTemplate.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyTemplate.java
@@ -1,0 +1,72 @@
+package com.marketinghub.journey.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * Blueprint describing the phases and messaging cadence for a journey.
+ */
+@Entity
+@Table(name = "journey_template")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JourneyTemplate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Lob
+    private String description;
+
+    private String objective;
+
+    @Column(name = "preferred_channel")
+    private String preferredChannel;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "journey_template_phase", joinColumns = @JoinColumn(name = "template_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "phase", nullable = false)
+    @OrderColumn(name = "phase_order")
+    @Builder.Default
+    private List<JourneyPhase> phases = new ArrayList<>(List.of(JourneyPhase.ATTENTION,
+            JourneyPhase.INTEREST,
+            JourneyPhase.DESIRE,
+            JourneyPhase.ACTION));
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "journey_template_tag", joinColumns = @JoinColumn(name = "template_id"))
+    @Column(name = "tag")
+    @Builder.Default
+    private Set<String> tags = new LinkedHashSet<>();
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "journey_template_metadata", joinColumns = @JoinColumn(name = "template_id"))
+    @MapKeyColumn(name = "meta_key")
+    @Column(name = "meta_value")
+    @Builder.Default
+    private Map<String, String> metadata = new LinkedHashMap<>();
+
+    @OneToMany(mappedBy = "template", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("position ASC")
+    @Builder.Default
+    private List<JourneyStep> steps = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/repository/EventLogRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/repository/EventLogRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.journey.repository;
+
+import com.marketinghub.journey.model.EventLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository handling persisted journey events.
+ */
+public interface EventLogRepository extends JpaRepository<EventLog, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyAssignmentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyAssignmentRepository.java
@@ -1,0 +1,16 @@
+package com.marketinghub.journey.repository;
+
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyAssignmentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for assignments tying actors to journeys.
+ */
+public interface JourneyAssignmentRepository extends JpaRepository<JourneyAssignment, Long> {
+    Page<JourneyAssignment> findByJourneyId(Long journeyId, Pageable pageable);
+
+    Page<JourneyAssignment> findByJourneyIdAndStatus(Long journeyId, JourneyAssignmentStatus status, Pageable pageable);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyRepository.java
@@ -1,0 +1,18 @@
+package com.marketinghub.journey.repository;
+
+import com.marketinghub.journey.model.Journey;
+import com.marketinghub.journey.model.JourneyStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for {@link Journey} instances.
+ */
+public interface JourneyRepository extends JpaRepository<Journey, Long> {
+    Page<Journey> findByTemplateId(Long templateId, Pageable pageable);
+
+    Page<Journey> findByStatus(JourneyStatus status, Pageable pageable);
+
+    Page<Journey> findByTemplateIdAndStatus(Long templateId, JourneyStatus status, Pageable pageable);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyStepRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyStepRepository.java
@@ -1,0 +1,14 @@
+package com.marketinghub.journey.repository;
+
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Repository for journey steps.
+ */
+public interface JourneyStepRepository extends JpaRepository<JourneyStep, Long> {
+    List<JourneyStep> findByTemplateOrderByPositionAsc(JourneyTemplate template);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyTemplateRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyTemplateRepository.java
@@ -1,0 +1,15 @@
+package com.marketinghub.journey.repository;
+
+import com.marketinghub.journey.model.JourneyTemplate;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * Repository for {@link JourneyTemplate} aggregates.
+ */
+public interface JourneyTemplateRepository extends JpaRepository<JourneyTemplate, Long> {
+    @EntityGraph(attributePaths = {"steps"})
+    Optional<JourneyTemplate> findWithStepsById(Long id);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/service/EventLogService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/service/EventLogService.java
@@ -1,0 +1,85 @@
+package com.marketinghub.journey.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.journey.dto.EventLogRequest;
+import com.marketinghub.journey.model.EventLog;
+import com.marketinghub.journey.model.Journey;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.repository.EventLogRepository;
+import com.marketinghub.journey.repository.JourneyRepository;
+import com.marketinghub.journey.repository.JourneyStepRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Service capturing canonical event logs for journeys.
+ */
+@Service
+public class EventLogService {
+    private final EventLogRepository eventLogRepository;
+    private final JourneyRepository journeyRepository;
+    private final JourneyStepRepository journeyStepRepository;
+    private final ObjectMapper objectMapper;
+
+    public EventLogService(EventLogRepository eventLogRepository,
+                           JourneyRepository journeyRepository,
+                           JourneyStepRepository journeyStepRepository,
+                           ObjectMapper objectMapper) {
+        this.eventLogRepository = eventLogRepository;
+        this.journeyRepository = journeyRepository;
+        this.journeyStepRepository = journeyStepRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public EventLog record(EventLogRequest request) {
+        Journey journey = null;
+        if (request.journeyId() != null) {
+            journey = journeyRepository.findById(request.journeyId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey not found"));
+        }
+
+        JourneyStep journeyStep = null;
+        if (request.journeyStepId() != null) {
+            journeyStep = journeyStepRepository.findById(request.journeyStepId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey step not found"));
+            if (journey != null && !journeyStep.getTemplate().getId().equals(journey.getTemplate().getId())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Step does not belong to journey template");
+            }
+        }
+
+        Instant occurredAt = request.occurredAt() != null ? request.occurredAt() : Instant.now();
+        String metadata = serializeMetadata(request.metadata());
+
+        EventLog log = EventLog.builder()
+                .actorId(request.actorId())
+                .eventType(request.eventType())
+                .journey(journey)
+                .journeyStep(journeyStep)
+                .source(request.source())
+                .campaignId(request.campaignId())
+                .metadata(metadata)
+                .value(request.value())
+                .occurredAt(occurredAt)
+                .build();
+
+        return eventLogRepository.save(log);
+    }
+
+    private String serializeMetadata(Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(metadata);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid metadata payload", e);
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyAssignmentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyAssignmentService.java
@@ -1,0 +1,151 @@
+package com.marketinghub.journey.service;
+
+import com.marketinghub.journey.dto.JourneyAssignmentRequest;
+import com.marketinghub.journey.model.*;
+import com.marketinghub.journey.repository.JourneyAssignmentRepository;
+import com.marketinghub.journey.repository.JourneyRepository;
+import com.marketinghub.journey.repository.JourneyStepRepository;
+import com.marketinghub.model.Lead;
+import com.marketinghub.repository.LeadRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Service responsible for linking leads or segments to journeys.
+ */
+@Service
+public class JourneyAssignmentService {
+    private final JourneyRepository journeyRepository;
+    private final JourneyAssignmentRepository assignmentRepository;
+    private final JourneyStepRepository stepRepository;
+    private final LeadRepository leadRepository;
+
+    public JourneyAssignmentService(JourneyRepository journeyRepository,
+                                    JourneyAssignmentRepository assignmentRepository,
+                                    JourneyStepRepository stepRepository,
+                                    LeadRepository leadRepository) {
+        this.journeyRepository = journeyRepository;
+        this.assignmentRepository = assignmentRepository;
+        this.stepRepository = stepRepository;
+        this.leadRepository = leadRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<JourneyAssignment> list(Long journeyId, JourneyAssignmentStatus status, Pageable pageable) {
+        verifyJourneyExists(journeyId);
+        if (status != null) {
+            return assignmentRepository.findByJourneyIdAndStatus(journeyId, status, pageable);
+        }
+        return assignmentRepository.findByJourneyId(journeyId, pageable);
+    }
+
+    @Transactional
+    public List<JourneyAssignment> assign(Long journeyId, JourneyAssignmentRequest request) {
+        Journey journey = journeyRepository.findById(journeyId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey not found"));
+
+        JourneyStep currentStep = resolveStep(journey.getTemplate(), request.currentStepId());
+        JourneyStep nextStep = resolveNextStep(journey.getTemplate(), request.nextStepId());
+        JourneyAssignmentStatus status = request.status() != null ? request.status() : JourneyAssignmentStatus.PENDING;
+        String contextPayload = request.contextPayload();
+
+        List<JourneyAssignment> assignments = new ArrayList<>();
+
+        if (request.leadIds() != null && !request.leadIds().isEmpty()) {
+            assignments.addAll(createLeadAssignments(journey, request.leadIds(), status, currentStep, nextStep, contextPayload));
+        }
+
+        if (request.segmentIdentifiers() != null && !request.segmentIdentifiers().isEmpty()) {
+            for (String identifier : request.segmentIdentifiers()) {
+                JourneyAssignment assignment = JourneyAssignment.builder()
+                        .journey(journey)
+                        .type(JourneyAssignmentType.SEGMENT)
+                        .segmentIdentifier(identifier)
+                        .status(status)
+                        .currentStep(currentStep)
+                        .nextStep(nextStep)
+                        .contextPayload(contextPayload)
+                        .build();
+                assignments.add(assignment);
+            }
+        }
+
+        if (assignments.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "At least one leadId or segmentIdentifier must be provided");
+        }
+
+        journey.getAssignments().addAll(assignments);
+        return assignmentRepository.saveAll(assignments);
+    }
+
+    @Transactional
+    public void delete(Long assignmentId) {
+        JourneyAssignment assignment = assignmentRepository.findById(assignmentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey assignment not found"));
+        assignmentRepository.delete(assignment);
+    }
+
+    private List<JourneyAssignment> createLeadAssignments(Journey journey,
+                                                          List<UUID> leadIds,
+                                                          JourneyAssignmentStatus status,
+                                                          JourneyStep currentStep,
+                                                          JourneyStep nextStep,
+                                                          String contextPayload) {
+        List<Lead> leads = leadRepository.findAllById(leadIds);
+        Set<UUID> retrievedIds = leads.stream().map(Lead::getId).collect(Collectors.toSet());
+        for (UUID requestedId : leadIds) {
+            if (!retrievedIds.contains(requestedId)) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Lead not found: " + requestedId);
+            }
+        }
+        List<JourneyAssignment> assignments = new ArrayList<>();
+        for (Lead lead : leads) {
+            JourneyAssignment assignment = JourneyAssignment.builder()
+                    .journey(journey)
+                    .type(JourneyAssignmentType.LEAD)
+                    .lead(lead)
+                    .status(status)
+                    .currentStep(currentStep)
+                    .nextStep(nextStep)
+                    .contextPayload(contextPayload)
+                    .build();
+            assignments.add(assignment);
+        }
+        return assignments;
+    }
+
+    private JourneyStep resolveStep(JourneyTemplate template, Long stepId) {
+        if (stepId == null) {
+            return null;
+        }
+        JourneyStep step = stepRepository.findById(stepId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey step not found"));
+        if (!step.getTemplate().getId().equals(template.getId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Step does not belong to template");
+        }
+        return step;
+    }
+
+    private JourneyStep resolveNextStep(JourneyTemplate template, Long stepId) {
+        JourneyStep explicitStep = resolveStep(template, stepId);
+        if (explicitStep != null) {
+            return explicitStep;
+        }
+        return stepRepository.findByTemplateOrderByPositionAsc(template).stream()
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void verifyJourneyExists(Long journeyId) {
+        if (!journeyRepository.existsById(journeyId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey not found");
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyService.java
@@ -1,0 +1,161 @@
+package com.marketinghub.journey.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.journey.dto.JourneyRequest;
+import com.marketinghub.journey.dto.JourneyUpdateRequest;
+import com.marketinghub.journey.model.Journey;
+import com.marketinghub.journey.model.JourneyStatus;
+import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.journey.repository.JourneyRepository;
+import com.marketinghub.journey.repository.JourneyTemplateRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Application service orchestrating journey lifecycle operations.
+ */
+@Service
+public class JourneyService {
+    private final JourneyRepository journeyRepository;
+    private final JourneyTemplateRepository templateRepository;
+    private final MarketNicheRepository marketNicheRepository;
+    private final ExperimentRepository experimentRepository;
+
+    public JourneyService(JourneyRepository journeyRepository,
+                          JourneyTemplateRepository templateRepository,
+                          MarketNicheRepository marketNicheRepository,
+                          ExperimentRepository experimentRepository) {
+        this.journeyRepository = journeyRepository;
+        this.templateRepository = templateRepository;
+        this.marketNicheRepository = marketNicheRepository;
+        this.experimentRepository = experimentRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Journey> list(Long templateId, JourneyStatus status, Pageable pageable) {
+        if (templateId != null && status != null) {
+            return journeyRepository.findByTemplateIdAndStatus(templateId, status, pageable);
+        }
+        if (templateId != null) {
+            return journeyRepository.findByTemplateId(templateId, pageable);
+        }
+        if (status != null) {
+            return journeyRepository.findByStatus(status, pageable);
+        }
+        return journeyRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Journey get(Long id) {
+        return journeyRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey not found"));
+    }
+
+    @Transactional
+    public Journey create(JourneyRequest request) {
+        JourneyTemplate template = templateRepository.findById(request.templateId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey template not found"));
+
+        Journey journey = Journey.builder()
+                .template(template)
+                .name(request.name())
+                .description(request.description())
+                .status(request.status() != null ? request.status() : JourneyStatus.DRAFT)
+                .segmentReference(request.segmentReference())
+                .segmentFilter(request.segmentFilter())
+                .startAt(request.startAt())
+                .endAt(request.endAt())
+                .build();
+
+        journey.setMetadata(normaliseMetadata(request.metadata()));
+        journey.setMarketNiche(resolveNiche(request.marketNicheId()));
+        journey.setExperiment(resolveExperiment(request.experimentId()));
+
+        return journeyRepository.save(journey);
+    }
+
+    @Transactional
+    public Journey update(Long id, JourneyUpdateRequest request) {
+        Journey journey = journeyRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey not found"));
+
+        if (request.templateId() != null && !Objects.equals(request.templateId(), journey.getTemplate().getId())) {
+            JourneyTemplate template = templateRepository.findById(request.templateId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey template not found"));
+            journey.setTemplate(template);
+        }
+        if (request.name() != null) {
+            journey.setName(request.name());
+        }
+        if (request.description() != null) {
+            journey.setDescription(request.description());
+        }
+        if (request.status() != null) {
+            journey.setStatus(request.status());
+        }
+        if (request.segmentReference() != null) {
+            journey.setSegmentReference(request.segmentReference());
+        }
+        if (request.segmentFilter() != null) {
+            journey.setSegmentFilter(request.segmentFilter());
+        }
+        if (request.startAt() != null) {
+            journey.setStartAt(request.startAt());
+        }
+        if (request.endAt() != null) {
+            journey.setEndAt(request.endAt());
+        }
+        if (request.metadata() != null) {
+            journey.setMetadata(normaliseMetadata(request.metadata()));
+        }
+        if (request.marketNicheId() != null) {
+            journey.setMarketNiche(resolveNiche(request.marketNicheId()));
+        }
+        if (request.experimentId() != null) {
+            journey.setExperiment(resolveExperiment(request.experimentId()));
+        }
+
+        return journeyRepository.save(journey);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        Journey journey = journeyRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey not found"));
+        journeyRepository.delete(journey);
+    }
+
+    private MarketNiche resolveNiche(Long nicheId) {
+        if (nicheId == null) {
+            return null;
+        }
+        return marketNicheRepository.findById(nicheId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Market niche not found"));
+    }
+
+    private Experiment resolveExperiment(Long experimentId) {
+        if (experimentId == null) {
+            return null;
+        }
+        return experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Experiment not found"));
+    }
+
+    private Map<String, String> normaliseMetadata(Map<String, String> metadata) {
+        if (metadata == null) {
+            return new LinkedHashMap<>();
+        }
+        return new LinkedHashMap<>(metadata);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyStepService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyStepService.java
@@ -1,0 +1,241 @@
+package com.marketinghub.journey.service;
+
+import com.marketinghub.creative.Creative;
+import com.marketinghub.creative.label.Angle;
+import com.marketinghub.creative.label.EmotionalTrigger;
+import com.marketinghub.creative.label.VisualProof;
+import com.marketinghub.creative.label.repository.AngleRepository;
+import com.marketinghub.creative.label.repository.EmotionalTriggerRepository;
+import com.marketinghub.creative.label.repository.VisualProofRepository;
+import com.marketinghub.creative.repository.CreativeRepository;
+import com.marketinghub.journey.dto.JourneyStepRequest;
+import com.marketinghub.journey.dto.JourneyStepUpdateRequest;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.journey.repository.JourneyStepRepository;
+import com.marketinghub.journey.repository.JourneyTemplateRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Service responsible for managing steps of a journey template.
+ */
+@Service
+public class JourneyStepService {
+    private final JourneyTemplateRepository templateRepository;
+    private final JourneyStepRepository stepRepository;
+    private final CreativeRepository creativeRepository;
+    private final AngleRepository angleRepository;
+    private final VisualProofRepository visualProofRepository;
+    private final EmotionalTriggerRepository emotionalTriggerRepository;
+
+    public JourneyStepService(JourneyTemplateRepository templateRepository,
+                              JourneyStepRepository stepRepository,
+                              CreativeRepository creativeRepository,
+                              AngleRepository angleRepository,
+                              VisualProofRepository visualProofRepository,
+                              EmotionalTriggerRepository emotionalTriggerRepository) {
+        this.templateRepository = templateRepository;
+        this.stepRepository = stepRepository;
+        this.creativeRepository = creativeRepository;
+        this.angleRepository = angleRepository;
+        this.visualProofRepository = visualProofRepository;
+        this.emotionalTriggerRepository = emotionalTriggerRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<JourneyStep> listByTemplate(Long templateId) {
+        JourneyTemplate template = templateRepository.findById(templateId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey template not found"));
+        return stepRepository.findByTemplateOrderByPositionAsc(template);
+    }
+
+    @Transactional(readOnly = true)
+    public JourneyStep get(Long stepId) {
+        return stepRepository.findById(stepId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey step not found"));
+    }
+
+    @Transactional
+    public JourneyStep create(Long templateId, JourneyStepRequest request) {
+        JourneyTemplate template = templateRepository.findById(templateId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey template not found"));
+
+        JourneyStep step = JourneyStep.builder()
+                .template(template)
+                .name(request.name())
+                .description(request.description())
+                .phase(request.phase())
+                .stimulusType(request.stimulusType())
+                .entryCondition(request.entryCondition())
+                .exitCondition(request.exitCondition())
+                .delayMinutes(request.delayMinutes())
+                .metadata(request.metadata() != null ? new LinkedHashMap<>(request.metadata()) : new LinkedHashMap<>())
+                .build();
+
+        step.setCreative(resolveCreative(request.creativeId()));
+        step.setAngle(resolveAngle(request.angleId()));
+        step.setVisualProof(resolveVisualProof(request.visualProofId()));
+        step.setEmotionalTrigger(resolveEmotionalTrigger(request.emotionalTriggerId()));
+
+        int initialPosition = resolveInitialPosition(template, request.position());
+        step.setPosition(initialPosition);
+
+        JourneyStep saved = stepRepository.save(step);
+        reorderSteps(template, saved, request.position());
+        return saved;
+    }
+
+    @Transactional
+    public JourneyStep update(Long stepId, JourneyStepUpdateRequest request) {
+        JourneyStep step = stepRepository.findById(stepId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey step not found"));
+
+        if (request.name() != null) {
+            step.setName(request.name());
+        }
+        if (request.description() != null) {
+            step.setDescription(request.description());
+        }
+        if (request.phase() != null) {
+            step.setPhase(request.phase());
+        }
+        if (request.stimulusType() != null) {
+            step.setStimulusType(request.stimulusType());
+        }
+        if (request.entryCondition() != null) {
+            step.setEntryCondition(request.entryCondition());
+        }
+        if (request.exitCondition() != null) {
+            step.setExitCondition(request.exitCondition());
+        }
+        if (request.delayMinutes() != null) {
+            step.setDelayMinutes(request.delayMinutes());
+        }
+        if (request.metadata() != null) {
+            step.setMetadata(new LinkedHashMap<>(request.metadata()));
+        }
+
+        boolean positionUpdated = request.position() != null && !Objects.equals(request.position(), step.getPosition());
+        if (positionUpdated) {
+            step.setPosition(resolveInitialPosition(step.getTemplate(), request.position()));
+        }
+
+        if (request.creativeId() != null) {
+            step.setCreative(resolveCreative(request.creativeId()));
+        }
+        if (request.angleId() != null) {
+            step.setAngle(resolveAngle(request.angleId()));
+        }
+        if (request.visualProofId() != null) {
+            step.setVisualProof(resolveVisualProof(request.visualProofId()));
+        }
+        if (request.emotionalTriggerId() != null) {
+            step.setEmotionalTrigger(resolveEmotionalTrigger(request.emotionalTriggerId()));
+        }
+
+        JourneyStep saved = stepRepository.save(step);
+        if (positionUpdated) {
+            reorderSteps(step.getTemplate(), saved, request.position());
+        }
+        return saved;
+    }
+
+    @Transactional
+    public void delete(Long stepId) {
+        JourneyStep step = stepRepository.findById(stepId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey step not found"));
+        JourneyTemplate template = step.getTemplate();
+        stepRepository.delete(step);
+        normalizeTemplatePositions(template);
+    }
+
+    private int resolveInitialPosition(JourneyTemplate template, Integer desiredPosition) {
+        if (desiredPosition != null && desiredPosition > 0) {
+            return desiredPosition;
+        }
+        return stepRepository.findByTemplateOrderByPositionAsc(template).stream()
+                .map(JourneyStep::getPosition)
+                .filter(Objects::nonNull)
+                .max(Integer::compareTo)
+                .map(pos -> pos + 1)
+                .orElse(1);
+    }
+
+    private void reorderSteps(JourneyTemplate template, JourneyStep targetStep, Integer desiredPosition) {
+        List<JourneyStep> steps = stepRepository.findByTemplateOrderByPositionAsc(template);
+        steps.removeIf(existing -> existing.getId() != null && existing.getId().equals(targetStep.getId()));
+
+        int totalSize = steps.size() + 1;
+        int insertionIndex = computeInsertionIndex(desiredPosition, totalSize);
+        steps.add(insertionIndex, targetStep);
+
+        persistNormalizedPositions(steps);
+    }
+
+    private int computeInsertionIndex(Integer desiredPosition, int totalSize) {
+        if (desiredPosition == null || desiredPosition <= 0) {
+            return totalSize - 1;
+        }
+        int zeroBased = desiredPosition - 1;
+        return Math.min(zeroBased, totalSize - 1);
+    }
+
+    private void normalizeTemplatePositions(JourneyTemplate template) {
+        List<JourneyStep> steps = stepRepository.findByTemplateOrderByPositionAsc(template);
+        persistNormalizedPositions(steps);
+    }
+
+    private void persistNormalizedPositions(List<JourneyStep> steps) {
+        int index = 1;
+        boolean dirty = false;
+        for (JourneyStep existing : steps) {
+            if (!Objects.equals(existing.getPosition(), index)) {
+                existing.setPosition(index);
+                dirty = true;
+            }
+            index++;
+        }
+        if (dirty) {
+            stepRepository.saveAll(steps);
+        }
+    }
+
+    private Creative resolveCreative(Long creativeId) {
+        if (creativeId == null) {
+            return null;
+        }
+        return creativeRepository.findById(creativeId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Creative not found"));
+    }
+
+    private Angle resolveAngle(Long angleId) {
+        if (angleId == null) {
+            return null;
+        }
+        return angleRepository.findById(angleId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Angle not found"));
+    }
+
+    private VisualProof resolveVisualProof(Long visualProofId) {
+        if (visualProofId == null) {
+            return null;
+        }
+        return visualProofRepository.findById(visualProofId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Visual proof not found"));
+    }
+
+    private EmotionalTrigger resolveEmotionalTrigger(Long emotionalTriggerId) {
+        if (emotionalTriggerId == null) {
+            return null;
+        }
+        return emotionalTriggerRepository.findById(emotionalTriggerId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Emotional trigger not found"));
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyTemplateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyTemplateService.java
@@ -1,0 +1,109 @@
+package com.marketinghub.journey.service;
+
+import com.marketinghub.journey.dto.JourneyTemplateRequest;
+import com.marketinghub.journey.dto.JourneyTemplateUpdateRequest;
+import com.marketinghub.journey.model.JourneyPhase;
+import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.journey.repository.JourneyTemplateRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.*;
+
+/**
+ * Application service encapsulating template manipulation logic.
+ */
+@Service
+public class JourneyTemplateService {
+    private static final List<JourneyPhase> DEFAULT_PHASES = List.of(
+            JourneyPhase.ATTENTION,
+            JourneyPhase.INTEREST,
+            JourneyPhase.DESIRE,
+            JourneyPhase.ACTION
+    );
+
+    private final JourneyTemplateRepository templateRepository;
+
+    public JourneyTemplateService(JourneyTemplateRepository templateRepository) {
+        this.templateRepository = templateRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<JourneyTemplate> list(Pageable pageable) {
+        return templateRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public JourneyTemplate get(Long id) {
+        return templateRepository.findWithStepsById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey template not found"));
+    }
+
+    @Transactional
+    public JourneyTemplate create(JourneyTemplateRequest request) {
+        JourneyTemplate template = JourneyTemplate.builder()
+                .name(request.name())
+                .description(request.description())
+                .objective(request.objective())
+                .preferredChannel(request.preferredChannel())
+                .build();
+        applyMutableFields(template, request.phases(), request.tags(), request.metadata());
+        return templateRepository.save(template);
+    }
+
+    @Transactional
+    public JourneyTemplate update(Long id, JourneyTemplateUpdateRequest request) {
+        JourneyTemplate template = templateRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey template not found"));
+
+        if (request.name() != null) {
+            template.setName(request.name());
+        }
+        if (request.description() != null) {
+            template.setDescription(request.description());
+        }
+        if (request.objective() != null) {
+            template.setObjective(request.objective());
+        }
+        if (request.preferredChannel() != null) {
+            template.setPreferredChannel(request.preferredChannel());
+        }
+        if (request.phases() != null) {
+            template.setPhases(resolvePhases(request.phases()));
+        }
+        if (request.tags() != null) {
+            template.setTags(new LinkedHashSet<>(request.tags()));
+        }
+        if (request.metadata() != null) {
+            template.setMetadata(new LinkedHashMap<>(request.metadata()));
+        }
+        return templateRepository.save(template);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        JourneyTemplate template = templateRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Journey template not found"));
+        templateRepository.delete(template);
+    }
+
+    private void applyMutableFields(JourneyTemplate template,
+                                    List<JourneyPhase> phases,
+                                    Set<String> tags,
+                                    Map<String, String> metadata) {
+        template.setPhases(resolvePhases(phases));
+        template.setTags(tags != null ? new LinkedHashSet<>(tags) : new LinkedHashSet<>());
+        template.setMetadata(metadata != null ? new LinkedHashMap<>(metadata) : new LinkedHashMap<>());
+    }
+
+    private List<JourneyPhase> resolvePhases(List<JourneyPhase> phases) {
+        if (phases == null || phases.isEmpty()) {
+            return new ArrayList<>(DEFAULT_PHASES);
+        }
+        return new ArrayList<>(phases);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/web/EventLogController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/web/EventLogController.java
@@ -1,0 +1,30 @@
+package com.marketinghub.journey.web;
+
+import com.marketinghub.journey.dto.EventLogRequest;
+import com.marketinghub.journey.dto.EventLogResponse;
+import com.marketinghub.journey.mapper.JourneyMapper;
+import com.marketinghub.journey.service.EventLogService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * REST endpoint ingesting events across channels.
+ */
+@RestController
+@RequestMapping("/api/events")
+public class EventLogController {
+    private final EventLogService eventLogService;
+    private final JourneyMapper mapper;
+
+    public EventLogController(EventLogService eventLogService, JourneyMapper mapper) {
+        this.eventLogService = eventLogService;
+        this.mapper = mapper;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public EventLogResponse record(@Valid @RequestBody EventLogRequest request) {
+        return mapper.toEventLogResponse(eventLogService.record(request));
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/web/JourneyAssignmentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/web/JourneyAssignmentController.java
@@ -1,0 +1,52 @@
+package com.marketinghub.journey.web;
+
+import com.marketinghub.journey.dto.JourneyAssignmentRequest;
+import com.marketinghub.journey.dto.JourneyAssignmentResponse;
+import com.marketinghub.journey.mapper.JourneyMapper;
+import com.marketinghub.journey.model.JourneyAssignmentStatus;
+import com.marketinghub.journey.service.JourneyAssignmentService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST surface for journey assignments.
+ */
+@RestController
+@RequestMapping("/api")
+public class JourneyAssignmentController {
+    private final JourneyAssignmentService assignmentService;
+    private final JourneyMapper mapper;
+
+    public JourneyAssignmentController(JourneyAssignmentService assignmentService, JourneyMapper mapper) {
+        this.assignmentService = assignmentService;
+        this.mapper = mapper;
+    }
+
+    @GetMapping("/journeys/{journeyId}/assignments")
+    public Page<JourneyAssignmentResponse> list(@PathVariable Long journeyId,
+                                                @RequestParam(value = "status", required = false) JourneyAssignmentStatus status,
+                                                @PageableDefault(size = 50) Pageable pageable) {
+        return assignmentService.list(journeyId, status, pageable).map(mapper::toAssignmentResponse);
+    }
+
+    @PostMapping("/journeys/{journeyId}/assignments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public List<JourneyAssignmentResponse> assign(@PathVariable Long journeyId,
+                                                  @Valid @RequestBody JourneyAssignmentRequest request) {
+        return assignmentService.assign(journeyId, request).stream()
+                .map(mapper::toAssignmentResponse)
+                .toList();
+    }
+
+    @DeleteMapping("/journey-assignments/{assignmentId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long assignmentId) {
+        assignmentService.delete(assignmentId);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/web/JourneyController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/web/JourneyController.java
@@ -1,0 +1,61 @@
+package com.marketinghub.journey.web;
+
+import com.marketinghub.journey.dto.JourneyRequest;
+import com.marketinghub.journey.dto.JourneyResponse;
+import com.marketinghub.journey.dto.JourneyUpdateRequest;
+import com.marketinghub.journey.mapper.JourneyMapper;
+import com.marketinghub.journey.model.Journey;
+import com.marketinghub.journey.model.JourneyStatus;
+import com.marketinghub.journey.service.JourneyService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * REST controller for journey instances.
+ */
+@RestController
+@RequestMapping("/api/journeys")
+public class JourneyController {
+    private final JourneyService journeyService;
+    private final JourneyMapper mapper;
+
+    public JourneyController(JourneyService journeyService, JourneyMapper mapper) {
+        this.journeyService = journeyService;
+        this.mapper = mapper;
+    }
+
+    @GetMapping
+    public Page<JourneyResponse> list(@RequestParam(value = "templateId", required = false) Long templateId,
+                                      @RequestParam(value = "status", required = false) JourneyStatus status,
+                                      @PageableDefault(size = 20) Pageable pageable) {
+        return journeyService.list(templateId, status, pageable).map(mapper::toJourneyResponse);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public JourneyResponse create(@Valid @RequestBody JourneyRequest request) {
+        Journey journey = journeyService.create(request);
+        return mapper.toJourneyResponse(journeyService.get(journey.getId()));
+    }
+
+    @GetMapping("/{id}")
+    public JourneyResponse get(@PathVariable Long id) {
+        return mapper.toJourneyResponse(journeyService.get(id));
+    }
+
+    @PatchMapping("/{id}")
+    public JourneyResponse update(@PathVariable Long id, @Valid @RequestBody JourneyUpdateRequest request) {
+        Journey updated = journeyService.update(id, request);
+        return mapper.toJourneyResponse(journeyService.get(updated.getId()));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        journeyService.delete(id);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/web/JourneyStepController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/web/JourneyStepController.java
@@ -1,0 +1,40 @@
+package com.marketinghub.journey.web;
+
+import com.marketinghub.journey.dto.JourneyStepResponse;
+import com.marketinghub.journey.dto.JourneyStepUpdateRequest;
+import com.marketinghub.journey.mapper.JourneyMapper;
+import com.marketinghub.journey.service.JourneyStepService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Controller exposing operations on individual journey steps.
+ */
+@RestController
+@RequestMapping("/api/journey-steps")
+public class JourneyStepController {
+    private final JourneyStepService stepService;
+    private final JourneyMapper mapper;
+
+    public JourneyStepController(JourneyStepService stepService, JourneyMapper mapper) {
+        this.stepService = stepService;
+        this.mapper = mapper;
+    }
+
+    @GetMapping("/{id}")
+    public JourneyStepResponse get(@PathVariable Long id) {
+        return mapper.toStepResponse(stepService.get(id));
+    }
+
+    @PatchMapping("/{id}")
+    public JourneyStepResponse update(@PathVariable Long id, @Valid @RequestBody JourneyStepUpdateRequest request) {
+        return mapper.toStepResponse(stepService.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        stepService.delete(id);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/web/JourneyTemplateController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/web/JourneyTemplateController.java
@@ -1,0 +1,75 @@
+package com.marketinghub.journey.web;
+
+import com.marketinghub.journey.dto.*;
+import com.marketinghub.journey.mapper.JourneyMapper;
+import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.journey.service.JourneyStepService;
+import com.marketinghub.journey.service.JourneyTemplateService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST controller exposing CRUD operations for journey templates and their steps.
+ */
+@RestController
+@RequestMapping("/api/journey-templates")
+public class JourneyTemplateController {
+    private final JourneyTemplateService templateService;
+    private final JourneyStepService stepService;
+    private final JourneyMapper mapper;
+
+    public JourneyTemplateController(JourneyTemplateService templateService,
+                                     JourneyStepService stepService,
+                                     JourneyMapper mapper) {
+        this.templateService = templateService;
+        this.stepService = stepService;
+        this.mapper = mapper;
+    }
+
+    @GetMapping
+    public Page<JourneyTemplateSummaryResponse> list(@PageableDefault(size = 20) Pageable pageable) {
+        return templateService.list(pageable).map(mapper::toSummary);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public JourneyTemplateResponse create(@Valid @RequestBody JourneyTemplateRequest request) {
+        JourneyTemplate template = templateService.create(request);
+        return mapper.toResponse(templateService.get(template.getId()));
+    }
+
+    @GetMapping("/{id}")
+    public JourneyTemplateResponse get(@PathVariable Long id) {
+        return mapper.toResponse(templateService.get(id));
+    }
+
+    @PatchMapping("/{id}")
+    public JourneyTemplateResponse update(@PathVariable Long id,
+                                          @Valid @RequestBody JourneyTemplateUpdateRequest request) {
+        JourneyTemplate updated = templateService.update(id, request);
+        return mapper.toResponse(templateService.get(updated.getId()));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        templateService.delete(id);
+    }
+
+    @GetMapping("/{id}/steps")
+    public List<JourneyStepResponse> listSteps(@PathVariable Long id) {
+        return stepService.listByTemplate(id).stream().map(mapper::toStepResponse).toList();
+    }
+
+    @PostMapping("/{id}/steps")
+    @ResponseStatus(HttpStatus.CREATED)
+    public JourneyStepResponse createStep(@PathVariable Long id, @Valid @RequestBody JourneyStepRequest request) {
+        return mapper.toStepResponse(stepService.create(id, request));
+    }
+}

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_15__create_journey_tables.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_15__create_journey_tables.sql
@@ -1,0 +1,143 @@
+--liquibase formatted sql
+
+--changeset marketinghub:2025-10-15-create-journey-template
+CREATE TABLE journey_template (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    description LONGTEXT,
+    objective VARCHAR(255),
+    preferred_channel VARCHAR(100),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+--changeset marketinghub:2025-10-15-create-journey-template-phase
+CREATE TABLE journey_template_phase (
+    template_id BIGINT NOT NULL,
+    phase_order INT NOT NULL,
+    phase VARCHAR(32) NOT NULL,
+    PRIMARY KEY (template_id, phase_order),
+    CONSTRAINT fk_journey_template_phase_template FOREIGN KEY (template_id) REFERENCES journey_template(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+--changeset marketinghub:2025-10-15-create-journey-template-tag
+CREATE TABLE journey_template_tag (
+    template_id BIGINT NOT NULL,
+    tag VARCHAR(255) NOT NULL,
+    PRIMARY KEY (template_id, tag),
+    CONSTRAINT fk_journey_template_tag_template FOREIGN KEY (template_id) REFERENCES journey_template(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+--changeset marketinghub:2025-10-15-create-journey-template-metadata
+CREATE TABLE journey_template_metadata (
+    template_id BIGINT NOT NULL,
+    meta_key VARCHAR(255) NOT NULL,
+    meta_value LONGTEXT,
+    PRIMARY KEY (template_id, meta_key),
+    CONSTRAINT fk_journey_template_metadata_template FOREIGN KEY (template_id) REFERENCES journey_template(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+--changeset marketinghub:2025-10-15-create-journey-step
+CREATE TABLE journey_step (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    template_id BIGINT NOT NULL,
+    position INT NOT NULL,
+    name VARCHAR(255),
+    description LONGTEXT,
+    phase VARCHAR(32) NOT NULL,
+    stimulus_type VARCHAR(32) NOT NULL,
+    creative_id BIGINT,
+    angle_id BIGINT,
+    visual_proof_id BIGINT,
+    emotional_trigger_id BIGINT,
+    entry_condition VARCHAR(255),
+    exit_condition VARCHAR(255),
+    delay_minutes INT,
+    CONSTRAINT fk_journey_step_template FOREIGN KEY (template_id) REFERENCES journey_template(id) ON DELETE CASCADE,
+    CONSTRAINT fk_journey_step_creative FOREIGN KEY (creative_id) REFERENCES creative(id),
+    CONSTRAINT fk_journey_step_angle FOREIGN KEY (angle_id) REFERENCES angle(id),
+    CONSTRAINT fk_journey_step_visual_proof FOREIGN KEY (visual_proof_id) REFERENCES visual_proof(id),
+    CONSTRAINT fk_journey_step_emotional_trigger FOREIGN KEY (emotional_trigger_id) REFERENCES emotional_trigger(id)
+) ENGINE=InnoDB;
+
+--changeset marketinghub:2025-10-15-create-journey-step-metadata
+CREATE TABLE journey_step_metadata (
+    step_id BIGINT NOT NULL,
+    meta_key VARCHAR(255) NOT NULL,
+    meta_value LONGTEXT,
+    PRIMARY KEY (step_id, meta_key),
+    CONSTRAINT fk_journey_step_metadata_step FOREIGN KEY (step_id) REFERENCES journey_step(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+--changeset marketinghub:2025-10-15-create-journey
+CREATE TABLE journey (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    template_id BIGINT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description LONGTEXT,
+    status VARCHAR(32) NOT NULL,
+    niche_id BIGINT,
+    experiment_id BIGINT,
+    segment_reference VARCHAR(255),
+    segment_filter LONGTEXT,
+    start_at DATETIME,
+    end_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_journey_template FOREIGN KEY (template_id) REFERENCES journey_template(id),
+    CONSTRAINT fk_journey_niche FOREIGN KEY (niche_id) REFERENCES market_niche(id),
+    CONSTRAINT fk_journey_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id)
+) ENGINE=InnoDB;
+
+--changeset marketinghub:2025-10-15-create-journey-metadata
+CREATE TABLE journey_metadata (
+    journey_id BIGINT NOT NULL,
+    meta_key VARCHAR(255) NOT NULL,
+    meta_value LONGTEXT,
+    PRIMARY KEY (journey_id, meta_key),
+    CONSTRAINT fk_journey_metadata_journey FOREIGN KEY (journey_id) REFERENCES journey(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+--changeset marketinghub:2025-10-15-create-journey-assignment
+CREATE TABLE journey_assignment (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    journey_id BIGINT NOT NULL,
+    type VARCHAR(20) NOT NULL,
+    lead_id BINARY(16),
+    segment_identifier VARCHAR(255),
+    status VARCHAR(20) NOT NULL,
+    current_step_id BIGINT,
+    next_step_id BIGINT,
+    last_event_at DATETIME,
+    context_payload LONGTEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_journey_assignment_journey FOREIGN KEY (journey_id) REFERENCES journey(id) ON DELETE CASCADE,
+    CONSTRAINT fk_journey_assignment_lead FOREIGN KEY (lead_id) REFERENCES `lead`(id),
+    CONSTRAINT fk_journey_assignment_current_step FOREIGN KEY (current_step_id) REFERENCES journey_step(id),
+    CONSTRAINT fk_journey_assignment_next_step FOREIGN KEY (next_step_id) REFERENCES journey_step(id)
+) ENGINE=InnoDB;
+
+--changeset marketinghub:2025-10-15-create-journey-event-log
+CREATE TABLE journey_event_log (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    actor_id BINARY(16),
+    event_type VARCHAR(100) NOT NULL,
+    journey_id BIGINT,
+    journey_step_id BIGINT,
+    source VARCHAR(100),
+    campaign_id VARCHAR(100),
+    metadata LONGTEXT,
+    value DECIMAL(12,2),
+    occurred_at DATETIME NOT NULL,
+    received_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_event_log_journey FOREIGN KEY (journey_id) REFERENCES journey(id),
+    CONSTRAINT fk_event_log_step FOREIGN KEY (journey_step_id) REFERENCES journey_step(id)
+) ENGINE=InnoDB;
+
+--changeset marketinghub:2025-10-15-create-journey-indexes
+CREATE INDEX idx_journey_step_template ON journey_step(template_id);
+CREATE INDEX idx_journey_template_name ON journey_template(name);
+CREATE INDEX idx_journey_status ON journey(status);
+CREATE INDEX idx_journey_assignment_journey ON journey_assignment(journey_id);
+CREATE INDEX idx_journey_event_log_actor ON journey_event_log(actor_id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -92,3 +92,6 @@ databaseChangeLog:
   - include:
       file: V2025_10_10__move_audience_approval.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_10_15__create_journey_tables.sql
+      relativeToChangelogFile: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,36 +1,59 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: Marketing Hub API
   version: 1.0.0
+  description: |
+    REST surface used by MarketingHub frontends, workers and integrations.
+    This document highlights the orchestration endpoints introduced in Journey
+    Orchestration Stage 2 while keeping the existing experiment and creative
+    resources available.
+servers:
+  - url: https://api.marketinghub.local
+    description: Production (placeholder)
+  - url: http://localhost:8000
+    description: Local development
+tags:
+  - name: Journeys
+    description: Modelagem de templates, passos e instâncias operacionais da jornada AIDA.
+  - name: Journey Assignments
+    description: Vínculo de leads ou segmentos às jornadas em execução.
+  - name: Journey Events
+    description: Ingestão de eventos multicanal utilizados para medir e avançar a jornada.
 paths:
   /api/niches/{nicheId}/experiments:
     post:
+      tags: [Experiments]
       summary: Criar experimento
       parameters:
-        - in: path
-          name: nicheId
-          required: true
-          schema:
-            type: integer
+        - $ref: '#/components/parameters/NicheIdParam'
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateExperimentRequest'
+      responses:
+        '201':
+          description: Experimento criado com sucesso
+        '400':
+          description: Dados inválidos
     get:
+      tags: [Experiments]
       summary: Listar experimentos do nicho
       parameters:
-        - in: path
-          name: nicheId
-          required: true
-          schema:
-            type: integer
+        - $ref: '#/components/parameters/NicheIdParam'
       responses:
         '200':
-          description: OK
+          description: Lista de experimentos do nicho
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Experiment'
   /api/experiments:
     post:
+      tags: [Experiments]
       summary: Criar experimento
       requestBody:
         required: true
@@ -39,10 +62,11 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateExperimentRequest'
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Experimento criado
   /api/experiments/{id}/duplicate:
     post:
+      tags: [Experiments]
       summary: Duplicar experimento
       parameters:
         - in: path
@@ -52,9 +76,827 @@ paths:
             type: string
       responses:
         '200':
-          description: OK
+          description: Experimento duplicado
+  /api/experiments/{id}/creatives:
+    post:
+      tags: [Creatives]
+      summary: Criar criativo
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCreativeRequest'
+      responses:
+        '201':
+          description: Criativo criado
+    get:
+      tags: [Creatives]
+      summary: Listar criativos do experimento
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Lista de criativos
+  /api/creatives/{id}/preview:
+    get:
+      tags: [Creatives]
+      summary: Preview do criativo
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Preview retornado
+  /api/experiments/{experimentId}/landing:
+    post:
+      tags: [Landing Pages]
+      summary: Criar landing page
+      parameters:
+        - in: path
+          name: experimentId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateLandingPageRequest'
+      responses:
+        '201':
+          description: Landing criada
+    get:
+      tags: [Landing Pages]
+      summary: Listar landing pages do experimento
+      parameters:
+        - in: path
+          name: experimentId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Lista de landings
+  /api/angles:
+    get:
+      tags: [Creatives]
+      summary: Listar angles
+      responses:
+        '200':
+          description: Lista de angles
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AngleDto'
+    post:
+      tags: [Creatives]
+      summary: Criar angle
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAngleRequest'
+      responses:
+        '201':
+          description: Angle criado
+        '400':
+          description: Dados inválidos
+  /api/angles/{id}:
+    put:
+      tags: [Creatives]
+      summary: Atualizar angle
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AngleDto'
+      responses:
+        '200':
+          description: Angle atualizado
+  /api/visual-proofs:
+    get:
+      tags: [Creatives]
+      summary: Listar visual proofs
+      responses:
+        '200':
+          description: Lista de visual proofs
+    post:
+      tags: [Creatives]
+      summary: Criar visual proof
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateVisualProofRequest'
+      responses:
+        '201':
+          description: Visual proof criado
+  /api/emotional-triggers:
+    get:
+      tags: [Creatives]
+      summary: Listar emotional triggers
+      responses:
+        '200':
+          description: Lista de gatilhos emocionais
+    post:
+      tags: [Creatives]
+      summary: Criar emotional trigger
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEmotionalTriggerRequest'
+      responses:
+        '201':
+          description: Trigger criado
+  /api/creatives/{id}/labels:
+    patch:
+      tags: [Creatives]
+      summary: Atualizar labels do criativo
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCreativeLabelsRequest'
+      responses:
+        '200':
+          description: Labels atualizadas
+  /api/niches/{nicheId}/hypotheses:
+    get:
+      tags: [Hypotheses]
+      summary: Listar hipóteses do nicho
+      parameters:
+        - $ref: '#/components/parameters/NicheIdParam'
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Lista de hipóteses
+  /api/hypotheses:
+    post:
+      tags: [Hypotheses]
+      summary: Criar hipótese
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateHypothesisRequest'
+      responses:
+        '201':
+          description: Hipótese criada
+    get:
+      tags: [Hypotheses]
+      summary: Listar hipóteses
+      parameters:
+        - in: query
+          name: status
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Lista de hipóteses
+  /api/hypotheses/{id}:
+    put:
+      tags: [Hypotheses]
+      summary: Atualizar hipótese
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateHypothesisRequest'
+      responses:
+        '200':
+          description: Hipótese atualizada
+  /api/hypotheses/{id}/status:
+    patch:
+      tags: [Hypotheses]
+      summary: Atualizar status da hipótese
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+      responses:
+        '200':
+          description: Status atualizado
+  /api/experiments/{experimentId}/hypotheses/board:
+    get:
+      tags: [Hypotheses]
+      summary: Visualizar hipóteses em formato Kanban
+      parameters:
+        - in: path
+          name: experimentId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Quadro retornado
+  /api/instagram-creatives/approved:
+    get:
+      tags: [Creatives]
+      summary: Listar criativos do Instagram aprovados
+      responses:
+        '200':
+          description: Lista de criativos aprovados
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InstagramCreative'
+  /api/facebook-campaigns/experiments-ready:
+    get:
+      tags: [Experiments]
+      summary: Listar experimentos prontos para campanhas no Facebook
+      responses:
+        '200':
+          description: Lista de experimentos prontos
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Experiment'
+
+  /api/journey-templates:
+    get:
+      tags: [Journeys]
+      summary: Listar templates de jornada
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/SizeParam'
+      responses:
+        '200':
+          description: Lista paginada de templates
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  content:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/JourneyTemplateSummary'
+                  totalElements:
+                    type: integer
+                  totalPages:
+                    type: integer
+                  number:
+                    type: integer
+    post:
+      tags: [Journeys]
+      summary: Criar template de jornada
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JourneyTemplateRequest'
+      responses:
+        '201':
+          description: Template criado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JourneyTemplate'
+        '400':
+          description: Erro de validação ao criar o template
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+  /api/journey-templates/{id}:
+    get:
+      tags: [Journeys]
+      summary: Consultar template de jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyTemplateIdParam'
+      responses:
+        '200':
+          description: Template encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JourneyTemplate'
+        '404':
+          description: Template não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+    patch:
+      tags: [Journeys]
+      summary: Atualizar template de jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyTemplateIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JourneyTemplateUpdateRequest'
+      responses:
+        '200':
+          description: Template atualizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JourneyTemplate'
+        '400':
+          description: Erro de validação ao atualizar o template
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+        '404':
+          description: Template não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+    delete:
+      tags: [Journeys]
+      summary: Remover template de jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyTemplateIdParam'
+      responses:
+        '204':
+          description: Template removido
+        '404':
+          description: Template não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+  /api/journey-templates/{id}/steps:
+    get:
+      tags: [Journeys]
+      summary: Listar passos de um template
+      parameters:
+        - $ref: '#/components/parameters/JourneyTemplateIdParam'
+      responses:
+        '200':
+          description: Passos ordenados do template
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/JourneyStep'
+        '404':
+          description: Template não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+    post:
+      tags: [Journeys]
+      summary: Adicionar passo ao template
+      parameters:
+        - $ref: '#/components/parameters/JourneyTemplateIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JourneyStepRequest'
+      responses:
+        '201':
+          description: Passo criado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JourneyStep'
+        '400':
+          description: Erro de validação ao criar o passo
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+        '404':
+          description: Template não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+  /api/journey-steps/{id}:
+    get:
+      tags: [Journeys]
+      summary: Consultar passo específico
+      parameters:
+        - $ref: '#/components/parameters/JourneyStepIdParam'
+      responses:
+        '200':
+          description: Passo encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JourneyStep'
+        '404':
+          description: Passo não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+    patch:
+      tags: [Journeys]
+      summary: Atualizar passo de jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyStepIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JourneyStepUpdateRequest'
+      responses:
+        '200':
+          description: Passo atualizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JourneyStep'
+        '400':
+          description: Erro de validação ao atualizar o passo
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+        '404':
+          description: Passo não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+    delete:
+      tags: [Journeys]
+      summary: Remover passo de jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyStepIdParam'
+      responses:
+        '204':
+          description: Passo removido
+        '404':
+          description: Passo não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+  /api/journeys:
+    get:
+      tags: [Journeys]
+      summary: Listar jornadas
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/SizeParam'
+        - in: query
+          name: templateId
+          schema:
+            type: integer
+        - in: query
+          name: status
+          schema:
+            $ref: '#/components/schemas/JourneyStatus'
+      responses:
+        '200':
+          description: Lista paginada de jornadas
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  content:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Journey'
+                  totalElements:
+                    type: integer
+                  totalPages:
+                    type: integer
+                  number:
+                    type: integer
+    post:
+      tags: [Journeys]
+      summary: Criar jornada operacional
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JourneyRequest'
+      responses:
+        '201':
+          description: Jornada criada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Journey'
+        '400':
+          description: Erro de validação ao criar a jornada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+        '404':
+          description: Recursos relacionados não encontrados (template, nicho ou experimento)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+  /api/journeys/{id}:
+    get:
+      tags: [Journeys]
+      summary: Consultar jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyIdParam'
+      responses:
+        '200':
+          description: Jornada encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Journey'
+        '404':
+          description: Jornada não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+    patch:
+      tags: [Journeys]
+      summary: Atualizar jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JourneyUpdateRequest'
+      responses:
+        '200':
+          description: Jornada atualizada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Journey'
+        '400':
+          description: Erro de validação ao atualizar a jornada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+        '404':
+          description: Jornada não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+    delete:
+      tags: [Journeys]
+      summary: Remover jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyIdParam'
+      responses:
+        '204':
+          description: Jornada removida
+        '404':
+          description: Jornada não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+  /api/journeys/{id}/assignments:
+    get:
+      tags: [Journey Assignments]
+      summary: Listar vínculos da jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyIdParam'
+        - in: query
+          name: status
+          schema:
+            $ref: '#/components/schemas/JourneyAssignmentStatus'
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/SizeParam'
+      responses:
+        '200':
+          description: Lista paginada de vínculos
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  content:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/JourneyAssignment'
+                  totalElements:
+                    type: integer
+                  totalPages:
+                    type: integer
+                  number:
+                    type: integer
+        '404':
+          description: Jornada não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+    post:
+      tags: [Journey Assignments]
+      summary: Vincular leads ou segmentos à jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JourneyAssignmentRequest'
+      responses:
+        '201':
+          description: Vínculos criados
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/JourneyAssignment'
+        '400':
+          description: Erro de validação ao atribuir leads ou segmentos
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+        '404':
+          description: Jornada ou passo relacionado não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+  /api/journey-assignments/{assignmentId}:
+    delete:
+      tags: [Journey Assignments]
+      summary: Remover vínculo de jornada
+      parameters:
+        - $ref: '#/components/parameters/JourneyAssignmentIdParam'
+      responses:
+        '204':
+          description: Vínculo removido
+        '404':
+          description: Vínculo não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+  /api/events:
+    post:
+      tags: [Journey Events]
+      summary: Registrar evento multicanal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventLogRequest'
+      responses:
+        '201':
+          description: Evento armazenado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventLog'
+        '400':
+          description: Payload inválido
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+        '404':
+          description: Jornada ou passo de jornada não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemResponse'
+
 components:
+  parameters:
+    NicheIdParam:
+      in: path
+      name: nicheId
+      required: true
+      schema:
+        type: integer
+    JourneyTemplateIdParam:
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+    JourneyStepIdParam:
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+    JourneyIdParam:
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+    JourneyAssignmentIdParam:
+      in: path
+      name: assignmentId
+      required: true
+      schema:
+        type: integer
+    PageParam:
+      in: query
+      name: page
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    SizeParam:
+      in: query
+      name: size
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 20
+
   schemas:
+    ProblemResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+        error:
+          type: string
+        message:
+          type: string
+        path:
+          type: string
     CreateExperimentRequest:
       type: object
       properties:
@@ -82,77 +924,17 @@ components:
           format: date
         salesFunnelName:
           type: string
-  /api/experiments/{id}/creatives:
-    post:
-      summary: Criar criativo
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateCreativeRequest'
-    get:
-      summary: Listar criativos do experimento
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: OK
-  /api/creatives/{id}/preview:
-    get:
-      summary: Preview do criativo
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: OK
-  /api/experiments/{experimentId}/landing:
-    post:
-      summary: Criar landing page
-      parameters:
-        - in: path
-          name: experimentId
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                type:
-                  type: string
-                html:
-                  type: string
-    get:
-      summary: Listar landing pages do experimento
-      parameters:
-        - in: path
-          name: experimentId
-          required: true
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: OK
-components:
-  schemas:
+    Experiment:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        hypothesis:
+          type: string
+        status:
+          type: string
     CreateCreativeRequest:
       type: object
       properties:
@@ -165,102 +947,13 @@ components:
         status:
           type: string
           enum: [DRAFT, READY]
-
-  /api/angles:
-    get:
-      summary: Listar angles
-      responses:
-        '200':
-          description: OK
-    post:
-      summary: Criar angle
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateAngleRequest'
-      responses:
-        '200':
-          description: OK
-        '400':
-          description: Invalid data
-  /api/angles/{id}:
-    put:
-      summary: Atualizar angle
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AngleDto'
-      responses:
-        '200':
-          description: OK
-        '400':
-          description: Invalid data
-        '404':
-          description: Not found
-  /api/visual-proofs:
-    get:
-      summary: Listar visual proofs
-      responses:
-        '200':
-          description: OK
-    post:
-      summary: Criar visual proof
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateVisualProofRequest'
-      responses:
-        '200':
-          description: OK
-  /api/emotional-triggers:
-    get:
-      summary: Listar emotional triggers
-      responses:
-        '200':
-          description: OK
-    post:
-      summary: Criar emotional trigger
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateEmotionalTriggerRequest'
-      responses:
-        '200':
-          description: OK
-  /api/creatives/{id}/labels:
-    patch:
-      summary: Atualizar labels do criativo
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateCreativeLabelsRequest'
-      responses:
-        '200':
-          description: OK
-components:
-  schemas:
+    CreateLandingPageRequest:
+      type: object
+      properties:
+        type:
+          type: string
+        html:
+          type: string
     CreateAngleRequest:
       type: object
       properties:
@@ -275,15 +968,15 @@ components:
           type: string
         frameType:
           type: string
-  AngleDto:
-    type: object
-    properties:
-      id:
-        type: integer
-      name:
-        type: string
-      description:
-        type: string
+    AngleDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
     CreateVisualProofRequest:
       type: object
       properties:
@@ -311,123 +1004,6 @@ components:
           type: integer
         emotionalTriggerId:
           type: integer
-  /api/niches/{nicheId}/hypotheses:
-    get:
-      summary: Listar hipóteses do nicho
-      parameters:
-        - in: path
-          name: nicheId
-          required: true
-          schema:
-            type: integer
-        - in: query
-          name: status
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          description: OK
-  /api/hypotheses:
-    post:
-      summary: Criar hipótese
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateHypothesisRequest'
-      responses:
-        '201':
-          description: Created
-    get:
-      summary: Listar hipóteses
-      parameters:
-        - in: query
-          name: status
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          description: OK
-  /api/hypotheses/{id}:
-    put:
-      summary: Atualizar hipótese
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateHypothesisRequest'
-      responses:
-        '200':
-          description: OK
-  /api/hypotheses/{id}/status:
-    patch:
-      summary: Atualizar status da hipótese
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                status:
-                  type: string
-      responses:
-        '200':
-          description: OK
-  /api/experiments/{experimentId}/hypotheses/board:
-    get:
-      summary: Kanban de hipóteses
-      parameters:
-        - in: path
-          name: experimentId
-          required: true
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: OK
-  /api/instagram-creatives/approved:
-    get:
-      summary: Listar criativos do Instagram aprovados
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/InstagramCreative'
-  /api/facebook-campaigns/experiments-ready:
-    get:
-      summary: Listar experimentos prontos para campanhas no Facebook
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Experiment'
-components:
-  schemas:
     CreateHypothesisRequest:
       type: object
       properties:
@@ -441,14 +1017,14 @@ components:
           type: string
         problem:
           type: string
-          persona:
-            type: string
-          entrega:
-            type: string
-          mechanism:
-            type: string
-          uniqueMechanism:
-            type: string
+        persona:
+          type: string
+        entrega:
+          type: string
+        mechanism:
+          type: string
+        uniqueMechanism:
+          type: string
         successRule:
           type: string
         prompt:
@@ -474,15 +1050,413 @@ components:
           type: string
         content:
           type: string
-    Experiment:
+
+    JourneyPhase:
+      type: string
+      enum: [ATTENTION, INTEREST, DESIRE, ACTION]
+      description: Fases do modelo AIDA utilizadas no template.
+    JourneyStimulusType:
+      type: string
+      enum: [AD, EMAIL, WHATSAPP, LANDING_PAGE]
+    JourneyStatus:
+      type: string
+      enum: [DRAFT, ACTIVE, PAUSED, COMPLETED, ARCHIVED]
+    JourneyAssignmentStatus:
+      type: string
+      enum: [PENDING, IN_PROGRESS, COMPLETED, STOPPED]
+    JourneyAssignmentType:
+      type: string
+      enum: [LEAD, SEGMENT]
+
+    JourneyTemplateRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        objective:
+          type: string
+        phases:
+          type: array
+          items:
+            $ref: '#/components/schemas/JourneyPhase'
+        preferredChannel:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    JourneyTemplateUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        objective:
+          type: string
+        phases:
+          type: array
+          items:
+            $ref: '#/components/schemas/JourneyPhase'
+        preferredChannel:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    JourneyTemplateSummary:
       type: object
       properties:
         id:
           type: integer
         name:
           type: string
-        salesFunnelId:
+        objective:
+          type: string
+        phases:
+          type: array
+          items:
+            $ref: '#/components/schemas/JourneyPhase'
+        preferredChannel:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    JourneyTemplate:
+      allOf:
+        - $ref: '#/components/schemas/JourneyTemplateSummary'
+        - type: object
+          properties:
+            description:
+              type: string
+            steps:
+              type: array
+              items:
+                $ref: '#/components/schemas/JourneyStep'
+    JourneyStepRequest:
+      type: object
+      required: [phase, stimulusType]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        phase:
+          $ref: '#/components/schemas/JourneyPhase'
+        stimulusType:
+          $ref: '#/components/schemas/JourneyStimulusType'
+        position:
+          type: integer
+        creativeId:
+          type: integer
+        angleId:
+          type: integer
+        visualProofId:
+          type: integer
+        emotionalTriggerId:
+          type: integer
+        entryCondition:
+          type: string
+        exitCondition:
+          type: string
+        delayMinutes:
+          type: integer
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    JourneyStepUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        phase:
+          $ref: '#/components/schemas/JourneyPhase'
+        stimulusType:
+          $ref: '#/components/schemas/JourneyStimulusType'
+        position:
+          type: integer
+        creativeId:
+          type: integer
+        angleId:
+          type: integer
+        visualProofId:
+          type: integer
+        emotionalTriggerId:
+          type: integer
+        entryCondition:
+          type: string
+        exitCondition:
+          type: string
+        delayMinutes:
+          type: integer
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    JourneyStep:
+      type: object
+      properties:
+        id:
+          type: integer
+        templateId:
+          type: integer
+        position:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        phase:
+          $ref: '#/components/schemas/JourneyPhase'
+        stimulusType:
+          $ref: '#/components/schemas/JourneyStimulusType'
+        creativeId:
+          type: integer
+        angleId:
+          type: integer
+        visualProofId:
+          type: integer
+        emotionalTriggerId:
+          type: integer
+        entryCondition:
+          type: string
+        exitCondition:
+          type: string
+        delayMinutes:
+          type: integer
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    JourneyRequest:
+      type: object
+      required: [templateId, name]
+      properties:
+        templateId:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        status:
+          $ref: '#/components/schemas/JourneyStatus'
+        marketNicheId:
+          type: integer
+        experimentId:
+          type: integer
+        segmentReference:
+          type: string
+        segmentFilter:
+          type: string
+        startAt:
+          type: string
+          format: date-time
+        endAt:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    JourneyUpdateRequest:
+      type: object
+      properties:
+        templateId:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        status:
+          $ref: '#/components/schemas/JourneyStatus'
+        marketNicheId:
+          type: integer
+        experimentId:
+          type: integer
+        segmentReference:
+          type: string
+        segmentFilter:
+          type: string
+        startAt:
+          type: string
+          format: date-time
+        endAt:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    Journey:
+      type: object
+      properties:
+        id:
+          type: integer
+        templateId:
+          type: integer
+        templateName:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        status:
+          $ref: '#/components/schemas/JourneyStatus'
+        marketNicheId:
+          type: integer
+        experimentId:
+          type: integer
+        segmentReference:
+          type: string
+        segmentFilter:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+        startAt:
+          type: string
+          format: date-time
+        endAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    JourneyAssignmentRequest:
+      type: object
+      properties:
+        leadIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        segmentIdentifiers:
+          type: array
+          items:
+            type: string
+        status:
+          $ref: '#/components/schemas/JourneyAssignmentStatus'
+        currentStepId:
+          type: integer
+        nextStepId:
+          type: integer
+        contextPayload:
+          type: string
+      description: Pelo menos um dos campos `leadIds` ou `segmentIdentifiers` é obrigatório.
+    JourneyAssignment:
+      type: object
+      properties:
+        id:
+          type: integer
+        journeyId:
+          type: integer
+        type:
+          $ref: '#/components/schemas/JourneyAssignmentType'
+        status:
+          $ref: '#/components/schemas/JourneyAssignmentStatus'
+        leadId:
           type: string
           format: uuid
-        salesFunnelName:
+        segmentIdentifier:
           type: string
+        currentStepId:
+          type: integer
+        nextStepId:
+          type: integer
+        lastEventAt:
+          type: string
+          format: date-time
+        contextPayload:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    EventLogRequest:
+      type: object
+      required: [eventType]
+      properties:
+        actorId:
+          type: string
+          format: uuid
+        eventType:
+          type: string
+        journeyId:
+          type: integer
+        journeyStepId:
+          type: integer
+        source:
+          type: string
+        campaignId:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: {}
+        value:
+          type: number
+          format: float
+        occurredAt:
+          type: string
+          format: date-time
+          description: Data/hora do evento; quando omitido, o backend aplica o horário de ingestão.
+    EventLog:
+      type: object
+      properties:
+        id:
+          type: integer
+        actorId:
+          type: string
+          format: uuid
+        eventType:
+          type: string
+        journeyId:
+          type: integer
+        journeyStepId:
+          type: integer
+        source:
+          type: string
+        campaignId:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: {}
+        value:
+          type: number
+          format: float
+        occurredAt:
+          type: string
+          format: date-time
+        receivedAt:
+          type: string
+          format: date-time


### PR DESCRIPTION
## Summary
- introduce journey orchestration domain models for templates, steps, journeys, assignments and events with repositories, services and controllers
- add Liquibase migration to persist templates, steps, journeys, assignments and canonical event logs
- refresh OpenAPI 3.1 specification documenting all new journey orchestration endpoints, payloads and enums

## Testing
- `mvn -s ../settings.xml test` *(fails: cannot resolve spring-boot-starter-parent from GitHub Packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2c4ebb008321bfcaf203d65d59d3