### PR TITLE
Fix Liquibase sql-check precondition formatting

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_21__rename_journey_event_value_column.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_21__rename_journey_event_value_column.sql
@@ -2,5 +2,6 @@
 
 --changeset marketinghub:2025-10-21-rename-journey-event-value-column
 --preconditions onFail=MARK_RAN onError=HALT
---precondition-sql-check expectedResult: 1 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'journey_event_log' AND column_name = 'value';
+--precondition-sql-check expectedResult: 1
+SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'journey_event_log' AND column_name = 'value';
 ALTER TABLE journey_event_log CHANGE value event_value DECIMAL(12,2);


### PR DESCRIPTION
## Summary
- adjust the SQL check precondition in the journey event changelog so the query is parsed correctly by Liquibase

## Testing
- mvn -s ../settings.xml liquibase:validate *(fails: Network is unreachable while resolving spring-boot-starter-parent from GitHub Packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cdefc0434083218d3b1e739e26af6a