### PR TITLE
Fix account API paths to match backend routes

### DIFF
--- a/frontend/src/api/facebookAccountMutations.ts
+++ b/frontend/src/api/facebookAccountMutations.ts
@@ -10,7 +10,7 @@ export function useCreateFacebookAccount() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (account: FacebookAccountPayload) =>
-      axios.post("/api/accounts/facebook", account),
+      axios.post("/accounts/facebook", account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
   });
@@ -20,7 +20,7 @@ export function useUpdateFacebookAccount() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (account: FacebookAccountPayload) =>
-      axios.put(`/api/accounts/facebook/${account.id}`, account),
+      axios.put(`/accounts/facebook/${account.id}`, account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
   });
@@ -29,7 +29,7 @@ export function useUpdateFacebookAccount() {
 export function useDeleteFacebookAccount() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => axios.delete(`/api/accounts/facebook/${id}`),
+    mutationFn: (id: number) => axios.delete(`/accounts/facebook/${id}`),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
   });

--- a/frontend/src/api/instagramAccountMutations.ts
+++ b/frontend/src/api/instagramAccountMutations.ts
@@ -6,7 +6,7 @@ export function useCreateInstagramAccount() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (account: InstagramAccount) =>
-      axios.post("/api/accounts/instagram", account),
+      axios.post("/accounts/instagram", account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["instagram-accounts"] }),
   });
@@ -16,7 +16,7 @@ export function useUpdateInstagramAccount() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (account: InstagramAccount) =>
-      axios.put(`/api/accounts/instagram/${account.id}`, account),
+      axios.put(`/accounts/instagram/${account.id}`, account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["instagram-accounts"] }),
   });
@@ -25,7 +25,7 @@ export function useUpdateInstagramAccount() {
 export function useDeleteInstagramAccount() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => axios.delete(`/api/accounts/instagram/${id}`),
+    mutationFn: (id: string) => axios.delete(`/accounts/instagram/${id}`),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["instagram-accounts"] }),
   });

--- a/frontend/src/api/useFacebookAccounts.ts
+++ b/frontend/src/api/useFacebookAccounts.ts
@@ -12,7 +12,7 @@ export function useFacebookAccounts() {
     queryKey: ["facebook-accounts"],
     queryFn: async () => {
       const { data } = await axios.get<FacebookAccount[]>(
-        "/api/accounts/facebook",
+        "/accounts/facebook",
       );
       return data;
     },

--- a/frontend/src/api/useInstagramAccounts.ts
+++ b/frontend/src/api/useInstagramAccounts.ts
@@ -12,7 +12,7 @@ export function useInstagramAccounts() {
     queryKey: ["instagram-accounts"],
     queryFn: async () => {
       const { data } = await axios.get<InstagramAccount[]>(
-        "/api/accounts/instagram",
+        "/accounts/instagram",
       );
       return data;
     },


### PR DESCRIPTION
## Summary
- update Facebook account queries and mutations to call `/accounts/facebook`
- adjust Instagram account queries and mutations to call `/accounts/instagram`

## Testing
- npm run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d6fe5443dc8321b6dc62105ab36cb7