### PR TITLE
Fix Facebook campaign creation payload

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -5,6 +5,10 @@ posicionamentos no Facebook e no Instagram, e coletar métricas usando a API de
 Marketing do Facebook. O serviço reutiliza o modelo de
 dados definido no projeto `backend`, evitando duplicação de entidades.
 
+As campanhas criadas utilizam o objetivo `OUTCOME_TRAFFIC`, são iniciadas com
+status `PAUSED` e preenchem `special_ad_categories` com `NONE`, atendendo às
+novas regras da Graph API para criação de campanhas.
+
 As chamadas ao backend utilizam o prefixo `/api`. Atualmente o worker consome
 `/api/facebook-campaigns/experiments-ready`, tratando respostas `404` como
 "nenhum experimento disponível" para evitar falhas no agendamento. Falhas de

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -25,6 +26,8 @@ public class FacebookAdsService {
             .bodyValue(Map.of(
                 "name", name,
                 "objective", "OUTCOME_TRAFFIC",
+                "status", "PAUSED",
+                "special_ad_categories", List.of("NONE"),
                 "access_token", accessToken
             ))
             .retrieve()

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.facebookadsworker;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -16,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class FacebookAdsServiceTest {
     private MockWebServer server;
     private FacebookAdsService service;
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -23,6 +25,7 @@ class FacebookAdsServiceTest {
         server.start();
         String baseUrl = server.url("/").toString();
         service = new FacebookAdsService(WebClient.builder(), baseUrl, "token");
+        objectMapper = new ObjectMapper();
     }
 
     @AfterEach
@@ -37,6 +40,11 @@ class FacebookAdsServiceTest {
         String id = service.createInstagramCampaign("1", "Camp");
         RecordedRequest request = server.takeRequest();
         assertEquals("/v20.0/act_1/campaigns", request.getPath());
+        JsonNode body = objectMapper.readTree(request.getBody().inputStream());
+        assertEquals("Camp", body.get("name").asText());
+        assertEquals("OUTCOME_TRAFFIC", body.get("objective").asText());
+        assertEquals("PAUSED", body.get("status").asText());
+        assertEquals("NONE", body.get("special_ad_categories").get(0).asText());
         assertEquals("123", id);
     }
 


### PR DESCRIPTION
## Summary
- include the required `status` and `special_ad_categories` fields when creating campaigns through the Graph API
- document the new defaults applied to campaign creation in the worker README
- extend the service unit test to validate the full payload sent to Facebook

## Testing
- `mvn -s settings.xml test` *(fails: Network is unreachable for parent POM download)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b5f5592c832194e122d0aacd142f