### PR TITLE
Fix main navigation width calculation

### DIFF
--- a/frontend/src/components/MainNavigation.css
+++ b/frontend/src/components/MainNavigation.css
@@ -4,6 +4,7 @@
   align-self: flex-start;
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
   width: 72px;
   height: 100vh;
   padding: 1.5rem 0.75rem;


### PR DESCRIPTION
## Summary
- ensure the main navigation drawer accounts for its padding when expanded
- set the sidebar to use border-box sizing so its width stays at 288px and no longer triggers horizontal scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ef64b3bc8321b820206e35ea2408