### PR TITLE
Add campaign readiness context for Facebook experiments

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -20,6 +20,8 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
     List<Experiment> findByStatusAndPlatform(ExperimentStatus status, ExperimentPlatform platform);
     @Query("""
             select e from Experiment e
+            join fetch e.niche n
+            join fetch e.hypothesisRef h
             where e.status = :status
               and e.platform = :platform
               and e.creativeApproved = true

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
@@ -1,5 +1,6 @@
 package com.marketinghub.facebookads.web;
 
+import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.facebookads.BudgetMode;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -25,13 +27,7 @@ public class FacebookAdsCampaignController {
     @GetMapping("/experiments-ready")
     public List<ExperimentSummary> experimentsReady() {
         return experimentService.listReadyForCampaign().stream()
-                .map(e -> new ExperimentSummary(
-                        e.getId(),
-                        e.getName(),
-                        e.getHypothesis(),
-                        e.getKpiTargetCpl(),
-                        e.getStartDate(),
-                        e.getEndDate()))
+                .map(this::toSummary)
                 .toList();
     }
 
@@ -41,13 +37,7 @@ public class FacebookAdsCampaignController {
         return experimentService
                 .listByStatusAndPlatform(status, com.marketinghub.experiment.ExperimentPlatform.FACEBOOK)
                 .stream()
-                .map(e -> new ExperimentSummary(
-                        e.getId(),
-                        e.getName(),
-                        e.getHypothesis(),
-                        e.getKpiTargetCpl(),
-                        e.getStartDate(),
-                        e.getEndDate()))
+                .map(this::toSummary)
                 .toList();
     }
 
@@ -62,13 +52,55 @@ public class FacebookAdsCampaignController {
         return campaignRepository.save(campaign);
     }
 
+    private ExperimentSummary toSummary(Experiment experiment) {
+        return new ExperimentSummary(
+                experiment.getId(),
+                experiment.getName(),
+                experiment.getHypothesis(),
+                experiment.getKpiTargetCpl(),
+                experiment.getStartDate(),
+                experiment.getEndDate(),
+                experiment.getNiche() != null ? experiment.getNiche().getName() : null,
+                experiment.getHypothesisRef() != null ? experiment.getHypothesisRef().getTitle() : null,
+                computeMissingConfiguration(experiment));
+    }
+
+    private List<String> computeMissingConfiguration(Experiment experiment) {
+        List<String> missing = new ArrayList<>();
+        if (!experiment.isCreativeApproved()) {
+            missing.add("creativeApproval");
+        }
+        if (experiment.getKpiTargetCpl() == null) {
+            missing.add("kpiTargetCpl");
+        }
+        if (experiment.getStopLossCpl() == null) {
+            missing.add("stopLossCpl");
+        }
+        if (experiment.getSampleSize() == null) {
+            missing.add("sampleSize");
+        }
+        if (experiment.getStartDate() == null) {
+            missing.add("startDate");
+        }
+        if (experiment.getEndDate() == null) {
+            missing.add("endDate");
+        }
+        if (experiment.getSalesFunnel() == null) {
+            missing.add("salesFunnel");
+        }
+        return missing;
+    }
+
     public record ExperimentSummary(
             Long id,
             String name,
             String hypothesis,
             BigDecimal kpiTargetCpl,
             LocalDate startDate,
-            LocalDate endDate) {}
+            LocalDate endDate,
+            String nicheName,
+            String hypothesisTitle,
+            List<String> missingConfiguration) {}
 
     public record CreateCampaignRequest(
             String id,

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -2,6 +2,9 @@ package com.marketinghub.facebookads.web;
 
 import com.marketinghub.ads.AdsServiceApplication;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.funnel.SalesFunnel;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.experiment.service.ExperimentService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,13 +42,31 @@ class FacebookAdsCampaignControllerTest {
 
     @Test
     void listExperimentsByStatus() throws Exception {
+        var niche = MarketNiche.builder()
+                .id(10L)
+                .name("Test Nicho")
+                .build();
+        var hypothesis = Hypothesis.builder()
+                .id(java.util.UUID.randomUUID())
+                .title("Hipótese do Nicho")
+                .build();
+        var funnel = SalesFunnel.builder()
+                .id(java.util.UUID.randomUUID())
+                .name("Funil de Conversão")
+                .build();
         var exp = Experiment.builder()
                 .id(1L)
+                .niche(niche)
                 .name("Exp")
                 .hypothesis("Hipótese")
+                .hypothesisRef(hypothesis)
                 .kpiTargetCpl(BigDecimal.TEN)
+                .stopLossCpl(BigDecimal.valueOf(20))
+                .sampleSize(1200)
                 .startDate(LocalDate.of(2024, 1, 1))
                 .endDate(LocalDate.of(2024, 1, 31))
+                .creativeApproved(true)
+                .salesFunnel(funnel)
                 .build();
         when(experimentService.listByStatusAndPlatform(
                 com.marketinghub.experiment.ExperimentStatus.PLANNED,
@@ -58,6 +79,10 @@ class FacebookAdsCampaignControllerTest {
                 .andExpect(jsonPath("$[0].hypothesis").value("Hipótese"))
                 .andExpect(jsonPath("$[0].kpiTargetCpl").value(10))
                 .andExpect(jsonPath("$[0].startDate").value("2024-01-01"))
-                .andExpect(jsonPath("$[0].endDate").value("2024-01-31"));
+                .andExpect(jsonPath("$[0].endDate").value("2024-01-31"))
+                .andExpect(jsonPath("$[0].nicheName").value("Test Nicho"))
+                .andExpect(jsonPath("$[0].hypothesisTitle").value("Hipótese do Nicho"))
+                .andExpect(jsonPath("$[0].missingConfiguration").isArray())
+                .andExpect(jsonPath("$[0].missingConfiguration").isEmpty());
     }
 }

--- a/frontend/src/api/useFacebookCampaignExperiments.ts
+++ b/frontend/src/api/useFacebookCampaignExperiments.ts
@@ -8,6 +8,9 @@ export interface ExperimentSummary {
   kpiTargetCpl: number | null;
   startDate: string | null;
   endDate: string | null;
+  nicheName: string | null;
+  hypothesisTitle: string | null;
+  missingConfiguration: string[];
 }
 
 export function useFacebookCampaignExperiments(status: string) {

--- a/frontend/src/api/useFacebookReadyExperiments.ts
+++ b/frontend/src/api/useFacebookReadyExperiments.ts
@@ -8,6 +8,9 @@ export interface FacebookReadyExperiment {
   kpiTargetCpl: number | null;
   startDate: string | null;
   endDate: string | null;
+  nicheName: string | null;
+  hypothesisTitle: string | null;
+  missingConfiguration: string[];
 }
 
 export function useFacebookReadyExperiments() {

--- a/frontend/src/pages/facebook/FacebookExperimentsReadyPage.css
+++ b/frontend/src/pages/facebook/FacebookExperimentsReadyPage.css
@@ -59,6 +59,36 @@
   text-decoration: underline;
 }
 
+.experiments-ready-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.experiments-ready-card-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background-color: var(--bs-tertiary-bg);
+  color: var(--bs-secondary-color);
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid var(--bs-border-color);
+}
+
+.experiments-ready-card-tag svg {
+  color: var(--bs-primary);
+}
+
+.experiments-ready-card-subtitle {
+  margin: 0;
+  color: var(--bs-secondary-color);
+  font-size: 0.95rem;
+}
+
 .experiments-ready-meta {
   display: grid;
   gap: 0.5rem;
@@ -95,4 +125,45 @@
   margin: 0;
   color: var(--bs-secondary-color);
   max-width: 420px;
+}
+
+.experiments-ready-card-status {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  font-size: 0.9rem;
+}
+
+.experiments-ready-card-status strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.experiments-ready-card-status ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.experiments-ready-card-status-warning {
+  background-color: var(--bs-warning-bg-subtle);
+  border-color: var(--bs-warning-border-subtle);
+  color: var(--bs-warning-text-emphasis);
+}
+
+.experiments-ready-card-status-warning svg {
+  color: var(--bs-warning-text-emphasis);
+}
+
+.experiments-ready-card-status-ready {
+  background-color: var(--bs-success-bg-subtle);
+  border-color: var(--bs-success-border-subtle);
+  color: var(--bs-success-text-emphasis);
+}
+
+.experiments-ready-card-status-ready svg {
+  color: var(--bs-success-text-emphasis);
 }

--- a/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
+++ b/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
@@ -1,6 +1,15 @@
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { AlertTriangle, CalendarDays, Flag, Gauge, Target } from "lucide-react";
+import {
+  AlertTriangle,
+  CalendarDays,
+  CheckCircle2,
+  Flag,
+  Gauge,
+  Layers,
+  Lightbulb,
+  Target,
+} from "lucide-react";
 
 import PageTitle from "../../components/PageTitle";
 import { useFacebookReadyExperiments } from "../../api/useFacebookReadyExperiments";
@@ -30,6 +39,15 @@ export default function FacebookExperimentsReadyPage() {
   const experiments = useMemo(() => (Array.isArray(data) ? data : []), [data]);
   const isEmpty = !isLoading && experiments.length === 0 && !isError;
   const requiresPageSetup = configuration && !configuration.hasConfiguredPages;
+  const missingLabels: Record<string, string> = {
+    creativeApproval: "Aprovar pelo menos um criativo",
+    kpiTargetCpl: "Definir o KPI alvo (CPL)",
+    stopLossCpl: "Definir o stop-loss de CPL",
+    sampleSize: "Informar o tamanho da amostra",
+    startDate: "Definir a data de início",
+    endDate: "Definir a data de término",
+    salesFunnel: "Associar um funil de vendas",
+  };
 
   return (
     <div>
@@ -90,17 +108,50 @@ export default function FacebookExperimentsReadyPage() {
           {experiments.map((experiment) => (
             <article key={experiment.id} className="experiments-ready-card">
               <div className="experiments-ready-card-header">
-                <h2 className="experiments-ready-card-title">
-                  <Link to={`/experiments/${experiment.id}`}>
-                    {experiment.name}
-                  </Link>
-                </h2>
+                <div>
+                  <h2 className="experiments-ready-card-title">
+                    <Link to={`/experiments/${experiment.id}`}>
+                      {experiment.name}
+                    </Link>
+                  </h2>
+                  <div className="experiments-ready-card-tags">
+                    {experiment.nicheName ? (
+                      <span className="experiments-ready-card-tag">
+                        <Layers size={14} />
+                        {experiment.nicheName}
+                      </span>
+                    ) : null}
+                    {experiment.hypothesisTitle ? (
+                      <span className="experiments-ready-card-tag">
+                        <Lightbulb size={14} />
+                        {experiment.hypothesisTitle}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
                 <span className="badge text-bg-success">Pronto</span>
               </div>
+              {experiment.hypothesis ? (
+                <p className="experiments-ready-card-subtitle">
+                  {experiment.hypothesis}
+                </p>
+              ) : null}
               <div className="experiments-ready-meta">
                 <div className="experiments-ready-meta-item">
+                  <Layers size={16} className="text-primary" />
+                  <span>Nicho: {experiment.nicheName || "Sem nicho"}</span>
+                </div>
+                <div className="experiments-ready-meta-item">
+                  <Lightbulb size={16} className="text-primary" />
+                  <span>
+                    Hipótese: {experiment.hypothesisTitle || "Sem título"}
+                  </span>
+                </div>
+                <div className="experiments-ready-meta-item">
                   <Target size={16} className="text-primary" />
-                  <span>{experiment.hypothesis || "Sem hipótese vinculada"}</span>
+                  <span>
+                    Narrativa: {experiment.hypothesis || "Sem hipótese vinculada"}
+                  </span>
                 </div>
                 <div className="experiments-ready-meta-item">
                   <Gauge size={16} className="text-primary" />
@@ -114,6 +165,40 @@ export default function FacebookExperimentsReadyPage() {
                   <CalendarDays size={16} className="text-secondary" />
                   <span>Término: {formatDate(experiment.endDate)}</span>
                 </div>
+              </div>
+              <div
+                className={`experiments-ready-card-status ${
+                  experiment.missingConfiguration.length > 0
+                    ? "experiments-ready-card-status-warning"
+                    : "experiments-ready-card-status-ready"
+                }`}
+              >
+                {experiment.missingConfiguration.length > 0 ? (
+                  <>
+                    <AlertTriangle size={18} />
+                    <div>
+                      <strong>Pendências antes da campanha</strong>
+                      <ul>
+                        {experiment.missingConfiguration.map((item) => (
+                          <li key={item}>
+                            {missingLabels[item] || "Revise o experimento"}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <CheckCircle2 size={18} />
+                    <div>
+                      <strong>Pronto para o worker</strong>
+                      <p className="mb-0">
+                        O agendador criará a campanha assim que encontrar este
+                        experimento.
+                      </p>
+                    </div>
+                  </>
+                )}
               </div>
               <div className="d-flex justify-content-end">
                 <Link


### PR DESCRIPTION
## Summary
- expose niche titles, hypothesis titles and missing setup items in the Facebook campaign experiments API
- surface the new context in the "Experimentos prontos" cards with updated layout and status messaging
- refresh types, tests and styles to support the enriched readiness information

## Testing
- npm run build
- mvn -s ../settings.xml test *(fails: repository host unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d749eb15208321b0fa3c1d08afa62d