### PR TITLE
Handle automatic Facebook token renewal after expiration

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -161,10 +161,12 @@ uma vez e delega a renovação para o `FacebookAccessTokenManager`. O serviço t
 renovar o token automaticamente via Graph API quando `facebook.app-id` e
 `facebook.app-secret` estão configurados. Em caso de sucesso, o novo token é
 aplicado sem reiniciar o worker e os experimentos voltam a ser processados na
-próxima execução. Se a renovação automática estiver desabilitada ou falhar, o log
-registra uma mensagem de erro única com os detalhes retornados pela Graph API,
-orientando a atualizar o token manualmente e reiniciar o serviço após a
-substituição.
+próxima execução. Caso a primeira tentativa falhe, o worker continua tentando a
+renovação em cada ciclo agendado e retoma o processamento assim que obtiver um
+token válido novamente. Se a renovação automática estiver desabilitada ou falhar
+repetidamente, o log registra uma mensagem de erro com os detalhes retornados
+pela Graph API, orientando a atualizar o token manualmente e reiniciar o serviço
+após a substituição.
 
 ## Build
 ```

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -91,14 +91,25 @@ public class FacebookCampaignService {
 
     public void createCampaignsFromExperiments() {
         if (accessTokenExpired.get()) {
-            if (accessTokenExpiryWarningLogged.compareAndSet(false, true)) {
-                LOGGER.warn(
-                    "Skipping Facebook campaign processing because the configured access token has expired; renew the token and restart the worker."
+            FacebookAccessTokenManager.RenewalAttemptResult renewalResult = accessTokenManager.tryRenewAccessTokenIfPossible();
+            if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.SUCCESS) {
+                LOGGER.info(
+                    "Facebook access token renewed automatically after a previous expiration; resuming campaign processing."
                 );
+                accessTokenExpired.set(false);
+                accessTokenExpiryWarningLogged.set(false);
+            } else {
+                if (accessTokenExpiryWarningLogged.compareAndSet(false, true)) {
+                    LOGGER.warn(
+                        "Skipping Facebook campaign processing because the configured access token has expired; renew the token and restart the worker."
+                    );
+                    logAutomaticRenewalOutcome(renewalResult);
+                }
+                return;
             }
-            return;
+        } else {
+            accessTokenExpiryWarningLogged.set(false);
         }
-        accessTokenExpiryWarningLogged.set(false);
 
         List<Experiment> experiments = Collections.emptyList();
 
@@ -234,14 +245,9 @@ public class FacebookCampaignService {
                     ex.getErrorDetails()
                 );
                 if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.NOT_CONFIGURED) {
-                    LOGGER.error(
-                        "Automatic token renewal is not configured. Provide facebook.app-id and facebook.app-secret so the worker can revalidate the access token without manual intervention."
-                    );
+                    logAutomaticRenewalOutcome(renewalResult);
                 } else if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.FAILED) {
-                    LOGGER.error(
-                        "Automatic token renewal attempt failed: {}",
-                        StringUtils.hasText(renewalResult.errorMessage()) ? renewalResult.errorMessage() : "unknown error"
-                    );
+                    logAutomaticRenewalOutcome(renewalResult);
                 }
             }
             LOGGER.warn(
@@ -302,6 +308,22 @@ public class FacebookCampaignService {
             LOGGER.info("Marked experiment {} as FAILED after Facebook permission error", experimentId);
         } catch (Exception ex) {
             LOGGER.warn("Could not mark experiment {} as FAILED after Facebook permission error: {}", experimentId, ex.getMessage(), ex);
+        }
+    }
+
+    private void logAutomaticRenewalOutcome(FacebookAccessTokenManager.RenewalAttemptResult renewalResult) {
+        if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.NOT_CONFIGURED) {
+            LOGGER.error(
+                "Automatic token renewal is not configured. Provide facebook.app-id and facebook.app-secret so the worker can revalidate the access token without manual intervention."
+            );
+            return;
+        }
+
+        if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.FAILED) {
+            LOGGER.error(
+                "Automatic token renewal attempt failed: {}",
+                StringUtils.hasText(renewalResult.errorMessage()) ? renewalResult.errorMessage() : "unknown error"
+            );
         }
     }
 

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Queue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -22,6 +24,7 @@ class FacebookCampaignServiceTest {
     private MockWebServer facebook;
     private FacebookCampaignService service;
     private ObjectMapper objectMapper;
+    private FacebookAdsService adsService;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -34,7 +37,7 @@ class FacebookCampaignServiceTest {
         String facebookUrl = facebook.url("/").toString();
 
         objectMapper = new ObjectMapper();
-        FacebookAdsService adsService = new FacebookAdsService(
+        adsService = new FacebookAdsService(
             WebClient.builder(),
             facebookUrl,
             "token",
@@ -219,5 +222,124 @@ class FacebookCampaignServiceTest {
 
         assertEquals(1, facebook.getRequestCount());
         assertEquals(4, backend.getRequestCount());
+    }
+
+    @Test
+    void resumesProcessingAfterAutomaticTokenRenewalWhenPreviouslyExpired() throws Exception {
+        StubFacebookAccessTokenManager renewingManager = new StubFacebookAccessTokenManager(adsService);
+        renewingManager.enqueue(new FacebookAccessTokenManager.RenewalAttemptResult(
+            FacebookAccessTokenManager.RenewalOutcome.NOT_CONFIGURED,
+            null,
+            null
+        ));
+        renewingManager.enqueue(new FacebookAccessTokenManager.RenewalAttemptResult(
+            FacebookAccessTokenManager.RenewalOutcome.SUCCESS,
+            "fresh-token",
+            null
+        ));
+
+        service = new FacebookCampaignService(
+            adsService,
+            renewingManager,
+            WebClient.builder(),
+            backend.url("/").toString(),
+            "/api",
+            "1",
+            "2000",
+            "IMPRESSIONS",
+            "LINK_CLICKS",
+            "WEBSITE",
+            "LOWEST_COST_WITHOUT_CAP",
+            "150",
+            "BR",
+            "42",
+            "11",
+            "https://example.com",
+            "Conheça %s",
+            "LEARN_MORE"
+        );
+
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"pageId\":\"84\"}]")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse()
+            .setResponseCode(400)
+            .setBody("{\"error\":{\"message\":\"Error validating access token: Session has expired\",\"type\":\"OAuthException\",\"code\":190,\"error_subcode\":463}}")
+            .addHeader("Content-Type", "application/json"));
+
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"pageId\":\"84\"}]")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"10\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"20\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"30\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"40\"}")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setBody("{}")
+            .addHeader("Content-Type", "application/json"));
+
+        service.createCampaignsFromExperiments();
+        service.createCampaignsFromExperiments();
+
+        RecordedRequest firstExperimentRequest = backend.takeRequest();
+        assertEquals("/api/facebook-campaigns/experiments-ready", firstExperimentRequest.getPath());
+        RecordedRequest firstCreativeRequest = backend.takeRequest();
+        assertEquals("/api/experiments/1/creatives", firstCreativeRequest.getPath());
+        RecordedRequest expiredCampaignRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/campaigns", expiredCampaignRequest.getPath());
+
+        RecordedRequest secondExperimentRequest = backend.takeRequest();
+        assertEquals("/api/facebook-campaigns/experiments-ready", secondExperimentRequest.getPath());
+        RecordedRequest secondCreativeRequest = backend.takeRequest();
+        assertEquals("/api/experiments/1/creatives", secondCreativeRequest.getPath());
+        RecordedRequest renewedCampaignRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/campaigns", renewedCampaignRequest.getPath());
+
+        JsonNode renewedPayload = objectMapper.readTree(renewedCampaignRequest.getBody().inputStream());
+        assertEquals("fresh-token", renewedPayload.get("access_token").asText());
+
+        RecordedRequest adSetRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/adsets", adSetRequest.getPath());
+        RecordedRequest creativeRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/adcreatives", creativeRequest.getPath());
+        RecordedRequest adRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/ads", adRequest.getPath());
+
+        RecordedRequest finalBackendPost = backend.takeRequest();
+        assertEquals("/api/facebook-campaigns", finalBackendPost.getPath());
+    }
+
+    private static class StubFacebookAccessTokenManager extends FacebookAccessTokenManager {
+        private final Queue<FacebookAccessTokenManager.RenewalAttemptResult> results = new ArrayDeque<>();
+        private final FacebookAdsService adsService;
+
+        StubFacebookAccessTokenManager(FacebookAdsService adsService) {
+            super(adsService, "", "");
+            this.adsService = adsService;
+        }
+
+        void enqueue(FacebookAccessTokenManager.RenewalAttemptResult result) {
+            results.add(result);
+        }
+
+        @Override
+        public FacebookAccessTokenManager.RenewalAttemptResult tryRenewAccessTokenIfPossible() {
+            FacebookAccessTokenManager.RenewalAttemptResult result = results.isEmpty()
+                ? new FacebookAccessTokenManager.RenewalAttemptResult(
+                    FacebookAccessTokenManager.RenewalOutcome.NOT_CONFIGURED,
+                    null,
+                    null
+                )
+                : results.poll();
+            if (result.outcome() == FacebookAccessTokenManager.RenewalOutcome.SUCCESS && result.newToken() != null) {
+                adsService.updateAccessToken(result.newToken());
+            }
+            return result;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- resume Facebook campaign processing automatically once the token is renewed after a previous expiration, including shared logging for renewal failures
- cover the renewed flow with an integration-style test using MockWebServer
- document that the worker now retries the automatic token renewal on every scheduler cycle until it succeeds

## Testing
- mvn -s settings.xml test *(fails: Network is unreachable while downloading Spring Boot parent)*

------
https://chatgpt.com/codex/tasks/task_e_68dae42f94bc8321b733215eb298ab75