### PR TITLE
Revamp niche detail breadcrumb and card headings

### DIFF
--- a/frontend/src/app/AppLayout.tsx
+++ b/frontend/src/app/AppLayout.tsx
@@ -1,14 +1,9 @@
-import { Link, Outlet } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 import BreadcrumbsProvider from "./breadcrumbs";
 
 export default function AppLayout() {
   return (
     <BreadcrumbsProvider>
-      <header className="mb-3">
-        <Link to="/niches" className="navbar-brand">
-          Marketing Hub
-        </Link>
-      </header>
       <Outlet />
     </BreadcrumbsProvider>
   );

--- a/frontend/src/app/breadcrumbs.css
+++ b/frontend/src/app/breadcrumbs.css
@@ -1,0 +1,83 @@
+.app-breadcrumbs {
+  margin-bottom: clamp(1.25rem, 1rem + 1vw, 2rem);
+  padding: clamp(0.9rem, 0.8rem + 0.5vw, 1.3rem) clamp(1.1rem, 0.95rem + 1vw, 1.9rem);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.18);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--bs-primary-rgb, 13, 110, 253), 0.08) 0%,
+    rgba(var(--bs-purple-rgb, 111, 66, 193), 0.06) 100%
+  );
+  box-shadow: 0 18px 36px -26px rgba(var(--bs-primary-rgb, 13, 110, 253), 0.38);
+}
+
+.app-breadcrumbs__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.app-breadcrumbs__item {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.2);
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.12);
+  color: rgb(var(--bs-primary-rgb, 13, 110, 253));
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.app-breadcrumbs__item a,
+.app-breadcrumbs__item span {
+  color: inherit;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+}
+
+.app-breadcrumbs__item a:hover,
+.app-breadcrumbs__item a:focus-visible {
+  text-decoration: underline;
+}
+
+.app-breadcrumbs__item.is-active {
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.18);
+  color: var(--bs-emphasis-color, #212529);
+  border-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.3);
+}
+
+.app-breadcrumbs__item-label {
+  max-width: min(100%, 32ch);
+  line-height: 1.2;
+}
+
+@media (max-width: 576px) {
+  .app-breadcrumbs {
+    border-radius: 1rem;
+    padding: 0.85rem 1.1rem;
+  }
+
+  .app-breadcrumbs__list {
+    gap: 0.45rem;
+  }
+
+  .app-breadcrumbs__item {
+    padding: 0.3rem 0.75rem;
+    font-size: 0.8rem;
+  }
+
+  .app-breadcrumbs__item-label {
+    max-width: min(100%, 22ch);
+  }
+}

--- a/frontend/src/app/breadcrumbs.tsx
+++ b/frontend/src/app/breadcrumbs.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
+import "./breadcrumbs.css";
+
 export interface Crumb {
   label: string;
   to?: string;
@@ -23,15 +25,32 @@ export default function BreadcrumbsProvider({
   const [crumbs, setCrumbs] = useState<Crumb[]>([]);
   return (
     <SetCrumbsContext.Provider value={setCrumbs}>
-      <nav aria-label="breadcrumb" className="mb-3">
-        <ol className="breadcrumb mb-0">
-          {crumbs.map((c, i) => (
-            <li key={i} className="breadcrumb-item">
-              {c.to ? <Link to={c.to}>{c.label}</Link> : c.label}
-            </li>
-          ))}
-        </ol>
-      </nav>
+      {crumbs.length > 0 ? (
+        <nav aria-label="breadcrumb" className="app-breadcrumbs">
+          <ol className="app-breadcrumbs__list">
+            {crumbs.map((c, i) => {
+              const isActive = i === crumbs.length - 1;
+              const label = (
+                <span className="app-breadcrumbs__item-label">{c.label}</span>
+              );
+              return (
+                <li
+                  key={i}
+                  className={`app-breadcrumbs__item${
+                    isActive ? " is-active" : ""
+                  }`}
+                >
+                  {c.to && !isActive ? (
+                    <Link to={c.to}>{label}</Link>
+                  ) : (
+                    <span aria-current={isActive ? "page" : undefined}>{label}</span>
+                  )}
+                </li>
+              );
+            })}
+          </ol>
+        </nav>
+      ) : null}
       {children}
     </SetCrumbsContext.Provider>
   );

--- a/frontend/src/pages/niche/NicheDetailPage.css
+++ b/frontend/src/pages/niche/NicheDetailPage.css
@@ -166,11 +166,21 @@
 
 .niche-detail__card-title {
   margin: 0;
-  font-size: 0.9rem;
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.25);
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.12);
+  color: var(--bs-primary-text-emphasis, #052c65);
+  font-size: clamp(0.95rem, 0.9rem + 0.35vw, 1.1rem);
   font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--bs-secondary-color, #6c757d);
+  letter-spacing: 0.01em;
+  text-transform: none;
+  line-height: 1.1;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
 .niche-detail__card-content {


### PR DESCRIPTION
## Summary
- restyle the breadcrumb trail with pill chips and remove the legacy Marketing Hub header
- highlight niche information card titles with primary accents to improve readability
- add dedicated stylesheet for breadcrumb layout to match current UI tokens

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1ada1f76c8321a4fd4f57f37d0485