### PR TITLE
feat: redesign frontend main navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes, Link } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
 import FacebookAccountsPage from "./pages/FacebookAccountsPage";
 import InstagramAccountsPage from "./pages/InstagramAccountsPage";
@@ -50,114 +50,12 @@ import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import FacebookCampaignExperimentsPage from "./pages/facebook/FacebookCampaignExperimentsPage";
 import FacebookExperimentsReadyPage from "./pages/facebook/FacebookExperimentsReadyPage";
+import MainNavigation from "./components/MainNavigation";
 
 export default function App() {
   return (
     <div className="container py-4">
-      <nav className="navbar navbar-expand-lg navbar-light bg-light mb-4">
-        <div className="container-fluid">
-          <Link className="navbar-brand" to="/">
-            Marketing Hub
-          </Link>
-          <div className="navbar-nav">
-            <Link className="nav-link" to="/accounts/facebook">
-              Contas do Facebook
-            </Link>
-            <Link className="nav-link" to="/accounts/instagram">
-              Contas do Instagram
-            </Link>
-            <Link className="nav-link" to="/media">
-              Mídia
-            </Link>
-            <Link className="nav-link" to="/courses">
-              Cursos
-            </Link>
-            <Link className="nav-link" to="/products">
-              Produtos
-            </Link>
-            <Link className="nav-link" to="/success-products">
-              Produtos de Sucesso
-            </Link>
-            <Link className="nav-link" to="/niches">
-              Nichos
-            </Link>
-            <Link className="nav-link" to="/experiments">
-              Testes de Nicho
-            </Link>
-            <Link className="nav-link" to="/hypotheses">
-              Hipóteses
-            </Link>
-            <Link className="nav-link" to="/ai-services">
-              IA
-            </Link>
-            <Link className="nav-link" to="/chat-dialogs">
-              ChatGPT
-            </Link>
-            <Link className="nav-link" to="/angles">
-              Angles
-            </Link>
-            <Link className="nav-link" to="/visual-proofs">
-              Provas Visuais
-            </Link>
-            <Link className="nav-link" to="/emotional-triggers">
-              Gatilhos Emocionais
-            </Link>
-            <Link className="nav-link" to="/funnels">
-              Funil de Vendas
-            </Link>
-            <Link className="nav-link" to="/facebook-campaigns">
-              Experimentos para Campanha
-            </Link>
-            <Link className="nav-link" to="/facebook-campaigns/ready">
-              Experimentos prontos
-            </Link>
-            <Link className="nav-link" to="/prompt-entities">
-              Objetos de Prompt
-            </Link>
-            <div className="nav-item dropdown">
-              <span
-                className="nav-link dropdown-toggle"
-                id="market-test-dropdown"
-                role="button"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                Teste de Mercado
-              </span>
-              <ul
-                className="dropdown-menu"
-                aria-labelledby="market-test-dropdown"
-              >
-                <li>
-                  <a className="dropdown-item" href="#">
-                    1- Hipotese e Oferta Isca
-                  </a>
-                </li>
-                <li>
-                  <a className="dropdown-item" href="#">
-                    2- Funil Mínimo
-                  </a>
-                </li>
-                <li>
-                  <a className="dropdown-item" href="#">
-                    3- Trafego e Segmentação
-                  </a>
-                </li>
-                <li>
-                  <a className="dropdown-item" href="#">
-                    4- KPIs e limiares de decisão
-                  </a>
-                </li>
-                <li>
-                  <a className="dropdown-item" href="#">
-                    5- Automação analítica
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <MainNavigation />
       <Routes>
         <Route path="/accounts/facebook" element={<FacebookAccountsPage />} />
         <Route path="/accounts/instagram" element={<InstagramAccountsPage />} />

--- a/frontend/src/components/MainNavigation.css
+++ b/frontend/src/components/MainNavigation.css
@@ -1,0 +1,218 @@
+.main-navigation {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.main-navigation__hero {
+  position: relative;
+  overflow: hidden;
+  padding: 2.75rem clamp(1.5rem, 4vw, 3.5rem);
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, var(--bs-primary), var(--bs-indigo));
+  color: var(--bs-white);
+  box-shadow: 0 1.5rem 3rem -1.5rem rgba(14, 23, 38, 0.55);
+}
+
+.main-navigation__hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at top right,
+    rgba(255, 255, 255, 0.4),
+    rgba(255, 255, 255, 0)
+  );
+  pointer-events: none;
+}
+
+.main-navigation__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
+.main-navigation__title {
+  font-size: clamp(1.875rem, 3vw, 2.625rem);
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.main-navigation__subtitle {
+  max-width: 52rem;
+  font-size: 1.05rem;
+  margin: 0;
+  opacity: 0.95;
+}
+
+.main-navigation__sections {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.main-navigation__card {
+  background: var(--bs-body-bg);
+  border-radius: 1rem;
+  border: 1px solid var(--bs-border-color);
+  box-shadow: 0 1.25rem 2rem -1.5rem rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  padding: 1.75rem;
+  gap: 1.25rem;
+}
+
+.main-navigation__card-header h2 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.main-navigation__card-header p {
+  margin: 0;
+  color: var(--bs-secondary-color);
+  font-size: 0.95rem;
+}
+
+.main-navigation__links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.main-navigation__link {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 0.9rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid transparent;
+  background: var(--bs-tertiary-bg);
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.main-navigation__link:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.main-navigation__link:hover {
+  transform: translateY(-2px);
+  border-color: var(--bs-primary-border-subtle, rgba(32, 99, 226, 0.35));
+  background: var(--bs-body-bg);
+  box-shadow: 0 1rem 1.5rem -1.25rem rgba(32, 99, 226, 0.35);
+}
+
+.main-navigation__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  background: rgba(32, 99, 226, 0.12);
+  color: var(--bs-primary);
+}
+
+.main-navigation__link-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.main-navigation__link-label {
+  font-weight: 600;
+  color: var(--bs-body-color);
+}
+
+.main-navigation__link-description {
+  font-size: 0.85rem;
+  color: var(--bs-secondary-color);
+}
+
+.main-navigation__market-test {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.main-navigation__market-card {
+  border-radius: 1.25rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  border: 1px dashed rgba(32, 99, 226, 0.35);
+  background: linear-gradient(
+    135deg,
+    rgba(32, 99, 226, 0.08),
+    rgba(111, 66, 193, 0.08)
+  );
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.main-navigation__market-card h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.main-navigation__market-card p {
+  margin-bottom: 1.25rem;
+  color: var(--bs-secondary-color);
+}
+
+.main-navigation__market-steps {
+  counter-reset: step;
+  display: grid;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.main-navigation__market-steps li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  box-shadow: 0 0.75rem 1.25rem -1rem rgba(32, 99, 226, 0.25);
+}
+
+.main-navigation__step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--bs-primary);
+  color: var(--bs-white);
+  font-weight: 600;
+}
+
+.main-navigation__step-text {
+  font-weight: 500;
+  color: var(--bs-body-color);
+}
+
+@media (max-width: 576px) {
+  .main-navigation__hero {
+    padding: 2.25rem 1.5rem;
+  }
+
+  .main-navigation__sections {
+    gap: 1rem;
+  }
+
+  .main-navigation__card {
+    padding: 1.5rem;
+  }
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -1,0 +1,221 @@
+import { Link } from "react-router-dom";
+import {
+  Sparkles,
+  Layers,
+  LayoutGrid,
+  Users2,
+  Share2,
+  BookOpen,
+  Box,
+  Trophy,
+  Milestone,
+  Beaker,
+  Brain,
+  MessagesSquare,
+  Workflow,
+  Compass,
+} from "lucide-react";
+import "./MainNavigation.css";
+
+const sections = [
+  {
+    title: "Operações essenciais",
+    description: "Cadastre contas, produtos e ativos que sustentam as campanhas.",
+    items: [
+      {
+        to: "/accounts/facebook",
+        label: "Contas do Facebook",
+        description: "Gerencie conexões e ativos da Meta.",
+        icon: Users2,
+      },
+      {
+        to: "/accounts/instagram",
+        label: "Contas do Instagram",
+        description: "Sincronize perfis e monitore publicações.",
+        icon: Share2,
+      },
+      {
+        to: "/media",
+        label: "Mídia",
+        description: "Biblioteca de criativos e vídeos aprovados.",
+        icon: Layers,
+      },
+      {
+        to: "/courses",
+        label: "Cursos",
+        description: "Organize trilhas e materiais educativos.",
+        icon: BookOpen,
+      },
+      {
+        to: "/products",
+        label: "Produtos",
+        description: "Gerencie ofertas principais em um só lugar.",
+        icon: Box,
+      },
+      {
+        to: "/success-products",
+        label: "Produtos de Sucesso",
+        description: "Colecione provas de produtos validados.",
+        icon: Trophy,
+      },
+    ],
+  },
+  {
+    title: "Pesquisa e experimentos",
+    description: "Planeje hipóteses, conduza testes e acompanhe resultados.",
+    items: [
+      {
+        to: "/niches",
+        label: "Nichos",
+        description: "Mapeie segmentos e oportunidades.",
+        icon: Compass,
+      },
+      {
+        to: "/experiments",
+        label: "Testes de Nicho",
+        description: "Execute experimentos com acompanhamento guiado.",
+        icon: Beaker,
+      },
+      {
+        to: "/hypotheses",
+        label: "Hipóteses",
+        description: "Valide aprendizados e itere rapidamente.",
+        icon: Workflow,
+      },
+      {
+        to: "/funnels",
+        label: "Funil de Vendas",
+        description: "Estruture jornadas e fluxos de conversão.",
+        icon: Milestone,
+      },
+      {
+        to: "/facebook-campaigns",
+        label: "Experimentos para Campanha",
+        description: "Organize variações e públicos para mídia paga.",
+        icon: Sparkles,
+      },
+      {
+        to: "/facebook-campaigns/ready",
+        label: "Experimentos prontos",
+        description: "Acesse execuções aprovadas e replicáveis.",
+        icon: LayoutGrid,
+      },
+    ],
+  },
+  {
+    title: "Conteúdo e criativos",
+    description: "Inspire sua produção com ângulos, provas e gatilhos emocionais.",
+    items: [
+      {
+        to: "/angles",
+        label: "Angles",
+        description: "Coleção de abordagens para headlines.",
+        icon: Sparkles,
+      },
+      {
+        to: "/visual-proofs",
+        label: "Provas Visuais",
+        description: "Destaque evidências que geram confiança.",
+        icon: LayoutGrid,
+      },
+      {
+        to: "/emotional-triggers",
+        label: "Gatilhos Emocionais",
+        description: "Active emoções certas em cada campanha.",
+        icon: Brain,
+      },
+    ],
+  },
+  {
+    title: "Inteligência Artificial",
+    description: "Automatize tarefas, crie diálogos e personalize prompts.",
+    items: [
+      {
+        to: "/ai-services",
+        label: "IA",
+        description: "Configure serviços e automações inteligentes.",
+        icon: Sparkles,
+      },
+      {
+        to: "/chat-dialogs",
+        label: "ChatGPT",
+        description: "Gerencie roteiros conversacionais assistidos.",
+        icon: MessagesSquare,
+      },
+      {
+        to: "/prompt-entities",
+        label: "Objetos de Prompt",
+        description: "Centralize entidades e atributos reutilizáveis.",
+        icon: Brain,
+      },
+    ],
+  },
+];
+
+const marketTestSteps = [
+  "Hipótese e oferta isca",
+  "Funil mínimo",
+  "Tráfego e segmentação",
+  "KPIs e limiares de decisão",
+  "Automação analítica",
+];
+
+export default function MainNavigation() {
+  return (
+    <section className="main-navigation" aria-labelledby="main-navigation-heading">
+      <div className="main-navigation__hero">
+        <span className="main-navigation__eyebrow">Marketing Hub</span>
+        <h1 id="main-navigation-heading" className="main-navigation__title">
+          Escolha onde acelerar seus resultados
+        </h1>
+        <p className="main-navigation__subtitle">
+          Conecte dados, experimente novas ideias e use a inteligência da plataforma para escalar campanhas com confiança.
+        </p>
+      </div>
+
+      <div className="main-navigation__sections">
+        {sections.map((section) => (
+          <article key={section.title} className="main-navigation__card">
+            <header className="main-navigation__card-header">
+              <h2>{section.title}</h2>
+              <p>{section.description}</p>
+            </header>
+            <nav aria-label={section.title} className="main-navigation__links">
+              {section.items.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <Link key={item.to} to={item.to} className="main-navigation__link">
+                    <span className="main-navigation__icon" aria-hidden="true">
+                      <Icon size={18} />
+                    </span>
+                    <span className="main-navigation__link-text">
+                      <span className="main-navigation__link-label">{item.label}</span>
+                      <span className="main-navigation__link-description">{item.description}</span>
+                    </span>
+                  </Link>
+                );
+              })}
+            </nav>
+          </article>
+        ))}
+      </div>
+
+      <aside className="main-navigation__market-test" aria-label="Roteiro de teste de mercado">
+        <div className="main-navigation__market-card">
+          <h2>Teste de Mercado guiado</h2>
+          <p>
+            Percorra as etapas essenciais para validar oportunidades de forma estruturada e com foco em decisões baseadas em dados.
+          </p>
+          <ol className="main-navigation__market-steps">
+            {marketTestSteps.map((step, index) => (
+              <li key={step}>
+                <span className="main-navigation__step-index">{index + 1}</span>
+                <span className="main-navigation__step-text">{step}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </aside>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the top navbar with a richer hero navigation component grouped by focus areas
- highlight the market test journey with an illustrated roadmap panel and lucide icons
- add responsive styling that mirrors the creative tab’s tokens and spacing

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d6f1bdd70c8321ba4b326f208ef3c4