### PR TITLE
Enhance creatives tab feedback experience

### DIFF
--- a/frontend/src/pages/experiment/CriativosTab.css
+++ b/frontend/src/pages/experiment/CriativosTab.css
@@ -138,3 +138,159 @@
     transform: none;
   }
 }
+
+.creative-feedback {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.1));
+  background: var(--bs-body-bg, #fff);
+  box-shadow: 0 22px 40px -28px rgba(15, 23, 42, 0.5);
+  margin-bottom: 1.5rem;
+  color: var(--bs-emphasis-color, #212529);
+}
+
+.creative-feedback-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  border: 1px solid transparent;
+}
+
+.creative-feedback-content {
+  flex: 1 1 auto;
+}
+
+.creative-feedback-title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+  color: inherit;
+}
+
+.creative-feedback-description {
+  margin: 0.35rem 0 0;
+  color: inherit;
+  opacity: 0.75;
+  font-size: 0.95rem;
+}
+
+.creative-feedback-close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  opacity: 0.65;
+  transition: background-color 0.2s ease, opacity 0.2s ease;
+}
+
+.creative-feedback-close:hover,
+.creative-feedback-close:focus-visible {
+  opacity: 1;
+  background: rgba(15, 23, 42, 0.08);
+  outline: none;
+}
+
+.creative-feedback-success {
+  border-color: var(--bs-success-border-subtle, rgba(25, 135, 84, 0.24));
+  background: linear-gradient(
+    135deg,
+    var(--bs-success-bg-subtle, rgba(25, 135, 84, 0.16)) 0%,
+    var(--bs-body-bg, #fff) 120%
+  );
+  color: var(--bs-success-text-emphasis, #0f5132);
+}
+
+.creative-feedback-success .creative-feedback-icon {
+  background: rgba(25, 135, 84, 0.16);
+  border-color: rgba(25, 135, 84, 0.24);
+  color: var(--bs-success-text-emphasis, #0f5132);
+}
+
+.creative-feedback-warning {
+  border-color: var(--bs-warning-border-subtle, rgba(255, 193, 7, 0.3));
+  background: linear-gradient(
+    135deg,
+    var(--bs-warning-bg-subtle, rgba(255, 193, 7, 0.18)) 0%,
+    var(--bs-body-bg, #fff) 120%
+  );
+  color: var(--bs-warning-text-emphasis, #664d03);
+}
+
+.creative-feedback-warning .creative-feedback-icon {
+  background: rgba(255, 193, 7, 0.16);
+  border-color: rgba(255, 193, 7, 0.28);
+  color: var(--bs-warning-text-emphasis, #664d03);
+}
+
+.creative-feedback-error {
+  border-color: var(--bs-danger-border-subtle, rgba(220, 53, 69, 0.32));
+  background: linear-gradient(
+    135deg,
+    var(--bs-danger-bg-subtle, rgba(220, 53, 69, 0.18)) 0%,
+    var(--bs-body-bg, #fff) 120%
+  );
+  color: var(--bs-danger-text-emphasis, #842029);
+}
+
+.creative-feedback-error .creative-feedback-icon {
+  background: rgba(220, 53, 69, 0.16);
+  border-color: rgba(220, 53, 69, 0.28);
+  color: var(--bs-danger-text-emphasis, #842029);
+}
+
+.creative-request-modal .modal-content {
+  border-radius: 1rem;
+  border: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.08));
+  box-shadow: 0 26px 44px -24px rgba(15, 23, 42, 0.55);
+}
+
+.creative-request-modal .modal-header,
+.creative-request-modal .modal-footer {
+  border-color: var(--bs-border-color, rgba(0, 0, 0, 0.08));
+}
+
+.creative-request-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.creative-request-body .form-label {
+  font-weight: 600;
+  color: var(--bs-emphasis-color, #212529);
+}
+
+.creative-request-body .form-control {
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.creative-request-body .form-control:focus {
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.15);
+}
+
+.creative-request-error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--bs-danger-bg-subtle, rgba(220, 53, 69, 0.12));
+  color: var(--bs-danger-text-emphasis, #842029);
+  font-size: 0.9rem;
+}
+
+.creative-request-error svg {
+  flex-shrink: 0;
+}

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Creative, useCreatives } from "../../api/creative/useCreatives";
 import { useCreateCreative } from "../../api/creative/useCreateCreative";
@@ -13,6 +13,7 @@ import { useExperiment } from "../../api/experiment/useExperiment";
 import InstagramAdPreview from "../../components/InstagramAdPreview";
 import { resolveAssetUrl } from "../../utils/resolveAssetUrl";
 import {
+  AlertTriangle,
   CheckCircle2,
   Copy,
   Edit3,
@@ -20,6 +21,8 @@ import {
   Plus,
   Sparkles,
   Trash2,
+  X,
+  XCircle,
 } from "lucide-react";
 import "./CriativosTab.css";
 
@@ -41,6 +44,14 @@ interface CreativeForm {
 }
 
 const ICON_SIZE = 16;
+
+type FeedbackVariant = "success" | "warning" | "error";
+
+interface FeedbackState {
+  variant: FeedbackVariant;
+  title: string;
+  description?: string;
+}
 
 const statusVariant = (status: string) => {
   switch (status) {
@@ -70,6 +81,7 @@ export default function CriativosTab({ experimentId }: Props) {
   const { data: experiment } = useExperiment(experimentId);
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<Creative | null>(null);
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const [form, setForm] = useState<CreativeForm>({
     format: "LINK",
     headline: "",
@@ -89,12 +101,27 @@ export default function CriativosTab({ experimentId }: Props) {
   const [selectedAngle, setSelectedAngle] = useState<string>("");
   const [selectedProof, setSelectedProof] = useState<string>("");
   const [selectedTrigger, setSelectedTrigger] = useState<string>("");
+  const [isRequestDialogOpen, setRequestDialogOpen] = useState(false);
+  const [requestQuantity, setRequestQuantity] = useState("1");
+  const [requestError, setRequestError] = useState<string | null>(null);
   const patchLabels = useUpdateCreativeLabels(experimentId);
   const create = useCreateCreative(experimentId);
   const update = useUpdateCreative(experimentId);
   const del = useDeleteCreative(experimentId);
   const [showPreview, setShowPreview] = useState(false);
   const requestCreatives = useRequestCreatives(experimentId);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const timeout = window.setTimeout(() => {
+      setFeedback(null);
+    }, 8000);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [feedback]);
+
+  const dismissFeedback = () => setFeedback(null);
 
   const fillFormFromCreative = (c: Creative) => {
     setForm({
@@ -135,6 +162,18 @@ export default function CriativosTab({ experimentId }: Props) {
     setEditing(c);
     fillFormFromCreative(c);
     setShowForm(true);
+  };
+
+  const openRequestDialog = () => {
+    const defaultQty = Math.max(1, experiment?.creativesToGenerate ?? 1);
+    setRequestQuantity(String(defaultQty));
+    setRequestError(null);
+    setRequestDialogOpen(true);
+  };
+
+  const closeRequestDialog = () => {
+    setRequestDialogOpen(false);
+    setRequestError(null);
   };
 
   const submit = async () => {
@@ -192,30 +231,75 @@ export default function CriativosTab({ experimentId }: Props) {
     const file = e.target.files?.[0];
     if (!file) return;
     const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
     img.onload = async () => {
       if (img.width < 600) {
-        alert("Largura mínima 600px");
+        setFeedback({
+          variant: "warning",
+          title: "Imagem muito pequena",
+          description:
+            "Use arquivos com pelo menos 600px de largura para manter a qualidade dos criativos.",
+        });
+        URL.revokeObjectURL(objectUrl);
         return;
       }
       const fd = new FormData();
       fd.append("file", file);
-      const res = await fetch("/api/assets", { method: "POST", body: fd });
-      const url = await res.text();
-      setForm({ ...form, imageUrl: url });
+      try {
+        const res = await fetch("/api/assets", { method: "POST", body: fd });
+        if (!res.ok) {
+          throw new Error("Upload failed");
+        }
+        const url = await res.text();
+        setForm((prev) => ({ ...prev, imageUrl: url }));
+        setFeedback({
+          variant: "success",
+          title: "Imagem carregada",
+          description: "O criativo foi atualizado com a nova imagem.",
+        });
+      } catch {
+        setFeedback({
+          variant: "error",
+          title: "Não foi possível enviar a imagem",
+          description: "Tente novamente em instantes.",
+        });
+      } finally {
+        URL.revokeObjectURL(objectUrl);
+      }
     };
-    img.src = URL.createObjectURL(file);
+    img.onerror = () => {
+      setFeedback({
+        variant: "error",
+        title: "Não foi possível ler a imagem",
+        description: "Selecione outro arquivo ou tente novamente.",
+      });
+      URL.revokeObjectURL(objectUrl);
+    };
+    img.src = objectUrl;
   };
 
-  const generateCreatives = async () => {
-    const qtyStr = prompt("Quantos criativos gerar?");
-    if (!qtyStr) return;
-    const qty = Number(qtyStr);
-    if (!qty || qty <= 0) return;
+  const submitRequestCreatives = async () => {
+    const qty = Number.parseInt(requestQuantity, 10);
+    if (!Number.isInteger(qty) || qty <= 0) {
+      setRequestError("Informe um número válido maior que zero.");
+      return;
+    }
+    setRequestError(null);
     try {
       await requestCreatives.mutateAsync(qty);
-      alert("Solicitação enviada!");
+      setFeedback({
+        variant: "success",
+        title: "Solicitação enviada",
+        description: `Geraremos ${qty} ${qty === 1 ? "criativo" : "criativos"} em breve.`,
+      });
+      closeRequestDialog();
     } catch {
-      alert("Erro ao solicitar criativos");
+      setRequestError("Não foi possível enviar o pedido agora. Tente novamente.");
+      setFeedback({
+        variant: "error",
+        title: "Erro ao solicitar criativos",
+        description: "Tente novamente em instantes.",
+      });
     }
   };
 
@@ -224,6 +308,37 @@ export default function CriativosTab({ experimentId }: Props) {
 
   return (
     <div className="mt-3">
+      {feedback && (
+        <div
+          className={`creative-feedback creative-feedback-${feedback.variant}`}
+          role="alert"
+          aria-live="polite"
+        >
+          <div className="creative-feedback-icon" aria-hidden>
+            {feedback.variant === "success" ? (
+              <CheckCircle2 size={20} />
+            ) : feedback.variant === "warning" ? (
+              <AlertTriangle size={20} />
+            ) : (
+              <XCircle size={20} />
+            )}
+          </div>
+          <div className="creative-feedback-content">
+            <p className="creative-feedback-title">{feedback.title}</p>
+            {feedback.description && (
+              <p className="creative-feedback-description">{feedback.description}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            className="creative-feedback-close"
+            onClick={dismissFeedback}
+            aria-label="Dispensar aviso"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      )}
       <div className="creative-toolbar">
         <div>
           <h2 className="h5 mb-1">Biblioteca de criativos</h2>
@@ -240,7 +355,7 @@ export default function CriativosTab({ experimentId }: Props) {
           <button
             type="button"
             className="btn btn-outline-secondary d-flex align-items-center gap-2"
-            onClick={generateCreatives}
+            onClick={openRequestDialog}
             disabled={requestCreatives.isPending}
           >
             {requestCreatives.isPending ? (
@@ -377,6 +492,78 @@ export default function CriativosTab({ experimentId }: Props) {
               </article>
             );
           })}
+        </div>
+      )}
+
+      {isRequestDialogOpen && (
+        <div
+          className="modal d-block creative-request-modal"
+          tabIndex={-1}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="modal-dialog modal-dialog-centered">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Gerar novos criativos</h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  onClick={closeRequestDialog}
+                  aria-label="Fechar"
+                />
+              </div>
+              <div className="modal-body">
+                <div className="creative-request-body">
+                  <p className="mb-0 text-muted">
+                    Informe quantos novos criativos deseja solicitar para este experimento.
+                  </p>
+                  <div>
+                    <label className="form-label" htmlFor="requestedQuantity">
+                      Quantidade de criativos
+                    </label>
+                    <input
+                      id="requestedQuantity"
+                      type="number"
+                      min={1}
+                      className="form-control"
+                      value={requestQuantity}
+                      onChange={(e) => setRequestQuantity(e.target.value)}
+                      disabled={requestCreatives.isPending}
+                    />
+                  </div>
+                  {requestError && (
+                    <div className="creative-request-error" role="alert">
+                      <XCircle size={18} />
+                      <span>{requestError}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  onClick={closeRequestDialog}
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-primary d-flex align-items-center gap-2"
+                  onClick={submitRequestCreatives}
+                  disabled={requestCreatives.isPending}
+                >
+                  {requestCreatives.isPending ? (
+                    <span className="spinner-border spinner-border-sm" role="status" />
+                  ) : (
+                    <Sparkles size={ICON_SIZE} />
+                  )}
+                  <span>{requestCreatives.isPending ? "Enviando..." : "Solicitar"}</span>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- replace browser alerts in the creatives tab with a styled inline feedback banner that auto-dismisses and can be closed manually
- add a modal workflow for AI creative requests with validation, error handling and matching visual polish
- extend the creatives stylesheet with feedback and modal styling to keep the screen consistent with the new visual language

## Testing
- npm run build
- npm run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d03f96dde08321bd05f1d6b1d15ee2