### PR TITLE
Fix WhatsApp text body resolution

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/WhatsAppChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/WhatsAppChannelHandler.java
@@ -114,12 +114,18 @@ public class WhatsAppChannelHandler implements JourneyChannelHandler {
         } else {
             payload.put("type", "text");
             Map<String, Object> text = new HashMap<>();
-            Object body = step.getMetadata().getOrDefault("body", context.get("message"));
+            String body = step.getMetadata().get("body");
+            if (body == null) {
+                Object message = context.get("message");
+                if (message != null) {
+                    body = message.toString();
+                }
+            }
             if (body == null) {
                 throw new IllegalArgumentException("Missing WhatsApp message body");
             }
             text.put("preview_url", Boolean.FALSE);
-            text.put("body", body.toString());
+            text.put("body", body);
             payload.put("text", text);
         }
         return payload;


### PR DESCRIPTION
## Summary
- avoid passing a generic context value as the default metadata body by looking up the metadata first and stringifying the context message when needed
- keep the WhatsApp text payload body as a String to satisfy the metadata map contract

## Testing
- `mvn -s ../settings.xml test` *(fails: unable to download org.springframework.boot:spring-boot-starter-parent due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9cbdd36083219ff83fee5d7aa3f9