### PR TITLE
Fix SendGridEmailChannelHandler instantiation error

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/SendGridEmailChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/SendGridEmailChannelHandler.java
@@ -5,6 +5,7 @@ import com.marketinghub.journey.model.JourneyAssignment;
 import com.marketinghub.journey.model.JourneyStep;
 import com.marketinghub.journey.model.JourneyStimulusType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -33,6 +34,7 @@ public class SendGridEmailChannelHandler implements JourneyChannelHandler {
     private final RestTemplate restTemplate;
     private final SendGridProperties properties;
 
+    @Autowired
     public SendGridEmailChannelHandler(RestTemplateBuilder restTemplateBuilder,
                                        SendGridProperties properties) {
         this(restTemplateBuilder.build(), properties);


### PR DESCRIPTION
## Summary
- annotate the SendGridEmailChannelHandler constructor with @Autowired so Spring can resolve its dependencies during bean creation

## Testing
- mvn -s ../settings.xml test *(fails: Network is unreachable when downloading spring-boot-starter-parent from GitHub Packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9bf21314832184d40879a43283e0