### PR TITLE
Add page for Facebook experiments ready queue

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,7 @@ import PromptEntityDescriptionPage from "./pages/prompt/PromptEntityDescriptionP
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import FacebookCampaignExperimentsPage from "./pages/facebook/FacebookCampaignExperimentsPage";
+import FacebookExperimentsReadyPage from "./pages/facebook/FacebookExperimentsReadyPage";
 
 export default function App() {
   return (
@@ -106,6 +107,9 @@ export default function App() {
             </Link>
             <Link className="nav-link" to="/facebook-campaigns">
               Experimentos para Campanha
+            </Link>
+            <Link className="nav-link" to="/facebook-campaigns/ready">
+              Experimentos prontos
             </Link>
             <Link className="nav-link" to="/prompt-entities">
               Objetos de Prompt
@@ -232,6 +236,10 @@ export default function App() {
           element={<PromptAttributesPage />}
         />
         <Route path="/facebook-campaigns" element={<FacebookCampaignExperimentsPage />} />
+        <Route
+          path="/facebook-campaigns/ready"
+          element={<FacebookExperimentsReadyPage />}
+        />
         <Route path="*" element={<div>Início</div>} />
       </Routes>
       <ToastContainer position="top-right" />

--- a/frontend/src/api/useFacebookReadyExperiments.ts
+++ b/frontend/src/api/useFacebookReadyExperiments.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface FacebookReadyExperiment {
+  id: number;
+  name: string;
+  hypothesis: string;
+  kpiTargetCpl: number | null;
+  startDate: string | null;
+  endDate: string | null;
+}
+
+export function useFacebookReadyExperiments() {
+  return useQuery({
+    queryKey: ["facebook-experiments-ready"],
+    queryFn: async () => {
+      const { data } = await axios.get<FacebookReadyExperiment[]>(
+        "/api/facebook-campaigns/experiments-ready",
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/facebook/FacebookExperimentsReadyPage.css
+++ b/frontend/src/pages/facebook/FacebookExperimentsReadyPage.css
@@ -1,0 +1,98 @@
+.experiments-ready-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 1rem 1.25rem;
+  background-color: var(--bs-tertiary-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.experiments-ready-toolbar-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  color: var(--bs-emphasis-color);
+}
+
+.experiments-ready-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.experiments-ready-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background-color: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: var(--bs-box-shadow-sm);
+}
+
+.experiments-ready-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.experiments-ready-card-title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--bs-emphasis-color);
+}
+
+.experiments-ready-card-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.experiments-ready-card-title a:hover {
+  text-decoration: underline;
+}
+
+.experiments-ready-meta {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--bs-secondary-color);
+}
+
+.experiments-ready-meta-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.experiments-ready-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem 1.5rem;
+  border: 2px dashed var(--bs-border-color);
+  border-radius: 1rem;
+  background-color: var(--bs-body-bg);
+  text-align: center;
+}
+
+.experiments-ready-empty h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.experiments-ready-empty p {
+  margin: 0;
+  color: var(--bs-secondary-color);
+  max-width: 420px;
+}

--- a/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
+++ b/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
@@ -1,0 +1,120 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { CalendarDays, Flag, Gauge, Target } from "lucide-react";
+
+import PageTitle from "../../components/PageTitle";
+import { useFacebookReadyExperiments } from "../../api/useFacebookReadyExperiments";
+import "./FacebookExperimentsReadyPage.css";
+
+function formatCurrency(value: number | null) {
+  if (value === null) return "Sem KPI";
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    maximumFractionDigits: 2,
+  }).format(Number(value));
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "Data não definida";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString("pt-BR");
+}
+
+export default function FacebookExperimentsReadyPage() {
+  const { data, isLoading, isError, refetch, isRefetching } =
+    useFacebookReadyExperiments();
+  const experiments = useMemo(() => (Array.isArray(data) ? data : []), [data]);
+  const isEmpty = !isLoading && experiments.length === 0 && !isError;
+
+  return (
+    <div>
+      <PageTitle>Experimentos prontos para campanha</PageTitle>
+      <div className="experiments-ready-toolbar">
+        <span className="experiments-ready-toolbar-title">
+          <Flag size={18} className="text-primary" />
+          <span>Fila aguardando publicação no Facebook Ads</span>
+        </span>
+        <div className="d-flex align-items-center gap-2">
+          <span className="badge text-bg-primary">
+            {experiments.length} pronto(s)
+          </span>
+          <button
+            type="button"
+            className="btn btn-outline-primary btn-sm"
+            onClick={() => refetch()}
+            disabled={isRefetching}
+          >
+            {isRefetching ? "Atualizando..." : "Atualizar"}
+          </button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="d-flex justify-content-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Carregando…</span>
+          </div>
+        </div>
+      ) : isError ? (
+        <div className="alert alert-danger" role="alert">
+          Não foi possível carregar os experimentos prontos. Tente novamente.
+        </div>
+      ) : isEmpty ? (
+        <div className="experiments-ready-empty">
+          <Flag size={32} className="text-primary" />
+          <h2>Nenhum experimento pronto</h2>
+          <p>
+            Assim que os experimentos aprovados estiverem aguardando publicação
+            no Facebook Ads, eles aparecerão aqui.
+          </p>
+          <Link className="btn btn-outline-primary" to="/experiments">
+            Ir para testes de nicho
+          </Link>
+        </div>
+      ) : (
+        <div className="experiments-ready-grid">
+          {experiments.map((experiment) => (
+            <article key={experiment.id} className="experiments-ready-card">
+              <div className="experiments-ready-card-header">
+                <h2 className="experiments-ready-card-title">
+                  <Link to={`/experiments/${experiment.id}`}>
+                    {experiment.name}
+                  </Link>
+                </h2>
+                <span className="badge text-bg-success">Pronto</span>
+              </div>
+              <div className="experiments-ready-meta">
+                <div className="experiments-ready-meta-item">
+                  <Target size={16} className="text-primary" />
+                  <span>{experiment.hypothesis || "Sem hipótese vinculada"}</span>
+                </div>
+                <div className="experiments-ready-meta-item">
+                  <Gauge size={16} className="text-primary" />
+                  <span>KPI alvo: {formatCurrency(experiment.kpiTargetCpl)}</span>
+                </div>
+                <div className="experiments-ready-meta-item">
+                  <CalendarDays size={16} className="text-primary" />
+                  <span>Início: {formatDate(experiment.startDate)}</span>
+                </div>
+                <div className="experiments-ready-meta-item">
+                  <CalendarDays size={16} className="text-secondary" />
+                  <span>Término: {formatDate(experiment.endDate)}</span>
+                </div>
+              </div>
+              <div className="d-flex justify-content-end">
+                <Link
+                  className="btn btn-link p-0"
+                  to={`/experiments/${experiment.id}`}
+                >
+                  Ver detalhes
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add navigation entry and routing for Facebook experiments ready queue
- create hook and responsive page that surfaces experiments returned by /api/facebook-campaigns/experiments-ready
- include refreshed styles, loading, empty and error states for the ready queue screen

## Testing
- npm run build
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d4a5891514832184d652c785e57fb3