### PR TITLE
Fix journey event log column name for H2 compatibility

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/journey/model/EventLog.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/model/EventLog.java
@@ -47,7 +47,7 @@ public class EventLog {
     @Lob
     private String metadata;
 
-    @Column(precision = 12, scale = 2)
+    @Column(name = "event_value", precision = 12, scale = 2)
     private BigDecimal value;
 
     @Column(name = "occurred_at", nullable = false)

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_15__create_journey_tables.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_15__create_journey_tables.sql
@@ -128,7 +128,7 @@ CREATE TABLE journey_event_log (
     source VARCHAR(100),
     campaign_id VARCHAR(100),
     metadata LONGTEXT,
-    value DECIMAL(12,2),
+    event_value DECIMAL(12,2),
     occurred_at DATETIME NOT NULL,
     received_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_event_log_journey FOREIGN KEY (journey_id) REFERENCES journey(id),


### PR DESCRIPTION
## Summary
- map the EventLog monetary value to the event_value column to avoid using reserved identifiers in H2
- align the Liquibase changelog so the journey_event_log table creates the event_value column

## Testing
- mvn -s ../settings.xml test *(fails: unable to download parent POM from GitHub Packages in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd63f699888321ae7706692b675bf7