### PR TITLE
Ajusta largura do menu lateral expandido

### DIFF
--- a/frontend/src/components/MainNavigation.css
+++ b/frontend/src/components/MainNavigation.css
@@ -13,10 +13,11 @@
   box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.02), 0 18px 36px -24px rgba(15, 23, 42, 0.32);
   transition: width 0.24s ease;
   z-index: 1030;
+  overflow-x: hidden;
 }
 
 .main-navigation.is-expanded {
-  width: 260px;
+  width: 288px;
 }
 
 .main-navigation__header {


### PR DESCRIPTION
## Summary
- amplia a largura do menu lateral quando expandido para acomodar os rótulos sem causar rolagem horizontal
- oculta o transbordamento horizontal do container do menu para remover a barra de rolagem

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d757abe0b083218b8aa5db06115173