### PR TITLE
feat: display icons in niche hypothesis experiment pages

### DIFF
--- a/frontend/src/assets/icons/experiment-icon.svg
+++ b/frontend/src/assets/icons/experiment-icon.svg
@@ -1,0 +1,79 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="experimentBg" x1="24" y1="20" x2="136" y2="148" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#e7fbf7" />
+      <stop offset="1" stop-color="#d5f0ff" />
+    </linearGradient>
+    <linearGradient id="experimentGlass" x1="64" y1="36" x2="104" y2="132" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7cd9ff" />
+      <stop offset="1" stop-color="#3bc9db" />
+    </linearGradient>
+    <linearGradient id="experimentLiquid" x1="60" y1="86" x2="112" y2="132" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#63e6be" />
+      <stop offset="1" stop-color="#12b886" />
+    </linearGradient>
+    <linearGradient id="experimentHighlight" x1="72" y1="58" x2="92" y2="102" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f8fff4" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#c8fff5" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="36" fill="url(#experimentBg)" />
+  <path
+    d="M94 40H66c-2.2 0-3.6 2.3-2.6 4.3l14.6 29.4a8 8 0 0 1 .8 3.6v10.7c0 2.1-.8 4.2-2.2 5.8l-18.6 20.6c-3.5 3.9-.7 10.1 4.5 10.1h55.4c5.2 0 8-6.2 4.5-10.1L103.8 94c-1.4-1.6-2.2-3.7-2.2-5.8V77.3c0-1.2.3-2.4.8-3.6L117 44.3c1-2-.5-4.3-2.6-4.3H94z"
+    fill="url(#experimentGlass)"
+    opacity="0.9"
+  />
+  <path
+    d="M62 101h36c2.6 0 5.1 1 6.9 2.9l13.6 14.4H55.5l12.3-13c1.7-1.8 4.1-2.8 6.6-2.8z"
+    fill="url(#experimentLiquid)"
+  />
+  <path
+    d="M74 82h12"
+    stroke="#ffffff"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-opacity="0.65"
+  />
+  <path
+    d="M70 70h20"
+    stroke="#ffffff"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-opacity="0.45"
+  />
+  <circle cx="88" cy="94" r="8" fill="#0d6efd" fill-opacity="0.18" />
+  <circle cx="88" cy="94" r="4" fill="#4dabf7" />
+  <circle cx="104" cy="66" r="6" fill="#12b886" fill-opacity="0.35" />
+  <circle cx="106" cy="50" r="5" fill="#0d6efd" fill-opacity="0.25" />
+  <circle cx="54" cy="62" r="7" fill="#4dabf7" fill-opacity="0.35" />
+  <path
+    d="M66 40h28"
+    stroke="#0d6efd"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-opacity="0.45"
+  />
+  <path
+    d="M82 46v30"
+    stroke="#6f42c1"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-opacity="0.4"
+  />
+  <ellipse cx="82" cy="104" rx="26" ry="6" fill="#0d6efd" fill-opacity="0.18" />
+  <path
+    d="M86 94c-4.5 0-8.5 2.4-10.7 6.2L64 118"
+    stroke="#12b886"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    opacity="0.55"
+  />
+  <circle cx="80" cy="80" r="64" stroke="white" stroke-opacity="0.2" stroke-width="8" />
+  <path
+    d="M92 52c0 5.5-4.5 10-10 10s-10-4.5-10-10"
+    stroke="url(#experimentHighlight)"
+    stroke-width="6"
+    stroke-linecap="round"
+  />
+</svg>

--- a/frontend/src/assets/icons/hypothesis-icon.svg
+++ b/frontend/src/assets/icons/hypothesis-icon.svg
@@ -1,0 +1,61 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="hypothesisBg" x1="36" y1="18" x2="134" y2="150" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff7eb" />
+      <stop offset="1" stop-color="#ffe3d4" />
+    </linearGradient>
+    <linearGradient id="hypothesisBulb" x1="60" y1="40" x2="108" y2="108" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f9b516" />
+      <stop offset="1" stop-color="#f76707" />
+    </linearGradient>
+    <linearGradient id="hypothesisBase" x1="68" y1="108" x2="92" y2="130" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6f42c1" />
+      <stop offset="1" stop-color="#4dabf7" />
+    </linearGradient>
+    <linearGradient id="hypothesisGlow" x1="80" y1="32" x2="80" y2="128" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffe8cc" stop-opacity="0.95" />
+      <stop offset="1" stop-color="#ffd8a8" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="36" fill="url(#hypothesisBg)" />
+  <circle cx="80" cy="80" r="60" fill="url(#hypothesisGlow)" />
+  <path
+    d="M80 40c-19 0-34 15-34 33.5 0 10.5 5 20.3 13.3 26.8 4 3.2 6.7 7.9 6.7 13v4.7c0 2.1 1.7 3.8 3.8 3.8h20.4c2.1 0 3.8-1.7 3.8-3.8v-4.7c0-5.1 2.7-9.8 6.7-13 8.3-6.5 13.3-16.3 13.3-26.8C114 55 99 40 80 40z"
+    fill="url(#hypothesisBulb)"
+  />
+  <path
+    d="M64 113h32"
+    stroke="white"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-opacity="0.65"
+  />
+  <path
+    d="M68 122h24"
+    stroke="white"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-opacity="0.5"
+  />
+  <path
+    d="M70 128h20"
+    stroke="white"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-opacity="0.45"
+  />
+  <path
+    d="M68 103h24c4.4 0 8-3.6 8-8v-1c0-1.5-.5-3-1.4-4.3l-6.2-8.6a4 4 0 0 0-3.2-1.6H70.8a4 4 0 0 0-3.2 1.6l-6.2 8.6c-.9 1.3-1.4 2.8-1.4 4.3v1c0 4.4 3.6 8 8 8z"
+    fill="url(#hypothesisBase)"
+  />
+  <g stroke="#f08c00" stroke-linecap="round" stroke-width="6" opacity="0.75">
+    <line x1="80" y1="26" x2="80" y2="14" />
+    <line x1="60" y1="32" x2="52" y2="22" />
+    <line x1="100" y1="32" x2="108" y2="22" />
+  </g>
+  <g stroke="#6f42c1" stroke-linecap="round" stroke-width="4" opacity="0.6">
+    <line x1="52" y1="52" x2="40" y2="48" />
+    <line x1="108" y1="52" x2="120" y2="48" />
+  </g>
+  <circle cx="80" cy="80" r="64" stroke="white" stroke-opacity="0.2" stroke-width="8" />
+</svg>

--- a/frontend/src/assets/icons/niche-icon.svg
+++ b/frontend/src/assets/icons/niche-icon.svg
@@ -1,0 +1,54 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="nicheBg" x1="30" y1="18" x2="132" y2="150" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f8f9ff" />
+      <stop offset="1" stop-color="#e9edff" />
+    </linearGradient>
+    <linearGradient id="nicheRing" x1="40" y1="40" x2="120" y2="120" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0d6efd" />
+      <stop offset="1" stop-color="#6f42c1" />
+    </linearGradient>
+    <linearGradient id="nicheCenter" x1="68" y1="64" x2="102" y2="100" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0d6efd" />
+      <stop offset="1" stop-color="#4dabf7" />
+    </linearGradient>
+    <linearGradient id="nicheArc" x1="48" y1="54" x2="120" y2="106" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6f42c1" />
+      <stop offset="1" stop-color="#51cf66" stop-opacity="0.85" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="36" fill="url(#nicheBg)" />
+  <g opacity="0.9">
+    <circle cx="80" cy="80" r="54" fill="#ffffff" fill-opacity="0.85" />
+    <circle cx="80" cy="80" r="54" stroke="url(#nicheRing)" stroke-width="4" />
+    <circle cx="80" cy="80" r="38" fill="#ffffff" fill-opacity="0.75" />
+    <circle cx="80" cy="80" r="38" stroke="url(#nicheRing)" stroke-width="3" opacity="0.65" />
+    <circle cx="80" cy="80" r="22" fill="url(#nicheCenter)" />
+    <circle cx="80" cy="80" r="12" fill="#ffffff" fill-opacity="0.65" />
+  </g>
+  <g stroke-linecap="round" stroke-width="4" stroke="url(#nicheRing)" opacity="0.65">
+    <line x1="80" y1="40" x2="80" y2="64" />
+    <line x1="80" y1="96" x2="80" y2="120" />
+    <line x1="40" y1="80" x2="64" y2="80" />
+    <line x1="96" y1="80" x2="120" y2="80" />
+  </g>
+  <path
+    d="M108.5 55.5c5.6 7.7 7.7 18.1 5.1 27.5-2.6 9.4-9.3 17.5-18.2 22.1"
+    stroke="url(#nicheArc)"
+    stroke-width="5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    fill="none"
+    opacity="0.75"
+  />
+  <path
+    d="M108 55l-17 4.5c-1.6.4-2.1 2.4-.9 3.5l6 5.4"
+    fill="none"
+    stroke="#6f42c1"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    opacity="0.8"
+  />
+  <circle cx="80" cy="80" r="64" stroke="white" stroke-opacity="0.25" stroke-width="8" />
+</svg>

--- a/frontend/src/components/PageTitle.css
+++ b/frontend/src/components/PageTitle.css
@@ -2,7 +2,7 @@
   margin-bottom: clamp(1.5rem, 1.2rem + 1vw, 2.25rem);
   display: inline-flex;
   align-items: center;
-  gap: 0.85rem;
+  gap: clamp(0.85rem, 0.65rem + 0.65vw, 1.5rem);
   font-size: clamp(2rem, 1.5rem + 1.2vw, 2.75rem);
   font-weight: 700;
   line-height: 1.1;
@@ -10,6 +10,31 @@
   color: var(--bs-emphasis-color, #212529);
   font-family: "Segoe UI", "Inter", "Helvetica Neue", Arial, sans-serif;
   position: relative;
+}
+
+.page-title-icon {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(52px, 7.5vw, 92px);
+  height: clamp(52px, 7.5vw, 92px);
+  padding: clamp(0.35rem, 0.3rem + 0.35vw, 0.65rem);
+  border-radius: clamp(18px, 14px + 1vw, 28px);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--bs-primary-rgb, 13, 110, 253), 0.12) 0%,
+    rgba(var(--bs-purple-rgb, 111, 66, 193), 0.12) 100%
+  );
+  box-shadow: 0 22px 48px -20px rgba(var(--bs-primary-rgb, 13, 110, 253), 0.35);
+  overflow: hidden;
+}
+
+.page-title-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
 }
 
 .page-title::after {

--- a/frontend/src/components/PageTitle.tsx
+++ b/frontend/src/components/PageTitle.tsx
@@ -3,11 +3,22 @@ import "./PageTitle.css";
 
 interface PageTitleProps {
   children: ReactNode;
+  icon?: string;
+  iconAlt?: string;
 }
 
-export default function PageTitle({ children }: PageTitleProps) {
+export default function PageTitle({
+  children,
+  icon,
+  iconAlt = "",
+}: PageTitleProps) {
   return (
     <h1 className="page-title">
+      {icon ? (
+        <span className="page-title-icon">
+          <img src={icon} alt={iconAlt} loading="lazy" />
+        </span>
+      ) : null}
       <span className="page-title-text">{children}</span>
     </h1>
   );

--- a/frontend/src/pages/experiment/EditExperimentPage.tsx
+++ b/frontend/src/pages/experiment/EditExperimentPage.tsx
@@ -6,6 +6,7 @@ import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
 import { useMetricPresets } from "../../api/experiment/useMetricPresets";
 import { useFunnels } from "../../api/funnel/useFunnels";
 import PageTitle from "../../components/PageTitle";
+import experimentIcon from "../../assets/icons/experiment-icon.svg";
 
 interface FormData {
   name: string;
@@ -59,7 +60,7 @@ export default function EditExperimentPage() {
 
   return (
     <div style={{ maxWidth: 480 }}>
-      <PageTitle>Editar Experimento</PageTitle>
+      <PageTitle icon={experimentIcon}>Editar Experimento</PageTitle>
       <form onSubmit={handleSubmit(onSubmit)} noValidate>
         <label className="form-label" htmlFor="name">
           Nome

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -5,6 +5,7 @@ import { useMetricPresets } from "../../api/experiment/useMetricPresets";
 import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import PageTitle from "../../components/PageTitle";
+import experimentIcon from "../../assets/icons/experiment-icon.svg";
 import CriativosTab from "./CriativosTab";
 import PublicosTab from "./PublicosTab";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
@@ -128,7 +129,7 @@ export default function ExperimentDetailPage() {
     <div>
       <div className="d-flex justify-content-between align-items-start">
         <div>
-          <PageTitle>{data.name}</PageTitle>
+          <PageTitle icon={experimentIcon}>{data.name}</PageTitle>
           <p className="text-muted mb-0">{data.hypothesis}</p>
         </div>
         <div className="d-flex align-items-center">

--- a/frontend/src/pages/experiment/ExperimentListPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { useExperiments } from "../../api/experiment/useExperiments";
 import { useNiches } from "../../api/niche/useNiches";
 import PageTitle from "../../components/PageTitle";
+import experimentIcon from "../../assets/icons/experiment-icon.svg";
 import { useState } from "react";
 
 export default function ExperimentListPage() {
@@ -20,7 +21,7 @@ export default function ExperimentListPage() {
   if (isLoading) return <p>Carregando...</p>;
   return (
     <div>
-      <PageTitle>Testes de Nicho</PageTitle>
+      <PageTitle icon={experimentIcon}>Testes de Nicho</PageTitle>
       <Link className="btn btn-primary mb-3" to="/experiments/new">
         Novo Teste
       </Link>

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -7,6 +7,7 @@ import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useMetricPresets } from "../../api/experiment/useMetricPresets";
 import { useFunnels } from "../../api/funnel/useFunnels";
 import PageTitle from "../../components/PageTitle";
+import experimentIcon from "../../assets/icons/experiment-icon.svg";
 
 export default function NewExperimentPage() {
   const [params] = useSearchParams();
@@ -83,7 +84,9 @@ export default function NewExperimentPage() {
 
   return (
     <div>
-      <PageTitle>{selectedNiche?.name || "Novo Teste de Nicho"}</PageTitle>
+      <PageTitle icon={experimentIcon}>
+        {selectedNiche?.name || "Novo Teste de Nicho"}
+      </PageTitle>
       {showNicheSelect && (
         <select
           className="form-select mb-2"

--- a/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/EditHypothesisPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import PageTitle from "../../components/PageTitle";
+import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import { useAngles } from "../../api/angle/useAngles";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useUpdateHypothesis } from "../../api/hypothesis/useUpdateHypothesis";
@@ -106,7 +107,7 @@ export default function EditHypothesisPage() {
 
   return (
     <div style={{ maxWidth: 480 }}>
-      <PageTitle>Editar Hipótese</PageTitle>
+      <PageTitle icon={hypothesisIcon}>Editar Hipótese</PageTitle>
       <form onSubmit={handleSubmit(onSubmit)} noValidate>
         <label className="form-label" htmlFor="title">
           Título

--- a/frontend/src/pages/hypothesis/HypothesesPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesesPage.tsx
@@ -3,6 +3,7 @@ import HypothesisBoard from "./HypothesisBoard";
 import NewHypothesisModal from "./NewHypothesisModal";
 import { useSearchParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
+import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import { useState } from "react";
 import Button from "../../components/ui/Button";
 
@@ -13,7 +14,7 @@ export default function HypothesesPage() {
   const [open, setOpen] = useState(params.get("open") === "new");
   return (
     <div>
-      <PageTitle>Hipóteses</PageTitle>
+      <PageTitle icon={hypothesisIcon}>Hipóteses</PageTitle>
       <div className="mb-3">
         <Button onClick={() => setOpen(true)}>Nova Hipótese</Button>
       </div>

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -5,6 +5,7 @@ import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useExperimentsByHypothesis } from "../../api/experiment/useExperimentsByHypothesis";
 import { useAudiencesByNiche } from "../../api/audience/useAudiencesByNiche";
 import PageTitle from "../../components/PageTitle";
+import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import { AudienceApprovalCard } from "../../components/AudienceApprovalCard";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 import { useForm } from "react-hook-form";
@@ -75,7 +76,7 @@ export default function HypothesisDetailPage() {
   return (
     <div>
       <div className="d-flex justify-content-between align-items-center mb-4">
-        <PageTitle>{data.title}</PageTitle>
+        <PageTitle icon={hypothesisIcon}>{data.title}</PageTitle>
         <div className="d-flex gap-2">
           {data.status === "BACKLOG" && (
             <Link

--- a/frontend/src/pages/hypothesis/HypothesisListPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisListPage.tsx
@@ -1,10 +1,11 @@
 import PageTitle from "../../components/PageTitle";
+import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import HypothesisList from "./HypothesisList";
 
 export default function HypothesisListPage() {
   return (
     <div>
-      <PageTitle>Hipóteses</PageTitle>
+      <PageTitle icon={hypothesisIcon}>Hipóteses</PageTitle>
       <HypothesisList />
     </div>
   );

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
+import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import { useNiche } from "../../api/niche/useNiche";
 
 const schema = z
@@ -102,7 +103,7 @@ export default function NewHypothesisPage() {
 
   return (
     <div style={{ maxWidth: 480 }}>
-      <PageTitle>Nova Hipótese</PageTitle>
+      <PageTitle icon={hypothesisIcon}>Nova Hipótese</PageTitle>
       {niche && (
         <div className="mb-3">
           <div className="d-flex justify-content-between align-items-center">

--- a/frontend/src/pages/niche/EditNichePage.tsx
+++ b/frontend/src/pages/niche/EditNichePage.tsx
@@ -5,6 +5,7 @@ import { useUpdateNiche } from "../../api/niche/useUpdateNiche";
 import { useNiche } from "../../api/niche/useNiche";
 import { useChatDialogs } from "../../api/chatDialog/useChatDialogs";
 import PageTitle from "../../components/PageTitle";
+import nicheIcon from "../../assets/icons/niche-icon.svg";
 import { MarketNiche } from "../../api/niche/useNiches";
 
 export default function EditNichePage() {
@@ -48,7 +49,7 @@ export default function EditNichePage() {
 
   return (
     <div>
-      <PageTitle>Editar Nicho</PageTitle>
+      <PageTitle icon={nicheIcon}>Editar Nicho</PageTitle>
       <label className="form-label">Nome</label>
       <input
         className="form-control mb-2"

--- a/frontend/src/pages/niche/NewNichePage.tsx
+++ b/frontend/src/pages/niche/NewNichePage.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { useCreateNiche } from "../../api/niche/useCreateNiche";
 import { useChatDialogs } from "../../api/chatDialog/useChatDialogs";
 import PageTitle from "../../components/PageTitle";
+import nicheIcon from "../../assets/icons/niche-icon.svg";
 
 export default function NewNichePage() {
   const create = useCreateNiche();
@@ -29,7 +30,7 @@ export default function NewNichePage() {
 
   return (
     <div>
-      <PageTitle>Novo Nicho de Mercado</PageTitle>
+      <PageTitle icon={nicheIcon}>Novo Nicho de Mercado</PageTitle>
       <input
         className="form-control mb-2"
         placeholder="Nome"

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -3,6 +3,7 @@ import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
 import { useAudiencesByNiche } from "../../api/audience/useAudiencesByNiche";
 import PageTitle from "../../components/PageTitle";
+import nicheIcon from "../../assets/icons/niche-icon.svg";
 import { AudienceApprovalCard } from "../../components/AudienceApprovalCard";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 import { useChatDialog } from "../../api/chatDialog/useChatDialog";
@@ -152,7 +153,7 @@ export default function NicheDetailPage() {
       <div className="niche-detail__header">
         <div className="niche-detail__title">
           <span className="niche-detail__badge">Nicho</span>
-          <PageTitle>{data.name}</PageTitle>
+          <PageTitle icon={nicheIcon}>{data.name}</PageTitle>
           <p className="niche-detail__subtitle">
             {`Nicho #${data.id}`}
             {updatedAtLabel ? ` • Atualizado em ${updatedAtLabel}` : ""}

--- a/frontend/src/pages/niche/NicheListPage.tsx
+++ b/frontend/src/pages/niche/NicheListPage.tsx
@@ -4,6 +4,7 @@ import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche"
 import { useExperimentsByNiche } from "../../api/experiment/useExperimentsByNiche";
 import { useAudiencesByNiche } from "../../api/audience/useAudiencesByNiche";
 import PageTitle from "../../components/PageTitle";
+import nicheIcon from "../../assets/icons/niche-icon.svg";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 
 export default function NicheListPage() {
@@ -14,7 +15,7 @@ export default function NicheListPage() {
   if (isLoading) return <p>Carregando...</p>;
   return (
     <div>
-      <PageTitle>Nichos de Mercado</PageTitle>
+      <PageTitle icon={nicheIcon}>Nichos de Mercado</PageTitle>
       <Link className="btn btn-primary mb-3" to="/niches/new">
         Novo Nicho
       </Link>


### PR DESCRIPTION
## Summary
- allow PageTitle to render optional icons with styling that fits the new illustrations
- show the new niche, hipótese and experimento icons across their list, detail and form screens so they appear on the actual pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d41cb441908321b415c26b6ef9acab