### PR TITLE
Fix FacebookCampaignService test setup after token manager addition

### DIFF
--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -88,6 +88,27 @@ classDiagram
         -reportResult(id, payload)
     }
 
+    class FacebookAccessTokenManager {
+        -facebookAdsService : FacebookAdsService
+        -appId : String
+        -appSecret : String
+        +tryRenewAccessTokenIfPossible() : RenewalAttemptResult
+    }
+
+    class RenewalAttemptResult {
+        <<record>>
+        +outcome : RenewalOutcome
+        +newToken : String
+        +errorMessage : String
+    }
+
+    class RenewalOutcome {
+        <<enum>>
+        SUCCESS
+        NOT_CONFIGURED
+        FAILED
+    }
+
     class CreateCampaignRequest {
         <<record>>
         +id : String
@@ -145,6 +166,7 @@ classDiagram
 
     FacebookCampaignScheduler --> FacebookCampaignService : dispara ciclo
     FacebookCampaignService --> FacebookAdsService : cria campanha/ad set/ad
+    FacebookCampaignService --> FacebookAccessTokenManager : gerencia expiração de token
     FacebookAdsService --> AdSetRequest
     FacebookAdsService --> AdCreativeRequest
     FacebookAdsService --> AdRequest
@@ -175,6 +197,9 @@ classDiagram
 * `FacebookTokenRenewalService` busca as contas elegíveis no backend, chama a
   Graph API para obter um novo token e registra o resultado por meio do endpoint
   `/api/accounts/facebook/{id}/token/renewal`.
+* `FacebookAccessTokenManager` encapsula a renovação imediata de tokens quando o
+  `FacebookCampaignService` detecta expiração durante a criação de campanhas,
+  reutilizando o `FacebookAdsService` para atualizar o `access_token` em memória.
 * `CreateCampaignRequest` representa o payload enviado ao backend contendo os
   campos mínimos para materializar a entidade de campanha.
 * `FacebookAdsCampaign` é a entidade JPA do backend responsável por armazenar a

--- a/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
+++ b/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
@@ -61,7 +61,10 @@ montar a hierarquia completa:
    ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L120-L124)).
 
 Todos os pontos de contato com a Graph API reutilizam o mesmo `access_token`
-configurado para o worker.
+configurado para o worker. Quando a Graph API responde com `(#190) OAuthException`
+indicando expiração do token, o `FacebookCampaignService` interrompe o fluxo
+temporariamente e delega a renovação para o `FacebookAccessTokenManager`. O
+processamento normal é retomado assim que o token é atualizado.
 
 ### 3. Persistência no backend
 

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -55,11 +55,12 @@ O fluxo funciona da seguinte forma:
 3. O backend é notificado com `POST /api/accounts/facebook/{id}/token/renewal`,
    atualizando o token, a nova data de expiração e registrando o status da
    tentativa (`SUCCESS` ou `FAILED`).
-4. Quando a Graph API devolve `(#190) OAuthException` o worker tenta imediatamente
-   revalidar o token atual utilizando o mesmo fluxo descrito acima. Caso o
-   aplicativo (`facebook.app-id`/`facebook.app-secret`) esteja configurado, o
-   novo token é aplicado em memória e a fila de experimentos volta a ser
-   processada sem necessidade de reiniciar o serviço.
+4. Quando a Graph API devolve `(#190) OAuthException` o `FacebookCampaignService`
+   intercepta a exceção, pausa o processamento de experimentos e delega para o
+   `FacebookAccessTokenManager` revalidar o token atual utilizando o mesmo fluxo
+   descrito acima. Caso o aplicativo (`facebook.app-id`/`facebook.app-secret`)
+   esteja configurado, o novo token é aplicado em memória e a fila de
+   experimentos volta a ser processada sem necessidade de reiniciar o serviço.
 5. Esses dados são exibidos na tela de contas do frontend, permitindo acompanhar
    a última tentativa, o último sucesso e eventuais mensagens de erro.
 
@@ -154,13 +155,16 @@ Anúncios antes de reiniciar o serviço.
 
 Quando o Facebook devolve `code = 190` com `error_subcode = 463/467` ou
 mensagem "Session has expired", o worker interpreta que o token configurado em
-`facebook.access-token` não é mais válido. O serviço tenta renovar o token
-automaticamente via Graph API quando `facebook.app-id` e `facebook.app-secret`
-estão configurados. Em caso de sucesso, o novo token é aplicado sem reiniciar o
-worker e os experimentos voltam a ser processados na próxima execução. Se a
-renovação automática estiver desabilitada ou falhar, o log registra uma mensagem
-de erro única com os detalhes retornados pela Graph API, orientando a atualizar
-o token manualmente e reiniciar o serviço após a substituição.
+`facebook.access-token` não é mais válido. O `FacebookCampaignService` interrompe
+temporariamente a transformação de novos experimentos, registra o aviso apenas
+uma vez e delega a renovação para o `FacebookAccessTokenManager`. O serviço tenta
+renovar o token automaticamente via Graph API quando `facebook.app-id` e
+`facebook.app-secret` estão configurados. Em caso de sucesso, o novo token é
+aplicado sem reiniciar o worker e os experimentos voltam a ser processados na
+próxima execução. Se a renovação automática estiver desabilitada ou falhar, o log
+registra uma mensagem de erro única com os detalhes retornados pela Graph API,
+orientando a atualizar o token manualmente e reiniciar o serviço após a
+substituição.
 
 ## Build
 ```

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -2,6 +2,7 @@ package com.marketinghub.facebookadsworker.facebookcampaign;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.facebookadsworker.FacebookAccessTokenManager;
 import com.marketinghub.facebookadsworker.FacebookAdsService;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -40,8 +41,14 @@ class FacebookCampaignServiceTest {
             "v23.0",
             objectMapper
         );
+        FacebookAccessTokenManager accessTokenManager = new FacebookAccessTokenManager(
+            adsService,
+            "",
+            ""
+        );
         service = new FacebookCampaignService(
             adsService,
+            accessTokenManager,
             WebClient.builder(),
             backendUrl,
             "/api",


### PR DESCRIPTION
## Summary
- update the FacebookCampaignService test to provide the new FacebookAccessTokenManager dependency
- document how the campaign service coordinates token renewal when the Graph API reports expiration

## Testing
- mvn -s settings.xml test *(fails: cannot reach GitHub Maven repository from the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dadfa1b1888321bee745995af112c7