### PR TITLE
feat(niche): refine detail layout and surface experiment counts

### DIFF
--- a/frontend/src/pages/niche/NicheDetailPage.css
+++ b/frontend/src/pages/niche/NicheDetailPage.css
@@ -21,8 +21,31 @@
   box-shadow: 0 24px 48px -30px rgba(var(--bs-primary-rgb, 13, 110, 253), 0.38);
 }
 
+.niche-detail__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .niche-detail__header .page-title {
   margin-bottom: 0;
+  font-size: clamp(1.75rem, 1.35rem + 0.9vw, 2.2rem);
+}
+
+.niche-detail__badge {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.3);
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.15);
+  color: rgb(var(--bs-primary-rgb, 13, 110, 253));
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .niche-detail__subtitle {
@@ -127,7 +150,7 @@
 .niche-detail__grid {
   display: grid;
   gap: clamp(1rem, 0.85rem + 0.8vw, 1.75rem);
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .niche-detail__card {
@@ -290,11 +313,34 @@
   gap: 1.1rem;
 }
 
+.niche-hypothesis-card__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 .niche-hypothesis-card__title {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
   color: var(--bs-emphasis-color, #212529);
+}
+
+.niche-hypothesis-card__counter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.25);
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.12);
+  color: rgb(var(--bs-primary-rgb, 13, 110, 253));
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .niche-hypothesis-card__fields {

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -8,6 +8,7 @@ import { useBreadcrumbs } from "../../app/breadcrumbs";
 import { useChatDialog } from "../../api/chatDialog/useChatDialog";
 import { useForm } from "react-hook-form";
 import { useRequestAudiences } from "../../api/niche/useRequestAudiences";
+import { useExperimentsByNiche } from "../../api/experiment/useExperimentsByNiche";
 import {
   ArrowUpRight,
   Clock3,
@@ -25,6 +26,7 @@ export default function NicheDetailPage() {
   const { data: chatDialog } = useChatDialog(data?.chatDialogId);
   const { data: hypotheses } = useHypothesesByNiche(nicheId, "ALL");
   const { data: audiences } = useAudiencesByNiche(nicheId);
+  const { data: experiments } = useExperimentsByNiche(nicheId);
   const requestAudiences = useRequestAudiences(id);
   const { register, handleSubmit, reset } = useForm<{ quantity: number }>({
     defaultValues: { quantity: 1 },
@@ -66,6 +68,14 @@ export default function NicheDetailPage() {
       })
     : [];
   const audienceList = Array.isArray(audiences) ? audiences : [];
+  const experimentsList = Array.isArray(experiments) ? experiments : [];
+  const experimentsCountByHypothesis = experimentsList.reduce<
+    Record<string, number>
+  >((acc, experiment) => {
+    const key = experiment.hypothesisId;
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
   const createdAtLabel = data.createdAt
     ? new Date(data.createdAt).toLocaleString("pt-BR")
     : undefined;
@@ -141,6 +151,7 @@ export default function NicheDetailPage() {
     <div className="niche-detail">
       <div className="niche-detail__header">
         <div className="niche-detail__title">
+          <span className="niche-detail__badge">Nicho</span>
           <PageTitle>{data.name}</PageTitle>
           <p className="niche-detail__subtitle">
             {`Nicho #${data.id}`}
@@ -271,6 +282,11 @@ export default function NicheDetailPage() {
         ) : (
           <div className="niche-section__grid">
             {list.map((h) => {
+              const experimentCount = experimentsCountByHypothesis[h.id] ?? 0;
+              const experimentLabel =
+                experimentCount === 1
+                  ? "1 experimento criado"
+                  : `${experimentCount} experimentos criados`;
               const fields = [
                 { label: "Promessa", value: h.promise },
                 { label: "Problema", value: h.problem },
@@ -282,7 +298,12 @@ export default function NicheDetailPage() {
               return (
                 <div key={h.id} className="card h-100 niche-section__card">
                   <div className="card-body niche-hypothesis-card__body">
-                    <h3 className="niche-hypothesis-card__title">{h.title}</h3>
+                    <div className="niche-hypothesis-card__head">
+                      <h3 className="niche-hypothesis-card__title">{h.title}</h3>
+                      <span className="niche-hypothesis-card__counter">
+                        {experimentLabel}
+                      </span>
+                    </div>
                     <div className="niche-hypothesis-card__fields">
                       {fields.map((field) => (
                         <div
@@ -290,7 +311,7 @@ export default function NicheDetailPage() {
                           className="niche-hypothesis-card__field"
                         >
                           <span className="niche-hypothesis-card__field-label">
-                            {field.label}
+                            {`${field.label}:`}
                           </span>
                           <p className="niche-hypothesis-card__field-value">
                             {field.value || "-"}


### PR DESCRIPTION
## Summary
- surface experiment counts on each hypothesis card in the niche detail view
- update the hero card with a "Nicho" badge, tighter title sizing, and vertically stacked info cards

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d1a83d235c8321b58b3683ba1dfc4f