### PR TITLE
Update experiment readiness hint to reference edit page

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -103,9 +103,11 @@ export default function ExperimentDetailPage() {
       isMet: hasExperimentPage,
       hint: hasExperimentPage
         ? `Este experimento usa a página ${data.pageId}.`
-        : "Defina a página na aba Criativos deste experimento para garantir que os anúncios publiquem no local correto. A edição deve ser feita no experimento.",
-      action: hasExperimentPage ? undefined : () => setTab("creatives"),
-      actionLabel: hasExperimentPage ? undefined : "Ir para Criativos",
+        : "Defina a página na edição do experimento para garantir que os anúncios publiquem no local correto. A edição deve ser feita no experimento.",
+      action: hasExperimentPage
+        ? undefined
+        : () => navigate(`/experiments/${expId}/edit`),
+      actionLabel: hasExperimentPage ? undefined : "Editar experimento",
     },
     {
       id: "platform",


### PR DESCRIPTION
## Summary
- update the experiment readiness hint to mention editing the experiment instead of the creatives tab
- adjust the quick action to open the experiment edit page when no page is configured

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d93be1a830832180d4e9e16cb83812