### PR TITLE
feat: gerar conjuntos e anuncios ao criar campanha

### DIFF
--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -17,15 +17,58 @@ classDiagram
         -backendBaseUrl : String
         -apiPrefix : String
         -adAccountId : String
+        -adSetDailyBudget : String
+        -adSetBillingEvent : String
+        -adSetOptimizationGoal : String
+        -adSetDestinationType : String
+        -adSetTargetCountry : String
+        -pageId : String
+        -instagramActorId : String
+        -websiteUrl : String
+        -creativeMessageTemplate : String
+        -callToActionType : String
         +createCampaignsFromExperiments()
         -processExperiment(exp)
+        -formatCreativeMessage(name) String
     }
 
     class FacebookAdsService {
         -webClient : WebClient
         -accessToken : String
         +createCampaign(adAccountId, name) String
+        +createAdSet(adAccountId, request) String
+        +createAdCreative(adAccountId, request) String
+        +createAd(adAccountId, request) String
         +getCampaignMetrics(campaignId) JsonNode
+    }
+
+    class AdSetRequest {
+        <<record>>
+        +name : String
+        +campaignId : String
+        +dailyBudget : String
+        +billingEvent : String
+        +optimizationGoal : String
+        +destinationType : String
+        +pageId : String
+        +targetCountry : String
+    }
+
+    class AdCreativeRequest {
+        <<record>>
+        +name : String
+        +pageId : String
+        +instagramActorId : String
+        +websiteUrl : String
+        +message : String
+        +callToActionType : String
+    }
+
+    class AdRequest {
+        <<record>>
+        +name : String
+        +adSetId : String
+        +creativeId : String
     }
 
     class CreateCampaignRequest {
@@ -84,7 +127,10 @@ classDiagram
     }
 
     FacebookCampaignScheduler --> FacebookCampaignService : dispara ciclo
-    FacebookCampaignService --> FacebookAdsService : cria campanhas
+    FacebookCampaignService --> FacebookAdsService : cria campanha/ad set/ad
+    FacebookAdsService --> AdSetRequest
+    FacebookAdsService --> AdCreativeRequest
+    FacebookAdsService --> AdRequest
     FacebookCampaignService --> CreateCampaignRequest : monta payload do backend
     CreateCampaignRequest ..> FacebookAdsCampaign : persiste entidade
     FacebookAdsCampaign --> FacebookAdStatus
@@ -96,9 +142,10 @@ classDiagram
 * `FacebookCampaignScheduler` agenda a execução periódica do worker utilizando
   `@Scheduled`.
 * `FacebookCampaignService` consulta o backend por experimentos prontos, cria a
-  campanha na Graph API e registra o resultado de volta no backend.
-* `FacebookAdsService` encapsula as chamadas à Graph API (criação de campanhas e
-  consulta de métricas).
+  campanha, conjunto, criativo e anúncio na Graph API e registra o resultado da
+  campanha no backend.
+* `FacebookAdsService` encapsula as chamadas à Graph API (criação da hierarquia
+  de mídia e consulta de métricas).
 * `CreateCampaignRequest` representa o payload enviado ao backend contendo os
   campos mínimos para materializar a entidade de campanha.
 * `FacebookAdsCampaign` é a entidade JPA do backend responsável por armazenar a

--- a/docs/facebook-ads-worker/input-output-mapping.md
+++ b/docs/facebook-ads-worker/input-output-mapping.md
@@ -2,10 +2,10 @@
 
 Este documento descreve como o **Facebook Ads Worker** converte os
 experimentos aprovados pelo backend em chamadas à Graph API do Facebook e em
-registros persistidos nas tabelas `facebook_ads_*`. O fluxo atual utiliza apenas
-os dados necessários para registrar a campanha criada; o enriquecimento com
-informações de conjuntos de anúncios, criativos e UTM permanece listado em
-[pendencias.md](./pendencias.md).
+registros persistidos nas tabelas `facebook_ads_*`. O fluxo atual cria a
+hierarquia completa (campanha → ad set → criativo → anúncio) utilizando valores
+padrão configuráveis enquanto o backend evolui para fornecer parâmetros mais
+ricos.
 
 Os experimentos que alimentam esse fluxo são apresentados ao time na tela
 "Experimentos para Campanha" do frontend, garantindo o alinhamento entre a visão
@@ -19,10 +19,11 @@ flowchart TD
     service --> fetch["GET /facebook-campaigns/experiments-ready"]
     fetch --> experiments["Experimentos prontos"]
     experiments --> service
-    service --> graphApi["POST /v20.0/act_<adAccountId>/campaigns"]
-    graphApi --> fbResponse["ID da campanha no Facebook"]
-    fbResponse --> service
-    service --> persist["POST /facebook-campaigns"]
+    service --> createCampaign["POST /v20.0/act_<adAccountId>/campaigns"]
+    createCampaign --> createAdSet["POST /v20.0/act_<adAccountId>/adsets"]
+    createAdSet --> createCreative["POST /v20.0/act_<adAccountId>/adcreatives"]
+    createCreative --> createAd["POST /v20.0/act_<adAccountId>/ads"]
+    createAd --> persist["POST /facebook-campaigns"]
     persist --> db["Tabelas facebook_ads_*"]
 ```
 
@@ -35,10 +36,10 @@ flowchart TD
 
 | Campo | Tipo | Uso atual |
 | --- | --- | --- |
-| `id` | `long` | Disponível para evoluções futuras (não utilizado na criação da campanha) |
-| `name` | `string` | Usado como nome da campanha no Facebook e no backend |
+| `id` | `long` | Disponível para evoluções futuras (não utilizado diretamente na criação) |
+| `name` | `string` | Usado como nome base para campanha, ad set, criativo e anúncio |
 
-## 2. Criação de campanha no Facebook
+## 2. Criação da campanha no Facebook
 
 * **Endpoint da Graph API:** `POST https://graph.facebook.com/v20.0/act_<adAccountId>/campaigns`
 * **Payload enviado:**
@@ -47,33 +48,87 @@ flowchart TD
 | --- | --- | --- |
 | `name` | `Experiment.name` | Nome exibido no Gerenciador de Anúncios |
 | `objective` | Constante | Valor fixo `OUTCOME_TRAFFIC` |
+| `status` | Constante | `PAUSED` para evitar publicação automática |
+| `special_ad_categories` | Constante | Lista com `NONE`, atendendo às políticas atuais |
 | `access_token` | Configuração `facebook.access-token` | Token com permissão para o Ad Account |
 
-* **Resposta tratada:** apenas o identificador retornado em `id` é utilizado.
+* **Resposta tratada:** o identificador retornado em `id` abastece as etapas seguintes.
 
-## 3. Persistência da campanha no backend
+## 3. Criação do conjunto de anúncios
 
-Após receber o `id` da Graph API, o worker envia um `CreateCampaignRequest` para
-o backend.
+* **Endpoint da Graph API:** `POST https://graph.facebook.com/v20.0/act_<adAccountId>/adsets`
+* **Payload enviado:**
+
+| Campo | Origem | Observações |
+| --- | --- | --- |
+| `name` | `Experiment.name` + sufixo | Mantém rastreabilidade visual no Gerenciador |
+| `campaign_id` | Resposta da campanha | Vincula o ad set à campanha recém-criada |
+| `daily_budget` | Configuração `facebook.ad-set.daily-budget` | Valor em centavos da moeda da conta |
+| `billing_event` | Configuração `facebook.ad-set.billing-event` | Default `IMPRESSIONS` |
+| `optimization_goal` | Configuração `facebook.ad-set.optimization-goal` | Default `LINK_CLICKS` |
+| `destination_type` | Configuração `facebook.ad-set.destination-type` | Default `WEBSITE` |
+| `targeting.geo_locations.countries` | Configuração `facebook.ad-set.target-country` | Segmentação inicial simplificada |
+| `promoted_object.page_id` | Configuração `facebook.page-id` | Necessário para campanhas de tráfego |
+| `status` | Constante | `PAUSED` |
+| `access_token` | Configuração `facebook.access-token` | Token com permissão para o Ad Account |
+
+* **Resposta tratada:** o `id` do ad set é utilizado na criação do anúncio.
+
+## 4. Criação do criativo
+
+* **Endpoint da Graph API:** `POST https://graph.facebook.com/v20.0/act_<adAccountId>/adcreatives`
+* **Payload enviado:**
+
+| Campo | Origem | Observações |
+| --- | --- | --- |
+| `name` | `Experiment.name` + sufixo | Nome amigável para o criativo |
+| `object_story_spec.page_id` | Configuração `facebook.page-id` | Página responsável pelo anúncio |
+| `object_story_spec.instagram_actor_id` | Configuração `facebook.instagram-actor-id` | Opcional; usado quando há Instagram vinculado |
+| `object_story_spec.link_data.message` | Template `facebook.creative.message-template` | Substitui `%s` pelo nome do experimento |
+| `object_story_spec.link_data.link` | Configuração `facebook.website-url` | URL de destino padrão |
+| `object_story_spec.link_data.call_to_action.type` | Configuração `facebook.creative.call-to-action-type` | Default `LEARN_MORE` |
+| `object_story_spec.link_data.call_to_action.value.link` | Configuração `facebook.website-url` | Mesmo destino do link principal |
+| `access_token` | Configuração `facebook.access-token` | Token com permissão para o Ad Account |
+
+* **Resposta tratada:** o `id` do criativo abastece a criação do anúncio.
+
+## 5. Criação do anúncio
+
+* **Endpoint da Graph API:** `POST https://graph.facebook.com/v20.0/act_<adAccountId>/ads`
+* **Payload enviado:**
+
+| Campo | Origem | Observações |
+| --- | --- | --- |
+| `name` | `Experiment.name` + sufixo | Permite localizar o anúncio dentro do conjunto |
+| `adset_id` | Resposta do ad set | Mantém o vínculo com a etapa anterior |
+| `creative.creative_id` | Resposta do criativo | Referencia o criativo recém-criado |
+| `status` | Constante | `PAUSED` |
+| `access_token` | Configuração `facebook.access-token` | Token com permissão para o Ad Account |
+
+* **Resposta tratada:** o identificador é armazenado apenas para auditoria de execução (não é persistido no backend ainda).
+
+## 6. Persistência da campanha no backend
+
+Após criar a hierarquia na Graph API, o worker envia um `CreateCampaignRequest`
+para o backend.
 
 * **Endpoint chamado:** `POST {backend.base-url}{api-prefix}/facebook-campaigns`
 * **Campos enviados:**
 
 | Campo | Fonte | Transformação |
 | --- | --- | --- |
-| `id` | Resposta da Graph API | Copiado diretamente do `id` retornado na criação |
+| `id` | Resposta da Graph API (campanha) | Copiado diretamente do `id` retornado na criação |
 | `adAccountId` | Propriedade `facebook.ad-account-id` | Mantido conforme configuração do worker |
 | `name` | `Experiment.name` | Replicado para manter rastreabilidade entre backend e Facebook |
-| `objective` | Constante | Valor fixo `OUTCOME_TRAFFIC` (mesmo utilizado na Graph API) |
+| `objective` | Constante | Valor fixo `OUTCOME_TRAFFIC` |
 | `budgetMode` | Constante | Valor fixo `CAMPAIGN` até que o backend passe a enviar planejamento detalhado |
 
 ## Observações
 
-* As tabelas `facebook_ads_campaign`, `facebook_ads_ad_set`, `facebook_ads_ad`
-  e demais estruturas descritas em [../data-model.md](../data-model.md) recebem
-  atualmente apenas os dados relacionados à criação da campanha. O preenchimento
-  de campos adicionais será implementado junto com as pendências listadas em
-  [pendencias.md](./pendencias.md).
+* As tabelas `facebook_ads_ad_set`, `facebook_ads_ad` e entidades auxiliares já
+  estão preparadas no backend, mas ainda não recebem dados adicionais além do
+  identificador da campanha. O enriquecimento com segmentação detalhada, criativos
+  aprovados pelo usuário e UTMs permanece listado em [pendencias.md](./pendencias.md).
 * A composição das URLs dos endpoints do backend utiliza `UrlUtils.joinPath`
   para garantir que `backend.base-url`, `backend.api-prefix` e o caminho do
   recurso não gerem barras duplicadas.

--- a/docs/facebook-ads-worker/pendencias.md
+++ b/docs/facebook-ads-worker/pendencias.md
@@ -1,9 +1,9 @@
 # Pendências para campanha no Facebook Ads
 
-O worker já consulta o backend por experimentos aprovados e cria uma campanha no
-Facebook Ads com objetivo `OUTCOME_TRAFFIC`, registrando o resultado no backend.
-Para completar o fluxo de veiculação e governança, ainda faltam os itens abaixo,
-agrupados por tema.
+O worker já consulta o backend por experimentos aprovados, cria a campanha com
+objetivo `OUTCOME_TRAFFIC`, gera o ad set, criativo e anúncio correspondentes na
+Graph API e registra a campanha no backend. Para completar o fluxo de veiculação
+e governança, ainda faltam os itens abaixo, agrupados por tema.
 
 ## Planejamento e configuração
 
@@ -13,13 +13,15 @@ agrupados por tema.
   de constantes.
 - Suportar janelas de veiculação (datas de início/fim) e status da campanha
   (ex.: programada, ativa, pausada).
+- Alimentar o backend com os identificadores de ad set, criativo e anúncio para
+  manter rastreabilidade completa no modelo de dados.
 
 ## Segmentação, criativos e lances
 
 - Criar conjuntos de anúncios com segmentação derivada de localização,
   interesses, públicos semelhantes e demais filtros definidos no planejamento.
 - Carregar e associar criativos aprovados (media assets, ad creatives e ads) às
-  campanhas geradas.
+  campanhas geradas, substituindo os placeholders atuais.
 - Implementar configuração de posicionamentos, dispositivos e estratégia de
   lance/otimização.
 

--- a/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
+++ b/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
@@ -1,8 +1,8 @@
 # Transformação de Experimentos em Campanhas do Facebook
 
 Este documento descreve como o MarketingHub converte experimentos aprovados em
-campanhas no Facebook Ads e os próximos passos para incluir entidades
-relacionadas (conjuntos de anúncios, criativos e rastreamento).
+campanhas no Facebook Ads, criando automaticamente conjuntos de anúncios,
+criativos e anúncios associados antes de registrar os dados no backend.
 
 A fila de trabalho usada aqui é a mesma exibida na tela "Experimentos para
 Campanha" do frontend, que lista os experimentos aprovados e prontos para serem
@@ -15,9 +15,11 @@ flowchart TD
     scheduler["FacebookCampaignScheduler"] --> service["FacebookCampaignService"]
     service --> backendFetch["GET /facebook-campaigns/experiments-ready"]
     backendFetch --> service
-    service --> graphApi["POST /v20.0/act_{adAccountId}/campaigns"]
-    graphApi --> fbId["ID da campanha no Facebook"]
-    fbId --> persist["POST /facebook-campaigns"]
+    service --> campaign["POST /v20.0/act_{adAccountId}/campaigns"]
+    campaign --> adset["POST /v20.0/act_{adAccountId}/adsets"]
+    adset --> creative["POST /v20.0/act_{adAccountId}/adcreatives"]
+    creative --> ad["POST /v20.0/act_{adAccountId}/ads"]
+    ad --> persist["POST /facebook-campaigns"]
     persist --> db["Tabela facebook_ads_campaign"]
 ```
 
@@ -31,73 +33,78 @@ O `FacebookCampaignScheduler` agenda periodicamente a execução de
 Quando executado, o serviço faz um `GET` em
 `/api/facebook-campaigns/experiments-ready`, aceitando respostas `404` como
 "nenhum experimento disponível" e, em caso de sucesso, converte o corpo em uma
-lista de `Experiment` antes de prosseguir ([FacebookCampaignScheduler.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignScheduler.java#L7-L17), [FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L21-L55)).
+lista de `Experiment` antes de prosseguir ([FacebookCampaignScheduler.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignScheduler.java#L7-L17), [FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L70-L99)).
 
 O endpoint `experiments-ready` é exposto pelo backend e retorna os experimentos
 planejados para Facebook cuja audiência e criativos já foram aprovados, graças à
 consulta `listReadyForCampaign()` no serviço de experimentos ([FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L22-L37), [ExperimentService.java](../../backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java#L157-L160)).
 
-### 2. Criação da campanha na Graph API
+### 2. Criação da hierarquia na Graph API
 
-Para cada experimento coletado, o worker chama o
-[FacebookAdsService](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java),
-que executa `POST /v20.0/act_{adAccountId}/campaigns` com o nome do experimento
-como `name` e o objetivo fixo `OUTCOME_TRAFFIC`, retornando o identificador
-criado pela API do Facebook ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L57-L64), [FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L19-L36)).
+Para cada experimento, o worker utiliza o
+[FacebookAdsService](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java) para
+montar a hierarquia completa:
+
+1. **Campanha**: `POST /campaigns` com objetivo `OUTCOME_TRAFFIC`, status
+   `PAUSED` e `special_ad_categories = NONE`. O identificador retornado alimenta
+   as etapas seguintes ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L101-L105)).
+2. **Conjunto de anúncios**: `POST /adsets` com orçamento diário, billing event,
+   objetivo de otimização e destino (`WEBSITE`) definidos por propriedades de
+   configuração. A segmentação inicial utiliza apenas país (`facebook.ad-set.target-country`) até que o backend envie dados mais
+   ricos. O `id` retornado é usado na criação do anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L111)).
+3. **Criativo**: `POST /adcreatives` baseado em um `object_story_spec` que inclui
+   `page_id`, `instagram_actor_id` opcional, template de mensagem com o nome do
+   experimento e call-to-action configurável. O `id` retornado alimenta o anúncio
+   ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L119)).
+4. **Anúncio**: `POST /ads` referenciando o ad set e o criativo recém-criados, em
+   status `PAUSED` para permitir revisão manual antes da ativação
+   ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L120-L124)).
+
+Todos os pontos de contato com a Graph API reutilizam o mesmo `access_token`
+configurado para o worker.
 
 ### 3. Persistência no backend
 
-Após obter o `id` gerado pela Graph API, o worker envia um
+Após concluir as chamadas à Graph API, o worker envia um
 `CreateCampaignRequest` para o backend com os campos mínimos necessários para
 registrar a campanha na tabela `facebook_ads_campaign`. A chamada utiliza o
 mesmo nome do experimento e preenche `objective` e `budgetMode` com constantes
-(`OUTCOME_TRAFFIC` e `CAMPAIGN`) ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L57-L67), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L39-L57)).
+(`OUTCOME_TRAFFIC` e `CAMPAIGN`) ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L39-L57)).
 
 ## Mapeamento de campos
 
 | Fonte | Destino | Observações |
 | --- | --- | --- |
-| `Experiment.name` | `Graph API - name` | Nome da campanha no Facebook Ads (replicado do experimento). ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L57-L62)) |
-| `Experiment.name` | `CreateCampaignRequest.name` | Mantém rastreabilidade entre backend e Facebook. ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L57-L67)) |
-| `facebook.ad-account-id` (configuração) | `Graph API - URL` | Define o Ad Account usado no `POST /campaigns`. ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L21-L33)) |
-| `facebook.access-token` (configuração) | `Graph API - access_token` | Token enviado pelo `FacebookAdsService`. ([FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L19-L36)) |
-| Resposta da Graph API (`id`) | `CreateCampaignRequest.id` | Persistido como identificador principal da campanha. ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L57-L67)) |
-| Constante `OUTCOME_TRAFFIC` | `Graph API - objective` e `CreateCampaignRequest.objective` | Objetivo padrão até que exista planejamento específico por experimento. ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L57-L67), [FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L25-L33)) |
-| Constante `CAMPAIGN` | `CreateCampaignRequest.budgetMode` | Modo de orçamento usado atualmente pelo backend. ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L57-L67)) |
+| `Experiment.name` | `Graph API - name` | Nome base para campanha, ad set, criativo e anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L101-L124)) |
+| `Experiment.name` | `CreateCampaignRequest.name` | Mantém rastreabilidade entre backend e Facebook ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132)) |
+| `facebook.ad-account-id` | `Graph API - URLs` | Define o Ad Account usado em todas as chamadas `POST` ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L38-L67)) |
+| `facebook.access-token` | `Graph API - access_token` | Token reutilizado em campanha, ad set, criativo e anúncio ([FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L18-L127)) |
+| `facebook.ad-set.*` | `Graph API - adsets` | Define orçamento, otimização e país padrão ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L111)) |
+| `facebook.page-id` | `Graph API - promoted_object` / `object_story_spec.page_id` | Necessário para ad sets e criativos ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L119)) |
+| `facebook.instagram-actor-id` | `Graph API - object_story_spec.instagram_actor_id` | Opcional, incluído apenas quando configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L118)) |
+| `facebook.creative.message-template` | `Graph API - object_story_spec.link_data.message` | Template com suporte a `%s` para o nome do experimento ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L134-L141)) |
+| `facebook.website-url` | `Graph API - link_data.link` e `call_to_action.value.link` | URL padrão de destino ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L118)) |
+| Resposta da Graph API (`id`) | `CreateCampaignRequest.id` | Persistido como identificador principal da campanha ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132)) |
+| Constante `OUTCOME_TRAFFIC` | `Graph API - objective` e `CreateCampaignRequest.objective` | Objetivo padrão até existir planejamento específico |
+| Constante `CAMPAIGN` | `CreateCampaignRequest.budgetMode` | Modo de orçamento usado atualmente pelo backend |
 
 ## Informações de experimento ainda não utilizadas
 
 O backend já expõe no resumo do experimento campos como hipótese, KPI alvo de
-CPL e janela de veiculação (datas de início e fim), mas o worker ainda não os
-consome, limitando-se ao nome e identificador numérico. Esses atributos serão
-necessários para parametrizar orçamento, datas e segmentações em versões
-posteriores ([FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L22-L57)).
+CPL, janelas de veiculação e audiências detalhadas, mas o worker ainda não os
+consome. Esses atributos serão necessários para parametrizar orçamento,
+segmentações ricas e mensagens específicas em versões futuras ([FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L22-L57), [ExperimentReadyForAdSetDto.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/dto/ExperimentReadyForAdSetDto.java#L18-L23)).
 
 ## Entidades relacionadas e próximos passos
 
 Os experimentos concentram entidades auxiliares que precisarão ser mapeadas
-para completar a configuração da campanha:
+para completar a configuração avançada da campanha:
 
 - `creative` (variantes de criativos gerados para o experimento). ([data-model.md](../data-model.md#creative))
-- `ad_set` (configurações de orçamento, duração e segmentação). ([data-model.md](../data-model.md#ad_set))
+- `ad_set` (configurações completas de orçamento, duração e segmentação). ([data-model.md](../data-model.md#ad_set))
 - `landing_page` e `metric_snapshot` (rastreio de performance e destino de
   tráfego). ([data-model.md](../data-model.md#landing_page), [data-model.md](../data-model.md#metric_snapshot))
 
-As pendências registradas para o Facebook Ads Worker já listam a necessidade de
-mapear orçamento, segmentação, criativos e UTMs para futuras iterações ([pendencias.md](./pendencias.md)). Com base nisso, recomenda-se o seguinte plano incremental:
-
-1. **Enriquecer o consumo do endpoint** `experiments-ready`, expandindo o record
-   `Experiment` do worker para incluir datas, metas financeiras e hipóteses, e
-   propagá-las ao payload da Graph API quando os campos estiverem
-   disponíveis. ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L34-L69), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L22-L57))
-2. **Gerar conjuntos de anúncios** a partir de `ad_set` ligados ao experimento,
-   respeitando interesses, públicos semelhantes e orçamento diário listado nas
-   pendências do worker. ([data-model.md](../data-model.md#ad_set), seção "Segmentação, criativos e lances" em [pendencias.md](./pendencias.md))
-3. **Associar criativos aprovados** (`creative` e `creative_variant`) e
-   configurar parâmetros de rastreamento UTM conforme planejado, garantindo
-   rastreabilidade ponta a ponta entre experimento, campanha e métricas de
-   performance. ([data-model.md](../data-model.md#creative), [data-model.md](../data-model.md#creative_variant), seção "Rastreamento e conformidade" em [pendencias.md](./pendencias.md))
-
-Esses passos mantêm a coesão com o modelo de dados existente e orientam a
-ampliação da transformação de experimentos em campanhas completas no Facebook
-Ads.
+As pendências registradas para o Facebook Ads Worker agora se concentram em
+alimentar essas entidades com dados reais, gerar UTMs e sincronizar métricas
+([pendencias.md](./pendencias.md)).

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -1,25 +1,47 @@
 # Facebook Ads Worker
 
-Worker responsável por criar campanhas no Facebook Ads, incluindo
+Worker responsável por criar campanhas no Facebook Ads, incluindo os
 posicionamentos no Facebook e no Instagram, e coletar métricas usando a API de
-Marketing do Facebook. O serviço reutiliza o modelo de
-dados definido no projeto `backend`, evitando duplicação de entidades.
+Marketing do Facebook. O serviço reutiliza o modelo de dados definido no
+projeto `backend`, evitando duplicação de entidades.
 
-As campanhas criadas utilizam o objetivo `OUTCOME_TRAFFIC`, são iniciadas com
-status `PAUSED` e preenchem `special_ad_categories` com `NONE`, atendendo às
-novas regras da Graph API para criação de campanhas.
+O fluxo automatizado cria toda a hierarquia necessária para veiculação:
 
-As chamadas ao backend utilizam o prefixo `/api`. Atualmente o worker consome
+1. **Campanha** (`POST /campaigns`) com objetivo `OUTCOME_TRAFFIC`, status
+   inicial `PAUSED` e `special_ad_categories = NONE`.
+2. **Conjunto de anúncios** (`POST /adsets`) atrelado à campanha, também em
+   `PAUSED`, com segmentação geográfica simples e destino `WEBSITE`.
+3. **Criativo** (`POST /adcreatives`) baseado em um `object_story_spec`
+   contendo `page_id`, opcionalmente `instagram_actor_id`, mensagem formatada a
+   partir do experimento e call-to-action configurável.
+4. **Anúncio** (`POST /ads`) que referencia o conjunto e o criativo recém
+   criados, mantido pausado até que o time operacional revise os detalhes no
+   Gerenciador de Anúncios.
+
+As chamadas ao backend utilizam o prefixo `/api`. O worker consome
 `/api/facebook-campaigns/experiments-ready`, tratando respostas `404` como
 "nenhum experimento disponível" para evitar falhas no agendamento. Falhas de
 conexão ao recuperar os experimentos são registradas em log e ignoradas para
-que o agendamento continue saudável. O endpoint
-`/api/instagram-creatives/approved` permanece documentado para uso futuro.
+que o agendamento continue saudável. Após criar campanha, conjunto, criativo e
+anúncio, o worker persiste o identificador da campanha via
+`POST /api/facebook-campaigns`.
 
 Os acessos são configurados pelas propriedades:
 
 - `backend.base-url` (default: `http://191.252.92.222:8000`)
 - `backend.api-prefix` (default: `/api`)
+- `facebook.ad-set.daily-budget` (default: `2000`, em centavos da moeda da
+  conta)
+- `facebook.ad-set.billing-event` (default: `IMPRESSIONS`)
+- `facebook.ad-set.optimization-goal` (default: `LINK_CLICKS`)
+- `facebook.ad-set.destination-type` (default: `WEBSITE`)
+- `facebook.ad-set.target-country` (default: `BR`)
+- `facebook.page-id` (sem default – obrigatório)
+- `facebook.instagram-actor-id` (opcional)
+- `facebook.website-url` (sem default – obrigatório)
+- `facebook.creative.message-template` (default: `%s` – utiliza o nome do
+  experimento quando contém `%s`)
+- `facebook.creative.call-to-action-type` (default: `LEARN_MORE`)
 
 ## Data Model
 
@@ -32,7 +54,9 @@ rastreamento.
 
 Um diagrama de classes simplificado pode ser encontrado em
 [docs/facebook-ads-worker/class-diagram.md](../docs/facebook-ads-worker/class-diagram.md).
-Consulte também a documentação oficial da Graph API sempre que precisar interagir com a plataforma: https://developers.facebook.com/docs/graph-api e https://developers.facebook.com/docs/graph-api/reference.
+Consulte também a documentação oficial da Graph API sempre que precisar
+interagir com a plataforma: https://developers.facebook.com/docs/graph-api e
+https://developers.facebook.com/docs/graph-api/reference.
 
 ## Build
 ```

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -5,8 +5,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Service
 public class FacebookAdsService {
@@ -40,6 +42,90 @@ public class FacebookAdsService {
         return createInstagramCampaign(adAccountId, name);
     }
 
+    public String createAdSet(String adAccountId, AdSetRequest request) {
+        Objects.requireNonNull(request, "request");
+
+        Map<String, Object> targeting = Map.of(
+            "geo_locations", Map.of("countries", List.of(request.targetCountry()))
+        );
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", request.name());
+        body.put("campaign_id", request.campaignId());
+        body.put("daily_budget", request.dailyBudget());
+        body.put("billing_event", request.billingEvent());
+        body.put("optimization_goal", request.optimizationGoal());
+        body.put("status", "PAUSED");
+        body.put("destination_type", request.destinationType());
+        body.put("targeting", targeting);
+        if (request.pageId() != null && !request.pageId().isBlank()) {
+            body.put("promoted_object", Map.of("page_id", request.pageId()));
+        }
+        body.put("access_token", accessToken);
+
+        JsonNode response = webClient.post()
+            .uri("/v20.0/act_" + adAccountId + "/adsets")
+            .bodyValue(body)
+            .retrieve()
+            .bodyToMono(JsonNode.class)
+            .block();
+
+        return response.path("id").asText();
+    }
+
+    public String createAdCreative(String adAccountId, AdCreativeRequest request) {
+        Objects.requireNonNull(request, "request");
+
+        Map<String, Object> linkData = new HashMap<>();
+        linkData.put("link", request.websiteUrl());
+        linkData.put("message", request.message());
+        linkData.put("call_to_action", Map.of(
+            "type", request.callToActionType(),
+            "value", Map.of("link", request.websiteUrl())
+        ));
+
+        Map<String, Object> objectStorySpec = new HashMap<>();
+        objectStorySpec.put("page_id", request.pageId());
+        if (request.instagramActorId() != null && !request.instagramActorId().isBlank()) {
+            objectStorySpec.put("instagram_actor_id", request.instagramActorId());
+        }
+        objectStorySpec.put("link_data", linkData);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", request.name());
+        body.put("object_story_spec", objectStorySpec);
+        body.put("access_token", accessToken);
+
+        JsonNode response = webClient.post()
+            .uri("/v20.0/act_" + adAccountId + "/adcreatives")
+            .bodyValue(body)
+            .retrieve()
+            .bodyToMono(JsonNode.class)
+            .block();
+
+        return response.path("id").asText();
+    }
+
+    public String createAd(String adAccountId, AdRequest request) {
+        Objects.requireNonNull(request, "request");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", request.name());
+        body.put("adset_id", request.adSetId());
+        body.put("creative", Map.of("creative_id", request.creativeId()));
+        body.put("status", "PAUSED");
+        body.put("access_token", accessToken);
+
+        JsonNode response = webClient.post()
+            .uri("/v20.0/act_" + adAccountId + "/ads")
+            .bodyValue(body)
+            .retrieve()
+            .bodyToMono(JsonNode.class)
+            .block();
+
+        return response.path("id").asText();
+    }
+
     public JsonNode getCampaignMetrics(String campaignId) {
         return webClient.get()
             .uri("/v20.0/" + campaignId + "/insights?access_token=" + accessToken)
@@ -47,4 +133,30 @@ public class FacebookAdsService {
             .bodyToMono(JsonNode.class)
             .block();
     }
+
+    public record AdSetRequest(
+        String name,
+        String campaignId,
+        String dailyBudget,
+        String billingEvent,
+        String optimizationGoal,
+        String destinationType,
+        String pageId,
+        String targetCountry
+    ) {}
+
+    public record AdCreativeRequest(
+        String name,
+        String pageId,
+        String instagramActorId,
+        String websiteUrl,
+        String message,
+        String callToActionType
+    ) {}
+
+    public record AdRequest(
+        String name,
+        String adSetId,
+        String creativeId
+    ) {}
 }

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -24,17 +24,47 @@ public class FacebookCampaignService {
     private final String backendBaseUrl;
     private final String apiPrefix;
     private final String adAccountId;
+    private final String adSetDailyBudget;
+    private final String adSetBillingEvent;
+    private final String adSetOptimizationGoal;
+    private final String adSetDestinationType;
+    private final String adSetTargetCountry;
+    private final String pageId;
+    private final String instagramActorId;
+    private final String websiteUrl;
+    private final String creativeMessageTemplate;
+    private final String callToActionType;
 
     public FacebookCampaignService(FacebookAdsService facebookAdsService,
                                    WebClient.Builder builder,
                                    @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
                                    @Value("${backend.api-prefix:/api}") String apiPrefix,
-                                   @Value("${facebook.ad-account-id}") String adAccountId) {
+                                   @Value("${facebook.ad-account-id}") String adAccountId,
+                                   @Value("${facebook.ad-set.daily-budget:1000}") String adSetDailyBudget,
+                                   @Value("${facebook.ad-set.billing-event:IMPRESSIONS}") String adSetBillingEvent,
+                                   @Value("${facebook.ad-set.optimization-goal:LINK_CLICKS}") String adSetOptimizationGoal,
+                                   @Value("${facebook.ad-set.destination-type:WEBSITE}") String adSetDestinationType,
+                                   @Value("${facebook.ad-set.target-country:BR}") String adSetTargetCountry,
+                                   @Value("${facebook.page-id}") String pageId,
+                                   @Value("${facebook.instagram-actor-id:}") String instagramActorId,
+                                   @Value("${facebook.website-url}") String websiteUrl,
+                                   @Value("${facebook.creative.message-template:%s}") String creativeMessageTemplate,
+                                   @Value("${facebook.creative.call-to-action-type:LEARN_MORE}") String callToActionType) {
         this.facebookAdsService = facebookAdsService;
         this.backendClient = builder.build();
         this.backendBaseUrl = backendBaseUrl;
         this.apiPrefix = apiPrefix;
         this.adAccountId = adAccountId;
+        this.adSetDailyBudget = adSetDailyBudget;
+        this.adSetBillingEvent = adSetBillingEvent;
+        this.adSetOptimizationGoal = adSetOptimizationGoal;
+        this.adSetDestinationType = adSetDestinationType;
+        this.adSetTargetCountry = adSetTargetCountry;
+        this.pageId = pageId;
+        this.instagramActorId = instagramActorId;
+        this.websiteUrl = websiteUrl;
+        this.creativeMessageTemplate = creativeMessageTemplate;
+        this.callToActionType = callToActionType;
     }
 
     public void createCampaignsFromExperiments() {
@@ -69,6 +99,29 @@ public class FacebookCampaignService {
 
     private void processExperiment(Experiment exp) {
         String campaignId = facebookAdsService.createCampaign(adAccountId, exp.name());
+        String adSetId = facebookAdsService.createAdSet(adAccountId, new FacebookAdsService.AdSetRequest(
+            exp.name() + " - Ad Set",
+            campaignId,
+            adSetDailyBudget,
+            adSetBillingEvent,
+            adSetOptimizationGoal,
+            adSetDestinationType,
+            pageId,
+            adSetTargetCountry
+        ));
+        String creativeId = facebookAdsService.createAdCreative(adAccountId, new FacebookAdsService.AdCreativeRequest(
+            exp.name() + " - Creative",
+            pageId,
+            instagramActorId,
+            websiteUrl,
+            formatCreativeMessage(exp.name()),
+            callToActionType
+        ));
+        facebookAdsService.createAd(adAccountId, new FacebookAdsService.AdRequest(
+            exp.name() + " - Ad",
+            adSetId,
+            creativeId
+        ));
         CreateCampaignRequest req = new CreateCampaignRequest(campaignId, adAccountId, exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
         backendClient.post()
             .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns"))
@@ -76,6 +129,16 @@ public class FacebookCampaignService {
             .retrieve()
             .toBodilessEntity()
             .block();
+    }
+
+    private String formatCreativeMessage(String experimentName) {
+        if (creativeMessageTemplate == null || creativeMessageTemplate.isBlank()) {
+            return experimentName;
+        }
+        if (creativeMessageTemplate.contains("%s")) {
+            return String.format(creativeMessageTemplate, experimentName);
+        }
+        return creativeMessageTemplate;
     }
 
     public record Experiment(long id, String name) {}

--- a/facebook-ads-worker/src/main/resources/application.properties
+++ b/facebook-ads-worker/src/main/resources/application.properties
@@ -2,4 +2,14 @@ spring.application.name=facebook-ads-worker
 backend.base-url=http://191.252.92.222:8000
 instagramcampaign.scheduler.delay=60000
 backend.api-prefix=/api
+facebook.ad-set.daily-budget=2000
+facebook.ad-set.billing-event=IMPRESSIONS
+facebook.ad-set.optimization-goal=LINK_CLICKS
+facebook.ad-set.destination-type=WEBSITE
+facebook.ad-set.target-country=BR
+facebook.page-id=
+facebook.instagram-actor-id=
+facebook.website-url=https://example.com
+facebook.creative.message-template=%s
+facebook.creative.call-to-action-type=LEARN_MORE
 

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -49,6 +49,83 @@ class FacebookAdsServiceTest {
     }
 
     @Test
+    void createAdSetPostsCorrectRequest() throws Exception {
+        server.enqueue(new MockResponse().setBody("{\"id\":\"222\"}")
+            .addHeader("Content-Type", "application/json"));
+        FacebookAdsService.AdSetRequest request = new FacebookAdsService.AdSetRequest(
+            "Camp - Ad Set",
+            "123",
+            "1500",
+            "IMPRESSIONS",
+            "LINK_CLICKS",
+            "WEBSITE",
+            "42",
+            "BR"
+        );
+        String id = service.createAdSet("1", request);
+        RecordedRequest recorded = server.takeRequest();
+        assertEquals("/v20.0/act_1/adsets", recorded.getPath());
+        JsonNode body = objectMapper.readTree(recorded.getBody().inputStream());
+        assertEquals("Camp - Ad Set", body.get("name").asText());
+        assertEquals("123", body.get("campaign_id").asText());
+        assertEquals("1500", body.get("daily_budget").asText());
+        assertEquals("IMPRESSIONS", body.get("billing_event").asText());
+        assertEquals("LINK_CLICKS", body.get("optimization_goal").asText());
+        assertEquals("PAUSED", body.get("status").asText());
+        assertEquals("WEBSITE", body.get("destination_type").asText());
+        assertEquals("BR", body.get("targeting").get("geo_locations").get("countries").get(0).asText());
+        assertEquals("42", body.get("promoted_object").get("page_id").asText());
+        assertEquals("222", id);
+    }
+
+    @Test
+    void createAdCreativePostsCorrectRequest() throws Exception {
+        server.enqueue(new MockResponse().setBody("{\"id\":\"333\"}")
+            .addHeader("Content-Type", "application/json"));
+        FacebookAdsService.AdCreativeRequest request = new FacebookAdsService.AdCreativeRequest(
+            "Camp - Creative",
+            "42",
+            "11",
+            "https://example.com",
+            "Mensagem",
+            "LEARN_MORE"
+        );
+        String id = service.createAdCreative("1", request);
+        RecordedRequest recorded = server.takeRequest();
+        assertEquals("/v20.0/act_1/adcreatives", recorded.getPath());
+        JsonNode body = objectMapper.readTree(recorded.getBody().inputStream());
+        JsonNode storySpec = body.get("object_story_spec");
+        assertEquals("42", storySpec.get("page_id").asText());
+        assertEquals("11", storySpec.get("instagram_actor_id").asText());
+        JsonNode linkData = storySpec.get("link_data");
+        assertEquals("https://example.com", linkData.get("link").asText());
+        assertEquals("Mensagem", linkData.get("message").asText());
+        assertEquals("LEARN_MORE", linkData.get("call_to_action").get("type").asText());
+        assertEquals("https://example.com", linkData.get("call_to_action").get("value").get("link").asText());
+        assertEquals("333", id);
+    }
+
+    @Test
+    void createAdPostsCorrectRequest() throws Exception {
+        server.enqueue(new MockResponse().setBody("{\"id\":\"444\"}")
+            .addHeader("Content-Type", "application/json"));
+        FacebookAdsService.AdRequest request = new FacebookAdsService.AdRequest(
+            "Camp - Ad",
+            "adset",
+            "creative"
+        );
+        String id = service.createAd("1", request);
+        RecordedRequest recorded = server.takeRequest();
+        assertEquals("/v20.0/act_1/ads", recorded.getPath());
+        JsonNode body = objectMapper.readTree(recorded.getBody().inputStream());
+        assertEquals("Camp - Ad", body.get("name").asText());
+        assertEquals("adset", body.get("adset_id").asText());
+        assertEquals("creative", body.get("creative").get("creative_id").asText());
+        assertEquals("PAUSED", body.get("status").asText());
+        assertEquals("444", id);
+    }
+
+    @Test
     void metricsRequestsCampaignInsights() throws Exception {
         server.enqueue(new MockResponse().setBody("{\"data\":[{\"impressions\":\"10\"}]}")
             .addHeader("Content-Type", "application/json"));

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -1,5 +1,7 @@
 package com.marketinghub.facebookadsworker.facebookcampaign;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.facebookadsworker.FacebookAdsService;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -18,6 +20,7 @@ class FacebookCampaignServiceTest {
     private MockWebServer backend;
     private MockWebServer facebook;
     private FacebookCampaignService service;
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -30,7 +33,24 @@ class FacebookCampaignServiceTest {
         String facebookUrl = facebook.url("/").toString();
 
         FacebookAdsService adsService = new FacebookAdsService(WebClient.builder(), facebookUrl, "token");
-        service = new FacebookCampaignService(adsService, WebClient.builder(), backendUrl, "/api", "1");
+        service = new FacebookCampaignService(
+            adsService,
+            WebClient.builder(),
+            backendUrl,
+            "/api",
+            "1",
+            "2000",
+            "IMPRESSIONS",
+            "LINK_CLICKS",
+            "WEBSITE",
+            "BR",
+            "42",
+            "11",
+            "https://example.com",
+            "Conheça %s",
+            "LEARN_MORE"
+        );
+        objectMapper = new ObjectMapper();
     }
 
     @AfterEach
@@ -40,10 +60,16 @@ class FacebookCampaignServiceTest {
     }
 
     @Test
-    void createsCampaignForEachExperiment() throws Exception {
+    void createsCampaignHierarchyForEachExperiment() throws Exception {
         backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\"}]")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"10\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"20\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"30\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"40\"}")
             .addHeader("Content-Type", "application/json"));
         backend.enqueue(new MockResponse().setBody("{}")
             .addHeader("Content-Type", "application/json"));
@@ -52,8 +78,32 @@ class FacebookCampaignServiceTest {
 
         RecordedRequest get = backend.takeRequest();
         assertEquals("/api/facebook-campaigns/experiments-ready", get.getPath());
-        RecordedRequest postFb = facebook.takeRequest();
-        assertEquals("/v20.0/act_1/campaigns", postFb.getPath());
+
+        RecordedRequest postCampaign = facebook.takeRequest();
+        assertEquals("/v20.0/act_1/campaigns", postCampaign.getPath());
+
+        RecordedRequest postAdSet = facebook.takeRequest();
+        assertEquals("/v20.0/act_1/adsets", postAdSet.getPath());
+        JsonNode adSetPayload = objectMapper.readTree(postAdSet.getBody().inputStream());
+        assertEquals("Exp - Ad Set", adSetPayload.get("name").asText());
+        assertEquals("10", adSetPayload.get("campaign_id").asText());
+        assertEquals("2000", adSetPayload.get("daily_budget").asText());
+
+        RecordedRequest postCreative = facebook.takeRequest();
+        assertEquals("/v20.0/act_1/adcreatives", postCreative.getPath());
+        JsonNode creativePayload = objectMapper.readTree(postCreative.getBody().inputStream());
+        assertEquals("Exp - Creative", creativePayload.get("name").asText());
+        JsonNode storySpec = creativePayload.get("object_story_spec");
+        assertEquals("42", storySpec.get("page_id").asText());
+        assertEquals("Conheça Exp", storySpec.get("link_data").get("message").asText());
+
+        RecordedRequest postAd = facebook.takeRequest();
+        assertEquals("/v20.0/act_1/ads", postAd.getPath());
+        JsonNode adPayload = objectMapper.readTree(postAd.getBody().inputStream());
+        assertEquals("Exp - Ad", adPayload.get("name").asText());
+        assertEquals("20", adPayload.get("adset_id").asText());
+        assertEquals("30", adPayload.get("creative").get("creative_id").asText());
+
         RecordedRequest postBackend = backend.takeRequest();
         assertEquals("/api/facebook-campaigns", postBackend.getPath());
     }


### PR DESCRIPTION
## Summary
- expandir o FacebookAdsService com métodos para criar ad sets, criativos e anúncios utilizando a Graph API
- ajustar o FacebookCampaignService para montar toda a hierarquia de mídia com base em novas propriedades configuráveis e formatar mensagens do criativo
- atualizar testes e documentação do facebook-ads-worker para refletir a criação de ad set e anúncio

## Testing
- `mvn -s settings.xml test` *(falhou: Network is unreachable ao baixar parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d5495ccdc483218894c66a5c59adc6