### PR TITLE
Ensure creative approval updates run within transactions

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/service/CreativeService.java
@@ -69,6 +69,7 @@ public class CreativeService {
     /**
      * Updates an existing creative.
      */
+    @Transactional
     public Creative update(Long id, CreateCreativeRequest request) {
         Creative creative = repository.findByIdWithExperiment(id).orElseThrow();
         creative.setHeadline(request.getHeadline());
@@ -80,6 +81,7 @@ public class CreativeService {
         return saved;
     }
 
+    @Transactional
     public void delete(Long id) {
         Creative creative = repository.findByIdWithExperiment(id).orElseThrow();
         Experiment experiment = creative.getExperiment();


### PR DESCRIPTION
## Summary
- wrap CreativeService#update and delete operations in @Transactional to keep the Hibernate session open while refreshing the parent experiment status

## Testing
- `mvn -s ../settings.xml -Dtest=CreativeServiceTest#approvingCreativeMarksExperimentAsReady test` *(fails: repository parent POM cannot be resolved because the private GitHub Packages registry is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4417b37208321ba951a09e058df50