### PR TITLE
Align account endpoints with API namespace

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/CampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/CampaignController.java
@@ -19,12 +19,12 @@ public class CampaignController {
         this.campaignRepo = campaignRepo;
     }
 
-    @GetMapping("/accounts/{id}/campaigns")
+    @GetMapping("/api/accounts/{id}/campaigns")
     public List<Campaign> listCampaigns(@PathVariable Long id) {
         return campaignRepo.findByFacebookAccountIdOrInstagramAccountId(id, id);
     }
 
-    @PostMapping("/accounts/{id}/campaigns")
+    @PostMapping("/api/accounts/{id}/campaigns")
     public Campaign createCampaign(@PathVariable Long id,
                                   @RequestParam("platform") String platform,
                                   @RequestBody Campaign campaign) {

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
+@RequestMapping("/api/accounts/facebook")
 public class FacebookAccountController {
     private final FacebookAccountRepository repository;
 
@@ -12,23 +13,23 @@ public class FacebookAccountController {
         this.repository = repository;
     }
 
-    @GetMapping("/accounts/facebook")
+    @GetMapping
     public List<FacebookAccount> findAll() {
         return repository.findAll();
     }
 
-    @PostMapping("/accounts/facebook")
+    @PostMapping
     public FacebookAccount create(@RequestBody FacebookAccount account) {
         return repository.save(account);
     }
 
-    @PutMapping("/accounts/facebook/{id}")
+    @PutMapping("/{id}")
     public FacebookAccount update(@PathVariable Long id, @RequestBody FacebookAccount account) {
         account.setId(id);
         return repository.save(account);
     }
 
-    @DeleteMapping("/accounts/facebook/{id}")
+    @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         repository.deleteById(id);
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookPageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookPageController.java
@@ -7,7 +7,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 
 @RestController
-@RequestMapping("/accounts/facebook/{accountId}/pages")
+@RequestMapping("/api/accounts/facebook/{accountId}/pages")
 public class FacebookPageController {
     private final FacebookAccountRepository accountRepository;
     private final FacebookPageRepository pageRepository;

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccountController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
+@RequestMapping("/api/accounts/instagram")
 public class InstagramAccountController {
     private final InstagramAccountRepository repository;
 
@@ -12,23 +13,23 @@ public class InstagramAccountController {
         this.repository = repository;
     }
 
-    @GetMapping("/accounts/instagram")
+    @GetMapping
     public List<InstagramAccount> findAll() {
         return repository.findAll();
     }
 
-    @PostMapping("/accounts/instagram")
+    @PostMapping
     public InstagramAccount create(@RequestBody InstagramAccount account) {
         return repository.save(account);
     }
 
-    @PutMapping("/accounts/instagram/{id}")
+    @PutMapping("/{id}")
     public InstagramAccount update(@PathVariable Long id, @RequestBody InstagramAccount account) {
         account.setId(id);
         return repository.save(account);
     }
 
-    @DeleteMapping("/accounts/instagram/{id}")
+    @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         repository.deleteById(id);
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/post/InstagramPostController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/post/InstagramPostController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/accounts/instagram/{accountId}/posts")
+@RequestMapping("/api/accounts/instagram/{accountId}/posts")
 public class InstagramPostController {
     private final InstagramAccountRepository accountRepository;
     private final InstagramPostRepository repository;

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/CampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/CampaignControllerTest.java
@@ -45,19 +45,19 @@ public class CampaignControllerTest {
                 .name("IG Account")
                 .build());
 
-        mockMvc.perform(post("/accounts/" + fb.getId() + "/campaigns?platform=facebook")
+        mockMvc.perform(post("/api/accounts/" + fb.getId() + "/campaigns?platform=facebook")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"name\":\"FB Campaign\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").exists());
 
-        mockMvc.perform(post("/accounts/" + ig.getId() + "/campaigns?platform=instagram")
+        mockMvc.perform(post("/api/accounts/" + ig.getId() + "/campaigns?platform=instagram")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"name\":\"IG Campaign\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").exists());
 
-        mockMvc.perform(get("/accounts/" + fb.getId() + "/campaigns"))
+        mockMvc.perform(get("/api/accounts/" + fb.getId() + "/campaigns"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2));
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -41,7 +41,7 @@ public class FacebookAccountControllerTest {
                         .currency("USD")
                         .build()));
 
-        mockMvc.perform(get("/accounts/facebook"))
+        mockMvc.perform(get("/api/accounts/facebook"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(3));
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookPageControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookPageControllerTest.java
@@ -56,7 +56,7 @@ class FacebookPageControllerTest {
                 "Página Principal"
         );
 
-        mockMvc.perform(post("/accounts/facebook/" + account.getId() + "/pages")
+        mockMvc.perform(post("/api/accounts/facebook/" + account.getId() + "/pages")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -70,22 +70,22 @@ class FacebookPageControllerTest {
                 "Página Atualizada"
         );
 
-        mockMvc.perform(put("/accounts/facebook/" + account.getId() + "/pages/" + saved.getId())
+        mockMvc.perform(put("/api/accounts/facebook/" + account.getId() + "/pages/" + saved.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(update)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.pageId").value("654321"))
                 .andExpect(jsonPath("$.name").value("Página Atualizada"));
 
-        mockMvc.perform(get("/accounts/facebook/" + account.getId() + "/pages"))
+        mockMvc.perform(get("/api/accounts/facebook/" + account.getId() + "/pages"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].pageId").value("654321"));
 
-        mockMvc.perform(delete("/accounts/facebook/" + account.getId() + "/pages/" + saved.getId()))
+        mockMvc.perform(delete("/api/accounts/facebook/" + account.getId() + "/pages/" + saved.getId()))
                 .andExpect(status().isNoContent());
 
-        mockMvc.perform(get("/accounts/facebook/" + account.getId() + "/pages"))
+        mockMvc.perform(get("/api/accounts/facebook/" + account.getId() + "/pages"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(0));
     }


### PR DESCRIPTION
## Summary
- add the /api namespace to the Facebook and Instagram account, page, post, and campaign endpoints so they match the frontend requests
- update the associated controller tests to exercise the new API routes

## Testing
- mvn -s ../settings.xml test *(fails: unable to reach GitHub Packages to download the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fe5443dc8321b6dc62105ab36cb7