### PR TITLE
Prevent horizontal scrolling in app shell

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -11,12 +11,14 @@
   display: flex;
   flex-direction: column;
   padding: clamp(1.5rem, 4vw, 2.5rem);
+  min-width: 0;
 }
 
 .app-shell__main {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }
 
 .app-shell__main > .container-fluid {


### PR DESCRIPTION
## Summary
- allow the shell content and main areas to shrink within the flex layout
- eliminate the extra width that was producing a horizontal scrollbar next to the navigation

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d6fd7b0d7c83218676f3978bee0d0a