### PR TITLE
Fix LazyInitialization in creative approval workflow

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/repository/CreativeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/repository/CreativeRepository.java
@@ -3,8 +3,11 @@ package com.marketinghub.creative.repository;
 import com.marketinghub.creative.Creative;
 import com.marketinghub.creative.CreativeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Repository for creatives.
@@ -13,4 +16,7 @@ public interface CreativeRepository extends JpaRepository<Creative, Long> {
     List<Creative> findByExperimentId(Long experimentId);
 
     boolean existsByExperimentIdAndStatus(Long experimentId, CreativeStatus status);
+
+    @Query("select c from Creative c join fetch c.experiment where c.id = :id")
+    Optional<Creative> findByIdWithExperiment(@Param("id") Long id);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
@@ -69,20 +69,19 @@ public class CreativeService {
     /**
      * Updates an existing creative.
      */
-    @Transactional
     public Creative update(Long id, CreateCreativeRequest request) {
-        Creative creative = repository.findById(id).orElseThrow();
+        Creative creative = repository.findByIdWithExperiment(id).orElseThrow();
         creative.setHeadline(request.getHeadline());
         creative.setPrimaryText(request.getPrimaryText());
         creative.setImageUrl(request.getImageUrl());
         creative.setStatus(request.getStatus());
-        refreshExperimentApproval(creative.getExperiment());
-        return creative;
+        Creative saved = repository.save(creative);
+        refreshExperimentApproval(saved.getExperiment());
+        return saved;
     }
 
-    @Transactional
     public void delete(Long id) {
-        Creative creative = repository.findById(id).orElseThrow();
+        Creative creative = repository.findByIdWithExperiment(id).orElseThrow();
         Experiment experiment = creative.getExperiment();
         repository.delete(creative);
         refreshExperimentApproval(experiment);
@@ -113,6 +112,7 @@ public class CreativeService {
         boolean hasApprovedCreatives = repository.existsByExperimentIdAndStatus(
                 experiment.getId(), CreativeStatus.READY);
         experiment.setCreativeApproved(hasApprovedCreatives);
+        experimentRepository.save(experiment);
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure creative updates and deletes load the parent experiment eagerly to avoid LazyInitializationException
- persist the creative approval flag after recalculating readiness so detached entities are updated

## Testing
- `mvn -s ../settings.xml test -Dtest=CreativeServiceTest#approvingCreativeMarksExperimentAsReady` *(fails: unable to download parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d43d0bceac8321a196dd3770666eb2