### PR TITLE
Ensure asset prompt column can store long prompts

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/media/Asset.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/media/Asset.java
@@ -34,6 +34,7 @@ public class Asset {
     private String url;
 
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String payload;
 
     private Long campaignId;
@@ -41,6 +42,7 @@ public class Asset {
     private String model;
 
     @Lob
+    @Column(columnDefinition = "LONGTEXT")
     private String prompt;
 
     @CreationTimestamp

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_11_20__ensure_asset_prompt_longtext.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_11_20__ensure_asset_prompt_longtext.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--changeset marketinghub:2025-11-20-ensure-asset-prompt-longtext dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'prompt'
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'asset' AND column_name = 'prompt' AND data_type = 'longtext'
+ALTER TABLE asset MODIFY COLUMN prompt LONGTEXT;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -113,3 +113,6 @@ databaseChangeLog:
   - include:
       file: V2025_11_15__widen_asset_prompt.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_11_20__ensure_asset_prompt_longtext.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/media/AssetRepositoryTest.java
@@ -28,4 +28,22 @@ class AssetRepositoryTest {
         repository.save(asset);
         assertThat(repository.findById(asset.getId())).isPresent();
     }
+
+    @Test
+    void shouldPersistLargePromptWithoutTruncation() {
+        String prompt = "x".repeat(120_000);
+        Asset asset = Asset.builder()
+                .type(AssetType.IMAGE)
+                .provider(MediaProvider.OPENAI)
+                .status(AssetStatus.READY)
+                .prompt(prompt)
+                .payload("{}").build();
+
+        Asset saved = repository.save(asset);
+
+        assertThat(repository.findById(saved.getId()))
+                .get()
+                .extracting(Asset::getPrompt)
+                .isEqualTo(prompt);
+    }
 }


### PR DESCRIPTION
## Summary
- add a Liquibase migration that forcefully converts the `asset.prompt` column to `LONGTEXT`
- annotate the JPA entity so both `payload` and `prompt` map explicitly to `LONGTEXT`
- extend the repository test suite with a regression test that saves a large prompt

## Testing
- `mvn -s ../settings.xml test` *(fails: network unreachable while downloading parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d309a1624c8321b1c064fd3248981e