### PR TITLE
Show pending experiments in Facebook campaigns list

### DIFF
--- a/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
+++ b/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
 import { useFacebookCampaignExperiments } from "../../api/useFacebookCampaignExperiments";
 import PageTitle from "../../components/PageTitle";
 import { useFacebookConfigurationStatus } from "../../api/useFacebookConfigurationStatus";
+import { getMissingConfigurationLabel } from "./missingConfigurationLabels";
 
 export default function FacebookCampaignExperimentsPage() {
   const [status, setStatus] = useState("PLANNED");
@@ -55,6 +56,7 @@ export default function FacebookCampaignExperimentsPage() {
                 <th>KPI alvo</th>
                 <th>Início</th>
                 <th>Término</th>
+                <th>Pendências</th>
               </tr>
             </thead>
             <tbody>
@@ -67,6 +69,26 @@ export default function FacebookCampaignExperimentsPage() {
                   <td>{e.kpiTargetCpl}</td>
                   <td>{e.startDate}</td>
                   <td>{e.endDate}</td>
+                  <td>
+                    {e.missingConfiguration.length > 0 ? (
+                      <div>
+                        <span className="badge text-bg-warning d-inline-flex align-items-center gap-1 mb-1">
+                          <AlertTriangle size={14} aria-hidden="true" />
+                          Pendências
+                        </span>
+                        <ul className="mb-0 ps-3 small">
+                          {e.missingConfiguration.map((item) => (
+                            <li key={item}>{getMissingConfigurationLabel(item)}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : (
+                      <span className="badge text-bg-success d-inline-flex align-items-center gap-1">
+                        <CheckCircle2 size={14} aria-hidden="true" />
+                        Em dia
+                      </span>
+                    )}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
+++ b/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
@@ -16,6 +16,7 @@ import PageTitle from "../../components/PageTitle";
 import { useFacebookReadyExperiments } from "../../api/useFacebookReadyExperiments";
 import { useFacebookConfigurationStatus } from "../../api/useFacebookConfigurationStatus";
 import "./FacebookExperimentsReadyPage.css";
+import { getMissingConfigurationLabel } from "./missingConfigurationLabels";
 
 function formatCurrency(value: number | null) {
   if (value === null) return "Sem KPI";
@@ -40,16 +41,6 @@ export default function FacebookExperimentsReadyPage() {
   const experiments = useMemo(() => (Array.isArray(data) ? data : []), [data]);
   const isEmpty = !isLoading && experiments.length === 0 && !isError;
   const requiresPageSetup = configuration && !configuration.hasConfiguredPages;
-  const missingLabels: Record<string, string> = {
-    creativeApproval: "Aprovar pelo menos um criativo",
-    kpiTargetCpl: "Definir o KPI alvo (CPL)",
-    stopLossCpl: "Definir o stop-loss de CPL",
-    sampleSize: "Informar o tamanho da amostra",
-    startDate: "Definir a data de início",
-    endDate: "Definir a data de término",
-    salesFunnel: "Associar um funil de vendas",
-  };
-
   return (
     <div>
       <PageTitle>Experimentos prontos para campanha</PageTitle>
@@ -190,7 +181,7 @@ export default function FacebookExperimentsReadyPage() {
                       <ul>
                         {experiment.missingConfiguration.map((item) => (
                           <li key={item}>
-                            {missingLabels[item] || "Revise o experimento"}
+                            {getMissingConfigurationLabel(item)}
                           </li>
                         ))}
                       </ul>

--- a/frontend/src/pages/facebook/missingConfigurationLabels.ts
+++ b/frontend/src/pages/facebook/missingConfigurationLabels.ts
@@ -1,0 +1,13 @@
+export const missingConfigurationLabels: Record<string, string> = {
+  creativeApproval: "Aprovar pelo menos um criativo",
+  kpiTargetCpl: "Definir o KPI alvo (CPL)",
+  stopLossCpl: "Definir o stop-loss de CPL",
+  sampleSize: "Informar o tamanho da amostra",
+  startDate: "Definir a data de início",
+  endDate: "Definir a data de término",
+  salesFunnel: "Associar um funil de vendas",
+};
+
+export function getMissingConfigurationLabel(key: string) {
+  return missingConfigurationLabels[key] || "Revise o experimento";
+}


### PR DESCRIPTION
## Summary
- surface pending Facebook experiment configurations in the campaign list with badges and labels
- centralize the mapping of configuration keys to human friendly labels for reuse
- reuse the shared labels when showing experiment readiness details

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d92cb64d6c83218d48dd8715ae1f65