### PR TITLE
Fix unit tests for FacebookAdsService constructor

### DIFF
--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -24,8 +24,8 @@ class FacebookAdsServiceTest {
         server = new MockWebServer();
         server.start();
         String baseUrl = server.url("/").toString();
-        service = new FacebookAdsService(WebClient.builder(), baseUrl, "token", "v23.0");
         objectMapper = new ObjectMapper();
+        service = new FacebookAdsService(WebClient.builder(), baseUrl, "token", "v23.0", objectMapper);
     }
 
     @AfterEach

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -32,7 +32,14 @@ class FacebookCampaignServiceTest {
         String backendUrl = backend.url("/").toString();
         String facebookUrl = facebook.url("/").toString();
 
-        FacebookAdsService adsService = new FacebookAdsService(WebClient.builder(), facebookUrl, "token", "v23.0");
+        objectMapper = new ObjectMapper();
+        FacebookAdsService adsService = new FacebookAdsService(
+            WebClient.builder(),
+            facebookUrl,
+            "token",
+            "v23.0",
+            objectMapper
+        );
         service = new FacebookCampaignService(
             adsService,
             WebClient.builder(),
@@ -50,7 +57,6 @@ class FacebookCampaignServiceTest {
             "Conheça %s",
             "LEARN_MORE"
         );
-        objectMapper = new ObjectMapper();
     }
 
     @AfterEach


### PR DESCRIPTION
## Summary
- update FacebookAdsService unit tests to build ObjectMapper before constructing the service
- ensure FacebookCampaignService tests pass the required ObjectMapper to FacebookAdsService

## Testing
- `mvn -s settings.xml test` *(fails: unable to reach https://maven.pkg.github.com/paulofor/marketing-hub)*

------
https://chatgpt.com/codex/tasks/task_e_68d5905a4a3c8321b1766fe7d500ab40