### PR TITLE
Enable automatic Facebook token revalidation

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -55,7 +55,12 @@ O fluxo funciona da seguinte forma:
 3. O backend é notificado com `POST /api/accounts/facebook/{id}/token/renewal`,
    atualizando o token, a nova data de expiração e registrando o status da
    tentativa (`SUCCESS` ou `FAILED`).
-4. Esses dados são exibidos na tela de contas do frontend, permitindo acompanhar
+4. Quando a Graph API devolve `(#190) OAuthException` o worker tenta imediatamente
+   revalidar o token atual utilizando o mesmo fluxo descrito acima. Caso o
+   aplicativo (`facebook.app-id`/`facebook.app-secret`) esteja configurado, o
+   novo token é aplicado em memória e a fila de experimentos volta a ser
+   processada sem necessidade de reiniciar o serviço.
+5. Esses dados são exibidos na tela de contas do frontend, permitindo acompanhar
    a última tentativa, o último sucesso e eventuais mensagens de erro.
 
 Caso a chamada à Graph API falhe, o backend recebe o status `FAILED` com a
@@ -81,6 +86,8 @@ Os acessos são configurados pelas propriedades:
 - `facebook.instagram-actor-id` (opcional)
 - `facebook.website-url` (sem default – obrigatório)
 - `facebook.graph-api.version` (default: `v23.0` – utilizado para montar os caminhos da Graph API)
+- `facebook.app-id` (opcional – obrigatório para renovação automática quando o token expira em produção)
+- `facebook.app-secret` (opcional – obrigatório para renovação automática quando o token expira em produção)
 - `facebook.creative.message-template` (default: `%s` – utiliza o nome do
   experimento quando contém `%s`)
 - `facebook.creative.call-to-action-type` (default: `LEARN_MORE`)
@@ -142,6 +149,18 @@ valores adicionais. Caso sua conta utilize políticas diferentes, preencha
 `facebook.ad-set.bid-amount` com o lance desejado (em centavos) ou ajuste
 `facebook.ad-set.bid-strategy` para refletir a configuração do Gerenciador de
 Anúncios antes de reiniciar o serviço.
+
+### Erro `(#190) OAuthException` indicando token expirado
+
+Quando o Facebook devolve `code = 190` com `error_subcode = 463/467` ou
+mensagem "Session has expired", o worker interpreta que o token configurado em
+`facebook.access-token` não é mais válido. O serviço tenta renovar o token
+automaticamente via Graph API quando `facebook.app-id` e `facebook.app-secret`
+estão configurados. Em caso de sucesso, o novo token é aplicado sem reiniciar o
+worker e os experimentos voltam a ser processados na próxima execução. Se a
+renovação automática estiver desabilitada ou falhar, o log registra uma mensagem
+de erro única com os detalhes retornados pela Graph API, orientando a atualizar
+o token manualmente e reiniciar o serviço após a substituição.
 
 ## Build
 ```

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAccessTokenExpiredException.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAccessTokenExpiredException.java
@@ -1,0 +1,19 @@
+package com.marketinghub.facebookadsworker;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Signals that the Facebook Graph API rejected the request because the access token has expired.
+ */
+public class FacebookAccessTokenExpiredException extends RuntimeException {
+    private final ObjectNode errorDetails;
+
+    public FacebookAccessTokenExpiredException(String message, ObjectNode errorDetails, Throwable cause) {
+        super(message, cause);
+        this.errorDetails = errorDetails;
+    }
+
+    public ObjectNode getErrorDetails() {
+        return errorDetails;
+    }
+}

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAccessTokenManager.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAccessTokenManager.java
@@ -1,0 +1,67 @@
+package com.marketinghub.facebookadsworker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class FacebookAccessTokenManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FacebookAccessTokenManager.class);
+
+    private final FacebookAdsService facebookAdsService;
+    private final String appId;
+    private final String appSecret;
+
+    public FacebookAccessTokenManager(
+        FacebookAdsService facebookAdsService,
+        @Value("${facebook.app-id:}") String appId,
+        @Value("${facebook.app-secret:}") String appSecret
+    ) {
+        this.facebookAdsService = facebookAdsService;
+        this.appId = normalize(appId);
+        this.appSecret = normalize(appSecret);
+    }
+
+    public RenewalAttemptResult tryRenewAccessTokenIfPossible() {
+        if (!isConfigured()) {
+            LOGGER.debug("Skipping automatic Facebook token renewal because app credentials are missing");
+            return new RenewalAttemptResult(RenewalOutcome.NOT_CONFIGURED, null, null);
+        }
+
+        String currentToken = facebookAdsService.getCurrentAccessToken();
+        try {
+            FacebookAdsService.TokenRenewalResponse response = facebookAdsService.renewLongLivedToken(
+                appId,
+                appSecret,
+                currentToken
+            );
+            facebookAdsService.updateAccessToken(response.accessToken());
+            LOGGER.info(
+                "Facebook access token renewed successfully via Graph API; expiresInSeconds={}",
+                response.expiresInSeconds()
+            );
+            return new RenewalAttemptResult(RenewalOutcome.SUCCESS, response.accessToken(), null);
+        } catch (Exception ex) {
+            LOGGER.error("Failed to renew Facebook access token automatically: {}", ex.getMessage(), ex);
+            return new RenewalAttemptResult(RenewalOutcome.FAILED, null, ex.getMessage());
+        }
+    }
+
+    private boolean isConfigured() {
+        return StringUtils.hasText(appId) && StringUtils.hasText(appSecret);
+    }
+
+    private String normalize(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    public enum RenewalOutcome {
+        SUCCESS,
+        NOT_CONFIGURED,
+        FAILED
+    }
+
+    public record RenewalAttemptResult(RenewalOutcome outcome, String newToken, String errorMessage) {}
+}

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,7 +27,7 @@ public class FacebookAdsService {
     private static final Logger LOGGER = LoggerFactory.getLogger(FacebookAdsService.class);
 
     private final WebClient webClient;
-    private final String accessToken;
+    private final AtomicReference<String> accessToken;
     private final String apiVersion;
     private final ObjectMapper objectMapper;
 
@@ -36,10 +37,26 @@ public class FacebookAdsService {
                               @Value("${facebook.graph-api.version:v23.0}") String apiVersion,
                               ObjectMapper objectMapper) {
         this.webClient = builder.baseUrl(baseUrl).build();
-        this.accessToken = accessToken;
+        this.accessToken = new AtomicReference<>(Objects.requireNonNull(accessToken, "facebook.access-token"));
         this.apiVersion = normalizeVersion(apiVersion);
         this.objectMapper = objectMapper;
         LOGGER.info("Configured Facebook Graph API version: {}", this.apiVersion);
+    }
+
+    public String getCurrentAccessToken() {
+        return accessToken.get();
+    }
+
+    public void updateAccessToken(String newToken) {
+        Objects.requireNonNull(newToken, "newToken");
+        String maskedOldToken = maskAccessToken(accessToken.get());
+        String maskedNewToken = maskAccessToken(newToken);
+        accessToken.set(newToken);
+        LOGGER.info(
+            "Facebook access token updated: previousToken={}, newToken={}",
+            maskedOldToken,
+            maskedNewToken
+        );
     }
 
     public String createInstagramCampaign(String adAccountId, String name) {
@@ -49,7 +66,7 @@ public class FacebookAdsService {
             "objective", "OUTCOME_TRAFFIC",
             "status", "PAUSED",
             "special_ad_categories", List.of(),
-            "access_token", accessToken
+            "access_token", getCurrentAccessToken()
         );
 
         JsonNode response = executePost(path, body);
@@ -85,7 +102,7 @@ public class FacebookAdsService {
         if (request.pageId() != null && !request.pageId().isBlank()) {
             body.put("promoted_object", Map.of("page_id", request.pageId()));
         }
-        body.put("access_token", accessToken);
+        body.put("access_token", getCurrentAccessToken());
 
         String path = buildVersionedPath("/act_" + adAccountId + "/adsets");
 
@@ -120,7 +137,7 @@ public class FacebookAdsService {
         Map<String, Object> body = new HashMap<>();
         body.put("name", request.name());
         body.put("object_story_spec", objectStorySpec);
-        body.put("access_token", accessToken);
+        body.put("access_token", getCurrentAccessToken());
 
         String path = buildVersionedPath("/act_" + adAccountId + "/adcreatives");
 
@@ -136,7 +153,7 @@ public class FacebookAdsService {
         body.put("adset_id", request.adSetId());
         body.put("creative", Map.of("creative_id", request.creativeId()));
         body.put("status", "PAUSED");
-        body.put("access_token", accessToken);
+        body.put("access_token", getCurrentAccessToken());
 
         String path = buildVersionedPath("/act_" + adAccountId + "/ads");
 
@@ -145,7 +162,7 @@ public class FacebookAdsService {
     }
 
     public JsonNode getCampaignMetrics(String campaignId) {
-        String path = buildVersionedPath("/" + campaignId + "/insights?access_token=" + accessToken);
+        String path = buildVersionedPath("/" + campaignId + "/insights?access_token=" + getCurrentAccessToken());
         String maskedPath = maskAccessTokenInPath(path);
         LOGGER.info("Sending GET request to Facebook API: path={}", maskedPath);
         try {
@@ -168,14 +185,18 @@ public class FacebookAdsService {
             return nonNullResponse.body();
         } catch (WebClientResponseException ex) {
             String responseBody = ex.getResponseBodyAsString();
+            ObjectNode errorDetails = extractErrorDetails(responseBody);
             LOGGER.error(
                 "Facebook API GET request failed: path={}, status={}, responseBody={}, errorDetails={}",
                 maskedPath,
                 ex.getRawStatusCode(),
                 maskAccessToken(responseBody),
-                extractErrorDetails(responseBody),
+                errorDetails,
                 ex
             );
+            if (isAccessTokenExpired(errorDetails)) {
+                throw new FacebookAccessTokenExpiredException(resolveAccessTokenExpiredMessage(errorDetails), errorDetails, ex);
+            }
             throw ex;
         } catch (WebClientRequestException ex) {
             LOGGER.error("Facebook API GET request could not be completed: path={}, message={}", maskedPath, ex.getMessage(), ex);
@@ -218,6 +239,9 @@ public class FacebookAdsService {
                 ex.getHeaders(),
                 ex
             );
+            if (isAccessTokenExpired(errorDetails)) {
+                throw new FacebookAccessTokenExpiredException(resolveAccessTokenExpiredMessage(errorDetails), errorDetails, ex);
+            }
             if (isPermissionError(errorDetails)) {
                 throw new FacebookPermissionException(resolvePermissionMessage(errorDetails), errorDetails, ex);
             }
@@ -305,10 +329,11 @@ public class FacebookAdsService {
     }
 
     private String maskAccessTokenInPath(String path) {
-        if (path == null || path.isBlank() || accessToken == null || accessToken.isBlank()) {
+        String currentToken = accessToken.get();
+        if (path == null || path.isBlank() || currentToken == null || currentToken.isBlank()) {
             return path;
         }
-        return path.replace(accessToken, maskAccessToken(accessToken));
+        return path.replace(currentToken, maskAccessToken(currentToken));
     }
 
     private ObjectNode extractErrorDetails(String responseBody) {
@@ -387,6 +412,37 @@ public class FacebookAdsService {
             return errorDetails.get("message").asText();
         }
         return "Facebook API returned a permissions error";
+    }
+
+    private boolean isAccessTokenExpired(ObjectNode errorDetails) {
+        if (errorDetails == null) {
+            return false;
+        }
+        int code = errorDetails.path("code").asInt();
+        if (code != 190) {
+            return false;
+        }
+
+        int subcode = errorDetails.path("error_subcode").asInt();
+        if (subcode == 463 || subcode == 467) {
+            return true;
+        }
+
+        String message = errorDetails.path("message").asText("").toLowerCase();
+        return message.contains("session has expired") || message.contains("token has expired");
+    }
+
+    private String resolveAccessTokenExpiredMessage(ObjectNode errorDetails) {
+        if (errorDetails == null) {
+            return "Facebook access token has expired";
+        }
+        if (errorDetails.hasNonNull("error_user_msg")) {
+            return errorDetails.get("error_user_msg").asText();
+        }
+        if (errorDetails.hasNonNull("message")) {
+            return errorDetails.get("message").asText();
+        }
+        return "Facebook access token has expired";
     }
 
     private String buildVersionedPath(String resourcePath) {

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -1,5 +1,7 @@
 package com.marketinghub.facebookadsworker.facebookcampaign;
 
+import com.marketinghub.facebookadsworker.FacebookAccessTokenExpiredException;
+import com.marketinghub.facebookadsworker.FacebookAccessTokenManager;
 import com.marketinghub.facebookadsworker.FacebookAdsService;
 import com.marketinghub.facebookadsworker.FacebookPermissionException;
 import com.marketinghub.facebookadsworker.util.UrlUtils;
@@ -18,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Service
 public class FacebookCampaignService {
@@ -41,8 +44,12 @@ public class FacebookCampaignService {
     private final String defaultCreativeMessageTemplate;
     private final String defaultCallToActionType;
     private final Set<Long> experimentsBlockedByPermissions;
+    private final AtomicBoolean accessTokenExpired;
+    private final AtomicBoolean accessTokenExpiryWarningLogged;
+    private final FacebookAccessTokenManager accessTokenManager;
 
     public FacebookCampaignService(FacebookAdsService facebookAdsService,
+                                   FacebookAccessTokenManager accessTokenManager,
                                    WebClient.Builder builder,
                                    @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
                                    @Value("${backend.api-prefix:/api}") String apiPrefix,
@@ -60,6 +67,7 @@ public class FacebookCampaignService {
                                    @Value("${facebook.creative.message-template:%s}") String creativeMessageTemplate,
                                    @Value("${facebook.creative.call-to-action-type:LEARN_MORE}") String callToActionType) {
         this.facebookAdsService = facebookAdsService;
+        this.accessTokenManager = accessTokenManager;
         this.backendClient = builder.build();
         this.backendBaseUrl = backendBaseUrl;
         this.apiPrefix = apiPrefix;
@@ -77,9 +85,21 @@ public class FacebookCampaignService {
         this.defaultCreativeMessageTemplate = creativeMessageTemplate;
         this.defaultCallToActionType = callToActionType;
         this.experimentsBlockedByPermissions = ConcurrentHashMap.newKeySet();
+        this.accessTokenExpired = new AtomicBoolean(false);
+        this.accessTokenExpiryWarningLogged = new AtomicBoolean(false);
     }
 
     public void createCampaignsFromExperiments() {
+        if (accessTokenExpired.get()) {
+            if (accessTokenExpiryWarningLogged.compareAndSet(false, true)) {
+                LOGGER.warn(
+                    "Skipping Facebook campaign processing because the configured access token has expired; renew the token and restart the worker."
+                );
+            }
+            return;
+        }
+        accessTokenExpiryWarningLogged.set(false);
+
         List<Experiment> experiments = Collections.emptyList();
 
         try {
@@ -193,6 +213,41 @@ public class FacebookCampaignService {
                 ex.getErrorDetails()
             );
             markExperimentAsFailed(exp.id());
+        } catch (FacebookAccessTokenExpiredException ex) {
+            FacebookAccessTokenManager.RenewalAttemptResult renewalResult = accessTokenManager.tryRenewAccessTokenIfPossible();
+            if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.SUCCESS) {
+                LOGGER.info(
+                    "Facebook access token renewed automatically after detecting expiration while processing experiment {}; the worker will retry on the next cycle.",
+                    exp.id()
+                );
+                accessTokenExpired.set(false);
+                accessTokenExpiryWarningLogged.set(false);
+                return;
+            }
+
+            boolean firstDetection = accessTokenExpired.compareAndSet(false, true);
+            accessTokenExpiryWarningLogged.set(false);
+            if (firstDetection) {
+                LOGGER.error(
+                    "Facebook access token expired; the worker will pause campaign creation until the token is renewed. message={}, details={}",
+                    ex.getMessage(),
+                    ex.getErrorDetails()
+                );
+                if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.NOT_CONFIGURED) {
+                    LOGGER.error(
+                        "Automatic token renewal is not configured. Provide facebook.app-id and facebook.app-secret so the worker can revalidate the access token without manual intervention."
+                    );
+                } else if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.FAILED) {
+                    LOGGER.error(
+                        "Automatic token renewal attempt failed: {}",
+                        StringUtils.hasText(renewalResult.errorMessage()) ? renewalResult.errorMessage() : "unknown error"
+                    );
+                }
+            }
+            LOGGER.warn(
+                "Skipping experiment {} because the Facebook access token has expired; it will be retried after updating the token.",
+                exp.id()
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- track the Facebook access token in memory so it can be replaced after renewal without restarting the worker
- attempt an immediate Graph API renewal when error (#190) is detected during campaign processing and surface the outcome in the logs
- document the new automatic revalidation flow and the facebook.app-id / facebook.app-secret properties required for it

## Testing
- mvn -s settings.xml test *(fails: Network is unreachable while downloading spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68daa6082d248321b62b0faa96f172c0