### PR TITLE
Store Facebook token metadata and warn on expiry

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
@@ -1,13 +1,19 @@
 package com.marketinghub.ads;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Entity(name = "fb_account")
 @Data
@@ -15,10 +21,50 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FacebookAccount {
+    private static final long TOKEN_RENEWAL_THRESHOLD_DAYS = 7;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
     private String currency;
+
+    @Column(columnDefinition = "LONGTEXT")
+    private String accessToken;
+    private LocalDateTime tokenExpiresAt;
+    private LocalDateTime tokenLastRefreshedAt;
+    private String authorizedUserId;
+    private String authorizedUserName;
+    private String authorizedUserEmail;
+
+    @Transient
+    @JsonProperty("tokenExpired")
+    public boolean isTokenExpired() {
+        return tokenExpiresAt != null && tokenExpiresAt.isBefore(LocalDateTime.now());
+    }
+
+    @Transient
+    @JsonProperty("requiresTokenRenewal")
+    public boolean isTokenRenewalRequired() {
+        if (accessToken == null || accessToken.isBlank()) {
+            return true;
+        }
+        if (tokenExpiresAt == null) {
+            return true;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime threshold = now.plusDays(TOKEN_RENEWAL_THRESHOLD_DAYS);
+        return !tokenExpiresAt.isAfter(threshold);
+    }
+
+    @Transient
+    @JsonProperty("tokenExpiresInDays")
+    public Long getTokenExpiresInDays() {
+        if (tokenExpiresAt == null) {
+            return null;
+        }
+        long days = ChronoUnit.DAYS.between(LocalDateTime.now(), tokenExpiresAt);
+        return days;
+    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -2,6 +2,7 @@ package com.marketinghub.ads;
 
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -20,17 +21,66 @@ public class FacebookAccountController {
 
     @PostMapping
     public FacebookAccount create(@RequestBody FacebookAccount account) {
+        normalizeAccount(account);
+        if (account.getAccessToken() == null) {
+            account.setTokenExpiresAt(null);
+            account.setTokenLastRefreshedAt(null);
+        } else if (account.getTokenLastRefreshedAt() == null) {
+            account.setTokenLastRefreshedAt(LocalDateTime.now());
+        }
         return repository.save(account);
     }
 
     @PutMapping("/{id}")
     public FacebookAccount update(@PathVariable Long id, @RequestBody FacebookAccount account) {
-        account.setId(id);
-        return repository.save(account);
+        FacebookAccount persisted = repository.findById(id).orElseThrow();
+        normalizeAccount(account);
+
+        persisted.setName(account.getName());
+        persisted.setCurrency(account.getCurrency());
+        persisted.setAuthorizedUserId(account.getAuthorizedUserId());
+        persisted.setAuthorizedUserName(account.getAuthorizedUserName());
+        persisted.setAuthorizedUserEmail(account.getAuthorizedUserEmail());
+
+        String newToken = account.getAccessToken();
+        if (newToken == null) {
+            persisted.setAccessToken(null);
+            persisted.setTokenExpiresAt(null);
+            persisted.setTokenLastRefreshedAt(null);
+        } else {
+            if (!newToken.equals(persisted.getAccessToken())) {
+                persisted.setTokenLastRefreshedAt(LocalDateTime.now());
+            }
+            persisted.setAccessToken(newToken);
+            persisted.setTokenExpiresAt(account.getTokenExpiresAt());
+        }
+
+        return repository.save(persisted);
     }
 
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         repository.deleteById(id);
+    }
+
+    private void normalizeAccount(FacebookAccount account) {
+        account.setName(trim(account.getName()));
+        account.setCurrency(trim(account.getCurrency()));
+        account.setAccessToken(trimToNull(account.getAccessToken()));
+        account.setAuthorizedUserId(trimToNull(account.getAuthorizedUserId()));
+        account.setAuthorizedUserName(trimToNull(account.getAuthorizedUserName()));
+        account.setAuthorizedUserEmail(trimToNull(account.getAuthorizedUserEmail()));
+    }
+
+    private static String trim(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/V2025_12_20__extend_fb_account_with_token.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2025_12_20__extend_fb_account_with_token.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+--changeset marketinghub:2025-12-20-extend-fb-account-with-token dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'fb_account' AND column_name = 'access_token';
+ALTER TABLE fb_account
+  ADD COLUMN access_token LONGTEXT NULL,
+  ADD COLUMN token_expires_at DATETIME NULL,
+  ADD COLUMN token_last_refreshed_at DATETIME NULL,
+  ADD COLUMN authorized_user_id VARCHAR(128) NULL,
+  ADD COLUMN authorized_user_name VARCHAR(255) NULL,
+  ADD COLUMN authorized_user_email VARCHAR(320) NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -125,3 +125,6 @@ databaseChangeLog:
   - include:
       file: V2025_12_10__move_page_id_to_experiment.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2025_12_20__extend_fb_account_with_token.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -7,13 +7,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.stream.IntStream;
+import java.time.LocalDateTime;
 
 import com.marketinghub.ads.FacebookAccount;
 import com.marketinghub.ads.FacebookAccountRepository;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.contains;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -34,15 +35,35 @@ public class FacebookAccountControllerTest {
     FacebookAccountRepository repository;
 
     @Test
-    void shouldReturnThreeAccounts() throws Exception {
-        IntStream.rangeClosed(1, 3)
-                .forEach(i -> repository.save(FacebookAccount.builder()
-                        .name("Account " + i)
-                        .currency("USD")
-                        .build()));
+    void shouldReturnAccountsWithTokenStatus() throws Exception {
+        repository.save(FacebookAccount.builder()
+                .name("Account valid")
+                .currency("USD")
+                .accessToken("token-valid")
+                .tokenExpiresAt(LocalDateTime.now().plusDays(30))
+                .authorizedUserId("123")
+                .authorizedUserName("Marketing Hub")
+                .authorizedUserEmail("contato@example.com")
+                .build());
+
+        repository.save(FacebookAccount.builder()
+                .name("Account expiring")
+                .currency("USD")
+                .accessToken("token-expiring")
+                .tokenExpiresAt(LocalDateTime.now().plusDays(2))
+                .build());
+
+        repository.save(FacebookAccount.builder()
+                .name("Account missing token")
+                .currency("USD")
+                .build());
 
         mockMvc.perform(get("/api/accounts/facebook"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(3));
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[?(@.name=='Account valid')].requiresTokenRenewal", contains(false)))
+                .andExpect(jsonPath("$[?(@.name=='Account expiring')].requiresTokenRenewal", contains(true)))
+                .andExpect(jsonPath("$[?(@.name=='Account missing token')].requiresTokenRenewal", contains(true)))
+                .andExpect(jsonPath("$[?(@.name=='Account expiring')].tokenExpired", contains(false)));
     }
 }

--- a/frontend/src/api/facebookAccountMutations.ts
+++ b/frontend/src/api/facebookAccountMutations.ts
@@ -4,6 +4,12 @@ export interface FacebookAccountPayload {
   id?: number;
   name: string;
   currency: string;
+  accessToken?: string | null;
+  tokenExpiresAt?: string | null;
+  tokenLastRefreshedAt?: string | null;
+  authorizedUserId?: string | null;
+  authorizedUserName?: string | null;
+  authorizedUserEmail?: string | null;
 }
 
 export function useCreateFacebookAccount() {

--- a/frontend/src/api/useFacebookAccounts.ts
+++ b/frontend/src/api/useFacebookAccounts.ts
@@ -5,6 +5,15 @@ export interface FacebookAccount {
   id: number;
   name: string;
   currency: string;
+  accessToken?: string | null;
+  tokenExpiresAt?: string | null;
+  tokenLastRefreshedAt?: string | null;
+  authorizedUserId?: string | null;
+  authorizedUserName?: string | null;
+  authorizedUserEmail?: string | null;
+  tokenExpired?: boolean;
+  requiresTokenRenewal?: boolean;
+  tokenExpiresInDays?: number | null;
 }
 
 export function useFacebookAccounts() {

--- a/frontend/src/pages/FacebookAccountsPage.tsx
+++ b/frontend/src/pages/FacebookAccountsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import PageTitle from "../components/PageTitle";
 import { useFacebookAccounts } from "../api/useFacebookAccounts";
+import type { FacebookAccount as RemoteFacebookAccount } from "../api/useFacebookAccounts";
 import {
   useCreateFacebookAccount,
   useDeleteFacebookAccount,
@@ -17,6 +18,11 @@ import {
 interface AccountFormState {
   id?: number;
   name: string;
+  accessToken: string;
+  tokenExpiresAt: string;
+  authorizedUserId: string;
+  authorizedUserName: string;
+  authorizedUserEmail: string;
 }
 
 interface PageFormState {
@@ -27,15 +33,68 @@ interface PageFormState {
 
 const BRAZILIAN_REAL = "BRL";
 
-const emptyAccountForm: AccountFormState = { name: "" };
+const emptyAccountForm: AccountFormState = {
+  name: "",
+  accessToken: "",
+  tokenExpiresAt: "",
+  authorizedUserId: "",
+  authorizedUserName: "",
+  authorizedUserEmail: "",
+};
 const emptyPageForm: PageFormState = { pageId: "", name: "" };
+
+const dateTimeFormatter = new Intl.DateTimeFormat("pt-BR", {
+  dateStyle: "short",
+  timeStyle: "short",
+});
+
+function toInputDateValue(value?: string | null): string {
+  if (!value) return "";
+  return value.slice(0, 16);
+}
+
+function toBackendDateValue(value?: string): string | null {
+  if (!value) return null;
+  return value.length === 16 ? `${value}:00` : value;
+}
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "—";
+  return dateTimeFormatter.format(parsed);
+}
+
+function describeTokenExpiration(account: RemoteFacebookAccount): string {
+  if (!account.accessToken) {
+    return "Token não informado";
+  }
+  if (!account.tokenExpiresAt) {
+    return "Validade não informada";
+  }
+  if (account.tokenExpired) {
+    if (typeof account.tokenExpiresInDays === "number") {
+      const absoluteDays = Math.abs(account.tokenExpiresInDays);
+      if (absoluteDays === 0) return "Expirou hoje";
+      if (absoluteDays === 1) return "Expirou há 1 dia";
+      return `Expirou há ${absoluteDays} dias`;
+    }
+    return "Token expirado";
+  }
+  if (typeof account.tokenExpiresInDays === "number") {
+    if (account.tokenExpiresInDays <= 0) return "Expira hoje";
+    if (account.tokenExpiresInDays === 1) return "Expira em 1 dia";
+    return `Expira em ${account.tokenExpiresInDays} dias`;
+  }
+  return "Validade não informada";
+}
 
 export default function FacebookAccountsPage() {
   const { data, isLoading, error } = useFacebookAccounts();
   const accounts = useMemo(() => (Array.isArray(data) ? data : []), [data]);
   const [selectedAccountId, setSelectedAccountId] = useState<number | null>(null);
-  const [accountForm, setAccountForm] = useState<AccountFormState>(emptyAccountForm);
-  const [pageForm, setPageForm] = useState<PageFormState>(emptyPageForm);
+  const [accountForm, setAccountForm] = useState<AccountFormState>({ ...emptyAccountForm });
+  const [pageForm, setPageForm] = useState<PageFormState>({ ...emptyPageForm });
   const [deletingAccountId, setDeletingAccountId] = useState<number | null>(null);
   const [deletingPageId, setDeletingPageId] = useState<number | null>(null);
 
@@ -47,6 +106,13 @@ export default function FacebookAccountsPage() {
     selectedAccountId ?? undefined,
   );
   const pages = useMemo(() => (Array.isArray(pagesData) ? pagesData : []), [pagesData]);
+  const accountsNeedingRenewal = useMemo(
+    () =>
+      accounts.filter(
+        (account) => Boolean(account.requiresTokenRenewal) || !account.accessToken,
+      ),
+    [accounts],
+  );
 
   const createPageMutation = useCreateFacebookPage(selectedAccountId ?? undefined);
   const updatePageMutation = useUpdateFacebookPage(selectedAccountId ?? undefined);
@@ -63,7 +129,7 @@ export default function FacebookAccountsPage() {
   }, [accounts, selectedAccountId]);
 
   useEffect(() => {
-    setPageForm(emptyPageForm);
+    setPageForm({ ...emptyPageForm });
   }, [selectedAccountId]);
 
   if (isLoading) return <p>Carregando...</p>;
@@ -83,11 +149,16 @@ export default function FacebookAccountsPage() {
       id: accountForm.id,
       name: accountForm.name,
       currency: BRAZILIAN_REAL,
+      accessToken: accountForm.accessToken.trim() || null,
+      tokenExpiresAt: toBackendDateValue(accountForm.tokenExpiresAt),
+      authorizedUserId: accountForm.authorizedUserId.trim() || null,
+      authorizedUserName: accountForm.authorizedUserName.trim() || null,
+      authorizedUserEmail: accountForm.authorizedUserEmail.trim() || null,
     };
     const mutation = isEditingAccount ? updateAccountMutation : createAccountMutation;
     mutation.mutate(payload, {
       onSuccess: () => {
-        setAccountForm(emptyAccountForm);
+        setAccountForm({ ...emptyAccountForm });
       },
     });
   };
@@ -103,7 +174,7 @@ export default function FacebookAccountsPage() {
     const mutation = isEditingPage ? updatePageMutation : createPageMutation;
     mutation.mutate(payload, {
       onSuccess: () => {
-        setPageForm(emptyPageForm);
+        setPageForm({ ...emptyPageForm });
       },
     });
   };
@@ -125,6 +196,22 @@ export default function FacebookAccountsPage() {
   return (
     <div>
       <PageTitle>Contas do Facebook</PageTitle>
+      {accountsNeedingRenewal.length > 0 && (
+        <div className="alert alert-warning" role="alert">
+          <h2 className="h6 mb-2">Renovação de token necessária</h2>
+          <p className="mb-2">
+            Atualize o token de acesso de longa duração para evitar que as integrações com o
+            Facebook Ads sejam interrompidas.
+          </p>
+          <ul className="mb-0 ps-3">
+            {accountsNeedingRenewal.map((account) => (
+              <li key={account.id}>
+                <strong>{account.name}</strong>: {describeTokenExpiration(account)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       <div className="row g-4">
         <div className="col-12 col-xl-6">
           <div className="card h-100">
@@ -140,65 +227,116 @@ export default function FacebookAccountsPage() {
                       <th>ID</th>
                       <th>Nome</th>
                       <th>Moeda</th>
+                      <th>Status do token</th>
                       <th className="text-end">Ações</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {accounts.map(({ id, name, currency }) => (
-                      <tr key={id} className={selectedAccountId === id ? "table-primary" : ""}>
-                        <td>{id}</td>
-                        <td>{name}</td>
-                        <td>{currency}</td>
-                        <td className="text-end d-flex justify-content-end gap-2">
-                          {(() => {
-                            const isDeletingThisAccount =
-                              deleteAccountMutation.isPending && deletingAccountId === id;
-                            return (
-                              <>
-                                <button
-                                  className="btn btn-sm btn-outline-primary"
-                                  onClick={() => {
-                                    setAccountForm({ id, name });
-                                  }}
-                                  disabled={isDeletingThisAccount}
-                                >
-                                  Editar
-                                </button>
-                                <button
-                                  className="btn btn-sm btn-outline-secondary"
-                                  onClick={() => setSelectedAccountId(id)}
-                                  disabled={isDeletingThisAccount}
-                                >
-                                  Páginas
-                                </button>
-                                <button
-                                  className="btn btn-sm btn-outline-danger"
-                                  onClick={() => handleDeleteAccount(id)}
-                                  disabled={deleteAccountMutation.isPending}
-                                >
-                                  {isDeletingThisAccount ? (
-                                    <>
-                                      <span
-                                        className="spinner-border spinner-border-sm me-2"
-                                        role="status"
-                                      />
-                                      Excluindo...
-                                    </>
-                                  ) : (
-                                    "Excluir"
-                                  )}
-                                </button>
-                              </>
-                            );
-                          })()}
-                        </td>
-                      </tr>
-                    ))}
+                    {accounts.map((account) => {
+                      const { id, name, currency } = account;
+                      const isDeletingThisAccount =
+                        deleteAccountMutation.isPending && deletingAccountId === id;
+                      const rowClasses = [
+                        selectedAccountId === id ? "table-primary" : "",
+                        account.requiresTokenRenewal || !account.accessToken ? "table-warning" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ");
+                      const badgeClass = !account.accessToken
+                        ? "text-bg-danger"
+                        : account.tokenExpired
+                        ? "text-bg-danger"
+                        : account.requiresTokenRenewal
+                        ? "text-bg-warning"
+                        : "text-bg-success";
+                      const badgeLabel = !account.accessToken
+                        ? "Token ausente"
+                        : account.tokenExpired
+                        ? "Token expirado"
+                        : account.requiresTokenRenewal
+                        ? "Renovar token"
+                        : "Token válido";
+                      return (
+                        <tr key={id} className={rowClasses}>
+                          <td>{id}</td>
+                          <td>{name}</td>
+                          <td>{currency}</td>
+                          <td>
+                            <div className="d-flex flex-column gap-1">
+                              <span className={`badge ${badgeClass}`}>{badgeLabel}</span>
+                              <small className="text-muted">
+                                {describeTokenExpiration(account)}
+                              </small>
+                              <small className="text-muted">
+                                Validade: {formatDateTime(account.tokenExpiresAt)}
+                              </small>
+                              {account.authorizedUserName && (
+                                <small className="text-muted">
+                                  Usuário autorizado: {account.authorizedUserName}
+                                  {account.authorizedUserEmail
+                                    ? ` (${account.authorizedUserEmail})`
+                                    : ""}
+                                </small>
+                              )}
+                              {account.authorizedUserId && (
+                                <small className="text-muted">
+                                  ID do usuário: {account.authorizedUserId}
+                                </small>
+                              )}
+                            </div>
+                          </td>
+                          <td className="text-end d-flex justify-content-end gap-2">
+                            <button
+                              className="btn btn-sm btn-outline-primary"
+                              onClick={() => {
+                                setAccountForm({
+                                  id,
+                                  name,
+                                  accessToken: account.accessToken ?? "",
+                                  tokenExpiresAt: toInputDateValue(account.tokenExpiresAt ?? undefined),
+                                  authorizedUserId: account.authorizedUserId ?? "",
+                                  authorizedUserName: account.authorizedUserName ?? "",
+                                  authorizedUserEmail: account.authorizedUserEmail ?? "",
+                                });
+                              }}
+                              disabled={isDeletingThisAccount}
+                            >
+                              Editar
+                            </button>
+                            <button
+                              className="btn btn-sm btn-outline-secondary"
+                              onClick={() => setSelectedAccountId(id)}
+                              disabled={isDeletingThisAccount}
+                            >
+                              Páginas
+                            </button>
+                            <button
+                              className="btn btn-sm btn-outline-danger"
+                              onClick={() => handleDeleteAccount(id)}
+                              disabled={deleteAccountMutation.isPending}
+                            >
+                              {isDeletingThisAccount ? (
+                                <>
+                                  <span
+                                    className="spinner-border spinner-border-sm me-2"
+                                    role="status"
+                                  />
+                                  Excluindo...
+                                </>
+                              ) : (
+                                "Excluir"
+                              )}
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>
-              <div className="row g-2">
-                <div className="col-md-5">
+              <div className="row g-3">
+                <div className="col-12">
+                  <label className="form-label">Nome da conta</label>
                   <input
                     className="form-control"
                     placeholder="Nome da conta"
@@ -209,9 +347,94 @@ export default function FacebookAccountsPage() {
                         name: event.target.value,
                       }))
                     }
+                    disabled={isAccountMutationPending}
                   />
                 </div>
-                <div className="col-md-7">
+                <div className="col-12">
+                  <label className="form-label">Token de acesso (longa duração)</label>
+                  <textarea
+                    className="form-control"
+                    placeholder="Cole o token de acesso gerado no Business Manager"
+                    rows={3}
+                    value={accountForm.accessToken}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        accessToken: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                  <div className="form-text">
+                    Utilize sempre um token de longa duração para que o Marketing Hub possa
+                    renovar o acesso automaticamente.
+                  </div>
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Validade do token</label>
+                  <input
+                    type="datetime-local"
+                    className="form-control"
+                    value={accountForm.tokenExpiresAt}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        tokenExpiresAt: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                  <div className="form-text">
+                    Exibiremos um alerta 7 dias antes do vencimento.
+                  </div>
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">ID do usuário autorizado</label>
+                  <input
+                    className="form-control"
+                    placeholder="ID do usuário do Facebook"
+                    value={accountForm.authorizedUserId}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        authorizedUserId: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Nome do usuário autorizado</label>
+                  <input
+                    className="form-control"
+                    placeholder="Nome completo"
+                    value={accountForm.authorizedUserName}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        authorizedUserName: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">E-mail do usuário autorizado</label>
+                  <input
+                    type="email"
+                    className="form-control"
+                    placeholder="email@exemplo.com"
+                    value={accountForm.authorizedUserEmail}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        authorizedUserEmail: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12">
                   <button
                     className="btn btn-primary w-100"
                     onClick={submitAccount}


### PR DESCRIPTION
## Summary
- add long-lived token metadata to Facebook accounts with renewal status helpers and persistence logic
- extend Liquibase changelog to persist tokens, expiry timestamps, and authorized user details
- surface renewal alerts, token status badges, and token management fields in the Facebook accounts UI

## Testing
- `./mvnw -f ads-service/pom.xml test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d94787eb1883219b3696db9e22183b