### PR TITLE
Fix account API calls to use backend prefix

### DIFF
--- a/frontend/src/api/facebookAccountMutations.ts
+++ b/frontend/src/api/facebookAccountMutations.ts
@@ -10,7 +10,7 @@ export function useCreateFacebookAccount() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (account: FacebookAccountPayload) =>
-      axios.post("/accounts/facebook", account),
+      axios.post("/api/accounts/facebook", account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
   });
@@ -20,7 +20,7 @@ export function useUpdateFacebookAccount() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (account: FacebookAccountPayload) =>
-      axios.put(`/accounts/facebook/${account.id}`, account),
+      axios.put(`/api/accounts/facebook/${account.id}`, account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
   });
@@ -29,7 +29,8 @@ export function useUpdateFacebookAccount() {
 export function useDeleteFacebookAccount() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => axios.delete(`/accounts/facebook/${id}`),
+    mutationFn: (id: number) =>
+      axios.delete(`/api/accounts/facebook/${id}`),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
   });

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+const API_PREFIX = "/api";
+const ABSOLUTE_URL_PATTERN = /^([a-z][a-z\d+\-.]*:)?\/\//i;
+
+axios.interceptors.request.use((config) => {
+  const url = config.url;
+
+  if (!url || ABSOLUTE_URL_PATTERN.test(url)) {
+    return config;
+  }
+
+  if (url.startsWith(API_PREFIX) || url.startsWith(`${API_PREFIX}?`)) {
+    return config;
+  }
+
+  const leadingSlash = url.startsWith("/") ? "" : "/";
+  config.url = `${API_PREFIX}${leadingSlash}${url}`;
+
+  return config;
+});

--- a/frontend/src/api/instagramAccountMutations.ts
+++ b/frontend/src/api/instagramAccountMutations.ts
@@ -6,7 +6,7 @@ export function useCreateInstagramAccount() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (account: InstagramAccount) =>
-      axios.post("/accounts/instagram", account),
+      axios.post("/api/accounts/instagram", account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["instagram-accounts"] }),
   });
@@ -16,7 +16,7 @@ export function useUpdateInstagramAccount() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (account: InstagramAccount) =>
-      axios.put(`/accounts/instagram/${account.id}`, account),
+      axios.put(`/api/accounts/instagram/${account.id}`, account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["instagram-accounts"] }),
   });
@@ -25,7 +25,8 @@ export function useUpdateInstagramAccount() {
 export function useDeleteInstagramAccount() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => axios.delete(`/accounts/instagram/${id}`),
+    mutationFn: (id: string) =>
+      axios.delete(`/api/accounts/instagram/${id}`),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["instagram-accounts"] }),
   });

--- a/frontend/src/api/useFacebookAccounts.ts
+++ b/frontend/src/api/useFacebookAccounts.ts
@@ -12,7 +12,7 @@ export function useFacebookAccounts() {
     queryKey: ["facebook-accounts"],
     queryFn: async () => {
       const { data } = await axios.get<FacebookAccount[]>(
-        "/accounts/facebook",
+        "/api/accounts/facebook",
       );
       return data;
     },

--- a/frontend/src/api/useInstagramAccounts.ts
+++ b/frontend/src/api/useInstagramAccounts.ts
@@ -12,7 +12,7 @@ export function useInstagramAccounts() {
     queryKey: ["instagram-accounts"],
     queryFn: async () => {
       const { data } = await axios.get<InstagramAccount[]>(
-        "/accounts/instagram",
+        "/api/accounts/instagram",
       );
       return data;
     },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import { io } from "socket.io-client";
 import App from "./App";
 import axios from "axios";
 import { apiBaseUrl } from "./config/api";
+import "./api/http";
 
 axios.defaults.baseURL = apiBaseUrl;
 


### PR DESCRIPTION
## Summary
- update Facebook and Instagram account queries and mutations to call the /api endpoints that exist in the backend
- add a shared Axios interceptor so future relative requests automatically receive the /api prefix
- register the interceptor during app bootstrap to ensure every request goes through the guard

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d73b6916a8832199128fd749338663