### PR TITLE
Fix channel handlers to handle missing metadata

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/MetaAdsChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/MetaAdsChannelHandler.java
@@ -65,7 +65,7 @@ public class MetaAdsChannelHandler implements JourneyChannelHandler {
                 MetaAdResponse body = response.getBody();
                 Map<String, Object> metadata = new HashMap<>();
                 metadata.put("adId", body.id());
-                metadata.put("creativeId", step.getMetadata().get("creativeId"));
+                metadata.put("creativeId", safeMetadata(step).get("creativeId"));
                 metadata.put("status", payload.get("status"));
                 return ChannelDispatchResult.success(body.id(), metadata);
             }
@@ -89,23 +89,29 @@ public class MetaAdsChannelHandler implements JourneyChannelHandler {
     private Map<String, Object> buildPayload(JourneyStep step) {
         Map<String, Object> payload = new HashMap<>();
         payload.put("name", step.getName() != null ? step.getName() : "Journey Step " + step.getId());
-        String status = step.getMetadata().getOrDefault("status", properties.getDefaultAdStatus());
+        Map<String, String> metadata = safeMetadata(step);
+        String status = metadata.getOrDefault("status", properties.getDefaultAdStatus());
         payload.put("status", status);
-        if (step.getMetadata().containsKey("adsetId")) {
-            payload.put("adset_id", step.getMetadata().get("adsetId"));
+        if (metadata.containsKey("adsetId")) {
+            payload.put("adset_id", metadata.get("adsetId"));
         }
-        if (step.getMetadata().containsKey("campaignId")) {
-            payload.put("campaign_id", step.getMetadata().get("campaignId"));
+        if (metadata.containsKey("campaignId")) {
+            payload.put("campaign_id", metadata.get("campaignId"));
         }
-        if (step.getMetadata().containsKey("creativeId")) {
+        if (metadata.containsKey("creativeId")) {
             Map<String, Object> creative = new HashMap<>();
-            creative.put("creative_id", step.getMetadata().get("creativeId"));
+            creative.put("creative_id", metadata.get("creativeId"));
             payload.put("creative", creative);
         }
-        if (step.getMetadata().containsKey("bidAmount")) {
-            payload.put("bid_amount", step.getMetadata().get("bidAmount"));
+        if (metadata.containsKey("bidAmount")) {
+            payload.put("bid_amount", metadata.get("bidAmount"));
         }
         return payload;
+    }
+
+    private Map<String, String> safeMetadata(JourneyStep step) {
+        Map<String, String> metadata = step.getMetadata();
+        return metadata != null ? metadata : Map.of();
     }
 
     private Instant resolveRetryAt(HttpHeaders headers) {

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/SendGridEmailChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/SendGridEmailChannelHandler.java
@@ -74,7 +74,7 @@ public class SendGridEmailChannelHandler implements JourneyChannelHandler {
             if (response.getStatusCode().value() == 202 || response.getStatusCode().is2xxSuccessful()) {
                 Map<String, Object> metadata = new HashMap<>();
                 metadata.put("to", toEmail);
-                metadata.put("templateId", step.getMetadata().get("templateId"));
+                metadata.put("templateId", safeMetadata(step).get("templateId"));
                 return ChannelDispatchResult.success(null, metadata);
             }
             if (response.getStatusCode().is5xxServerError() || response.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
@@ -108,19 +108,25 @@ public class SendGridEmailChannelHandler implements JourneyChannelHandler {
         personalization.put("dynamic_template_data", context);
         payload.put("personalizations", List.of(personalization));
 
-        if (step.getMetadata().containsKey("templateId")) {
-            payload.put("template_id", step.getMetadata().get("templateId"));
+        Map<String, String> metadata = safeMetadata(step);
+        if (metadata.containsKey("templateId")) {
+            payload.put("template_id", metadata.get("templateId"));
         }
-        if (step.getMetadata().containsKey("subject")) {
-            personalization.put("subject", step.getMetadata().get("subject"));
+        if (metadata.containsKey("subject")) {
+            personalization.put("subject", metadata.get("subject"));
         }
-        if (step.getMetadata().containsKey("content")) {
+        if (metadata.containsKey("content")) {
             payload.put("content", List.of(Map.of(
                     "type", "text/plain",
-                    "value", Objects.toString(step.getMetadata().get("content"))
+                    "value", Objects.toString(metadata.get("content"))
             )));
         }
         return payload;
+    }
+
+    private Map<String, String> safeMetadata(JourneyStep step) {
+        Map<String, String> metadata = step.getMetadata();
+        return metadata != null ? metadata : Map.of();
     }
 
     private String resolveRecipient(Map<String, Object> context) {

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/WhatsAppChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/WhatsAppChannelHandler.java
@@ -103,18 +103,19 @@ public class WhatsAppChannelHandler implements JourneyChannelHandler {
         Map<String, Object> payload = new HashMap<>();
         payload.put("messaging_product", "whatsapp");
         payload.put("to", to);
-        if (step.getMetadata().containsKey("templateName")) {
+        Map<String, String> metadata = safeMetadata(step);
+        if (metadata.containsKey("templateName")) {
             payload.put("type", "template");
             Map<String, Object> template = new HashMap<>();
-            template.put("name", step.getMetadata().get("templateName"));
+            template.put("name", metadata.get("templateName"));
             Map<String, Object> language = new HashMap<>();
-            language.put("code", step.getMetadata().getOrDefault("templateLanguage", "en_US"));
+            language.put("code", metadata.getOrDefault("templateLanguage", "en_US"));
             template.put("language", language);
             payload.put("template", template);
         } else {
             payload.put("type", "text");
             Map<String, Object> text = new HashMap<>();
-            String body = step.getMetadata().get("body");
+            String body = metadata.get("body");
             if (body == null) {
                 Object message = context.get("message");
                 if (message != null) {
@@ -129,6 +130,11 @@ public class WhatsAppChannelHandler implements JourneyChannelHandler {
             payload.put("text", text);
         }
         return payload;
+    }
+
+    private Map<String, String> safeMetadata(JourneyStep step) {
+        Map<String, String> metadata = step.getMetadata();
+        return metadata != null ? metadata : Map.of();
     }
 
     private String resolvePhone(Map<String, Object> context) {


### PR DESCRIPTION
## Summary
- guard SendGrid, Meta ads and WhatsApp channel handlers against journey steps that lack metadata
- reuse a safe metadata lookup when building payloads and recording dispatch metadata

## Testing
- not run (maven dependencies unavailable offline)

------
https://chatgpt.com/codex/tasks/task_e_68cd8b2a4fdc8321a9ea355cc50de786