### PR TITLE
Update AI worker image model to gpt-image-1

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
@@ -48,7 +48,7 @@ public class CreativeImageClient {
                                CreativeImageOptimizer imageOptimizer,
                                @Value("${openai.api-key:}") String apiKey,
                                @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
-                               @Value("${openai.image-model:dall-e-3}") String model) {
+                               @Value("${openai.image-model:gpt-image-1}") String model) {
         this.enabled = apiKey != null && !apiKey.isBlank();
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) CONNECT_TIMEOUT.toMillis())

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -7,6 +7,7 @@ spring.jpa.properties.hibernate.format_sql=true
 openai.api-key=${OPENAI_API_KEY:}
 openai.model=${OPENAI_MODEL:o3}
 openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
+openai.image-model=${OPENAI_IMAGE_MODEL:gpt-image-1}
 creative.image.max-bytes=${CREATIVE_IMAGE_MAX_BYTES:900000}
 creative.image.max-dimension=${CREATIVE_IMAGE_MAX_DIMENSION:1024}
 backend.base-url=${BACKEND_BASE_URL:http://191.252.92.222:8000}


### PR DESCRIPTION
## Summary
- set the default OpenAI image model to `gpt-image-1` in the AI worker configuration
- align the `CreativeImageClient` default model with the new configuration so image requests use the higher capacity model

## Testing
- `mvn -s settings.xml test` *(fails: could not download spring-boot parent POM due to network restrictions when accessing GitHub Packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d2410886bc832182af1f0f36ff153f