### PR TITLE
Handle Facebook permission errors gracefully

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -79,6 +79,12 @@ de [códigos de erro da Marketing API](https://developers.facebook.com/docs/mark
 para confirmar os requisitos de permissão. Após ajustar as permissões,
 reinicie o worker para que o novo token seja utilizado.
 
+O worker captura automaticamente esse erro, interrompe o processamento dos
+demais experimentos na execução atual e registra no log uma mensagem com o
+`error_user_msg` retornado pela API. Isso evita múltiplas tentativas na mesma
+execução e fornece contexto adicional para o time operacional verificar as
+credenciais.
+
 ## Build
 ```
 mvn -s settings.xml package

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -142,15 +142,17 @@ public class FacebookAdsService {
             return response;
         } catch (WebClientResponseException ex) {
             String responseBody = ex.getResponseBodyAsString();
+            ObjectNode errorDetailsNode = extractErrorDetails(responseBody);
+            FacebookApiException.ErrorDetails errorDetails = FacebookApiException.ErrorDetails.from(errorDetailsNode);
             LOGGER.error(
                 "Facebook API GET request failed: path={}, status={}, responseBody={}, errorDetails={}",
                 maskedPath,
                 ex.getRawStatusCode(),
                 maskAccessToken(responseBody),
-                extractErrorDetails(responseBody),
+                errorDetailsNode,
                 ex
             );
-            throw ex;
+            throw buildFacebookApiException("GET", maskedPath, ex, errorDetails);
         } catch (WebClientRequestException ex) {
             LOGGER.error("Facebook API GET request could not be completed: path={}, message={}", maskedPath, ex.getMessage(), ex);
             throw ex;
@@ -159,7 +161,8 @@ public class FacebookAdsService {
 
     private JsonNode executePost(String path, Map<String, Object> body) {
         Map<String, Object> sanitizedBody = sanitizeBody(body);
-        LOGGER.info("Sending POST request to Facebook API: path={}, body={}", maskAccessTokenInPath(path), sanitizedBody);
+        String sanitizedPath = maskAccessTokenInPath(path);
+        LOGGER.info("Sending POST request to Facebook API: path={}, body={}", sanitizedPath, sanitizedBody);
         try {
             JsonNode response = webClient.post()
                 .uri(path)
@@ -167,29 +170,70 @@ public class FacebookAdsService {
                 .retrieve()
                 .bodyToMono(JsonNode.class)
                 .block();
-            LOGGER.info("Received response from Facebook API: path={}, response={}", maskAccessTokenInPath(path), response);
+            LOGGER.info("Received response from Facebook API: path={}, response={}", sanitizedPath, response);
             return response;
         } catch (WebClientResponseException ex) {
             String responseBody = ex.getResponseBodyAsString();
+            ObjectNode errorDetailsNode = extractErrorDetails(responseBody);
+            FacebookApiException.ErrorDetails errorDetails = FacebookApiException.ErrorDetails.from(errorDetailsNode);
             LOGGER.error(
                 "Facebook API POST request failed: path={}, status={}, responseBody={}, errorDetails={}, headers={}",
-                maskAccessTokenInPath(path),
+                sanitizedPath,
                 ex.getRawStatusCode(),
                 maskAccessToken(responseBody),
-                extractErrorDetails(responseBody),
+                errorDetailsNode,
                 ex.getHeaders(),
                 ex
             );
-            throw ex;
+            throw buildFacebookApiException("POST", sanitizedPath, ex, errorDetails);
         } catch (WebClientRequestException ex) {
             LOGGER.error(
                 "Facebook API POST request could not be completed: path={}, message={}",
-                maskAccessTokenInPath(path),
+                sanitizedPath,
                 ex.getMessage(),
                 ex
             );
             throw ex;
         }
+    }
+
+    private FacebookApiException buildFacebookApiException(String method,
+                                                           String sanitizedPath,
+                                                           WebClientResponseException ex,
+                                                           FacebookApiException.ErrorDetails errorDetails) {
+        String message = buildExceptionMessage(method, sanitizedPath, ex, errorDetails);
+        return new FacebookApiException(message, ex.getRawStatusCode(), sanitizedPath, errorDetails, ex);
+    }
+
+    private String buildExceptionMessage(String method,
+                                         String path,
+                                         WebClientResponseException ex,
+                                         FacebookApiException.ErrorDetails errorDetails) {
+        StringBuilder builder = new StringBuilder("Facebook API ")
+            .append(method)
+            .append(" request failed with status ")
+            .append(ex.getRawStatusCode());
+
+        if (ex.getStatusText() != null && !ex.getStatusText().isBlank()) {
+            builder.append(" (").append(ex.getStatusText()).append(')');
+        }
+
+        if (errorDetails != null) {
+            String summary = errorDetails.summary();
+            if (summary != null && !summary.isBlank()) {
+                builder.append(": ").append(summary);
+            }
+            if (errorDetails.code() != null) {
+                builder.append(" [code=").append(errorDetails.code());
+                if (errorDetails.errorSubcode() != null) {
+                    builder.append(", subcode=").append(errorDetails.errorSubcode());
+                }
+                builder.append(']');
+            }
+        }
+
+        builder.append(" - path=").append(path);
+        return builder.toString();
     }
 
     private Map<String, Object> sanitizeBody(Map<String, Object> body) {

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookApiException.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookApiException.java
@@ -1,0 +1,89 @@
+package com.marketinghub.facebookadsworker;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Objects;
+
+/**
+ * Exception that enriches Facebook API errors with structured metadata exposed in the error payload.
+ */
+public class FacebookApiException extends RuntimeException {
+    private final int status;
+    private final String path;
+    private final ErrorDetails errorDetails;
+
+    public FacebookApiException(String message,
+                                int status,
+                                String path,
+                                ErrorDetails errorDetails,
+                                Throwable cause) {
+        super(message, cause);
+        this.status = status;
+        this.path = path;
+        this.errorDetails = errorDetails;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public ErrorDetails getErrorDetails() {
+        return errorDetails;
+    }
+
+    public boolean isPermissionsError() {
+        return errorDetails != null
+            && Objects.equals(errorDetails.code(), 200)
+            && Objects.equals(errorDetails.errorSubcode(), 1815066);
+    }
+
+    public record ErrorDetails(
+        String type,
+        Integer code,
+        Integer errorSubcode,
+        String message,
+        String errorUserTitle,
+        String errorUserMsg,
+        String fbtraceId
+    ) {
+        public static ErrorDetails from(ObjectNode node) {
+            if (node == null) {
+                return null;
+            }
+            return new ErrorDetails(
+                textValue(node, "type"),
+                intValue(node, "code"),
+                intValue(node, "error_subcode"),
+                textValue(node, "message"),
+                textValue(node, "error_user_title"),
+                textValue(node, "error_user_msg"),
+                textValue(node, "fbtrace_id")
+            );
+        }
+
+        private static String textValue(ObjectNode node, String field) {
+            return node.hasNonNull(field) ? node.get(field).asText() : null;
+        }
+
+        private static Integer intValue(ObjectNode node, String field) {
+            return node.hasNonNull(field) ? node.get(field).asInt() : null;
+        }
+
+        public String summary() {
+            if (errorUserMsg != null && !errorUserMsg.isBlank()) {
+                if (errorUserTitle != null && !errorUserTitle.isBlank()) {
+                    return errorUserTitle + ": " + errorUserMsg;
+                }
+                return errorUserMsg;
+            }
+            if (message != null && !message.isBlank()) {
+                return message;
+            }
+            return null;
+        }
+    }
+}

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.facebookadsworker.facebookcampaign;
 
 import com.marketinghub.facebookadsworker.FacebookAdsService;
+import com.marketinghub.facebookadsworker.FacebookApiException;
 import com.marketinghub.facebookadsworker.util.UrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +95,44 @@ public class FacebookCampaignService {
             return;
         }
 
-        experiments.forEach(this::processExperiment);
+        for (Experiment experiment : experiments) {
+            try {
+                processExperiment(experiment);
+            } catch (FacebookApiException ex) {
+                if (ex.isPermissionsError()) {
+                    String reason = extractReadableReason(ex);
+                    LOGGER.error(
+                        "Facebook rejeitou a criação da campanha do experimento {} (id={}): {}. " +
+                            "Revise o token configurado e confirme se a conta de anúncios {} possui permissão 'ads_management' habilitada.",
+                        experiment.name(),
+                        experiment.id(),
+                        reason,
+                        adAccountId,
+                        ex
+                    );
+                    break;
+                }
+                LOGGER.error(
+                    "Falha ao criar campanha do experimento {} (id={}): {}",
+                    experiment.name(),
+                    experiment.id(),
+                    ex.getMessage(),
+                    ex
+                );
+                throw ex;
+            }
+        }
+    }
+
+    private String extractReadableReason(FacebookApiException exception) {
+        FacebookApiException.ErrorDetails details = exception.getErrorDetails();
+        if (details != null) {
+            String summary = details.summary();
+            if (summary != null && !summary.isBlank()) {
+                return summary;
+            }
+        }
+        return exception.getMessage();
     }
 
     private void processExperiment(Experiment exp) {

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -13,6 +13,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FacebookAdsServiceTest {
     private MockWebServer server;
@@ -133,5 +135,33 @@ class FacebookAdsServiceTest {
         RecordedRequest request = server.takeRequest();
         assertEquals("/v23.0/77/insights?access_token=token", request.getPath());
         assertEquals("10", node.get("data").get(0).path("impressions").asText());
+    }
+
+    @Test
+    void wrapsFacebookErrorsWithStructuredException() {
+        server.enqueue(new MockResponse()
+            .setResponseCode(400)
+            .setBody("{" +
+                "\"error\":{" +
+                "\"type\":\"OAuthException\"," +
+                "\"code\":200," +
+                "\"error_subcode\":1815066," +
+                "\"message\":\"Permissions error\"," +
+                "\"error_user_title\":\"O usuário não tem permissão\"," +
+                "\"error_user_msg\":\"O usuário não tem permissão para criar anúncios com esta conta de anúncios\"," +
+                "\"fbtrace_id\":\"trace\"}" +
+                "}")
+            .addHeader("Content-Type", "application/json"));
+
+        FacebookApiException ex = assertThrows(
+            FacebookApiException.class,
+            () -> service.createInstagramCampaign("1", "Camp")
+        );
+
+        assertEquals(400, ex.getStatus());
+        assertTrue(ex.isPermissionsError());
+        assertEquals("O usuário não tem permissão para criar anúncios com esta conta de anúncios",
+            ex.getErrorDetails().errorUserMsg());
+        assertTrue(ex.getMessage().contains("Permissions error"));
     }
 }

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -123,4 +123,28 @@ class FacebookCampaignServiceTest {
         assertEquals(1, backend.getRequestCount());
         assertEquals(0, facebook.getRequestCount());
     }
+
+    @Test
+    void stopsProcessingWhenFacebookReturnsPermissionError() {
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\"},{\"id\":2,\"name\":\"Exp 2\"}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse()
+            .setResponseCode(400)
+            .setBody("{" +
+                "\"error\":{" +
+                "\"type\":\"OAuthException\"," +
+                "\"code\":200," +
+                "\"error_subcode\":1815066," +
+                "\"message\":\"Permissions error\"," +
+                "\"error_user_title\":\"O usuário não tem permissão\"," +
+                "\"error_user_msg\":\"O usuário não tem permissão para criar anúncios com esta conta de anúncios\"," +
+                "\"fbtrace_id\":\"trace\"}" +
+                "}")
+            .addHeader("Content-Type", "application/json"));
+
+        service.createCampaignsFromExperiments();
+
+        assertEquals(1, backend.getRequestCount());
+        assertEquals(1, facebook.getRequestCount());
+    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `FacebookApiException` that captures structured error details returned by the Graph API
- wrap WebClient failures in `FacebookAdsService` so the scheduler can detect permission errors and stop processing on the current run
- document the new behaviour and cover it with unit tests for the service and scheduler

## Testing
- `mvn -s settings.xml test` *(fails: could not download parent POM from GitHub Packages because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a963f72c832190355b8c0d7623b9