### PR TITLE
Refine experiment detail visuals

### DIFF
--- a/frontend/src/components/PageTitle.css
+++ b/frontend/src/components/PageTitle.css
@@ -1,0 +1,72 @@
+.page-title {
+  margin-bottom: clamp(1.5rem, 1.2rem + 1vw, 2.25rem);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  font-size: clamp(2rem, 1.5rem + 1.2vw, 2.75rem);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--bs-emphasis-color, #212529);
+  font-family: "Segoe UI", "Inter", "Helvetica Neue", Arial, sans-serif;
+  position: relative;
+}
+
+.page-title::after {
+  content: "";
+  display: block;
+  width: clamp(56px, 8vw, 120px);
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    var(--bs-primary, #0d6efd) 0%,
+    var(--bs-secondary, #6c757d) 100%
+  );
+  opacity: 0.65;
+}
+
+.page-title-text {
+  position: relative;
+  z-index: 1;
+  color: var(--bs-emphasis-color, #212529);
+  text-shadow: 0 12px 30px rgba(13, 110, 253, 0.18);
+}
+
+@supports (-webkit-background-clip: text) {
+  .page-title-text {
+    background: linear-gradient(
+      90deg,
+      var(--bs-primary, #0d6efd) 0%,
+      var(--bs-purple, #6f42c1) 100%
+    );
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    text-shadow: none;
+  }
+}
+
+@supports (background-clip: text) {
+  .page-title-text {
+    background: linear-gradient(
+      90deg,
+      var(--bs-primary, #0d6efd) 0%,
+      var(--bs-purple, #6f42c1) 100%
+    );
+    background-clip: text;
+    color: transparent;
+    text-shadow: none;
+  }
+}
+
+@media (max-width: 576px) {
+  .page-title {
+    flex-wrap: wrap;
+    gap: 0.65rem;
+  }
+
+  .page-title::after {
+    width: 100%;
+    max-width: 180px;
+  }
+}

--- a/frontend/src/components/PageTitle.tsx
+++ b/frontend/src/components/PageTitle.tsx
@@ -1,3 +1,14 @@
-export default function PageTitle({ children }: { children: string }) {
-  return <h1 className="mb-4">{children}</h1>;
+import type { ReactNode } from "react";
+import "./PageTitle.css";
+
+interface PageTitleProps {
+  children: ReactNode;
+}
+
+export default function PageTitle({ children }: PageTitleProps) {
+  return (
+    <h1 className="page-title">
+      <span className="page-title-text">{children}</span>
+    </h1>
+  );
 }

--- a/frontend/src/pages/experiment/CriativosTab.css
+++ b/frontend/src/pages/experiment/CriativosTab.css
@@ -140,113 +140,154 @@
 }
 
 .creative-feedback {
+  position: relative;
   display: flex;
   align-items: flex-start;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
+  gap: 1.125rem;
+  padding: 1.125rem 1.5rem;
   border-radius: 1rem;
-  border: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.1));
-  background: var(--bs-body-bg, #fff);
-  box-shadow: 0 22px 40px -28px rgba(15, 23, 42, 0.5);
+  border: 1px solid var(
+    --creative-feedback-border,
+    var(--bs-border-color, rgba(0, 0, 0, 0.1))
+  );
+  background: linear-gradient(
+      135deg,
+      var(--creative-feedback-surface, rgba(13, 110, 253, 0.08)) 0%,
+      var(--bs-body-bg, #fff) 100%
+    )
+    border-box;
+  border-left: 0.5rem solid var(
+    --creative-feedback-accent,
+    var(--bs-primary, #0d6efd)
+  );
+  box-shadow: 0 26px 48px -30px rgba(15, 23, 42, 0.55);
   margin-bottom: 1.5rem;
-  color: var(--bs-emphasis-color, #212529);
+  color: var(
+    --creative-feedback-text,
+    var(--bs-emphasis-color, #212529)
+  );
+  overflow: hidden;
+}
+
+.creative-feedback::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    circle at top right,
+    var(--creative-feedback-glow, rgba(13, 110, 253, 0.18)) 0%,
+    transparent 65%
+  );
+  opacity: 0.9;
+}
+
+.creative-feedback-icon,
+.creative-feedback-content,
+.creative-feedback-close {
+  position: relative;
+  z-index: 1;
 }
 
 .creative-feedback-icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.75rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.85rem;
   display: grid;
   place-items: center;
   flex-shrink: 0;
-  border: 1px solid transparent;
+  border: 1px solid var(--creative-feedback-icon-border, transparent);
+  background: var(--creative-feedback-icon-bg, rgba(13, 110, 253, 0.12));
+  color: var(--creative-feedback-accent, var(--bs-primary, #0d6efd));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.24);
 }
 
 .creative-feedback-content {
   flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .creative-feedback-title {
   margin: 0;
-  font-weight: 600;
-  font-size: 1rem;
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
   color: inherit;
 }
 
 .creative-feedback-description {
-  margin: 0.35rem 0 0;
+  margin: 0;
   color: inherit;
-  opacity: 0.75;
+  opacity: 0.78;
   font-size: 0.95rem;
+  line-height: 1.5;
 }
 
 .creative-feedback-close {
   border: none;
-  background: transparent;
+  background: rgba(255, 255, 255, 0.16);
   color: inherit;
   display: grid;
   place-items: center;
-  width: 2rem;
-  height: 2rem;
+  width: 2.25rem;
+  height: 2.25rem;
   border-radius: 0.75rem;
   cursor: pointer;
-  opacity: 0.65;
-  transition: background-color 0.2s ease, opacity 0.2s ease;
+  opacity: 0.75;
+  transition: background-color 0.2s ease, opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
 .creative-feedback-close:hover,
 .creative-feedback-close:focus-visible {
   opacity: 1;
-  background: rgba(15, 23, 42, 0.08);
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.32);
   outline: none;
 }
 
 .creative-feedback-success {
-  border-color: var(--bs-success-border-subtle, rgba(25, 135, 84, 0.24));
-  background: linear-gradient(
-    135deg,
-    var(--bs-success-bg-subtle, rgba(25, 135, 84, 0.16)) 0%,
-    var(--bs-body-bg, #fff) 120%
-  );
-  color: var(--bs-success-text-emphasis, #0f5132);
-}
-
-.creative-feedback-success .creative-feedback-icon {
-  background: rgba(25, 135, 84, 0.16);
-  border-color: rgba(25, 135, 84, 0.24);
-  color: var(--bs-success-text-emphasis, #0f5132);
+  --creative-feedback-accent: var(--bs-success, #198754);
+  --creative-feedback-border: rgba(25, 135, 84, 0.28);
+  --creative-feedback-surface: rgba(25, 135, 84, 0.14);
+  --creative-feedback-icon-bg: rgba(25, 135, 84, 0.16);
+  --creative-feedback-icon-border: rgba(25, 135, 84, 0.32);
+  --creative-feedback-glow: rgba(25, 135, 84, 0.22);
+  --creative-feedback-text: var(--bs-success-text-emphasis, #0f5132);
 }
 
 .creative-feedback-warning {
-  border-color: var(--bs-warning-border-subtle, rgba(255, 193, 7, 0.3));
-  background: linear-gradient(
-    135deg,
-    var(--bs-warning-bg-subtle, rgba(255, 193, 7, 0.18)) 0%,
-    var(--bs-body-bg, #fff) 120%
-  );
-  color: var(--bs-warning-text-emphasis, #664d03);
-}
-
-.creative-feedback-warning .creative-feedback-icon {
-  background: rgba(255, 193, 7, 0.16);
-  border-color: rgba(255, 193, 7, 0.28);
-  color: var(--bs-warning-text-emphasis, #664d03);
+  --creative-feedback-accent: var(--bs-warning, #ffc107);
+  --creative-feedback-border: rgba(255, 193, 7, 0.32);
+  --creative-feedback-surface: rgba(255, 193, 7, 0.2);
+  --creative-feedback-icon-bg: rgba(255, 193, 7, 0.18);
+  --creative-feedback-icon-border: rgba(255, 193, 7, 0.32);
+  --creative-feedback-glow: rgba(255, 193, 7, 0.24);
+  --creative-feedback-text: var(--bs-warning-text-emphasis, #664d03);
 }
 
 .creative-feedback-error {
-  border-color: var(--bs-danger-border-subtle, rgba(220, 53, 69, 0.32));
-  background: linear-gradient(
-    135deg,
-    var(--bs-danger-bg-subtle, rgba(220, 53, 69, 0.18)) 0%,
-    var(--bs-body-bg, #fff) 120%
-  );
-  color: var(--bs-danger-text-emphasis, #842029);
+  --creative-feedback-accent: var(--bs-danger, #dc3545);
+  --creative-feedback-border: rgba(220, 53, 69, 0.32);
+  --creative-feedback-surface: rgba(220, 53, 69, 0.18);
+  --creative-feedback-icon-bg: rgba(220, 53, 69, 0.18);
+  --creative-feedback-icon-border: rgba(220, 53, 69, 0.32);
+  --creative-feedback-glow: rgba(220, 53, 69, 0.26);
+  --creative-feedback-text: var(--bs-danger-text-emphasis, #842029);
 }
 
-.creative-feedback-error .creative-feedback-icon {
-  background: rgba(220, 53, 69, 0.16);
-  border-color: rgba(220, 53, 69, 0.28);
-  color: var(--bs-danger-text-emphasis, #842029);
+@media (max-width: 576px) {
+  .creative-feedback {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .creative-feedback-close {
+    align-self: flex-end;
+  }
 }
 
 .creative-request-modal .modal-content {
@@ -283,14 +324,22 @@
 .creative-request-error {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  border-radius: 0.75rem;
+  gap: 0.65rem;
+  border-radius: 0.85rem;
   padding: 0.75rem 1rem;
-  background: var(--bs-danger-bg-subtle, rgba(220, 53, 69, 0.12));
+  border: 1px solid rgba(220, 53, 69, 0.28);
+  background: linear-gradient(
+    135deg,
+    rgba(220, 53, 69, 0.16) 0%,
+    rgba(220, 53, 69, 0.05) 100%
+  );
   color: var(--bs-danger-text-emphasis, #842029);
-  font-size: 0.9rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  box-shadow: 0 18px 36px -24px rgba(220, 53, 69, 0.6);
 }
 
 .creative-request-error svg {
   flex-shrink: 0;
+  color: var(--bs-danger, #dc3545);
 }

--- a/frontend/src/pages/experiment/CriativosTab.test.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.test.tsx
@@ -10,7 +10,7 @@ describe("CriativosTab", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
-  it("opens modal", async () => {
+  it("opens request dialog", async () => {
     (axios.get as any).mockImplementation((url: string) => {
       if (url.endsWith("/experiments/1/creatives")) {
         return Promise.resolve({ data: [] });
@@ -27,8 +27,10 @@ describe("CriativosTab", () => {
       </QueryClientProvider>,
     );
     expect(await screen.findByText("Solicitados: 3")).toBeTruthy();
-    screen.getByText("Novo Criativo").click();
-    expect(await screen.findByText("Novo Criativo")).toBeTruthy();
+    screen.getByText("Gerar criativos").click();
+    expect(
+      await screen.findByLabelText("Quantidade de criativos"),
+    ).toBeTruthy();
   });
 
   it("shows preview", async () => {

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -18,7 +18,6 @@ import {
   Copy,
   Edit3,
   Eye,
-  Plus,
   Sparkles,
   Trash2,
   X,
@@ -136,26 +135,6 @@ export default function CriativosTab({ experimentId }: Props) {
       instagramUserId: c.instagramUserId || "",
       status: c.status,
     });
-  };
-
-  const openNew = () => {
-    setEditing(null);
-    setForm({
-      format: "LINK",
-      headline: "",
-      primaryText: "",
-      description: "",
-      cta: "LEARN_MORE",
-      destinationUrl: "",
-      imageUrl: "",
-      pageId: "",
-      instagramUserId: "",
-      status: "DRAFT",
-    });
-    setSelectedAngle("");
-    setSelectedProof("");
-    setSelectedTrigger("");
-    setShowForm(true);
   };
 
   const openEdit = (c: Creative) => {
@@ -365,14 +344,6 @@ export default function CriativosTab({ experimentId }: Props) {
             )}
             <span>{requestCreatives.isPending ? "Solicitando..." : "Gerar criativos"}</span>
           </button>
-          <button
-            type="button"
-            className="btn btn-primary d-flex align-items-center gap-2"
-            onClick={openNew}
-          >
-            <Plus size={ICON_SIZE} />
-            <span>Novo Criativo</span>
-          </button>
         </div>
       </div>
 
@@ -389,8 +360,8 @@ export default function CriativosTab({ experimentId }: Props) {
           </div>
           <h3 className="h6 fw-semibold mb-1">Nenhum criativo cadastrado</h3>
           <p className="text-muted mb-0">
-            Gere sugestões com IA ou cadastre um novo criativo para começar a testar
-            variações.
+            Gere sugestões com IA para começar a testar variações e construa seu
+            acervo criativo com os resultados aprovados.
           </p>
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- remove the "Novo Criativo" button from the creatives tab and update the empty state messaging
- refresh the creatives feedback banner styles for richer alerts
- restyle the experiment page title component with a gradient headline treatment and update coverage

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d1713b5b58832180c0db8295abb05d