### PR TITLE
Refine niche detail layout with responsive styling

### DIFF
--- a/frontend/src/pages/niche/NicheDetailPage.css
+++ b/frontend/src/pages/niche/NicheDetailPage.css
@@ -1,0 +1,367 @@
+.niche-detail {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 1.4rem + 1vw, 2.75rem);
+}
+
+.niche-detail__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.25rem;
+  padding: clamp(1.5rem, 1.3rem + 1vw, 2.25rem);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.18);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--bs-primary-rgb, 13, 110, 253), 0.08) 0%,
+    rgba(var(--bs-purple-rgb, 111, 66, 193), 0.06) 100%
+  );
+  box-shadow: 0 24px 48px -30px rgba(var(--bs-primary-rgb, 13, 110, 253), 0.38);
+}
+
+.niche-detail__header .page-title {
+  margin-bottom: 0;
+}
+
+.niche-detail__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.niche-detail__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.niche-detail__export-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  box-shadow: 0 16px 30px -20px rgba(var(--bs-primary-rgb, 13, 110, 253), 0.45);
+}
+
+.niche-detail__export-btn:focus-visible {
+  outline: 3px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.35);
+  outline-offset: 2px;
+}
+
+.niche-detail__stats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.niche-detail__stat {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.12);
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.05);
+}
+
+.niche-detail__stat:nth-of-type(2) {
+  border-color: rgba(var(--bs-purple-rgb, 111, 66, 193), 0.18);
+  background: rgba(var(--bs-purple-rgb, 111, 66, 193), 0.06);
+}
+
+.niche-detail__stat:nth-of-type(3) {
+  border-color: rgba(var(--bs-secondary-rgb, 108, 117, 125), 0.22);
+  background: var(--bs-tertiary-bg, #f8f9fa);
+}
+
+.niche-detail__stat-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.14);
+  color: rgb(var(--bs-primary-rgb, 13, 110, 253));
+}
+
+.niche-detail__stat:nth-of-type(2) .niche-detail__stat-icon {
+  background: rgba(var(--bs-purple-rgb, 111, 66, 193), 0.14);
+  color: rgb(var(--bs-purple-rgb, 111, 66, 193));
+}
+
+.niche-detail__stat:nth-of-type(3) .niche-detail__stat-icon {
+  background: rgba(var(--bs-secondary-rgb, 108, 117, 125), 0.18);
+  color: rgb(var(--bs-secondary-rgb, 108, 117, 125));
+}
+
+.niche-detail__stat-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.niche-detail__stat-value {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--bs-emphasis-color, #212529);
+}
+
+.niche-detail__stat-label {
+  font-size: 0.95rem;
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.niche-detail__stat-helper {
+  font-size: 0.8rem;
+  color: var(--bs-secondary-color, #6c757d);
+  opacity: 0.85;
+}
+
+.niche-detail__grid {
+  display: grid;
+  gap: clamp(1rem, 0.85rem + 0.8vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.niche-detail__card {
+  padding: clamp(1.25rem, 1rem + 1vw, 1.85rem);
+  border-radius: 1rem;
+  border: 1px solid var(--bs-border-color, rgba(33, 37, 41, 0.1));
+  background: var(--bs-body-bg, #fff);
+  box-shadow: 0 18px 36px -28px rgba(var(--bs-primary-rgb, 13, 110, 253), 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.niche-detail__card-title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.niche-detail__card-content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: var(--bs-emphasis-color, #212529);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.niche-detail__card-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.niche-detail__card-empty {
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.niche-detail__card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--bs-primary, #0d6efd);
+  text-decoration: none;
+}
+
+.niche-detail__card-link:hover,
+.niche-detail__card-link:focus-visible {
+  text-decoration: underline;
+}
+
+.niche-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 1.3rem + 1vw, 2.25rem);
+  border-radius: 1.5rem;
+  border: 1px solid var(--bs-border-color, rgba(33, 37, 41, 0.12));
+  background: var(--bs-body-bg, #fff);
+  box-shadow: 0 24px 48px -28px rgba(33, 37, 41, 0.4);
+}
+
+.niche-section__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.niche-section__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 1.2rem + 0.6vw, 1.65rem);
+  font-weight: 600;
+  color: var(--bs-emphasis-color, #212529);
+}
+
+.niche-section__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.niche-section__status {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.niche-section__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.niche-section__actions .form-control {
+  flex: 1 1 140px;
+  max-width: 160px;
+}
+
+.niche-section__actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.55rem 1.25rem;
+}
+
+.niche-section__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.niche-section__empty {
+  margin: 0;
+  padding: 2.5rem 1.5rem;
+  border-radius: 1rem;
+  border: 2px dashed var(--bs-border-color, rgba(33, 37, 41, 0.15));
+  background: var(--bs-tertiary-bg, #f8f9fa);
+  color: var(--bs-secondary-color, #6c757d);
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.card.niche-section__card {
+  border-radius: 1rem;
+  border: 1px solid var(--bs-border-color, rgba(33, 37, 41, 0.12));
+  box-shadow: 0 20px 42px -28px rgba(33, 37, 41, 0.4);
+  background: var(--bs-body-bg, #fff);
+}
+
+.card.niche-section__card .card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.card.niche-section__card .card-footer {
+  background: rgba(248, 249, 250, 0.75);
+  border-top: 1px solid rgba(33, 37, 41, 0.08);
+  font-size: 0.85rem;
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.card.niche-section__card .btn {
+  font-weight: 600;
+  border-radius: 999px;
+}
+
+.niche-hypothesis-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.niche-hypothesis-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--bs-emphasis-color, #212529);
+}
+
+.niche-hypothesis-card__fields {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.niche-hypothesis-card__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.niche-hypothesis-card__field-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.niche-hypothesis-card__field-value {
+  margin: 0;
+  color: var(--bs-emphasis-color, #212529);
+  white-space: pre-wrap;
+}
+
+.niche-hypothesis-card__actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.niche-hypothesis-card__actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.niche-hypothesis-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 576px) {
+  .niche-detail__header {
+    padding: 1.25rem;
+  }
+
+  .niche-detail__stats {
+    grid-template-columns: 1fr;
+  }
+
+  .niche-section__actions {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+  }
+
+  .niche-section__actions .form-control {
+    max-width: none;
+  }
+
+  .niche-section__actions .btn {
+    justify-content: center;
+  }
+}

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -1,4 +1,3 @@
-import { Fragment } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
@@ -9,6 +8,15 @@ import { useBreadcrumbs } from "../../app/breadcrumbs";
 import { useChatDialog } from "../../api/chatDialog/useChatDialog";
 import { useForm } from "react-hook-form";
 import { useRequestAudiences } from "../../api/niche/useRequestAudiences";
+import {
+  ArrowUpRight,
+  Clock3,
+  FileDown,
+  Lightbulb,
+  Sparkles,
+  Users,
+} from "lucide-react";
+import "./NicheDetailPage.css";
 
 export default function NicheDetailPage() {
   const { nicheId } = useParams();
@@ -58,7 +66,13 @@ export default function NicheDetailPage() {
       })
     : [];
   const audienceList = Array.isArray(audiences) ? audiences : [];
-  const rows = [
+  const createdAtLabel = data.createdAt
+    ? new Date(data.createdAt).toLocaleString("pt-BR")
+    : undefined;
+  const updatedAtLabel = data.updatedAt
+    ? new Date(data.updatedAt).toLocaleString("pt-BR")
+    : undefined;
+  const infoCards = [
     { label: "Descrição", value: data.description },
     { label: "Volume de demanda", value: data.demandVolume },
     { label: "Promessas", value: data.promises },
@@ -72,144 +86,241 @@ export default function NicheDetailPage() {
     {
       label: "Chat Dialog",
       value: chatDialog ? (
-        <a href={chatDialog.url} target="_blank" rel="noopener noreferrer">
+        <a
+          className="niche-detail__card-link"
+          href={chatDialog.url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           {chatDialog.description}
         </a>
       ) : undefined,
     },
+  ];
+  const stats = [
     {
-      label: "Criado em",
-      value: data.createdAt
-        ? new Date(data.createdAt).toLocaleString("pt-BR")
-        : undefined,
+      icon: Users,
+      label: "Públicos",
+      value: `${audienceList.length}`,
+      helper: `Meta: ${data.audiencesToGenerate ?? 0}`,
     },
     {
+      icon: Lightbulb,
+      label: "Hipóteses",
+      value: `${list.length}`,
+      helper: `Meta: ${data.hypothesesToGenerate ?? 0}`,
+    },
+    {
+      icon: Clock3,
       label: "Atualizado em",
-      value: data.updatedAt
-        ? new Date(data.updatedAt).toLocaleString("pt-BR")
-        : undefined,
+      value: updatedAtLabel ?? "-",
+      helper: createdAtLabel ? `Criado em ${createdAtLabel}` : undefined,
     },
   ];
+  const audienceStatusLabel =
+    requestAudiences.isPending || (isFetching && !isLoading)
+      ? "Atualizando públicos..."
+      : `Solicitados ao Worker: ${data.audiencesToGenerate ?? 0}`;
+  const onRequestAudiences = handleSubmit(
+    async ({ quantity }) => {
+      if (!quantity || quantity <= 0) return;
+      try {
+        await requestAudiences.mutateAsync(quantity);
+        alert("Solicitação enviada!");
+        reset({ quantity: 1 });
+      } catch {
+        alert("Erro ao solicitar públicos");
+      }
+    },
+    (errors) => {
+      console.log("Validation errors", errors);
+    },
+  );
 
   return (
-    <div>
-      <div className="d-flex justify-content-between align-items-center">
-        <PageTitle>{data.name}</PageTitle>
-        <button
-          type="button"
-          className="btn btn-outline-secondary btn-sm"
-          onClick={handleSaveMarkdown}
-        >
-          Salvar em Markdown
-        </button>
+    <div className="niche-detail">
+      <div className="niche-detail__header">
+        <div className="niche-detail__title">
+          <PageTitle>{data.name}</PageTitle>
+          <p className="niche-detail__subtitle">
+            {`Nicho #${data.id}`}
+            {updatedAtLabel ? ` • Atualizado em ${updatedAtLabel}` : ""}
+          </p>
+        </div>
+        <div className="niche-detail__actions">
+          <button
+            type="button"
+            className="btn btn-outline-secondary niche-detail__export-btn"
+            onClick={handleSaveMarkdown}
+          >
+            <FileDown size={18} />
+            <span>Salvar em Markdown</span>
+          </button>
+        </div>
       </div>
-      <dl className="row mb-4">
-        {rows.map((r, idx) => (
-          <Fragment key={r.label}>
-            <dt className={`col-sm-3 py-2${idx % 2 === 0 ? " bg-light" : ""}`}>
-              {r.label}
-            </dt>
-            <dd className={`col-sm-9 py-2${idx % 2 === 0 ? " bg-light" : ""}`}>
-              <span className="text-break" style={{ whiteSpace: "pre-wrap" }}>
-                {r.value ?? "-"}
-              </span>
-            </dd>
-          </Fragment>
+      <ul className="niche-detail__stats">
+        {stats.map((stat) => (
+          <li key={stat.label} className="niche-detail__stat">
+            <span className="niche-detail__stat-icon">
+              <stat.icon size={20} strokeWidth={1.75} />
+            </span>
+            <div className="niche-detail__stat-content">
+              <span className="niche-detail__stat-value">{stat.value}</span>
+              <span className="niche-detail__stat-label">{stat.label}</span>
+              {stat.helper ? (
+                <span className="niche-detail__stat-helper">{stat.helper}</span>
+              ) : null}
+            </div>
+          </li>
         ))}
-      </dl>
-      <h4 className="mt-4">
-        Públicos ({audienceList.length}/{data.audiencesToGenerate ?? 0})
-      </h4>
-      <div className="d-flex align-items-center mb-2">
-        <input
-          type="number"
-          min={1}
-          className="form-control w-auto me-2"
-          title="Quantidade de públicos que o Worker IA irá gerar"
-          {...register("quantity", { valueAsNumber: true })}
-        />
-        <button
-          type="button"
-          className="btn btn-secondary"
-          onClick={handleSubmit(
-            async ({ quantity }) => {
-              if (!quantity || quantity <= 0) return;
-              try {
-                await requestAudiences.mutateAsync(quantity);
-                alert("Solicitação enviada!");
-                reset();
-              } catch {
-                alert("Erro ao solicitar públicos");
-              }
-            },
-            (errors) => {
-              console.log("Validation errors", errors);
-            },
-          )}
-          disabled={requestAudiences.isPending}
-        >
-          Gerar Públicos
-        </button>
-        <span className="ms-2">
-          {requestAudiences.isPending || (isFetching && !isLoading)
-            ? "Atualizando..."
-            : `Solicitados: ${data.audiencesToGenerate ?? 0}`}
-        </span>
-      </div>
-      {audienceList.length === 0 ? (
-        <p>Nenhum público ainda.</p>
-      ) : (
-        <div className="row row-cols-1 row-cols-md-2 g-4 mb-4">
-          {audienceList.map((a) => (
-            <div key={a.id} className="col">
-              <AudienceApprovalCard audience={a} nicheId={nicheId} />
-            </div>
-          ))}
-        </div>
-      )}
-      <h4 className="mt-4">Hipóteses</h4>
-      {list.length === 0 ? (
-        <p>Nenhuma hipótese ainda.</p>
-      ) : (
-        <div className="row row-cols-1 row-cols-md-2 g-4">
-          {list.map((h) => (
-            <div key={h.id} className="col">
-              <div className="card h-100 rounded-3">
-                <div className="card-body">
-                  <h5 className="card-title">{h.title}</h5>
-                  <p className="card-text">
-                    <strong>Promessa:</strong> {h.promise || "-"}
-                  </p>
-                  <p className="card-text">
-                    <strong>Problema:</strong> {h.problem || "-"}
-                  </p>
-                  <p className="card-text">
-                    <strong>Mecanismo:</strong> {h.mechanism || "-"}
-                  </p>
-                  <p className="card-text">
-                    <strong>Mecanismo único:</strong> {h.uniqueMechanism || "-"}
-                  </p>
-                  <p className="card-text">
-                    <strong>Persona:</strong> {h.persona || "-"}
-                  </p>
-                  <p className="card-text">
-                    <strong>Entrega:</strong> {h.entrega || "-"}
-                  </p>
-                  <Link
-                    className="btn btn-sm btn-outline-primary mt-2"
-                    to={`hypotheses/${h.id}`}
-                  >
-                    Ver detalhes
-                  </Link>
-                </div>
-                <div className="card-footer text-muted">
-                  {`Gerado com ${h.model || "-"} em ${h.createdAt ? new Date(h.createdAt).toLocaleString("pt-BR") : "-"}`}
-                </div>
+      </ul>
+      <section aria-label="Informações do nicho">
+        <div className="niche-detail__grid">
+          {infoCards.map((card) => (
+            <article key={card.label} className="niche-detail__card">
+              <h3 className="niche-detail__card-title">{card.label}</h3>
+              <div className="niche-detail__card-content">
+                {card.value === null || card.value === undefined || card.value === ""
+                  ? (
+                      <span className="niche-detail__card-empty">-</span>
+                    )
+                  : typeof card.value === "string" || typeof card.value === "number"
+                    ? (
+                        <span className="niche-detail__card-text">{card.value}</span>
+                      )
+                    : (
+                        card.value
+                      )}
               </div>
-            </div>
+            </article>
           ))}
         </div>
-      )}
+      </section>
+      <section className="niche-section" aria-labelledby="niche-audiences">
+        <div className="niche-section__header">
+          <div>
+            <h2 className="niche-section__title" id="niche-audiences">
+              Públicos
+            </h2>
+            <p className="niche-section__subtitle">
+              {`${audienceList.length}/${data.audiencesToGenerate ?? 0} gerados ou pendentes`}
+            </p>
+            <p className="niche-section__status">{audienceStatusLabel}</p>
+          </div>
+          <form className="niche-section__actions" onSubmit={onRequestAudiences}>
+            <label htmlFor="audience-quantity" className="visually-hidden">
+              Quantidade de públicos que o Worker IA irá gerar
+            </label>
+            <input
+              id="audience-quantity"
+              type="number"
+              min={1}
+              className="form-control"
+              title="Quantidade de públicos que o Worker IA irá gerar"
+              disabled={requestAudiences.isPending}
+              {...register("quantity", { valueAsNumber: true })}
+            />
+            <button
+              type="submit"
+              className="btn btn-secondary"
+              disabled={requestAudiences.isPending}
+            >
+              {requestAudiences.isPending ? (
+                <span
+                  className="spinner-border spinner-border-sm"
+                  role="status"
+                  aria-hidden="true"
+                />
+              ) : (
+                <Sparkles size={18} />
+              )}
+              <span>Gerar Públicos</span>
+            </button>
+          </form>
+        </div>
+        {audienceList.length === 0 ? (
+          <p className="niche-section__empty">Nenhum público ainda.</p>
+        ) : (
+          <div className="niche-section__grid">
+            {audienceList.map((a) => (
+              <AudienceApprovalCard
+                key={a.id}
+                audience={a}
+                nicheId={nicheId}
+                className="niche-section__card"
+              />
+            ))}
+          </div>
+        )}
+      </section>
+      <section className="niche-section" aria-labelledby="niche-hypotheses">
+        <div className="niche-section__header">
+          <div>
+            <h2 className="niche-section__title" id="niche-hypotheses">
+              Hipóteses
+            </h2>
+            <p className="niche-section__subtitle">
+              {list.length === 0
+                ? "As hipóteses aparecerão aqui quando forem geradas pela IA."
+                : "Principais ângulos sugeridos pela IA para o nicho."}
+            </p>
+          </div>
+        </div>
+        {list.length === 0 ? (
+          <p className="niche-section__empty">Nenhuma hipótese ainda.</p>
+        ) : (
+          <div className="niche-section__grid">
+            {list.map((h) => {
+              const fields = [
+                { label: "Promessa", value: h.promise },
+                { label: "Problema", value: h.problem },
+                { label: "Mecanismo", value: h.mechanism },
+                { label: "Mecanismo único", value: h.uniqueMechanism },
+                { label: "Persona", value: h.persona },
+                { label: "Entrega", value: h.entrega },
+              ];
+              return (
+                <div key={h.id} className="card h-100 niche-section__card">
+                  <div className="card-body niche-hypothesis-card__body">
+                    <h3 className="niche-hypothesis-card__title">{h.title}</h3>
+                    <div className="niche-hypothesis-card__fields">
+                      {fields.map((field) => (
+                        <div
+                          key={field.label}
+                          className="niche-hypothesis-card__field"
+                        >
+                          <span className="niche-hypothesis-card__field-label">
+                            {field.label}
+                          </span>
+                          <p className="niche-hypothesis-card__field-value">
+                            {field.value || "-"}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="niche-hypothesis-card__actions">
+                      <Link
+                        className="btn btn-sm btn-outline-primary"
+                        to={`hypotheses/${h.id}`}
+                      >
+                        <span>Ver detalhes</span>
+                        <ArrowUpRight size={16} />
+                      </Link>
+                    </div>
+                  </div>
+                  <div className="card-footer niche-hypothesis-card__footer">
+                    {`Gerado com ${h.model || "-"} em ${
+                      h.createdAt
+                        ? new Date(h.createdAt).toLocaleString("pt-BR")
+                        : "-"
+                    }`}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restyled the niche detail header with stats, export shortcut and responsive layout
- replaced the description list with reusable cards and modernized audiences & hypotheses sections
- added dedicated CSS with grid layouts, card refinements and mobile tweaks for the page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1945585e48321b3ffa4a654e5b929