### PR TITLE
feat: add detailed logging for facebook api requests

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -28,6 +28,11 @@ que o agendamento continue saudável. Após criar campanha, conjunto, criativo e
 anúncio, o worker persiste o identificador da campanha via
 `POST /api/facebook-campaigns`.
 
+Todas as chamadas à Graph API são logadas detalhadamente para facilitar
+investigações de erros (por exemplo, respostas `400 Bad Request`). Os logs
+registram caminho da requisição, payload enviado (com `access_token`
+anonimizado) e o corpo da resposta retornada pelo Facebook.
+
 Os acessos são configurados pelas propriedades:
 
 - `backend.base-url` (default: `http://191.252.92.222:8000`)

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -1,10 +1,15 @@
 package com.marketinghub.facebookadsworker;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -12,6 +17,8 @@ import java.util.Objects;
 
 @Service
 public class FacebookAdsService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FacebookAdsService.class);
+
     private final WebClient webClient;
     private final String accessToken;
 
@@ -23,18 +30,16 @@ public class FacebookAdsService {
     }
 
     public String createInstagramCampaign(String adAccountId, String name) {
-        JsonNode response = webClient.post()
-            .uri("/v20.0/act_" + adAccountId + "/campaigns")
-            .bodyValue(Map.of(
-                "name", name,
-                "objective", "OUTCOME_TRAFFIC",
-                "status", "PAUSED",
-                "special_ad_categories", List.of(),
-                "access_token", accessToken
-            ))
-            .retrieve()
-            .bodyToMono(JsonNode.class)
-            .block();
+        String path = "/v20.0/act_" + adAccountId + "/campaigns";
+        Map<String, Object> body = Map.of(
+            "name", name,
+            "objective", "OUTCOME_TRAFFIC",
+            "status", "PAUSED",
+            "special_ad_categories", List.of(),
+            "access_token", accessToken
+        );
+
+        JsonNode response = executePost(path, body);
         return response.path("id").asText();
     }
 
@@ -63,13 +68,9 @@ public class FacebookAdsService {
         }
         body.put("access_token", accessToken);
 
-        JsonNode response = webClient.post()
-            .uri("/v20.0/act_" + adAccountId + "/adsets")
-            .bodyValue(body)
-            .retrieve()
-            .bodyToMono(JsonNode.class)
-            .block();
+        String path = "/v20.0/act_" + adAccountId + "/adsets";
 
+        JsonNode response = executePost(path, body);
         return response.path("id").asText();
     }
 
@@ -96,13 +97,9 @@ public class FacebookAdsService {
         body.put("object_story_spec", objectStorySpec);
         body.put("access_token", accessToken);
 
-        JsonNode response = webClient.post()
-            .uri("/v20.0/act_" + adAccountId + "/adcreatives")
-            .bodyValue(body)
-            .retrieve()
-            .bodyToMono(JsonNode.class)
-            .block();
+        String path = "/v20.0/act_" + adAccountId + "/adcreatives";
 
+        JsonNode response = executePost(path, body);
         return response.path("id").asText();
     }
 
@@ -116,22 +113,114 @@ public class FacebookAdsService {
         body.put("status", "PAUSED");
         body.put("access_token", accessToken);
 
-        JsonNode response = webClient.post()
-            .uri("/v20.0/act_" + adAccountId + "/ads")
-            .bodyValue(body)
-            .retrieve()
-            .bodyToMono(JsonNode.class)
-            .block();
+        String path = "/v20.0/act_" + adAccountId + "/ads";
 
+        JsonNode response = executePost(path, body);
         return response.path("id").asText();
     }
 
     public JsonNode getCampaignMetrics(String campaignId) {
-        return webClient.get()
-            .uri("/v20.0/" + campaignId + "/insights?access_token=" + accessToken)
-            .retrieve()
-            .bodyToMono(JsonNode.class)
-            .block();
+        String path = "/v20.0/" + campaignId + "/insights?access_token=" + accessToken;
+        String maskedPath = maskAccessTokenInPath(path);
+        LOGGER.info("Sending GET request to Facebook API: path={}", maskedPath);
+        try {
+            JsonNode response = webClient.get()
+                .uri(path)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+            LOGGER.info("Received response from Facebook API: path={}, response={}", maskedPath, response);
+            return response;
+        } catch (WebClientResponseException ex) {
+            LOGGER.error(
+                "Facebook API GET request failed: path={}, status={}, responseBody={}",
+                maskedPath,
+                ex.getRawStatusCode(),
+                maskAccessToken(ex.getResponseBodyAsString()),
+                ex
+            );
+            throw ex;
+        } catch (WebClientRequestException ex) {
+            LOGGER.error("Facebook API GET request could not be completed: path={}, message={}", maskedPath, ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    private JsonNode executePost(String path, Map<String, Object> body) {
+        Map<String, Object> sanitizedBody = sanitizeBody(body);
+        LOGGER.info("Sending POST request to Facebook API: path={}, body={}", maskAccessTokenInPath(path), sanitizedBody);
+        try {
+            JsonNode response = webClient.post()
+                .uri(path)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+            LOGGER.info("Received response from Facebook API: path={}, response={}", maskAccessTokenInPath(path), response);
+            return response;
+        } catch (WebClientResponseException ex) {
+            LOGGER.error(
+                "Facebook API POST request failed: path={}, status={}, responseBody={}, headers={}",
+                maskAccessTokenInPath(path),
+                ex.getRawStatusCode(),
+                maskAccessToken(ex.getResponseBodyAsString()),
+                ex.getHeaders(),
+                ex
+            );
+            throw ex;
+        } catch (WebClientRequestException ex) {
+            LOGGER.error(
+                "Facebook API POST request could not be completed: path={}, message={}",
+                maskAccessTokenInPath(path),
+                ex.getMessage(),
+                ex
+            );
+            throw ex;
+        }
+    }
+
+    private Map<String, Object> sanitizeBody(Map<String, Object> body) {
+        Map<String, Object> sanitized = new HashMap<>();
+        body.forEach((key, value) -> sanitized.put(key, sanitizeValue(key, value)));
+        return sanitized;
+    }
+
+    private Object sanitizeValue(String key, Object value) {
+        if (value instanceof Map<?, ?> valueMap) {
+            Map<String, Object> nested = new HashMap<>();
+            valueMap.forEach((nestedKey, nestedValue) ->
+                nested.put(String.valueOf(nestedKey), sanitizeValue(String.valueOf(nestedKey), nestedValue))
+            );
+            return nested;
+        }
+        if (value instanceof List<?> listValue) {
+            List<Object> sanitizedList = new ArrayList<>(listValue.size());
+            for (Object item : listValue) {
+                sanitizedList.add(sanitizeValue(key, item));
+            }
+            return sanitizedList;
+        }
+        if ("access_token".equalsIgnoreCase(key) && value instanceof String stringValue) {
+            return maskAccessToken(stringValue);
+        }
+        return value;
+    }
+
+    private String maskAccessToken(String token) {
+        if (token == null || token.isBlank()) {
+            return token;
+        }
+        if (token.length() <= 6) {
+            return "***";
+        }
+        return token.substring(0, 3) + "..." + token.substring(token.length() - 3);
+    }
+
+    private String maskAccessTokenInPath(String path) {
+        if (path == null || path.isBlank() || accessToken == null || accessToken.isBlank()) {
+            return path;
+        }
+        return path.replace(accessToken, maskAccessToken(accessToken));
     }
 
     public record AdSetRequest(


### PR DESCRIPTION
## Summary
- add structured logging around Facebook Graph API requests and responses with token masking
- describe the expanded Facebook API logging in the worker documentation

## Testing
- mvn -s settings.xml test *(fails: unable to download parent POM because the network to GitHub Packages is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d5722f0af08321b83a6fbb16116c71