### PR TITLE
Melhora prompt de imagem com contexto de experimento

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
@@ -5,6 +5,7 @@ import com.marketinghub.creative.dto.CreateCreativeRequest;
 import com.marketinghub.creative.service.CreativeService;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.hypothesis.Hypothesis;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -72,7 +73,8 @@ public class ExperimentCreativeService {
                     }
                     req.setPrimaryText(primary);
                     try {
-                        String imageUrl = imageClient.generateImage(req.getHeadline());
+                        String imagePrompt = buildImagePrompt(exp, req);
+                        String imageUrl = imageClient.generateImage(imagePrompt);
                         req.setImageUrl(imageUrl);
                     } catch (Exception e) {
                         log.error("Failed to generate image for experiment {}: {}", exp.getId(), req.getHeadline(), e);
@@ -119,5 +121,54 @@ public class ExperimentCreativeService {
             sb.append(part);
         }
         return sb.toString();
+    }
+
+    private static String buildImagePrompt(Experiment experiment, CreateCreativeRequest request) {
+        List<String> parts = new ArrayList<>();
+        parts.add("Crie uma imagem envolvente para um anúncio de Facebook e Instagram que desperte interesse e desejo.");
+        if (hasText(request.getHeadline())) {
+            parts.add("A imagem deve acompanhar a headline \"" + request.getHeadline() + "\".");
+        }
+        if (experiment != null) {
+            if (hasText(experiment.getName())) {
+                parts.add("Experimento: " + experiment.getName() + ".");
+            } else if (experiment.getId() != null) {
+                parts.add("Experimento ID: " + experiment.getId() + ".");
+            }
+            if (hasText(experiment.getHypothesis())) {
+                parts.add("Resumo do experimento: " + experiment.getHypothesis() + ".");
+            }
+        }
+        Hypothesis hypothesis = experiment != null ? experiment.getHypothesisRef() : null;
+        if (hypothesis != null) {
+            if (hasText(hypothesis.getTitle())) {
+                parts.add("Baseie-se na hipótese \"" + hypothesis.getTitle() + "\".");
+            } else if (hypothesis.getId() != null) {
+                parts.add("Baseie-se na hipótese de ID " + hypothesis.getId() + ".");
+            }
+            if (hasText(hypothesis.getPersona())) {
+                parts.add("Persona: " + hypothesis.getPersona() + ".");
+            }
+            if (hasText(hypothesis.getProblem())) {
+                parts.add("Problema: " + hypothesis.getProblem() + ".");
+            }
+            if (hasText(hypothesis.getPromise())) {
+                parts.add("Promessa: " + hypothesis.getPromise() + ".");
+            }
+            if (hasText(hypothesis.getMechanism())) {
+                parts.add("Mecanismo: " + hypothesis.getMechanism() + ".");
+            }
+            if (hasText(hypothesis.getUniqueMechanism())) {
+                parts.add("Mecanismo único: " + hypothesis.getUniqueMechanism() + ".");
+            }
+            if (hasText(hypothesis.getEntrega())) {
+                parts.add("Entrega: " + hypothesis.getEntrega() + ".");
+            }
+        }
+        return String.join(" ", parts);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
@@ -43,9 +43,14 @@ class ExperimentCreativeServiceTest {
     void setup() {
         experiment = new Experiment();
         experiment.setId(1L);
+        experiment.setName("Experimento A");
+        experiment.setHypothesis("Validar proposta principal para o público-alvo");
         experiment.setCreativesToGenerate(1);
         Hypothesis h = new Hypothesis();
         h.setTitle("title");
+        h.setPersona("profissionais autônomos");
+        h.setProblem("não conseguem manter um fluxo constante de clientes");
+        h.setPromise("aumentar a base de clientes com campanhas digitais");
         experiment.setHypothesisRef(h);
     }
 
@@ -56,13 +61,19 @@ class ExperimentCreativeServiceTest {
         req.setHeadline("h1");
         req.setPrimaryText("p1");
         when(chatGptClient.generateCreatives(experiment, 1)).thenReturn(List.of(req));
-        when(imageClient.generateImage("h1")).thenReturn("img");
+        when(imageClient.generateImage(anyString())).thenReturn("img");
         Creative saved = new Creative();
         when(creativeService.create(1L, req)).thenReturn(saved);
 
         Map<Long, List<Creative>> result = service.generate();
 
-        verify(imageClient).generateImage("h1");
+        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(imageClient).generateImage(promptCaptor.capture());
+        String usedPrompt = promptCaptor.getValue();
+        assertThat(usedPrompt).contains("Facebook e Instagram");
+        assertThat(usedPrompt).contains("headline \"h1\"");
+        assertThat(usedPrompt).contains("Experimento: Experimento A");
+        assertThat(usedPrompt).contains("hipótese \"title\"");
         assertThat(req.getImageUrl()).isEqualTo("img");
         verify(creativeService).create(1L, req);
         verify(experimentRepository).save(experiment);


### PR DESCRIPTION
## Summary
- inclui construção de prompt de imagem com informações do experimento e da hipótese para orientar geração para anúncios
- ajusta serviço para enviar o novo prompt ao cliente de imagens e mantém truncamento de textos
- atualiza testes para validar o conteúdo do prompt enriquecido e os dados de contexto simulados

## Testing
- mvn -s settings.xml test *(falhou: Network is unreachable ao baixar dependências do parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d24414654483219ca80b5d8f50bde3