### PR TITLE
Fix campaign creation special ad categories

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -8,7 +8,9 @@ projeto `backend`, evitando duplicação de entidades.
 O fluxo automatizado cria toda a hierarquia necessária para veiculação:
 
 1. **Campanha** (`POST /campaigns`) com objetivo `OUTCOME_TRAFFIC`, status
-   inicial `PAUSED` e `special_ad_categories = NONE`.
+   inicial `PAUSED` e `special_ad_categories = []`, conforme documentado na
+   [Marketing API](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group#Creating) para contas que
+   não se enquadram em categorias especiais.
 2. **Conjunto de anúncios** (`POST /adsets`) atrelado à campanha, também em
    `PAUSED`, com segmentação geográfica simples e destino `WEBSITE`.
 3. **Criativo** (`POST /adcreatives`) baseado em um `object_story_spec`

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -29,7 +29,7 @@ public class FacebookAdsService {
                 "name", name,
                 "objective", "OUTCOME_TRAFFIC",
                 "status", "PAUSED",
-                "special_ad_categories", List.of("NONE"),
+                "special_ad_categories", List.of(),
                 "access_token", accessToken
             ))
             .retrieve()

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -44,7 +44,7 @@ class FacebookAdsServiceTest {
         assertEquals("Camp", body.get("name").asText());
         assertEquals("OUTCOME_TRAFFIC", body.get("objective").asText());
         assertEquals("PAUSED", body.get("status").asText());
-        assertEquals("NONE", body.get("special_ad_categories").get(0).asText());
+        assertEquals(0, body.get("special_ad_categories").size());
         assertEquals("123", id);
     }
 


### PR DESCRIPTION
## Summary
- ensure campaign creation requests use an empty special_ad_categories array per the Marketing API guidance for non-special accounts
- update the unit test expectation for the serialized payload
- document the requirement in the module README with a link to the official reference

## Testing
- `mvn -s settings.xml test` *(fails: parent POM could not be resolved in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5599f9f18832192392d5e53f3e80a