### PR TITLE
Remove niche breadcrumb prefix and show full hypothesis title

### DIFF
--- a/frontend/src/app/breadcrumbs.css
+++ b/frontend/src/app/breadcrumbs.css
@@ -63,7 +63,6 @@
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  max-width: min(100%, 32ch);
   line-height: 1.2;
   white-space: nowrap;
 }
@@ -87,8 +86,6 @@
   display: inline-block;
   min-width: 0;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 @media (max-width: 576px) {

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -30,7 +30,6 @@ export default function ExperimentDetailPage() {
   const [tab, setTab] = useState("overview");
   const [isFunnelPreviewOpen, setFunnelPreviewOpen] = useState(false);
   useBreadcrumbs([
-    { label: "Nichos", to: "/niches", icon: nicheIcon },
     {
       label: niche?.name || "...",
       to: `/niches/${data?.nicheId}`,


### PR DESCRIPTION
## Summary
- remove the generic "Nichos" crumb from the experiment detail breadcrumb trail
- allow breadcrumb labels to expand without ellipsis so hypothesis titles are fully visible

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4569571948321a3bd396ca36b8580