### PR TITLE
Fix Liquibase precondition formatting in rename changelog

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_21__rename_journey_event_value_column.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_21__rename_journey_event_value_column.sql
@@ -2,6 +2,6 @@
 
 --changeset marketinghub:2025-10-21-rename-journey-event-value-column
 --preconditions onFail=MARK_RAN onError=HALT
---precondition-sql-check expectedResult: 1
+--precondition-sql-check expectedResult:1
 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'journey_event_log' AND column_name = 'value';
 ALTER TABLE journey_event_log CHANGE value event_value DECIMAL(12,2);


### PR DESCRIPTION
## Summary
- correct the Liquibase SQL precondition format in the journey event log rename changelog so Liquibase can parse it

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: Network is unreachable when resolving parent POM from GitHub Packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf319a0008321bc601deb4c55c358