### PR TITLE
Fix WhatsApp channel handler instantiation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/WhatsAppChannelHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/channel/WhatsAppChannelHandler.java
@@ -5,6 +5,7 @@ import com.marketinghub.journey.model.JourneyAssignment;
 import com.marketinghub.journey.model.JourneyStep;
 import com.marketinghub.journey.model.JourneyStimulusType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -32,6 +33,7 @@ public class WhatsAppChannelHandler implements JourneyChannelHandler {
     private final RestTemplate restTemplate;
     private final WhatsAppProperties properties;
 
+    @Autowired
     public WhatsAppChannelHandler(RestTemplateBuilder restTemplateBuilder,
                                   WhatsAppProperties properties) {
         this(restTemplateBuilder.build(), properties);


### PR DESCRIPTION
## Summary
- add explicit constructor autowiring for `WhatsAppChannelHandler` so Spring can pick the proper dependency-injected constructor

## Testing
- `mvn -s ../settings.xml test` *(fails: cannot download parent POM from GitHub Packages in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cda4997a98832197d2f93d646cbecd