### PR TITLE
Handle backend connection errors gracefully

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -7,7 +7,9 @@ dados definido no projeto `backend`, evitando duplicação de entidades.
 
 As chamadas ao backend utilizam o prefixo `/api`. Atualmente o worker consome
 `/api/facebook-campaigns/experiments-ready`, tratando respostas `404` como
-"nenhum experimento disponível" para evitar falhas no agendamento. O endpoint
+"nenhum experimento disponível" para evitar falhas no agendamento. Falhas de
+conexão ao recuperar os experimentos são registradas em log e ignoradas para
+que o agendamento continue saudável. O endpoint
 `/api/instagram-creatives/approved` permanece documentado para uso futuro.
 
 Os acessos são configurados pelas propriedades:

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -2,17 +2,23 @@ package com.marketinghub.facebookadsworker.facebookcampaign;
 
 import com.marketinghub.facebookadsworker.FacebookAdsService;
 import com.marketinghub.facebookadsworker.util.UrlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
 public class FacebookCampaignService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FacebookCampaignService.class);
+
     private final FacebookAdsService facebookAdsService;
     private final WebClient backendClient;
     private final String backendBaseUrl;
@@ -32,21 +38,27 @@ public class FacebookCampaignService {
     }
 
     public void createCampaignsFromExperiments() {
-        List<Experiment> experiments = backendClient.get()
-            .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/experiments-ready"))
-            .exchangeToFlux(response -> {
-                if (response.statusCode().value() == HttpStatus.NOT_FOUND.value()) {
-                    return Flux.empty();
-                }
+        List<Experiment> experiments = Collections.emptyList();
 
-                if (response.statusCode().isError()) {
-                    return response.createException().flatMapMany(Mono::error);
-                }
+        try {
+            experiments = backendClient.get()
+                .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/experiments-ready"))
+                .exchangeToFlux(response -> {
+                    if (response.statusCode().value() == HttpStatus.NOT_FOUND.value()) {
+                        return Flux.empty();
+                    }
 
-                return response.bodyToFlux(Experiment.class);
-            })
-            .collectList()
-            .block();
+                    if (response.statusCode().isError()) {
+                        return response.createException().flatMapMany(Mono::error);
+                    }
+
+                    return response.bodyToFlux(Experiment.class);
+                })
+                .collectList()
+                .block();
+        } catch (WebClientRequestException ex) {
+            LOGGER.warn("Failed to fetch experiments from backend", ex);
+        }
 
         if (experiments == null || experiments.isEmpty()) {
             return;

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -4,6 +4,7 @@ import com.marketinghub.facebookadsworker.FacebookAdsService;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,5 +56,15 @@ class FacebookCampaignServiceTest {
         assertEquals("/v20.0/act_1/campaigns", postFb.getPath());
         RecordedRequest postBackend = backend.takeRequest();
         assertEquals("/api/facebook-campaigns", postBackend.getPath());
+    }
+
+    @Test
+    void ignoresConnectionIssuesFetchingExperiments() {
+        backend.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+
+        service.createCampaignsFromExperiments();
+
+        assertEquals(1, backend.getRequestCount());
+        assertEquals(0, facebook.getRequestCount());
     }
 }


### PR DESCRIPTION
## Summary
- log and ignore backend connection failures when fetching experiments so the scheduler keeps running
- cover the disconnection scenario with a new unit test
- document the resilient behaviour in the Facebook Ads worker README

## Testing
- mvn -s settings.xml test *(fails: unable to reach https://maven.pkg.github.com/paulofor/marketing-hub)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b06beb94832183b9f05b14681df1