### PR TITLE
Fix equals/hashCode for Experiment and Creative entities

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/creative/Creative.java
@@ -12,13 +12,16 @@ import lombok.*;
  */
 @Entity
 @Table(name = "creative")
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Creative {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -15,13 +15,16 @@ import java.time.LocalDate;
  */
 @Entity
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"niche_id", "name"}))
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Experiment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)


### PR DESCRIPTION
## Summary
- replace Lombok @Data on Experiment and Creative entities with explicit accessor annotations
- restrict equals/hashCode implementations to the identifier to avoid triggering lazy-loading proxies

## Testing
- `mvn -s backend/settings.xml test` *(fails: unable to resolve org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 because the GitHub Packages host is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d45188cd308321b3e89ed7a8ff7083