### PR TITLE
Fix Liquibase SQL precondition syntax

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_21__rename_journey_event_value_column.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_21__rename_journey_event_value_column.sql
@@ -2,5 +2,5 @@
 
 --changeset marketinghub:2025-10-21-rename-journey-event-value-column
 --preconditions onFail=MARK_RAN onError=HALT
---precondition-sql-check expectedResult=1 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'journey_event_log' AND column_name = 'value';
+--precondition-sql-check expectedResult: 1 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'journey_event_log' AND column_name = 'value';
 ALTER TABLE journey_event_log CHANGE value event_value DECIMAL(12,2);


### PR DESCRIPTION
## Summary
- fix the SQL precondition syntax in the Liquibase changeset that renames the journey event value column

## Testing
- mvn -s ../settings.xml test *(fails: Network is unreachable when downloading parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cded85879c8321b0c2c6267ac141fb