### PR TITLE
Fix outbox scheduler to deliver welcome messages

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/service/LeadService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/service/LeadService.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.List;
 
 /**
  * Handles lead persistence and outbox creation.
@@ -21,15 +20,18 @@ public class LeadService {
     private final OutboxRepository outboxRepository;
     private final GraphApiClient graphApiClient;
     private final TaskExecutor taskExecutor;
+    private final WelcomeSequenceFactory welcomeSequenceFactory;
 
     public LeadService(LeadRepository leadRepository,
                        OutboxRepository outboxRepository,
                        GraphApiClient graphApiClient,
-                       TaskExecutor taskExecutor) {
+                       TaskExecutor taskExecutor,
+                       WelcomeSequenceFactory welcomeSequenceFactory) {
         this.leadRepository = leadRepository;
         this.outboxRepository = outboxRepository;
         this.graphApiClient = graphApiClient;
         this.taskExecutor = taskExecutor;
+        this.welcomeSequenceFactory = welcomeSequenceFactory;
     }
 
     /**
@@ -53,24 +55,17 @@ public class LeadService {
             exp.setId(dto.experimentId());
             lead.setExperiment(exp);
         }
-        leadRepository.save(lead);
+        lead = leadRepository.save(lead);
 
         OutboxEvent event = OutboxEvent.builder()
                 .aggregateId(lead.getId())
                 .eventType("LEAD_CREATED")
-                .payload("{}")
+                .payload(String.format("{\"leadId\":\"%s\"}", lead.getId()))
                 .createdAt(Instant.now())
                 .build();
         outboxRepository.save(event);
 
-        SequenceTemplate template = SequenceTemplate.builder()
-                .name("Welcome")
-                .steps(List.of(
-                        SequenceStep.builder().stepOrder(1).content("Welcome!").delaySeconds(0).build(),
-                        SequenceStep.builder().stepOrder(2).content("How can we help?").delaySeconds(5).build()
-                ))
-                .build();
-        template.getSteps().forEach(s -> s.setSequenceTemplate(template));
+        SequenceTemplate template = welcomeSequenceFactory.createWelcomeTemplate();
 
         taskExecutor.execute(() -> graphApiClient.sendWelcomeAsync(lead, template));
         return lead;

--- a/backend/ads-service/src/main/java/com/marketinghub/service/OutboxScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/service/OutboxScheduler.java
@@ -1,12 +1,15 @@
 package com.marketinghub.service;
 
+import com.marketinghub.model.Lead;
 import com.marketinghub.model.OutboxEvent;
 import com.marketinghub.repository.OutboxRepository;
+import com.marketinghub.repository.LeadRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Periodically processes pending outbox events.
@@ -14,11 +17,18 @@ import java.util.List;
 @Component
 public class OutboxScheduler {
     private final OutboxRepository outboxRepository;
+    private final LeadRepository leadRepository;
     private final GraphApiClient graphApiClient;
+    private final WelcomeSequenceFactory welcomeSequenceFactory;
 
-    public OutboxScheduler(OutboxRepository outboxRepository, GraphApiClient graphApiClient) {
+    public OutboxScheduler(OutboxRepository outboxRepository,
+                           LeadRepository leadRepository,
+                           GraphApiClient graphApiClient,
+                           WelcomeSequenceFactory welcomeSequenceFactory) {
         this.outboxRepository = outboxRepository;
+        this.leadRepository = leadRepository;
         this.graphApiClient = graphApiClient;
+        this.welcomeSequenceFactory = welcomeSequenceFactory;
     }
 
     /**
@@ -28,7 +38,14 @@ public class OutboxScheduler {
     public void processPending() {
         List<OutboxEvent> events = outboxRepository.findByProcessedAtIsNull();
         for (OutboxEvent e : events) {
-            graphApiClient.sendWelcomeAsync(null, null);
+            if (e.getAggregateId() == null) {
+                continue;
+            }
+            Optional<Lead> lead = leadRepository.findById(e.getAggregateId());
+            if (lead.isEmpty()) {
+                continue;
+            }
+            graphApiClient.sendWelcomeAsync(lead.get(), welcomeSequenceFactory.createWelcomeTemplate());
             e.setProcessedAt(Instant.now());
             outboxRepository.save(e);
         }

--- a/backend/ads-service/src/main/java/com/marketinghub/service/WelcomeSequenceFactory.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/service/WelcomeSequenceFactory.java
@@ -1,0 +1,30 @@
+package com.marketinghub.service;
+
+import com.marketinghub.model.SequenceTemplate;
+import com.marketinghub.model.SequenceStep;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Factory responsible for building the default welcome sequence sent to new leads.
+ */
+@Component
+public class WelcomeSequenceFactory {
+
+    /**
+     * Creates the default welcome template used when a lead is captured.
+     */
+    public SequenceTemplate createWelcomeTemplate() {
+        SequenceTemplate template = SequenceTemplate.builder()
+                .name("Welcome")
+                .steps(List.of(
+                        SequenceStep.builder().stepOrder(1).content("Welcome!").delaySeconds(0).build(),
+                        SequenceStep.builder().stepOrder(2).content("How can we help?").delaySeconds(5).build()
+                ))
+                .build();
+        template.getSteps().forEach(step -> step.setSequenceTemplate(template));
+        return template;
+    }
+}
+

--- a/backend/ads-service/src/test/java/com/marketinghub/service/LeadServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/service/LeadServiceTest.java
@@ -3,6 +3,7 @@ package com.marketinghub.service;
 import com.marketinghub.dto.LeadDTO;
 import com.marketinghub.model.Lead;
 import com.marketinghub.model.NurtureStage;
+import com.marketinghub.model.OutboxEvent;
 import com.marketinghub.repository.LeadRepository;
 import com.marketinghub.repository.OutboxRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,12 +30,14 @@ class LeadServiceTest {
     GraphApiClient graphApiClient;
 
     TaskExecutor taskExecutor = Runnable::run;
+    WelcomeSequenceFactory welcomeSequenceFactory;
 
     LeadService leadService;
 
     @BeforeEach
     void setUp() {
-        leadService = new LeadService(leadRepository, outboxRepository, graphApiClient, taskExecutor);
+        welcomeSequenceFactory = new WelcomeSequenceFactory();
+        leadService = new LeadService(leadRepository, outboxRepository, graphApiClient, taskExecutor, welcomeSequenceFactory);
     }
 
     @Test
@@ -49,7 +52,11 @@ class LeadServiceTest {
         Lead lead = leadService.saveFromWebhook(dto);
 
         verify(leadRepository).save(any());
-        verify(outboxRepository).save(any());
+        var eventCaptor = org.mockito.ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxRepository).save(eventCaptor.capture());
+        OutboxEvent savedEvent = eventCaptor.getValue();
+        assertEquals(lead.getId(), savedEvent.getAggregateId());
+        assertEquals("{\"leadId\":\"" + lead.getId() + "\"}", savedEvent.getPayload());
         verify(graphApiClient).sendWelcomeAsync(any(), any());
         assertEquals(dto.leadgenId(), lead.getLeadgenId());
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/service/OutboxSchedulerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/service/OutboxSchedulerTest.java
@@ -1,13 +1,17 @@
 package com.marketinghub.service;
 
+import com.marketinghub.model.Lead;
 import com.marketinghub.model.OutboxEvent;
+import com.marketinghub.repository.LeadRepository;
 import com.marketinghub.repository.OutboxRepository;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
 
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -18,19 +22,33 @@ class OutboxSchedulerTest {
     @Mock
     OutboxRepository outboxRepository;
     @Mock
+    LeadRepository leadRepository;
+    @Mock
     GraphApiClient graphApiClient;
 
-    @InjectMocks
     OutboxScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new OutboxScheduler(outboxRepository, leadRepository, graphApiClient, new WelcomeSequenceFactory());
+    }
 
     @Test
     void processPendingMarksEventsProcessed() {
-        OutboxEvent event = OutboxEvent.builder().build();
+        UUID leadId = UUID.randomUUID();
+        Lead lead = Lead.builder().id(leadId).build();
+        OutboxEvent event = OutboxEvent.builder()
+                .aggregateId(leadId)
+                .payload("{\"leadId\":\"" + leadId + "\"}")
+                .build();
         when(outboxRepository.findByProcessedAtIsNull()).thenReturn(Collections.singletonList(event));
+        when(leadRepository.findById(leadId)).thenReturn(Optional.of(lead));
+        when(outboxRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         scheduler.processPending();
 
         assertNotNull(event.getProcessedAt());
         verify(outboxRepository).save(event);
+        verify(graphApiClient).sendWelcomeAsync(eq(lead), any());
     }
 }


### PR DESCRIPTION
## Summary
- ensure leads saved from the webhook persist the generated id into the outbox payload and reuse a shared welcome template
- introduce a WelcomeSequenceFactory so both the lead service and outbox scheduler send the same welcome sequence
- update the outbox scheduler to load the lead before dispatching and cover the behaviour with unit tests

## Testing
- mvn -s ../settings.xml test *(fails: Network is unreachable while downloading spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68cd785ecf1483219548206ac0c60af2