### PR TITLE
docs: orientar uso de autowired em construtores

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Todo o modelo de dados deve estar definido aqui no projeto **backend**.
  - O projeto **ai-worker** deve usar este modelo sem manter uma cópia própria.
+- Em classes do Spring com mais de um construtor (por exemplo handlers que recebem `RestTemplateBuilder`), marque explicitamente o construtor usado para injeção com `@Autowired` e certifique-se de importar a anotação, evitando que o container selecione um construtor incorreto.


### PR DESCRIPTION
## Summary
- orienta no AGENTS.md do backend para anotar explicitamente com `@Autowired` o construtor destinado à injeção quando houver múltiplos construtores, evitando seleção incorreta pelo Spring

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdb08c9b7083218e530e31a3e76740