### PR TITLE
Fix metadata serialization for transient failure events

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/journey/execution/JourneyExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/execution/JourneyExecutionService.java
@@ -62,7 +62,9 @@ public class JourneyExecutionService {
         this.retryBackoffCalculator = retryBackoffCalculator;
         this.conditionEvaluator = conditionEvaluator;
         this.telemetryService = telemetryService;
-        this.objectMapper = objectMapper;
+        ObjectMapper mapper = objectMapper.copy();
+        mapper.findAndRegisterModules();
+        this.objectMapper = mapper;
         this.transactionTemplate = new TransactionTemplate(transactionManager);
         this.transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
         this.handlerByType = handlers.stream()

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/execution/JourneyExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/execution/JourneyExecutionServiceTest.java
@@ -138,7 +138,15 @@ class JourneyExecutionServiceTest {
         assertThat(assignment.getStatus()).isEqualTo(JourneyAssignmentStatus.IN_PROGRESS);
         assertThat(assignment.getRetryCount()).isEqualTo(1);
         assertThat(assignment.getNextAttemptAt()).isNotNull();
-        verify(eventLogRepository).save(argThat(log -> log.getEventType().equals(JourneyEventType.STIMULUS_FAILED.getCode())));
+        ArgumentCaptor<EventLog> logCaptor = ArgumentCaptor.forClass(EventLog.class);
+        verify(eventLogRepository, atLeastOnce()).save(logCaptor.capture());
+        EventLog failedLog = logCaptor.getAllValues().stream()
+                .filter(log -> JourneyEventType.STIMULUS_FAILED.getCode().equals(log.getEventType()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(failedLog.getMetadata()).isNotNull();
+        assertThat(failedLog.getMetadata()).contains("\"retryCount\":1");
+        assertThat(failedLog.getMetadata()).contains("\"nextAttemptAt\"");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ensure `JourneyExecutionService` uses an `ObjectMapper` that discovers Java Time modules so retry metadata can be serialised
- extend `JourneyExecutionServiceTest` to assert transient failure metadata is captured with the retry payload

## Testing
- `mvn test` *(fails: could not resolve org.springframework.boot:spring-boot-starter-parent:3.2.5 because external repositories are unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1697c22088321919e5fd8303b7de3