### PR TITLE
Add Graph API documentation reference for Facebook Ads worker

### DIFF
--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -6,6 +6,7 @@
 - Em produção utilizamos **MySql 5**.
 - Tipos de dados permitidos (MySql 5): `INT`, `BIGINT`, `DECIMAL`, `DOUBLE`, `FLOAT`, `CHAR`, `VARCHAR`, `TEXT`, `LONGTEXT`, `BINARY(16)` para `UUID`, `DATE`, `DATETIME`, `TIMESTAMP`, `BOOLEAN`.
 - Utilize o `facebook-ads-worker` para todas as chamadas à API do Facebook.
+- Consulte sempre a documentação oficial da Graph API ao trabalhar neste módulo: https://developers.facebook.com/docs/graph-api e https://developers.facebook.com/docs/graph-api/reference.
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.
 - Endpoints do backend devem ser acessados com o prefixo configurado em `backend.api-prefix` (default `/api`).
 

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -32,6 +32,7 @@ rastreamento.
 
 Um diagrama de classes simplificado pode ser encontrado em
 [docs/facebook-ads-worker/class-diagram.md](../docs/facebook-ads-worker/class-diagram.md).
+Consulte também a documentação oficial da Graph API sempre que precisar interagir com a plataforma: https://developers.facebook.com/docs/graph-api e https://developers.facebook.com/docs/graph-api/reference.
 
 ## Build
 ```


### PR DESCRIPTION
## Summary
- highlight the official Facebook Graph API documentation as a required reference for Facebook Ads Worker development
- mirror the documentation link across both markdown files in the module per contributing guidelines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d542142ba48321bbec7bb9a92cb1ef