### PR TITLE
Add Facebook page management UI and configuration alerts

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookPage.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookPage.java
@@ -1,0 +1,28 @@
+package com.marketinghub.ads;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "fb_page")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FacebookPage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private FacebookAccount account;
+
+    @Column(name = "page_id", nullable = false, length = 128)
+    private String pageId;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookPageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookPageController.java
@@ -1,0 +1,77 @@
+package com.marketinghub.ads;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/accounts/facebook/{accountId}/pages")
+public class FacebookPageController {
+    private final FacebookAccountRepository accountRepository;
+    private final FacebookPageRepository pageRepository;
+
+    public FacebookPageController(FacebookAccountRepository accountRepository,
+                                  FacebookPageRepository pageRepository) {
+        this.accountRepository = accountRepository;
+        this.pageRepository = pageRepository;
+    }
+
+    @GetMapping
+    public List<FacebookPageDto> list(@PathVariable Long accountId) {
+        ensureAccountExists(accountId);
+        return pageRepository.findByAccountId(accountId).stream()
+                .map(FacebookPageController::toDto)
+                .toList();
+    }
+
+    @PostMapping
+    public FacebookPageDto create(@PathVariable Long accountId,
+                                  @RequestBody UpsertFacebookPageRequest request) {
+        FacebookAccount account = ensureAccountExists(accountId);
+        FacebookPage page = FacebookPage.builder()
+                .account(account)
+                .name(request.name())
+                .pageId(request.pageId())
+                .build();
+        return toDto(pageRepository.save(page));
+    }
+
+    @PutMapping("/{pageRecordId}")
+    public FacebookPageDto update(@PathVariable Long accountId,
+                                  @PathVariable Long pageRecordId,
+                                  @RequestBody UpsertFacebookPageRequest request) {
+        ensureAccountExists(accountId);
+        FacebookPage page = pageRepository.findById(pageRecordId)
+                .filter(existing -> existing.getAccount().getId().equals(accountId))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        page.setName(request.name());
+        page.setPageId(request.pageId());
+        return toDto(pageRepository.save(page));
+    }
+
+    @DeleteMapping("/{pageRecordId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long accountId, @PathVariable Long pageRecordId) {
+        ensureAccountExists(accountId);
+        FacebookPage page = pageRepository.findById(pageRecordId)
+                .filter(existing -> existing.getAccount().getId().equals(accountId))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        pageRepository.delete(page);
+    }
+
+    private FacebookAccount ensureAccountExists(Long accountId) {
+        return accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    }
+
+    private static FacebookPageDto toDto(FacebookPage page) {
+        return new FacebookPageDto(page.getId(), page.getAccount().getId(), page.getPageId(), page.getName());
+    }
+
+    public record FacebookPageDto(Long id, Long accountId, String pageId, String name) {}
+
+    public record UpsertFacebookPageRequest(String pageId, String name) {}
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookPageRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookPageRepository.java
@@ -1,0 +1,11 @@
+package com.marketinghub.ads;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FacebookPageRepository extends JpaRepository<FacebookPage, Long> {
+    List<FacebookPage> findByAccountId(Long accountId);
+
+    long countByAccountId(Long accountId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookConfigurationController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookConfigurationController.java
@@ -1,0 +1,24 @@
+package com.marketinghub.facebookads.web;
+
+import com.marketinghub.ads.FacebookPageRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/facebook")
+public class FacebookConfigurationController {
+    private final FacebookPageRepository pageRepository;
+
+    public FacebookConfigurationController(FacebookPageRepository pageRepository) {
+        this.pageRepository = pageRepository;
+    }
+
+    @GetMapping("/configuration-status")
+    public FacebookConfigurationStatus configurationStatus() {
+        boolean hasConfiguredPages = pageRepository.count() > 0;
+        return new FacebookConfigurationStatus(hasConfiguredPages);
+    }
+
+    public record FacebookConfigurationStatus(boolean hasConfiguredPages) {}
+}

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_12_05__create_fb_page_table.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_12_05__create_fb_page_table.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+--changeset marketinghub:2025-12-05-create-fb-page-table dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'fb_page';
+CREATE TABLE fb_page (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  account_id BIGINT NOT NULL,
+  page_id VARCHAR(128) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  CONSTRAINT fk_fb_page_account FOREIGN KEY (account_id) REFERENCES fb_account(id),
+  CONSTRAINT uq_fb_page_account_page UNIQUE (account_id, page_id)
+);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -119,3 +119,6 @@ databaseChangeLog:
   - include:
       file: V2025_11_26__extend_creative_with_meta_fields.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_12_05__create_fb_page_table.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookPageControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookPageControllerTest.java
@@ -1,0 +1,92 @@
+package com.marketinghub.ads;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
+})
+class FacebookPageControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    FacebookAccountRepository accountRepository;
+
+    @Autowired
+    FacebookPageRepository pageRepository;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    FacebookAccount account;
+
+    @BeforeEach
+    void setup() {
+        pageRepository.deleteAll();
+        accountRepository.deleteAll();
+        account = accountRepository.save(FacebookAccount.builder()
+                .name("Account")
+                .currency("BRL")
+                .build());
+    }
+
+    @Test
+    void shouldCreateListAndDeletePages() throws Exception {
+        FacebookPageController.UpsertFacebookPageRequest request = new FacebookPageController.UpsertFacebookPageRequest(
+                "123456",
+                "Página Principal"
+        );
+
+        mockMvc.perform(post("/accounts/facebook/" + account.getId() + "/pages")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pageId").value("123456"))
+                .andExpect(jsonPath("$.name").value("Página Principal"));
+
+        FacebookPage saved = pageRepository.findAll().getFirst();
+
+        FacebookPageController.UpsertFacebookPageRequest update = new FacebookPageController.UpsertFacebookPageRequest(
+                "654321",
+                "Página Atualizada"
+        );
+
+        mockMvc.perform(put("/accounts/facebook/" + account.getId() + "/pages/" + saved.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(update)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pageId").value("654321"))
+                .andExpect(jsonPath("$.name").value("Página Atualizada"));
+
+        mockMvc.perform(get("/accounts/facebook/" + account.getId() + "/pages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].pageId").value("654321"));
+
+        mockMvc.perform(delete("/accounts/facebook/" + account.getId() + "/pages/" + saved.getId()))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/accounts/facebook/" + account.getId() + "/pages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookConfigurationControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookConfigurationControllerTest.java
@@ -1,0 +1,68 @@
+package com.marketinghub.facebookads.web;
+
+import com.marketinghub.ads.FacebookAccount;
+import com.marketinghub.ads.FacebookAccountRepository;
+import com.marketinghub.ads.FacebookPage;
+import com.marketinghub.ads.FacebookPageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
+})
+class FacebookConfigurationControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    FacebookAccountRepository accountRepository;
+
+    @Autowired
+    FacebookPageRepository pageRepository;
+
+    @BeforeEach
+    void clean() {
+        pageRepository.deleteAll();
+        accountRepository.deleteAll();
+    }
+
+    @Test
+    void shouldReportConfigurationStatus() throws Exception {
+        mockMvc.perform(get("/api/facebook/configuration-status").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasConfiguredPages").value(false));
+
+        FacebookAccount account = accountRepository.save(FacebookAccount.builder()
+                .name("Account")
+                .currency("USD")
+                .build());
+
+        pageRepository.save(FacebookPage.builder()
+                .account(account)
+                .pageId("123")
+                .name("Main Page")
+                .build());
+
+        mockMvc.perform(get("/api/facebook/configuration-status").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasConfiguredPages").value(true));
+    }
+}

--- a/frontend/src/api/facebookAccountMutations.ts
+++ b/frontend/src/api/facebookAccountMutations.ts
@@ -1,11 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
-import { FacebookAccount } from "./useFacebookAccounts";
+export interface FacebookAccountPayload {
+  id?: number;
+  name: string;
+  currency: string;
+}
 
 export function useCreateFacebookAccount() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (account: FacebookAccount) =>
+    mutationFn: (account: FacebookAccountPayload) =>
       axios.post("/api/accounts/facebook", account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
@@ -15,7 +19,7 @@ export function useCreateFacebookAccount() {
 export function useUpdateFacebookAccount() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (account: FacebookAccount) =>
+    mutationFn: (account: FacebookAccountPayload) =>
       axios.put(`/api/accounts/facebook/${account.id}`, account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
@@ -25,7 +29,7 @@ export function useUpdateFacebookAccount() {
 export function useDeleteFacebookAccount() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => axios.delete(`/api/accounts/facebook/${id}`),
+    mutationFn: (id: number) => axios.delete(`/api/accounts/facebook/${id}`),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
   });

--- a/frontend/src/api/facebookPageMutations.ts
+++ b/frontend/src/api/facebookPageMutations.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface UpsertFacebookPage {
+  id?: number;
+  pageId: string;
+  name: string;
+}
+
+export function useCreateFacebookPage(accountId: string | number | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (page: UpsertFacebookPage) =>
+      axios.post(`/accounts/facebook/${accountId}/pages`, page),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["facebook-pages", accountId] });
+      queryClient.invalidateQueries({ queryKey: ["facebook-configuration-status"] });
+    },
+  });
+}
+
+export function useUpdateFacebookPage(accountId: string | number | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (page: UpsertFacebookPage) =>
+      axios.put(`/accounts/facebook/${accountId}/pages/${page.id}`, page),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["facebook-pages", accountId] });
+    },
+  });
+}
+
+export function useDeleteFacebookPage(accountId: string | number | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (pageId: number) =>
+      axios.delete(`/accounts/facebook/${accountId}/pages/${pageId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["facebook-pages", accountId] });
+      queryClient.invalidateQueries({ queryKey: ["facebook-configuration-status"] });
+    },
+  });
+}

--- a/frontend/src/api/useFacebookAccounts.ts
+++ b/frontend/src/api/useFacebookAccounts.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 
 export interface FacebookAccount {
-  id: string;
+  id: number;
   name: string;
   currency: string;
 }

--- a/frontend/src/api/useFacebookConfigurationStatus.ts
+++ b/frontend/src/api/useFacebookConfigurationStatus.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface FacebookConfigurationStatus {
+  hasConfiguredPages: boolean;
+}
+
+export function useFacebookConfigurationStatus() {
+  return useQuery({
+    queryKey: ["facebook-configuration-status"],
+    queryFn: async () => {
+      const { data } = await axios.get<FacebookConfigurationStatus>(
+        "/api/facebook/configuration-status",
+      );
+      return data;
+    },
+    staleTime: 1000 * 30,
+  });
+}

--- a/frontend/src/api/useFacebookPages.ts
+++ b/frontend/src/api/useFacebookPages.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface FacebookPage {
+  id: number;
+  accountId: number;
+  pageId: string;
+  name: string;
+}
+
+export function useFacebookPages(accountId?: string | number) {
+  return useQuery({
+    queryKey: ["facebook-pages", accountId],
+    queryFn: async () => {
+      if (!accountId) {
+        return [] as FacebookPage[];
+      }
+      const { data } = await axios.get<FacebookPage[]>(
+        `/accounts/facebook/${accountId}/pages`,
+      );
+      return data;
+    },
+    enabled: Boolean(accountId),
+  });
+}

--- a/frontend/src/pages/FacebookAccountsPage.tsx
+++ b/frontend/src/pages/FacebookAccountsPage.tsx
@@ -1,105 +1,291 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import PageTitle from "../components/PageTitle";
 import { useFacebookAccounts } from "../api/useFacebookAccounts";
 import {
   useCreateFacebookAccount,
-  useUpdateFacebookAccount,
   useDeleteFacebookAccount,
+  useUpdateFacebookAccount,
+  FacebookAccountPayload,
 } from "../api/facebookAccountMutations";
-import PageTitle from "../components/PageTitle";
+import { useFacebookPages } from "../api/useFacebookPages";
+import {
+  useCreateFacebookPage,
+  useDeleteFacebookPage,
+  useUpdateFacebookPage,
+} from "../api/facebookPageMutations";
+
+interface AccountFormState {
+  id?: number;
+  name: string;
+  currency: string;
+}
+
+interface PageFormState {
+  id?: number;
+  pageId: string;
+  name: string;
+}
+
+const emptyAccountForm: AccountFormState = { name: "", currency: "" };
+const emptyPageForm: PageFormState = { pageId: "", name: "" };
 
 export default function FacebookAccountsPage() {
   const { data, isLoading, error } = useFacebookAccounts();
-  const accounts = Array.isArray(data) ? data : [];
-  const createMutation = useCreateFacebookAccount();
-  const updateMutation = useUpdateFacebookAccount();
-  const deleteMutation = useDeleteFacebookAccount();
+  const accounts = useMemo(() => (Array.isArray(data) ? data : []), [data]);
+  const [selectedAccountId, setSelectedAccountId] = useState<number | null>(null);
+  const [accountForm, setAccountForm] = useState<AccountFormState>(emptyAccountForm);
+  const [pageForm, setPageForm] = useState<PageFormState>(emptyPageForm);
 
-  const [form, setForm] = useState({ id: "", name: "", currency: "" });
-  const [editing, setEditing] = useState<boolean | string>(false);
+  const createAccountMutation = useCreateFacebookAccount();
+  const updateAccountMutation = useUpdateFacebookAccount();
+  const deleteAccountMutation = useDeleteFacebookAccount();
+
+  const { data: pagesData, isLoading: pagesLoading } = useFacebookPages(
+    selectedAccountId ?? undefined,
+  );
+  const pages = useMemo(() => (Array.isArray(pagesData) ? pagesData : []), [pagesData]);
+
+  const createPageMutation = useCreateFacebookPage(selectedAccountId ?? undefined);
+  const updatePageMutation = useUpdateFacebookPage(selectedAccountId ?? undefined);
+  const deletePageMutation = useDeleteFacebookPage(selectedAccountId ?? undefined);
+
+  useEffect(() => {
+    if (accounts.length === 0) {
+      setSelectedAccountId(null);
+      return;
+    }
+    if (!selectedAccountId || !accounts.some((account) => account.id === selectedAccountId)) {
+      setSelectedAccountId(accounts[0].id);
+    }
+  }, [accounts, selectedAccountId]);
+
+  useEffect(() => {
+    setPageForm(emptyPageForm);
+  }, [selectedAccountId]);
 
   if (isLoading) return <p>Carregando...</p>;
   if (error) return <p>Erro ao carregar contas</p>;
 
-  const submit = () => {
-    if (editing) {
-      updateMutation.mutate(form);
-    } else {
-      createMutation.mutate(form);
-    }
-    setForm({ id: "", name: "", currency: "" });
-    setEditing(false);
+  const isEditingAccount = typeof accountForm.id === "number";
+  const isEditingPage = typeof pageForm.id === "number";
+
+  const submitAccount = () => {
+    const payload: FacebookAccountPayload = {
+      id: accountForm.id,
+      name: accountForm.name,
+      currency: accountForm.currency,
+    };
+    const mutation = isEditingAccount ? updateAccountMutation : createAccountMutation;
+    mutation.mutate(payload, {
+      onSuccess: () => {
+        setAccountForm(emptyAccountForm);
+      },
+    });
+  };
+
+  const submitPage = () => {
+    if (!selectedAccountId) return;
+    const payload: PageFormState = {
+      id: pageForm.id,
+      pageId: pageForm.pageId,
+      name: pageForm.name,
+    };
+    const mutation = isEditingPage ? updatePageMutation : createPageMutation;
+    mutation.mutate(payload, {
+      onSuccess: () => {
+        setPageForm(emptyPageForm);
+      },
+    });
   };
 
   return (
     <div>
       <PageTitle>Contas do Facebook</PageTitle>
-      <div className="table-responsive">
-        <table className="table table-striped">
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Nome</th>
-            <th>Moeda</th>
-            <th>Ações</th>
-          </tr>
-        </thead>
-        <tbody>
-          {accounts.map(({ id, name, currency }) => (
-            <tr key={id}>
-              <td>{id}</td>
-              <td>{name}</td>
-              <td>{currency}</td>
-              <td>
-                <button
-                  className="btn btn-sm btn-outline-primary me-2"
-                  onClick={() => {
-                    setForm({ id, name, currency });
-                    setEditing(id);
-                  }}
-                >
-                  Editar
-                </button>
-                <button
-                  className="btn btn-sm btn-outline-danger"
-                  onClick={() => deleteMutation.mutate(id)}
-                >
-                  Excluir
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-        </table>
-      </div>
-      <div className="row g-2">
-        <div className="col-md-2">
-          <input
-            className="form-control"
-            placeholder="id"
-            value={form.id}
-            onChange={(e) => setForm({ ...form, id: e.target.value })}
-          />
+      <div className="row g-4">
+        <div className="col-12 col-xl-6">
+          <div className="card h-100">
+            <div className="card-body">
+              <div className="d-flex justify-content-between align-items-center mb-3">
+                <h2 className="h5 mb-0">Contas conectadas</h2>
+                <span className="badge text-bg-primary">{accounts.length} conta(s)</span>
+              </div>
+              <div className="table-responsive mb-3">
+                <table className="table table-striped align-middle">
+                  <thead>
+                    <tr>
+                      <th>ID</th>
+                      <th>Nome</th>
+                      <th>Moeda</th>
+                      <th className="text-end">Ações</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {accounts.map(({ id, name, currency }) => (
+                      <tr key={id} className={selectedAccountId === id ? "table-primary" : ""}>
+                        <td>{id}</td>
+                        <td>{name}</td>
+                        <td>{currency}</td>
+                        <td className="text-end d-flex justify-content-end gap-2">
+                          <button
+                            className="btn btn-sm btn-outline-primary"
+                            onClick={() => {
+                              setAccountForm({ id, name, currency });
+                            }}
+                          >
+                            Editar
+                          </button>
+                          <button
+                            className="btn btn-sm btn-outline-secondary"
+                            onClick={() => setSelectedAccountId(id)}
+                          >
+                            Páginas
+                          </button>
+                          <button
+                            className="btn btn-sm btn-outline-danger"
+                            onClick={() => deleteAccountMutation.mutate(id)}
+                          >
+                            Excluir
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="row g-2">
+                <div className="col-md-5">
+                  <input
+                    className="form-control"
+                    placeholder="Nome da conta"
+                    value={accountForm.name}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        name: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="col-md-3">
+                  <input
+                    className="form-control"
+                    placeholder="Moeda"
+                    value={accountForm.currency}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        currency: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="col-md-4">
+                  <button className="btn btn-primary w-100" onClick={submitAccount}>
+                    {isEditingAccount ? "Atualizar conta" : "Adicionar conta"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-        <div className="col-md-4">
-          <input
-            className="form-control"
-            placeholder="nome"
-            value={form.name}
-            onChange={(e) => setForm({ ...form, name: e.target.value })}
-          />
-        </div>
-        <div className="col-md-2">
-          <input
-            className="form-control"
-            placeholder="moeda"
-            value={form.currency}
-            onChange={(e) => setForm({ ...form, currency: e.target.value })}
-          />
-        </div>
-        <div className="col-md-2">
-          <button className="btn btn-primary w-100" onClick={submit}>
-            {editing ? "Atualizar" : "Criar"}
-          </button>
+        <div className="col-12 col-xl-6">
+          <div className="card h-100">
+            <div className="card-body">
+              <div className="d-flex justify-content-between align-items-center mb-3">
+                <h2 className="h5 mb-0">Páginas vinculadas</h2>
+                <span className="badge text-bg-primary">
+                  {selectedAccountId ? pages.length : 0} página(s)
+                </span>
+              </div>
+              {!selectedAccountId ? (
+                <p className="text-muted mb-0">
+                  Cadastre ou selecione uma conta para configurar as páginas utilizadas nas
+                  campanhas.
+                </p>
+              ) : pagesLoading ? (
+                <p>Carregando páginas...</p>
+              ) : (
+                <div className="table-responsive mb-3">
+                  <table className="table table-hover align-middle">
+                    <thead>
+                      <tr>
+                        <th>ID da página</th>
+                        <th>Nome</th>
+                        <th className="text-end">Ações</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {pages.map((page) => (
+                        <tr key={page.id}>
+                          <td>{page.pageId}</td>
+                          <td>{page.name}</td>
+                          <td className="text-end d-flex justify-content-end gap-2">
+                            <button
+                              className="btn btn-sm btn-outline-primary"
+                              onClick={() =>
+                                setPageForm({
+                                  id: page.id,
+                                  pageId: page.pageId,
+                                  name: page.name,
+                                })
+                              }
+                            >
+                              Editar
+                            </button>
+                            <button
+                              className="btn btn-sm btn-outline-danger"
+                              onClick={() => deletePageMutation.mutate(page.id)}
+                            >
+                              Excluir
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+              <div className="row g-2">
+                <div className="col-md-5">
+                  <input
+                    className="form-control"
+                    placeholder="ID da página"
+                    value={pageForm.pageId}
+                    onChange={(event) =>
+                      setPageForm((current) => ({
+                        ...current,
+                        pageId: event.target.value,
+                      }))
+                    }
+                    disabled={!selectedAccountId}
+                  />
+                </div>
+                <div className="col-md-4">
+                  <input
+                    className="form-control"
+                    placeholder="Nome da página"
+                    value={pageForm.name}
+                    onChange={(event) =>
+                      setPageForm((current) => ({
+                        ...current,
+                        name: event.target.value,
+                      }))
+                    }
+                    disabled={!selectedAccountId}
+                  />
+                </div>
+                <div className="col-md-3">
+                  <button
+                    className="btn btn-primary w-100"
+                    onClick={submitPage}
+                    disabled={!selectedAccountId}
+                  >
+                    {isEditingPage ? "Atualizar página" : "Adicionar página"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
+++ b/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
@@ -1,15 +1,28 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { AlertTriangle } from "lucide-react";
 import { useFacebookCampaignExperiments } from "../../api/useFacebookCampaignExperiments";
 import PageTitle from "../../components/PageTitle";
+import { useFacebookConfigurationStatus } from "../../api/useFacebookConfigurationStatus";
 
 export default function FacebookCampaignExperimentsPage() {
   const [status, setStatus] = useState("PLANNED");
   const { data, isLoading } = useFacebookCampaignExperiments(status);
+  const { data: configuration } = useFacebookConfigurationStatus();
   const experiments = Array.isArray(data) ? data : [];
+  const requiresPageSetup = configuration && !configuration.hasConfiguredPages;
   return (
     <div>
       <PageTitle>Experimentos para Campanha</PageTitle>
+      {requiresPageSetup ? (
+        <div className="alert alert-warning d-flex align-items-center gap-2" role="alert">
+          <AlertTriangle size={18} />
+          <div>
+            Configure ao menos uma página do Facebook para continuar publicando
+            campanhas.
+          </div>
+        </div>
+      ) : null}
       <div className="btn-group mb-3">
         <button
           className={`btn btn-outline-primary${status === "PLANNED" ? " active" : ""}`}

--- a/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
+++ b/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { CalendarDays, Flag, Gauge, Target } from "lucide-react";
+import { AlertTriangle, CalendarDays, Flag, Gauge, Target } from "lucide-react";
 
 import PageTitle from "../../components/PageTitle";
 import { useFacebookReadyExperiments } from "../../api/useFacebookReadyExperiments";
+import { useFacebookConfigurationStatus } from "../../api/useFacebookConfigurationStatus";
 import "./FacebookExperimentsReadyPage.css";
 
 function formatCurrency(value: number | null) {
@@ -25,12 +26,23 @@ function formatDate(value: string | null) {
 export default function FacebookExperimentsReadyPage() {
   const { data, isLoading, isError, refetch, isRefetching } =
     useFacebookReadyExperiments();
+  const { data: configuration } = useFacebookConfigurationStatus();
   const experiments = useMemo(() => (Array.isArray(data) ? data : []), [data]);
   const isEmpty = !isLoading && experiments.length === 0 && !isError;
+  const requiresPageSetup = configuration && !configuration.hasConfiguredPages;
 
   return (
     <div>
       <PageTitle>Experimentos prontos para campanha</PageTitle>
+      {requiresPageSetup ? (
+        <div className="alert alert-warning d-flex align-items-center gap-2" role="alert">
+          <AlertTriangle size={18} />
+          <div>
+            Configure ao menos uma página do Facebook para liberar as campanhas
+            automáticas.
+          </div>
+        </div>
+      ) : null}
       <div className="experiments-ready-toolbar">
         <span className="experiments-ready-toolbar-title">
           <Flag size={18} className="text-primary" />


### PR DESCRIPTION
## Summary
- add Facebook page entity, repository, controller, and Liquibase migration, plus configuration status endpoint
- cover the new Facebook page APIs with integration tests
- enhance the Facebook accounts UI with page management and alerts when no Facebook page is configured

## Testing
- mvn -s ../settings.xml test *(fails: parent POM download blocked in sandbox)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d6eba5e5a08321bbc1139aa1ddf16e