### PR TITLE
Fix H2 configuration for experiment controller tests

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
         "spring.datasource.driverClassName=org.h2.Driver",
         "spring.datasource.username=sa",
         "spring.datasource.password=",


### PR DESCRIPTION
## Summary
- update the experiment controller integration test to run H2 in MySQL compatibility mode
- ensure the in-memory schema supports MySQL-specific column definitions used by the entities

## Testing
- `../mvnw test -pl ads-service` *(fails: unable to download dependencies because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd563e22388321a01acb853ed40af7