### PR TITLE
Organize creative sections and add separation border

### DIFF
--- a/frontend/src/pages/experiment/CriativosTab.css
+++ b/frontend/src/pages/experiment/CriativosTab.css
@@ -33,6 +33,13 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.12));
+}
+
+.creative-section:first-of-type {
+  padding-top: 0;
+  border-top: none;
 }
 
 .creative-section-header {

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -306,16 +306,16 @@ export default function CriativosTab({ experimentId }: Props) {
   const pendingCreatives = creatives.filter((c) => c.status !== "READY");
   const creativeSections = [
     {
-      id: "pending",
-      title: "Aguardando aprovação",
-      badgeClass: "text-bg-warning",
-      creatives: pendingCreatives,
-    },
-    {
       id: "approved",
       title: "Aprovados",
       badgeClass: "text-bg-success",
       creatives: readyCreatives,
+    },
+    {
+      id: "pending",
+      title: "Aguardando aprovação",
+      badgeClass: "text-bg-warning",
+      creatives: pendingCreatives,
     },
   ].filter((section) => section.creatives.length > 0);
 


### PR DESCRIPTION
## Summary
- show approved creatives before pending ones in the creatives tab
- add a top border and padding to visually separate creative status sections

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d41c7d96e8832180cc22261bf413c0