### PR TITLE
Adjust breadcrumb display to path format

### DIFF
--- a/frontend/src/app/breadcrumbs.css
+++ b/frontend/src/app/breadcrumbs.css
@@ -11,29 +11,28 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0;
 }
 
 .app-breadcrumbs__item {
   min-width: 0;
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0;
   color: var(--bs-secondary-color, #6c757d);
   font-size: 0.95rem;
   font-weight: 500;
 }
 
-.app-breadcrumbs__item + .app-breadcrumbs__item::before {
-  content: "/";
-  color: var(--bs-border-color, rgba(0, 0, 0, 0.35));
+.app-breadcrumbs__separator {
+  display: inline-flex;
+  align-items: center;
+  color: var(--bs-border-color, rgba(0, 0, 0, 0.45));
   font-size: 0.85em;
-  display: inline-block;
-  margin-inline: 0.35rem;
 }
 
-.app-breadcrumbs__item a,
-.app-breadcrumbs__item span {
+.app-breadcrumbs__item > a,
+.app-breadcrumbs__item > span {
   display: inline-flex;
   align-items: center;
   color: inherit;
@@ -41,8 +40,8 @@
   transition: color 0.2s ease, text-decoration-color 0.2s ease;
 }
 
-.app-breadcrumbs__item a:hover,
-.app-breadcrumbs__item a:focus-visible {
+.app-breadcrumbs__item > a:hover,
+.app-breadcrumbs__item > a:focus-visible {
   color: var(--bs-body-color, #212529);
   text-decoration: underline;
   text-decoration-color: currentColor;
@@ -53,7 +52,7 @@
   font-weight: 600;
 }
 
-.app-breadcrumbs__item.is-active span {
+.app-breadcrumbs__item.is-active > span {
   cursor: default;
 }
 
@@ -67,15 +66,7 @@
     padding-bottom: 0.65rem;
   }
 
-  .app-breadcrumbs__list {
-    gap: 0.25rem;
-  }
-
   .app-breadcrumbs__item {
     font-size: 0.9rem;
-  }
-
-  .app-breadcrumbs__item + .app-breadcrumbs__item::before {
-    margin-inline: 0.25rem 0.15rem;
   }
 }

--- a/frontend/src/app/breadcrumbs.tsx
+++ b/frontend/src/app/breadcrumbs.tsx
@@ -31,7 +31,12 @@ export default function BreadcrumbsProvider({
             {crumbs.map((c, i) => {
               const isActive = i === crumbs.length - 1;
               const label = (
-                <span className="app-breadcrumbs__item-label">{c.label}</span>
+                <>
+                  <span className="app-breadcrumbs__separator" aria-hidden="true">
+                    /
+                  </span>
+                  <span className="app-breadcrumbs__item-label">{c.label}</span>
+                </>
               );
               return (
                 <li


### PR DESCRIPTION
## Summary
- render breadcrumb items with explicit slash separators so the trail reads like a path
- update breadcrumb styles to remove gaps and support the new separator element

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d1c4f3100c8321b4bf0e1ae041d230