### PR TITLE
Fix H2 datasource configuration for Spring tests

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/ads/CampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/CampaignControllerTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -21,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/label/web/AngleControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/label/web/AngleControllerTest.java
@@ -20,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/web/CreativeControllerTest.java
@@ -33,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/AdSetServiceTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/CreativeVariantServiceTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdSetControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdSetControllerTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -25,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/web/HypothesisControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/web/HypothesisControllerTest.java
@@ -21,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/niche/web/MarketNicheControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/niche/web/MarketNicheControllerTest.java
@@ -20,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })

--- a/backend/ads-service/src/test/java/com/marketinghub/prompt/PromptAttributeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/prompt/PromptAttributeServiceTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
+        "spring.datasource.password=",
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })


### PR DESCRIPTION
## Summary
- add an explicit blank H2 password to every Spring Boot test that overrides the datasource properties
- prevent the test ApplicationContext from attempting to authenticate against H2 with the production MySQL password

## Testing
- mvn -s ../settings.xml test *(fails: unable to resolve parent POM because the remote repository is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cce331d9788321962aa81207754274