### PR TITLE
Align Facebook worker backend base URL

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -14,7 +14,7 @@ que o agendamento continue saudável. O endpoint
 
 Os acessos são configurados pelas propriedades:
 
-- `backend.base-url` (default: `http://localhost:8000`)
+- `backend.base-url` (default: `http://191.252.92.222:8000`)
 - `backend.api-prefix` (default: `/api`)
 
 ## Data Model

--- a/facebook-ads-worker/src/main/resources/application.properties
+++ b/facebook-ads-worker/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=facebook-ads-worker
-backend.base-url=http://191.252.92.222:8080
+backend.base-url=http://191.252.92.222:8000
 instagramcampaign.scheduler.delay=60000
 backend.api-prefix=/api
 


### PR DESCRIPTION
## Summary
- align the Facebook Ads worker backend base URL with the AI worker configuration
- document the updated default backend address in the module README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4b2f594a48321aa076a2aa19ffe67