### PR TITLE
Use favicon in sidebar brand

### DIFF
--- a/frontend/src/components/MainNavigation.css
+++ b/frontend/src/components/MainNavigation.css
@@ -68,6 +68,13 @@
   letter-spacing: 0.08em;
 }
 
+.main-navigation__logo-image {
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+  object-fit: contain;
+}
+
 .main-navigation__brand-name {
   display: none;
   font-weight: 600;

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -146,7 +146,13 @@ export default function MainNavigation() {
         </button>
         <div className="main-navigation__brand">
           <span className="main-navigation__logo" aria-hidden="true">
-            MH
+            <img
+              src="/favicon.ico"
+              alt=""
+              width={32}
+              height={32}
+              className="main-navigation__logo-image"
+            />
           </span>
           <span className="main-navigation__brand-name">Marketing Hub</span>
         </div>


### PR DESCRIPTION
## Summary
- replace the "MH" text badge in the sidebar header with the application favicon
- add styling so the favicon image is sized and centered inside the existing brand container

## Testing
- npm run dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68d7f046e1e08321b9eec0d8d6fcd115