### PR TITLE
Prevent repeated retries after Facebook permission errors

### DIFF
--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -27,6 +27,7 @@ classDiagram
         -websiteUrl : String
         -creativeMessageTemplate : String
         -callToActionType : String
+        -experimentsBlockedByPermissions : Set<Long>
         +createCampaignsFromExperiments()
         -processExperiment(exp)
         -formatCreativeMessage(name) String
@@ -143,7 +144,9 @@ classDiagram
   `@Scheduled`.
 * `FacebookCampaignService` consulta o backend por experimentos prontos, cria a
   campanha, conjunto, criativo e anúncio na Graph API e registra o resultado da
-  campanha no backend.
+  campanha no backend. Quando o Facebook devolve erro de permissão, o serviço
+  adiciona o experimento a uma lista de bloqueio em memória para evitar novas
+  tentativas até que o worker seja reiniciado.
 * `FacebookAdsService` encapsula as chamadas à Graph API (criação da hierarquia
   de mídia e consulta de métricas).
 * `CreateCampaignRequest` representa o payload enviado ao backend contendo os

--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -10,6 +10,7 @@
 - A versão da Graph API é configurável via propriedade `facebook.graph-api.version` (default `v23.0`) e deve estar alinhada com a recomendação oficial.
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.
 - Endpoints do backend devem ser acessados com o prefixo configurado em `backend.api-prefix` (default `/api`).
+- Em caso de erro de permissão do Facebook, o worker bloqueia o experimento em memória até que o serviço seja reiniciado.
 
 ## Serviços existentes
 - **Campanhas de Facebook Ads** (`campaign`): cria campanhas para Facebook e Instagram utilizando o `facebook-ads-worker` com criativos gerados pelo **AI Worker** e aprovados pelo usuário no frontend.

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -80,9 +80,11 @@ de [códigos de erro da Marketing API](https://developers.facebook.com/docs/mark
 para confirmar os requisitos de permissão. Quando esse cenário ocorre, o
 worker marca automaticamente o experimento como `FAILED` via
 `PATCH /api/experiments/{id}/status?status=FAILED` para evitar novas tentativas
-sem intervenção humana. Após ajustar as permissões, atualize manualmente o
-status do experimento para que ele volte a ser elegível e reinicie o worker
-para que o novo token seja utilizado.
+sem intervenção humana. Caso o backend retorne erro e não consiga atualizar o
+status, o worker mantém o identificador do experimento em uma lista de bloqueio
+em memória e ignora execuções seguintes até que o serviço seja reiniciado. Após
+ajustar as permissões, atualize manualmente o status do experimento para que ele
+volte a ser elegível e reinicie o worker para que o novo token seja utilizado.
 
 ### Erro `(#100) Invalid parameter` ao criar o criativo
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -15,6 +15,8 @@ import reactor.core.publisher.Mono;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class FacebookCampaignService {
@@ -35,6 +37,7 @@ public class FacebookCampaignService {
     private final String websiteUrl;
     private final String creativeMessageTemplate;
     private final String callToActionType;
+    private final Set<Long> experimentsBlockedByPermissions;
 
     public FacebookCampaignService(FacebookAdsService facebookAdsService,
                                    WebClient.Builder builder,
@@ -66,6 +69,7 @@ public class FacebookCampaignService {
         this.websiteUrl = websiteUrl;
         this.creativeMessageTemplate = creativeMessageTemplate;
         this.callToActionType = callToActionType;
+        this.experimentsBlockedByPermissions = ConcurrentHashMap.newKeySet();
     }
 
     public void createCampaignsFromExperiments() {
@@ -95,7 +99,16 @@ public class FacebookCampaignService {
             return;
         }
 
-        experiments.forEach(this::processExperiment);
+        experiments.forEach(exp -> {
+            if (experimentsBlockedByPermissions.contains(exp.id())) {
+                LOGGER.warn(
+                    "Skipping experiment {} due to unresolved Facebook permission error; retry requires manual intervention",
+                    exp.id()
+                );
+                return;
+            }
+            processExperiment(exp);
+        });
     }
 
     private void processExperiment(Experiment exp) {
@@ -132,6 +145,11 @@ public class FacebookCampaignService {
                 .toBodilessEntity()
                 .block();
         } catch (FacebookPermissionException ex) {
+            experimentsBlockedByPermissions.add(exp.id());
+            LOGGER.warn(
+                "Experiment {} blocked after Facebook permission error; the worker will keep it skipped until restart",
+                exp.id()
+            );
             LOGGER.warn(
                 "Skipping experiment due to Facebook permission error: id={}, name={}, message={}, details={}",
                 exp.id(),

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -151,4 +151,39 @@ class FacebookCampaignServiceTest {
         assertEquals("/api/experiments/1/status?status=FAILED", patch.getPath());
         assertEquals(2, backend.getRequestCount());
     }
+
+    @Test
+    void skipsExperimentAfterPermissionErrorEvenIfBackendKeepsReturningIt() throws Exception {
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\"}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse()
+            .setResponseCode(400)
+            .setBody("{\"error\":{\"message\":\"Permissions error\",\"type\":\"OAuthException\",\"code\":200,\"error_subcode\":1815066}}")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setResponseCode(500));
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\"}]")
+            .addHeader("Content-Type", "application/json"));
+
+        service.createCampaignsFromExperiments();
+        service.createCampaignsFromExperiments();
+
+        RecordedRequest firstGet = backend.takeRequest();
+        assertEquals("GET", firstGet.getMethod());
+        assertEquals("/api/facebook-campaigns/experiments-ready", firstGet.getPath());
+
+        RecordedRequest campaignPost = facebook.takeRequest();
+        assertEquals("POST", campaignPost.getMethod());
+        assertEquals("/v23.0/act_1/campaigns", campaignPost.getPath());
+
+        RecordedRequest failedPatch = backend.takeRequest();
+        assertEquals("PATCH", failedPatch.getMethod());
+        assertEquals("/api/experiments/1/status?status=FAILED", failedPatch.getPath());
+
+        RecordedRequest secondGet = backend.takeRequest();
+        assertEquals("GET", secondGet.getMethod());
+        assertEquals("/api/facebook-campaigns/experiments-ready", secondGet.getPath());
+
+        assertEquals(1, facebook.getRequestCount());
+        assertEquals(3, backend.getRequestCount());
+    }
 }


### PR DESCRIPTION
## Summary
- cache experiments that hit Facebook permission errors so the worker skips them until the issue is fixed
- cover the new flow with unit tests and update worker documentation and diagrams to describe the in-memory blocklist behavior

## Testing
- mvn -s settings.xml test *(fails: Network is unreachable while downloading spring-boot-starter-parent from GitHub Packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bbea6af08321b0c89450d5348950