### PR TITLE
Fix asset provider column to accept OpenAI values

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_11_05__widen_asset_provider.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_11_05__widen_asset_provider.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset marketinghub:2025-11-05-widen-asset-provider dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'provider' AND data_type = 'varchar' AND character_maximum_length >= 255
+ALTER TABLE asset MODIFY COLUMN provider VARCHAR(255);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -104,3 +104,6 @@ databaseChangeLog:
   - include:
       file: V2025_10_30__create_asset_table.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_11_05__widen_asset_provider.sql
+      relativeToChangelogFile: true


### PR DESCRIPTION
## Summary
- add a Liquibase changeset to normalize the asset.provider column to VARCHAR(255)
- register the new changeset in the master changelog

## Testing
- mvn -s ../settings.xml test *(fails: network is unreachable to download the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b858cefc8321949511aab99fcc52