### PR TITLE
feat: automate facebook token renewal

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
@@ -1,16 +1,20 @@
 package com.marketinghub.ads;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Transient;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -37,6 +41,25 @@ public class FacebookAccount {
     private String authorizedUserId;
     private String authorizedUserName;
     private String authorizedUserEmail;
+    private String appId;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Setter(AccessLevel.NONE)
+    @Column(columnDefinition = "LONGTEXT")
+    private String appSecret;
+
+    private boolean tokenRenewalEnabled;
+    private String tokenRenewalStatus;
+    private LocalDateTime tokenRenewalLastAttemptAt;
+    private LocalDateTime tokenRenewedAt;
+
+    @Column(columnDefinition = "LONGTEXT")
+    private String tokenRenewalLastError;
+
+    @Transient
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private boolean appSecretProvided;
 
     @Transient
     @JsonProperty("tokenExpired")
@@ -66,5 +89,27 @@ public class FacebookAccount {
         }
         long days = ChronoUnit.DAYS.between(LocalDateTime.now(), tokenExpiresAt);
         return days;
+    }
+
+    @JsonSetter("appSecret")
+    public void jsonAppSecretSetter(String appSecret) {
+        this.appSecret = appSecret;
+        this.appSecretProvided = true;
+    }
+
+    public void overwriteAppSecret(String appSecret) {
+        this.appSecret = appSecret;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isAppSecretProvided() {
+        return appSecretProvided;
+    }
+
+    @Transient
+    @JsonProperty("hasAppSecret")
+    public boolean hasAppSecret() {
+        return appSecret != null && !appSecret.isBlank();
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -1,9 +1,11 @@
 package com.marketinghub.ads;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/accounts/facebook")
@@ -25,8 +27,18 @@ public class FacebookAccountController {
         if (account.getAccessToken() == null) {
             account.setTokenExpiresAt(null);
             account.setTokenLastRefreshedAt(null);
+            account.setTokenRenewalStatus(FacebookTokenRenewalStatus.NEVER_ATTEMPTED.name());
+            account.setTokenRenewalLastAttemptAt(null);
+            account.setTokenRenewedAt(null);
+            account.setTokenRenewalLastError(null);
         } else if (account.getTokenLastRefreshedAt() == null) {
             account.setTokenLastRefreshedAt(LocalDateTime.now());
+        }
+        if (account.getTokenRenewalStatus() == null || account.getTokenRenewalStatus().isBlank()) {
+            account.setTokenRenewalStatus(FacebookTokenRenewalStatus.NEVER_ATTEMPTED.name());
+        }
+        if (!account.isTokenRenewalEnabled()) {
+            account.setTokenRenewalEnabled(false);
         }
         return repository.save(account);
     }
@@ -41,12 +53,18 @@ public class FacebookAccountController {
         persisted.setAuthorizedUserId(account.getAuthorizedUserId());
         persisted.setAuthorizedUserName(account.getAuthorizedUserName());
         persisted.setAuthorizedUserEmail(account.getAuthorizedUserEmail());
+        persisted.setAppId(account.getAppId());
+        persisted.setTokenRenewalEnabled(account.isTokenRenewalEnabled());
 
         String newToken = account.getAccessToken();
         if (newToken == null) {
             persisted.setAccessToken(null);
             persisted.setTokenExpiresAt(null);
             persisted.setTokenLastRefreshedAt(null);
+            persisted.setTokenRenewalStatus(FacebookTokenRenewalStatus.NEVER_ATTEMPTED.name());
+            persisted.setTokenRenewalLastAttemptAt(null);
+            persisted.setTokenRenewedAt(null);
+            persisted.setTokenRenewalLastError(null);
         } else {
             if (!newToken.equals(persisted.getAccessToken())) {
                 persisted.setTokenLastRefreshedAt(LocalDateTime.now());
@@ -55,7 +73,67 @@ public class FacebookAccountController {
             persisted.setTokenExpiresAt(account.getTokenExpiresAt());
         }
 
+        if (account.isAppSecretProvided()) {
+            persisted.overwriteAppSecret(account.getAppSecret());
+        }
+
+        if (account.getTokenRenewalStatus() != null) {
+            persisted.setTokenRenewalStatus(account.getTokenRenewalStatus());
+        }
+        
         return repository.save(persisted);
+    }
+
+    @GetMapping("/renewal/eligible")
+    public List<FacebookAccountRenewalCandidate> findEligibleForRenewal() {
+        return repository
+            .findAll()
+            .stream()
+            .filter(FacebookAccount::isTokenRenewalEnabled)
+            .filter(account -> account.getAccessToken() != null && !account.getAccessToken().isBlank())
+            .filter(account -> account.getAppId() != null && !account.getAppId().isBlank())
+            .filter(account -> account.getAppSecret() != null && !account.getAppSecret().isBlank())
+            .filter(FacebookAccount::isTokenRenewalRequired)
+            .map(account -> new FacebookAccountRenewalCandidate(
+                account.getId(),
+                account.getName(),
+                account.getAppId(),
+                account.getAppSecret(),
+                account.getAccessToken(),
+                account.getTokenExpiresAt(),
+                account.getTokenRenewalStatus(),
+                account.getTokenRenewalLastAttemptAt(),
+                account.getTokenRenewalLastError()
+            ))
+            .collect(Collectors.toList());
+    }
+
+    @PostMapping("/{id}/token/renewal")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public FacebookAccount registerRenewal(
+        @PathVariable Long id,
+        @RequestBody FacebookTokenRenewalRequest request
+    ) {
+        FacebookAccount account = repository.findById(id).orElseThrow();
+        LocalDateTime attemptedAt = request.attemptedAt() != null ? request.attemptedAt() : LocalDateTime.now();
+        account.setTokenRenewalLastAttemptAt(attemptedAt);
+        account.setTokenRenewalStatus(request.status().name());
+
+        if (request.status() == FacebookTokenRenewalStatus.SUCCESS) {
+            if (request.accessToken() == null || request.accessToken().isBlank()) {
+                throw new IllegalArgumentException("Renewal requires a non-empty access token");
+            }
+            account.setAccessToken(request.accessToken());
+            account.setTokenExpiresAt(request.tokenExpiresAt());
+            LocalDateTime refreshedAt = request.renewedAt() != null ? request.renewedAt() : attemptedAt;
+            account.setTokenLastRefreshedAt(refreshedAt);
+            account.setTokenRenewedAt(refreshedAt);
+            account.setTokenRenewalLastError(null);
+        } else if (request.status() == FacebookTokenRenewalStatus.FAILED) {
+            account.setTokenRenewalLastError(trimToNull(request.errorMessage()));
+        }
+
+        return repository.save(account);
     }
 
     @DeleteMapping("/{id}")
@@ -70,6 +148,19 @@ public class FacebookAccountController {
         account.setAuthorizedUserId(trimToNull(account.getAuthorizedUserId()));
         account.setAuthorizedUserName(trimToNull(account.getAuthorizedUserName()));
         account.setAuthorizedUserEmail(trimToNull(account.getAuthorizedUserEmail()));
+        account.setAppId(trimToNull(account.getAppId()));
+        if (account.isAppSecretProvided()) {
+            account.overwriteAppSecret(trimToNull(account.getAppSecret()));
+        }
+        account.setTokenRenewalLastError(trimToNull(account.getTokenRenewalLastError()));
+        if (account.getTokenRenewalStatus() != null) {
+            String normalizedStatus = account.getTokenRenewalStatus().trim().toUpperCase();
+            try {
+                account.setTokenRenewalStatus(FacebookTokenRenewalStatus.valueOf(normalizedStatus).name());
+            } catch (IllegalArgumentException ex) {
+                account.setTokenRenewalStatus(FacebookTokenRenewalStatus.NEVER_ATTEMPTED.name());
+            }
+        }
     }
 
     private static String trim(String value) {
@@ -83,4 +174,25 @@ public class FacebookAccountController {
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
     }
+
+    public record FacebookAccountRenewalCandidate(
+        Long id,
+        String name,
+        String appId,
+        String appSecret,
+        String accessToken,
+        LocalDateTime tokenExpiresAt,
+        String tokenRenewalStatus,
+        LocalDateTime tokenRenewalLastAttemptAt,
+        String tokenRenewalLastError
+    ) {}
+
+    public record FacebookTokenRenewalRequest(
+        FacebookTokenRenewalStatus status,
+        String accessToken,
+        LocalDateTime tokenExpiresAt,
+        LocalDateTime renewedAt,
+        LocalDateTime attemptedAt,
+        String errorMessage
+    ) {}
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookTokenRenewalStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookTokenRenewalStatus.java
@@ -1,0 +1,7 @@
+package com.marketinghub.ads;
+
+public enum FacebookTokenRenewalStatus {
+    NEVER_ATTEMPTED,
+    SUCCESS,
+    FAILED
+}

--- a/backend/ads-service/src/main/resources/db/changelog/V2026_01_05__add_fb_account_token_renewal.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2026_01_05__add_fb_account_token_renewal.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+--changeset marketinghub:2026-01-05-add-fb-account-token-renewal dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'fb_account' AND column_name = 'app_id';
+ALTER TABLE fb_account
+  ADD COLUMN app_id VARCHAR(255) NULL,
+  ADD COLUMN app_secret LONGTEXT NULL,
+  ADD COLUMN token_renewal_enabled TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN token_renewal_status VARCHAR(40) NULL,
+  ADD COLUMN token_renewal_last_attempt_at DATETIME NULL,
+  ADD COLUMN token_renewed_at DATETIME NULL,
+  ADD COLUMN token_renewal_last_error LONGTEXT NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -128,3 +128,6 @@ databaseChangeLog:
   - include:
       file: V2025_12_20__extend_fb_account_with_token.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2026_01_05__add_fb_account_token_renewal.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -4,17 +4,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 
-import com.marketinghub.ads.FacebookAccount;
-import com.marketinghub.ads.FacebookAccountRepository;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -65,5 +66,67 @@ public class FacebookAccountControllerTest {
                 .andExpect(jsonPath("$[?(@.name=='Account expiring')].requiresTokenRenewal", contains(true)))
                 .andExpect(jsonPath("$[?(@.name=='Account missing token')].requiresTokenRenewal", contains(true)))
                 .andExpect(jsonPath("$[?(@.name=='Account expiring')].tokenExpired", contains(false)));
+    }
+
+    @Test
+    void shouldReturnAccountsEligibleForRenewal() throws Exception {
+        FacebookAccount eligible = repository.save(FacebookAccount.builder()
+            .name("Eligible")
+            .currency("USD")
+            .accessToken("token-eligible")
+            .tokenExpiresAt(LocalDateTime.now().plusDays(1))
+            .appId("123")
+            .appSecret("secret")
+            .tokenRenewalEnabled(true)
+            .build());
+
+        repository.save(FacebookAccount.builder()
+            .name("Disabled")
+            .currency("USD")
+            .accessToken("token-disabled")
+            .tokenExpiresAt(LocalDateTime.now().plusDays(1))
+            .appId("123")
+            .appSecret("secret")
+            .tokenRenewalEnabled(false)
+            .build());
+
+        mockMvc.perform(get("/api/accounts/facebook/renewal/eligible"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].id").value(eligible.getId()))
+            .andExpect(jsonPath("$[0].accessToken").value("token-eligible"))
+            .andExpect(jsonPath("$[0].appSecret").value("secret"));
+    }
+
+    @Test
+    void shouldRegisterSuccessfulRenewal() throws Exception {
+        FacebookAccount account = repository.save(FacebookAccount.builder()
+            .name("Needs Renewal")
+            .currency("USD")
+            .accessToken("old-token")
+            .tokenExpiresAt(LocalDateTime.now().plusDays(1))
+            .appId("app-1")
+            .appSecret("secret")
+            .tokenRenewalEnabled(true)
+            .build());
+
+        String payload = "{" +
+            "\"status\":\"SUCCESS\"," +
+            "\"accessToken\":\"new-token\"," +
+            "\"tokenExpiresAt\":\"2030-01-01T00:00:00\"," +
+            "\"renewedAt\":\"2029-12-31T23:00:00\"" +
+            "}";
+
+        mockMvc.perform(post("/api/accounts/facebook/" + account.getId() + "/token/renewal")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(payload))
+            .andExpect(status().isAccepted());
+
+        FacebookAccount updated = repository.findById(account.getId()).orElseThrow();
+        assertThat(updated.getAccessToken()).isEqualTo("new-token");
+        assertThat(updated.getTokenExpiresAt()).isEqualTo(LocalDateTime.parse("2030-01-01T00:00:00"));
+        assertThat(updated.getTokenRenewedAt()).isEqualTo(LocalDateTime.parse("2029-12-31T23:00:00"));
+        assertThat(updated.getTokenRenewalStatus()).isEqualTo(FacebookTokenRenewalStatus.SUCCESS.name());
+        assertThat(updated.getTokenRenewalLastError()).isNull();
     }
 }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -414,6 +414,32 @@ allow variants to be created before an experiment is defined.
 - `utm_content` VARCHAR(128)
 - `utm_term` VARCHAR(128)
 
+### fb_account
+
+- `id` BIGINT AUTO_INCREMENT PRIMARY KEY
+- `name` VARCHAR(255)
+- `currency` VARCHAR(10)
+- `access_token` LONGTEXT
+- `token_expires_at` DATETIME
+- `token_last_refreshed_at` DATETIME
+- `authorized_user_id` VARCHAR(128)
+- `authorized_user_name` VARCHAR(255)
+- `authorized_user_email` VARCHAR(320)
+- `app_id` VARCHAR(255)
+- `app_secret` LONGTEXT
+- `token_renewal_enabled` TINYINT(1) DEFAULT 0
+- `token_renewal_status` VARCHAR(40)
+- `token_renewal_last_attempt_at` DATETIME
+- `token_renewed_at` DATETIME
+- `token_renewal_last_error` LONGTEXT
+
+Registra as credenciais do Facebook Ads configuradas no backend. Quando a
+renovação automática está habilitada (`token_renewal_enabled = 1`), o Facebook
+Ads Worker monitora `token_expires_at` e solicita um novo token de longa duração
+antes do vencimento. Cada tentativa atualiza `token_renewal_status`,
+`token_renewal_last_attempt_at`, `token_renewed_at` e armazena mensagens de erro
+em `token_renewal_last_error` quando a renovação falha.
+
 ## Diagram
 
 ```mermaid

--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -41,6 +41,7 @@ classDiagram
         +createAdCreative(adAccountId, request) String
         +createAd(adAccountId, request) String
         +getCampaignMetrics(campaignId) JsonNode
+        +renewLongLivedToken(appId, appSecret, token) TokenRenewalResponse
     }
 
     class AdSetRequest {
@@ -70,6 +71,21 @@ classDiagram
         +name : String
         +adSetId : String
         +creativeId : String
+    }
+
+    class FacebookTokenRenewalScheduler {
+        +scheduleRenewal()
+    }
+
+    class FacebookTokenRenewalService {
+        -backendClient : WebClient
+        -facebookAdsService : FacebookAdsService
+        -backendBaseUrl : String
+        -apiPrefix : String
+        +renewTokensIfNeeded()
+        -fetchEligibleAccounts()
+        -renewCandidateToken(candidate)
+        -reportResult(id, payload)
     }
 
     class CreateCampaignRequest {
@@ -138,6 +154,9 @@ classDiagram
     FacebookAdsCampaign --> BudgetMode
     FacebookAdsCampaign --> SpecialAdCategory
     FacebookCampaignService ..> UrlUtils : compõe URLs do backend
+    FacebookTokenRenewalScheduler --> FacebookTokenRenewalService : agenda renovação
+    FacebookTokenRenewalService --> FacebookAdsService : renova token
+    FacebookTokenRenewalService ..> UrlUtils : reutiliza composição de URLs
 ```
 
 * `FacebookCampaignScheduler` agenda a execução periódica do worker utilizando
@@ -150,7 +169,12 @@ classDiagram
   experimento a uma lista de bloqueio em memória para evitar novas tentativas
   até que o worker seja reiniciado.
 * `FacebookAdsService` encapsula as chamadas à Graph API (criação da hierarquia
-  de mídia e consulta de métricas).
+  de mídia, consulta de métricas e renovação de tokens de longa duração).
+* `FacebookTokenRenewalScheduler` agenda o fluxo periódico de renovação de token
+  e delega para `FacebookTokenRenewalService`.
+* `FacebookTokenRenewalService` busca as contas elegíveis no backend, chama a
+  Graph API para obter um novo token e registra o resultado por meio do endpoint
+  `/api/accounts/facebook/{id}/token/renewal`.
 * `CreateCampaignRequest` representa o payload enviado ao backend contendo os
   campos mínimos para materializar a entidade de campanha.
 * `FacebookAdsCampaign` é a entidade JPA do backend responsável por armazenar a

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -38,6 +38,30 @@ presente, os campos estruturados de erro (`type`, `code`, `error_subcode`,
 `error_user_title`, `error_user_msg`, `fbtrace_id` e `error_data`). Isso
 permite cruzar rapidamente o incidente com a documentação oficial.
 
+## Renovação automática de tokens
+
+Além da criação de campanhas, o worker monitora tokens configurados nas
+contas do backend e renova automaticamente aqueles que estão prestes a expirar.
+O fluxo funciona da seguinte forma:
+
+1. A cada execução do agendador (`FacebookTokenRenewalScheduler`) o worker
+   consulta o endpoint `/api/accounts/facebook/renewal/eligible`, que devolve
+   apenas as contas com `tokenRenewalEnabled = true`, token prestes a expirar e
+   credenciais completas (`appId`, `appSecret`).
+2. Para cada conta elegível, o serviço `FacebookTokenRenewalService` chama a
+   rota `/{version}/oauth/access_token` da Graph API utilizando o `appId`,
+   `appSecret` e o token atual, seguindo o mesmo fluxo utilizado no script em
+   PowerShell (grant type `fb_exchange_token`).
+3. O backend é notificado com `POST /api/accounts/facebook/{id}/token/renewal`,
+   atualizando o token, a nova data de expiração e registrando o status da
+   tentativa (`SUCCESS` ou `FAILED`).
+4. Esses dados são exibidos na tela de contas do frontend, permitindo acompanhar
+   a última tentativa, o último sucesso e eventuais mensagens de erro.
+
+Caso a chamada à Graph API falhe, o backend recebe o status `FAILED` com a
+mensagem de erro no campo `tokenRenewalLastError`, mantendo o token anterior e
+exigindo uma ação manual.
+
 Os acessos são configurados pelas propriedades:
 
 - `backend.base-url` (default: `http://191.252.92.222:8000`)
@@ -60,6 +84,8 @@ Os acessos são configurados pelas propriedades:
 - `facebook.creative.message-template` (default: `%s` – utiliza o nome do
   experimento quando contém `%s`)
 - `facebook.creative.call-to-action-type` (default: `LEARN_MORE`)
+- `facebook.token-renewal.scheduler.delay` (default: `21600000`, em
+  milissegundos – intervalo entre as tentativas de renovação automática)
 
 ## Data Model
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -405,6 +405,72 @@ public class FacebookAdsService {
         return trimmed.startsWith("v") ? trimmed : "v" + trimmed;
     }
 
+    public TokenRenewalResponse renewLongLivedToken(String appId, String appSecret, String currentToken) {
+        Objects.requireNonNull(appId, "appId");
+        Objects.requireNonNull(appSecret, "appSecret");
+        Objects.requireNonNull(currentToken, "currentToken");
+
+        String path = buildVersionedPath("/oauth/access_token");
+        LOGGER.info(
+            "Requesting Facebook long-lived token renewal: appId={}, token={}",
+            appId,
+            maskAccessToken(currentToken)
+        );
+
+        try {
+            JsonNode response = webClient
+                .get()
+                .uri(uriBuilder ->
+                    uriBuilder
+                        .path(path)
+                        .queryParam("grant_type", "fb_exchange_token")
+                        .queryParam("client_id", appId)
+                        .queryParam("client_secret", appSecret)
+                        .queryParam("fb_exchange_token", currentToken)
+                        .build()
+                )
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+            if (response == null || response.isMissingNode()) {
+                throw new IllegalStateException("Facebook returned an empty response while renewing the token");
+            }
+
+            String newToken = response.path("access_token").asText(null);
+            long expiresInSeconds = response.path("expires_in").asLong(0L);
+            if (newToken == null || newToken.isBlank()) {
+                throw new IllegalStateException("Facebook response does not contain access_token");
+            }
+
+            LOGGER.info(
+                "Facebook token renewal succeeded for appId={}, expiresInSeconds={}, token={}",
+                appId,
+                expiresInSeconds,
+                maskAccessToken(newToken)
+            );
+            return new TokenRenewalResponse(newToken, expiresInSeconds);
+        } catch (WebClientResponseException ex) {
+            String body = ex.getResponseBodyAsString();
+            LOGGER.error(
+                "Facebook token renewal failed: appId={}, status={}, responseBody={}",
+                appId,
+                ex.getRawStatusCode(),
+                maskAccessToken(body),
+                ex
+            );
+            throw ex;
+        } catch (WebClientRequestException ex) {
+            LOGGER.error(
+                "Facebook token renewal request could not be completed: appId={}, message={}",
+                appId,
+                ex.getMessage(),
+                ex
+            );
+            throw ex;
+        }
+    }
+
     public record AdSetRequest(
         String name,
         String campaignId,
@@ -434,6 +500,8 @@ public class FacebookAdsService {
         String adSetId,
         String creativeId
     ) {}
+
+    public record TokenRenewalResponse(String accessToken, long expiresInSeconds) {}
 
     private record FacebookApiResponse(HttpStatusCode statusCode, HttpHeaders headers, JsonNode body) {}
 }

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalScheduler.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalScheduler.java
@@ -1,0 +1,18 @@
+package com.marketinghub.facebookadsworker.facebooktokenrenewal;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FacebookTokenRenewalScheduler {
+    private final FacebookTokenRenewalService renewalService;
+
+    public FacebookTokenRenewalScheduler(FacebookTokenRenewalService renewalService) {
+        this.renewalService = renewalService;
+    }
+
+    @Scheduled(fixedDelayString = "${facebook.token-renewal.scheduler.delay:21600000}")
+    public void scheduleRenewal() {
+        renewalService.renewTokensIfNeeded();
+    }
+}

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
@@ -1,0 +1,158 @@
+package com.marketinghub.facebookadsworker.facebooktokenrenewal;
+
+import com.marketinghub.facebookadsworker.FacebookAdsService;
+import com.marketinghub.facebookadsworker.util.UrlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class FacebookTokenRenewalService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FacebookTokenRenewalService.class);
+
+    private final WebClient backendClient;
+    private final FacebookAdsService facebookAdsService;
+    private final String backendBaseUrl;
+    private final String apiPrefix;
+
+    public FacebookTokenRenewalService(
+        WebClient.Builder builder,
+        FacebookAdsService facebookAdsService,
+        @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
+        @Value("${backend.api-prefix:/api}") String apiPrefix
+    ) {
+        this.backendClient = builder.build();
+        this.facebookAdsService = facebookAdsService;
+        this.backendBaseUrl = backendBaseUrl;
+        this.apiPrefix = apiPrefix;
+    }
+
+    public void renewTokensIfNeeded() {
+        List<FacebookAccountRenewalCandidate> candidates = fetchEligibleAccounts();
+        if (candidates.isEmpty()) {
+            LOGGER.debug("No Facebook accounts require token renewal");
+            return;
+        }
+
+        candidates.forEach(this::renewCandidateToken);
+    }
+
+    private List<FacebookAccountRenewalCandidate> fetchEligibleAccounts() {
+        try {
+            return backendClient
+                .get()
+                .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/accounts/facebook/renewal/eligible"))
+                .retrieve()
+                .bodyToFlux(FacebookAccountRenewalCandidate.class)
+                .collectList()
+                .blockOptional()
+                .orElse(Collections.emptyList());
+        } catch (WebClientResponseException | WebClientRequestException ex) {
+            LOGGER.error(
+                "Failed to fetch Facebook accounts for token renewal: status={}, message={}",
+                ex instanceof WebClientResponseException responseException ? responseException.getRawStatusCode() : "N/A",
+                ex.getMessage(),
+                ex
+            );
+            return Collections.emptyList();
+        }
+    }
+
+    private void renewCandidateToken(FacebookAccountRenewalCandidate candidate) {
+        LocalDateTime attemptTime = LocalDateTime.now();
+        LOGGER.info(
+            "Attempting token renewal for Facebook account id={}, name={}, expiresAt={}",
+            candidate.id(),
+            candidate.name(),
+            candidate.tokenExpiresAt()
+        );
+
+        try {
+            FacebookAdsService.TokenRenewalResponse response = facebookAdsService.renewLongLivedToken(
+                candidate.appId(),
+                candidate.appSecret(),
+                candidate.accessToken()
+            );
+
+            LocalDateTime renewedAt = attemptTime;
+            LocalDateTime expiresAt = attemptTime.plusSeconds(Math.max(response.expiresInSeconds(), 0));
+
+            reportResult(candidate.id(), new RenewalResultPayload(
+                TokenRenewalStatus.SUCCESS,
+                response.accessToken(),
+                expiresAt,
+                renewedAt,
+                attemptTime,
+                null
+            ));
+        } catch (Exception ex) {
+            LOGGER.error(
+                "Token renewal failed for Facebook account id={}, name={}: {}",
+                candidate.id(),
+                candidate.name(),
+                ex.getMessage(),
+                ex
+            );
+            reportResult(candidate.id(), new RenewalResultPayload(
+                TokenRenewalStatus.FAILED,
+                null,
+                null,
+                null,
+                attemptTime,
+                ex.getMessage()
+            ));
+        }
+    }
+
+    private void reportResult(Long accountId, RenewalResultPayload payload) {
+        String path = "/accounts/facebook/" + accountId + "/token/renewal";
+        try {
+            backendClient
+                .post()
+                .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, path))
+                .bodyValue(payload)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+        } catch (WebClientResponseException | WebClientRequestException ex) {
+            LOGGER.error(
+                "Failed to report token renewal result to backend for account {}: status={}, message={}",
+                accountId,
+                ex instanceof WebClientResponseException responseException ? responseException.getRawStatusCode() : "N/A",
+                ex.getMessage(),
+                ex
+            );
+        }
+    }
+
+    public enum TokenRenewalStatus {
+        SUCCESS,
+        FAILED
+    }
+
+    public record FacebookAccountRenewalCandidate(
+        Long id,
+        String name,
+        String appId,
+        String appSecret,
+        String accessToken,
+        LocalDateTime tokenExpiresAt
+    ) {}
+
+    public record RenewalResultPayload(
+        TokenRenewalStatus status,
+        String accessToken,
+        LocalDateTime tokenExpiresAt,
+        LocalDateTime renewedAt,
+        LocalDateTime attemptedAt,
+        String errorMessage
+    ) {}
+}

--- a/frontend/src/api/facebookAccountMutations.ts
+++ b/frontend/src/api/facebookAccountMutations.ts
@@ -10,6 +10,9 @@ export interface FacebookAccountPayload {
   authorizedUserId?: string | null;
   authorizedUserName?: string | null;
   authorizedUserEmail?: string | null;
+  appId?: string | null;
+  appSecret?: string | null;
+  tokenRenewalEnabled?: boolean;
 }
 
 export function useCreateFacebookAccount() {

--- a/frontend/src/api/useFacebookAccounts.ts
+++ b/frontend/src/api/useFacebookAccounts.ts
@@ -14,6 +14,13 @@ export interface FacebookAccount {
   tokenExpired?: boolean;
   requiresTokenRenewal?: boolean;
   tokenExpiresInDays?: number | null;
+  appId?: string | null;
+  hasAppSecret?: boolean;
+  tokenRenewalEnabled?: boolean;
+  tokenRenewalStatus?: string | null;
+  tokenRenewalLastAttemptAt?: string | null;
+  tokenRenewedAt?: string | null;
+  tokenRenewalLastError?: string | null;
 }
 
 export function useFacebookAccounts() {

--- a/frontend/src/pages/FacebookAccountsPage.tsx
+++ b/frontend/src/pages/FacebookAccountsPage.tsx
@@ -23,6 +23,10 @@ interface AccountFormState {
   authorizedUserId: string;
   authorizedUserName: string;
   authorizedUserEmail: string;
+  appId: string;
+  appSecret: string;
+  tokenRenewalEnabled: boolean;
+  clearAppSecret: boolean;
 }
 
 interface PageFormState {
@@ -40,6 +44,10 @@ const emptyAccountForm: AccountFormState = {
   authorizedUserId: "",
   authorizedUserName: "",
   authorizedUserEmail: "",
+  appId: "",
+  appSecret: "",
+  tokenRenewalEnabled: false,
+  clearAppSecret: false,
 };
 const emptyPageForm: PageFormState = { pageId: "", name: "" };
 
@@ -87,6 +95,39 @@ function describeTokenExpiration(account: RemoteFacebookAccount): string {
     return `Expira em ${account.tokenExpiresInDays} dias`;
   }
   return "Validade não informada";
+}
+
+function describeRenewalStatus(account: RemoteFacebookAccount): string {
+  if (!account.tokenRenewalEnabled) {
+    return "Renovação automática desativada";
+  }
+  const status = account.tokenRenewalStatus ?? "NEVER_ATTEMPTED";
+  switch (status) {
+    case "SUCCESS":
+      return "Última renovação concluída";
+    case "FAILED":
+      return "Falha na última tentativa";
+    case "NEVER_ATTEMPTED":
+    default:
+      return "Nunca tentamos renovar automaticamente";
+  }
+}
+
+function formatRenewalStatusBadge(account: RemoteFacebookAccount): {
+  className: string;
+  label: string;
+} {
+  const status = account.tokenRenewalStatus ?? "NEVER_ATTEMPTED";
+  if (!account.tokenRenewalEnabled) {
+    return { className: "text-bg-secondary", label: "Automação inativa" };
+  }
+  if (status === "SUCCESS") {
+    return { className: "text-bg-success", label: "Renovação em dia" };
+  }
+  if (status === "FAILED") {
+    return { className: "text-bg-danger", label: "Erro ao renovar" };
+  }
+  return { className: "text-bg-info", label: "Aguardando primeira tentativa" };
 }
 
 export default function FacebookAccountsPage() {
@@ -154,7 +195,14 @@ export default function FacebookAccountsPage() {
       authorizedUserId: accountForm.authorizedUserId.trim() || null,
       authorizedUserName: accountForm.authorizedUserName.trim() || null,
       authorizedUserEmail: accountForm.authorizedUserEmail.trim() || null,
+      appId: accountForm.appId.trim() || null,
+      tokenRenewalEnabled: accountForm.tokenRenewalEnabled,
     };
+    if (accountForm.clearAppSecret) {
+      payload.appSecret = null;
+    } else if (accountForm.appSecret.trim()) {
+      payload.appSecret = accountForm.appSecret.trim();
+    }
     const mutation = isEditingAccount ? updateAccountMutation : createAccountMutation;
     mutation.mutate(payload, {
       onSuccess: () => {
@@ -256,6 +304,7 @@ export default function FacebookAccountsPage() {
                         : account.requiresTokenRenewal
                         ? "Renovar token"
                         : "Token válido";
+                      const renewalBadge = formatRenewalStatusBadge(account);
                       return (
                         <tr key={id} className={rowClasses}>
                           <td>{id}</td>
@@ -270,6 +319,27 @@ export default function FacebookAccountsPage() {
                               <small className="text-muted">
                                 Validade: {formatDateTime(account.tokenExpiresAt)}
                               </small>
+                              <span className={`badge ${renewalBadge.className}`}>
+                                {renewalBadge.label}
+                              </span>
+                              <small className="text-muted">
+                                {describeRenewalStatus(account)}
+                              </small>
+                              {account.tokenRenewedAt && (
+                                <small className="text-muted">
+                                  Última renovação: {formatDateTime(account.tokenRenewedAt)}
+                                </small>
+                              )}
+                              {account.tokenRenewalLastAttemptAt && (
+                                <small className="text-muted">
+                                  Última tentativa: {formatDateTime(account.tokenRenewalLastAttemptAt)}
+                                </small>
+                              )}
+                              {account.tokenRenewalLastError && (
+                                <small className="text-danger">
+                                  Erro recente: {account.tokenRenewalLastError}
+                                </small>
+                              )}
                               {account.authorizedUserName && (
                                 <small className="text-muted">
                                   Usuário autorizado: {account.authorizedUserName}
@@ -297,6 +367,10 @@ export default function FacebookAccountsPage() {
                                   authorizedUserId: account.authorizedUserId ?? "",
                                   authorizedUserName: account.authorizedUserName ?? "",
                                   authorizedUserEmail: account.authorizedUserEmail ?? "",
+                                  appId: account.appId ?? "",
+                                  appSecret: "",
+                                  tokenRenewalEnabled: Boolean(account.tokenRenewalEnabled),
+                                  clearAppSecret: false,
                                 });
                               }}
                               disabled={isDeletingThisAccount}
@@ -371,6 +445,67 @@ export default function FacebookAccountsPage() {
                   </div>
                 </div>
                 <div className="col-12 col-md-6">
+                  <label className="form-label">ID do aplicativo (App ID)</label>
+                  <input
+                    className="form-control"
+                    placeholder="ID do aplicativo vinculado ao Business Manager"
+                    value={accountForm.appId}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        appId: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Segredo do aplicativo (App Secret)</label>
+                  <input
+                    type="password"
+                    className="form-control"
+                    placeholder={
+                      isEditingAccount && accounts.find((acc) => acc.id === accountForm.id)?.hasAppSecret
+                        ? "Informe um novo segredo para atualizar"
+                        : "Cole o segredo do aplicativo"
+                    }
+                    value={accountForm.appSecret}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        appSecret: event.target.value,
+                        clearAppSecret: false,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                  {isEditingAccount &&
+                    accounts.find((acc) => acc.id === accountForm.id)?.hasAppSecret && (
+                      <div className="form-check mt-2">
+                        <input
+                          className="form-check-input"
+                          type="checkbox"
+                          id="clear-app-secret"
+                          checked={accountForm.clearAppSecret}
+                          onChange={(event) =>
+                            setAccountForm((current) => ({
+                              ...current,
+                              clearAppSecret: event.target.checked,
+                              appSecret: event.target.checked ? "" : current.appSecret,
+                            }))
+                          }
+                          disabled={isAccountMutationPending}
+                        />
+                        <label className="form-check-label" htmlFor="clear-app-secret">
+                          Remover segredo salvo
+                        </label>
+                      </div>
+                    )}
+                  <div className="form-text">
+                    Guardamos o segredo apenas para renovar tokens automaticamente. Ele não é exibido novamente.
+                  </div>
+                </div>
+                <div className="col-12 col-md-6">
                   <label className="form-label">Validade do token</label>
                   <input
                     type="datetime-local"
@@ -386,6 +521,31 @@ export default function FacebookAccountsPage() {
                   />
                   <div className="form-text">
                     Exibiremos um alerta 7 dias antes do vencimento.
+                  </div>
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Renovação automática</label>
+                  <div className="form-check form-switch">
+                    <input
+                      className="form-check-input"
+                      type="checkbox"
+                      id="token-renewal-enabled"
+                      checked={accountForm.tokenRenewalEnabled}
+                      onChange={(event) =>
+                        setAccountForm((current) => ({
+                          ...current,
+                          tokenRenewalEnabled: event.target.checked,
+                        }))
+                      }
+                      disabled={isAccountMutationPending}
+                    />
+                    <label className="form-check-label" htmlFor="token-renewal-enabled">
+                      Permitir que o Marketing Hub renove o token automaticamente
+                    </label>
+                  </div>
+                  <div className="form-text">
+                    Mantenha o App ID e o App Secret atualizados para que o worker consiga solicitar um novo token antes do
+                    vencimento.
                   </div>
                 </div>
                 <div className="col-12 col-md-6">


### PR DESCRIPTION
## Summary
- extend Facebook account persistence and API to capture app credentials and renewal status required by the worker
- add a scheduled token renewal flow in the Facebook Ads Worker and surface status/controls in the Facebook Accounts UI
- document the automatic renewal process and database changes for the worker

## Testing
- `mvn -s ../settings.xml test` *(fails: repository parent POM unavailable due to network restrictions)*
- `npm run build`
- `mvn -s settings.xml test` *(fails: repository parent POM unavailable due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d951b4dd14832193ec7eff2d61473c