### PR TITLE
Build backend asset upload endpoint for worker images

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/BackendAssetClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/BackendAssetClient.java
@@ -1,6 +1,7 @@
 package com.marketinghub.worker.creative;
 
 import com.marketinghub.worker.util.UrlUtils;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,36 +28,89 @@ public class BackendAssetClient {
     private final WebClient webClient;
     private final String backendBaseUrl;
     private final String apiPrefix;
+    private final String assetPath;
+    private final String explicitAssetUrl;
 
     public BackendAssetClient(WebClient.Builder builder,
                               @Value("${backend.base-url:http://localhost:8080}") String backendBaseUrl,
-                              @Value("${backend.api-prefix:/api}") String apiPrefix) {
+                              @Value("${backend.api-prefix:/api}") String apiPrefix,
+                              @Value("${backend.asset-path:/assets}") String assetPath,
+                              @Value("${backend.asset-url:}") String assetUrl) {
         this.webClient = builder.build();
         this.backendBaseUrl = backendBaseUrl;
         this.apiPrefix = apiPrefix;
+        this.assetPath = normalizeAssetPath(assetPath);
+        this.explicitAssetUrl = assetUrl;
     }
 
     /**
      * Sends the provided image bytes to {@code POST /api/assets} in the backend and returns the
      * relative URL exposed by the service.
      */
-    public String uploadImage(byte[] content, String filename) {
+    public String uploadImage(byte[] content, String filename, String model, String prompt) {
         if (content == null || content.length == 0) {
             throw new IllegalArgumentException("Image content must not be empty");
         }
+        if (!StringUtils.hasText(prompt)) {
+            throw new IllegalArgumentException("Prompt must not be empty");
+        }
         String effectiveName = StringUtils.hasText(filename) ? filename : "creative.png";
-        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/assets");
+        BackendAssetUploadException lastException = null;
+        for (String targetUrl : resolveUploadUrls()) {
+            try {
+                return performUpload(content, effectiveName, targetUrl, model, prompt);
+            } catch (BackendAssetUploadException ex) {
+                if (!shouldFallback(ex)) {
+                    throw ex;
+                }
+                lastException = ex;
+                log.warn("Asset upload to {} failed with status {}. Trying fallback endpoint...",
+                        targetUrl, ex.getStatusCode());
+            }
+        }
+        if (lastException != null) {
+            throw lastException;
+        }
+        throw new BackendAssetUploadException("Backend did not return an asset URL");
+    }
+
+    private void logBackendRequest(String method, String url) {
+        if (log.isInfoEnabled()) {
+            log.info("Calling backend {} {}", method, url);
+        }
+    }
+
+    private List<String> resolveUploadUrls() {
+        if (StringUtils.hasText(explicitAssetUrl)) {
+            return List.of(explicitAssetUrl);
+        }
+        String primary = UrlUtils.joinPath(backendBaseUrl, apiPrefix, assetPath);
+        if (!StringUtils.hasText(apiPrefix)) {
+            return List.of(primary);
+        }
+        String fallback = UrlUtils.joinPath(backendBaseUrl, "", assetPath);
+        if (primary.equals(fallback)) {
+            return List.of(primary);
+        }
+        return List.of(primary, fallback);
+    }
+
+    private String performUpload(byte[] content, String filename, String url, String model, String prompt) {
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
         ByteArrayResource resource = new ByteArrayResource(content) {
             @Override
             public String getFilename() {
-                return effectiveName;
+                return filename;
             }
         };
         HttpHeaders partHeaders = new HttpHeaders();
         partHeaders.setContentType(MediaType.APPLICATION_OCTET_STREAM);
         HttpEntity<ByteArrayResource> filePart = new HttpEntity<>(resource, partHeaders);
         body.add("file", filePart);
+        body.add("prompt", prompt);
+        if (StringUtils.hasText(model)) {
+            body.add("model", model);
+        }
 
         logBackendRequest("POST", url);
         return webClient.post()
@@ -69,7 +123,7 @@ public class BackendAssetClient {
                         return response.bodyToMono(String.class)
                                 .defaultIfEmpty("")
                                 .flatMap(bodyContent -> Mono.error(new BackendAssetUploadException(
-                                        errorMessage(status, url, bodyContent))));
+                                        status, url, bodyContent)));
                     }
                     return response.bodyToMono(String.class);
                 })
@@ -78,10 +132,19 @@ public class BackendAssetClient {
                         "Backend did not return an asset URL"));
     }
 
-    private void logBackendRequest(String method, String url) {
-        if (log.isInfoEnabled()) {
-            log.info("Calling backend {} {}", method, url);
+    private boolean shouldFallback(BackendAssetUploadException exception) {
+        if (StringUtils.hasText(explicitAssetUrl)) {
+            return false;
         }
+        Integer statusCode = exception.getStatusCode();
+        return statusCode != null && statusCode == 404;
+    }
+
+    private static String normalizeAssetPath(String path) {
+        if (!StringUtils.hasText(path)) {
+            return "/assets";
+        }
+        return path.startsWith("/") ? path : "/" + path;
     }
 
     private static String errorMessage(HttpStatusCode status, String url, String body) {
@@ -91,12 +154,41 @@ public class BackendAssetClient {
 
     /** Exception thrown when the backend refuses the upload. */
     public static class BackendAssetUploadException extends RuntimeException {
+        private final Integer statusCode;
+        private final String url;
+        private final String responseBody;
+
         public BackendAssetUploadException(String message) {
             super(message);
+            this.statusCode = null;
+            this.url = null;
+            this.responseBody = null;
         }
 
         public BackendAssetUploadException(String message, Throwable cause) {
             super(message, cause);
+            this.statusCode = null;
+            this.url = null;
+            this.responseBody = null;
+        }
+
+        public BackendAssetUploadException(HttpStatusCode status, String url, String body) {
+            super(errorMessage(status, url, body));
+            this.statusCode = status != null ? status.value() : null;
+            this.url = url;
+            this.responseBody = body;
+        }
+
+        public Integer getStatusCode() {
+            return statusCode;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public String getResponseBody() {
+            return responseBody;
         }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
@@ -72,7 +72,7 @@ public class CreativeImageClient {
             try {
                 byte[] imageBytes = Base64.getDecoder().decode(data.base64());
                 String filename = "creative-" + UUID.randomUUID() + ".png";
-                return assetClient.uploadImage(imageBytes, filename);
+                return assetClient.uploadImage(imageBytes, filename, model, prompt);
             } catch (IllegalArgumentException e) {
                 throw new RuntimeException("Failed to decode image payload", e);
             }

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
@@ -45,12 +45,15 @@ class CreativeImageClientTest {
 
     @Test
     void uploadsReturnedImageToBackend() {
-        when(backendAssetClient.uploadImage(any(), any())).thenReturn("/uploads/img.png");
+        when(backendAssetClient.uploadImage(any(), any(), any(), any())).thenReturn("/uploads/img.png");
 
         String result = client.generateImage("prompt");
 
         assertThat(result).isEqualTo("/uploads/img.png");
-        verify(backendAssetClient).uploadImage(any(byte[].class), argThat(name -> name.startsWith("creative-") && name.endsWith(".png")));
+        verify(backendAssetClient).uploadImage(any(byte[].class),
+                argThat(name -> name.startsWith("creative-") && name.endsWith(".png")),
+                argThat(model -> model.equals("image-model")),
+                argThat(prompt -> prompt.equals("prompt")));
     }
 
     @Test
@@ -65,12 +68,12 @@ class CreativeImageClientTest {
                 .build());
         WebClient.Builder builder = WebClient.builder().exchangeFunction(exchange);
         CreativeImageClient largeClient = new CreativeImageClient(builder, backendAssetClient, "key", "http://openai", "image-model");
-        when(backendAssetClient.uploadImage(any(), any())).thenReturn("/uploads/large.png");
+        when(backendAssetClient.uploadImage(any(), any(), any(), any())).thenReturn("/uploads/large.png");
 
         String result = largeClient.generateImage("prompt");
 
         assertThat(result).isEqualTo("/uploads/large.png");
-        verify(backendAssetClient).uploadImage(argThat(bytes -> bytes.length == imageBytes.length), any());
+        verify(backendAssetClient).uploadImage(argThat(bytes -> bytes.length == imageBytes.length), any(), any(), any());
     }
 }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
@@ -10,10 +10,16 @@ import com.marketinghub.creative.label.repository.VisualProofRepository;
 import com.marketinghub.creative.label.repository.EmotionalTriggerRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.media.Asset;
+import com.marketinghub.media.AssetStatus;
+import com.marketinghub.media.AssetType;
+import com.marketinghub.media.MediaProvider;
+import com.marketinghub.media.repository.AssetRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.net.URI;
@@ -39,6 +45,7 @@ public class CreativeService {
     private final AngleRepository angleRepository;
     private final VisualProofRepository visualProofRepository;
     private final EmotionalTriggerRepository emotionalTriggerRepository;
+    private final AssetRepository assetRepository;
     private final HttpClient httpClient;
 
     /**
@@ -99,12 +106,30 @@ public class CreativeService {
     /**
      * Saves the uploaded image and returns a public URL.
      */
-    public String uploadImage(MultipartFile file) throws IOException {
+    public String uploadImage(MultipartFile file, String model, String prompt) throws IOException {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("File must not be empty");
+        }
+        if (!StringUtils.hasText(prompt)) {
+            throw new IllegalArgumentException("Prompt must not be blank");
+        }
         Path dir = Path.of("uploads");
         Files.createDirectories(dir);
-        Path path = Files.createTempFile(dir, "img", file.getOriginalFilename());
+        String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        String suffix = extension != null && !extension.isBlank() ? "." + extension : ".bin";
+        Path path = Files.createTempFile(dir, "img-", suffix);
         file.transferTo(path);
-        return "/uploads/" + path.getFileName();
+        String relativeUrl = "/uploads/" + path.getFileName();
+        Asset asset = Asset.builder()
+                .type(AssetType.IMAGE)
+                .provider(MediaProvider.OPENAI)
+                .status(AssetStatus.READY)
+                .url(relativeUrl)
+                .model(StringUtils.hasText(model) ? model : null)
+                .prompt(prompt)
+                .build();
+        assetRepository.save(asset);
+        return relativeUrl;
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/web/CreativeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/web/CreativeController.java
@@ -55,8 +55,10 @@ public class CreativeController {
     }
 
     @PostMapping("/api/assets")
-    public String upload(@RequestParam("file") MultipartFile file) throws IOException {
-        return service.uploadImage(file);
+    public String upload(@RequestParam("file") MultipartFile file,
+                         @RequestParam("prompt") String prompt,
+                         @RequestParam(value = "model", required = false) String model) throws IOException {
+        return service.uploadImage(file, model, prompt);
     }
 
     @GetMapping("/api/creatives/{id}/preview")

--- a/backend/ads-service/src/main/java/com/marketinghub/media/Asset.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/media/Asset.java
@@ -38,6 +38,11 @@ public class Asset {
 
     private Long campaignId;
 
+    private String model;
+
+    @Lob
+    private String prompt;
+
     @CreationTimestamp
     private Instant createdAt;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/media/AssetType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/media/AssetType.java
@@ -6,5 +6,6 @@ package com.marketinghub.media;
 public enum AssetType {
     VIDEO,
     AUDIO,
-    BROLL
+    BROLL,
+    IMAGE
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/media/MediaProvider.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/media/MediaProvider.java
@@ -7,5 +7,6 @@ public enum MediaProvider {
     SYNTHESIA,
     HEYGEN,
     ELEVENLABS,
-    RUNWAY
+    RUNWAY,
+    OPENAI
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/media/dto/AssetDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/media/dto/AssetDto.java
@@ -19,6 +19,8 @@ public class AssetDto {
     private AssetStatus status;
     private String url;
     private String payload;
+    private String model;
+    private String prompt;
     private Long campaignId;
     private Instant createdAt;
     private Instant updatedAt;

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_30__create_asset_table.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_30__create_asset_table.sql
@@ -1,0 +1,27 @@
+--changeset marketinghub:2025-10-30-create-asset-table
+--preconditions onFail=MARK_RAN
+--precondition-sql-check expectedResult=0 dbms=mysql SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'asset'
+CREATE TABLE asset (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    type VARCHAR(255),
+    provider VARCHAR(255),
+    external_id VARCHAR(255),
+    status VARCHAR(255),
+    url VARCHAR(1024),
+    payload LONGTEXT,
+    campaign_id BIGINT,
+    model VARCHAR(255),
+    prompt LONGTEXT,
+    created_at DATETIME(6),
+    updated_at DATETIME(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--changeset marketinghub:2025-10-30-add-asset-model-column
+--preconditions onFail=MARK_RAN
+--precondition-sql-check expectedResult=0 dbms=mysql SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'model'
+ALTER TABLE asset ADD COLUMN model VARCHAR(255);
+
+--changeset marketinghub:2025-10-30-add-asset-prompt-column
+--preconditions onFail=MARK_RAN
+--precondition-sql-check expectedResult=0 dbms=mysql SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'prompt'
+ALTER TABLE asset ADD COLUMN prompt LONGTEXT;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -101,3 +101,6 @@ databaseChangeLog:
   - include:
       file: V2025_10_21__rename_journey_event_value_column.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_10_30__create_asset_table.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
@@ -11,6 +11,10 @@ import com.marketinghub.creative.label.repository.VisualProofRepository;
 import com.marketinghub.creative.label.repository.EmotionalTriggerRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.FixtureUtils;
+import com.marketinghub.media.Asset;
+import com.marketinghub.media.AssetStatus;
+import com.marketinghub.media.AssetType;
+import com.marketinghub.media.repository.AssetRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -49,18 +53,22 @@ class CreativeServiceTest {
     EmotionalTriggerRepository emotionalTriggerRepository;
     @Autowired
     FixtureUtils fixtures;
+    @Autowired
+    AssetRepository assetRepository;
 
     CreativeService service;
 
     @BeforeEach
     void setup() {
         HttpClient client = Mockito.mock(HttpClient.class);
+        assetRepository.deleteAll();
         service = new CreativeService(
                 repository,
                 experimentRepository,
                 angleRepository,
                 visualProofRepository,
                 emotionalTriggerRepository,
+                assetRepository,
                 client);
     }
 
@@ -68,8 +76,17 @@ class CreativeServiceTest {
     void uploadImageReturnsPath() throws Exception {
         MultipartFile file = new org.springframework.mock.web.MockMultipartFile(
                 "file", "test.png", "image/png", new byte[]{1,2});
-        String url = service.uploadImage(file);
+        assetRepository.deleteAll();
+
+        String url = service.uploadImage(file, "dall-e-3", "prompt text");
+
         assertThat(url).contains("/uploads/");
+        Asset saved = assetRepository.findAll().stream().findFirst().orElseThrow();
+        assertThat(saved.getUrl()).isEqualTo(url);
+        assertThat(saved.getType()).isEqualTo(AssetType.IMAGE);
+        assertThat(saved.getStatus()).isEqualTo(AssetStatus.READY);
+        assertThat(saved.getModel()).isEqualTo("dall-e-3");
+        assertThat(saved.getPrompt()).isEqualTo("prompt text");
     }
 
     @Test
@@ -90,6 +107,7 @@ class CreativeServiceTest {
                     angleRepository,
                     visualProofRepository,
                     emotionalTriggerRepository,
+                    assetRepository,
                     client);
             String html = service.preview(1L);
             assertThat(html).contains("ok");

--- a/docs/ai-worker/README.md
+++ b/docs/ai-worker/README.md
@@ -45,7 +45,11 @@ de IA quando necessário e persistem os resultados de volta no serviço principa
 - **Fonte dos dados:** experimentos com `creativesToGenerate > 0`.
 - **O que faz:** `ExperimentCreativeService` chama o `CreativeChatGptClient` para gerar textos e o
   `CreativeImageClient` para gerar as imagens. As imagens são enviadas para o backend com `POST /api/assets`
-  via `BackendAssetClient`, e os criativos são salvos com `CreativeService`.
+  via `BackendAssetClient`, incluindo os campos de `prompt` e `model` utilizados na geração, e os criativos são
+  salvos com `CreativeService`.
+  Caso o endpoint de upload esteja exposto em outro caminho ou domínio, utilize as variáveis
+  `BACKEND_ASSET_PATH` ou `BACKEND_ASSET_URL` para ajustá-lo. O worker tenta repetir a chamada sem o
+  prefixo configurado quando recebe `404`, evitando falhas em ambientes com roteamento diferente.
 - **Referências:** detalhes e fluxo em [experimento-criativo-service.md](experimento-criativo-service.md).
 
 - **Disparo:** `AudienceAdSetScheduler` (cron `0 */5 * * * *`).


### PR DESCRIPTION
## Summary
- persist AI-generated assets with prompt/model metadata and serve stored file URLs from the backend
- update the AI worker to send prompt/model values when uploading images
- add Liquibase changelog and tests covering asset persistence

## Testing
- mvn -s ../settings.xml test *(fails: Network is unreachable while downloading spring-boot-starter-parent)*
- mvn -s settings.xml test *(fails: Network is unreachable while downloading spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68d04cd035e883219ea9c34729303b01