### PR TITLE
refactor: migrate AI worker to OpenAI responses API

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
@@ -3,6 +3,8 @@ package com.marketinghub.worker;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.successproduct.SuccessProduct;
+import com.marketinghub.worker.openai.OpenAiRequestUtils;
+import com.marketinghub.worker.openai.OpenAiResponse;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -12,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -58,17 +61,13 @@ public class OpenAiChatGptClient implements ChatGptClient {
         log.info("Enriching product {} with OpenAI", product.getId());
 
         // ===== 1. Mensagens iniciais
-        List<Map<String, Object>> messages = new ArrayList<>();
-        messages.add(Map.of("role", "system", "content", "Você é um especialista em marketing."));
         String prompt = "Preencha os campos name, explicitPain, promise, uniqueMechanism, " +
                 "tripwire, riskReversal, socialProof, checkoutMonetization, salesFunnel, audienceType, " +
                 "creativeVolume, storytelling, salesPageUrl, instagramUrl, facebookUrl, " +
                 "youtubeUrl em formato JSON. Se houver um link de p\u00e1gina de vendas na\n" +
                 "descri\u00e7\u00e3o, visite a p\u00e1gina para coletar esses detalhes de copy e\n" +
                 "marketing, incluindo links de redes sociais.";
-        messages.add(Map.of("role", "user", "content", prompt + "\n" + product.getDescription()));
 
-        // ===== 2. Definição do tool search_web
         Map<String, Object> searchTool = Map.of(
                 "type", "function",
                 "function", Map.of(
@@ -81,79 +80,65 @@ public class OpenAiChatGptClient implements ChatGptClient {
         List<Object> tools = List.of(searchTool);
 
         try {
-            // ===== 3. Loop principal (tool calling)
+            List<Map<String, Object>> input = new ArrayList<>();
+            input.add(OpenAiRequestUtils.message("system", "Você é um especialista em marketing."));
+            input.add(OpenAiRequestUtils.message("user", prompt + "\n" + product.getDescription()));
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("model", model);
+            payload.put("input", input);
+            payload.put("tools", tools);
+            payload.put("tool_choice", "auto");
+            OpenAiRequestUtils.maybeAddReasoning(payload, model);
+
+            OpenAiResponse response = executeResponseRequest(payload);
+
             while (true) {
-                String requestBody = MAPPER.writeValueAsString(Map.of(
-                        "model", model,
-                        "messages", messages,
-                        "tools", tools,
-                        "tool_choice", "auto"));
-
-                log.info("Sending ChatGPT request with {} messages", messages.size());
-                log.info("ChatGPT request body: {}", requestBody);
-
-                HttpRequest request = HttpRequest.newBuilder()
-                        .uri(URI.create("https://api.openai.com/v1/chat/completions"))
-                        .timeout(Duration.ofMinutes(2))
-                        .header("Authorization", "Bearer " + apiKey)
-                        .header("Content-Type", "application/json")
-                        .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
-                        .build();
-
-                HttpResponse<String> response =
-                        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-                log.info("ChatGPT response body: {}", response.body());
-
-                JsonNode root = MAPPER.readTree(response.body());
-                if (root.has("error")) {
-                    log.error("OpenAI error: {}", root.path("error").path("message").asText());
+                if (response == null) {
+                    log.error("OpenAI returned null response for product {}", product.getId());
+                    return product;
+                }
+                if (response.hasError()) {
+                    log.error("OpenAI error: {}", response.errorMessage());
                     return product;
                 }
 
-                JsonNode choice = root.path("choices").get(0);
-                if (choice == null || choice.isNull()) {
-                    log.error("OpenAI response missing choices");
-                    return product;
-                }
-
-                JsonNode messageNode = choice.path("message");
-                // add the assistant message so the next request keeps the conversation context
-                @SuppressWarnings("unchecked")
-                Map<String, Object> assistantMsg = MAPPER.convertValue(messageNode, Map.class);
-                messages.add(assistantMsg);
-
-                String finishReason = choice.path("finish_reason").asText();
-
-                log.info("OpenAI finish reason: {}", finishReason);
-
-                // ===== 3a. Modelo quer usar o tool search_web
-                if ("tool".equals(finishReason) || "tool_calls".equals(finishReason)) {
-                    JsonNode toolCall = choice.path("message").path("tool_call");
-                    if (toolCall == null || toolCall.isMissingNode() || toolCall.isNull()) {
-                        JsonNode array = choice.path("message").path("tool_calls");
-                        if (array.isArray() && array.size() > 0) {
-                            toolCall = array.get(0);
-                        }
+                List<OpenAiResponse.OpenAiToolCall> toolCalls = response.firstToolCalls();
+                if (!toolCalls.isEmpty()) {
+                    OpenAiResponse.OpenAiToolCall toolCall = toolCalls.get(0);
+                    String functionName = toolCall.function() != null ? toolCall.function().name() : null;
+                    if (!"search_web".equals(functionName)) {
+                        log.warn("Ignoring unsupported tool {} for product {}", functionName, product.getId());
+                        return product;
                     }
-
-                    String callId = toolCall.path("id").asText();
-                    String query = toolCall.path("function").path("arguments").path("query").asText();
+                    String query = extractSearchQuery(toolCall);
+                    if (query == null || query.isBlank()) {
+                        log.warn("Search tool call without query for product {}", product.getId());
+                        return product;
+                    }
                     log.info("Searching web for '{}'", query);
                     List<SearchResult> results = searchWeb(query);
                     log.info("Search returned {} results", results.size());
                     String toolContent = MAPPER.writeValueAsString(Map.of("results", results));
 
-                    messages.add(Map.of(
-                            "role", "tool",
-                            "tool_call_id", callId,
-                            "name", "search_web",
-                            "content", toolContent));
-                    continue; // volta ao início do loop
+                    Map<String, Object> followUp = new LinkedHashMap<>();
+                    followUp.put("model", model);
+                    followUp.put("previous_response_id", response.id());
+                    followUp.put("input", List.of(OpenAiRequestUtils.toolOutput(toolCall.effectiveCallId(), toolContent)));
+                    followUp.put("tools", tools);
+                    followUp.put("tool_choice", "auto");
+                    OpenAiRequestUtils.maybeAddReasoning(followUp, model);
+
+                    response = executeResponseRequest(followUp);
+                    continue;
                 }
 
-                // ===== 3b. Resposta final do modelo
-                String content = choice.path("message").path("content").asText();
+                String content = response.firstText();
+                if (content == null || content.isBlank()) {
+                    log.error("OpenAI returned empty content for product {}", product.getId());
+                    return product;
+                }
+
                 content = stripCodeFence(content);
                 JsonNode data = MAPPER.readTree(content);
 
@@ -212,6 +197,46 @@ public class OpenAiChatGptClient implements ChatGptClient {
             }
         }
         return list;
+    }
+
+    private OpenAiResponse executeResponseRequest(Map<String, Object> payload) throws Exception {
+        String requestBody = MAPPER.writeValueAsString(payload);
+        log.info("Sending OpenAI Responses request: {}", requestBody);
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create("https://api.openai.com/v1/responses"))
+                .timeout(Duration.ofMinutes(2))
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Content-Type", "application/json");
+        if (OpenAiRequestUtils.requiresReasoning(model)) {
+            builder.header("OpenAI-Beta", "reasoning=1");
+        }
+        HttpRequest request = builder
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        log.info("OpenAI response body: {}", response.body());
+        return MAPPER.readValue(response.body(), OpenAiResponse.class);
+    }
+
+    private String extractSearchQuery(OpenAiResponse.OpenAiToolCall toolCall) {
+        if (toolCall == null || toolCall.function() == null) {
+            return null;
+        }
+        String args = toolCall.function().arguments();
+        if (args == null || args.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode node = MAPPER.readTree(args);
+            JsonNode queryNode = node.path("query");
+            if (queryNode.isTextual()) {
+                return queryNode.asText();
+            }
+            return queryNode.isNull() ? null : queryNode.toString();
+        } catch (Exception e) {
+            log.warn("Failed to parse tool arguments: {}", args, e);
+            return null;
+        }
     }
 
     private static String stripCodeFence(String text) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/adset/AudienceAdSetChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/adset/AudienceAdSetChatGptClient.java
@@ -9,6 +9,8 @@ import com.marketinghub.audience.Audience;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.worker.openai.OpenAiRequestUtils;
+import com.marketinghub.worker.openai.OpenAiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,6 +20,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -41,35 +44,45 @@ public class AudienceAdSetChatGptClient {
                                       @Value("${openai.api-key:}") String apiKey,
                                       @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
                                       @Value("${openai.model:gpt-3.5-turbo}") String model) {
-        this.webClient = builder
+        WebClient.Builder clientBuilder = builder
                 .baseUrl(baseUrl)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
-                .build();
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
+        if (OpenAiRequestUtils.requiresReasoning(model)) {
+            clientBuilder.defaultHeader("OpenAI-Beta", "reasoning=1");
+        }
+        this.webClient = clientBuilder.build();
         this.objectMapper = objectMapper;
         this.model = model;
     }
 
     public AdSetPlan planAdSet(Experiment experiment, Audience audience) {
         String prompt = buildPrompt(experiment, audience);
-        Map<String, Object> payload = Map.of(
-                "model", model,
-                "messages", List.of(
-                        Map.of("role", "system", "content", "Você é um especialista em mídia paga para Meta Ads."),
-                        Map.of("role", "user", "content", prompt)
-                )
+        List<Map<String, Object>> input = List.of(
+                OpenAiRequestUtils.message("system", "Você é um especialista em mídia paga para Meta Ads."),
+                OpenAiRequestUtils.message("user", prompt)
         );
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("model", model);
+        payload.put("input", input);
+        OpenAiRequestUtils.maybeAddReasoning(payload, model);
         log.info("Sending ad set planning prompt for experiment {} audience {}", experiment.getId(), audience.getId());
         log.debug("Ad set planning payload: {}", payload);
-        ChatCompletionResponse response = webClient.post()
-                .uri("/chat/completions")
+        OpenAiResponse response = webClient.post()
+                .uri("/responses")
                 .bodyValue(payload)
                 .retrieve()
-                .bodyToMono(ChatCompletionResponse.class)
+                .bodyToMono(OpenAiResponse.class)
                 .block();
-        if (response == null || response.choices().isEmpty()) {
+        if (response == null) {
             throw new IllegalStateException("ChatGPT returned no choices for ad set planning");
         }
-        String content = response.choices().get(0).message().content();
+        if (response.hasError()) {
+            throw new RuntimeException("OpenAI error: " + response.errorMessage());
+        }
+        String content = response.firstText();
+        if (content == null || content.isBlank()) {
+            throw new IllegalStateException("ChatGPT returned empty content for ad set planning");
+        }
         log.info("ChatGPT ad set content: {}", content);
         try {
             return parseContent(content, prompt);
@@ -309,10 +322,4 @@ public class AudienceAdSetChatGptClient {
             sb.append(label).append(": ").append(value.trim()).append('\n');
         }
     }
-
-    private record ChatCompletionResponse(List<Choice> choices) {}
-
-    private record Choice(Message message) {}
-
-    private record Message(String content) {}
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/audience/AudienceChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/audience/AudienceChatGptClient.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.audience.dto.CreateAudienceRequest;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.worker.openai.OpenAiRequestUtils;
+import com.marketinghub.worker.openai.OpenAiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -35,10 +38,13 @@ public class AudienceChatGptClient {
                                  @Value("${openai.api-key:}") String apiKey,
                                  @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
                                  @Value("${openai.model:gpt-3.5-turbo}") String model) {
-        this.webClient = builder
+        WebClient.Builder clientBuilder = builder
                 .baseUrl(baseUrl)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
-                .build();
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
+        if (OpenAiRequestUtils.requiresReasoning(model)) {
+            clientBuilder.defaultHeader("OpenAI-Beta", "reasoning=1");
+        }
+        this.webClient = clientBuilder.build();
         this.objectMapper = objectMapper;
         this.model = model;
     }
@@ -47,30 +53,40 @@ public class AudienceChatGptClient {
                                                          List<Hypothesis> hypotheses,
                                                          int quantity) {
         PromptData promptData = buildPrompt(niche, hypotheses, quantity);
-        Map<String, Object> payload = Map.of(
-                "model", model,
-                "messages", List.of(
-                        Map.of("role", "system", "content", "Você é um especialista em marketing e segmentação para anúncios da Meta."),
-                        Map.of("role", "user", "content", promptData.prompt())
-                )
+        List<Map<String, Object>> input = List.of(
+                OpenAiRequestUtils.message("system", "Você é um especialista em marketing e segmentação para anúncios da Meta."),
+                OpenAiRequestUtils.message("user", promptData.prompt())
         );
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("model", model);
+        payload.put("input", input);
+        OpenAiRequestUtils.maybeAddReasoning(payload, model);
 
         log.info("Sending prompt to ChatGPT for niche {}: {}", niche.getId(), promptData.prompt());
         log.debug("ChatGPT payload: {}", payload);
 
-        ChatCompletionResponse response = webClient.post()
-                .uri("/chat/completions")
+        OpenAiResponse response = webClient.post()
+                .uri("/responses")
                 .bodyValue(payload)
                 .retrieve()
-                .bodyToMono(ChatCompletionResponse.class)
+                .bodyToMono(OpenAiResponse.class)
                 .block();
 
-        if (response == null || response.choices().isEmpty()) {
+        if (response == null) {
             log.warn("ChatGPT returned no choices for niche {}", niche.getId());
             return List.of();
         }
 
-        String content = response.choices().get(0).message().content();
+        if (response.hasError()) {
+            throw new RuntimeException("OpenAI error: " + response.errorMessage());
+        }
+
+        String content = response.firstText();
+        if (content == null || content.isBlank()) {
+            log.warn("ChatGPT returned empty content for niche {}", niche.getId());
+            return List.of();
+        }
         log.info("ChatGPT content: {}", content);
 
         try {
@@ -198,8 +214,5 @@ public class AudienceChatGptClient {
         return trimmed.substring(0, maxLength);
     }
 
-    private record ChatCompletionResponse(List<Choice> choices) {}
-    private record Choice(Message message) {}
-    private record Message(String content) {}
     private record PromptData(String prompt, Set<UUID> hypothesisIds) {}
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
@@ -19,8 +19,12 @@ import reactor.netty.http.client.HttpClient;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.marketinghub.worker.openai.OpenAiRequestUtils;
+import com.marketinghub.worker.openai.OpenAiResponse;
 
 /**
  * Simple wrapper around the OpenAI chat completions API for creative generation.
@@ -52,6 +56,9 @@ public class CreativeChatGptClient {
                 .clientConnector(new ReactorClientHttpConnector(httpClient));
         if (enabled) {
             clientBuilder.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
+            if (OpenAiRequestUtils.requiresReasoning(model)) {
+                clientBuilder.defaultHeader("OpenAI-Beta", "reasoning=1");
+            }
         }
         this.webClient = clientBuilder.build();
         this.objectMapper = objectMapper;
@@ -67,24 +74,26 @@ public class CreativeChatGptClient {
             return List.of();
         }
         String prompt = buildPrompt(experiment, quantity);
-        Map<String, Object> payload = Map.of(
-                "model", model,
-                "messages", List.of(
-                        Map.of("role", "system", "content", "Você é um especialista em marketing."),
-                        Map.of("role", "user", "content", prompt)
-                )
+        List<Map<String, Object>> input = List.of(
+                OpenAiRequestUtils.message("system", "Você é um especialista em marketing."),
+                OpenAiRequestUtils.message("user", prompt)
         );
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("model", model);
+        payload.put("input", input);
+        OpenAiRequestUtils.maybeAddReasoning(payload, model);
 
         log.info("Sending prompt to ChatGPT for experiment {}: {}", experiment.getId(), prompt);
         log.debug("ChatGPT payload: {}", payload);
 
-        ChatCompletionResponse response;
+        OpenAiResponse response;
         try {
             response = webClient.post()
-                    .uri("/chat/completions")
+                    .uri("/responses")
                     .bodyValue(payload)
                     .retrieve()
-                    .bodyToMono(ChatCompletionResponse.class)
+                    .bodyToMono(OpenAiResponse.class)
                     .block(REQUEST_TIMEOUT);
         } catch (Exception ex) {
             log.error("ChatGPT request failed for experiment {} after {} seconds", experiment.getId(),
@@ -94,11 +103,18 @@ public class CreativeChatGptClient {
 
         log.info("ChatGPT raw response: {}", response);
 
-        if (response == null || response.choices().isEmpty()) {
+        if (response == null) {
             log.warn("ChatGPT returned no choices for experiment {}", experiment.getId());
             return List.of();
         }
-        String content = response.choices().get(0).message().content();
+        if (response.hasError()) {
+            throw new RuntimeException("OpenAI error: " + response.errorMessage());
+        }
+        String content = response.firstText();
+        if (content == null || content.isBlank()) {
+            log.warn("ChatGPT returned empty content for experiment {}", experiment.getId());
+            return List.of();
+        }
         log.info("ChatGPT content: {}", content);
         try {
             List<CreateCreativeRequest> parsed = parseContent(content);
@@ -151,7 +167,4 @@ public class CreativeChatGptClient {
         return Arrays.asList(arr);
     }
 
-    private record ChatCompletionResponse(List<Choice> choices) {}
-    private record Choice(Message message) {}
-    private record Message(String content) {}
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -9,6 +9,8 @@ import com.marketinghub.prompt.PromptAttribute;
 import com.marketinghub.prompt.PromptAttributeDescription;
 import com.marketinghub.prompt.repository.PromptAttributeDescriptionRepository;
 import com.marketinghub.prompt.repository.PromptAttributeRepository;
+import com.marketinghub.worker.openai.OpenAiRequestUtils;
+import com.marketinghub.worker.openai.OpenAiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -41,10 +44,13 @@ public class ChatGptClient {
                          @Value("${openai.model:gpt-3.5-turbo}") String model,
                          PromptAttributeRepository attributeRepository,
                          PromptAttributeDescriptionRepository descriptionRepository) {
-        this.webClient = builder
+        WebClient.Builder clientBuilder = builder
                 .baseUrl(baseUrl)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
-                .build();
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
+        if (OpenAiRequestUtils.requiresReasoning(model)) {
+            clientBuilder.defaultHeader("OpenAI-Beta", "reasoning=1");
+        }
+        this.webClient = clientBuilder.build();
         this.objectMapper = objectMapper;
         this.model = model;
         this.attributeRepository = attributeRepository;
@@ -53,31 +59,40 @@ public class ChatGptClient {
 
     public List<CreateHypothesisRequest> generateHypotheses(MarketNiche niche, int quantity) {
         PromptData promptData = buildPrompt(niche, quantity);
-        Map<String, Object> payload = Map.of(
-                "model", model,
-                "messages", List.of(
-                        Map.of("role", "system", "content", "Você é um especialista em marketing."),
-                        Map.of("role", "user", "content", promptData.prompt())
-                )
+        List<Map<String, Object>> input = List.of(
+                OpenAiRequestUtils.message("system", "Você é um especialista em marketing."),
+                OpenAiRequestUtils.message("user", promptData.prompt())
         );
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("model", model);
+        payload.put("input", input);
+        OpenAiRequestUtils.maybeAddReasoning(payload, model);
 
         log.info("Sending prompt to ChatGPT for niche {}: {}", niche.getId(), promptData.prompt());
         log.debug("ChatGPT payload: {}", payload);
 
-        ChatCompletionResponse response = webClient.post()
-                .uri("/chat/completions")
+        OpenAiResponse response = webClient.post()
+                .uri("/responses")
                 .bodyValue(payload)
                 .retrieve()
-                .bodyToMono(ChatCompletionResponse.class)
+                .bodyToMono(OpenAiResponse.class)
                 .block();
 
         log.info("ChatGPT raw response: {}", response);
 
-        if (response == null || response.choices().isEmpty()) {
+        if (response == null) {
             log.warn("ChatGPT returned no choices for niche {}", niche.getId());
             return List.of();
         }
-        String content = response.choices().get(0).message().content();
+        if (response.hasError()) {
+            throw new RuntimeException("OpenAI error: " + response.errorMessage());
+        }
+        String content = response.firstText();
+        if (content == null || content.isBlank()) {
+            log.warn("ChatGPT returned empty content for niche {}", niche.getId());
+            return List.of();
+        }
         log.info("ChatGPT content: {}", content);
         try {
             List<CreateHypothesisRequest> parsed = parseContent(content, niche, promptData);
@@ -145,10 +160,6 @@ public class ChatGptClient {
         sb.append("Retorne apenas um array JSON com esses objetos, sem texto adicional.");
         return new PromptData(sb.toString(), descriptionIds);
     }
-
-    private record ChatCompletionResponse(List<Choice> choices) {}
-    private record Choice(Message message) {}
-    private record Message(String content) {}
 
     private List<CreateHypothesisRequest> parseContent(String content, MarketNiche niche, PromptData data) throws Exception {
         JsonNode root = objectMapper.readTree(content);

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/OpenAiRequestUtils.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/OpenAiRequestUtils.java
@@ -1,0 +1,50 @@
+package com.marketinghub.worker.openai;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Helper methods to build payloads for the OpenAI Responses API.
+ */
+public final class OpenAiRequestUtils {
+
+    private OpenAiRequestUtils() {
+    }
+
+    public static Map<String, Object> message(String role, String text) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("role", role);
+        message.put("content", List.of(textContent(text)));
+        return message;
+    }
+
+    public static Map<String, Object> textContent(String text) {
+        Map<String, Object> content = new LinkedHashMap<>();
+        content.put("type", "input_text");
+        content.put("text", text);
+        return content;
+    }
+
+    public static Map<String, Object> toolOutput(String callId, String output) {
+        Map<String, Object> tool = new LinkedHashMap<>();
+        tool.put("type", "function_call_output");
+        tool.put("call_id", callId);
+        tool.put("output", output);
+        return tool;
+    }
+
+    public static void maybeAddReasoning(Map<String, Object> payload, String model) {
+        if (requiresReasoning(model)) {
+            payload.put("reasoning", Map.of("effort", "medium"));
+        }
+    }
+
+    public static boolean requiresReasoning(String model) {
+        if (model == null) {
+            return false;
+        }
+        String normalized = model.toLowerCase();
+        return normalized.startsWith("o");
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/OpenAiResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/OpenAiResponse.java
@@ -1,0 +1,120 @@
+package com.marketinghub.worker.openai;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record OpenAiResponse(
+        String id,
+        @JsonProperty("output_text") String outputText,
+        List<OpenAiOutput> output,
+        OpenAiError error,
+        String status) {
+
+    public String firstText() {
+        if (outputText != null && !outputText.isBlank()) {
+            return outputText;
+        }
+        if (output != null) {
+            for (OpenAiOutput item : output) {
+                String text = item.firstText();
+                if (text != null && !text.isBlank()) {
+                    return text;
+                }
+            }
+        }
+        return null;
+    }
+
+    public List<OpenAiToolCall> firstToolCalls() {
+        if (output == null) {
+            return List.of();
+        }
+        for (OpenAiOutput item : output) {
+            List<OpenAiToolCall> calls = item.combinedToolCalls();
+            if (!calls.isEmpty()) {
+                return calls;
+            }
+        }
+        return List.of();
+    }
+
+    public boolean hasError() {
+        return error != null && error.message() != null && !error.message().isBlank();
+    }
+
+    public String errorMessage() {
+        if (!hasError()) {
+            return null;
+        }
+        if (error.code() != null && !error.code().isBlank()) {
+            return error.code() + ": " + error.message();
+        }
+        if (error.type() != null && !error.type().isBlank()) {
+            return error.type() + ": " + error.message();
+        }
+        return error.message();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OpenAiError(String message, String type, String code) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OpenAiOutput(
+            String id,
+            String type,
+            String role,
+            List<OpenAiContent> content,
+            @JsonProperty("tool_call") OpenAiToolCall toolCall,
+            @JsonProperty("tool_calls") List<OpenAiToolCall> toolCalls) {
+
+        public List<OpenAiToolCall> combinedToolCalls() {
+            if (toolCalls != null && !toolCalls.isEmpty()) {
+                return toolCalls;
+            }
+            if (toolCall != null) {
+                return List.of(toolCall);
+            }
+            return Collections.emptyList();
+        }
+
+        public String firstText() {
+            if (content == null) {
+                return null;
+            }
+            for (OpenAiContent item : content) {
+                if (item.text() != null && !item.text().isBlank()) {
+                    return item.text();
+                }
+            }
+            return null;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OpenAiContent(String type, String text) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OpenAiToolCall(
+            String id,
+            @JsonProperty("call_id") String callId,
+            String type,
+            OpenAiFunctionCall function) {
+
+        public String effectiveCallId() {
+            if (callId != null && !callId.isBlank()) {
+                return callId;
+            }
+            return id;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OpenAiFunctionCall(String name, String arguments) {
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/successproduct/SuccessProductOpenAiChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/successproduct/SuccessProductOpenAiChatGptClient.java
@@ -3,6 +3,9 @@ package com.marketinghub.worker.successproduct;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.successproduct.SuccessProduct;
+import com.marketinghub.worker.openai.OpenAiRequestUtils;
+import com.marketinghub.worker.openai.OpenAiResponse;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -32,37 +35,51 @@ public class SuccessProductOpenAiChatGptClient implements ChatGptClient {
             @Value("${openai.api-key:}") String apiKey,
             @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
             @Value("${openai.model:gpt-3.5-turbo}") String model) {
-        this.webClient = builder
+        WebClient.Builder clientBuilder = builder
                 .baseUrl(baseUrl)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
-                .build();
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
+        if (OpenAiRequestUtils.requiresReasoning(model)) {
+            clientBuilder.defaultHeader("OpenAI-Beta", "reasoning=1");
+        }
+        this.webClient = clientBuilder.build();
         this.objectMapper = objectMapper;
         this.model = model;
     }
 
     @Override
     public NicheHypothesis extract(SuccessProduct product) {
-        Map<String, Object> payload = Map.of(
-                "model", model,
-                "messages", List.of(
-                        Map.of("role", "system", "content", "Você é um especialista em marketing."),
-                        Map.of("role", "user", "content", buildPrompt(product))));
+        List<Map<String, Object>> input = List.of(
+                OpenAiRequestUtils.message("system", "Você é um especialista em marketing."),
+                OpenAiRequestUtils.message("user", buildPrompt(product))
+        );
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("model", model);
+        payload.put("input", input);
+        OpenAiRequestUtils.maybeAddReasoning(payload, model);
 
         log.info("Sending prompt to ChatGPT for product {}", product.getId());
-        ChatCompletionResponse response = webClient.post()
-                .uri("/chat/completions")
+        OpenAiResponse response = webClient.post()
+                .uri("/responses")
                 .bodyValue(payload)
                 .retrieve()
-                .bodyToMono(ChatCompletionResponse.class)
+                .bodyToMono(OpenAiResponse.class)
                 .block();
 
         log.info("ChatGPT raw response: {}", response);
 
-        if (response == null || response.choices().isEmpty()) {
+        if (response == null) {
             log.warn("ChatGPT returned no choices for product {}", product.getId());
             return null;
         }
-        String content = response.choices().get(0).message().content();
+        if (response.hasError()) {
+            log.error("OpenAI error while processing product {}: {}", product.getId(), response.errorMessage());
+            return null;
+        }
+        String content = response.firstText();
+        if (content == null || content.isBlank()) {
+            log.warn("ChatGPT returned empty content for product {}", product.getId());
+            return null;
+        }
         log.info("ChatGPT content: {}", content);
         try {
             JsonNode node = objectMapper.readTree(content);
@@ -98,7 +115,4 @@ public class SuccessProductOpenAiChatGptClient implements ChatGptClient {
         return v != null && !v.isNull() ? v.asText() : null;
     }
 
-    private record ChatCompletionResponse(List<Choice> choices) {}
-    private record Choice(Message message) {}
-    private record Message(String content) {}
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -100,7 +100,14 @@ class NicheHypothesisServiceTest {
                 """;
         try {
             String body = new ObjectMapper().writeValueAsString(
-                    Map.of("choices", List.of(Map.of("message", Map.of("content", content)))));
+                    Map.of(
+                            "output", List.of(Map.of(
+                                    "type", "message",
+                                    "role", "assistant",
+                                    "content", List.of(Map.of(
+                                            "type", "output_text",
+                                            "text", content))))),
+                            "output_text", content));
             mockWebServer.enqueue(new MockResponse()
                     .addHeader("Content-Type", "application/json")
                     .setBody(body));
@@ -143,7 +150,14 @@ class NicheHypothesisServiceTest {
                 """;
         try {
             String body = new ObjectMapper().writeValueAsString(
-                    Map.of("choices", List.of(Map.of("message", Map.of("content", content)))));
+                    Map.of(
+                            "output", List.of(Map.of(
+                                    "type", "message",
+                                    "role", "assistant",
+                                    "content", List.of(Map.of(
+                                            "type", "output_text",
+                                            "text", content))))),
+                            "output_text", content));
             mockWebServer.enqueue(new MockResponse()
                     .addHeader("Content-Type", "application/json")
                     .setBody(body));
@@ -177,7 +191,14 @@ class NicheHypothesisServiceTest {
                 """;
         try {
             String body = new ObjectMapper().writeValueAsString(
-                    Map.of("choices", List.of(Map.of("message", Map.of("content", content)))));
+                    Map.of(
+                            "output", List.of(Map.of(
+                                    "type", "message",
+                                    "role", "assistant",
+                                    "content", List.of(Map.of(
+                                            "type", "output_text",
+                                            "text", content))))),
+                            "output_text", content));
             mockWebServer.enqueue(new MockResponse()
                     .addHeader("Content-Type", "application/json")
                     .setBody(body));
@@ -208,7 +229,14 @@ class NicheHypothesisServiceTest {
                 """;
         try {
             String body = new ObjectMapper().writeValueAsString(
-                    Map.of("choices", List.of(Map.of("message", Map.of("content", content)))));
+                    Map.of(
+                            "output", List.of(Map.of(
+                                    "type", "message",
+                                    "role", "assistant",
+                                    "content", List.of(Map.of(
+                                            "type", "output_text",
+                                            "text", content))))),
+                            "output_text", content));
             mockWebServer.enqueue(new MockResponse()
                     .addHeader("Content-Type", "application/json")
                     .setBody(body));


### PR DESCRIPTION
## Summary
- update all chat-based worker clients to call the OpenAI Responses API with the new input schema and error handling
- add reusable helpers to build payloads, parse response text/tool calls, and apply the reasoning header for o-series models
- refactor the success product enrichment loop to feed tool outputs via previous responses and adapt tests to the new payload format

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM; Maven cannot reach https://maven.pkg.github.com/paulofor/marketing-hub)*

------
https://chatgpt.com/codex/tasks/task_e_68d3162d1dcc8321b5b857045739b4f6