### PR TITLE
Fix transaction manager usage in JourneyExecutionServiceTest

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/JourneyExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/JourneyExecutionServiceTest.java
@@ -19,7 +19,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.transaction.support.ResourcelessTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -70,7 +73,7 @@ class JourneyExecutionServiceTest {
                 conditionEvaluator,
                 telemetryService,
                 objectMapper,
-                new ResourcelessTransactionManager(),
+                new NoOpTransactionManager(),
                 List.of(emailHandler));
     }
 
@@ -186,5 +189,22 @@ class JourneyExecutionServiceTest {
                 .build();
         assignment.setCreatedAt(Instant.now().minus(Duration.ofHours(2)));
         return assignment;
+    }
+
+    private static class NoOpTransactionManager implements PlatformTransactionManager {
+        @Override
+        public TransactionStatus getTransaction(TransactionDefinition definition) {
+            return new SimpleTransactionStatus();
+        }
+
+        @Override
+        public void commit(TransactionStatus status) {
+            // no-op
+        }
+
+        @Override
+        public void rollback(TransactionStatus status) {
+            // no-op
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the use of the removed `ResourcelessTransactionManager` in `JourneyExecutionServiceTest`
- provide a simple no-op `PlatformTransactionManager` implementation for the unit test

## Testing
- mvn -s ../settings.xml test *(fails: unable to resolve parent POM due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca0f0326c8321a0d9ac13e0bb4a95