### PR TITLE
Fix journey execution tests to use public channel handler constructors

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/JourneyExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/JourneyExecutionServiceTest.java
@@ -8,6 +8,7 @@ import com.marketinghub.journey.execution.policy.FrequencyCapService;
 import com.marketinghub.journey.execution.policy.RetryBackoffCalculator;
 import com.marketinghub.journey.model.*;
 import com.marketinghub.journey.model.EventLog;
+import com.marketinghub.model.Lead;
 import com.marketinghub.journey.repository.EventLogRepository;
 import com.marketinghub.journey.repository.JourneyAssignmentRepository;
 import com.marketinghub.journey.repository.JourneyStepRepository;

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/MetaAdsChannelHandlerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/MetaAdsChannelHandlerTest.java
@@ -13,12 +13,15 @@ import com.marketinghub.journey.model.JourneyTemplate;
 import com.marketinghub.model.Lead;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,13 +35,14 @@ class MetaAdsChannelHandlerTest {
 
     @BeforeEach
     void setup() {
-        RestTemplate restTemplate = new RestTemplate();
-        server = MockRestServiceServer.createServer(restTemplate);
         MetaMarketingProperties properties = new MetaMarketingProperties();
         properties.setEnabled(true);
         properties.setAccessToken("token");
         properties.setAdAccountId("123");
-        handler = new MetaAdsChannelHandler(restTemplate, properties);
+        handler = new MetaAdsChannelHandler(new RestTemplateBuilder(), properties);
+        RestTemplate restTemplate = (RestTemplate) Objects.requireNonNull(
+                ReflectionTestUtils.getField(handler, "restTemplate"));
+        server = MockRestServiceServer.createServer(restTemplate);
     }
 
     @Test
@@ -74,7 +78,7 @@ class MetaAdsChannelHandlerTest {
     void returnsPermanentFailureWhenDisabled() {
         MetaMarketingProperties properties = new MetaMarketingProperties();
         properties.setEnabled(false);
-        MetaAdsChannelHandler disabledHandler = new MetaAdsChannelHandler(new RestTemplate(), properties);
+        MetaAdsChannelHandler disabledHandler = new MetaAdsChannelHandler(new RestTemplateBuilder(), properties);
         JourneyStep step = JourneyStep.builder()
                 .id(1L)
                 .template(JourneyTemplate.builder().id(2L).name("template").build())

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/SendGridEmailChannelHandlerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/SendGridEmailChannelHandlerTest.java
@@ -14,14 +14,17 @@ import com.marketinghub.journey.model.JourneyStatus;
 import com.marketinghub.model.Lead;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,14 +38,15 @@ class SendGridEmailChannelHandlerTest {
 
     @BeforeEach
     void setup() {
-        RestTemplate restTemplate = new RestTemplate();
-        server = MockRestServiceServer.createServer(restTemplate);
         SendGridProperties properties = new SendGridProperties();
         properties.setEnabled(true);
         properties.setApiKey("test-key");
         properties.setFromEmail("hello@example.com");
         properties.setFromName("Marketing Hub");
-        handler = new SendGridEmailChannelHandler(restTemplate, properties);
+        handler = new SendGridEmailChannelHandler(new RestTemplateBuilder(), properties);
+        RestTemplate restTemplate = (RestTemplate) Objects.requireNonNull(
+                ReflectionTestUtils.getField(handler, "restTemplate"));
+        server = MockRestServiceServer.createServer(restTemplate);
     }
 
     @Test

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/WhatsAppChannelHandlerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/WhatsAppChannelHandlerTest.java
@@ -13,12 +13,15 @@ import com.marketinghub.journey.model.JourneyTemplate;
 import com.marketinghub.model.Lead;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,13 +35,14 @@ class WhatsAppChannelHandlerTest {
 
     @BeforeEach
     void setup() {
-        RestTemplate restTemplate = new RestTemplate();
-        server = MockRestServiceServer.createServer(restTemplate);
         WhatsAppProperties properties = new WhatsAppProperties();
         properties.setEnabled(true);
         properties.setAccessToken("token");
         properties.setPhoneNumberId("1234");
-        handler = new WhatsAppChannelHandler(restTemplate, properties);
+        handler = new WhatsAppChannelHandler(new RestTemplateBuilder(), properties);
+        RestTemplate restTemplate = (RestTemplate) Objects.requireNonNull(
+                ReflectionTestUtils.getField(handler, "restTemplate"));
+        server = MockRestServiceServer.createServer(restTemplate);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- import the Lead entity in `JourneyExecutionServiceTest` so the builder call compiles
- update channel handler tests to construct handlers via `RestTemplateBuilder` and access the managed `RestTemplate` for the mock server

## Testing
- `mvn -s ../settings.xml test` *(fails: unable to resolve parent POM because https://maven.pkg.github.com is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccda93ad988321aece6b72a48771e9