### PR TITLE
Fix Facebook configuration controller test context

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookConfigurationControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookConfigurationControllerTest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.facebookads.web;
 
+import com.marketinghub.ads.AdsServiceApplication;
 import com.marketinghub.ads.FacebookAccount;
 import com.marketinghub.ads.FacebookAccountRepository;
 import com.marketinghub.ads.FacebookPage;
@@ -17,7 +18,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = AdsServiceApplication.class)
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
         "spring.datasource.url=jdbc:h2:mem:testdb",


### PR DESCRIPTION
## Summary
- point the Facebook configuration controller test to the AdsServiceApplication configuration
- ensure the Spring Boot test context can locate the main application class

## Testing
- mvn -s ../settings.xml test *(fails: requires access to private GitHub package repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f28fdf908321964cdc9ad53f03c2