### PR TITLE
Limit creative card width on large screens

### DIFF
--- a/frontend/src/pages/experiment/CriativosTab.css
+++ b/frontend/src/pages/experiment/CriativosTab.css
@@ -23,6 +23,16 @@
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+@media (min-width: 992px) {
+  .creative-grid {
+    grid-template-columns: repeat(
+      auto-fit,
+      minmax(260px, clamp(260px, 32vw, 360px))
+    );
+    justify-content: center;
+  }
+}
+
 .creative-card {
   border-radius: 1rem;
   border: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.1));


### PR DESCRIPTION
## Summary
- keep the creative gallery grid responsive but introduce a desktop breakpoint that clamps each column width
- center the grid tracks on large viewports so a small amount of cards no longer stretch excessively

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d340896dcc83219c3233de3e310e54