### PR TITLE
Remove Nichos title from breadcrumbs

### DIFF
--- a/frontend/src/__tests__/NicheFlow.test.tsx
+++ b/frontend/src/__tests__/NicheFlow.test.tsx
@@ -95,8 +95,8 @@ describe("niche navigation", () => {
     expect(await screen.findByText("Exp 1")).toBeTruthy();
     const bc = screen.getByRole("navigation", { name: /breadcrumb/i });
     expect(bc).toBeTruthy();
-    expect(within(bc).getByText("Nichos")).toBeTruthy();
     expect(within(bc).getByText("Fitness")).toBeTruthy();
     expect(await within(bc).findByText("Hip 1")).toBeTruthy();
+    expect(within(bc).queryByText("Nichos")).toBeNull();
   });
 });

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -27,7 +27,6 @@ export default function HypothesisDetailPage() {
     defaultValues: { quantity: 1 },
   });
   useBreadcrumbs([
-    { label: "Nichos", to: "/niches", icon: nicheIcon },
     {
       label: niche?.name || "...",
       to: `/niches/${nicheId}`,

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -32,10 +32,7 @@ export default function NicheDetailPage() {
   const { register, handleSubmit, reset } = useForm<{ quantity: number }>({
     defaultValues: { quantity: 1 },
   });
-  useBreadcrumbs([
-    { label: "Nichos", to: "/niches", icon: nicheIcon },
-    { label: data?.name || "...", icon: nicheIcon },
-  ]);
+  useBreadcrumbs([{ label: data?.name || "...", icon: nicheIcon }]);
 
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;

--- a/frontend/src/pages/niche/NicheListPage.tsx
+++ b/frontend/src/pages/niche/NicheListPage.tsx
@@ -8,7 +8,7 @@ import nicheIcon from "../../assets/icons/niche-icon.svg";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 
 export default function NicheListPage() {
-  useBreadcrumbs([{ label: "Nichos", icon: nicheIcon }]);
+  useBreadcrumbs([]);
   const { data, isLoading } = useNiches();
   const niches = Array.isArray(data) ? data : [];
 


### PR DESCRIPTION
## Summary
- remove the "Nichos" breadcrumb item from the list, detail, and hypothesis pages to drop the title from the navigation trail
- update the niche navigation flow test to reflect the new breadcrumb structure

## Testing
- npm run test -- --watch=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d45be84bf083219c9ae45657de3043