### PR TITLE
Fix Facebook Ads API error handling

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -84,6 +84,18 @@ sem intervenção humana. Após ajustar as permissões, atualize manualmente o
 status do experimento para que ele volte a ser elegível e reinicie o worker
 para que o novo token seja utilizado.
 
+### Erro `(#100) Invalid parameter` ao criar o criativo
+
+O endpoint [`POST /{ad_account_id}/adcreatives`](https://developers.facebook.com/docs/marketing-api/reference/ad-creative#Creating)
+exige um `page_id` válido no `object_story_spec` quando o criativo representa
+uma Página do Facebook. Se a propriedade `facebook.page-id` estiver vazia, a
+API responde com `error_subcode = 1443121` e a mensagem "A Página do Facebook
+está ausente". Desde a versão atual o worker interrompe o fluxo assim que a
+Graph API devolve qualquer status de erro, evitando que IDs vazios sejam
+propagados para chamadas subsequentes. Configure o identificador da Página
+antes de reiniciar o serviço para que a criação dos criativos seja bem
+sucedida.
+
 ## Build
 ```
 mvn -s settings.xml package

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -139,12 +140,15 @@ public class FacebookAdsService {
             FacebookApiResponse apiResponse = webClient
                 .get()
                 .uri(path)
-                .exchangeToMono(response ->
-                    response
+                .exchangeToMono(response -> {
+                    if (response.statusCode().isError()) {
+                        return response.createException().flatMap(Mono::error);
+                    }
+                    return response
                         .bodyToMono(JsonNode.class)
                         .defaultIfEmpty(objectMapper.nullNode())
-                        .map(body -> new FacebookApiResponse(response.statusCode(), response.headers().asHttpHeaders(), body))
-                )
+                        .map(body -> new FacebookApiResponse(response.statusCode(), response.headers().asHttpHeaders(), body));
+                })
                 .block();
             FacebookApiResponse nonNullResponse =
                 apiResponse != null ? apiResponse : new FacebookApiResponse(null, HttpHeaders.EMPTY, objectMapper.nullNode());
@@ -176,12 +180,15 @@ public class FacebookAdsService {
                 .post()
                 .uri(path)
                 .bodyValue(body)
-                .exchangeToMono(response ->
-                    response
+                .exchangeToMono(response -> {
+                    if (response.statusCode().isError()) {
+                        return response.createException().flatMap(Mono::error);
+                    }
+                    return response
                         .bodyToMono(JsonNode.class)
                         .defaultIfEmpty(objectMapper.nullNode())
-                        .map(bodyNode -> new FacebookApiResponse(response.statusCode(), response.headers().asHttpHeaders(), bodyNode))
-                )
+                        .map(bodyNode -> new FacebookApiResponse(response.statusCode(), response.headers().asHttpHeaders(), bodyNode));
+                })
                 .block();
             FacebookApiResponse nonNullResponse =
                 apiResponse != null ? apiResponse : new FacebookApiResponse(null, HttpHeaders.EMPTY, objectMapper.nullNode());


### PR DESCRIPTION
## Summary
- ensure FacebookAdsService propagates Graph API error statuses so permission issues halt the automation
- document the required page identifier for creatives and note the new error handling behaviour in the README

## Testing
- mvn -s settings.xml test *(fails: could not reach https://maven.pkg.github.com/paulofor/marketing-hub)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b4081dc48321b879c4099512c911