### PR TITLE
Add dropdown for selecting Facebook page on experiment edit

### DIFF
--- a/frontend/src/api/useAllFacebookPages.ts
+++ b/frontend/src/api/useAllFacebookPages.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { FacebookAccount } from "./useFacebookAccounts";
+import type { FacebookPage } from "./useFacebookPages";
+
+export function useAllFacebookPages() {
+  return useQuery({
+    queryKey: ["facebook-pages", "all"],
+    queryFn: async () => {
+      const { data: accounts } = await axios.get<FacebookAccount[]>(
+        "/api/accounts/facebook",
+      );
+
+      if (!Array.isArray(accounts) || accounts.length === 0) {
+        return [] as FacebookPage[];
+      }
+
+      const pagesByAccount = await Promise.all(
+        accounts.map(async (account) => {
+          const { data } = await axios.get<FacebookPage[]>(
+            `/api/accounts/facebook/${account.id}/pages`,
+          );
+          return data;
+        }),
+      );
+
+      return pagesByAccount.flat();
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/frontend/src/pages/experiment/EditExperimentPage.tsx
+++ b/frontend/src/pages/experiment/EditExperimentPage.tsx
@@ -5,6 +5,7 @@ import { useExperiment } from "../../api/experiment/useExperiment";
 import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
 import { useMetricPresets } from "../../api/experiment/useMetricPresets";
 import { useFunnels } from "../../api/funnel/useFunnels";
+import { useAllFacebookPages } from "../../api/useAllFacebookPages";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
 
@@ -25,6 +26,8 @@ export default function EditExperimentPage() {
   const { data: funnels } = useFunnels();
   const update = useUpdateExperiment(expId);
   const { register, handleSubmit, reset } = useForm<FormData>();
+  const { data: facebookPages, isLoading: isLoadingFacebookPages } =
+    useAllFacebookPages();
 
   useEffect(() => {
     if (data) {
@@ -113,14 +116,25 @@ export default function EditExperimentPage() {
             ))}
         </select>
         <label className="form-label" htmlFor="pageId">
-          ID da página do Facebook
+          Página do Facebook
         </label>
-        <input
+        <select
           id="pageId"
-          className="form-control mb-2"
+          className="form-select mb-2"
           {...register("pageId")}
-          placeholder="Ex.: 123456789"
-        />
+        >
+          <option value="">
+            {isLoadingFacebookPages
+              ? "Carregando páginas cadastradas..."
+              : "Nenhuma página selecionada"}
+          </option>
+          {Array.isArray(facebookPages) &&
+            facebookPages.map((page) => (
+              <option key={page.id} value={page.pageId}>
+                {page.name}
+              </option>
+            ))}
+        </select>
         <div className="alert alert-info" role="status">
           A aprovação dos públicos agora é feita individualmente na aba
           {" "}


### PR DESCRIPTION
## Summary
- load all configured Facebook pages in a dedicated hook
- replace the Facebook page ID text input with a dropdown showing the registered page names

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d92c71598c83219b37d5271eb0d651