### PR TITLE
Fix Liquibase precondition syntax

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -5,3 +5,4 @@
 - Em classes do Spring com mais de um construtor (por exemplo handlers que recebem `RestTemplateBuilder`), marque explicitamente o construtor usado para injeção com `@Autowired` e certifique-se de importar a anotação, evitando que o container selecione um construtor incorreto.
 - Liquibase: nunca altere arquivos de changelog já aplicados para evitar erros de checksum. Em vez disso, crie um novo changelog incremental e, se necessário, atualize os `include` do master.
 - Liquibase (MySQL 5): ao escrever `preConditions`, utilize apenas SQL válida no MySQL 5 (testando as consultas antes de incluí-las) e configure `dbms="mysql"` quando a condição depender do banco para evitar erros de sintaxe.
+- Liquibase (SQL formatado): mantenha os atributos (`expectedResult`, `dbms`, etc.) na mesma linha do `--precondition-sql-check` junto com a consulta SQL (`SELECT ...`) exatamente como suportado pelo Liquibase para evitar falhas de parsing.

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_21__rename_journey_event_value_column.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_21__rename_journey_event_value_column.sql
@@ -2,6 +2,5 @@
 
 --changeset marketinghub:2025-10-21-rename-journey-event-value-column
 --preconditions onFail=MARK_RAN onError=HALT
---precondition-sql-check expectedResult:1
-SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'journey_event_log' AND column_name = 'value';
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'journey_event_log' AND column_name = 'value';
 ALTER TABLE journey_event_log CHANGE value event_value DECIMAL(12,2);


### PR DESCRIPTION
## Summary
- fix the SQL changelog precondition so Liquibase can parse the query correctly
- document in backend/AGENTS.md how to format `--precondition-sql-check` to avoid parsing errors

## Testing
- `mvn -s ../settings.xml liquibase:validate` *(fails: GitHub Packages unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf5108cf883218db6de38a47fc971