### PR TITLE
Fix Liquibase checksum failure for journey event log column rename

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_15__create_journey_tables.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_15__create_journey_tables.sql
@@ -128,7 +128,7 @@ CREATE TABLE journey_event_log (
     source VARCHAR(100),
     campaign_id VARCHAR(100),
     metadata LONGTEXT,
-    event_value DECIMAL(12,2),
+    value DECIMAL(12,2),
     occurred_at DATETIME NOT NULL,
     received_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_event_log_journey FOREIGN KEY (journey_id) REFERENCES journey(id),

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_21__rename_journey_event_value_column.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_21__rename_journey_event_value_column.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset marketinghub:2025-10-21-rename-journey-event-value-column
+--preconditions onFail=MARK_RAN onError=HALT
+--precondition-sql-check expectedResult=1 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'journey_event_log' AND column_name = 'value';
+ALTER TABLE journey_event_log CHANGE value event_value DECIMAL(12,2);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -98,3 +98,6 @@ databaseChangeLog:
   - include:
       file: V2025_10_20__journey_execution_runtime.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_10_21__rename_journey_event_value_column.sql
+      relativeToChangelogFile: true


### PR DESCRIPTION
## Summary
- restore the original journey event log change set definition so its checksum matches production
- add a dedicated Liquibase change set that renames the `value` column to `event_value` with a protective precondition
- register the new migration in the master changelog to keep database updates ordered

## Testing
- `mvn -s ../settings.xml test` *(fails: network unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cde2f1b66c8321b54ac539c52cb32a