### PR TITLE
Implement journey execution orchestrator and telemetry runtime

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/JourneyConditionEvaluator.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/JourneyConditionEvaluator.java
@@ -1,0 +1,66 @@
+package com.marketinghub.journey.execution;
+
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyStep;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.SimpleEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Evaluates simple conditions declared in journey steps using SpEL.
+ */
+@Component
+@Slf4j
+public class JourneyConditionEvaluator {
+    private final ExpressionParser parser = new SpelExpressionParser();
+
+    public boolean evaluateEntryCondition(JourneyAssignment assignment,
+                                          JourneyStep step,
+                                          Map<String, Object> context) {
+        String entryCondition = step.getEntryCondition();
+        if (entryCondition == null || entryCondition.isBlank()) {
+            return true;
+        }
+        return evaluate(entryCondition, assignment, step, context);
+    }
+
+    public boolean evaluateExitCondition(JourneyAssignment assignment,
+                                         JourneyStep step,
+                                         Map<String, Object> context) {
+        String exitCondition = step.getExitCondition();
+        if (exitCondition == null || exitCondition.isBlank()) {
+            return false;
+        }
+        return evaluate(exitCondition, assignment, step, context);
+    }
+
+    private boolean evaluate(String expression,
+                             JourneyAssignment assignment,
+                             JourneyStep step,
+                             Map<String, Object> context) {
+        try {
+            Map<String, Object> root = new HashMap<>();
+            root.put("assignment", assignment);
+            root.put("journey", assignment.getJourney());
+            root.put("lead", assignment.getLead());
+            root.put("step", step);
+            root.put("context", context);
+            SimpleEvaluationContext evalContext = SimpleEvaluationContext
+                    .forReadOnlyDataBinding()
+                    .withRootObject(root)
+                    .build();
+            Expression compiled = parser.parseExpression(expression);
+            Boolean result = compiled.getValue(evalContext, Boolean.class);
+            return Boolean.TRUE.equals(result);
+        } catch (Exception ex) {
+            log.warn("Failed to evaluate condition '{}' for assignment {}", expression, assignment.getId(), ex);
+            return false;
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/JourneyExecutionProperties.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/JourneyExecutionProperties.java
@@ -1,0 +1,66 @@
+package com.marketinghub.journey.execution;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Configuration knobs for journey orchestration runtime.
+ */
+@Component
+@ConfigurationProperties(prefix = "journey.execution")
+@Getter
+@Setter
+@ToString
+public class JourneyExecutionProperties {
+    @NotNull
+    private Duration pollInterval = Duration.ofSeconds(30);
+
+    @Min(1)
+    @Max(500)
+    private int batchSize = 50;
+
+    @NotNull
+    private FrequencyCapProperties frequencyCap = new FrequencyCapProperties();
+
+    @NotNull
+    private RetryProperties retry = new RetryProperties();
+
+    @Getter
+    @Setter
+    @ToString
+    public static class FrequencyCapProperties {
+        private boolean enabled = true;
+        @Min(1)
+        private int perDay = 3;
+        @Min(1)
+        private int perWeek = 10;
+        @NotNull
+        private Duration cooldown = Duration.ofHours(6);
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class RetryProperties {
+        @Min(1)
+        private int maxAttempts = 3;
+        @NotNull
+        private Duration initialBackoff = Duration.ofSeconds(30);
+        @NotNull
+        private Duration maxBackoff = Duration.ofMinutes(30);
+        /**
+         * Jitter factor applied to backoff (percentage in the range [0,100]).
+         */
+        @Min(0)
+        @Max(100)
+        private int jitterPercentage = 25;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/JourneyExecutionScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/JourneyExecutionScheduler.java
@@ -1,0 +1,27 @@
+package com.marketinghub.journey.execution;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Periodically pulls journey assignments and triggers dispatch.
+ */
+@Component
+@Slf4j
+public class JourneyExecutionScheduler {
+    private final JourneyExecutionService executionService;
+
+    public JourneyExecutionScheduler(JourneyExecutionService executionService) {
+        this.executionService = executionService;
+    }
+
+    @Scheduled(fixedDelayString = "#{@journeyExecutionProperties.pollInterval.toMillis()}")
+    public void run() {
+        try {
+            executionService.processDueAssignments();
+        } catch (Exception ex) {
+            log.error("Unexpected error while processing journey assignments", ex);
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/JourneyExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/JourneyExecutionService.java
@@ -1,0 +1,346 @@
+package com.marketinghub.journey.execution;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.journey.execution.channel.ChannelDispatchResult;
+import com.marketinghub.journey.execution.channel.ChannelDispatchStatus;
+import com.marketinghub.journey.execution.channel.JourneyChannelHandler;
+import com.marketinghub.journey.execution.policy.FrequencyCapResult;
+import com.marketinghub.journey.execution.policy.FrequencyCapService;
+import com.marketinghub.journey.execution.policy.RetryBackoffCalculator;
+import com.marketinghub.journey.model.*;
+import com.marketinghub.journey.repository.EventLogRepository;
+import com.marketinghub.journey.repository.JourneyAssignmentRepository;
+import com.marketinghub.journey.repository.JourneyStepRepository;
+import com.marketinghub.model.Lead;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Core orchestrator that transforms journey models into actionable stimuli.
+ */
+@Service
+@Slf4j
+public class JourneyExecutionService {
+    private final JourneyAssignmentRepository assignmentRepository;
+    private final JourneyStepRepository stepRepository;
+    private final EventLogRepository eventLogRepository;
+    private final JourneyExecutionProperties properties;
+    private final FrequencyCapService frequencyCapService;
+    private final RetryBackoffCalculator retryBackoffCalculator;
+    private final JourneyConditionEvaluator conditionEvaluator;
+    private final TelemetryService telemetryService;
+    private final ObjectMapper objectMapper;
+    private final TransactionTemplate transactionTemplate;
+    private final Map<JourneyStimulusType, JourneyChannelHandler> handlerByType;
+
+    public JourneyExecutionService(JourneyAssignmentRepository assignmentRepository,
+                                   JourneyStepRepository stepRepository,
+                                   EventLogRepository eventLogRepository,
+                                   JourneyExecutionProperties properties,
+                                   FrequencyCapService frequencyCapService,
+                                   RetryBackoffCalculator retryBackoffCalculator,
+                                   JourneyConditionEvaluator conditionEvaluator,
+                                   TelemetryService telemetryService,
+                                   ObjectMapper objectMapper,
+                                   PlatformTransactionManager transactionManager,
+                                   List<JourneyChannelHandler> handlers) {
+        this.assignmentRepository = assignmentRepository;
+        this.stepRepository = stepRepository;
+        this.eventLogRepository = eventLogRepository;
+        this.properties = properties;
+        this.frequencyCapService = frequencyCapService;
+        this.retryBackoffCalculator = retryBackoffCalculator;
+        this.conditionEvaluator = conditionEvaluator;
+        this.telemetryService = telemetryService;
+        this.objectMapper = objectMapper;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+        this.transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        this.handlerByType = handlers.stream()
+                .collect(Collectors.toMap(JourneyChannelHandler::supportedType, h -> h));
+    }
+
+    public void processDueAssignments() {
+        Instant now = Instant.now();
+        List<JourneyAssignment> candidates = assignmentRepository
+                .findEligibleAssignments(List.of(JourneyAssignmentStatus.PENDING, JourneyAssignmentStatus.IN_PROGRESS),
+                        now,
+                        PageRequest.of(0, properties.getBatchSize()))
+                .getContent();
+        for (JourneyAssignment assignment : candidates) {
+            transactionTemplate.executeWithoutResult(status -> processSingle(assignment.getId(), now));
+        }
+    }
+
+    private void processSingle(Long assignmentId, Instant referenceTime) {
+        Optional<JourneyAssignment> optional = assignmentRepository.findByIdForUpdate(assignmentId);
+        if (optional.isEmpty()) {
+            return;
+        }
+        JourneyAssignment assignment = optional.get();
+        JourneyStep step = assignment.getNextStep();
+        if (step == null) {
+            markJourneyCompleteIfNeeded(assignment, referenceTime);
+            assignmentRepository.save(assignment);
+            return;
+        }
+        if (!isJourneyActive(assignment.getJourney(), referenceTime)) {
+            return;
+        }
+        if (!isDue(assignment, step, referenceTime)) {
+            return;
+        }
+
+        Map<String, Object> context = parseContext(assignment.getContextPayload());
+        assignment.setStatus(JourneyAssignmentStatus.IN_PROGRESS);
+
+        if (!conditionEvaluator.evaluateEntryCondition(assignment, step, context)) {
+            skipStep(assignment, step, context, referenceTime, "entry_condition_false");
+            return;
+        }
+
+        FrequencyCapResult capResult = frequencyCapService.evaluate(assignment, referenceTime);
+        if (capResult.blocked()) {
+            handleFrequencyCap(assignment, step, referenceTime, capResult);
+            return;
+        }
+
+        JourneyChannelHandler handler = handlerByType.get(step.getStimulusType());
+        if (handler == null) {
+            log.warn("No handler registered for stimulus type {}", step.getStimulusType());
+            handlePermanentFailure(assignment, step, referenceTime,
+                    ChannelDispatchResult.permanentFailure("No handler for stimulus type", Map.of("stimulusType", step.getStimulusType().name())));
+            return;
+        }
+
+        ChannelDispatchResult dispatchResult;
+        try {
+            dispatchResult = handler.dispatch(assignment, step, context);
+        } catch (Exception ex) {
+            log.error("Unexpected error dispatching assignment {}", assignment.getId(), ex);
+            dispatchResult = ChannelDispatchResult.transientFailure("Unexpected error: " + ex.getMessage(), null, Map.of());
+        }
+        applyDispatchResult(assignment, step, context, referenceTime, dispatchResult);
+    }
+
+    private boolean isJourneyActive(Journey journey, Instant now) {
+        if (journey.getStatus() != JourneyStatus.ACTIVE) {
+            return false;
+        }
+        if (journey.getStartAt() != null && now.isBefore(journey.getStartAt())) {
+            return false;
+        }
+        return journey.getEndAt() == null || !now.isAfter(journey.getEndAt());
+    }
+
+    private boolean isDue(JourneyAssignment assignment, JourneyStep step, Instant now) {
+        Instant candidate = assignment.getNextAttemptAt();
+        if (candidate == null) {
+            Instant base = assignment.getLastEventAt();
+            if (base == null) {
+                base = assignment.getCreatedAt();
+            }
+            Instant journeyStart = assignment.getJourney().getStartAt();
+            if (journeyStart != null && (base == null || base.isBefore(journeyStart))) {
+                base = journeyStart;
+            }
+            if (base == null) {
+                base = now;
+            }
+            int delayMinutes = step.getDelayMinutes() != null ? step.getDelayMinutes() : 0;
+            candidate = base.plus(Duration.ofMinutes(delayMinutes));
+        }
+        return !candidate.isAfter(now);
+    }
+
+    private void skipStep(JourneyAssignment assignment,
+                          JourneyStep step,
+                          Map<String, Object> context,
+                          Instant occurredAt,
+                          String reason) {
+        log.debug("Skipping step {} for assignment {}", step.getId(), assignment.getId());
+        JourneyStep next = resolveNextStep(step);
+        assignment.setCurrentStep(step);
+        assignment.setLastEventAt(occurredAt);
+        assignment.setNextStep(next);
+        assignment.setRetryCount(0);
+        assignment.setNextAttemptAt(null);
+        assignment.setStatus(next == null ? JourneyAssignmentStatus.COMPLETED : JourneyAssignmentStatus.IN_PROGRESS);
+        assignmentRepository.save(assignment);
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("reason", reason);
+        metadata.put("stepId", step.getId());
+        metadata.put("context", context);
+        recordEvent(assignment, step, occurredAt, JourneyEventType.STIMULUS_SKIPPED, metadata);
+        if (next == null) {
+            recordEvent(assignment, step, occurredAt, JourneyEventType.JOURNEY_COMPLETED, Map.of());
+        }
+    }
+
+    private void handleFrequencyCap(JourneyAssignment assignment,
+                                    JourneyStep step,
+                                    Instant now,
+                                    FrequencyCapResult capResult) {
+        assignment.setNextAttemptAt(capResult.nextAttemptAt());
+        assignment.setRetryCount(0);
+        assignment.setStatus(JourneyAssignmentStatus.IN_PROGRESS);
+        assignmentRepository.save(assignment);
+        recordEvent(assignment, step, now, JourneyEventType.STIMULUS_FREQUENCY_CAPPED, capResult.metadata());
+    }
+
+    private void applyDispatchResult(JourneyAssignment assignment,
+                                     JourneyStep step,
+                                     Map<String, Object> context,
+                                     Instant occurredAt,
+                                     ChannelDispatchResult result) {
+        if (result.status() == ChannelDispatchStatus.OK) {
+            handleSuccess(assignment, step, context, occurredAt, result);
+            return;
+        }
+        if (result.status() == ChannelDispatchStatus.TRANSIENT_ERROR) {
+            handleTransientFailure(assignment, step, occurredAt, result);
+            return;
+        }
+        handlePermanentFailure(assignment, step, occurredAt, result);
+    }
+
+    private void handleSuccess(JourneyAssignment assignment,
+                                JourneyStep step,
+                                Map<String, Object> context,
+                                Instant occurredAt,
+                                ChannelDispatchResult result) {
+        JourneyStep next = resolveNextStep(step);
+        assignment.setCurrentStep(step);
+        assignment.setLastEventAt(occurredAt);
+        assignment.setNextStep(next);
+        assignment.setNextAttemptAt(null);
+        assignment.setRetryCount(0);
+        assignment.setStatus(next == null ? JourneyAssignmentStatus.COMPLETED : JourneyAssignmentStatus.IN_PROGRESS);
+        assignmentRepository.save(assignment);
+
+        Map<String, Object> metadata = new HashMap<>(result.metadata());
+        if (result.providerMessageId() != null) {
+            metadata.put("providerMessageId", result.providerMessageId());
+        }
+        metadata.put("stepId", step.getId());
+        recordEvent(assignment, step, occurredAt, JourneyEventType.STIMULUS_DISPATCHED, metadata);
+        telemetryService.emitStepDispatched(assignment, step, context, metadata);
+        if (next == null) {
+            recordEvent(assignment, step, occurredAt, JourneyEventType.JOURNEY_COMPLETED, Map.of());
+        }
+    }
+
+    private void handleTransientFailure(JourneyAssignment assignment,
+                                        JourneyStep step,
+                                        Instant now,
+                                        ChannelDispatchResult result) {
+        int attempt = assignment.getRetryCount() != null ? assignment.getRetryCount() + 1 : 1;
+        assignment.setRetryCount(attempt);
+        if (attempt >= properties.getRetry().getMaxAttempts()) {
+            log.warn("Max retry attempts reached for assignment {}", assignment.getId());
+            assignment.setStatus(JourneyAssignmentStatus.STOPPED);
+            assignment.setNextAttemptAt(null);
+            assignmentRepository.save(assignment);
+            Map<String, Object> metadata = new HashMap<>(result.metadata());
+            metadata.put("maxRetries", properties.getRetry().getMaxAttempts());
+            metadata.put("error", result.errorMessage());
+            recordEvent(assignment, step, now, JourneyEventType.STIMULUS_FAILED, metadata);
+            return;
+        }
+        Instant nextAttempt = result.nextAttemptAt();
+        if (nextAttempt == null) {
+            Duration backoff = retryBackoffCalculator.computeDelay(attempt);
+            nextAttempt = now.plus(backoff);
+        }
+        assignment.setNextAttemptAt(nextAttempt);
+        assignment.setStatus(JourneyAssignmentStatus.IN_PROGRESS);
+        assignmentRepository.save(assignment);
+        Map<String, Object> metadata = new HashMap<>(result.metadata());
+        metadata.put("retryCount", attempt);
+        metadata.put("nextAttemptAt", nextAttempt);
+        metadata.put("error", result.errorMessage());
+        recordEvent(assignment, step, now, JourneyEventType.STIMULUS_FAILED, metadata);
+    }
+
+    private void handlePermanentFailure(JourneyAssignment assignment,
+                                        JourneyStep step,
+                                        Instant now,
+                                        ChannelDispatchResult result) {
+        assignment.setStatus(JourneyAssignmentStatus.STOPPED);
+        assignment.setNextAttemptAt(null);
+        assignmentRepository.save(assignment);
+        Map<String, Object> metadata = new HashMap<>(result.metadata());
+        metadata.put("error", result.errorMessage());
+        recordEvent(assignment, step, now, JourneyEventType.STIMULUS_FAILED, metadata);
+    }
+
+    private void markJourneyCompleteIfNeeded(JourneyAssignment assignment, Instant now) {
+        if (assignment.getStatus() != JourneyAssignmentStatus.COMPLETED) {
+            assignment.setStatus(JourneyAssignmentStatus.COMPLETED);
+            recordEvent(assignment, null, now, JourneyEventType.JOURNEY_COMPLETED, Map.of());
+        }
+    }
+
+    private JourneyStep resolveNextStep(JourneyStep current) {
+        return stepRepository.findFirstByTemplateAndPositionGreaterThanOrderByPositionAsc(current.getTemplate(), current.getPosition())
+                .orElse(null);
+    }
+
+    private Map<String, Object> parseContext(String contextPayload) {
+        if (contextPayload == null || contextPayload.isBlank()) {
+            return new HashMap<>();
+        }
+        try {
+            return objectMapper.readValue(contextPayload, Map.class);
+        } catch (JsonProcessingException e) {
+            log.warn("Invalid context payload for journey assignment", e);
+            return new HashMap<>();
+        }
+    }
+
+    private void recordEvent(JourneyAssignment assignment,
+                              JourneyStep step,
+                              Instant occurredAt,
+                              JourneyEventType type,
+                              Map<String, Object> metadata) {
+        EventLog logEntry = EventLog.builder()
+                .actorId(extractActorId(assignment.getLead()))
+                .eventType(type.getCode())
+                .journey(assignment.getJourney())
+                .journeyStep(step)
+                .source("journey-orchestrator")
+                .metadata(toJson(metadata))
+                .occurredAt(occurredAt)
+                .build();
+        eventLogRepository.save(logEntry);
+    }
+
+    private UUID extractActorId(Lead lead) {
+        if (lead == null) {
+            return null;
+        }
+        return lead.getId();
+    }
+
+    private String toJson(Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(metadata);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialise metadata", e);
+            return null;
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/TelemetryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/TelemetryService.java
@@ -1,0 +1,198 @@
+package com.marketinghub.journey.execution;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.journey.execution.config.Ga4Properties;
+import com.marketinghub.journey.execution.config.MetaMarketingProperties;
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyStimulusType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Bridges server-side events to Meta Pixel and GA4 Measurement Protocol.
+ */
+@Service
+@Slf4j
+public class TelemetryService {
+    private final RestTemplate metaRestTemplate;
+    private final RestTemplate gaRestTemplate;
+    private final MetaMarketingProperties metaProperties;
+    private final Ga4Properties ga4Properties;
+    private final ObjectMapper objectMapper;
+
+    public TelemetryService(RestTemplateBuilder restTemplateBuilder,
+                            MetaMarketingProperties metaProperties,
+                            Ga4Properties ga4Properties,
+                            ObjectMapper objectMapper) {
+        this.metaRestTemplate = restTemplateBuilder.build();
+        this.gaRestTemplate = restTemplateBuilder.build();
+        this.metaProperties = metaProperties;
+        this.ga4Properties = ga4Properties;
+        this.objectMapper = objectMapper;
+    }
+
+    public void emitStepDispatched(JourneyAssignment assignment,
+                                   JourneyStep step,
+                                   Map<String, Object> context,
+                                   Map<String, Object> dispatchMetadata) {
+        Instant now = Instant.now();
+        if (metaProperties.isPixelEnabled()) {
+            sendPixelEvent(assignment, step, dispatchMetadata, now);
+        }
+        if (ga4Properties.isEnabled()) {
+            sendGa4Event(assignment, step, dispatchMetadata, now, context);
+        }
+    }
+
+    private void sendPixelEvent(JourneyAssignment assignment,
+                                JourneyStep step,
+                                Map<String, Object> dispatchMetadata,
+                                Instant now) {
+        if (metaProperties.getPixelId() == null || metaProperties.getAccessToken() == null) {
+            log.debug("Pixel not configured, skipping telemetry");
+            return;
+        }
+        String url = metaProperties.getBaseUrl() + "/" + metaProperties.getPixelId() + "/events";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setBearerAuth(metaProperties.getAccessToken());
+
+        Map<String, Object> customData = new HashMap<>();
+        customData.put("journey_id", assignment.getJourney().getId());
+        customData.put("step_id", step.getId());
+        customData.put("stimulus_type", step.getStimulusType().name());
+        customData.put("phase", step.getPhase().name());
+        if (dispatchMetadata != null) {
+            Object providerMessageId = dispatchMetadata.get("providerMessageId");
+            if (providerMessageId != null) {
+                customData.put("provider_message_id", providerMessageId);
+            }
+            Object value = dispatchMetadata.get("value");
+            if (value != null) {
+                customData.put("value", value);
+            }
+        }
+
+        Map<String, Object> event = new HashMap<>();
+        event.put("event_name", resolvePixelEventName(step));
+        event.put("event_time", now.getEpochSecond());
+        event.put("event_id", buildEventId(assignment, step));
+        event.put("custom_data", customData);
+
+        Map<String, Object> payload = Map.of("data", List.of(event));
+        try {
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+            metaRestTemplate.exchange(url, HttpMethod.POST, request, String.class);
+        } catch (RestClientException ex) {
+            log.warn("Failed to send Meta Pixel event", ex);
+        }
+    }
+
+    private void sendGa4Event(JourneyAssignment assignment,
+                              JourneyStep step,
+                              Map<String, Object> dispatchMetadata,
+                              Instant now,
+                              Map<String, Object> context) {
+        if (ga4Properties.getMeasurementId() == null || ga4Properties.getApiSecret() == null) {
+            log.debug("GA4 not configured, skipping telemetry");
+            return;
+        }
+        String url = ga4Properties.getEndpoint() + "?measurement_id=" + ga4Properties.getMeasurementId() + "&api_secret=" + ga4Properties.getApiSecret();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("journey_id", assignment.getJourney().getId());
+        params.put("step_id", step.getId());
+        params.put("stimulus_type", step.getStimulusType().name());
+        params.put("journey_phase", step.getPhase().name());
+        params.put("engagement_time_msec", 1);
+        if (dispatchMetadata != null) {
+            Object providerMessageId = dispatchMetadata.get("providerMessageId");
+            if (providerMessageId != null) {
+                params.put("provider_message_id", providerMessageId);
+            }
+            Object value = dispatchMetadata.get("value");
+            if (value != null) {
+                params.put("value", value);
+            }
+        }
+        if (context != null) {
+            Object source = context.get("source");
+            if (source instanceof String src) {
+                params.put("source", src);
+            }
+        }
+
+        Map<String, Object> event = new HashMap<>();
+        event.put("name", resolveGa4EventName(step));
+        event.put("params", params);
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("client_id", resolveClientId(assignment));
+        payload.put("timestamp_micros", now.toEpochMilli() * 1000);
+        payload.put("events", List.of(event));
+        try {
+            String json = objectMapper.writeValueAsString(payload);
+            HttpEntity<String> request = new HttpEntity<>(json, headers);
+            gaRestTemplate.exchange(url, HttpMethod.POST, request, String.class);
+        } catch (JsonProcessingException e) {
+            log.warn("Unable to serialise GA4 payload", e);
+        } catch (RestClientException ex) {
+            log.warn("Failed to send GA4 event", ex);
+        }
+    }
+
+    private String resolvePixelEventName(JourneyStep step) {
+        String metadataEvent = step.getMetadata().get("pixelEvent");
+        if (metadataEvent != null && !metadataEvent.isBlank()) {
+            return metadataEvent;
+        }
+        return switch (step.getPhase()) {
+            case ACTION -> "Purchase";
+            case DESIRE -> "AddToCart";
+            default -> "Lead";
+        };
+    }
+
+    private String resolveGa4EventName(JourneyStep step) {
+        String metadataEvent = step.getMetadata().get("ga4Event");
+        if (metadataEvent != null && !metadataEvent.isBlank()) {
+            return metadataEvent;
+        }
+        return switch (step.getStimulusType()) {
+            case AD -> "ad_impression";
+            case EMAIL -> "email_sent";
+            case WHATSAPP -> "whatsapp_message_sent";
+            case LANDING_PAGE -> "landing_view";
+        };
+    }
+
+    private String buildEventId(JourneyAssignment assignment, JourneyStep step) {
+        return assignment.getId() + "-" + step.getId();
+    }
+
+    private String resolveClientId(JourneyAssignment assignment) {
+        UUID actor = assignment.getLead() != null ? assignment.getLead().getId() : null;
+        if (actor != null) {
+            return actor.toString();
+        }
+        return assignment.getId().toString();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/ChannelDispatchResult.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/ChannelDispatchResult.java
@@ -1,0 +1,25 @@
+package com.marketinghub.journey.execution.channel;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Result of dispatching a journey stimulus through an external provider.
+ */
+public record ChannelDispatchResult(ChannelDispatchStatus status,
+                                    String providerMessageId,
+                                    Instant nextAttemptAt,
+                                    String errorMessage,
+                                    Map<String, Object> metadata) {
+    public static ChannelDispatchResult success(String providerMessageId, Map<String, Object> metadata) {
+        return new ChannelDispatchResult(ChannelDispatchStatus.OK, providerMessageId, null, null, metadata == null ? Map.of() : metadata);
+    }
+
+    public static ChannelDispatchResult transientFailure(String message, Instant nextAttemptAt, Map<String, Object> metadata) {
+        return new ChannelDispatchResult(ChannelDispatchStatus.TRANSIENT_ERROR, null, nextAttemptAt, message, metadata == null ? Map.of() : metadata);
+    }
+
+    public static ChannelDispatchResult permanentFailure(String message, Map<String, Object> metadata) {
+        return new ChannelDispatchResult(ChannelDispatchStatus.PERMANENT_ERROR, null, null, message, metadata == null ? Map.of() : metadata);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/ChannelDispatchStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/ChannelDispatchStatus.java
@@ -1,0 +1,10 @@
+package com.marketinghub.journey.execution.channel;
+
+/**
+ * Normalised status returned by channel handlers after attempting a dispatch.
+ */
+public enum ChannelDispatchStatus {
+    OK,
+    TRANSIENT_ERROR,
+    PERMANENT_ERROR
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/JourneyChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/JourneyChannelHandler.java
@@ -1,0 +1,16 @@
+package com.marketinghub.journey.execution.channel;
+
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyStimulusType;
+
+import java.util.Map;
+
+/**
+ * Contract for external channel adapters (Meta Ads, SendGrid, WhatsApp...).
+ */
+public interface JourneyChannelHandler {
+    JourneyStimulusType supportedType();
+
+    ChannelDispatchResult dispatch(JourneyAssignment assignment, JourneyStep step, Map<String, Object> context);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/MetaAdsChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/MetaAdsChannelHandler.java
@@ -1,0 +1,134 @@
+package com.marketinghub.journey.execution.channel;
+
+import com.marketinghub.journey.execution.config.MetaMarketingProperties;
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyStimulusType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handler responsible for dispatching ads through Meta Marketing API.
+ */
+@Component
+@Slf4j
+public class MetaAdsChannelHandler implements JourneyChannelHandler {
+    private final RestTemplate restTemplate;
+    private final MetaMarketingProperties properties;
+
+    public MetaAdsChannelHandler(RestTemplateBuilder restTemplateBuilder,
+                                 MetaMarketingProperties properties) {
+        this(restTemplateBuilder.build(), properties);
+    }
+
+    MetaAdsChannelHandler(RestTemplate restTemplate, MetaMarketingProperties properties) {
+        this.restTemplate = restTemplate;
+        this.properties = properties;
+    }
+
+    @Override
+    public JourneyStimulusType supportedType() {
+        return JourneyStimulusType.AD;
+    }
+
+    @Override
+    public ChannelDispatchResult dispatch(JourneyAssignment assignment, JourneyStep step, Map<String, Object> context) {
+        if (!properties.isEnabled()) {
+            return ChannelDispatchResult.permanentFailure("Meta Marketing API integration disabled", Map.of());
+        }
+        if (properties.getAccessToken() == null || properties.getAdAccountId() == null) {
+            return ChannelDispatchResult.permanentFailure("Meta access token or ad account not configured", Map.of());
+        }
+
+        try {
+            String url = properties.getBaseUrl() + "/act_" + properties.getAdAccountId() + "/ads";
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+            headers.setBearerAuth(properties.getAccessToken());
+
+            Map<String, Object> payload = buildPayload(step);
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+            ResponseEntity<MetaAdResponse> response = restTemplate.exchange(url, HttpMethod.POST, request, MetaAdResponse.class);
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                MetaAdResponse body = response.getBody();
+                Map<String, Object> metadata = new HashMap<>();
+                metadata.put("adId", body.id());
+                metadata.put("creativeId", step.getMetadata().get("creativeId"));
+                metadata.put("status", payload.get("status"));
+                return ChannelDispatchResult.success(body.id(), metadata);
+            }
+            if (response.getStatusCode().is5xxServerError() || response.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                Instant retryAt = resolveRetryAt(response.getHeaders());
+                return ChannelDispatchResult.transientFailure("Meta API transient response: " + response.getStatusCode(), retryAt, Map.of());
+            }
+            return ChannelDispatchResult.permanentFailure("Meta API returned status " + response.getStatusCode(), Map.of());
+        } catch (HttpStatusCodeException ex) {
+            if (ex.getStatusCode().is5xxServerError() || ex.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                Instant retryAt = resolveRetryAt(ex.getResponseHeaders());
+                return ChannelDispatchResult.transientFailure("Meta API error: " + ex.getStatusCode(), retryAt, Map.of("body", ex.getResponseBodyAsString()));
+            }
+            return ChannelDispatchResult.permanentFailure("Meta API error: " + ex.getStatusCode(), Map.of("body", ex.getResponseBodyAsString()));
+        } catch (ResourceAccessException ex) {
+            log.warn("Meta API network error", ex);
+            return ChannelDispatchResult.transientFailure("Meta API network error", null, Map.of());
+        }
+    }
+
+    private Map<String, Object> buildPayload(JourneyStep step) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("name", step.getName() != null ? step.getName() : "Journey Step " + step.getId());
+        String status = step.getMetadata().getOrDefault("status", properties.getDefaultAdStatus());
+        payload.put("status", status);
+        if (step.getMetadata().containsKey("adsetId")) {
+            payload.put("adset_id", step.getMetadata().get("adsetId"));
+        }
+        if (step.getMetadata().containsKey("campaignId")) {
+            payload.put("campaign_id", step.getMetadata().get("campaignId"));
+        }
+        if (step.getMetadata().containsKey("creativeId")) {
+            Map<String, Object> creative = new HashMap<>();
+            creative.put("creative_id", step.getMetadata().get("creativeId"));
+            payload.put("creative", creative);
+        }
+        if (step.getMetadata().containsKey("bidAmount")) {
+            payload.put("bid_amount", step.getMetadata().get("bidAmount"));
+        }
+        return payload;
+    }
+
+    private Instant resolveRetryAt(HttpHeaders headers) {
+        if (headers == null) {
+            return null;
+        }
+        String retryAfter = headers.getFirst("Retry-After");
+        if (retryAfter == null) {
+            return null;
+        }
+        try {
+            long seconds = Long.parseLong(retryAfter);
+            return Instant.now().plusSeconds(seconds);
+        } catch (NumberFormatException ignored) {
+            try {
+                return Instant.parse(retryAfter);
+            } catch (DateTimeParseException e) {
+                log.debug("Unable to parse Retry-After header: {}", retryAfter);
+                return null;
+            }
+        }
+    }
+
+    private record MetaAdResponse(String id) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/SendGridEmailChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/SendGridEmailChannelHandler.java
@@ -1,0 +1,156 @@
+package com.marketinghub.journey.execution.channel;
+
+import com.marketinghub.journey.execution.config.SendGridProperties;
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyStimulusType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Handles email dispatch via SendGrid.
+ */
+@Component
+@Slf4j
+public class SendGridEmailChannelHandler implements JourneyChannelHandler {
+    private final RestTemplate restTemplate;
+    private final SendGridProperties properties;
+
+    public SendGridEmailChannelHandler(RestTemplateBuilder restTemplateBuilder,
+                                       SendGridProperties properties) {
+        this(restTemplateBuilder.build(), properties);
+    }
+
+    SendGridEmailChannelHandler(RestTemplate restTemplate, SendGridProperties properties) {
+        this.restTemplate = restTemplate;
+        this.properties = properties;
+    }
+
+    @Override
+    public JourneyStimulusType supportedType() {
+        return JourneyStimulusType.EMAIL;
+    }
+
+    @Override
+    public ChannelDispatchResult dispatch(JourneyAssignment assignment, JourneyStep step, Map<String, Object> context) {
+        if (!properties.isEnabled()) {
+            return ChannelDispatchResult.permanentFailure("SendGrid integration disabled", Map.of());
+        }
+        if (properties.getApiKey() == null || properties.getFromEmail() == null) {
+            return ChannelDispatchResult.permanentFailure("SendGrid API key or sender email missing", Map.of());
+        }
+        String toEmail = resolveRecipient(context);
+        if (toEmail == null) {
+            return ChannelDispatchResult.permanentFailure("Missing recipient email in context", Map.of());
+        }
+
+        try {
+            String url = properties.getBaseUrl() + "/mail/send";
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+            headers.setBearerAuth(properties.getApiKey());
+
+            Map<String, Object> payload = buildPayload(step, context, toEmail);
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+            ResponseEntity<Void> response = restTemplate.exchange(url, HttpMethod.POST, request, Void.class);
+            if (response.getStatusCode().value() == 202 || response.getStatusCode().is2xxSuccessful()) {
+                Map<String, Object> metadata = new HashMap<>();
+                metadata.put("to", toEmail);
+                metadata.put("templateId", step.getMetadata().get("templateId"));
+                return ChannelDispatchResult.success(null, metadata);
+            }
+            if (response.getStatusCode().is5xxServerError() || response.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                Instant retryAt = parseRetryAfter(response.getHeaders().getFirst("Retry-After"));
+                return ChannelDispatchResult.transientFailure("SendGrid transient response: " + response.getStatusCode(), retryAt, Map.of());
+            }
+            return ChannelDispatchResult.permanentFailure("SendGrid returned status " + response.getStatusCode(), Map.of());
+        } catch (HttpStatusCodeException ex) {
+            if (ex.getStatusCode().is5xxServerError() || ex.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                Instant retryAt = parseRetryAfter(ex.getResponseHeaders() != null ? ex.getResponseHeaders().getFirst("Retry-After") : null);
+                return ChannelDispatchResult.transientFailure("SendGrid error: " + ex.getStatusCode(), retryAt, Map.of("body", ex.getResponseBodyAsString()));
+            }
+            return ChannelDispatchResult.permanentFailure("SendGrid error: " + ex.getStatusCode(), Map.of("body", ex.getResponseBodyAsString()));
+        } catch (ResourceAccessException ex) {
+            log.warn("SendGrid network error", ex);
+            return ChannelDispatchResult.transientFailure("SendGrid network error", null, Map.of());
+        }
+    }
+
+    private Map<String, Object> buildPayload(JourneyStep step, Map<String, Object> context, String toEmail) {
+        Map<String, Object> payload = new HashMap<>();
+        Map<String, Object> from = new HashMap<>();
+        from.put("email", properties.getFromEmail());
+        if (properties.getFromName() != null) {
+            from.put("name", properties.getFromName());
+        }
+        payload.put("from", from);
+
+        Map<String, Object> personalization = new HashMap<>();
+        personalization.put("to", List.of(Map.of("email", toEmail)));
+        personalization.put("dynamic_template_data", context);
+        payload.put("personalizations", List.of(personalization));
+
+        if (step.getMetadata().containsKey("templateId")) {
+            payload.put("template_id", step.getMetadata().get("templateId"));
+        }
+        if (step.getMetadata().containsKey("subject")) {
+            personalization.put("subject", step.getMetadata().get("subject"));
+        }
+        if (step.getMetadata().containsKey("content")) {
+            payload.put("content", List.of(Map.of(
+                    "type", "text/plain",
+                    "value", Objects.toString(step.getMetadata().get("content"))
+            )));
+        }
+        return payload;
+    }
+
+    private String resolveRecipient(Map<String, Object> context) {
+        Object email = context.get("email");
+        if (email instanceof String str && !str.isBlank()) {
+            return str;
+        }
+        Object nested = context.get("lead");
+        if (nested instanceof Map<?, ?> leadMap) {
+            Object nestedEmail = leadMap.get("email");
+            if (nestedEmail instanceof String nestedStr && !nestedStr.isBlank()) {
+                return nestedStr;
+            }
+        }
+        return null;
+    }
+
+    private Instant parseRetryAfter(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            long seconds = Long.parseLong(value);
+            return Instant.now().plusSeconds(seconds);
+        } catch (NumberFormatException ex) {
+            try {
+                return Instant.parse(value);
+            } catch (DateTimeParseException e) {
+                return null;
+            }
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/WhatsAppChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/WhatsAppChannelHandler.java
@@ -1,0 +1,167 @@
+package com.marketinghub.journey.execution.channel;
+
+import com.marketinghub.journey.execution.config.WhatsAppProperties;
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyStimulusType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handles WhatsApp messaging through Meta Cloud API.
+ */
+@Component
+@Slf4j
+public class WhatsAppChannelHandler implements JourneyChannelHandler {
+    private final RestTemplate restTemplate;
+    private final WhatsAppProperties properties;
+
+    public WhatsAppChannelHandler(RestTemplateBuilder restTemplateBuilder,
+                                  WhatsAppProperties properties) {
+        this(restTemplateBuilder.build(), properties);
+    }
+
+    WhatsAppChannelHandler(RestTemplate restTemplate, WhatsAppProperties properties) {
+        this.restTemplate = restTemplate;
+        this.properties = properties;
+    }
+
+    @Override
+    public JourneyStimulusType supportedType() {
+        return JourneyStimulusType.WHATSAPP;
+    }
+
+    @Override
+    public ChannelDispatchResult dispatch(JourneyAssignment assignment, JourneyStep step, Map<String, Object> context) {
+        if (!properties.isEnabled()) {
+            return ChannelDispatchResult.permanentFailure("WhatsApp integration disabled", Map.of());
+        }
+        if (properties.getAccessToken() == null || properties.getPhoneNumberId() == null) {
+            return ChannelDispatchResult.permanentFailure("WhatsApp credentials missing", Map.of());
+        }
+        String to = resolvePhone(context);
+        if (to == null) {
+            return ChannelDispatchResult.permanentFailure("Missing WhatsApp phone in context", Map.of());
+        }
+
+        try {
+            String url = properties.getBaseUrl() + "/" + properties.getPhoneNumberId() + "/messages";
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+            headers.setBearerAuth(properties.getAccessToken());
+
+            Map<String, Object> payload = buildPayload(step, context, to);
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+            ResponseEntity<WhatsAppResponse> response = restTemplate.exchange(url, HttpMethod.POST, request, WhatsAppResponse.class);
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                WhatsAppResponse body = response.getBody();
+                Map<String, Object> metadata = new HashMap<>();
+                metadata.put("to", to);
+                metadata.put("type", payload.get("type"));
+                String messageId = null;
+                if (body.messages() != null && !body.messages().isEmpty()) {
+                    messageId = body.messages().get(0).id();
+                    metadata.put("messageId", messageId);
+                }
+                return ChannelDispatchResult.success(messageId, metadata);
+            }
+            if (response.getStatusCode().is5xxServerError() || response.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                Instant retryAt = parseRetryAfter(response.getHeaders().getFirst("Retry-After"));
+                return ChannelDispatchResult.transientFailure("WhatsApp transient response: " + response.getStatusCode(), retryAt, Map.of());
+            }
+            return ChannelDispatchResult.permanentFailure("WhatsApp returned status " + response.getStatusCode(), Map.of());
+        } catch (HttpStatusCodeException ex) {
+            if (ex.getStatusCode().is5xxServerError() || ex.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                Instant retryAt = parseRetryAfter(ex.getResponseHeaders() != null ? ex.getResponseHeaders().getFirst("Retry-After") : null);
+                return ChannelDispatchResult.transientFailure("WhatsApp error: " + ex.getStatusCode(), retryAt, Map.of("body", ex.getResponseBodyAsString()));
+            }
+            return ChannelDispatchResult.permanentFailure("WhatsApp error: " + ex.getStatusCode(), Map.of("body", ex.getResponseBodyAsString()));
+        } catch (ResourceAccessException ex) {
+            log.warn("WhatsApp network error", ex);
+            return ChannelDispatchResult.transientFailure("WhatsApp network error", null, Map.of());
+        }
+    }
+
+    private Map<String, Object> buildPayload(JourneyStep step, Map<String, Object> context, String to) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("messaging_product", "whatsapp");
+        payload.put("to", to);
+        if (step.getMetadata().containsKey("templateName")) {
+            payload.put("type", "template");
+            Map<String, Object> template = new HashMap<>();
+            template.put("name", step.getMetadata().get("templateName"));
+            Map<String, Object> language = new HashMap<>();
+            language.put("code", step.getMetadata().getOrDefault("templateLanguage", "en_US"));
+            template.put("language", language);
+            payload.put("template", template);
+        } else {
+            payload.put("type", "text");
+            Map<String, Object> text = new HashMap<>();
+            Object body = step.getMetadata().getOrDefault("body", context.get("message"));
+            if (body == null) {
+                throw new IllegalArgumentException("Missing WhatsApp message body");
+            }
+            text.put("preview_url", Boolean.FALSE);
+            text.put("body", body.toString());
+            payload.put("text", text);
+        }
+        return payload;
+    }
+
+    private String resolvePhone(Map<String, Object> context) {
+        Object phone = context.get("phone");
+        if (phone instanceof String str && !str.isBlank()) {
+            return str;
+        }
+        Object whatsapp = context.get("whatsapp");
+        if (whatsapp instanceof String whats && !whats.isBlank()) {
+            return whats;
+        }
+        Object nested = context.get("lead");
+        if (nested instanceof Map<?, ?> map) {
+            Object nestedPhone = map.get("phone");
+            if (nestedPhone instanceof String nestedStr && !nestedStr.isBlank()) {
+                return nestedStr;
+            }
+        }
+        return null;
+    }
+
+    private Instant parseRetryAfter(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            long seconds = Long.parseLong(value);
+            return Instant.now().plusSeconds(seconds);
+        } catch (NumberFormatException ex) {
+            try {
+                return Instant.parse(value);
+            } catch (DateTimeParseException e) {
+                return null;
+            }
+        }
+    }
+
+    private record WhatsAppResponse(List<Message> messages) {
+        private record Message(String id) {
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/config/Ga4Properties.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/config/Ga4Properties.java
@@ -1,0 +1,22 @@
+package com.marketinghub.journey.execution.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Google Analytics 4 Measurement Protocol configuration.
+ */
+@Component
+@ConfigurationProperties(prefix = "integrations.ga4")
+@Getter
+@Setter
+@ToString
+public class Ga4Properties {
+    private boolean enabled = false;
+    private String endpoint = "https://www.google-analytics.com/mp/collect";
+    private String measurementId;
+    private String apiSecret;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/config/MetaMarketingProperties.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/config/MetaMarketingProperties.java
@@ -1,0 +1,25 @@
+package com.marketinghub.journey.execution.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration for Meta marketing integrations (Marketing API and Pixel).
+ */
+@Component
+@ConfigurationProperties(prefix = "integrations.meta")
+@Getter
+@Setter
+@ToString
+public class MetaMarketingProperties {
+    private boolean enabled = false;
+    private String baseUrl = "https://graph.facebook.com/v18.0";
+    private String accessToken;
+    private String adAccountId;
+    private String defaultAdStatus = "PAUSED";
+    private boolean pixelEnabled = false;
+    private String pixelId;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/config/SendGridProperties.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/config/SendGridProperties.java
@@ -1,0 +1,23 @@
+package com.marketinghub.journey.execution.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration for SendGrid email delivery.
+ */
+@Component
+@ConfigurationProperties(prefix = "integrations.sendgrid")
+@Getter
+@Setter
+@ToString
+public class SendGridProperties {
+    private boolean enabled = false;
+    private String baseUrl = "https://api.sendgrid.com/v3";
+    private String apiKey;
+    private String fromEmail;
+    private String fromName;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/config/WhatsAppProperties.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/config/WhatsAppProperties.java
@@ -1,0 +1,22 @@
+package com.marketinghub.journey.execution.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration for Meta WhatsApp Cloud API.
+ */
+@Component
+@ConfigurationProperties(prefix = "integrations.whatsapp")
+@Getter
+@Setter
+@ToString
+public class WhatsAppProperties {
+    private boolean enabled = false;
+    private String baseUrl = "https://graph.facebook.com/v18.0";
+    private String accessToken;
+    private String phoneNumberId;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/policy/FrequencyCapResult.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/policy/FrequencyCapResult.java
@@ -1,0 +1,17 @@
+package com.marketinghub.journey.execution.policy;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Result of evaluating the frequency cap policy for a stimulus.
+ */
+public record FrequencyCapResult(boolean blocked, Instant nextAttemptAt, Map<String, Object> metadata) {
+    public static FrequencyCapResult allow() {
+        return new FrequencyCapResult(false, null, Map.of());
+    }
+
+    public static FrequencyCapResult block(Instant nextAttemptAt, Map<String, Object> metadata) {
+        return new FrequencyCapResult(true, nextAttemptAt, metadata == null ? Map.of() : metadata);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/policy/FrequencyCapService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/policy/FrequencyCapService.java
@@ -1,0 +1,75 @@
+package com.marketinghub.journey.execution.policy;
+
+import com.marketinghub.journey.execution.JourneyExecutionProperties;
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyEventType;
+import com.marketinghub.journey.repository.EventLogRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Applies exposure limits per actor to avoid over stimulation.
+ */
+@Service
+@Slf4j
+public class FrequencyCapService {
+    private final EventLogRepository eventLogRepository;
+    private final JourneyExecutionProperties properties;
+
+    public FrequencyCapService(EventLogRepository eventLogRepository,
+                               JourneyExecutionProperties properties) {
+        this.eventLogRepository = eventLogRepository;
+        this.properties = properties;
+    }
+
+    public FrequencyCapResult evaluate(JourneyAssignment assignment, Instant now) {
+        JourneyExecutionProperties.FrequencyCapProperties cap = properties.getFrequencyCap();
+        if (!cap.isEnabled()) {
+            return FrequencyCapResult.allow();
+        }
+        if (assignment.getLead() == null || assignment.getLead().getId() == null) {
+            return FrequencyCapResult.allow();
+        }
+        UUID actorId = assignment.getLead().getId();
+        String eventType = JourneyEventType.STIMULUS_DISPATCHED.getCode();
+
+        if (cap.getPerDay() > 0) {
+            Instant dayStart = now.minus(Duration.ofDays(1));
+            long dailyCount = eventLogRepository.countByActorIdAndEventTypeAndOccurredAtAfter(actorId, eventType, dayStart);
+            if (dailyCount >= cap.getPerDay()) {
+                return block(actorId, "daily", cap.getPerDay(), dailyCount, now, cap);
+            }
+        }
+        if (cap.getPerWeek() > 0) {
+            Instant weekStart = now.minus(Duration.ofDays(7));
+            long weeklyCount = eventLogRepository.countByActorIdAndEventTypeAndOccurredAtAfter(actorId, eventType, weekStart);
+            if (weeklyCount >= cap.getPerWeek()) {
+                return block(actorId, "weekly", cap.getPerWeek(), weeklyCount, now, cap);
+            }
+        }
+        return FrequencyCapResult.allow();
+    }
+
+    private FrequencyCapResult block(UUID actorId,
+                                     String window,
+                                     int limit,
+                                     long current,
+                                     Instant now,
+                                     JourneyExecutionProperties.FrequencyCapProperties cap) {
+        Instant nextAttemptAt = now.plus(cap.getCooldown());
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("actorId", actorId);
+        metadata.put("window", window);
+        metadata.put("limit", limit);
+        metadata.put("current", current);
+        metadata.put("cooldownSeconds", cap.getCooldown().toSeconds());
+        log.debug("Frequency cap reached for actor {} on {} window", actorId, window);
+        return FrequencyCapResult.block(nextAttemptAt, metadata);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/policy/RetryBackoffCalculator.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/policy/RetryBackoffCalculator.java
@@ -1,0 +1,39 @@
+package com.marketinghub.journey.execution.policy;
+
+import com.marketinghub.journey.execution.JourneyExecutionProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Computes exponential backoff with jitter for retry attempts.
+ */
+@Component
+public class RetryBackoffCalculator {
+    private final JourneyExecutionProperties properties;
+
+    public RetryBackoffCalculator(JourneyExecutionProperties properties) {
+        this.properties = properties;
+    }
+
+    public Duration computeDelay(int attempt) {
+        if (attempt < 1) {
+            attempt = 1;
+        }
+        JourneyExecutionProperties.RetryProperties retry = properties.getRetry();
+        long base = retry.getInitialBackoff().toMillis();
+        long max = retry.getMaxBackoff().toMillis();
+        long delay = base * (1L << Math.min(attempt - 1, 20));
+        if (delay > max) {
+            delay = max;
+        }
+        int jitterPercentage = retry.getJitterPercentage();
+        if (jitterPercentage > 0) {
+            double jitterFraction = jitterPercentage / 100.0;
+            long jitter = Math.round(delay * ThreadLocalRandom.current().nextDouble(0.0, jitterFraction));
+            delay = Math.min(max, delay + jitter);
+        }
+        return Duration.ofMillis(delay);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyAssignment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyAssignment.java
@@ -56,6 +56,13 @@ public class JourneyAssignment {
     @Column(name = "context_payload")
     private String contextPayload;
 
+    @Column(name = "next_attempt_at")
+    private Instant nextAttemptAt;
+
+    @Builder.Default
+    @Column(name = "retry_count")
+    private Integer retryCount = 0;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private Instant createdAt;

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyEventType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/JourneyEventType.java
@@ -1,0 +1,22 @@
+package com.marketinghub.journey.model;
+
+/**
+ * Canonical event types emitted during journey execution.
+ */
+public enum JourneyEventType {
+    STIMULUS_DISPATCHED("journey.stimulus.dispatched"),
+    STIMULUS_FAILED("journey.stimulus.failed"),
+    STIMULUS_SKIPPED("journey.stimulus.skipped"),
+    STIMULUS_FREQUENCY_CAPPED("journey.stimulus.frequency_capped"),
+    JOURNEY_COMPLETED("journey.completed");
+
+    private final String code;
+
+    JourneyEventType(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/repository/EventLogRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/repository/EventLogRepository.java
@@ -3,8 +3,15 @@ package com.marketinghub.journey.repository;
 import com.marketinghub.journey.model.EventLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
 /**
  * Repository handling persisted journey events.
  */
 public interface EventLogRepository extends JpaRepository<EventLog, Long> {
+    long countByActorIdAndEventTypeAndOccurredAtAfter(UUID actorId, String eventType, Instant occurredAt);
+
+    Optional<EventLog> findFirstByActorIdAndEventTypeOrderByOccurredAtDesc(UUID actorId, String eventType);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyAssignmentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyAssignmentRepository.java
@@ -2,9 +2,18 @@ package com.marketinghub.journey.repository;
 
 import com.marketinghub.journey.model.JourneyAssignment;
 import com.marketinghub.journey.model.JourneyAssignmentStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Repository for assignments tying actors to journeys.
@@ -13,4 +22,25 @@ public interface JourneyAssignmentRepository extends JpaRepository<JourneyAssign
     Page<JourneyAssignment> findByJourneyId(Long journeyId, Pageable pageable);
 
     Page<JourneyAssignment> findByJourneyIdAndStatus(Long journeyId, JourneyAssignmentStatus status, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"journey", "journey.template", "nextStep", "lead"})
+    @Query("""
+            select a from JourneyAssignment a
+            join a.journey j
+            where a.status in :statuses
+              and a.nextStep is not null
+              and (a.nextAttemptAt is null or a.nextAttemptAt <= :now)
+              and j.status = com.marketinghub.journey.model.JourneyStatus.ACTIVE
+              and (j.startAt is null or j.startAt <= :now)
+              and (j.endAt is null or j.endAt >= :now)
+            order by a.updatedAt asc
+            """)
+    Page<JourneyAssignment> findEligibleAssignments(@Param("statuses") Collection<JourneyAssignmentStatus> statuses,
+                                                    @Param("now") Instant now,
+                                                    Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @EntityGraph(attributePaths = {"journey", "journey.template", "nextStep", "lead"})
+    @Query("select a from JourneyAssignment a where a.id = :id")
+    Optional<JourneyAssignment> findByIdForUpdate(@Param("id") Long id);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyStepRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyStepRepository.java
@@ -5,10 +5,14 @@ import com.marketinghub.journey.model.JourneyTemplate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Repository for journey steps.
  */
 public interface JourneyStepRepository extends JpaRepository<JourneyStep, Long> {
     List<JourneyStep> findByTemplateOrderByPositionAsc(JourneyTemplate template);
+
+    Optional<JourneyStep> findFirstByTemplateAndPositionGreaterThanOrderByPositionAsc(JourneyTemplate template,
+                                                                                    Integer position);
 }

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -30,3 +30,29 @@ spring.config.import=optional:metrics.yml
 # Expose Swagger UI at /swagger-ui.html for quick API inspection
 springdoc.swagger-ui.enabled=true
 springdoc.swagger-ui.path=/swagger-ui.html
+
+# Journey execution runtime
+journey.execution.poll-interval=PT30S
+journey.execution.batch-size=50
+journey.execution.frequency-cap.per-day=3
+journey.execution.frequency-cap.per-week=10
+journey.execution.frequency-cap.cooldown=PT6H
+journey.execution.retry.max-attempts=3
+journey.execution.retry.initial-backoff=PT30S
+journey.execution.retry.max-backoff=PT30M
+journey.execution.retry.jitter-percentage=25
+
+# Channel integrations (provide tokens through environment variables)
+integrations.meta.enabled=false
+integrations.meta.base-url=https://graph.facebook.com/v18.0
+integrations.meta.default-ad-status=PAUSED
+integrations.meta.pixel-enabled=false
+
+integrations.sendgrid.enabled=false
+integrations.sendgrid.base-url=https://api.sendgrid.com/v3
+
+integrations.whatsapp.enabled=false
+integrations.whatsapp.base-url=https://graph.facebook.com/v18.0
+
+integrations.ga4.enabled=false
+integrations.ga4.endpoint=https://www.google-analytics.com/mp/collect

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_20__journey_execution_runtime.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_20__journey_execution_runtime.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset marketinghub:2025-10-20-journey-assignment-execution-runtime
+ALTER TABLE journey_assignment
+    ADD COLUMN next_attempt_at DATETIME NULL,
+    ADD COLUMN retry_count INT DEFAULT 0;
+
+--changeset marketinghub:2025-10-20-journey-assignment-execution-index
+CREATE INDEX idx_journey_assignment_next_attempt
+    ON journey_assignment(next_attempt_at);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -95,3 +95,6 @@ databaseChangeLog:
   - include:
       file: V2025_10_15__create_journey_tables.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_10_20__journey_execution_runtime.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/JourneyExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/JourneyExecutionServiceTest.java
@@ -1,0 +1,190 @@
+package com.marketinghub.journey.execution;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.journey.execution.channel.ChannelDispatchResult;
+import com.marketinghub.journey.execution.channel.JourneyChannelHandler;
+import com.marketinghub.journey.execution.policy.FrequencyCapResult;
+import com.marketinghub.journey.execution.policy.FrequencyCapService;
+import com.marketinghub.journey.execution.policy.RetryBackoffCalculator;
+import com.marketinghub.journey.model.*;
+import com.marketinghub.journey.model.EventLog;
+import com.marketinghub.journey.repository.EventLogRepository;
+import com.marketinghub.journey.repository.JourneyAssignmentRepository;
+import com.marketinghub.journey.repository.JourneyStepRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.support.ResourcelessTransactionManager;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JourneyExecutionServiceTest {
+    @Mock
+    private JourneyAssignmentRepository assignmentRepository;
+    @Mock
+    private JourneyStepRepository stepRepository;
+    @Mock
+    private EventLogRepository eventLogRepository;
+    @Mock
+    private FrequencyCapService frequencyCapService;
+    @Mock
+    private RetryBackoffCalculator retryBackoffCalculator;
+    @Mock
+    private TelemetryService telemetryService;
+    @Mock
+    private JourneyChannelHandler emailHandler;
+
+    private JourneyExecutionService service;
+    private JourneyExecutionProperties properties;
+    private JourneyConditionEvaluator conditionEvaluator;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        properties = new JourneyExecutionProperties();
+        conditionEvaluator = new JourneyConditionEvaluator();
+        objectMapper = new ObjectMapper();
+        when(emailHandler.supportedType()).thenReturn(JourneyStimulusType.EMAIL);
+        service = new JourneyExecutionService(assignmentRepository,
+                stepRepository,
+                eventLogRepository,
+                properties,
+                frequencyCapService,
+                retryBackoffCalculator,
+                conditionEvaluator,
+                telemetryService,
+                objectMapper,
+                new ResourcelessTransactionManager(),
+                List.of(emailHandler));
+    }
+
+    @Test
+    void processDueAssignmentsDispatchesStep() {
+        JourneyAssignment assignment = buildAssignment(JourneyStimulusType.EMAIL);
+        when(assignmentRepository.findEligibleAssignments(anyList(), any(), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(assignment)));
+        when(assignmentRepository.findByIdForUpdate(assignment.getId())).thenReturn(Optional.of(assignment));
+        when(frequencyCapService.evaluate(eq(assignment), any())).thenReturn(FrequencyCapResult.allow());
+        when(stepRepository.findFirstByTemplateAndPositionGreaterThanOrderByPositionAsc(any(), anyInt()))
+                .thenReturn(Optional.empty());
+        when(emailHandler.dispatch(eq(assignment), eq(assignment.getNextStep()), anyMap()))
+                .thenReturn(ChannelDispatchResult.success("provider-123", Map.of("value", BigDecimal.TEN)));
+
+        service.processDueAssignments();
+
+        assertThat(assignment.getStatus()).isEqualTo(JourneyAssignmentStatus.COMPLETED);
+        assertThat(assignment.getNextStep()).isNull();
+        assertThat(assignment.getRetryCount()).isZero();
+        verify(telemetryService).emitStepDispatched(eq(assignment), eq(assignment.getCurrentStep()), anyMap(), argThat(m -> m.containsKey("providerMessageId")));
+
+        ArgumentCaptor<EventLog> eventCaptor = ArgumentCaptor.forClass(EventLog.class);
+        verify(eventLogRepository, atLeastOnce()).save(eventCaptor.capture());
+        assertThat(eventCaptor.getAllValues())
+                .extracting(EventLog::getEventType)
+                .contains(JourneyEventType.STIMULUS_DISPATCHED.getCode(), JourneyEventType.JOURNEY_COMPLETED.getCode());
+    }
+
+    @Test
+    void processDueAssignmentsHonoursFrequencyCap() {
+        JourneyAssignment assignment = buildAssignment(JourneyStimulusType.EMAIL);
+        Instant nextAttempt = Instant.now().plus(Duration.ofHours(6));
+        when(assignmentRepository.findEligibleAssignments(anyList(), any(), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(assignment)));
+        when(assignmentRepository.findByIdForUpdate(assignment.getId())).thenReturn(Optional.of(assignment));
+        when(frequencyCapService.evaluate(eq(assignment), any()))
+                .thenReturn(FrequencyCapResult.block(nextAttempt, Map.of("window", "daily")));
+
+        service.processDueAssignments();
+
+        assertThat(assignment.getNextAttemptAt()).isEqualTo(nextAttempt);
+        assertThat(assignment.getStatus()).isEqualTo(JourneyAssignmentStatus.IN_PROGRESS);
+        verify(emailHandler, never()).dispatch(any(), any(), anyMap());
+        verify(eventLogRepository).save(argThat(log -> log.getEventType().equals(JourneyEventType.STIMULUS_FREQUENCY_CAPPED.getCode())));
+    }
+
+    @Test
+    void processDueAssignmentsSchedulesRetryOnTransientFailure() {
+        JourneyAssignment assignment = buildAssignment(JourneyStimulusType.EMAIL);
+        when(assignmentRepository.findEligibleAssignments(anyList(), any(), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(assignment)));
+        when(assignmentRepository.findByIdForUpdate(assignment.getId())).thenReturn(Optional.of(assignment));
+        when(frequencyCapService.evaluate(eq(assignment), any())).thenReturn(FrequencyCapResult.allow());
+        when(emailHandler.dispatch(eq(assignment), eq(assignment.getNextStep()), anyMap()))
+                .thenReturn(ChannelDispatchResult.transientFailure("rate_limited", null, Map.of()));
+        when(retryBackoffCalculator.computeDelay(eq(1))).thenReturn(Duration.ofMinutes(5));
+
+        service.processDueAssignments();
+
+        assertThat(assignment.getStatus()).isEqualTo(JourneyAssignmentStatus.IN_PROGRESS);
+        assertThat(assignment.getRetryCount()).isEqualTo(1);
+        assertThat(assignment.getNextAttemptAt()).isNotNull();
+        verify(eventLogRepository).save(argThat(log -> log.getEventType().equals(JourneyEventType.STIMULUS_FAILED.getCode())));
+    }
+
+    @Test
+    void processDueAssignmentsStopsAfterPermanentFailure() {
+        JourneyAssignment assignment = buildAssignment(JourneyStimulusType.EMAIL);
+        when(assignmentRepository.findEligibleAssignments(anyList(), any(), any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(List.of(assignment)));
+        when(assignmentRepository.findByIdForUpdate(assignment.getId())).thenReturn(Optional.of(assignment));
+        when(frequencyCapService.evaluate(eq(assignment), any())).thenReturn(FrequencyCapResult.allow());
+        when(emailHandler.dispatch(eq(assignment), eq(assignment.getNextStep()), anyMap()))
+                .thenReturn(ChannelDispatchResult.permanentFailure("invalid_payload", Map.of()));
+
+        service.processDueAssignments();
+
+        assertThat(assignment.getStatus()).isEqualTo(JourneyAssignmentStatus.STOPPED);
+        assertThat(assignment.getNextAttemptAt()).isNull();
+        verify(eventLogRepository).save(argThat(log -> log.getEventType().equals(JourneyEventType.STIMULUS_FAILED.getCode())));
+    }
+
+    private JourneyAssignment buildAssignment(JourneyStimulusType stimulusType) {
+        JourneyTemplate template = JourneyTemplate.builder()
+                .id(10L)
+                .name("Template")
+                .build();
+        Journey journey = Journey.builder()
+                .id(22L)
+                .template(template)
+                .name("Journey")
+                .status(JourneyStatus.ACTIVE)
+                .startAt(Instant.now().minus(Duration.ofHours(1)))
+                .build();
+        JourneyStep step = JourneyStep.builder()
+                .id(33L)
+                .template(template)
+                .position(1)
+                .phase(JourneyPhase.ATTENTION)
+                .stimulusType(stimulusType)
+                .delayMinutes(0)
+                .name("Email welcome")
+                .build();
+        template.getSteps().add(step);
+        JourneyAssignment assignment = JourneyAssignment.builder()
+                .id(44L)
+                .journey(journey)
+                .type(JourneyAssignmentType.LEAD)
+                .lead(Lead.builder().id(UUID.randomUUID()).build())
+                .status(JourneyAssignmentStatus.PENDING)
+                .nextStep(step)
+                .build();
+        assignment.setCreatedAt(Instant.now().minus(Duration.ofHours(2)));
+        return assignment;
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/MetaAdsChannelHandlerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/MetaAdsChannelHandlerTest.java
@@ -1,0 +1,95 @@
+package com.marketinghub.journey.execution;
+
+import com.marketinghub.journey.execution.channel.ChannelDispatchResult;
+import com.marketinghub.journey.execution.channel.ChannelDispatchStatus;
+import com.marketinghub.journey.execution.channel.MetaAdsChannelHandler;
+import com.marketinghub.journey.execution.config.MetaMarketingProperties;
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyAssignmentType;
+import com.marketinghub.journey.model.JourneyPhase;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyStimulusType;
+import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.model.Lead;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+class MetaAdsChannelHandlerTest {
+    private MetaAdsChannelHandler handler;
+    private MockRestServiceServer server;
+
+    @BeforeEach
+    void setup() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.createServer(restTemplate);
+        MetaMarketingProperties properties = new MetaMarketingProperties();
+        properties.setEnabled(true);
+        properties.setAccessToken("token");
+        properties.setAdAccountId("123");
+        handler = new MetaAdsChannelHandler(restTemplate, properties);
+    }
+
+    @Test
+    void returnsTransientFailureOnRateLimit() {
+        JourneyStep step = JourneyStep.builder()
+                .id(1L)
+                .template(JourneyTemplate.builder().id(2L).name("template").build())
+                .position(1)
+                .phase(JourneyPhase.ATTENTION)
+                .stimulusType(JourneyStimulusType.AD)
+                .metadata(Map.of("adsetId", "456", "creativeId", "789"))
+                .build();
+        JourneyAssignment assignment = JourneyAssignment.builder()
+                .id(10L)
+                .type(JourneyAssignmentType.LEAD)
+                .lead(Lead.builder().id(UUID.randomUUID()).build())
+                .build();
+
+        server.expect(once(), requestTo("https://graph.facebook.com/v18.0/act_123/ads"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("Authorization", "Bearer token"))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andRespond(withStatus(org.springframework.http.HttpStatus.TOO_MANY_REQUESTS)
+                        .header("Retry-After", "60"));
+
+        ChannelDispatchResult result = handler.dispatch(assignment, step, Map.of());
+
+        assertThat(result.status()).isEqualTo(ChannelDispatchStatus.TRANSIENT_ERROR);
+        assertThat(result.nextAttemptAt()).isNotNull();
+    }
+
+    @Test
+    void returnsPermanentFailureWhenDisabled() {
+        MetaMarketingProperties properties = new MetaMarketingProperties();
+        properties.setEnabled(false);
+        MetaAdsChannelHandler disabledHandler = new MetaAdsChannelHandler(new RestTemplate(), properties);
+        JourneyStep step = JourneyStep.builder()
+                .id(1L)
+                .template(JourneyTemplate.builder().id(2L).name("template").build())
+                .position(1)
+                .phase(JourneyPhase.ATTENTION)
+                .stimulusType(JourneyStimulusType.AD)
+                .build();
+        JourneyAssignment assignment = JourneyAssignment.builder()
+                .id(10L)
+                .type(JourneyAssignmentType.LEAD)
+                .lead(Lead.builder().id(UUID.randomUUID()).build())
+                .build();
+
+        ChannelDispatchResult result = disabledHandler.dispatch(assignment, step, Map.of());
+
+        assertThat(result.status()).isEqualTo(ChannelDispatchStatus.PERMANENT_ERROR);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/SendGridEmailChannelHandlerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/SendGridEmailChannelHandlerTest.java
@@ -1,0 +1,105 @@
+package com.marketinghub.journey.execution;
+
+import com.marketinghub.journey.execution.channel.ChannelDispatchResult;
+import com.marketinghub.journey.execution.channel.ChannelDispatchStatus;
+import com.marketinghub.journey.execution.channel.SendGridEmailChannelHandler;
+import com.marketinghub.journey.execution.config.SendGridProperties;
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyAssignmentType;
+import com.marketinghub.journey.model.JourneyPhase;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyStimulusType;
+import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.journey.model.JourneyStatus;
+import com.marketinghub.model.Lead;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+class SendGridEmailChannelHandlerTest {
+    private SendGridEmailChannelHandler handler;
+    private MockRestServiceServer server;
+
+    @BeforeEach
+    void setup() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.createServer(restTemplate);
+        SendGridProperties properties = new SendGridProperties();
+        properties.setEnabled(true);
+        properties.setApiKey("test-key");
+        properties.setFromEmail("hello@example.com");
+        properties.setFromName("Marketing Hub");
+        handler = new SendGridEmailChannelHandler(restTemplate, properties);
+    }
+
+    @Test
+    void dispatchesEmailWithExpectedPayload() {
+        JourneyStep step = JourneyStep.builder()
+                .id(1L)
+                .template(JourneyTemplate.builder().id(2L).name("template").build())
+                .position(1)
+                .phase(JourneyPhase.ATTENTION)
+                .stimulusType(JourneyStimulusType.EMAIL)
+                .metadata(new HashMap<>(Map.of("templateId", "d-123", "subject", "Welcome")))
+                .build();
+        JourneyAssignment assignment = JourneyAssignment.builder()
+                .id(10L)
+                .type(JourneyAssignmentType.LEAD)
+                .lead(Lead.builder().id(UUID.randomUUID()).build())
+                .journey(com.marketinghub.journey.model.Journey.builder()
+                        .id(5L)
+                        .template(step.getTemplate())
+                        .name("Journey")
+                        .status(JourneyStatus.ACTIVE)
+                        .startAt(Instant.now())
+                        .build())
+                .build();
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("email", "lead@example.com");
+
+        server.expect(once(), requestTo("https://api.sendgrid.com/v3/mail/send"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("Authorization", "Bearer test-key"))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andRespond(withStatus(org.springframework.http.HttpStatus.ACCEPTED));
+
+        ChannelDispatchResult result = handler.dispatch(assignment, step, context);
+
+        assertThat(result.status()).isEqualTo(ChannelDispatchStatus.OK);
+        server.verify();
+    }
+
+    @Test
+    void returnsPermanentErrorWhenEmailMissing() {
+        JourneyStep step = JourneyStep.builder()
+                .id(1L)
+                .template(JourneyTemplate.builder().id(2L).name("template").build())
+                .position(1)
+                .phase(JourneyPhase.ATTENTION)
+                .stimulusType(JourneyStimulusType.EMAIL)
+                .build();
+        JourneyAssignment assignment = JourneyAssignment.builder()
+                .id(10L)
+                .type(JourneyAssignmentType.LEAD)
+                .lead(Lead.builder().id(UUID.randomUUID()).build())
+                .build();
+
+        ChannelDispatchResult result = handler.dispatch(assignment, step, Map.of());
+
+        assertThat(result.status()).isEqualTo(ChannelDispatchStatus.PERMANENT_ERROR);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/TelemetryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/TelemetryServiceTest.java
@@ -1,0 +1,156 @@
+package com.marketinghub.journey.execution;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.journey.execution.config.Ga4Properties;
+import com.marketinghub.journey.execution.config.MetaMarketingProperties;
+import com.marketinghub.journey.model.Journey;
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyAssignmentType;
+import com.marketinghub.journey.model.JourneyPhase;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyStimulusType;
+import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.model.Lead;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+class TelemetryServiceTest {
+
+    @Test
+    void sendsPixelEventWhenEnabled() {
+        RestTemplate metaTemplate = new RestTemplate();
+        RestTemplate gaTemplate = new RestTemplate();
+        RestTemplateBuilder builder = mock(RestTemplateBuilder.class);
+        when(builder.build()).thenReturn(metaTemplate, gaTemplate);
+
+        MetaMarketingProperties metaProperties = new MetaMarketingProperties();
+        metaProperties.setEnabled(true);
+        metaProperties.setPixelEnabled(true);
+        metaProperties.setPixelId("pixel123");
+        metaProperties.setAccessToken("pixel-token");
+
+        Ga4Properties ga4Properties = new Ga4Properties();
+
+        TelemetryService telemetryService = new TelemetryService(builder, metaProperties, ga4Properties, new ObjectMapper());
+
+        MockRestServiceServer metaServer = MockRestServiceServer.createServer(metaTemplate);
+        MockRestServiceServer gaServer = MockRestServiceServer.createServer(gaTemplate);
+
+        metaServer.expect(once(), requestTo("https://graph.facebook.com/v18.0/pixel123/events"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("Authorization", "Bearer pixel-token"))
+                .andExpect(content().string(containsString("\"event_name\":\"Lead\"")))
+                .andExpect(content().string(containsString("\"journey_id\":1")))
+                .andRespond(withStatus(HttpStatus.OK));
+
+        JourneyTemplate template = JourneyTemplate.builder()
+                .id(9L)
+                .name("Template")
+                .build();
+        Journey journey = Journey.builder()
+                .id(1L)
+                .template(template)
+                .name("Journey")
+                .build();
+        JourneyStep step = JourneyStep.builder()
+                .id(2L)
+                .template(template)
+                .position(1)
+                .phase(JourneyPhase.ATTENTION)
+                .stimulusType(JourneyStimulusType.EMAIL)
+                .metadata(new HashMap<>())
+                .build();
+        JourneyAssignment assignment = JourneyAssignment.builder()
+                .id(3L)
+                .journey(journey)
+                .type(JourneyAssignmentType.LEAD)
+                .lead(Lead.builder().id(UUID.randomUUID()).build())
+                .build();
+
+        telemetryService.emitStepDispatched(assignment, step, Map.of("source", "landing"), Map.of("providerMessageId", "abc123"));
+
+        metaServer.verify();
+        gaServer.verify();
+    }
+
+    @Test
+    void sendsGa4EventWhenEnabled() {
+        RestTemplate metaTemplate = new RestTemplate();
+        RestTemplate gaTemplate = new RestTemplate();
+        RestTemplateBuilder builder = mock(RestTemplateBuilder.class);
+        when(builder.build()).thenReturn(metaTemplate, gaTemplate);
+
+        MetaMarketingProperties metaProperties = new MetaMarketingProperties();
+        metaProperties.setPixelEnabled(false);
+
+        Ga4Properties ga4Properties = new Ga4Properties();
+        ga4Properties.setEnabled(true);
+        ga4Properties.setMeasurementId("G-XYZ");
+        ga4Properties.setApiSecret("secret");
+
+        TelemetryService telemetryService = new TelemetryService(builder, metaProperties, ga4Properties, new ObjectMapper());
+
+        MockRestServiceServer metaServer = MockRestServiceServer.createServer(metaTemplate);
+        MockRestServiceServer gaServer = MockRestServiceServer.createServer(gaTemplate);
+
+        UUID leadId = UUID.randomUUID();
+
+        gaServer.expect(once(), requestTo("https://www.google-analytics.com/mp/collect?measurement_id=G-XYZ&api_secret=secret"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().string(containsString("\"name\":\"email_sent\"")))
+                .andExpect(content().string(containsString("\"journey_id\":1")))
+                .andExpect(content().string(containsString("\"client_id\":\"" + leadId + "\"")))
+                .andRespond(withStatus(HttpStatus.OK));
+
+        JourneyTemplate template = JourneyTemplate.builder()
+                .id(9L)
+                .name("Template")
+                .build();
+        Journey journey = Journey.builder()
+                .id(1L)
+                .template(template)
+                .name("Journey")
+                .build();
+        JourneyStep step = JourneyStep.builder()
+                .id(2L)
+                .template(template)
+                .position(1)
+                .phase(JourneyPhase.INTEREST)
+                .stimulusType(JourneyStimulusType.EMAIL)
+                .metadata(new HashMap<>())
+                .build();
+        JourneyAssignment assignment = JourneyAssignment.builder()
+                .id(3L)
+                .journey(journey)
+                .type(JourneyAssignmentType.LEAD)
+                .lead(Lead.builder().id(leadId).build())
+                .build();
+
+        Map<String, Object> dispatchMetadata = Map.of(
+                "providerMessageId", "abc123",
+                "value", BigDecimal.ONE
+        );
+
+        telemetryService.emitStepDispatched(assignment, step, Map.of("source", "landing"), dispatchMetadata);
+
+        gaServer.verify();
+        metaServer.verify();
+    }
+}
+

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/WhatsAppChannelHandlerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/WhatsAppChannelHandlerTest.java
@@ -1,0 +1,100 @@
+package com.marketinghub.journey.execution;
+
+import com.marketinghub.journey.execution.channel.ChannelDispatchResult;
+import com.marketinghub.journey.execution.channel.ChannelDispatchStatus;
+import com.marketinghub.journey.execution.channel.WhatsAppChannelHandler;
+import com.marketinghub.journey.execution.config.WhatsAppProperties;
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.model.JourneyAssignmentType;
+import com.marketinghub.journey.model.JourneyPhase;
+import com.marketinghub.journey.model.JourneyStep;
+import com.marketinghub.journey.model.JourneyStimulusType;
+import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.model.Lead;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+class WhatsAppChannelHandlerTest {
+    private WhatsAppChannelHandler handler;
+    private MockRestServiceServer server;
+
+    @BeforeEach
+    void setup() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.createServer(restTemplate);
+        WhatsAppProperties properties = new WhatsAppProperties();
+        properties.setEnabled(true);
+        properties.setAccessToken("token");
+        properties.setPhoneNumberId("1234");
+        handler = new WhatsAppChannelHandler(restTemplate, properties);
+    }
+
+    @Test
+    void dispatchesTextMessage() {
+        JourneyStep step = JourneyStep.builder()
+                .id(1L)
+                .template(JourneyTemplate.builder().id(2L).name("template").build())
+                .position(1)
+                .phase(JourneyPhase.INTEREST)
+                .stimulusType(JourneyStimulusType.WHATSAPP)
+                .metadata(Map.of("body", "Hello from MarketingHub"))
+                .build();
+        JourneyAssignment assignment = JourneyAssignment.builder()
+                .id(10L)
+                .type(JourneyAssignmentType.LEAD)
+                .lead(Lead.builder().id(UUID.randomUUID()).build())
+                .build();
+
+        server.expect(once(), requestTo("https://graph.facebook.com/v18.0/1234/messages"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("Authorization", "Bearer token"))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andRespond(withStatus(org.springframework.http.HttpStatus.OK)
+                        .body("{\"messages\":[{\"id\":\"wamid.123\"}]}"));
+
+        ChannelDispatchResult result = handler.dispatch(assignment, step, Map.of("phone", "+551100000000"));
+
+        assertThat(result.status()).isEqualTo(ChannelDispatchStatus.OK);
+        assertThat(result.providerMessageId()).isEqualTo("wamid.123");
+        server.verify();
+    }
+
+    @Test
+    void returnsTransientFailureOnRateLimit() {
+        JourneyStep step = JourneyStep.builder()
+                .id(1L)
+                .template(JourneyTemplate.builder().id(2L).name("template").build())
+                .position(1)
+                .phase(JourneyPhase.INTEREST)
+                .stimulusType(JourneyStimulusType.WHATSAPP)
+                .metadata(Map.of("body", "Hello"))
+                .build();
+        JourneyAssignment assignment = JourneyAssignment.builder()
+                .id(11L)
+                .type(JourneyAssignmentType.LEAD)
+                .lead(Lead.builder().id(UUID.randomUUID()).build())
+                .build();
+
+        server.expect(once(), requestTo("https://graph.facebook.com/v18.0/1234/messages"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(org.springframework.http.HttpStatus.TOO_MANY_REQUESTS)
+                        .header("Retry-After", "120"));
+
+        ChannelDispatchResult result = handler.dispatch(assignment, step, Map.of("phone", "+551100000001"));
+
+        assertThat(result.status()).isEqualTo(ChannelDispatchStatus.TRANSIENT_ERROR);
+        assertThat(result.nextAttemptAt()).isNotNull();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/policy/FrequencyCapServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/policy/FrequencyCapServiceTest.java
@@ -1,0 +1,82 @@
+package com.marketinghub.journey.execution.policy;
+
+import com.marketinghub.journey.execution.JourneyExecutionProperties;
+import com.marketinghub.journey.model.JourneyAssignment;
+import com.marketinghub.journey.repository.EventLogRepository;
+import com.marketinghub.model.Lead;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FrequencyCapServiceTest {
+    private EventLogRepository eventLogRepository;
+    private JourneyExecutionProperties properties;
+    private FrequencyCapService service;
+    private Instant now;
+
+    @BeforeEach
+    void setup() {
+        eventLogRepository = mock(EventLogRepository.class);
+        properties = new JourneyExecutionProperties();
+        service = new FrequencyCapService(eventLogRepository, properties);
+        now = Instant.now();
+    }
+
+    @Test
+    void allowsWhenDisabled() {
+        properties.getFrequencyCap().setEnabled(false);
+        JourneyAssignment assignment = assignmentWithLead(UUID.randomUUID());
+
+        FrequencyCapResult result = service.evaluate(assignment, now);
+
+        assertThat(result.blocked()).isFalse();
+    }
+
+    @Test
+    void blocksWhenDailyLimitReached() {
+        properties.getFrequencyCap().setPerDay(1);
+        properties.getFrequencyCap().setCooldown(Duration.ofHours(1));
+        UUID leadId = UUID.randomUUID();
+        JourneyAssignment assignment = assignmentWithLead(leadId);
+        when(eventLogRepository.countByActorIdAndEventTypeAndOccurredAtAfter(eq(leadId), anyString(), any()))
+                .thenReturn(1L);
+
+        FrequencyCapResult result = service.evaluate(assignment, now);
+
+        assertThat(result.blocked()).isTrue();
+        assertThat(result.nextAttemptAt()).isAfter(now);
+        assertThat(result.metadata()).containsEntry("window", "daily");
+    }
+
+    @Test
+    void blocksWhenWeeklyLimitReached() {
+        properties.getFrequencyCap().setPerDay(5);
+        properties.getFrequencyCap().setPerWeek(6);
+        UUID leadId = UUID.randomUUID();
+        JourneyAssignment assignment = assignmentWithLead(leadId);
+        when(eventLogRepository.countByActorIdAndEventTypeAndOccurredAtAfter(eq(leadId), anyString(), any()))
+                .thenReturn(0L, 6L);
+
+        FrequencyCapResult result = service.evaluate(assignment, now);
+
+        assertThat(result.blocked()).isTrue();
+        assertThat(result.metadata()).containsEntry("window", "weekly");
+    }
+
+    private JourneyAssignment assignmentWithLead(UUID leadId) {
+        return JourneyAssignment.builder()
+                .lead(Lead.builder().id(leadId).build())
+                .build();
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement the journey execution scheduler, orchestration service, and runtime policies to drive assignments and telemetry
- add Meta Ads, SendGrid, and WhatsApp channel handlers with rate-limit awareness and shared configuration properties
- extend persistence with retry metadata and cover the new execution/telemetry flows with focused unit tests

## Testing
- mvn -s ../settings.xml test *(fails: Network is unreachable for github.com while resolving spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68cc69344ab08321b3de4ccdb33ce0b5