### PR TITLE
Rename campaign experiment menu item

### DIFF
--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -81,7 +81,7 @@ const NAV_SECTIONS: NavSection[] = [
         children: [
           {
             to: "/facebook-campaigns",
-            label: "Experimentos para Campanha",
+            label: "Para Campanha",
             icon: Flag,
             end: true,
           },


### PR DESCRIPTION
## Summary
- rename the Facebook campaign experiments navigation item to display "Para Campanha"

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d934067b288321af9ecc884196e89e