### PR TITLE
Improve Facebook error logging and document permissions troubleshooting

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -31,7 +31,10 @@ anúncio, o worker persiste o identificador da campanha via
 Todas as chamadas à Graph API são logadas detalhadamente para facilitar
 investigações de erros (por exemplo, respostas `400 Bad Request`). Os logs
 registram caminho da requisição, payload enviado (com `access_token`
-anonimizado) e o corpo da resposta retornada pelo Facebook.
+anonimizado), corpo da resposta retornada pelo Facebook e, quando presente,
+os campos estruturados de erro (`type`, `code`, `error_subcode`,
+`error_user_title`, `error_user_msg`, `fbtrace_id` e `error_data`). Isso
+permite cruzar rapidamente o incidente com a documentação oficial.
 
 Os acessos são configurados pelas propriedades:
 
@@ -65,6 +68,16 @@ Um diagrama de classes simplificado pode ser encontrado em
 Consulte também a documentação oficial da Graph API sempre que precisar
 interagir com a plataforma: https://developers.facebook.com/docs/graph-api e
 https://developers.facebook.com/docs/graph-api/reference.
+
+### Troubleshooting de campanhas com erro `(#200) Permissions error`
+
+Ao criar campanhas o Facebook pode devolver `400 Bad Request` com
+`error.code = 200` e mensagem `Permissions error`. Esse retorno indica que o
+token utilizado não possui o escopo `ads_management` aprovado ou que a conta
+de anúncios não tem acesso padrão liberado para produção. Consulte a tabela
+de [códigos de erro da Marketing API](https://developers.facebook.com/docs/marketing-api/error-reference/#ErrorCodes)
+para confirmar os requisitos de permissão. Após ajustar as permissões,
+reinicie o worker para que o novo token seja utilizado.
 
 ## Build
 ```

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -1,6 +1,8 @@
 package com.marketinghub.facebookadsworker;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,14 +24,17 @@ public class FacebookAdsService {
     private final WebClient webClient;
     private final String accessToken;
     private final String apiVersion;
+    private final ObjectMapper objectMapper;
 
     public FacebookAdsService(WebClient.Builder builder,
                               @Value("${facebook.graph-api.base-url:https://graph.facebook.com}") String baseUrl,
                               @Value("${facebook.access-token}") String accessToken,
-                              @Value("${facebook.graph-api.version:v23.0}") String apiVersion) {
+                              @Value("${facebook.graph-api.version:v23.0}") String apiVersion,
+                              ObjectMapper objectMapper) {
         this.webClient = builder.baseUrl(baseUrl).build();
         this.accessToken = accessToken;
         this.apiVersion = normalizeVersion(apiVersion);
+        this.objectMapper = objectMapper;
         LOGGER.info("Configured Facebook Graph API version: {}", this.apiVersion);
     }
 
@@ -136,11 +141,13 @@ public class FacebookAdsService {
             LOGGER.info("Received response from Facebook API: path={}, response={}", maskedPath, response);
             return response;
         } catch (WebClientResponseException ex) {
+            String responseBody = ex.getResponseBodyAsString();
             LOGGER.error(
-                "Facebook API GET request failed: path={}, status={}, responseBody={}",
+                "Facebook API GET request failed: path={}, status={}, responseBody={}, errorDetails={}",
                 maskedPath,
                 ex.getRawStatusCode(),
-                maskAccessToken(ex.getResponseBodyAsString()),
+                maskAccessToken(responseBody),
+                extractErrorDetails(responseBody),
                 ex
             );
             throw ex;
@@ -163,11 +170,13 @@ public class FacebookAdsService {
             LOGGER.info("Received response from Facebook API: path={}, response={}", maskAccessTokenInPath(path), response);
             return response;
         } catch (WebClientResponseException ex) {
+            String responseBody = ex.getResponseBodyAsString();
             LOGGER.error(
-                "Facebook API POST request failed: path={}, status={}, responseBody={}, headers={}",
+                "Facebook API POST request failed: path={}, status={}, responseBody={}, errorDetails={}, headers={}",
                 maskAccessTokenInPath(path),
                 ex.getRawStatusCode(),
-                maskAccessToken(ex.getResponseBodyAsString()),
+                maskAccessToken(responseBody),
+                extractErrorDetails(responseBody),
                 ex.getHeaders(),
                 ex
             );
@@ -225,6 +234,44 @@ public class FacebookAdsService {
             return path;
         }
         return path.replace(accessToken, maskAccessToken(accessToken));
+    }
+
+    private ObjectNode extractErrorDetails(String responseBody) {
+        if (responseBody == null || responseBody.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            JsonNode errorNode = root.path("error");
+            if (errorNode.isMissingNode() || errorNode.isNull()) {
+                return null;
+            }
+
+            ObjectNode details = objectMapper.createObjectNode();
+            copyIfPresent(errorNode, details, "type");
+            copyIfPresent(errorNode, details, "code");
+            copyIfPresent(errorNode, details, "error_subcode");
+            copyIfPresent(errorNode, details, "message");
+            copyIfPresent(errorNode, details, "error_user_title");
+            copyIfPresent(errorNode, details, "error_user_msg");
+            copyIfPresent(errorNode, details, "fbtrace_id");
+
+            if (errorNode.has("error_data")) {
+                details.set("error_data", errorNode.get("error_data"));
+            }
+
+            return details;
+        } catch (Exception parsingError) {
+            LOGGER.warn("Could not parse Facebook error payload: message={}", parsingError.getMessage(), parsingError);
+            return null;
+        }
+    }
+
+    private void copyIfPresent(JsonNode source, ObjectNode target, String fieldName) {
+        JsonNode value = source.get(fieldName);
+        if (value != null && !value.isNull()) {
+            target.set(fieldName, value);
+        }
     }
 
     private String buildVersionedPath(String resourcePath) {


### PR DESCRIPTION
## Summary
- extract structured error details from Facebook Graph API responses and include them in the logs for both GET and POST calls
- inject the shared ObjectMapper to avoid ad-hoc parsers and warn when the error payload cannot be parsed
- document the additional logging fields and add troubleshooting guidance for the `(#200) Permissions error`

## Testing
- `mvn -s settings.xml test` *(fails: Non-resolvable parent POM due to network is unreachable when downloading spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68d5800023d48321b4edddfb9d0858f3