### PR TITLE
Fix LeadService lambda capture to allow tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/service/LeadService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/service/LeadService.java
@@ -55,19 +55,19 @@ public class LeadService {
             exp.setId(dto.experimentId());
             lead.setExperiment(exp);
         }
-        lead = leadRepository.save(lead);
+        Lead savedLead = leadRepository.save(lead);
 
         OutboxEvent event = OutboxEvent.builder()
-                .aggregateId(lead.getId())
+                .aggregateId(savedLead.getId())
                 .eventType("LEAD_CREATED")
-                .payload(String.format("{\"leadId\":\"%s\"}", lead.getId()))
+                .payload(String.format("{\"leadId\":\"%s\"}", savedLead.getId()))
                 .createdAt(Instant.now())
                 .build();
         outboxRepository.save(event);
 
         SequenceTemplate template = welcomeSequenceFactory.createWelcomeTemplate();
 
-        taskExecutor.execute(() -> graphApiClient.sendWelcomeAsync(lead, template));
-        return lead;
+        taskExecutor.execute(() -> graphApiClient.sendWelcomeAsync(savedLead, template));
+        return savedLead;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the saved lead instance is stored separately so it can be reused safely after persistence
- update outbox event creation and async welcome call to use the persisted lead when scheduling the Graph API call

## Testing
- mvn -o -Dtest=LeadServiceTest,OutboxSchedulerTest test

------
https://chatgpt.com/codex/tasks/task_e_68cd7d4b6fd48321916bed079b5c5d6a