### PR TITLE
Adjust mobile navigation layout to remove horizontal scroll

### DIFF
--- a/frontend/src/components/MainNavigation.css
+++ b/frontend/src/components/MainNavigation.css
@@ -205,15 +205,16 @@
 
   .main-navigation__sections {
     flex-direction: row;
-    gap: 1rem;
-    overflow-x: auto;
-    overflow-y: visible;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    overflow: visible;
     padding-right: 0;
   }
 
   .main-navigation__section {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 0.5rem;
   }
 
@@ -224,6 +225,7 @@
 
   .main-navigation__items {
     flex-direction: row;
+    flex-wrap: wrap;
     gap: 0.5rem;
   }
 


### PR DESCRIPTION
## Summary
- allow mobile navigation sections to wrap and remove horizontal overflow to eliminate the horizontal scrollbar on small screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7494710e88321af4fba7e1e5ffd8a