### PR TITLE
Increase OpenAI image buffer size

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
@@ -21,6 +21,7 @@ public class CreativeImageClient {
     private final BackendAssetClient assetClient;
     private final String model;
     private static final Logger log = LoggerFactory.getLogger(CreativeImageClient.class);
+    private static final int DEFAULT_MAX_IN_MEMORY_SIZE = 10 * 1024 * 1024; // 10 MB
 
     public CreativeImageClient(WebClient.Builder builder,
                                BackendAssetClient assetClient,
@@ -30,6 +31,7 @@ public class CreativeImageClient {
         this.webClient = builder
                 .baseUrl(baseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(DEFAULT_MAX_IN_MEMORY_SIZE))
                 .build();
         this.assetClient = assetClient;
         this.model = model;

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,26 @@ class CreativeImageClientTest {
 
         assertThat(result).isEqualTo("/uploads/img.png");
         verify(backendAssetClient).uploadImage(any(byte[].class), argThat(name -> name.startsWith("creative-") && name.endsWith(".png")));
+    }
+
+    @Test
+    void supportsLargeBase64Payloads() {
+        byte[] imageBytes = new byte[512 * 1024];
+        Arrays.fill(imageBytes, (byte) 1);
+        String imagePayload = Base64.getEncoder().encodeToString(imageBytes);
+        String body = "{\"data\":[{\"b64_json\":\"" + imagePayload + "\"}]}";
+        ExchangeFunction exchange = request -> Mono.just(ClientResponse.create(HttpStatus.OK)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .body(body)
+                .build());
+        WebClient.Builder builder = WebClient.builder().exchangeFunction(exchange);
+        CreativeImageClient largeClient = new CreativeImageClient(builder, backendAssetClient, "key", "http://openai", "image-model");
+        when(backendAssetClient.uploadImage(any(), any())).thenReturn("/uploads/large.png");
+
+        String result = largeClient.generateImage("prompt");
+
+        assertThat(result).isEqualTo("/uploads/large.png");
+        verify(backendAssetClient).uploadImage(argThat(bytes -> bytes.length == imageBytes.length), any());
     }
 }
 


### PR DESCRIPTION
## Summary
- increase the WebClient in-memory buffer used by the OpenAI images client to 10MB to accommodate large base64 payloads
- add a regression test that verifies the client can upload large image payloads without overflowing the buffer

## Testing
- `mvn -s settings.xml test` *(fails: repository host unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d02f30dfb4832181abf4667062c53e