### PR TITLE
Handle backend-renewed Facebook tokens without app credentials

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -61,6 +61,11 @@ O fluxo funciona da seguinte forma:
    descrito acima. Caso o aplicativo (`facebook.app-id`/`facebook.app-secret`)
    esteja configurado, o novo token é aplicado em memória e a fila de
    experimentos volta a ser processada sem necessidade de reiniciar o serviço.
+   Quando as credenciais não estão configuradas, o agendador de renovação do
+   backend continua responsável por gerar um novo token. Ao detectar que o token
+   configurado foi trocado por esse processo externo, o worker aplica a nova
+   credencial em memória e retoma automaticamente o processamento, eliminando a
+   necessidade de reinicialização manual após a renovação via backend.
 5. Esses dados são exibidos na tela de contas do frontend, permitindo acompanhar
    a última tentativa, o último sucesso e eventuais mensagens de erro.
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Service
 public class FacebookCampaignService {
@@ -46,6 +47,7 @@ public class FacebookCampaignService {
     private final Set<Long> experimentsBlockedByPermissions;
     private final AtomicBoolean accessTokenExpired;
     private final AtomicBoolean accessTokenExpiryWarningLogged;
+    private final AtomicReference<String> lastExpiredAccessToken;
     private final FacebookAccessTokenManager accessTokenManager;
 
     public FacebookCampaignService(FacebookAdsService facebookAdsService,
@@ -87,10 +89,19 @@ public class FacebookCampaignService {
         this.experimentsBlockedByPermissions = ConcurrentHashMap.newKeySet();
         this.accessTokenExpired = new AtomicBoolean(false);
         this.accessTokenExpiryWarningLogged = new AtomicBoolean(false);
+        this.lastExpiredAccessToken = new AtomicReference<>(null);
     }
 
     public void createCampaignsFromExperiments() {
         if (accessTokenExpired.get()) {
+            if (hasTokenChangedSinceExpiration()) {
+                LOGGER.info(
+                    "Detected refreshed Facebook access token after a previous expiration; resuming campaign processing."
+                );
+                accessTokenExpired.set(false);
+                accessTokenExpiryWarningLogged.set(false);
+                lastExpiredAccessToken.set(null);
+            } else {
             FacebookAccessTokenManager.RenewalAttemptResult renewalResult = accessTokenManager.tryRenewAccessTokenIfPossible();
             if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.SUCCESS) {
                 LOGGER.info(
@@ -98,6 +109,7 @@ public class FacebookCampaignService {
                 );
                 accessTokenExpired.set(false);
                 accessTokenExpiryWarningLogged.set(false);
+                lastExpiredAccessToken.set(null);
             } else {
                 if (accessTokenExpiryWarningLogged.compareAndSet(false, true)) {
                     LOGGER.warn(
@@ -106,6 +118,7 @@ public class FacebookCampaignService {
                     logAutomaticRenewalOutcome(renewalResult);
                 }
                 return;
+            }
             }
         } else {
             accessTokenExpiryWarningLogged.set(false);
@@ -225,6 +238,7 @@ public class FacebookCampaignService {
             );
             markExperimentAsFailed(exp.id());
         } catch (FacebookAccessTokenExpiredException ex) {
+            lastExpiredAccessToken.compareAndSet(null, facebookAdsService.getCurrentAccessToken());
             FacebookAccessTokenManager.RenewalAttemptResult renewalResult = accessTokenManager.tryRenewAccessTokenIfPossible();
             if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.SUCCESS) {
                 LOGGER.info(
@@ -233,6 +247,7 @@ public class FacebookCampaignService {
                 );
                 accessTokenExpired.set(false);
                 accessTokenExpiryWarningLogged.set(false);
+                lastExpiredAccessToken.set(null);
                 return;
             }
 
@@ -255,6 +270,15 @@ public class FacebookCampaignService {
                 exp.id()
             );
         }
+    }
+
+    private boolean hasTokenChangedSinceExpiration() {
+        String expiredToken = lastExpiredAccessToken.get();
+        if (expiredToken == null) {
+            return false;
+        }
+        String currentToken = facebookAdsService.getCurrentAccessToken();
+        return currentToken != null && !currentToken.equals(expiredToken);
     }
 
     private String formatCreativeMessage(String experimentName) {

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
@@ -13,6 +13,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 public class FacebookTokenRenewalService {
@@ -84,6 +85,23 @@ public class FacebookTokenRenewalService {
 
             LocalDateTime renewedAt = attemptTime;
             LocalDateTime expiresAt = attemptTime.plusSeconds(Math.max(response.expiresInSeconds(), 0));
+
+            boolean matchesCurrentToken = Objects.equals(
+                candidate.accessToken(),
+                facebookAdsService.getCurrentAccessToken()
+            );
+            if (matchesCurrentToken) {
+                facebookAdsService.updateAccessToken(response.accessToken());
+                LOGGER.info(
+                    "Updated in-memory Facebook access token after backend renewal for account id={}",
+                    candidate.id()
+                );
+            } else {
+                LOGGER.debug(
+                    "Skipping in-memory Facebook token update because candidate token does not match the worker configuration: accountId={}",
+                    candidate.id()
+                );
+            }
 
             reportResult(candidate.id(), new RenewalResultPayload(
                 TokenRenewalStatus.SUCCESS,

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -314,6 +314,96 @@ class FacebookCampaignServiceTest {
         assertEquals("/api/facebook-campaigns", finalBackendPost.getPath());
     }
 
+    @Test
+    void resumesProcessingAfterBackendRenewsTokenWithoutAppCredentials() throws Exception {
+        StubFacebookAccessTokenManager manager = new StubFacebookAccessTokenManager(adsService);
+        manager.enqueue(new FacebookAccessTokenManager.RenewalAttemptResult(
+            FacebookAccessTokenManager.RenewalOutcome.NOT_CONFIGURED,
+            null,
+            null
+        ));
+        manager.enqueue(new FacebookAccessTokenManager.RenewalAttemptResult(
+            FacebookAccessTokenManager.RenewalOutcome.NOT_CONFIGURED,
+            null,
+            null
+        ));
+
+        service = new FacebookCampaignService(
+            adsService,
+            manager,
+            WebClient.builder(),
+            backend.url("/").toString(),
+            "/api",
+            "1",
+            "2000",
+            "IMPRESSIONS",
+            "LINK_CLICKS",
+            "WEBSITE",
+            "LOWEST_COST_WITHOUT_CAP",
+            "150",
+            "BR",
+            "42",
+            "11",
+            "https://example.com",
+            "Conheça %s",
+            "LEARN_MORE"
+        );
+
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"pageId\":\"84\"}]")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse()
+            .setResponseCode(400)
+            .setBody("{\"error\":{\"message\":\"Error validating access token: Session has expired\",\"type\":\"OAuthException\",\"code\":190,\"error_subcode\":463}}")
+            .addHeader("Content-Type", "application/json"));
+
+        service.createCampaignsFromExperiments();
+
+        adsService.updateAccessToken("renewed-by-backend");
+
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"pageId\":\"84\"}]")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"10\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"20\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"30\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"40\"}")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setBody("{}")
+            .addHeader("Content-Type", "application/json"));
+
+        service.createCampaignsFromExperiments();
+
+        RecordedRequest firstExperiment = backend.takeRequest();
+        assertEquals("/api/facebook-campaigns/experiments-ready", firstExperiment.getPath());
+        RecordedRequest firstCreative = backend.takeRequest();
+        assertEquals("/api/experiments/1/creatives", firstCreative.getPath());
+        RecordedRequest expiredCampaign = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/campaigns", expiredCampaign.getPath());
+
+        RecordedRequest secondExperiment = backend.takeRequest();
+        assertEquals("/api/facebook-campaigns/experiments-ready", secondExperiment.getPath());
+        RecordedRequest secondCreative = backend.takeRequest();
+        assertEquals("/api/experiments/1/creatives", secondCreative.getPath());
+        RecordedRequest renewedCampaign = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/campaigns", renewedCampaign.getPath());
+
+        JsonNode renewedPayload = objectMapper.readTree(renewedCampaign.getBody().inputStream());
+        assertEquals("renewed-by-backend", renewedPayload.get("access_token").asText());
+
+        facebook.takeRequest(); // ad set
+        facebook.takeRequest(); // creative
+        facebook.takeRequest(); // ad
+
+        RecordedRequest backendPost = backend.takeRequest();
+        assertEquals("/api/facebook-campaigns", backendPost.getPath());
+    }
+
     private static class StubFacebookAccessTokenManager extends FacebookAccessTokenManager {
         private final Queue<FacebookAccessTokenManager.RenewalAttemptResult> results = new ArrayDeque<>();
         private final FacebookAdsService adsService;


### PR DESCRIPTION
## Summary
- track the last expired Facebook token in the campaign worker and resume processing when a fresh token is detected
- update the token renewal service to refresh the in-memory token when the backend renewal matches the worker configuration
- document the fallback behaviour and add regression coverage for backend-driven renewals

## Testing
- mvn -s settings.xml test *(fails: Network is unreachable while resolving the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68dae895907c8321a5167ac8b1833aca