### PR TITLE
Adjust hypothesis and niche icon colors

### DIFF
--- a/frontend/src/assets/icons/hypothesis-icon.svg
+++ b/frontend/src/assets/icons/hypothesis-icon.svg
@@ -9,8 +9,8 @@
       <stop offset="1" stop-color="#f76707" />
     </linearGradient>
     <linearGradient id="hypothesisBase" x1="68" y1="108" x2="92" y2="130" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#6f42c1" />
-      <stop offset="1" stop-color="#4dabf7" />
+      <stop offset="0" stop-color="#ae3ec9" />
+      <stop offset="1" stop-color="#f06595" />
     </linearGradient>
     <linearGradient id="hypothesisGlow" x1="80" y1="32" x2="80" y2="128" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#ffe8cc" stop-opacity="0.95" />
@@ -53,7 +53,7 @@
     <line x1="60" y1="32" x2="52" y2="22" />
     <line x1="100" y1="32" x2="108" y2="22" />
   </g>
-  <g stroke="#6f42c1" stroke-linecap="round" stroke-width="4" opacity="0.6">
+  <g stroke="#d6336c" stroke-linecap="round" stroke-width="4" opacity="0.6">
     <line x1="52" y1="52" x2="40" y2="48" />
     <line x1="108" y1="52" x2="120" y2="48" />
   </g>

--- a/frontend/src/assets/icons/niche-icon.svg
+++ b/frontend/src/assets/icons/niche-icon.svg
@@ -1,20 +1,20 @@
 <svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="nicheBg" x1="30" y1="18" x2="132" y2="150" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#f8f9ff" />
-      <stop offset="1" stop-color="#e9edff" />
+      <stop offset="0" stop-color="#f3fff8" />
+      <stop offset="1" stop-color="#e6fff2" />
     </linearGradient>
     <linearGradient id="nicheRing" x1="40" y1="40" x2="120" y2="120" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0d6efd" />
-      <stop offset="1" stop-color="#6f42c1" />
+      <stop offset="0" stop-color="#0ca678" />
+      <stop offset="1" stop-color="#2f9e44" />
     </linearGradient>
     <linearGradient id="nicheCenter" x1="68" y1="64" x2="102" y2="100" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0d6efd" />
-      <stop offset="1" stop-color="#4dabf7" />
+      <stop offset="0" stop-color="#0ca678" />
+      <stop offset="1" stop-color="#63e6be" />
     </linearGradient>
     <linearGradient id="nicheArc" x1="48" y1="54" x2="120" y2="106" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#6f42c1" />
-      <stop offset="1" stop-color="#51cf66" stop-opacity="0.85" />
+      <stop offset="0" stop-color="#2f9e44" />
+      <stop offset="1" stop-color="#12b886" stop-opacity="0.85" />
     </linearGradient>
   </defs>
   <rect width="160" height="160" rx="36" fill="url(#nicheBg)" />
@@ -44,7 +44,7 @@
   <path
     d="M108 55l-17 4.5c-1.6.4-2.1 2.4-.9 3.5l6 5.4"
     fill="none"
-    stroke="#6f42c1"
+    stroke="#2b8a3e"
     stroke-width="4"
     stroke-linecap="round"
     stroke-linejoin="round"


### PR DESCRIPTION
## Summary
- refresh the hypothesis icon gradient accents to purple and pink hues for clearer differentiation from blue assets
- recolor the niche icon background and rings with green gradients to avoid confusion with hypothesis visuals

## Testing
- npm run build
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d437dcf94083219b278c32f53996fd