### PR TITLE
Improve AI worker logging and timeouts

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
@@ -5,13 +5,19 @@ import com.marketinghub.creative.CreativeStatus;
 import com.marketinghub.creative.dto.CreateCreativeRequest;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.hypothesis.Hypothesis;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -24,22 +30,42 @@ public class CreativeChatGptClient {
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
     private final String model;
+    private final boolean enabled;
     private static final Logger log = LoggerFactory.getLogger(CreativeChatGptClient.class);
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(90);
 
     public CreativeChatGptClient(WebClient.Builder builder,
                                  ObjectMapper objectMapper,
                                  @Value("${openai.api-key:}") String apiKey,
                                  @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
                                  @Value("${openai.model:gpt-3.5-turbo}") String model) {
-        this.webClient = builder
+        this.enabled = apiKey != null && !apiKey.isBlank();
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) CONNECT_TIMEOUT.toMillis())
+                .responseTimeout(REQUEST_TIMEOUT)
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler((int) REQUEST_TIMEOUT.getSeconds()))
+                        .addHandlerLast(new WriteTimeoutHandler((int) REQUEST_TIMEOUT.getSeconds())));
+        WebClient.Builder clientBuilder = builder.clone()
                 .baseUrl(baseUrl)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
-                .build();
+                .clientConnector(new ReactorClientHttpConnector(httpClient));
+        if (enabled) {
+            clientBuilder.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
+        }
+        this.webClient = clientBuilder.build();
         this.objectMapper = objectMapper;
         this.model = model;
+        if (!enabled) {
+            log.warn("OpenAI API key not configured; creative generation will be skipped");
+        }
     }
 
     public List<CreateCreativeRequest> generateCreatives(Experiment experiment, int quantity) {
+        if (!enabled) {
+            log.warn("Skipping creative generation for experiment {} because OpenAI API key is missing", experiment.getId());
+            return List.of();
+        }
         String prompt = buildPrompt(experiment, quantity);
         Map<String, Object> payload = Map.of(
                 "model", model,
@@ -52,12 +78,19 @@ public class CreativeChatGptClient {
         log.info("Sending prompt to ChatGPT for experiment {}: {}", experiment.getId(), prompt);
         log.debug("ChatGPT payload: {}", payload);
 
-        ChatCompletionResponse response = webClient.post()
-                .uri("/chat/completions")
-                .bodyValue(payload)
-                .retrieve()
-                .bodyToMono(ChatCompletionResponse.class)
-                .block();
+        ChatCompletionResponse response;
+        try {
+            response = webClient.post()
+                    .uri("/chat/completions")
+                    .bodyValue(payload)
+                    .retrieve()
+                    .bodyToMono(ChatCompletionResponse.class)
+                    .block(REQUEST_TIMEOUT);
+        } catch (Exception ex) {
+            log.error("ChatGPT request failed for experiment {} after {} seconds", experiment.getId(),
+                    REQUEST_TIMEOUT.getSeconds(), ex);
+            throw new RuntimeException("Failed to call ChatGPT", ex);
+        }
 
         log.info("ChatGPT raw response: {}", response);
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
@@ -5,21 +5,27 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
 
 /**
  * Simple wrapper around the OpenAI images API for creative image generation.
@@ -31,8 +37,11 @@ public class CreativeImageClient {
     private final String model;
     private final CreativeImageOptimizer imageOptimizer;
     private final ObjectMapper objectMapper;
+    private final boolean enabled;
     private static final Logger log = LoggerFactory.getLogger(CreativeImageClient.class);
     private static final int DEFAULT_MAX_IN_MEMORY_SIZE = 10 * 1024 * 1024; // 10 MB
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(90);
 
     public CreativeImageClient(WebClient.Builder builder,
                                BackendAssetClient assetClient,
@@ -40,18 +49,35 @@ public class CreativeImageClient {
                                @Value("${openai.api-key:}") String apiKey,
                                @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
                                @Value("${openai.image-model:dall-e-3}") String model) {
-        this.webClient = builder
+        this.enabled = apiKey != null && !apiKey.isBlank();
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) CONNECT_TIMEOUT.toMillis())
+                .responseTimeout(REQUEST_TIMEOUT)
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler((int) REQUEST_TIMEOUT.getSeconds()))
+                        .addHandlerLast(new WriteTimeoutHandler((int) REQUEST_TIMEOUT.getSeconds())));
+        WebClient.Builder clientBuilder = builder.clone()
                 .baseUrl(baseUrl)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
-                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(DEFAULT_MAX_IN_MEMORY_SIZE))
-                .build();
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(DEFAULT_MAX_IN_MEMORY_SIZE));
+        if (enabled) {
+            clientBuilder.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
+        }
+        this.webClient = clientBuilder.build();
         this.assetClient = assetClient;
         this.imageOptimizer = imageOptimizer;
         this.model = model;
         this.objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        if (!enabled) {
+            log.warn("OpenAI API key not configured; image generation will be skipped");
+        }
     }
 
     public String generateImage(String prompt) {
+        if (!enabled) {
+            log.warn("Skipping image generation because OpenAI API key is missing");
+            return null;
+        }
         Map<String, Object> payload = Map.of(
                 "model", model,
                 "prompt", prompt,
@@ -59,11 +85,17 @@ public class CreativeImageClient {
         );
 
         log.info("Sending image generation prompt to OpenAI: {}", prompt);
-        ImageResponse response = webClient.post()
-                .uri("/images/generations")
-                .bodyValue(payload)
-                .exchangeToMono(this::readImageResponse)
-                .block();
+        ImageResponse response;
+        try {
+            response = webClient.post()
+                    .uri("/images/generations")
+                    .bodyValue(payload)
+                    .exchangeToMono(this::readImageResponse)
+                    .block(REQUEST_TIMEOUT);
+        } catch (Exception ex) {
+            log.error("OpenAI image generation failed after {} seconds", REQUEST_TIMEOUT.getSeconds(), ex);
+            throw new RuntimeException("Failed to call OpenAI image API", ex);
+        }
 
         log.info("OpenAI image response: {}", response);
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeScheduler.java
@@ -19,11 +19,15 @@ public class ExperimentCreativeScheduler {
 
     @Scheduled(cron = "0 */5 * * * *")
     public void run() {
+        long start = System.currentTimeMillis();
         log.info("ExperimentCreativeScheduler started");
         try {
             service.generate();
+        } catch (Exception ex) {
+            log.error("ExperimentCreativeScheduler failed", ex);
         } finally {
-            log.info("ExperimentCreativeScheduler finished");
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("ExperimentCreativeScheduler finished in {} ms", elapsed);
         }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
@@ -51,34 +51,43 @@ public class ExperimentCreativeService {
         Iterable<Experiment> experiments = experimentRepository.findAllToGenerateCreatives();
         for (Experiment exp : experiments) {
             Integer qty = exp.getCreativesToGenerate();
-            log.info("Generating {} creatives for experiment {}", qty, exp.getId());
-            List<CreateCreativeRequest> requests = chatGptClient.generateCreatives(exp, qty);
-            log.info("ChatGPT returned {} creatives for experiment {}", requests.size(), exp.getId());
-            List<Creative> saved = new ArrayList<>();
-            for (CreateCreativeRequest req : requests) {
-                if (req.getHeadline() == null || req.getHeadline().isBlank()) {
-                    log.error("Skipping creative without headline for experiment {}: {}", exp.getId(), req);
-                    continue;
-                }
-                req.setHeadline(truncate(req.getHeadline(), HEADLINE_MAX));
-                String primary = limitHashtags(req.getPrimaryText(), MAX_HASHTAGS);
-                if (primary != null && !primary.contains("#")) {
-                    primary = truncate(primary, PRIMARY_TEXT_MAX);
-                }
-                req.setPrimaryText(primary);
-                try {
-                    String imageUrl = imageClient.generateImage(req.getHeadline());
-                    req.setImageUrl(imageUrl);
-                } catch (Exception e) {
-                    log.error("Failed to generate image for experiment {}: {}", exp.getId(), req.getHeadline(), e);
-                }
-                log.info("Saving creative for experiment {}: {}", exp.getId(), req);
-                saved.add(creativeService.create(exp.getId(), req));
+            if (qty == null || qty <= 0) {
+                log.info("Skipping experiment {} because creativesToGenerate is {}", exp.getId(), qty);
+                continue;
             }
-            log.info("Resetting creativesToGenerate for experiment {} to 0", exp.getId());
-            exp.setCreativesToGenerate(0);
-            experimentRepository.save(exp);
-            result.put(exp.getId(), saved);
+            log.info("Generating {} creatives for experiment {}", qty, exp.getId());
+            try {
+                List<CreateCreativeRequest> requests = chatGptClient.generateCreatives(exp, qty);
+                log.info("ChatGPT returned {} creatives for experiment {}", requests.size(), exp.getId());
+                List<Creative> saved = new ArrayList<>();
+                for (CreateCreativeRequest req : requests) {
+                    if (req.getHeadline() == null || req.getHeadline().isBlank()) {
+                        log.error("Skipping creative without headline for experiment {}: {}", exp.getId(), req);
+                        continue;
+                    }
+                    req.setHeadline(truncate(req.getHeadline(), HEADLINE_MAX));
+                    String primary = limitHashtags(req.getPrimaryText(), MAX_HASHTAGS);
+                    if (primary != null && !primary.contains("#")) {
+                        primary = truncate(primary, PRIMARY_TEXT_MAX);
+                    }
+                    req.setPrimaryText(primary);
+                    try {
+                        String imageUrl = imageClient.generateImage(req.getHeadline());
+                        req.setImageUrl(imageUrl);
+                    } catch (Exception e) {
+                        log.error("Failed to generate image for experiment {}: {}", exp.getId(), req.getHeadline(), e);
+                    }
+                    log.info("Saving creative for experiment {}: {}", exp.getId(), req);
+                    saved.add(creativeService.create(exp.getId(), req));
+                }
+                log.info("Resetting creativesToGenerate for experiment {} to 0", exp.getId());
+                exp.setCreativesToGenerate(0);
+                experimentRepository.save(exp);
+                result.put(exp.getId(), saved);
+                log.info("Finished experiment {} with {} creatives persisted", exp.getId(), saved.size());
+            } catch (Exception e) {
+                log.error("Failed to generate creatives for experiment {}", exp.getId(), e);
+            }
         }
         return result;
     }


### PR DESCRIPTION
## Summary
- add duration logging and defensive error handling to the experiment creative scheduler and service
- guard experiment processing against invalid quantities and surface per-experiment errors in the logs
- configure OpenAI chat/image clients with connection/read timeouts, API key checks, and clearer failure logs

## Testing
- mvn -s settings.xml test *(fails: unable to download parent POM because the GitHub Packages host is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e373e4d083219522078122167a4b