### PR TITLE
Sync experiment creative approval with creative statuses

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/repository/CreativeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/repository/CreativeRepository.java
@@ -1,6 +1,7 @@
 package com.marketinghub.creative.repository;
 
 import com.marketinghub.creative.Creative;
+import com.marketinghub.creative.CreativeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,4 +11,6 @@ import java.util.List;
  */
 public interface CreativeRepository extends JpaRepository<Creative, Long> {
     List<Creative> findByExperimentId(Long experimentId);
+
+    boolean existsByExperimentIdAndStatus(Long experimentId, CreativeStatus status);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
@@ -61,7 +61,9 @@ public class CreativeService {
                 .imageUrl(request.getImageUrl())
                 .status(request.getStatus())
                 .build();
-        return repository.save(creative);
+        Creative saved = repository.save(creative);
+        refreshExperimentApproval(exp);
+        return saved;
     }
 
     /**
@@ -74,12 +76,16 @@ public class CreativeService {
         creative.setPrimaryText(request.getPrimaryText());
         creative.setImageUrl(request.getImageUrl());
         creative.setStatus(request.getStatus());
+        refreshExperimentApproval(creative.getExperiment());
         return creative;
     }
 
     @Transactional
     public void delete(Long id) {
-        repository.deleteById(id);
+        Creative creative = repository.findById(id).orElseThrow();
+        Experiment experiment = creative.getExperiment();
+        repository.delete(creative);
+        refreshExperimentApproval(experiment);
     }
 
     public Iterable<Creative> listByExperiment(Long experimentId) {
@@ -101,6 +107,12 @@ public class CreativeService {
             creative.setEmotionalTriggers(java.util.Set.of(emotionalTriggerRepository.findById(triggerId).orElseThrow()));
         }
         return creative;
+    }
+
+    private void refreshExperimentApproval(Experiment experiment) {
+        boolean hasApprovedCreatives = repository.existsByExperimentIdAndStatus(
+                experiment.getId(), CreativeStatus.READY);
+        experiment.setCreativeApproved(hasApprovedCreatives);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/creative/service/CreativeServiceTest.java
@@ -15,6 +15,7 @@ import com.marketinghub.media.Asset;
 import com.marketinghub.media.AssetStatus;
 import com.marketinghub.media.AssetType;
 import com.marketinghub.media.repository.AssetRepository;
+import com.marketinghub.creative.dto.CreateCreativeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -114,5 +115,52 @@ class CreativeServiceTest {
         } finally {
             System.clearProperty("FB_ACCESS_TOKEN");
         }
+    }
+
+    @Test
+    void approvingCreativeMarksExperimentAsReady() {
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        Experiment exp = fixtures.createAndSaveExperiment(niche);
+
+        CreateCreativeRequest createRequest = new CreateCreativeRequest();
+        createRequest.setHeadline("Headline");
+        createRequest.setPrimaryText("Primary");
+        createRequest.setImageUrl("/img.png");
+        createRequest.setStatus(CreativeStatus.DRAFT);
+        Creative creative = service.create(exp.getId(), createRequest);
+
+        Experiment afterCreate = experimentRepository.findById(exp.getId()).orElseThrow();
+        assertThat(afterCreate.isCreativeApproved()).isFalse();
+
+        CreateCreativeRequest approveRequest = new CreateCreativeRequest();
+        approveRequest.setHeadline("Headline");
+        approveRequest.setPrimaryText("Primary");
+        approveRequest.setImageUrl("/img.png");
+        approveRequest.setStatus(CreativeStatus.READY);
+        service.update(creative.getId(), approveRequest);
+
+        Experiment afterApproval = experimentRepository.findById(exp.getId()).orElseThrow();
+        assertThat(afterApproval.isCreativeApproved()).isTrue();
+    }
+
+    @Test
+    void deletingLastApprovedCreativeResetsFlag() {
+        MarketNiche niche = fixtures.createAndSaveNiche();
+        Experiment exp = fixtures.createAndSaveExperiment(niche);
+
+        CreateCreativeRequest createRequest = new CreateCreativeRequest();
+        createRequest.setHeadline("Headline");
+        createRequest.setPrimaryText("Primary");
+        createRequest.setImageUrl("/img.png");
+        createRequest.setStatus(CreativeStatus.READY);
+        Creative creative = service.create(exp.getId(), createRequest);
+
+        Experiment afterApproval = experimentRepository.findById(exp.getId()).orElseThrow();
+        assertThat(afterApproval.isCreativeApproved()).isTrue();
+
+        service.delete(creative.getId());
+
+        Experiment afterDelete = experimentRepository.findById(exp.getId()).orElseThrow();
+        assertThat(afterDelete.isCreativeApproved()).isFalse();
     }
 }


### PR DESCRIPTION
## Summary
- refresh the experiment creative approval flag whenever creatives are created, updated or deleted
- expose a repository helper to detect ready creatives without loading all records
- cover the new behaviour with service tests to prevent regressions

## Testing
- mvn -s ../settings.xml test *(fails: unable to resolve spring-boot-starter-parent from github due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d436c1c4c88321b0b4f90a1a714d60