### PR TITLE
Store AI-generated creative images in backend assets

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/BackendAssetClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/BackendAssetClient.java
@@ -1,0 +1,103 @@
+package com.marketinghub.worker.creative;
+
+import com.marketinghub.worker.util.UrlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * HTTP client responsible for uploading generated assets to the backend service.
+ */
+@Component
+public class BackendAssetClient {
+    private static final Logger log = LoggerFactory.getLogger(BackendAssetClient.class);
+
+    private final WebClient webClient;
+    private final String backendBaseUrl;
+    private final String apiPrefix;
+
+    public BackendAssetClient(WebClient.Builder builder,
+                              @Value("${backend.base-url:http://localhost:8080}") String backendBaseUrl,
+                              @Value("${backend.api-prefix:/api}") String apiPrefix) {
+        this.webClient = builder.build();
+        this.backendBaseUrl = backendBaseUrl;
+        this.apiPrefix = apiPrefix;
+    }
+
+    /**
+     * Sends the provided image bytes to {@code POST /api/assets} in the backend and returns the
+     * relative URL exposed by the service.
+     */
+    public String uploadImage(byte[] content, String filename) {
+        if (content == null || content.length == 0) {
+            throw new IllegalArgumentException("Image content must not be empty");
+        }
+        String effectiveName = StringUtils.hasText(filename) ? filename : "creative.png";
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/assets");
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        ByteArrayResource resource = new ByteArrayResource(content) {
+            @Override
+            public String getFilename() {
+                return effectiveName;
+            }
+        };
+        HttpHeaders partHeaders = new HttpHeaders();
+        partHeaders.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        HttpEntity<ByteArrayResource> filePart = new HttpEntity<>(resource, partHeaders);
+        body.add("file", filePart);
+
+        logBackendRequest("POST", url);
+        return webClient.post()
+                .uri(url)
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(body))
+                .exchangeToMono(response -> {
+                    HttpStatusCode status = response.statusCode();
+                    if (status.isError()) {
+                        return response.bodyToMono(String.class)
+                                .defaultIfEmpty("")
+                                .flatMap(bodyContent -> Mono.error(new BackendAssetUploadException(
+                                        errorMessage(status, url, bodyContent))));
+                    }
+                    return response.bodyToMono(String.class);
+                })
+                .blockOptional()
+                .orElseThrow(() -> new BackendAssetUploadException(
+                        "Backend did not return an asset URL"));
+    }
+
+    private void logBackendRequest(String method, String url) {
+        if (log.isInfoEnabled()) {
+            log.info("Calling backend {} {}", method, url);
+        }
+    }
+
+    private static String errorMessage(HttpStatusCode status, String url, String body) {
+        return "Backend asset upload failed: status=" + status.value() + " url=" + url
+                + (body.isBlank() ? "" : " body=" + body);
+    }
+
+    /** Exception thrown when the backend refuses the upload. */
+    public static class BackendAssetUploadException extends RuntimeException {
+        public BackendAssetUploadException(String message) {
+            super(message);
+        }
+
+        public BackendAssetUploadException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}
+

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
@@ -1,5 +1,10 @@
 package com.marketinghub.worker.creative;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -7,19 +12,18 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.List;
-import java.util.Map;
-
 /**
  * Simple wrapper around the OpenAI images API for creative image generation.
  */
 @Component
 public class CreativeImageClient {
     private final WebClient webClient;
+    private final BackendAssetClient assetClient;
     private final String model;
     private static final Logger log = LoggerFactory.getLogger(CreativeImageClient.class);
 
     public CreativeImageClient(WebClient.Builder builder,
+                               BackendAssetClient assetClient,
                                @Value("${openai.api-key:}") String apiKey,
                                @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
                                @Value("${openai.image-model:dall-e-3}") String model) {
@@ -27,13 +31,15 @@ public class CreativeImageClient {
                 .baseUrl(baseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
                 .build();
+        this.assetClient = assetClient;
         this.model = model;
     }
 
     public String generateImage(String prompt) {
         Map<String, Object> payload = Map.of(
                 "model", model,
-                "prompt", prompt
+                "prompt", prompt,
+                "response_format", "b64_json"
         );
 
         log.info("Sending image generation prompt to OpenAI: {}", prompt);
@@ -49,9 +55,23 @@ public class CreativeImageClient {
         if (response == null || response.data().isEmpty()) {
             throw new RuntimeException("No image returned from OpenAI");
         }
-        return response.data().get(0).url();
+        ImageData data = response.data().get(0);
+        if (data.base64() != null && !data.base64().isBlank()) {
+            try {
+                byte[] imageBytes = Base64.getDecoder().decode(data.base64());
+                String filename = "creative-" + UUID.randomUUID() + ".png";
+                return assetClient.uploadImage(imageBytes, filename);
+            } catch (IllegalArgumentException e) {
+                throw new RuntimeException("Failed to decode image payload", e);
+            }
+        }
+        if (data.url() != null && !data.url().isBlank()) {
+            log.warn("OpenAI image response missing base64 payload, using remote URL");
+            return data.url();
+        }
+        throw new RuntimeException("No image returned from OpenAI");
     }
 
     private record ImageResponse(List<ImageData> data) {}
-    private record ImageData(String url) {}
+    private record ImageData(String url, @JsonProperty("b64_json") String base64) {}
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
@@ -1,0 +1,55 @@
+package com.marketinghub.worker.creative;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+class CreativeImageClientTest {
+    @Mock
+    BackendAssetClient backendAssetClient;
+
+    CreativeImageClient client;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        String imagePayload = Base64.getEncoder().encodeToString("img".getBytes(StandardCharsets.UTF_8));
+        String body = "{\"data\":[{\"b64_json\":\"" + imagePayload + "\"}]}";
+        ExchangeFunction exchange = request -> {
+            assertThat(request.url().toString()).endsWith("/images/generations");
+            return Mono.just(ClientResponse.create(HttpStatus.OK)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .body(body)
+                    .build());
+        };
+        WebClient.Builder builder = WebClient.builder().exchangeFunction(exchange);
+        client = new CreativeImageClient(builder, backendAssetClient, "key", "http://openai", "image-model");
+    }
+
+    @Test
+    void uploadsReturnedImageToBackend() {
+        when(backendAssetClient.uploadImage(any(), any())).thenReturn("/uploads/img.png");
+
+        String result = client.generateImage("prompt");
+
+        assertThat(result).isEqualTo("/uploads/img.png");
+        verify(backendAssetClient).uploadImage(any(byte[].class), argThat(name -> name.startsWith("creative-") && name.endsWith(".png")));
+    }
+}
+

--- a/docs/ai-worker/README.md
+++ b/docs/ai-worker/README.md
@@ -44,7 +44,8 @@ de IA quando necessário e persistem os resultados de volta no serviço principa
 - **Disparo:** `ExperimentCreativeScheduler` (cron `0 */5 * * * *`).
 - **Fonte dos dados:** experimentos com `creativesToGenerate > 0`.
 - **O que faz:** `ExperimentCreativeService` chama o `CreativeChatGptClient` para gerar textos e o
-  `CreativeImageClient` para sugerir imagens, salvando os criativos com `CreativeService`.
+  `CreativeImageClient` para gerar as imagens. As imagens são enviadas para o backend com `POST /api/assets`
+  via `BackendAssetClient`, e os criativos são salvos com `CreativeService`.
 - **Referências:** detalhes e fluxo em [experimento-criativo-service.md](experimento-criativo-service.md).
 
 - **Disparo:** `AudienceAdSetScheduler` (cron `0 */5 * * * *`).

--- a/docs/ai-worker/experimento-criativo-service.md
+++ b/docs/ai-worker/experimento-criativo-service.md
@@ -7,7 +7,8 @@ Este documento descreve o serviço do AI Worker que gera criativos para **EXPERI
 O serviço realiza as seguintes etapas:
 1. Busca experimentos com `creativesToGenerate > 0`.
 2. Consulta o ChatGPT para gerar textos dos criativos.
-3. Gera imagens com a API de imagens do OpenAI.
+3. Gera imagens com a API de imagens do OpenAI e envia o arquivo resultante para o backend por meio do `POST /api/assets`,
+   armazenando a URL pública retornada.
 4. Salva os criativos e zera o contador `creativesToGenerate`.
 
 ## Diagrama de fluxo


### PR DESCRIPTION
## Summary
- add BackendAssetClient to upload AI-generated images to the backend asset endpoint
- update CreativeImageClient to request base64 payloads, upload them through the new client and fall back to remote URLs when necessary
- cover the new behavior with unit tests and document the updated workflow for creative generation

## Testing
- `mvn -s settings.xml test` *(fails: unable to download parent POM from GitHub Packages due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdcd670808321ba93b70df70d0e46