### PR TITLE
Add MySQL 5 guidance for Liquibase preConditions

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md — Backend
 
 - Todo o modelo de dados deve estar definido aqui no projeto **backend**.
- - O projeto **ai-worker** deve usar este modelo sem manter uma cópia própria.
+- O projeto **ai-worker** deve usar este modelo sem manter uma cópia própria.
 - Em classes do Spring com mais de um construtor (por exemplo handlers que recebem `RestTemplateBuilder`), marque explicitamente o construtor usado para injeção com `@Autowired` e certifique-se de importar a anotação, evitando que o container selecione um construtor incorreto.
 - Liquibase: nunca altere arquivos de changelog já aplicados para evitar erros de checksum. Em vez disso, crie um novo changelog incremental e, se necessário, atualize os `include` do master.
+- Liquibase (MySQL 5): ao escrever `preConditions`, utilize apenas SQL válida no MySQL 5 (testando as consultas antes de incluí-las) e configure `dbms="mysql"` quando a condição depender do banco para evitar erros de sintaxe.


### PR DESCRIPTION
## Summary
- add a backend guideline reminding contributors to keep Liquibase preConditions compatible with MySQL 5 and to set dbms="mysql" when needed

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cdf179382c8321b745c3565eb81e59