### PR TITLE
Fix asset type truncation

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_11_10__widen_asset_type.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_11_10__widen_asset_type.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset marketinghub:2025-11-10-widen-asset-type dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'type' AND data_type = 'varchar' AND character_maximum_length >= 255
+ALTER TABLE asset MODIFY COLUMN type VARCHAR(255);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -107,3 +107,6 @@ databaseChangeLog:
   - include:
       file: V2025_11_05__widen_asset_provider.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_11_10__widen_asset_type.sql
+      relativeToChangelogFile: true

--- a/schema.sql
+++ b/schema.sql
@@ -1,14 +1,16 @@
 CREATE TABLE asset (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    type VARCHAR(20),
-    provider VARCHAR(20),
-    external_id VARCHAR(100),
-    status VARCHAR(20),
-    url VARCHAR(500),
-    payload TEXT,
+    type VARCHAR(255),
+    provider VARCHAR(255),
+    external_id VARCHAR(255),
+    status VARCHAR(255),
+    url VARCHAR(1024),
+    payload LONGTEXT,
     campaign_id BIGINT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    model VARCHAR(255),
+    prompt LONGTEXT,
+    created_at DATETIME(6),
+    updated_at DATETIME(6)
 );
 
 CREATE TABLE course_plan (


### PR DESCRIPTION
## Summary
- ensure the asset.type column is widened to VARCHAR(255) through a new Liquibase changeset
- refresh the schema.sql asset definition to match the backend model and avoid future truncation issues

## Testing
- ⚠️ `mvn -s ../settings.xml test` *(fails: unable to download org.springframework.boot:spring-boot-starter-parent:3.2.5 because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c3ec934c8321b03156b813d1c3e4