### PR TITLE
Fix WhatsApp test mock response media type

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/WhatsAppChannelHandlerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/WhatsAppChannelHandlerTest.java
@@ -66,6 +66,7 @@ class WhatsAppChannelHandlerTest {
                 .andExpect(header("Authorization", "Bearer token"))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andRespond(withStatus(org.springframework.http.HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
                         .body("{\"messages\":[{\"id\":\"wamid.123\"}]}"));
 
         ChannelDispatchResult result = handler.dispatch(assignment, step, Map.of("phone", "+551100000000"));


### PR DESCRIPTION
## Summary
- ensure the mocked WhatsApp API response in WhatsAppChannelHandlerTest declares an application/json content type so RestTemplate can deserialize the payload

## Testing
- mvn -s ../settings.xml test *(fails: unable to resolve parent POM because github.com was unreachable from the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd96edd1748321a5741b5f6bd0d45e