### PR TITLE
Fix asset prompt truncation

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2025_11_15__widen_asset_prompt.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_11_15__widen_asset_prompt.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--changeset marketinghub:2025-11-15-widen-asset-prompt dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'prompt'
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'prompt' AND data_type = 'longtext'
+ALTER TABLE asset MODIFY COLUMN prompt LONGTEXT;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -110,3 +110,6 @@ databaseChangeLog:
   - include:
       file: V2025_11_10__widen_asset_type.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_11_15__widen_asset_prompt.sql
+      relativeToChangelogFile: true


### PR DESCRIPTION
## Summary
- add a Liquibase change set to widen the `asset.prompt` column to `LONGTEXT`
- include the new change log file in the master changelog so migrations run automatically

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable for https://maven.pkg.github.com/paulofor/marketing-hub)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fec7a3408321b25b192ff3d35d88