### PR TITLE
Fix MetaAdsChannelHandler constructor injection

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/MetaAdsChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/MetaAdsChannelHandler.java
@@ -5,6 +5,7 @@ import com.marketinghub.journey.model.JourneyAssignment;
 import com.marketinghub.journey.model.JourneyStep;
 import com.marketinghub.journey.model.JourneyStimulusType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -27,6 +28,7 @@ public class MetaAdsChannelHandler implements JourneyChannelHandler {
     private final RestTemplate restTemplate;
     private final MetaMarketingProperties properties;
 
+    @Autowired
     public MetaAdsChannelHandler(RestTemplateBuilder restTemplateBuilder,
                                  MetaMarketingProperties properties) {
         this(restTemplateBuilder.build(), properties);


### PR DESCRIPTION
## Summary
- ensure Spring can instantiate `MetaAdsChannelHandler` by autowiring its primary constructor
- add the required `@Autowired` import

## Testing
- `mvn -s ../settings.xml test` *(fails: unable to download parent POM because the GitHub Packages repository is unreachable from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd931954988321a94e0b784fd81732