### PR TITLE
Fix image client test to use valid base64 payload

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/CreativeImageClientTest.java
@@ -112,7 +112,13 @@ class CreativeImageClientTest {
 
     @Test
     void requestsBase64PayloadExplicitlyForNonGptModels() {
-        String body = "{\"data\":[{\"b64_json\":\"" + Base64.getEncoder().encodeToString(new byte[] {1, 2, 3}) + "\"}]}";
+        String imagePayload;
+        try {
+            imagePayload = Base64.getEncoder().encodeToString(createSolidPng(64, 64));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        String body = "{\"data\":[{\"b64_json\":\"" + imagePayload + "\"}]}";
         AtomicReference<Map<String, Object>> requestPayload = new AtomicReference<>();
         ExchangeFunction exchange = stubImageApi(requestPayload, body, HttpStatus.OK);
         WebClient.Builder builder = WebClient.builder().exchangeFunction(exchange);


### PR DESCRIPTION
## Summary
- update CreativeImageClientTest to build the non-GPT stub payload from a generated PNG so the optimizer can process it

## Testing
- `mvn -s settings.xml -q -Dtest=CreativeImageClientTest test` *(fails: Non-resolvable parent POM because the GitHub Packages registry is unreachable in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c7c4e858832192bab69ea7d209e6