### PR TITLE
Adjust OpenAI image request for gpt-image-1

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeImageClient.java
@@ -7,7 +7,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import io.netty.channel.ChannelOption;
@@ -78,11 +80,12 @@ public class CreativeImageClient {
             log.warn("Skipping image generation because OpenAI API key is missing");
             return null;
         }
-        Map<String, Object> payload = Map.of(
-                "model", model,
-                "prompt", prompt,
-                "response_format", "b64_json"
-        );
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("model", model);
+        payload.put("prompt", prompt);
+        if (supportsResponseFormat(model)) {
+            payload.put("response_format", "b64_json");
+        }
 
         log.info("Sending image generation prompt to OpenAI: {}", prompt);
         ImageResponse response;
@@ -99,10 +102,19 @@ public class CreativeImageClient {
 
         log.info("OpenAI image response: {}", response);
 
-        if (response == null || response.data().isEmpty()) {
+        if (response == null) {
             throw new RuntimeException("No image returned from OpenAI");
         }
-        ImageData data = response.data().get(0);
+        List<ImageData> dataList = response.data();
+        if (dataList == null || dataList.isEmpty()) {
+            ApiError error = response.error();
+            if (error != null && error.message() != null && !error.message().isBlank()) {
+                log.error("OpenAI image API returned error: {}", error.message());
+                throw new RuntimeException("OpenAI image API returned error: " + error.message());
+            }
+            throw new RuntimeException("No image returned from OpenAI");
+        }
+        ImageData data = dataList.get(0);
         if (data.base64() != null && !data.base64().isBlank()) {
             try {
                 byte[] imageBytes = Base64.getDecoder().decode(data.base64());
@@ -158,6 +170,14 @@ public class CreativeImageClient {
         }
     }
 
-    private record ImageResponse(List<ImageData> data) {}
+    private boolean supportsResponseFormat(String selectedModel) {
+        if (selectedModel == null || selectedModel.isBlank()) {
+            return true;
+        }
+        return !selectedModel.toLowerCase(Locale.ROOT).startsWith("gpt-image-");
+    }
+
+    private record ImageResponse(List<ImageData> data, ApiError error) {}
     private record ImageData(String url, @JsonProperty("b64_json") String base64) {}
+    private record ApiError(String message, String type, String param, String code) {}
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
@@ -1,18 +1,25 @@
 package com.marketinghub.worker.creative;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Base64;
+import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -20,33 +27,33 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.http.client.reactive.MockClientHttpRequest;
+import org.springframework.web.reactive.function.BodyInserterContext;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 class CreativeImageClientTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     @Mock
     BackendAssetClient backendAssetClient;
 
     CreativeImageClient client;
     CreativeImageOptimizer optimizer;
+    AtomicReference<Map<String, Object>> lastRequestPayload;
 
     @BeforeEach
     void setup() throws Exception {
         MockitoAnnotations.openMocks(this);
         optimizer = new CreativeImageOptimizer(900_000, 1024);
+        lastRequestPayload = new AtomicReference<>();
         String imagePayload = Base64.getEncoder().encodeToString(createSolidPng(128, 128));
         String body = "{\"data\":[{\"b64_json\":\"" + imagePayload + "\"}]}";
-        ExchangeFunction exchange = request -> {
-            assertThat(request.url().toString()).endsWith("/images/generations");
-            return Mono.just(ClientResponse.create(HttpStatus.OK)
-                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                    .body(body)
-                    .build());
-        };
+        ExchangeFunction exchange = stubImageApi(lastRequestPayload, body, HttpStatus.OK);
         WebClient.Builder builder = WebClient.builder().exchangeFunction(exchange);
-        client = new CreativeImageClient(builder, backendAssetClient, optimizer, "key", "http://openai", "image-model");
+        client = new CreativeImageClient(builder, backendAssetClient, optimizer, "key", "http://openai", "gpt-image-1");
     }
 
     @Test
@@ -56,9 +63,13 @@ class CreativeImageClientTest {
         String result = client.generateImage("prompt");
 
         assertThat(result).isEqualTo("/uploads/img.jpg");
+        Map<String, Object> request = lastRequestPayload.get();
+        assertThat(request).containsEntry("model", "gpt-image-1");
+        assertThat(request).containsEntry("prompt", "prompt");
+        assertThat(request).doesNotContainKey("response_format");
         verify(backendAssetClient).uploadImage(any(byte[].class),
                 argThat(name -> name.startsWith("creative-") && name.endsWith(".jpg")),
-                argThat(model -> model.equals("image-model")),
+                argThat(model -> model.equals("gpt-image-1")),
                 argThat(prompt -> prompt.equals("prompt")));
     }
 
@@ -67,12 +78,10 @@ class CreativeImageClientTest {
         byte[] imageBytes = createRandomPng(1024, 1024);
         String imagePayload = Base64.getEncoder().encodeToString(imageBytes);
         String body = "{\"data\":[{\"b64_json\":\"" + imagePayload + "\"}]}";
-        ExchangeFunction exchange = request -> Mono.just(ClientResponse.create(HttpStatus.OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .body(body)
-                .build());
+        AtomicReference<Map<String, Object>> requestPayload = new AtomicReference<>();
+        ExchangeFunction exchange = stubImageApi(requestPayload, body, HttpStatus.OK);
         WebClient.Builder builder = WebClient.builder().exchangeFunction(exchange);
-        CreativeImageClient largeClient = new CreativeImageClient(builder, backendAssetClient, optimizer, "key", "http://openai", "image-model");
+        CreativeImageClient largeClient = new CreativeImageClient(builder, backendAssetClient, optimizer, "key", "http://openai", "gpt-image-1");
         when(backendAssetClient.uploadImage(any(), any(), any(), any())).thenReturn("/uploads/large.jpg");
 
         String result = largeClient.generateImage("prompt");
@@ -80,6 +89,58 @@ class CreativeImageClientTest {
         assertThat(result).isEqualTo("/uploads/large.jpg");
         verify(backendAssetClient).uploadImage(argThat(bytes -> bytes.length > 0),
                 argThat(name -> name.endsWith(".jpg")), any(), any());
+    }
+
+    @Test
+    void surfacesErrorMessageWhenResponseLacksData() {
+        String body = "{\"data\":null,\"error\":{\"message\":\"quota exceeded\"}}";
+        AtomicReference<Map<String, Object>> requestPayload = new AtomicReference<>();
+        ExchangeFunction exchange = stubImageApi(requestPayload, body, HttpStatus.BAD_REQUEST);
+        WebClient.Builder builder = WebClient.builder().exchangeFunction(exchange);
+        CreativeImageClient errorClient = new CreativeImageClient(builder, backendAssetClient, optimizer, "key", "http://openai", "gpt-image-1");
+
+        assertThatThrownBy(() -> errorClient.generateImage("prompt"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("quota exceeded");
+    }
+
+    @Test
+    void requestsBase64PayloadExplicitlyForNonGptModels() {
+        String body = "{\"data\":[{\"b64_json\":\"" + Base64.getEncoder().encodeToString(new byte[] {1, 2, 3}) + "\"}]}";
+        AtomicReference<Map<String, Object>> requestPayload = new AtomicReference<>();
+        ExchangeFunction exchange = stubImageApi(requestPayload, body, HttpStatus.OK);
+        WebClient.Builder builder = WebClient.builder().exchangeFunction(exchange);
+        CreativeImageClient dalleClient = new CreativeImageClient(builder, backendAssetClient, optimizer, "key", "http://openai", "dall-e-3");
+        when(backendAssetClient.uploadImage(any(), any(), any(), any())).thenReturn("/uploads/dalle.jpg");
+
+        String result = dalleClient.generateImage("prompt");
+
+        assertThat(result).isEqualTo("/uploads/dalle.jpg");
+        Map<String, Object> payload = requestPayload.get();
+        assertThat(payload).containsEntry("response_format", "b64_json");
+    }
+
+    private ExchangeFunction stubImageApi(AtomicReference<Map<String, Object>> capturedPayload,
+                                          String responseBody,
+                                          HttpStatus status) {
+        return request -> {
+            assertThat(request.url().toString()).endsWith("/images/generations");
+            MockClientHttpRequest httpRequest = new MockClientHttpRequest(request.method(), request.url());
+            request.body().insert(httpRequest, new BodyInserterContext());
+            String requestBody = httpRequest.getBodyAsString().block();
+            try {
+                Map<String, Object> payload = MAPPER.readValue(requestBody, new TypeReference<Map<String, Object>>() { });
+                if (capturedPayload != null) {
+                    capturedPayload.set(payload);
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            return Mono.just(ClientResponse.create(status)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .body(responseBody)
+                    .build());
+        };
     }
 
     private static byte[] createSolidPng(int width, int height) throws IOException {


### PR DESCRIPTION
## Summary
- stop sending the `response_format` parameter when calling gpt-image models so the OpenAI image request matches the supported contract
- keep requesting base64 payloads for DALL·E models and verify the generated request bodies in unit tests
- expand the CreativeImageClient tests to capture outgoing payloads and ensure both model families are handled correctly

## Testing
- mvn -s settings.xml test *(fails: unable to download parent POM from https://maven.pkg.github.com/paulofor/marketing-hub in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b1edc89483218eff3fb49bee317c