### PR TITLE
Fix Liquibase formatted SQL metadata

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_10_30__create_asset_table.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_10_30__create_asset_table.sql
@@ -1,8 +1,8 @@
 --liquibase formatted sql
 
---changeset marketinghub:2025-10-30-create-asset-table
---preconditions onFail=MARK_RAN
---precondition-sql-check expectedResult=0 dbms=mysql SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'asset'
+--changeset marketinghub:2025-10-30-create-asset-table dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'asset'
 CREATE TABLE asset (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     type VARCHAR(255),
@@ -18,12 +18,12 @@ CREATE TABLE asset (
     updated_at DATETIME(6)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
---changeset marketinghub:2025-10-30-add-asset-model-column
---preconditions onFail=MARK_RAN
---precondition-sql-check expectedResult=0 dbms=mysql SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'model'
+--changeset marketinghub:2025-10-30-add-asset-model-column dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'model'
 ALTER TABLE asset ADD COLUMN model VARCHAR(255);
 
---changeset marketinghub:2025-10-30-add-asset-prompt-column
---preconditions onFail=MARK_RAN
---precondition-sql-check expectedResult=0 dbms=mysql SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'prompt'
+--changeset marketinghub:2025-10-30-add-asset-prompt-column dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'prompt'
 ALTER TABLE asset ADD COLUMN prompt LONGTEXT;


### PR DESCRIPTION
## Summary
- ensure the asset changelog SQL is explicitly marked as MySQL-formatted so includeAll parses changesets correctly
- move the dbms attribute to the changeset declaration and switch precondition attributes to the supported colon syntax

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable when downloading spring-boot-starter-parent from github)*

------
https://chatgpt.com/codex/tasks/task_e_68d161d003e88321be12eda3dac10841