### PR TITLE
Add niche, hypothesis, and experiment icons to breadcrumbs

### DIFF
--- a/frontend/src/app/breadcrumbs.css
+++ b/frontend/src/app/breadcrumbs.css
@@ -60,9 +60,32 @@
 }
 
 .app-breadcrumbs__item-label {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   max-width: min(100%, 32ch);
   line-height: 1.2;
+  white-space: nowrap;
+}
+
+.app-breadcrumbs__item-icon {
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.app-breadcrumbs__item-icon > img {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.app-breadcrumbs__item-text {
+  display: inline-block;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/app/breadcrumbs.tsx
+++ b/frontend/src/app/breadcrumbs.tsx
@@ -6,6 +6,7 @@ import "./breadcrumbs.css";
 export interface Crumb {
   label: string;
   to?: string;
+  icon?: string;
 }
 
 const SetCrumbsContext = createContext<(c: Crumb[]) => void>(() => {});
@@ -35,7 +36,14 @@ export default function BreadcrumbsProvider({
                   <span className="app-breadcrumbs__separator" aria-hidden="true">
                     /
                   </span>
-                  <span className="app-breadcrumbs__item-label">{c.label}</span>
+                  <span className="app-breadcrumbs__item-label">
+                    {c.icon ? (
+                      <span className="app-breadcrumbs__item-icon" aria-hidden="true">
+                        <img src={c.icon} alt="" />
+                      </span>
+                    ) : null}
+                    <span className="app-breadcrumbs__item-text">{c.label}</span>
+                  </span>
                 </>
               );
               return (

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -6,6 +6,8 @@ import { useNiche } from "../../api/niche/useNiche";
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
+import nicheIcon from "../../assets/icons/niche-icon.svg";
+import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import CriativosTab from "./CriativosTab";
 import PublicosTab from "./PublicosTab";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
@@ -28,13 +30,18 @@ export default function ExperimentDetailPage() {
   const [tab, setTab] = useState("overview");
   const [isFunnelPreviewOpen, setFunnelPreviewOpen] = useState(false);
   useBreadcrumbs([
-    { label: "Nichos", to: "/niches" },
-    { label: niche?.name || "...", to: `/niches/${data?.nicheId}` },
+    { label: "Nichos", to: "/niches", icon: nicheIcon },
+    {
+      label: niche?.name || "...",
+      to: `/niches/${data?.nicheId}`,
+      icon: nicheIcon,
+    },
     {
       label: hyp?.title || "...",
       to: `/niches/${data?.nicheId}/hypotheses/${data?.hypothesisId}`,
+      icon: hypothesisIcon,
     },
-    { label: data?.name || "..." },
+    { label: data?.name || "...", icon: experimentIcon },
   ]);
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -6,6 +6,7 @@ import { useExperimentsByHypothesis } from "../../api/experiment/useExperimentsB
 import { useAudiencesByNiche } from "../../api/audience/useAudiencesByNiche";
 import PageTitle from "../../components/PageTitle";
 import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
+import nicheIcon from "../../assets/icons/niche-icon.svg";
 import { AudienceApprovalCard } from "../../components/AudienceApprovalCard";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 import { useForm } from "react-hook-form";
@@ -26,9 +27,13 @@ export default function HypothesisDetailPage() {
     defaultValues: { quantity: 1 },
   });
   useBreadcrumbs([
-    { label: "Nichos", to: "/niches" },
-    { label: niche?.name || "...", to: `/niches/${nicheId}` },
-    { label: data?.title || "..." },
+    { label: "Nichos", to: "/niches", icon: nicheIcon },
+    {
+      label: niche?.name || "...",
+      to: `/niches/${nicheId}`,
+      icon: nicheIcon,
+    },
+    { label: data?.title || "...", icon: hypothesisIcon },
   ]);
 
   if (isLoading) return <p>Carregando...</p>;

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -33,8 +33,8 @@ export default function NicheDetailPage() {
     defaultValues: { quantity: 1 },
   });
   useBreadcrumbs([
-    { label: "Nichos", to: "/niches" },
-    { label: data?.name || "..." },
+    { label: "Nichos", to: "/niches", icon: nicheIcon },
+    { label: data?.name || "...", icon: nicheIcon },
   ]);
 
   if (isLoading) return <p>Carregando...</p>;

--- a/frontend/src/pages/niche/NicheListPage.tsx
+++ b/frontend/src/pages/niche/NicheListPage.tsx
@@ -8,7 +8,7 @@ import nicheIcon from "../../assets/icons/niche-icon.svg";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 
 export default function NicheListPage() {
-  useBreadcrumbs([{ label: "Nichos" }]);
+  useBreadcrumbs([{ label: "Nichos", icon: nicheIcon }]);
   const { data, isLoading } = useNiches();
   const niches = Array.isArray(data) ? data : [];
 


### PR DESCRIPTION
## Summary
- extend breadcrumb items to support optional icons sized to match the text
- add niche, hypothesis, and experiment icons to the respective breadcrumb entries across detail and list pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d42f5718c483219b2d4ec200b2086c