### PR TITLE
Simplify breadcrumb styling

### DIFF
--- a/frontend/src/app/breadcrumbs.css
+++ b/frontend/src/app/breadcrumbs.css
@@ -1,14 +1,7 @@
 .app-breadcrumbs {
-  margin-bottom: clamp(1.25rem, 1rem + 1vw, 2rem);
-  padding: clamp(0.9rem, 0.8rem + 0.5vw, 1.3rem) clamp(1.1rem, 0.95rem + 1vw, 1.9rem);
-  border-radius: 1.25rem;
-  border: 1px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.18);
-  background: linear-gradient(
-    135deg,
-    rgba(var(--bs-primary-rgb, 13, 110, 253), 0.08) 0%,
-    rgba(var(--bs-purple-rgb, 111, 66, 193), 0.06) 100%
-  );
-  box-shadow: 0 18px 36px -26px rgba(var(--bs-primary-rgb, 13, 110, 253), 0.38);
+  margin-bottom: clamp(1rem, 0.8rem + 1vw, 1.75rem);
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.1));
 }
 
 .app-breadcrumbs__list {
@@ -17,44 +10,51 @@
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.6rem;
   align-items: center;
+  gap: 0.35rem;
 }
 
 .app-breadcrumbs__item {
   min-width: 0;
   display: inline-flex;
   align-items: center;
-  flex-wrap: wrap;
   gap: 0.35rem;
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.2);
-  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.12);
-  color: rgb(var(--bs-primary-rgb, 13, 110, 253));
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  color: var(--bs-secondary-color, #6c757d);
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.app-breadcrumbs__item + .app-breadcrumbs__item::before {
+  content: "/";
+  color: var(--bs-border-color, rgba(0, 0, 0, 0.35));
+  font-size: 0.85em;
+  display: inline-block;
+  margin-inline: 0.35rem;
 }
 
 .app-breadcrumbs__item a,
 .app-breadcrumbs__item span {
-  color: inherit;
-  text-decoration: none;
   display: inline-flex;
   align-items: center;
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
 }
 
 .app-breadcrumbs__item a:hover,
 .app-breadcrumbs__item a:focus-visible {
+  color: var(--bs-body-color, #212529);
   text-decoration: underline;
+  text-decoration-color: currentColor;
 }
 
 .app-breadcrumbs__item.is-active {
-  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.18);
   color: var(--bs-emphasis-color, #212529);
-  border-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.3);
+  font-weight: 600;
+}
+
+.app-breadcrumbs__item.is-active span {
+  cursor: default;
 }
 
 .app-breadcrumbs__item-label {
@@ -64,20 +64,18 @@
 
 @media (max-width: 576px) {
   .app-breadcrumbs {
-    border-radius: 1rem;
-    padding: 0.85rem 1.1rem;
+    padding-bottom: 0.65rem;
   }
 
   .app-breadcrumbs__list {
-    gap: 0.45rem;
+    gap: 0.25rem;
   }
 
   .app-breadcrumbs__item {
-    padding: 0.3rem 0.75rem;
-    font-size: 0.8rem;
+    font-size: 0.9rem;
   }
 
-  .app-breadcrumbs__item-label {
-    max-width: min(100%, 22ch);
+  .app-breadcrumbs__item + .app-breadcrumbs__item::before {
+    margin-inline: 0.25rem 0.15rem;
   }
 }


### PR DESCRIPTION
## Summary
- simplify the breadcrumb container to a clean line-based layout that better fits the rest of the UI
- lighten crumb items with neutral colors and slash separators while keeping hover and active emphasis states consistent

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d1b77199a483218b70d5165e1b491d