### PR TITLE
feat: redesign persistent main navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,35 @@
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}
+
+.app-shell__content {
+  flex: 1;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.app-shell__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell__main > .container-fluid {
+  flex: 1;
+  padding: 0;
+}
+
+@media (max-width: 991.98px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .app-shell__content {
+    padding: clamp(1rem, 4vw, 1.5rem);
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes, Link } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
 import FacebookAccountsPage from "./pages/FacebookAccountsPage";
 import InstagramAccountsPage from "./pages/InstagramAccountsPage";
@@ -48,201 +48,130 @@ import NewPromptEntityPage from "./pages/prompt/NewPromptEntityPage";
 import PromptEntityDescriptionPage from "./pages/prompt/PromptEntityDescriptionPage";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import MainNavigation from "./components/MainNavigation";
+import "./App.css";
 import FacebookCampaignExperimentsPage from "./pages/facebook/FacebookCampaignExperimentsPage";
 import FacebookExperimentsReadyPage from "./pages/facebook/FacebookExperimentsReadyPage";
 
 export default function App() {
   return (
-    <div className="container py-4">
-      <nav className="navbar navbar-expand-lg navbar-light bg-light mb-4">
-        <div className="container-fluid">
-          <Link className="navbar-brand" to="/">
-            Marketing Hub
-          </Link>
-          <div className="navbar-nav">
-            <Link className="nav-link" to="/accounts/facebook">
-              Contas do Facebook
-            </Link>
-            <Link className="nav-link" to="/accounts/instagram">
-              Contas do Instagram
-            </Link>
-            <Link className="nav-link" to="/media">
-              Mídia
-            </Link>
-            <Link className="nav-link" to="/courses">
-              Cursos
-            </Link>
-            <Link className="nav-link" to="/products">
-              Produtos
-            </Link>
-            <Link className="nav-link" to="/success-products">
-              Produtos de Sucesso
-            </Link>
-            <Link className="nav-link" to="/niches">
-              Nichos
-            </Link>
-            <Link className="nav-link" to="/experiments">
-              Testes de Nicho
-            </Link>
-            <Link className="nav-link" to="/hypotheses">
-              Hipóteses
-            </Link>
-            <Link className="nav-link" to="/ai-services">
-              IA
-            </Link>
-            <Link className="nav-link" to="/chat-dialogs">
-              ChatGPT
-            </Link>
-            <Link className="nav-link" to="/angles">
-              Angles
-            </Link>
-            <Link className="nav-link" to="/visual-proofs">
-              Provas Visuais
-            </Link>
-            <Link className="nav-link" to="/emotional-triggers">
-              Gatilhos Emocionais
-            </Link>
-            <Link className="nav-link" to="/funnels">
-              Funil de Vendas
-            </Link>
-            <Link className="nav-link" to="/facebook-campaigns">
-              Experimentos para Campanha
-            </Link>
-            <Link className="nav-link" to="/facebook-campaigns/ready">
-              Experimentos prontos
-            </Link>
-            <Link className="nav-link" to="/prompt-entities">
-              Objetos de Prompt
-            </Link>
-            <div className="nav-item dropdown">
-              <span
-                className="nav-link dropdown-toggle"
-                id="market-test-dropdown"
-                role="button"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                Teste de Mercado
-              </span>
-              <ul
-                className="dropdown-menu"
-                aria-labelledby="market-test-dropdown"
-              >
-                <li>
-                  <a className="dropdown-item" href="#">
-                    1- Hipotese e Oferta Isca
-                  </a>
-                </li>
-                <li>
-                  <a className="dropdown-item" href="#">
-                    2- Funil Mínimo
-                  </a>
-                </li>
-                <li>
-                  <a className="dropdown-item" href="#">
-                    3- Trafego e Segmentação
-                  </a>
-                </li>
-                <li>
-                  <a className="dropdown-item" href="#">
-                    4- KPIs e limiares de decisão
-                  </a>
-                </li>
-                <li>
-                  <a className="dropdown-item" href="#">
-                    5- Automação analítica
-                  </a>
-                </li>
-              </ul>
-            </div>
+    <div className="app-shell">
+      <MainNavigation />
+      <div className="app-shell__content">
+        <main className="app-shell__main">
+          <div className="container-fluid py-4">
+            <Routes>
+              <Route
+                path="/accounts/facebook"
+                element={<FacebookAccountsPage />}
+              />
+              <Route
+                path="/accounts/instagram"
+                element={<InstagramAccountsPage />}
+              />
+              <Route
+                path="/accounts/instagram/:id/posts"
+                element={<InstagramPostsPage />}
+              />
+              <Route path="/media" element={<MediaListPage />} />
+              <Route path="/media/new" element={<NewMediaPage />} />
+              <Route path="/media/:id" element={<MediaDetailPage />} />
+              <Route path="/courses" element={<CoursePlanListPage />} />
+              <Route path="/courses/new" element={<NewCoursePlanPage />} />
+              <Route path="/courses/:id" element={<CoursePlanDetailPage />} />
+              <Route path="/products" element={<ProductListPage />} />
+              <Route path="/products/new" element={<NewProductPage />} />
+              <Route
+                path="/success-products"
+                element={<SuccessProductListPage />}
+              />
+              <Route
+                path="/success-products/new"
+                element={<NewSuccessProductPage />}
+              />
+              <Route
+                path="/success-products/:id"
+                element={<SuccessProductDetailPage />}
+              />
+              <Route
+                path="/success-products/:id/edit"
+                element={<EditSuccessProductPage />}
+              />
+              <Route path="/niches" element={<AppLayout />}>
+                <Route index element={<NicheListPage />} />
+                <Route path="new" element={<NewNichePage />} />
+                <Route path=":nicheId" element={<NicheDetailPage />} />
+                <Route path=":nicheId/edit" element={<EditNichePage />} />
+                <Route
+                  path=":nicheId/hypotheses/new"
+                  element={<NewHypothesisPage />}
+                />
+                <Route
+                  path=":nicheId/hypotheses/:hypothesisId"
+                  element={<HypothesisDetailPage />}
+                />
+                <Route
+                  path=":nicheId/hypotheses/:hypothesisId/edit"
+                  element={<EditHypothesisPage />}
+                />
+              </Route>
+              <Route path="/experiments" element={<ExperimentListPage />} />
+              <Route path="/experiments/new" element={<NewExperimentPage />} />
+              <Route path="/experiments/:id" element={<AppLayout />}>
+                <Route index element={<ExperimentDetailPage />} />
+                <Route path="edit" element={<EditExperimentPage />} />
+              </Route>
+              <Route path="/hypotheses" element={<HypothesisListPage />} />
+              <Route path="/hypotheses/board" element={<HypothesesPage />} />
+              <Route path="/ai-services" element={<AiServiceListPage />} />
+              <Route path="/ai-services/new" element={<NewAiServicePage />} />
+              <Route
+                path="/ai-services/:id/edit"
+                element={<EditAiServicePage />}
+              />
+              <Route path="/angles" element={<AnglesPage />} />
+              <Route path="/visual-proofs" element={<VisualProofsPage />} />
+              <Route
+                path="/emotional-triggers"
+                element={<EmotionalTriggersPage />}
+              />
+              <Route path="/landing/:id" element={<LandingPreview />} />
+              <Route path="/analytics" element={<AnalyticsDashboard />} />
+              <Route path="/funnels" element={<FunnelListPage />} />
+              <Route path="/funnels/new" element={<NewFunnelPage />} />
+              <Route
+                path="/funnels/:id/edit"
+                element={<EditFunnelPage />}
+              />
+              <Route path="/chat-dialogs" element={<ChatDialogListPage />} />
+              <Route path="/chat-dialogs/new" element={<NewChatDialogPage />} />
+              <Route path="/prompt-entities" element={<PromptEntitiesPage />} />
+              <Route
+                path="/prompt-entities/new"
+                element={<NewPromptEntityPage />}
+              />
+              <Route
+                path="/prompt-entities/:entityId"
+                element={<PromptEntityDescriptionPage />}
+              />
+              <Route
+                path="/prompt-entities/:entityId/attributes"
+                element={<PromptAttributesPage />}
+              />
+              <Route
+                path="/facebook-campaigns"
+                element={<FacebookCampaignExperimentsPage />}
+              />
+              <Route
+                path="/facebook-campaigns/ready"
+                element={<FacebookExperimentsReadyPage />}
+              />
+              <Route path="*" element={<div>Início</div>} />
+            </Routes>
           </div>
-        </div>
-      </nav>
-      <Routes>
-        <Route path="/accounts/facebook" element={<FacebookAccountsPage />} />
-        <Route path="/accounts/instagram" element={<InstagramAccountsPage />} />
-        <Route
-          path="/accounts/instagram/:id/posts"
-          element={<InstagramPostsPage />}
-        />
-        <Route path="/media" element={<MediaListPage />} />
-        <Route path="/media/new" element={<NewMediaPage />} />
-        <Route path="/media/:id" element={<MediaDetailPage />} />
-        <Route path="/courses" element={<CoursePlanListPage />} />
-        <Route path="/courses/new" element={<NewCoursePlanPage />} />
-        <Route path="/courses/:id" element={<CoursePlanDetailPage />} />
-        <Route path="/products" element={<ProductListPage />} />
-        <Route path="/products/new" element={<NewProductPage />} />
-        <Route path="/success-products" element={<SuccessProductListPage />} />
-        <Route
-          path="/success-products/new"
-          element={<NewSuccessProductPage />}
-        />
-        <Route
-          path="/success-products/:id"
-          element={<SuccessProductDetailPage />}
-        />
-        <Route
-          path="/success-products/:id/edit"
-          element={<EditSuccessProductPage />}
-        />
-        <Route path="/niches" element={<AppLayout />}>
-          <Route index element={<NicheListPage />} />
-          <Route path="new" element={<NewNichePage />} />
-          <Route path=":nicheId" element={<NicheDetailPage />} />
-          <Route path=":nicheId/edit" element={<EditNichePage />} />
-          <Route
-            path=":nicheId/hypotheses/new"
-            element={<NewHypothesisPage />}
-          />
-          <Route
-            path=":nicheId/hypotheses/:hypothesisId"
-            element={<HypothesisDetailPage />}
-          />
-          <Route
-            path=":nicheId/hypotheses/:hypothesisId/edit"
-            element={<EditHypothesisPage />}
-          />
-        </Route>
-        <Route path="/experiments" element={<ExperimentListPage />} />
-        <Route path="/experiments/new" element={<NewExperimentPage />} />
-        <Route path="/experiments/:id" element={<AppLayout />}>
-          <Route index element={<ExperimentDetailPage />} />
-          <Route path="edit" element={<EditExperimentPage />} />
-        </Route>
-        <Route path="/hypotheses" element={<HypothesisListPage />} />
-        <Route path="/hypotheses/board" element={<HypothesesPage />} />
-        <Route path="/ai-services" element={<AiServiceListPage />} />
-        <Route path="/ai-services/new" element={<NewAiServicePage />} />
-        <Route path="/ai-services/:id/edit" element={<EditAiServicePage />} />
-        <Route path="/angles" element={<AnglesPage />} />
-        <Route path="/visual-proofs" element={<VisualProofsPage />} />
-        <Route path="/emotional-triggers" element={<EmotionalTriggersPage />} />
-        <Route path="/landing/:id" element={<LandingPreview />} />
-        <Route path="/analytics" element={<AnalyticsDashboard />} />
-        <Route path="/funnels" element={<FunnelListPage />} />
-        <Route path="/funnels/new" element={<NewFunnelPage />} />
-        <Route path="/funnels/:id/edit" element={<EditFunnelPage />} />
-        <Route path="/chat-dialogs" element={<ChatDialogListPage />} />
-        <Route path="/chat-dialogs/new" element={<NewChatDialogPage />} />
-        <Route path="/prompt-entities" element={<PromptEntitiesPage />} />
-        <Route path="/prompt-entities/new" element={<NewPromptEntityPage />} />
-        <Route
-          path="/prompt-entities/:entityId"
-          element={<PromptEntityDescriptionPage />}
-        />
-        <Route
-          path="/prompt-entities/:entityId/attributes"
-          element={<PromptAttributesPage />}
-        />
-        <Route path="/facebook-campaigns" element={<FacebookCampaignExperimentsPage />} />
-        <Route
-          path="/facebook-campaigns/ready"
-          element={<FacebookExperimentsReadyPage />}
-        />
-        <Route path="*" element={<div>Início</div>} />
-      </Routes>
-      <ToastContainer position="top-right" />
+        </main>
+        <ToastContainer position="top-right" />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/MainNavigation.css
+++ b/frontend/src/components/MainNavigation.css
@@ -1,0 +1,239 @@
+.main-navigation {
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  width: 72px;
+  height: 100vh;
+  padding: 1.5rem 0.75rem;
+  gap: 1.5rem;
+  background: var(--bs-body-bg);
+  border-right: 1px solid var(--bs-border-color);
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.02), 0 18px 36px -24px rgba(15, 23, 42, 0.32);
+  transition: width 0.24s ease;
+  z-index: 1030;
+}
+
+.main-navigation.is-expanded {
+  width: 260px;
+}
+
+.main-navigation__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.main-navigation__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.75rem;
+  background: var(--bs-tertiary-bg);
+  color: var(--bs-secondary-color);
+  transition: all 0.2s ease;
+}
+
+.main-navigation__toggle:hover,
+.main-navigation__toggle:focus-visible {
+  color: var(--bs-primary);
+  border-color: var(--bs-primary);
+  background: var(--bs-primary-bg-subtle);
+  outline: none;
+}
+
+.main-navigation__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.main-navigation__logo {
+  display: grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.9rem;
+  background: var(--bs-primary-bg-subtle);
+  color: var(--bs-primary);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+}
+
+.main-navigation__brand-name {
+  display: none;
+  font-weight: 600;
+  color: var(--bs-body-color);
+  white-space: nowrap;
+}
+
+.main-navigation.is-expanded .main-navigation__brand-name,
+.main-navigation:focus-within .main-navigation__brand-name {
+  display: inline;
+}
+
+.main-navigation__sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.main-navigation__section-title {
+  display: none;
+}
+
+.main-navigation.is-expanded .main-navigation__section-title,
+.main-navigation:focus-within .main-navigation__section-title {
+  display: block;
+  margin: 0 0 0.75rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--bs-secondary-color);
+}
+
+.main-navigation__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.main-navigation__link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.85rem;
+  color: var(--bs-secondary-color);
+  text-decoration: none;
+  font-weight: 500;
+  transition: all 0.18s ease;
+}
+
+.main-navigation__link:hover,
+.main-navigation__link:focus-visible {
+  background: var(--bs-tertiary-bg);
+  color: var(--bs-body-color);
+  outline: none;
+}
+
+.main-navigation__link.is-active {
+  background: var(--bs-primary-bg-subtle);
+  color: var(--bs-primary);
+  box-shadow: inset 0 0 0 1px rgba(13, 110, 253, 0.24);
+}
+
+.main-navigation__icon {
+  flex-shrink: 0;
+}
+
+.main-navigation__label {
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.main-navigation.is-expanded .main-navigation__label,
+.main-navigation:focus-within .main-navigation__label,
+.main-navigation__link:focus-visible .main-navigation__label {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.main-navigation__market-test {
+  display: none;
+  margin-top: auto;
+  padding: 1rem 0.75rem 0;
+  border-top: 1px solid var(--bs-border-color);
+}
+
+.main-navigation.is-expanded .main-navigation__market-test {
+  display: block;
+}
+
+.main-navigation__market-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.25rem;
+  color: var(--bs-secondary-color);
+  font-size: 0.8rem;
+}
+
+.main-navigation__market-step {
+  line-height: 1.3;
+}
+
+@media (max-width: 991.98px) {
+  .main-navigation {
+    position: sticky;
+    width: 100%;
+    height: auto;
+    flex-direction: row;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    gap: 1rem;
+    border-right: none;
+    border-bottom: 1px solid var(--bs-border-color);
+  }
+
+  .main-navigation,
+  .main-navigation.is-expanded {
+    width: 100%;
+  }
+
+  .main-navigation__toggle {
+    display: none;
+  }
+
+  .main-navigation__brand-name {
+    display: inline;
+  }
+
+  .main-navigation__sections {
+    flex-direction: row;
+    gap: 1rem;
+    overflow-x: auto;
+    overflow-y: visible;
+    padding-right: 0;
+  }
+
+  .main-navigation__section {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .main-navigation__section-title,
+  .main-navigation__market-test {
+    display: none !important;
+  }
+
+  .main-navigation__items {
+    flex-direction: row;
+    gap: 0.5rem;
+  }
+
+  .main-navigation__link {
+    justify-content: center;
+    padding: 0.5rem;
+    border-radius: 999px;
+  }
+
+  .main-navigation__label {
+    display: none !important;
+  }
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -1,0 +1,199 @@
+import { useState } from "react";
+import { NavLink } from "react-router-dom";
+import type { LucideIcon } from "lucide-react";
+import {
+  BadgeCheck,
+  BarChart3,
+  Bot,
+  ClipboardCheck,
+  Compass,
+  FlaskConical,
+  Flag,
+  GraduationCap,
+  Image,
+  Instagram,
+  Lightbulb,
+  MessageSquare,
+  Package,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Shapes,
+  Sparkles,
+  Target,
+  Trophy,
+  Users,
+  Workflow,
+} from "lucide-react";
+import "./MainNavigation.css";
+
+type NavItem = {
+  to: string;
+  label: string;
+  icon: LucideIcon;
+};
+
+type NavSection = {
+  title: string;
+  items: NavItem[];
+};
+
+const NAV_SECTIONS: NavSection[] = [
+  {
+    title: "Contas",
+    items: [
+      {
+        to: "/accounts/facebook",
+        label: "Contas do Facebook",
+        icon: Users,
+      },
+      {
+        to: "/accounts/instagram",
+        label: "Contas do Instagram",
+        icon: Instagram,
+      },
+    ],
+  },
+  {
+    title: "Biblioteca",
+    items: [
+      { to: "/media", label: "Mídia", icon: Image },
+      { to: "/courses", label: "Cursos", icon: GraduationCap },
+      { to: "/products", label: "Produtos", icon: Package },
+      {
+        to: "/success-products",
+        label: "Produtos de Sucesso",
+        icon: Trophy,
+      },
+    ],
+  },
+  {
+    title: "Testes",
+    items: [
+      { to: "/niches", label: "Nichos", icon: Target },
+      { to: "/experiments", label: "Testes de Nicho", icon: FlaskConical },
+      { to: "/hypotheses", label: "Hipóteses", icon: Lightbulb },
+    ],
+  },
+  {
+    title: "IA e Conteúdo",
+    items: [
+      { to: "/ai-services", label: "IA", icon: Bot },
+      { to: "/chat-dialogs", label: "ChatGPT", icon: MessageSquare },
+      { to: "/prompt-entities", label: "Objetos de Prompt", icon: Shapes },
+      { to: "/angles", label: "Angles", icon: Compass },
+      { to: "/visual-proofs", label: "Provas Visuais", icon: BadgeCheck },
+      {
+        to: "/emotional-triggers",
+        label: "Gatilhos Emocionais",
+        icon: Sparkles,
+      },
+    ],
+  },
+  {
+    title: "Campanhas",
+    items: [
+      { to: "/funnels", label: "Funil de Vendas", icon: Workflow },
+      {
+        to: "/facebook-campaigns",
+        label: "Experimentos para Campanha",
+        icon: Flag,
+      },
+      {
+        to: "/facebook-campaigns/ready",
+        label: "Experimentos prontos",
+        icon: ClipboardCheck,
+      },
+      { to: "/analytics", label: "Analytics", icon: BarChart3 },
+    ],
+  },
+];
+
+const MARKET_TEST_STEPS = [
+  "1- Hipótese e Oferta Isca",
+  "2- Funil Mínimo",
+  "3- Tráfego e Segmentação",
+  "4- KPIs e limiares de decisão",
+  "5- Automação analítica",
+];
+
+export default function MainNavigation() {
+  const [isPinned, setIsPinned] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const isExpanded = isPinned || isHovered;
+
+  return (
+    <aside
+      className={`main-navigation${isExpanded ? " is-expanded" : ""}`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <div className="main-navigation__header">
+        <button
+          type="button"
+          className="main-navigation__toggle"
+          onClick={() => setIsPinned((value) => !value)}
+          aria-label={
+            isPinned ? "Recolher menu principal" : "Expandir menu principal"
+          }
+        >
+          {isExpanded ? (
+            <PanelLeftClose aria-hidden="true" size={18} />
+          ) : (
+            <PanelLeftOpen aria-hidden="true" size={18} />
+          )}
+        </button>
+        <div className="main-navigation__brand">
+          <span className="main-navigation__logo" aria-hidden="true">
+            MH
+          </span>
+          <span className="main-navigation__brand-name">Marketing Hub</span>
+        </div>
+      </div>
+      <nav
+        className="main-navigation__sections"
+        aria-label="Navegação principal"
+      >
+        {NAV_SECTIONS.map((section) => (
+          <div className="main-navigation__section" key={section.title}>
+            <p className="main-navigation__section-title">{section.title}</p>
+            <div className="main-navigation__items">
+              {section.items.map((item) => (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  className={({ isActive }) =>
+                    [
+                      "main-navigation__link",
+                      isActive ? "is-active" : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ")
+                  }
+                  aria-label={item.label}
+                  title={item.label}
+                >
+                  <item.icon
+                    className="main-navigation__icon"
+                    size={20}
+                    aria-hidden="true"
+                  />
+                  <span className="main-navigation__label">{item.label}</span>
+                </NavLink>
+              ))}
+            </div>
+          </div>
+        ))}
+      </nav>
+      <div className="main-navigation__market-test" aria-label="Etapas do teste de mercado">
+        <p className="main-navigation__section-title">Teste de Mercado</p>
+        <ol className="main-navigation__market-list">
+          {MARKET_TEST_STEPS.map((step) => (
+            <li key={step} className="main-navigation__market-step">
+              {step}
+            </li>
+          ))}
+        </ol>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the old top navbar with an app shell that keeps navigation visible across pages
- add a compact MainNavigation component with icon-first links, hover/pin expansion, and market test guidance
- introduce supporting styles for the shell and navigation to ensure responsive behavior on large and small screens

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d6f54f9308832186f33e0b24e01ea9