### PR TITLE
Fix Facebook controller tests isolation

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -5,8 +5,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -27,6 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@Transactional
 public class FacebookAccountControllerTest {
 
     @Autowired

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookConfigurationControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookConfigurationControllerTest.java
@@ -5,14 +5,15 @@ import com.marketinghub.ads.FacebookAccount;
 import com.marketinghub.ads.FacebookAccountRepository;
 import com.marketinghub.ads.FacebookPage;
 import com.marketinghub.ads.FacebookPageRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -28,6 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "spring.jpa.hibernate.ddl-auto=create",
         "spring.liquibase.enabled=false"
 })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@Transactional
 class FacebookConfigurationControllerTest {
 
     @Autowired
@@ -38,12 +41,6 @@ class FacebookConfigurationControllerTest {
 
     @Autowired
     FacebookPageRepository pageRepository;
-
-    @BeforeEach
-    void clean() {
-        pageRepository.deleteAll();
-        accountRepository.deleteAll();
-    }
 
     @Test
     void shouldReportConfigurationStatus() throws Exception {


### PR DESCRIPTION
## Summary
- ensure `FacebookAccountControllerTest` uses a fresh Spring context and transactional rollback so it only sees its own seeded data
- isolate `FacebookConfigurationControllerTest` the same way and drop the manual delete routine that was breaking on foreign keys

## Testing
- mvn -q -Dtest=FacebookAccountControllerTest,FacebookConfigurationControllerTest test

------
https://chatgpt.com/codex/tasks/task_e_68da8965dde883218dc6e9e74681fc75