### PR TITLE
Update Facebook Ads Worker to use Graph API v23.0

### DIFF
--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -7,6 +7,7 @@
 - Tipos de dados permitidos (MySql 5): `INT`, `BIGINT`, `DECIMAL`, `DOUBLE`, `FLOAT`, `CHAR`, `VARCHAR`, `TEXT`, `LONGTEXT`, `BINARY(16)` para `UUID`, `DATE`, `DATETIME`, `TIMESTAMP`, `BOOLEAN`.
 - Utilize o `facebook-ads-worker` para todas as chamadas à API do Facebook.
 - Consulte sempre a documentação oficial da Graph API ao trabalhar neste módulo: https://developers.facebook.com/docs/graph-api e https://developers.facebook.com/docs/graph-api/reference.
+- A versão da Graph API é configurável via propriedade `facebook.graph-api.version` (default `v23.0`) e deve estar alinhada com a recomendação oficial.
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.
 - Endpoints do backend devem ser acessados com o prefixo configurado em `backend.api-prefix` (default `/api`).
 

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -46,6 +46,7 @@ Os acessos são configurados pelas propriedades:
 - `facebook.page-id` (sem default – obrigatório)
 - `facebook.instagram-actor-id` (opcional)
 - `facebook.website-url` (sem default – obrigatório)
+- `facebook.graph-api.version` (default: `v23.0` – utilizado para montar os caminhos da Graph API)
 - `facebook.creative.message-template` (default: `%s` – utiliza o nome do
   experimento quando contém `%s`)
 - `facebook.creative.call-to-action-type` (default: `LEARN_MORE`)

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -21,16 +21,20 @@ public class FacebookAdsService {
 
     private final WebClient webClient;
     private final String accessToken;
+    private final String apiVersion;
 
     public FacebookAdsService(WebClient.Builder builder,
                               @Value("${facebook.graph-api.base-url:https://graph.facebook.com}") String baseUrl,
-                              @Value("${facebook.access-token}") String accessToken) {
+                              @Value("${facebook.access-token}") String accessToken,
+                              @Value("${facebook.graph-api.version:v23.0}") String apiVersion) {
         this.webClient = builder.baseUrl(baseUrl).build();
         this.accessToken = accessToken;
+        this.apiVersion = normalizeVersion(apiVersion);
+        LOGGER.info("Configured Facebook Graph API version: {}", this.apiVersion);
     }
 
     public String createInstagramCampaign(String adAccountId, String name) {
-        String path = "/v20.0/act_" + adAccountId + "/campaigns";
+        String path = buildVersionedPath("/act_" + adAccountId + "/campaigns");
         Map<String, Object> body = Map.of(
             "name", name,
             "objective", "OUTCOME_TRAFFIC",
@@ -68,7 +72,7 @@ public class FacebookAdsService {
         }
         body.put("access_token", accessToken);
 
-        String path = "/v20.0/act_" + adAccountId + "/adsets";
+        String path = buildVersionedPath("/act_" + adAccountId + "/adsets");
 
         JsonNode response = executePost(path, body);
         return response.path("id").asText();
@@ -97,7 +101,7 @@ public class FacebookAdsService {
         body.put("object_story_spec", objectStorySpec);
         body.put("access_token", accessToken);
 
-        String path = "/v20.0/act_" + adAccountId + "/adcreatives";
+        String path = buildVersionedPath("/act_" + adAccountId + "/adcreatives");
 
         JsonNode response = executePost(path, body);
         return response.path("id").asText();
@@ -113,14 +117,14 @@ public class FacebookAdsService {
         body.put("status", "PAUSED");
         body.put("access_token", accessToken);
 
-        String path = "/v20.0/act_" + adAccountId + "/ads";
+        String path = buildVersionedPath("/act_" + adAccountId + "/ads");
 
         JsonNode response = executePost(path, body);
         return response.path("id").asText();
     }
 
     public JsonNode getCampaignMetrics(String campaignId) {
-        String path = "/v20.0/" + campaignId + "/insights?access_token=" + accessToken;
+        String path = buildVersionedPath("/" + campaignId + "/insights?access_token=" + accessToken);
         String maskedPath = maskAccessTokenInPath(path);
         LOGGER.info("Sending GET request to Facebook API: path={}", maskedPath);
         try {
@@ -221,6 +225,22 @@ public class FacebookAdsService {
             return path;
         }
         return path.replace(accessToken, maskAccessToken(accessToken));
+    }
+
+    private String buildVersionedPath(String resourcePath) {
+        String normalizedResource = resourcePath.startsWith("/") ? resourcePath : "/" + resourcePath;
+        return "/" + apiVersion + normalizedResource;
+    }
+
+    private String normalizeVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return "v23.0";
+        }
+        String trimmed = version.trim();
+        if (trimmed.startsWith("/")) {
+            trimmed = trimmed.substring(1);
+        }
+        return trimmed.startsWith("v") ? trimmed : "v" + trimmed;
     }
 
     public record AdSetRequest(

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -24,7 +24,7 @@ class FacebookAdsServiceTest {
         server = new MockWebServer();
         server.start();
         String baseUrl = server.url("/").toString();
-        service = new FacebookAdsService(WebClient.builder(), baseUrl, "token");
+        service = new FacebookAdsService(WebClient.builder(), baseUrl, "token", "v23.0");
         objectMapper = new ObjectMapper();
     }
 
@@ -39,7 +39,7 @@ class FacebookAdsServiceTest {
             .addHeader("Content-Type", "application/json"));
         String id = service.createInstagramCampaign("1", "Camp");
         RecordedRequest request = server.takeRequest();
-        assertEquals("/v20.0/act_1/campaigns", request.getPath());
+        assertEquals("/v23.0/act_1/campaigns", request.getPath());
         JsonNode body = objectMapper.readTree(request.getBody().inputStream());
         assertEquals("Camp", body.get("name").asText());
         assertEquals("OUTCOME_TRAFFIC", body.get("objective").asText());
@@ -64,7 +64,7 @@ class FacebookAdsServiceTest {
         );
         String id = service.createAdSet("1", request);
         RecordedRequest recorded = server.takeRequest();
-        assertEquals("/v20.0/act_1/adsets", recorded.getPath());
+        assertEquals("/v23.0/act_1/adsets", recorded.getPath());
         JsonNode body = objectMapper.readTree(recorded.getBody().inputStream());
         assertEquals("Camp - Ad Set", body.get("name").asText());
         assertEquals("123", body.get("campaign_id").asText());
@@ -92,7 +92,7 @@ class FacebookAdsServiceTest {
         );
         String id = service.createAdCreative("1", request);
         RecordedRequest recorded = server.takeRequest();
-        assertEquals("/v20.0/act_1/adcreatives", recorded.getPath());
+        assertEquals("/v23.0/act_1/adcreatives", recorded.getPath());
         JsonNode body = objectMapper.readTree(recorded.getBody().inputStream());
         JsonNode storySpec = body.get("object_story_spec");
         assertEquals("42", storySpec.get("page_id").asText());
@@ -116,7 +116,7 @@ class FacebookAdsServiceTest {
         );
         String id = service.createAd("1", request);
         RecordedRequest recorded = server.takeRequest();
-        assertEquals("/v20.0/act_1/ads", recorded.getPath());
+        assertEquals("/v23.0/act_1/ads", recorded.getPath());
         JsonNode body = objectMapper.readTree(recorded.getBody().inputStream());
         assertEquals("Camp - Ad", body.get("name").asText());
         assertEquals("adset", body.get("adset_id").asText());
@@ -131,7 +131,7 @@ class FacebookAdsServiceTest {
             .addHeader("Content-Type", "application/json"));
         JsonNode node = service.getCampaignMetrics("77");
         RecordedRequest request = server.takeRequest();
-        assertEquals("/v20.0/77/insights?access_token=token", request.getPath());
+        assertEquals("/v23.0/77/insights?access_token=token", request.getPath());
         assertEquals("10", node.get("data").get(0).path("impressions").asText());
     }
 }

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -32,7 +32,7 @@ class FacebookCampaignServiceTest {
         String backendUrl = backend.url("/").toString();
         String facebookUrl = facebook.url("/").toString();
 
-        FacebookAdsService adsService = new FacebookAdsService(WebClient.builder(), facebookUrl, "token");
+        FacebookAdsService adsService = new FacebookAdsService(WebClient.builder(), facebookUrl, "token", "v23.0");
         service = new FacebookCampaignService(
             adsService,
             WebClient.builder(),
@@ -80,17 +80,17 @@ class FacebookCampaignServiceTest {
         assertEquals("/api/facebook-campaigns/experiments-ready", get.getPath());
 
         RecordedRequest postCampaign = facebook.takeRequest();
-        assertEquals("/v20.0/act_1/campaigns", postCampaign.getPath());
+        assertEquals("/v23.0/act_1/campaigns", postCampaign.getPath());
 
         RecordedRequest postAdSet = facebook.takeRequest();
-        assertEquals("/v20.0/act_1/adsets", postAdSet.getPath());
+        assertEquals("/v23.0/act_1/adsets", postAdSet.getPath());
         JsonNode adSetPayload = objectMapper.readTree(postAdSet.getBody().inputStream());
         assertEquals("Exp - Ad Set", adSetPayload.get("name").asText());
         assertEquals("10", adSetPayload.get("campaign_id").asText());
         assertEquals("2000", adSetPayload.get("daily_budget").asText());
 
         RecordedRequest postCreative = facebook.takeRequest();
-        assertEquals("/v20.0/act_1/adcreatives", postCreative.getPath());
+        assertEquals("/v23.0/act_1/adcreatives", postCreative.getPath());
         JsonNode creativePayload = objectMapper.readTree(postCreative.getBody().inputStream());
         assertEquals("Exp - Creative", creativePayload.get("name").asText());
         JsonNode storySpec = creativePayload.get("object_story_spec");
@@ -98,7 +98,7 @@ class FacebookCampaignServiceTest {
         assertEquals("Conheça Exp", storySpec.get("link_data").get("message").asText());
 
         RecordedRequest postAd = facebook.takeRequest();
-        assertEquals("/v20.0/act_1/ads", postAd.getPath());
+        assertEquals("/v23.0/act_1/ads", postAd.getPath());
         JsonNode adPayload = objectMapper.readTree(postAd.getBody().inputStream());
         assertEquals("Exp - Ad", adPayload.get("name").asText());
         assertEquals("20", adPayload.get("adset_id").asText());


### PR DESCRIPTION
## Summary
- make the Facebook Graph API version configurable with a default of v23.0 and log the configured value
- update all Facebook Ads requests and associated tests to use the configured Graph API version helper
- document the new `facebook.graph-api.version` property in the module guides

## Testing
- `mvn -s settings.xml test` *(fails: unable to reach https://maven.pkg.github.com/paulofor/marketing-hub while resolving spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68d5778e15208321ad415b3ca775c99c