### PR TITLE
Fix duplicate Facebook campaign menu highlighting

### DIFF
--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -32,6 +32,7 @@ type NavItem = {
   to: string;
   label: string;
   icon: NavIcon;
+  end?: boolean;
 };
 
 type NavSection = {
@@ -99,6 +100,7 @@ const NAV_SECTIONS: NavSection[] = [
         to: "/facebook-campaigns",
         label: "Experimentos para Campanha",
         icon: Flag,
+        end: true,
       },
       {
         to: "/facebook-campaigns/ready",
@@ -163,6 +165,7 @@ export default function MainNavigation() {
                 <NavLink
                   key={item.to}
                   to={item.to}
+                  end={item.end}
                   className={({ isActive }) =>
                     [
                       "main-navigation__link",


### PR DESCRIPTION
## Summary
- allow navigation items to define exact matching behaviour
- ensure the Facebook campaign link only highlights on its exact route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7efe0a8bc8321ba4a07a57e8edf16