### PR TITLE
Handle Facebook permission errors gracefully

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -76,8 +76,12 @@ Ao criar campanhas o Facebook pode devolver `400 Bad Request` com
 token utilizado não possui o escopo `ads_management` aprovado ou que a conta
 de anúncios não tem acesso padrão liberado para produção. Consulte a tabela
 de [códigos de erro da Marketing API](https://developers.facebook.com/docs/marketing-api/error-reference/#ErrorCodes)
-para confirmar os requisitos de permissão. Após ajustar as permissões,
-reinicie o worker para que o novo token seja utilizado.
+para confirmar os requisitos de permissão. Quando esse cenário ocorre, o
+worker marca automaticamente o experimento como `FAILED` via
+`PATCH /api/experiments/{id}/status?status=FAILED` para evitar novas tentativas
+sem intervenção humana. Após ajustar as permissões, atualize manualmente o
+status do experimento para que ele volte a ser elegível e reinicie o worker
+para que o novo token seja utilizado.
 
 ## Build
 ```

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -171,15 +171,19 @@ public class FacebookAdsService {
             return response;
         } catch (WebClientResponseException ex) {
             String responseBody = ex.getResponseBodyAsString();
+            ObjectNode errorDetails = extractErrorDetails(responseBody);
             LOGGER.error(
                 "Facebook API POST request failed: path={}, status={}, responseBody={}, errorDetails={}, headers={}",
                 maskAccessTokenInPath(path),
                 ex.getRawStatusCode(),
                 maskAccessToken(responseBody),
-                extractErrorDetails(responseBody),
+                errorDetails,
                 ex.getHeaders(),
                 ex
             );
+            if (isPermissionError(errorDetails)) {
+                throw new FacebookPermissionException(resolvePermissionMessage(errorDetails), errorDetails, ex);
+            }
             throw ex;
         } catch (WebClientRequestException ex) {
             LOGGER.error(
@@ -272,6 +276,46 @@ public class FacebookAdsService {
         if (value != null && !value.isNull()) {
             target.set(fieldName, value);
         }
+    }
+
+    private boolean isPermissionError(ObjectNode errorDetails) {
+        if (errorDetails == null) {
+            return false;
+        }
+        int code = errorDetails.path("code").asInt();
+        if (code != 200) {
+            return false;
+        }
+
+        int subcode = errorDetails.path("error_subcode").asInt();
+        if (subcode == 1815066) {
+            return true;
+        }
+
+        StringBuilder messageBuilder = new StringBuilder();
+        if (errorDetails.has("message")) {
+            messageBuilder.append(errorDetails.path("message").asText(""));
+        }
+        if (errorDetails.has("error_user_title")) {
+            messageBuilder.append(' ').append(errorDetails.path("error_user_title").asText(""));
+        }
+        if (errorDetails.has("error_user_msg")) {
+            messageBuilder.append(' ').append(errorDetails.path("error_user_msg").asText(""));
+        }
+        return messageBuilder.toString().toLowerCase().contains("permission");
+    }
+
+    private String resolvePermissionMessage(ObjectNode errorDetails) {
+        if (errorDetails == null) {
+            return "Facebook API returned a permissions error";
+        }
+        if (errorDetails.hasNonNull("error_user_msg")) {
+            return errorDetails.get("error_user_msg").asText();
+        }
+        if (errorDetails.hasNonNull("message")) {
+            return errorDetails.get("message").asText();
+        }
+        return "Facebook API returned a permissions error";
     }
 
     private String buildVersionedPath(String resourcePath) {

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookPermissionException.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookPermissionException.java
@@ -1,0 +1,20 @@
+package com.marketinghub.facebookadsworker;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Exception raised when the Facebook API denies the requested operation due to missing permissions.
+ */
+public class FacebookPermissionException extends RuntimeException {
+    private final ObjectNode errorDetails;
+
+    public FacebookPermissionException(String message, ObjectNode errorDetails, Throwable cause) {
+        super(message, cause);
+        this.errorDetails = errorDetails == null ? null : errorDetails.deepCopy();
+    }
+
+    public ObjectNode getErrorDetails() {
+        return errorDetails;
+    }
+}
+

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.facebookadsworker.facebookcampaign;
 
 import com.marketinghub.facebookadsworker.FacebookAdsService;
+import com.marketinghub.facebookadsworker.FacebookPermissionException;
 import com.marketinghub.facebookadsworker.util.UrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,37 +99,48 @@ public class FacebookCampaignService {
     }
 
     private void processExperiment(Experiment exp) {
-        String campaignId = facebookAdsService.createCampaign(adAccountId, exp.name());
-        String adSetId = facebookAdsService.createAdSet(adAccountId, new FacebookAdsService.AdSetRequest(
-            exp.name() + " - Ad Set",
-            campaignId,
-            adSetDailyBudget,
-            adSetBillingEvent,
-            adSetOptimizationGoal,
-            adSetDestinationType,
-            pageId,
-            adSetTargetCountry
-        ));
-        String creativeId = facebookAdsService.createAdCreative(adAccountId, new FacebookAdsService.AdCreativeRequest(
-            exp.name() + " - Creative",
-            pageId,
-            instagramActorId,
-            websiteUrl,
-            formatCreativeMessage(exp.name()),
-            callToActionType
-        ));
-        facebookAdsService.createAd(adAccountId, new FacebookAdsService.AdRequest(
-            exp.name() + " - Ad",
-            adSetId,
-            creativeId
-        ));
-        CreateCampaignRequest req = new CreateCampaignRequest(campaignId, adAccountId, exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
-        backendClient.post()
-            .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns"))
-            .bodyValue(req)
-            .retrieve()
-            .toBodilessEntity()
-            .block();
+        try {
+            String campaignId = facebookAdsService.createCampaign(adAccountId, exp.name());
+            String adSetId = facebookAdsService.createAdSet(adAccountId, new FacebookAdsService.AdSetRequest(
+                exp.name() + " - Ad Set",
+                campaignId,
+                adSetDailyBudget,
+                adSetBillingEvent,
+                adSetOptimizationGoal,
+                adSetDestinationType,
+                pageId,
+                adSetTargetCountry
+            ));
+            String creativeId = facebookAdsService.createAdCreative(adAccountId, new FacebookAdsService.AdCreativeRequest(
+                exp.name() + " - Creative",
+                pageId,
+                instagramActorId,
+                websiteUrl,
+                formatCreativeMessage(exp.name()),
+                callToActionType
+            ));
+            facebookAdsService.createAd(adAccountId, new FacebookAdsService.AdRequest(
+                exp.name() + " - Ad",
+                adSetId,
+                creativeId
+            ));
+            CreateCampaignRequest req = new CreateCampaignRequest(campaignId, adAccountId, exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
+            backendClient.post()
+                .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns"))
+                .bodyValue(req)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+        } catch (FacebookPermissionException ex) {
+            LOGGER.warn(
+                "Skipping experiment due to Facebook permission error: id={}, name={}, message={}, details={}",
+                exp.id(),
+                exp.name(),
+                ex.getMessage(),
+                ex.getErrorDetails()
+            );
+            markExperimentAsFailed(exp.id());
+        }
     }
 
     private String formatCreativeMessage(String experimentName) {
@@ -143,4 +155,18 @@ public class FacebookCampaignService {
 
     public record Experiment(long id, String name) {}
     public record CreateCampaignRequest(String id, String adAccountId, String name, String objective, String budgetMode) {}
+
+    private void markExperimentAsFailed(long experimentId) {
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/status?status=FAILED");
+        try {
+            backendClient.patch()
+                .uri(url)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+            LOGGER.info("Marked experiment {} as FAILED after Facebook permission error", experimentId);
+        } catch (Exception ex) {
+            LOGGER.warn("Could not mark experiment {} as FAILED after Facebook permission error: {}", experimentId, ex.getMessage(), ex);
+        }
+    }
 }

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -123,4 +123,32 @@ class FacebookCampaignServiceTest {
         assertEquals(1, backend.getRequestCount());
         assertEquals(0, facebook.getRequestCount());
     }
+
+    @Test
+    void marksExperimentAsFailedWhenFacebookReturnsPermissionError() throws Exception {
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\"}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse()
+            .setResponseCode(400)
+            .setBody("{\"error\":{\"message\":\"Permissions error\",\"type\":\"OAuthException\",\"code\":200,\"error_subcode\":1815066,\"error_user_msg\":\"O usuário não tem permissão para criar anúncios com esta conta de anúncios\"}}")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setBody("{}")
+            .addHeader("Content-Type", "application/json"));
+
+        service.createCampaignsFromExperiments();
+
+        RecordedRequest get = backend.takeRequest();
+        assertEquals("GET", get.getMethod());
+        assertEquals("/api/facebook-campaigns/experiments-ready", get.getPath());
+
+        RecordedRequest postCampaign = facebook.takeRequest();
+        assertEquals("POST", postCampaign.getMethod());
+        assertEquals("/v23.0/act_1/campaigns", postCampaign.getPath());
+        assertEquals(1, facebook.getRequestCount());
+
+        RecordedRequest patch = backend.takeRequest();
+        assertEquals("PATCH", patch.getMethod());
+        assertEquals("/api/experiments/1/status?status=FAILED", patch.getPath());
+        assertEquals(2, backend.getRequestCount());
+    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `FacebookPermissionException` and teach `FacebookAdsService` to translate Graph API permission denials into it
- catch permission denials in `FacebookCampaignService`, log the incident, and mark the experiment as FAILED in the backend
- extend the campaign service tests and README to cover the new behaviour

## Testing
- `mvn -s settings.xml test` *(fails: Network is unreachable while downloading org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a963f72c832190355b8c0d7623b9