### PR TITLE
Impedir quebra de linha nas breadcrumbs do frontend

### DIFF
--- a/frontend/src/app/breadcrumbs.css
+++ b/frontend/src/app/breadcrumbs.css
@@ -9,9 +9,11 @@
   margin: 0;
   padding: 0;
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
   gap: 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
 }
 
 .app-breadcrumbs__item {
@@ -38,6 +40,7 @@
   color: inherit;
   text-decoration: none;
   transition: color 0.2s ease, text-decoration-color 0.2s ease;
+  min-width: 0;
 }
 
 .app-breadcrumbs__item > a:hover,
@@ -57,8 +60,12 @@
 }
 
 .app-breadcrumbs__item-label {
+  display: inline-block;
   max-width: min(100%, 32ch);
   line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 @media (max-width: 576px) {


### PR DESCRIPTION
## Summary
- impede a quebra de linha da lista de breadcrumbs habilitando rolagem horizontal
- garante que os rótulos dos itens usem ellipsis para manter o conteúdo em uma única linha

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2471a1b5883218409683aa03184ec