### PR TITLE
Document menu characteristics in frontend AGENTS guidelines

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,3 +1,10 @@
 # Frontend guidelines
 
 - Qualquer botão que dispare uma requisição assíncrona deve ficar desabilitado e exibir um indicador de carregamento (por exemplo, `spinner-border spinner-border-sm`) enquanto a operação estiver em andamento.
+
+## Menu lateral
+
+- O menu principal é um drawer lateral fixo à esquerda que controla a navegação global do aplicativo.
+- Ele possui largura de 288px quando está expandido, revelando rótulos e ícones completos.
+- No estado recolhido, o menu mostra apenas ícones para preservar o espaço do conteúdo.
+- A transição entre os estados aberto e fechado deve ser suave, mantendo o foco no conteúdo principal.


### PR DESCRIPTION
## Summary
- document the lateral navigation menu behavior in the frontend AGENTS guidelines
- note the expanded drawer width of 288px and other key interaction details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d75dd4529c83219d84b12afc26a9a7