### PR TITLE
Remove Facebook Ads worker environment defaults

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
@@ -46,10 +46,52 @@ public class FacebookAccount {
     @Column(name = "business_manager_app_id")
     private String businessManagerAppId;
 
+    @Column(name = "ad_account_id")
+    private String adAccountId;
+
+    @Column(name = "default_page_id")
+    private String defaultPageId;
+
+    @Column(name = "default_website_url", length = 512)
+    private String defaultWebsiteUrl;
+
+    @Column(name = "default_instagram_actor_id")
+    private String defaultInstagramActorId;
+
+    @Column(name = "default_creative_message_template")
+    private String defaultCreativeMessageTemplate;
+
+    @Column(name = "default_call_to_action_type")
+    private String defaultCallToActionType;
+
+    @Column(name = "ad_set_daily_budget")
+    private String adSetDailyBudget;
+
+    @Column(name = "ad_set_billing_event")
+    private String adSetBillingEvent;
+
+    @Column(name = "ad_set_optimization_goal")
+    private String adSetOptimizationGoal;
+
+    @Column(name = "ad_set_destination_type")
+    private String adSetDestinationType;
+
+    @Column(name = "ad_set_bid_strategy")
+    private String adSetBidStrategy;
+
+    @Column(name = "ad_set_bid_amount")
+    private String adSetBidAmount;
+
+    @Column(name = "ad_set_target_country")
+    private String adSetTargetCountry;
+
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Setter(AccessLevel.NONE)
     @Column(columnDefinition = "LONGTEXT")
     private String appSecret;
+
+    @Column(name = "worker_enabled")
+    private boolean workerEnabled;
 
     private boolean tokenRenewalEnabled;
     private String tokenRenewalStatus;

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -1,7 +1,9 @@
 package com.marketinghub.ads;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -40,7 +42,9 @@ public class FacebookAccountController {
         if (!account.isTokenRenewalEnabled()) {
             account.setTokenRenewalEnabled(false);
         }
-        return repository.save(account);
+        FacebookAccount saved = repository.save(account);
+        enforceSingleWorkerEnabled(saved);
+        return saved;
     }
 
     @PutMapping("/{id}")
@@ -55,7 +59,21 @@ public class FacebookAccountController {
         persisted.setAuthorizedUserEmail(account.getAuthorizedUserEmail());
         persisted.setAppId(account.getAppId());
         persisted.setBusinessManagerAppId(account.getBusinessManagerAppId());
+        persisted.setAdAccountId(account.getAdAccountId());
+        persisted.setDefaultPageId(account.getDefaultPageId());
+        persisted.setDefaultWebsiteUrl(account.getDefaultWebsiteUrl());
+        persisted.setDefaultInstagramActorId(account.getDefaultInstagramActorId());
+        persisted.setDefaultCreativeMessageTemplate(account.getDefaultCreativeMessageTemplate());
+        persisted.setDefaultCallToActionType(account.getDefaultCallToActionType());
+        persisted.setAdSetDailyBudget(account.getAdSetDailyBudget());
+        persisted.setAdSetBillingEvent(account.getAdSetBillingEvent());
+        persisted.setAdSetOptimizationGoal(account.getAdSetOptimizationGoal());
+        persisted.setAdSetDestinationType(account.getAdSetDestinationType());
+        persisted.setAdSetBidStrategy(account.getAdSetBidStrategy());
+        persisted.setAdSetBidAmount(account.getAdSetBidAmount());
+        persisted.setAdSetTargetCountry(account.getAdSetTargetCountry());
         persisted.setTokenRenewalEnabled(account.isTokenRenewalEnabled());
+        persisted.setWorkerEnabled(account.isWorkerEnabled());
 
         String newToken = account.getAccessToken();
         if (newToken == null) {
@@ -82,7 +100,18 @@ public class FacebookAccountController {
             persisted.setTokenRenewalStatus(account.getTokenRenewalStatus());
         }
         
-        return repository.save(persisted);
+        FacebookAccount updated = repository.save(persisted);
+        enforceSingleWorkerEnabled(updated);
+        return updated;
+    }
+
+    @GetMapping("/worker-config")
+    public FacebookWorkerConfiguration workerConfiguration() {
+        FacebookAccount account = repository
+            .findFirstByWorkerEnabledTrue()
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Facebook worker configuration not found"));
+        validateWorkerConfiguration(account);
+        return toWorkerConfiguration(account);
     }
 
     @GetMapping("/renewal/eligible")
@@ -151,6 +180,19 @@ public class FacebookAccountController {
         account.setAuthorizedUserEmail(trimToNull(account.getAuthorizedUserEmail()));
         account.setAppId(trimToNull(account.getAppId()));
         account.setBusinessManagerAppId(trimToNull(account.getBusinessManagerAppId()));
+        account.setAdAccountId(trimToNull(account.getAdAccountId()));
+        account.setDefaultPageId(trimToNull(account.getDefaultPageId()));
+        account.setDefaultWebsiteUrl(trimToNull(account.getDefaultWebsiteUrl()));
+        account.setDefaultInstagramActorId(trimToNull(account.getDefaultInstagramActorId()));
+        account.setDefaultCreativeMessageTemplate(trimToNull(account.getDefaultCreativeMessageTemplate()));
+        account.setDefaultCallToActionType(trimToNull(account.getDefaultCallToActionType()));
+        account.setAdSetDailyBudget(trimToNull(account.getAdSetDailyBudget()));
+        account.setAdSetBillingEvent(trimToNull(account.getAdSetBillingEvent()));
+        account.setAdSetOptimizationGoal(trimToNull(account.getAdSetOptimizationGoal()));
+        account.setAdSetDestinationType(trimToNull(account.getAdSetDestinationType()));
+        account.setAdSetBidStrategy(trimToNull(account.getAdSetBidStrategy()));
+        account.setAdSetBidAmount(trimToNull(account.getAdSetBidAmount()));
+        account.setAdSetTargetCountry(trimToNull(account.getAdSetTargetCountry()));
         if (account.isAppSecretProvided()) {
             account.overwriteAppSecret(trimToNull(account.getAppSecret()));
         }
@@ -162,6 +204,76 @@ public class FacebookAccountController {
             } catch (IllegalArgumentException ex) {
                 account.setTokenRenewalStatus(FacebookTokenRenewalStatus.NEVER_ATTEMPTED.name());
             }
+        }
+    }
+
+    private void enforceSingleWorkerEnabled(FacebookAccount saved) {
+        if (!saved.isWorkerEnabled()) {
+            return;
+        }
+        repository
+            .findAll()
+            .stream()
+            .filter(other -> !other.getId().equals(saved.getId()))
+            .filter(FacebookAccount::isWorkerEnabled)
+            .forEach(other -> {
+                other.setWorkerEnabled(false);
+                repository.save(other);
+            });
+    }
+
+    private FacebookWorkerConfiguration toWorkerConfiguration(FacebookAccount account) {
+        String creativeMessageTemplate = StringUtils.hasText(account.getDefaultCreativeMessageTemplate())
+            ? account.getDefaultCreativeMessageTemplate()
+            : "%s";
+        String callToAction = StringUtils.hasText(account.getDefaultCallToActionType())
+            ? account.getDefaultCallToActionType()
+            : "LEARN_MORE";
+        return new FacebookWorkerConfiguration(
+            account.getId(),
+            account.getAdAccountId(),
+            account.getAccessToken(),
+            account.getAppId(),
+            account.getAppSecret(),
+            account.getDefaultPageId(),
+            account.getDefaultInstagramActorId(),
+            account.getDefaultWebsiteUrl(),
+            creativeMessageTemplate,
+            callToAction,
+            account.getAdSetDailyBudget(),
+            account.getAdSetBillingEvent(),
+            account.getAdSetOptimizationGoal(),
+            account.getAdSetDestinationType(),
+            account.getAdSetBidStrategy(),
+            account.getAdSetBidAmount(),
+            account.getAdSetTargetCountry()
+        );
+    }
+
+    private void validateWorkerConfiguration(FacebookAccount account) {
+        if (!StringUtils.hasText(account.getAccessToken())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing access token");
+        }
+        if (!StringUtils.hasText(account.getAdAccountId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing ad account id");
+        }
+        if (!StringUtils.hasText(account.getDefaultWebsiteUrl())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing default website URL");
+        }
+        if (!StringUtils.hasText(account.getAdSetDailyBudget())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing ad set daily budget");
+        }
+        if (!StringUtils.hasText(account.getAdSetBillingEvent())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing ad set billing event");
+        }
+        if (!StringUtils.hasText(account.getAdSetOptimizationGoal())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing ad set optimization goal");
+        }
+        if (!StringUtils.hasText(account.getAdSetDestinationType())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing ad set destination type");
+        }
+        if (!StringUtils.hasText(account.getAdSetTargetCountry())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing target country");
         }
     }
 
@@ -196,5 +308,25 @@ public class FacebookAccountController {
         LocalDateTime renewedAt,
         LocalDateTime attemptedAt,
         String errorMessage
+    ) {}
+
+    public record FacebookWorkerConfiguration(
+        Long accountId,
+        String adAccountId,
+        String accessToken,
+        String appId,
+        String appSecret,
+        String defaultPageId,
+        String defaultInstagramActorId,
+        String defaultWebsiteUrl,
+        String defaultCreativeMessageTemplate,
+        String defaultCallToActionType,
+        String adSetDailyBudget,
+        String adSetBillingEvent,
+        String adSetOptimizationGoal,
+        String adSetDestinationType,
+        String adSetBidStrategy,
+        String adSetBidAmount,
+        String adSetTargetCountry
     ) {}
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountRepository.java
@@ -2,5 +2,8 @@ package com.marketinghub.ads;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FacebookAccountRepository extends JpaRepository<FacebookAccount, Long> {
+    Optional<FacebookAccount> findFirstByWorkerEnabledTrue();
 }

--- a/backend/ads-service/src/main/resources/db/changelog/V2026_03_20__extend_fb_account_worker_config.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2026_03_20__extend_fb_account_worker_config.sql
@@ -1,0 +1,19 @@
+--liquibase formatted sql
+--changeset marketinghub:2026-03-20-extend-fb-account-worker-config dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'fb_account' AND column_name = 'ad_account_id';
+ALTER TABLE fb_account
+  ADD COLUMN ad_account_id VARCHAR(64) NULL,
+  ADD COLUMN default_page_id VARCHAR(128) NULL,
+  ADD COLUMN default_website_url VARCHAR(512) NULL,
+  ADD COLUMN default_instagram_actor_id VARCHAR(64) NULL,
+  ADD COLUMN default_creative_message_template VARCHAR(255) NULL,
+  ADD COLUMN default_call_to_action_type VARCHAR(64) NULL,
+  ADD COLUMN ad_set_daily_budget VARCHAR(32) NULL,
+  ADD COLUMN ad_set_billing_event VARCHAR(64) NULL,
+  ADD COLUMN ad_set_optimization_goal VARCHAR(64) NULL,
+  ADD COLUMN ad_set_destination_type VARCHAR(64) NULL,
+  ADD COLUMN ad_set_bid_strategy VARCHAR(64) NULL,
+  ADD COLUMN ad_set_bid_amount VARCHAR(32) NULL,
+  ADD COLUMN ad_set_target_country VARCHAR(32) NULL,
+  ADD COLUMN worker_enabled TINYINT(1) NOT NULL DEFAULT 0;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -134,3 +134,6 @@ databaseChangeLog:
   - include:
       file: V2026_02_15__add_fb_account_business_manager_app_id.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2026_03_20__extend_fb_account_worker_config.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -160,4 +160,56 @@ public class FacebookAccountControllerTest {
         assertThat(updated.getTokenRenewalStatus()).isEqualTo(FacebookTokenRenewalStatus.SUCCESS.name());
         assertThat(updated.getTokenRenewalLastError()).isNull();
     }
+
+    @Test
+    void shouldExposeWorkerConfigurationWhenAccountEnabled() throws Exception {
+        repository.deleteAll();
+        FacebookAccount account = repository.save(FacebookAccount.builder()
+            .name("Worker Account")
+            .currency("BRL")
+            .accessToken("worker-token")
+            .adAccountId("1234567890")
+            .defaultWebsiteUrl("https://example.com")
+            .defaultCreativeMessageTemplate("Campanha %s")
+            .defaultCallToActionType("SIGN_UP")
+            .adSetDailyBudget("2000")
+            .adSetBillingEvent("IMPRESSIONS")
+            .adSetOptimizationGoal("LINK_CLICKS")
+            .adSetDestinationType("WEBSITE")
+            .adSetBidStrategy("LOWEST_COST_WITHOUT_CAP")
+            .adSetTargetCountry("BR")
+            .workerEnabled(true)
+            .build());
+
+        mockMvc.perform(get("/api/accounts/facebook/worker-config"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accountId").value(account.getId()))
+            .andExpect(jsonPath("$.accessToken").value("worker-token"))
+            .andExpect(jsonPath("$.adAccountId").value("1234567890"))
+            .andExpect(jsonPath("$.defaultWebsiteUrl").value("https://example.com"))
+            .andExpect(jsonPath("$.adSetDailyBudget").value("2000"))
+            .andExpect(jsonPath("$.adSetBillingEvent").value("IMPRESSIONS"))
+            .andExpect(jsonPath("$.defaultCallToActionType").value("SIGN_UP"))
+            .andExpect(jsonPath("$.defaultCreativeMessageTemplate").value("Campanha %s"));
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenWorkerConfigurationIncomplete() throws Exception {
+        repository.deleteAll();
+        repository.save(FacebookAccount.builder()
+            .name("Worker Account")
+            .currency("BRL")
+            .accessToken("worker-token")
+            .defaultWebsiteUrl("https://example.com")
+            .adSetDailyBudget("2000")
+            .adSetBillingEvent("IMPRESSIONS")
+            .adSetOptimizationGoal("LINK_CLICKS")
+            .adSetDestinationType("WEBSITE")
+            .adSetTargetCountry("BR")
+            .workerEnabled(true)
+            .build());
+
+        mockMvc.perform(get("/api/accounts/facebook/worker-config"))
+            .andExpect(status().isBadRequest());
+    }
 }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -426,19 +426,37 @@ allow variants to be created before an experiment is defined.
 - `authorized_user_name` VARCHAR(255)
 - `authorized_user_email` VARCHAR(320)
 - `app_id` VARCHAR(255)
+- `business_manager_app_id` VARCHAR(255)
 - `app_secret` LONGTEXT
 - `token_renewal_enabled` TINYINT(1) DEFAULT 0
 - `token_renewal_status` VARCHAR(40)
 - `token_renewal_last_attempt_at` DATETIME
 - `token_renewed_at` DATETIME
 - `token_renewal_last_error` LONGTEXT
+- `ad_account_id` VARCHAR(64)
+- `default_page_id` VARCHAR(128)
+- `default_website_url` VARCHAR(512)
+- `default_instagram_actor_id` VARCHAR(64)
+- `default_creative_message_template` VARCHAR(255)
+- `default_call_to_action_type` VARCHAR(64)
+- `ad_set_daily_budget` VARCHAR(32)
+- `ad_set_billing_event` VARCHAR(64)
+- `ad_set_optimization_goal` VARCHAR(64)
+- `ad_set_destination_type` VARCHAR(64)
+- `ad_set_bid_strategy` VARCHAR(64)
+- `ad_set_bid_amount` VARCHAR(32)
+- `ad_set_target_country` VARCHAR(32)
+- `worker_enabled` TINYINT(1) DEFAULT 0
 
 Registra as credenciais do Facebook Ads configuradas no backend. Quando a
 renovação automática está habilitada (`token_renewal_enabled = 1`), o Facebook
 Ads Worker monitora `token_expires_at` e solicita um novo token de longa duração
 antes do vencimento. Cada tentativa atualiza `token_renewal_status`,
 `token_renewal_last_attempt_at`, `token_renewed_at` e armazena mensagens de erro
-em `token_renewal_last_error` quando a renovação falha.
+em `token_renewal_last_error` quando a renovação falha. A conta marcada como
+`worker_enabled = 1` é exposta pelo endpoint `GET /api/accounts/facebook/worker-config`
+e fornece os parâmetros padrão utilizados pelo `facebook-ads-worker` (ID da conta
+de anúncios, token, App ID/Secret, página fallback, orçamento diário etc.).
 
 ## Diagram
 

--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -16,32 +16,23 @@ classDiagram
         -backendClient : WebClient
         -backendBaseUrl : String
         -apiPrefix : String
-        -adAccountId : String
-        -adSetDailyBudget : String
-        -adSetBillingEvent : String
-        -adSetOptimizationGoal : String
-        -adSetDestinationType : String
-        -adSetTargetCountry : String
-        -pageId : String
-        -instagramActorId : String
-        -websiteUrl : String
-        -creativeMessageTemplate : String
-        -callToActionType : String
+        -configurationClient : FacebookWorkerConfigurationClient
         -experimentsBlockedByPermissions : Set<Long>
         +createCampaignsFromExperiments()
-        -processExperiment(exp)
-        -formatCreativeMessage(name) String
+        -processExperiment(exp, config)
+        -formatCreativeMessage(name, config) String
     }
 
     class FacebookAdsService {
         -webClient : WebClient
-        -accessToken : String
+        -accessToken : AtomicReference<String>
         +createCampaign(adAccountId, name) String
         +createAdSet(adAccountId, request) String
         +createAdCreative(adAccountId, request) String
         +createAd(adAccountId, request) String
         +getCampaignMetrics(campaignId) JsonNode
         +renewLongLivedToken(appId, appSecret, token) TokenRenewalResponse
+        +updateAccessToken(token)
     }
 
     class AdSetRequest {
@@ -90,8 +81,7 @@ classDiagram
 
     class FacebookAccessTokenManager {
         -facebookAdsService : FacebookAdsService
-        -appId : String
-        -appSecret : String
+        -configurationClient : FacebookWorkerConfigurationClient
         +tryRenewAccessTokenIfPossible() : RenewalAttemptResult
     }
 
@@ -167,6 +157,7 @@ classDiagram
     FacebookCampaignScheduler --> FacebookCampaignService : dispara ciclo
     FacebookCampaignService --> FacebookAdsService : cria campanha/ad set/ad
     FacebookCampaignService --> FacebookAccessTokenManager : gerencia expiração de token
+    FacebookCampaignService --> FacebookWorkerConfigurationClient : carrega configuração
     FacebookAdsService --> AdSetRequest
     FacebookAdsService --> AdCreativeRequest
     FacebookAdsService --> AdRequest
@@ -178,18 +169,19 @@ classDiagram
     FacebookCampaignService ..> UrlUtils : compõe URLs do backend
     FacebookTokenRenewalScheduler --> FacebookTokenRenewalService : agenda renovação
     FacebookTokenRenewalService --> FacebookAdsService : renova token
+    FacebookAccessTokenManager --> FacebookWorkerConfigurationClient : lê credenciais do backend
     FacebookTokenRenewalService ..> UrlUtils : reutiliza composição de URLs
 ```
 
 * `FacebookCampaignScheduler` agenda a execução periódica do worker utilizando
   `@Scheduled`.
-* `FacebookCampaignService` consulta o backend por experimentos prontos, cria a
-  campanha, conjunto, criativo e anúncio na Graph API e registra o resultado da
-  campanha no backend. O serviço resolve o `pageId` a partir do experimento,
-  garantindo que todos os criativos publicados compartilhem a mesma página.
-  Quando o Facebook devolve erro de permissão, o serviço adiciona o
-  experimento a uma lista de bloqueio em memória para evitar novas tentativas
-  até que o worker seja reiniciado.
+* `FacebookCampaignService` consulta o backend por experimentos prontos, carrega
+  a configuração ativa (`worker-config`), sincroniza o token em memória e cria a
+  hierarquia de campanha na Graph API. O serviço resolve o `pageId` a partir do
+  experimento, utilizando o fallback da conta quando necessário, e registra o
+  resultado da campanha no backend. Quando o Facebook devolve erro de permissão,
+  o serviço adiciona o experimento a uma lista de bloqueio em memória para evitar
+  novas tentativas até que o worker seja reiniciado.
 * `FacebookAdsService` encapsula as chamadas à Graph API (criação da hierarquia
   de mídia, consulta de métricas e renovação de tokens de longa duração).
 * `FacebookTokenRenewalScheduler` agenda o fluxo periódico de renovação de token
@@ -199,7 +191,11 @@ classDiagram
   `/api/accounts/facebook/{id}/token/renewal`.
 * `FacebookAccessTokenManager` encapsula a renovação imediata de tokens quando o
   `FacebookCampaignService` detecta expiração durante a criação de campanhas,
-  reutilizando o `FacebookAdsService` para atualizar o `access_token` em memória.
+  consultando novamente o backend para reutilizar as credenciais e atualizar o
+  `access_token` em memória.
+* `FacebookWorkerConfigurationClient` fornece acesso ao endpoint
+  `/api/accounts/facebook/worker-config`, permitindo que os serviços leiam as
+  credenciais e parâmetros padrão preenchidos na interface web.
 * `CreateCampaignRequest` representa o payload enviado ao backend contendo os
   campos mínimos para materializar a entidade de campanha.
 * `FacebookAdsCampaign` é a entidade JPA do backend responsável por armazenar a
@@ -217,3 +213,31 @@ orçamento (`dailyBudgetMinor`, `lifetimeBudgetMinor`), versão da API utilizada
 listas para categorias e países especiais (`specialAdCategories` e
 `specialAdCountries`). Esses dados são enriquecidos conforme novas informações
 forem fornecidas pelo worker e pelo backend.
+    class FacebookWorkerConfigurationClient {
+        -backendClient : WebClient
+        -backendBaseUrl : String
+        -apiPrefix : String
+        +fetchConfiguration() Optional<FacebookWorkerConfiguration>
+    }
+
+    class FacebookWorkerConfiguration {
+        <<record>>
+        +accountId : Long
+        +adAccountId : String
+        +accessToken : String
+        +appId : String
+        +appSecret : String
+        +defaultPageId : String
+        +defaultInstagramActorId : String
+        +defaultWebsiteUrl : String
+        +defaultCreativeMessageTemplate : String
+        +defaultCallToActionType : String
+        +adSetDailyBudget : String
+        +adSetBillingEvent : String
+        +adSetOptimizationGoal : String
+        +adSetDestinationType : String
+        +adSetBidStrategy : String
+        +adSetBidAmount : String
+        +adSetTargetCountry : String
+    }
+

--- a/docs/facebook-ads-worker/input-output-mapping.md
+++ b/docs/facebook-ads-worker/input-output-mapping.md
@@ -3,9 +3,10 @@
 Este documento descreve como o **Facebook Ads Worker** converte os
 experimentos aprovados pelo backend em chamadas à Graph API do Facebook e em
 registros persistidos nas tabelas `facebook_ads_*`. O fluxo atual cria a
-hierarquia completa (campanha → ad set → criativo → anúncio) utilizando valores
-padrão configuráveis enquanto o backend evolui para fornecer parâmetros mais
-ricos.
+hierarquia completa (campanha → ad set → criativo → anúncio) utiliza os valores
+definidos na conta marcada para o worker na tela **Contas do Facebook**. O
+backend expõe esses dados via `GET /api/accounts/facebook/worker-config`, que
+reúne token, App ID/Secret e parâmetros padrão de orçamento, destino e criativos.
 
 Os experimentos que alimentam esse fluxo são apresentados ao time na tela
 "Experimentos para Campanha" do frontend, garantindo o alinhamento entre a visão
@@ -50,7 +51,7 @@ flowchart TD
 | `objective` | Constante | Valor fixo `OUTCOME_TRAFFIC` |
 | `status` | Constante | `PAUSED` para evitar publicação automática |
 | `special_ad_categories` | Constante | Lista com `NONE`, atendendo às políticas atuais |
-| `access_token` | Configuração `facebook.access-token` | Token com permissão para o Ad Account |
+| `access_token` | Conta configurada (`worker-config.accessToken`) | Token com permissão para o Ad Account |
 
 * **Resposta tratada:** o identificador retornado em `id` abastece as etapas seguintes.
 
@@ -63,14 +64,14 @@ flowchart TD
 | --- | --- | --- |
 | `name` | `Experiment.name` + sufixo | Mantém rastreabilidade visual no Gerenciador |
 | `campaign_id` | Resposta da campanha | Vincula o ad set à campanha recém-criada |
-| `daily_budget` | Configuração `facebook.ad-set.daily-budget` | Valor em centavos da moeda da conta |
-| `billing_event` | Configuração `facebook.ad-set.billing-event` | Default `IMPRESSIONS` |
-| `optimization_goal` | Configuração `facebook.ad-set.optimization-goal` | Default `LINK_CLICKS` |
-| `destination_type` | Configuração `facebook.ad-set.destination-type` | Default `WEBSITE` |
-| `targeting.geo_locations.countries` | Configuração `facebook.ad-set.target-country` | Segmentação inicial simplificada |
-| `promoted_object.page_id` | Configuração `facebook.page-id` | Necessário para campanhas de tráfego |
+| `daily_budget` | Conta configurada (`worker-config.adSetDailyBudget`) | Valor em centavos da moeda da conta |
+| `billing_event` | Conta configurada (`worker-config.adSetBillingEvent`) | Default `IMPRESSIONS` |
+| `optimization_goal` | Conta configurada (`worker-config.adSetOptimizationGoal`) | Default `LINK_CLICKS` |
+| `destination_type` | Conta configurada (`worker-config.adSetDestinationType`) | Default `WEBSITE` |
+| `targeting.geo_locations.countries` | Conta configurada (`worker-config.adSetTargetCountry`) | Segmentação inicial simplificada |
+| `promoted_object.page_id` | Conta configurada (`worker-config.defaultPageId`) | Necessário para campanhas de tráfego |
 | `status` | Constante | `PAUSED` |
-| `access_token` | Configuração `facebook.access-token` | Token com permissão para o Ad Account |
+| `access_token` | Conta configurada (`worker-config.accessToken`) | Token com permissão para o Ad Account |
 
 * **Resposta tratada:** o `id` do ad set é utilizado na criação do anúncio.
 
@@ -82,13 +83,13 @@ flowchart TD
 | Campo | Origem | Observações |
 | --- | --- | --- |
 | `name` | `Experiment.name` + sufixo | Nome amigável para o criativo |
-| `object_story_spec.page_id` | Configuração `facebook.page-id` | Página responsável pelo anúncio |
-| `object_story_spec.instagram_actor_id` | Configuração `facebook.instagram-actor-id` | Opcional; usado quando há Instagram vinculado |
-| `object_story_spec.link_data.message` | Template `facebook.creative.message-template` | Substitui `%s` pelo nome do experimento |
-| `object_story_spec.link_data.link` | Configuração `facebook.website-url` | URL de destino padrão |
-| `object_story_spec.link_data.call_to_action.type` | Configuração `facebook.creative.call-to-action-type` | Default `LEARN_MORE` |
-| `object_story_spec.link_data.call_to_action.value.link` | Configuração `facebook.website-url` | Mesmo destino do link principal |
-| `access_token` | Configuração `facebook.access-token` | Token com permissão para o Ad Account |
+| `object_story_spec.page_id` | Conta configurada (`worker-config.defaultPageId`) | Página responsável pelo anúncio |
+| `object_story_spec.instagram_actor_id` | Conta configurada (`worker-config.defaultInstagramActorId`) | Opcional; usado quando há Instagram vinculado |
+| `object_story_spec.link_data.message` | Template (`worker-config.defaultCreativeMessageTemplate`) | Substitui `%s` pelo nome do experimento |
+| `object_story_spec.link_data.link` | Conta configurada (`worker-config.defaultWebsiteUrl`) | URL de destino padrão |
+| `object_story_spec.link_data.call_to_action.type` | Conta configurada (`worker-config.defaultCallToActionType`) | Default `LEARN_MORE` |
+| `object_story_spec.link_data.call_to_action.value.link` | Conta configurada (`worker-config.defaultWebsiteUrl`) | Mesmo destino do link principal |
+| `access_token` | Conta configurada (`worker-config.accessToken`) | Token com permissão para o Ad Account |
 
 * **Resposta tratada:** o `id` do criativo abastece a criação do anúncio.
 
@@ -103,7 +104,7 @@ flowchart TD
 | `adset_id` | Resposta do ad set | Mantém o vínculo com a etapa anterior |
 | `creative.creative_id` | Resposta do criativo | Referencia o criativo recém-criado |
 | `status` | Constante | `PAUSED` |
-| `access_token` | Configuração `facebook.access-token` | Token com permissão para o Ad Account |
+| `access_token` | Conta configurada (`worker-config.accessToken`) | Token com permissão para o Ad Account |
 
 * **Resposta tratada:** o identificador é armazenado apenas para auditoria de execução (não é persistido no backend ainda).
 
@@ -118,7 +119,7 @@ para o backend.
 | Campo | Fonte | Transformação |
 | --- | --- | --- |
 | `id` | Resposta da Graph API (campanha) | Copiado diretamente do `id` retornado na criação |
-| `adAccountId` | Propriedade `facebook.ad-account-id` | Mantido conforme configuração do worker |
+| `adAccountId` | Conta configurada (`worker-config.adAccountId`) | Mantido conforme configuração do worker |
 | `name` | `Experiment.name` | Replicado para manter rastreabilidade entre backend e Facebook |
 | `objective` | Constante | Valor fixo `OUTCOME_TRAFFIC` |
 | `budgetMode` | Constante | Valor fixo `CAMPAIGN` até que o backend passe a enviar planejamento detalhado |

--- a/docs/facebook-ads-worker/meta-ads-campaign-fields.md
+++ b/docs/facebook-ads-worker/meta-ads-campaign-fields.md
@@ -1,6 +1,6 @@
 # Campos necessários para criar uma campanha no Meta Ads
 
-Este documento descreve todos os campos que precisam ser coletados e preenchidos para configurar uma campanha completa no Meta Ads (Facebook e Instagram). A estrutura segue os três níveis usados pela plataforma — **Campanha**, **Conjunto de Anúncios** e **Anúncio** — e explica o objetivo de cada campo, além de observações úteis para preenchimento.
+Este documento descreve todos os campos que precisam ser coletados e preenchidos para configurar uma campanha completa no Meta Ads (Facebook e Instagram). A estrutura segue os três níveis usados pela plataforma — **Campanha**, **Conjunto de Anúncios** e **Anúncio** — e explica o objetivo de cada campo, além de observações úteis para preenchimento. Os valores padrão aplicados pelo `facebook-ads-worker` são parametrizados na tela **Contas do Facebook** e consumidos pelo endpoint `GET /api/accounts/facebook/worker-config`.
 
 ## 1. Configurações no nível de Campanha
 

--- a/docs/facebook-ads-worker/pendencias.md
+++ b/docs/facebook-ads-worker/pendencias.md
@@ -15,6 +15,9 @@ e governança, ainda faltam os itens abaixo, agrupados por tema.
   (ex.: programada, ativa, pausada).
 - Alimentar o backend com os identificadores de ad set, criativo e anúncio para
   manter rastreabilidade completa no modelo de dados.
+- Versionar e auditar alterações na configuração do worker (`worker-config`),
+  registrando quem atualizou parâmetros sensíveis (token, orçamento padrão,
+  página fallback).
 
 ## Segmentação, criativos e lances
 

--- a/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
+++ b/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
@@ -49,22 +49,23 @@ montar a hierarquia completa:
    `PAUSED` e `special_ad_categories = NONE`. O identificador retornado alimenta
    as etapas seguintes ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L101-L105)).
 2. **Conjunto de anúncios**: `POST /adsets` com orçamento diário, billing event,
-   objetivo de otimização e destino (`WEBSITE`) definidos por propriedades de
-   configuração. A segmentação inicial utiliza apenas país (`facebook.ad-set.target-country`) até que o backend envie dados mais
-   ricos. O `id` retornado é usado na criação do anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L111)).
+   objetivo de otimização e destino (`WEBSITE`) vindos da conta configurada no
+   backend (`worker-config`). A segmentação inicial utiliza apenas o país padrão
+   enquanto o backend não envia dados mais ricos. O `id` retornado é usado na
+   criação do anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L111)).
 3. **Criativo**: `POST /adcreatives` baseado em um `object_story_spec` que inclui
    `page_id`, `instagram_actor_id` opcional, template de mensagem com o nome do
-   experimento e call-to-action configurável. O `id` retornado alimenta o anúncio
-   ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L119)).
+   experimento e call-to-action vindos da mesma configuração. O `id` retornado
+   alimenta o anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L119)).
 4. **Anúncio**: `POST /ads` referenciando o ad set e o criativo recém-criados, em
    status `PAUSED` para permitir revisão manual antes da ativação
    ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L120-L124)).
 
-Todos os pontos de contato com a Graph API reutilizam o mesmo `access_token`
-configurado para o worker. Quando a Graph API responde com `(#190) OAuthException`
+Todos os pontos de contato com a Graph API reutilizam o `access_token` exposto
+pelo `worker-config`. Quando a Graph API responde com `(#190) OAuthException`
 indicando expiração do token, o `FacebookCampaignService` interrompe o fluxo
-temporariamente e delega a renovação para o `FacebookAccessTokenManager`. O
-processamento normal é retomado assim que o token é atualizado.
+temporariamente e delega a renovação para o `FacebookAccessTokenManager`, que
+consulta novamente o backend antes de atualizar o token em memória.
 
 ### 3. Persistência no backend
 
@@ -80,13 +81,13 @@ mesmo nome do experimento e preenche `objective` e `budgetMode` com constantes
 | --- | --- | --- |
 | `Experiment.name` | `Graph API - name` | Nome base para campanha, ad set, criativo e anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L101-L124)) |
 | `Experiment.name` | `CreateCampaignRequest.name` | Mantém rastreabilidade entre backend e Facebook ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132)) |
-| `facebook.ad-account-id` | `Graph API - URLs` | Define o Ad Account usado em todas as chamadas `POST` ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L38-L67)) |
-| `facebook.access-token` | `Graph API - access_token` | Token reutilizado em campanha, ad set, criativo e anúncio ([FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L18-L127)) |
-| `facebook.ad-set.*` | `Graph API - adsets` | Define orçamento, otimização e país padrão ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L111)) |
-| `facebook.page-id` | `Graph API - promoted_object` / `object_story_spec.page_id` | Necessário para ad sets e criativos ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L119)) |
-| `facebook.instagram-actor-id` | `Graph API - object_story_spec.instagram_actor_id` | Opcional, incluído apenas quando configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L118)) |
-| `facebook.creative.message-template` | `Graph API - object_story_spec.link_data.message` | Template com suporte a `%s` para o nome do experimento ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L134-L141)) |
-| `facebook.website-url` | `Graph API - link_data.link` e `call_to_action.value.link` | URL padrão de destino ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L118)) |
+| `worker-config.adAccountId` | `Graph API - URLs` | Define o Ad Account usado em todas as chamadas `POST` ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L38-L67)) |
+| `worker-config.accessToken` | `Graph API - access_token` | Token reutilizado em campanha, ad set, criativo e anúncio ([FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L18-L132)) |
+| `worker-config.adSet*` | `Graph API - adsets` | Define orçamento, otimização e país padrão ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L111)) |
+| `worker-config.defaultPageId` | `Graph API - promoted_object` / `object_story_spec.page_id` | Necessário para ad sets e criativos ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L119)) |
+| `worker-config.defaultInstagramActorId` | `Graph API - object_story_spec.instagram_actor_id` | Opcional, incluído apenas quando configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L118)) |
+| `worker-config.defaultCreativeMessageTemplate` | `Graph API - object_story_spec.link_data.message` | Template com suporte a `%s` para o nome do experimento ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L134-L141)) |
+| `worker-config.defaultWebsiteUrl` | `Graph API - link_data.link` e `call_to_action.value.link` | URL padrão de destino ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L118)) |
 | Resposta da Graph API (`id`) | `CreateCampaignRequest.id` | Persistido como identificador principal da campanha ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132)) |
 | Constante `OUTCOME_TRAFFIC` | `Graph API - objective` e `CreateCampaignRequest.objective` | Objetivo padrão até existir planejamento específico |
 | Constante `CAMPAIGN` | `CreateCampaignRequest.budgetMode` | Modo de orçamento usado atualmente pelo backend |

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -14,8 +14,8 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
 2. **Conjunto de anúncios** (`POST /adsets`) atrelado à campanha, também em
    `PAUSED`, com segmentação geográfica simples e destino `WEBSITE`.
 3. **Criativo** (`POST /adcreatives`) baseado em um `object_story_spec`
-   contendo `page_id` definido no experimento (ou o fallback configurado em
-   `facebook.page-id`), opcionalmente `instagram_actor_id`, mensagem e
+   contendo `page_id` definido no experimento (ou o fallback configurado na
+   conta selecionada no backend), opcionalmente `instagram_actor_id`, mensagem e
    call-to-action vindos do próprio criativo.
 4. **Anúncio** (`POST /ads`) que referencia o conjunto e o criativo recém
    criados, mantido pausado até que o time operacional revise os detalhes no
@@ -73,32 +73,32 @@ Caso a chamada à Graph API falhe, o backend recebe o status `FAILED` com a
 mensagem de erro no campo `tokenRenewalLastError`, mantendo o token anterior e
 exigindo uma ação manual.
 
-Os acessos são configurados pelas propriedades:
+## Configuração via backend
 
-- `backend.base-url` (default: `http://191.252.92.222:8000`)
-- `backend.api-prefix` (default: `/api`)
-- `facebook.ad-set.daily-budget` (default: `2000`, em centavos da moeda da
-  conta)
-- `facebook.ad-set.billing-event` (default: `IMPRESSIONS`)
-- `facebook.ad-set.optimization-goal` (default: `LINK_CLICKS`)
-- `facebook.ad-set.destination-type` (default: `WEBSITE`)
-- `facebook.ad-set.bid-strategy` (default: `LOWEST_COST_WITHOUT_CAP` – evita a
-  exigência de limites de lance em contas que utilizam estratégias de custo
-  máximo)
-- `facebook.ad-set.bid-amount` (opcional – defina um valor fixo de lance em
-  centavos quando a conta exigir)
-- `facebook.ad-set.target-country` (default: `BR`)
-- `facebook.page-id` (opcional – usado como fallback quando o criativo não define `pageId`)
-- `facebook.instagram-actor-id` (opcional)
-- `facebook.website-url` (sem default – obrigatório)
-- `facebook.graph-api.version` (default: `v23.0` – utilizado para montar os caminhos da Graph API)
-- `facebook.app-id` (opcional – obrigatório para renovação automática quando o token expira em produção)
-- `facebook.app-secret` (opcional – obrigatório para renovação automática quando o token expira em produção)
-- `facebook.creative.message-template` (default: `%s` – utiliza o nome do
-  experimento quando contém `%s`)
-- `facebook.creative.call-to-action-type` (default: `LEARN_MORE`)
-- `facebook.token-renewal.scheduler.delay` (default: `21600000`, em
-  milissegundos – intervalo entre as tentativas de renovação automática)
+O worker não lê mais variáveis de ambiente para parametrizar o Facebook. Todas
+as credenciais e defaults operacionais são preenchidos pela equipe através da
+tela **Contas do Facebook** no frontend. A conta marcada com "Utilizar esta
+conta no Facebook Ads Worker" é exposta pelo endpoint
+`GET /api/accounts/facebook/worker-config` e contém:
+
+- **Token de acesso de longa duração**, **App ID** e **App Secret** usados para
+  autenticação e renovação automática;
+- **ID da conta de anúncios**, **Página padrão**, **Instagram Actor ID**,
+  **URL padrão** e **call-to-action** utilizados como fallback quando o
+  experimento não define esses valores;
+- Parâmetros padrão do conjunto de anúncios (orçamento diário, billing event,
+  optimization goal, destination type, estratégia de lance, bid amount e país
+  alvo);
+- Template de mensagem do criativo (com suporte a `%s` para incluir o nome do
+  experimento).
+
+Ao carregar uma execução o `FacebookCampaignService` consulta essa configuração,
+sincroniza o token em memória (`FacebookAdsService`) e aplica todos os valores
+nas chamadas à Graph API. Dessa forma basta atualizar os campos na interface web
+para trocar de conta, ajustar orçamento ou modificar o destino padrão sem
+reiniciar o worker. As únicas propriedades externas mantidas em arquivo de
+configuração são `backend.base-url`, `backend.api-prefix` e
+`facebook.graph-api.version`.
 
 ## Data Model
 
@@ -137,12 +137,13 @@ O endpoint [`POST /{ad_account_id}/adcreatives`](https://developers.facebook.com
 exige um `page_id` válido no `object_story_spec` quando o criativo representa
 uma Página do Facebook. O worker agora busca o `pageId` diretamente no
 experimento, garantindo que todos os criativos compartilhem a mesma página e
-utilizando a propriedade `facebook.page-id` apenas como fallback. Caso nenhum
-destes valores esteja preenchido, a API responde com `error_subcode = 1443121`
-e a mensagem "A Página do Facebook está ausente". O fluxo é interrompido
-imediatamente, registrando o aviso em log. Preencha o campo `pageId` do
-experimento (ou configure o fallback) antes da próxima execução para que a
-criação seja bem sucedida.
+utilizando o fallback cadastrado na conta do backend apenas quando o experimento
+não informa uma página específica. Caso nenhum destes valores esteja
+preenchido, a API responde com `error_subcode = 1443121` e a mensagem "A Página
+do Facebook está ausente". O fluxo é interrompido imediatamente, registrando o
+aviso em log. Preencha o campo `pageId` do experimento (ou informe a página
+padrão na interface de contas) antes da próxima execução para que a criação seja
+bem sucedida.
 
 ### Erro `(#100) Invalid parameter` ao criar o conjunto de anúncios
 
@@ -151,27 +152,29 @@ de lance (`bid_cap`) ou metas de retorno (`ROAS`). Nesses casos, a Graph API
 responde com `error_subcode = 2490487` e a mensagem "Valor ou restrições de
 lance obrigatórios". Para manter o fluxo padrão funcional, o worker agora envia
 `bid_strategy = LOWEST_COST_WITHOUT_CAP` por default, estratégia que não exige
-valores adicionais. Caso sua conta utilize políticas diferentes, preencha
-`facebook.ad-set.bid-amount` com o lance desejado (em centavos) ou ajuste
-`facebook.ad-set.bid-strategy` para refletir a configuração do Gerenciador de
-Anúncios antes de reiniciar o serviço.
+valores adicionais. Caso sua conta utilize políticas diferentes, atualize os
+campos **Valor do lance (centavos, opcional)** e **Estratégia de lance** na tela
+**Contas do Facebook** do frontend para refletir a configuração real do
+Gerenciador de Anúncios. O backend persiste essas alterações e o worker passa a
+utilizar os novos valores automaticamente no ciclo seguinte, sem necessidade de
+reiniciar o serviço.
 
 ### Erro `(#190) OAuthException` indicando token expirado
 
 Quando o Facebook devolve `code = 190` com `error_subcode = 463/467` ou
-mensagem "Session has expired", o worker interpreta que o token configurado em
-`facebook.access-token` não é mais válido. O `FacebookCampaignService` interrompe
+mensagem "Session has expired", o worker interpreta que o token fornecido pelo
+backend não é mais válido. O `FacebookCampaignService` interrompe
 temporariamente a transformação de novos experimentos, registra o aviso apenas
 uma vez e delega a renovação para o `FacebookAccessTokenManager`. O serviço tenta
-renovar o token automaticamente via Graph API quando `facebook.app-id` e
-`facebook.app-secret` estão configurados. Em caso de sucesso, o novo token é
-aplicado sem reiniciar o worker e os experimentos voltam a ser processados na
-próxima execução. Caso a primeira tentativa falhe, o worker continua tentando a
+renovar o token automaticamente via Graph API quando `appId` e `appSecret` estão
+preenchidos na conta selecionada. Em caso de sucesso, o novo token é aplicado sem
+reiniciar o worker e os experimentos voltam a ser processados na próxima
+execução. Caso a primeira tentativa falhe, o worker continua tentando a
 renovação em cada ciclo agendado e retoma o processamento assim que obtiver um
 token válido novamente. Se a renovação automática estiver desabilitada ou falhar
 repetidamente, o log registra uma mensagem de erro com os detalhes retornados
-pela Graph API, orientando a atualizar o token manualmente e reiniciar o serviço
-após a substituição.
+pela Graph API, orientando a atualizar o token manualmente na interface e
+reiniciar o serviço após a substituição.
 
 ## Build
 ```

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAccessTokenManager.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAccessTokenManager.java
@@ -1,8 +1,8 @@
 package com.marketinghub.facebookadsworker;
 
+import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -11,26 +11,36 @@ public class FacebookAccessTokenManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(FacebookAccessTokenManager.class);
 
     private final FacebookAdsService facebookAdsService;
-    private final String appId;
-    private final String appSecret;
+    private final FacebookWorkerConfigurationClient configurationClient;
 
     public FacebookAccessTokenManager(
         FacebookAdsService facebookAdsService,
-        @Value("${facebook.app-id:}") String appId,
-        @Value("${facebook.app-secret:}") String appSecret
+        FacebookWorkerConfigurationClient configurationClient
     ) {
         this.facebookAdsService = facebookAdsService;
-        this.appId = normalize(appId);
-        this.appSecret = normalize(appSecret);
+        this.configurationClient = configurationClient;
     }
 
     public RenewalAttemptResult tryRenewAccessTokenIfPossible() {
-        if (!isConfigured()) {
-            LOGGER.debug("Skipping automatic Facebook token renewal because app credentials are missing");
+        var configuration = configurationClient.fetchConfiguration();
+        if (configuration.isEmpty()) {
+            LOGGER.debug("Skipping automatic Facebook token renewal because worker configuration is unavailable");
+            return new RenewalAttemptResult(RenewalOutcome.NOT_CONFIGURED, null, null);
+        }
+
+        String appId = normalize(configuration.get().appId());
+        String appSecret = normalize(configuration.get().appSecret());
+        if (!StringUtils.hasText(appId) || !StringUtils.hasText(appSecret)) {
+            LOGGER.debug("Skipping automatic Facebook token renewal because app credentials are missing in the worker configuration");
             return new RenewalAttemptResult(RenewalOutcome.NOT_CONFIGURED, null, null);
         }
 
         String currentToken = facebookAdsService.getCurrentAccessToken();
+        if (!StringUtils.hasText(currentToken)) {
+            LOGGER.warn("Skipping automatic Facebook token renewal because the current access token is not configured");
+            return new RenewalAttemptResult(RenewalOutcome.NOT_CONFIGURED, null, null);
+        }
+
         try {
             FacebookAdsService.TokenRenewalResponse response = facebookAdsService.renewLongLivedToken(
                 appId,
@@ -47,10 +57,6 @@ public class FacebookAccessTokenManager {
             LOGGER.error("Failed to renew Facebook access token automatically: {}", ex.getMessage(), ex);
             return new RenewalAttemptResult(RenewalOutcome.FAILED, null, ex.getMessage());
         }
-    }
-
-    private boolean isConfigured() {
-        return StringUtils.hasText(appId) && StringUtils.hasText(appSecret);
     }
 
     private String normalize(String value) {

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -18,9 +18,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+
+import static org.springframework.util.StringUtils.hasText;
 
 @Service
 public class FacebookAdsService {
@@ -33,11 +34,10 @@ public class FacebookAdsService {
 
     public FacebookAdsService(WebClient.Builder builder,
                               @Value("${facebook.graph-api.base-url:https://graph.facebook.com}") String baseUrl,
-                              @Value("${facebook.access-token}") String accessToken,
                               @Value("${facebook.graph-api.version:v23.0}") String apiVersion,
                               ObjectMapper objectMapper) {
         this.webClient = builder.baseUrl(baseUrl).build();
-        this.accessToken = new AtomicReference<>(Objects.requireNonNull(accessToken, "facebook.access-token"));
+        this.accessToken = new AtomicReference<>(null);
         this.apiVersion = normalizeVersion(apiVersion);
         this.objectMapper = objectMapper;
         LOGGER.info("Configured Facebook Graph API version: {}", this.apiVersion);
@@ -47,11 +47,21 @@ public class FacebookAdsService {
         return accessToken.get();
     }
 
+    private String requireAccessToken() {
+        String token = accessToken.get();
+        if (!hasText(token)) {
+            throw new IllegalStateException("Facebook access token is not configured");
+        }
+        return token;
+    }
+
     public void updateAccessToken(String newToken) {
-        Objects.requireNonNull(newToken, "newToken");
+        if (!hasText(newToken)) {
+            throw new IllegalArgumentException("newToken must not be blank");
+        }
         String maskedOldToken = maskAccessToken(accessToken.get());
         String maskedNewToken = maskAccessToken(newToken);
-        accessToken.set(newToken);
+        accessToken.set(newToken.trim());
         LOGGER.info(
             "Facebook access token updated: previousToken={}, newToken={}",
             maskedOldToken,
@@ -66,7 +76,7 @@ public class FacebookAdsService {
             "objective", "OUTCOME_TRAFFIC",
             "status", "PAUSED",
             "special_ad_categories", List.of(),
-            "access_token", getCurrentAccessToken()
+            "access_token", requireAccessToken()
         );
 
         JsonNode response = executePost(path, body);
@@ -102,7 +112,7 @@ public class FacebookAdsService {
         if (request.pageId() != null && !request.pageId().isBlank()) {
             body.put("promoted_object", Map.of("page_id", request.pageId()));
         }
-        body.put("access_token", getCurrentAccessToken());
+        body.put("access_token", requireAccessToken());
 
         String path = buildVersionedPath("/act_" + adAccountId + "/adsets");
 
@@ -137,7 +147,7 @@ public class FacebookAdsService {
         Map<String, Object> body = new HashMap<>();
         body.put("name", request.name());
         body.put("object_story_spec", objectStorySpec);
-        body.put("access_token", getCurrentAccessToken());
+        body.put("access_token", requireAccessToken());
 
         String path = buildVersionedPath("/act_" + adAccountId + "/adcreatives");
 
@@ -153,7 +163,7 @@ public class FacebookAdsService {
         body.put("adset_id", request.adSetId());
         body.put("creative", Map.of("creative_id", request.creativeId()));
         body.put("status", "PAUSED");
-        body.put("access_token", getCurrentAccessToken());
+        body.put("access_token", requireAccessToken());
 
         String path = buildVersionedPath("/act_" + adAccountId + "/ads");
 
@@ -162,7 +172,7 @@ public class FacebookAdsService {
     }
 
     public JsonNode getCampaignMetrics(String campaignId) {
-        String path = buildVersionedPath("/" + campaignId + "/insights?access_token=" + getCurrentAccessToken());
+        String path = buildVersionedPath("/" + campaignId + "/insights?access_token=" + requireAccessToken());
         String maskedPath = maskAccessTokenInPath(path);
         LOGGER.info("Sending GET request to Facebook API: path={}", maskedPath);
         try {

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
@@ -1,0 +1,79 @@
+package com.marketinghub.facebookadsworker.configuration;
+
+import com.marketinghub.facebookadsworker.util.UrlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+@Component
+public class FacebookWorkerConfigurationClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FacebookWorkerConfigurationClient.class);
+
+    private final WebClient backendClient;
+    private final String backendBaseUrl;
+    private final String apiPrefix;
+
+    public FacebookWorkerConfigurationClient(
+        WebClient.Builder builder,
+        @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
+        @Value("${backend.api-prefix:/api}") String apiPrefix
+    ) {
+        this.backendClient = builder.build();
+        this.backendBaseUrl = backendBaseUrl;
+        this.apiPrefix = apiPrefix;
+    }
+
+    public Optional<FacebookWorkerConfiguration> fetchConfiguration() {
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/accounts/facebook/worker-config");
+        try {
+            FacebookWorkerConfiguration configuration = backendClient
+                .get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(FacebookWorkerConfiguration.class)
+                .onErrorResume(WebClientResponseException.NotFound.class, ex -> {
+                    LOGGER.warn("Facebook worker configuration not found in backend; skipping Facebook automation");
+                    return Mono.empty();
+                })
+                .block();
+            return Optional.ofNullable(configuration);
+        } catch (WebClientResponseException ex) {
+            LOGGER.error(
+                "Failed to fetch Facebook worker configuration from backend: status={}, response={}",
+                ex.getRawStatusCode(),
+                ex.getResponseBodyAsString(),
+                ex
+            );
+        } catch (WebClientRequestException ex) {
+            LOGGER.error("Failed to fetch Facebook worker configuration from backend: {}", ex.getMessage(), ex);
+        }
+        return Optional.empty();
+    }
+
+    public record FacebookWorkerConfiguration(
+        Long accountId,
+        String adAccountId,
+        String accessToken,
+        String appId,
+        String appSecret,
+        String defaultPageId,
+        String defaultInstagramActorId,
+        String defaultWebsiteUrl,
+        String defaultCreativeMessageTemplate,
+        String defaultCallToActionType,
+        String adSetDailyBudget,
+        String adSetBillingEvent,
+        String adSetOptimizationGoal,
+        String adSetDestinationType,
+        String adSetBidStrategy,
+        String adSetBidAmount,
+        String adSetTargetCountry
+    ) {}
+}

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -4,6 +4,8 @@ import com.marketinghub.facebookadsworker.FacebookAccessTokenExpiredException;
 import com.marketinghub.facebookadsworker.FacebookAccessTokenManager;
 import com.marketinghub.facebookadsworker.FacebookAdsService;
 import com.marketinghub.facebookadsworker.FacebookPermissionException;
+import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient;
+import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient.FacebookWorkerConfiguration;
 import com.marketinghub.facebookadsworker.util.UrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +20,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,19 +34,7 @@ public class FacebookCampaignService {
     private final WebClient backendClient;
     private final String backendBaseUrl;
     private final String apiPrefix;
-    private final String adAccountId;
-    private final String adSetDailyBudget;
-    private final String adSetBillingEvent;
-    private final String adSetOptimizationGoal;
-    private final String adSetDestinationType;
-    private final String adSetBidStrategy;
-    private final String adSetBidAmount;
-    private final String adSetTargetCountry;
-    private final String defaultPageId;
-    private final String defaultInstagramActorId;
-    private final String defaultWebsiteUrl;
-    private final String defaultCreativeMessageTemplate;
-    private final String defaultCallToActionType;
+    private final FacebookWorkerConfigurationClient configurationClient;
     private final Set<Long> experimentsBlockedByPermissions;
     private final AtomicBoolean accessTokenExpired;
     private final AtomicBoolean accessTokenExpiryWarningLogged;
@@ -53,39 +44,15 @@ public class FacebookCampaignService {
     public FacebookCampaignService(FacebookAdsService facebookAdsService,
                                    FacebookAccessTokenManager accessTokenManager,
                                    WebClient.Builder builder,
+                                   FacebookWorkerConfigurationClient configurationClient,
                                    @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
-                                   @Value("${backend.api-prefix:/api}") String apiPrefix,
-                                   @Value("${facebook.ad-account-id}") String adAccountId,
-                                   @Value("${facebook.ad-set.daily-budget:1000}") String adSetDailyBudget,
-                                   @Value("${facebook.ad-set.billing-event:IMPRESSIONS}") String adSetBillingEvent,
-                                   @Value("${facebook.ad-set.optimization-goal:LINK_CLICKS}") String adSetOptimizationGoal,
-                                   @Value("${facebook.ad-set.destination-type:WEBSITE}") String adSetDestinationType,
-                                   @Value("${facebook.ad-set.bid-strategy:LOWEST_COST_WITHOUT_CAP}") String adSetBidStrategy,
-                                   @Value("${facebook.ad-set.bid-amount:}") String adSetBidAmount,
-                                   @Value("${facebook.ad-set.target-country:BR}") String adSetTargetCountry,
-                                   @Value("${facebook.page-id}") String pageId,
-                                   @Value("${facebook.instagram-actor-id:}") String instagramActorId,
-                                   @Value("${facebook.website-url}") String websiteUrl,
-                                   @Value("${facebook.creative.message-template:%s}") String creativeMessageTemplate,
-                                   @Value("${facebook.creative.call-to-action-type:LEARN_MORE}") String callToActionType) {
+                                   @Value("${backend.api-prefix:/api}") String apiPrefix) {
         this.facebookAdsService = facebookAdsService;
         this.accessTokenManager = accessTokenManager;
         this.backendClient = builder.build();
         this.backendBaseUrl = backendBaseUrl;
         this.apiPrefix = apiPrefix;
-        this.adAccountId = adAccountId;
-        this.adSetDailyBudget = adSetDailyBudget;
-        this.adSetBillingEvent = adSetBillingEvent;
-        this.adSetOptimizationGoal = adSetOptimizationGoal;
-        this.adSetDestinationType = adSetDestinationType;
-        this.adSetBidStrategy = adSetBidStrategy;
-        this.adSetBidAmount = adSetBidAmount;
-        this.adSetTargetCountry = adSetTargetCountry;
-        this.defaultPageId = pageId;
-        this.defaultInstagramActorId = instagramActorId;
-        this.defaultWebsiteUrl = websiteUrl;
-        this.defaultCreativeMessageTemplate = creativeMessageTemplate;
-        this.defaultCallToActionType = callToActionType;
+        this.configurationClient = configurationClient;
         this.experimentsBlockedByPermissions = ConcurrentHashMap.newKeySet();
         this.accessTokenExpired = new AtomicBoolean(false);
         this.accessTokenExpiryWarningLogged = new AtomicBoolean(false);
@@ -124,6 +91,28 @@ public class FacebookCampaignService {
             accessTokenExpiryWarningLogged.set(false);
         }
 
+        var configuration = configurationClient.fetchConfiguration();
+        if (configuration.isEmpty()) {
+            LOGGER.warn("Facebook worker configuration is unavailable; skipping campaign creation");
+            return;
+        }
+
+        FacebookWorkerConfiguration config = configuration.get();
+        String configuredToken = config.accessToken();
+        if (!StringUtils.hasText(configuredToken)) {
+            LOGGER.error("Facebook worker configuration is missing an access token; skipping campaign processing");
+            return;
+        }
+        String currentToken = facebookAdsService.getCurrentAccessToken();
+        if (!Objects.equals(configuredToken, currentToken)) {
+            try {
+                facebookAdsService.updateAccessToken(configuredToken);
+            } catch (IllegalArgumentException ex) {
+                LOGGER.error("Facebook worker configuration returned an invalid access token: {}", ex.getMessage());
+                return;
+            }
+        }
+
         List<Experiment> experiments = Collections.emptyList();
 
         try {
@@ -158,11 +147,11 @@ public class FacebookCampaignService {
                 );
                 return;
             }
-            processExperiment(exp);
+            processExperiment(exp, config);
         });
     }
 
-    private void processExperiment(Experiment exp) {
+    private void processExperiment(Experiment exp, FacebookWorkerConfiguration config) {
         try {
             Creative creative = resolveCreative(exp.id());
             if (creative == null) {
@@ -170,13 +159,13 @@ public class FacebookCampaignService {
                 return;
             }
 
-            String resolvedPageId = coalesce(exp.pageId(), defaultPageId);
+            String resolvedPageId = coalesce(exp.pageId(), config.defaultPageId());
             if (!StringUtils.hasText(resolvedPageId)) {
                 LOGGER.warn("Skipping experiment {} because no Facebook page ID is configured", exp.id());
                 return;
             }
 
-            String resolvedWebsiteUrl = coalesce(creative.destinationUrl(), defaultWebsiteUrl);
+            String resolvedWebsiteUrl = coalesce(creative.destinationUrl(), config.defaultWebsiteUrl());
             if (!StringUtils.hasText(resolvedWebsiteUrl)) {
                 LOGGER.warn("Skipping experiment {} because no destination URL is configured", exp.id());
                 return;
@@ -184,24 +173,24 @@ public class FacebookCampaignService {
 
             String resolvedMessage = StringUtils.hasText(creative.primaryText())
                 ? creative.primaryText()
-                : formatCreativeMessage(exp.name());
-            String resolvedCallToAction = coalesce(creative.cta(), defaultCallToActionType);
-            String resolvedInstagramActorId = coalesce(creative.instagramUserId(), defaultInstagramActorId);
+                : formatCreativeMessage(exp.name(), config);
+            String resolvedCallToAction = coalesce(creative.cta(), config.defaultCallToActionType());
+            String resolvedInstagramActorId = coalesce(creative.instagramUserId(), config.defaultInstagramActorId());
 
-            String campaignId = facebookAdsService.createCampaign(adAccountId, exp.name());
-            String adSetId = facebookAdsService.createAdSet(adAccountId, new FacebookAdsService.AdSetRequest(
+            String campaignId = facebookAdsService.createCampaign(config.adAccountId(), exp.name());
+            String adSetId = facebookAdsService.createAdSet(config.adAccountId(), new FacebookAdsService.AdSetRequest(
                 exp.name() + " - Ad Set",
                 campaignId,
-                adSetDailyBudget,
-                adSetBillingEvent,
-                adSetOptimizationGoal,
-                adSetDestinationType,
-                adSetBidStrategy,
-                adSetBidAmount,
+                config.adSetDailyBudget(),
+                config.adSetBillingEvent(),
+                config.adSetOptimizationGoal(),
+                config.adSetDestinationType(),
+                config.adSetBidStrategy(),
+                config.adSetBidAmount(),
                 resolvedPageId,
-                adSetTargetCountry
+                config.adSetTargetCountry()
             ));
-            String creativeId = facebookAdsService.createAdCreative(adAccountId, new FacebookAdsService.AdCreativeRequest(
+            String creativeId = facebookAdsService.createAdCreative(config.adAccountId(), new FacebookAdsService.AdCreativeRequest(
                 exp.name() + " - Creative",
                 resolvedPageId,
                 resolvedInstagramActorId,
@@ -211,12 +200,12 @@ public class FacebookCampaignService {
                 creative.headline(),
                 creative.description()
             ));
-            facebookAdsService.createAd(adAccountId, new FacebookAdsService.AdRequest(
+            facebookAdsService.createAd(config.adAccountId(), new FacebookAdsService.AdRequest(
                 exp.name() + " - Ad",
                 adSetId,
                 creativeId
             ));
-            CreateCampaignRequest req = new CreateCampaignRequest(campaignId, adAccountId, exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
+            CreateCampaignRequest req = new CreateCampaignRequest(campaignId, config.adAccountId(), exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
             backendClient.post()
                 .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns"))
                 .bodyValue(req)
@@ -281,14 +270,15 @@ public class FacebookCampaignService {
         return currentToken != null && !currentToken.equals(expiredToken);
     }
 
-    private String formatCreativeMessage(String experimentName) {
-        if (defaultCreativeMessageTemplate == null || defaultCreativeMessageTemplate.isBlank()) {
+    private String formatCreativeMessage(String experimentName, FacebookWorkerConfiguration config) {
+        String template = config.defaultCreativeMessageTemplate();
+        if (template == null || template.isBlank()) {
             return experimentName;
         }
-        if (defaultCreativeMessageTemplate.contains("%s")) {
-            return String.format(defaultCreativeMessageTemplate, experimentName);
+        if (template.contains("%s")) {
+            return String.format(template, experimentName);
         }
-        return defaultCreativeMessageTemplate;
+        return template;
     }
 
     public record Experiment(long id, String name, String pageId) {}

--- a/facebook-ads-worker/src/main/resources/application.properties
+++ b/facebook-ads-worker/src/main/resources/application.properties
@@ -1,17 +1,5 @@
 spring.application.name=facebook-ads-worker
 backend.base-url=http://191.252.92.222:8000
-instagramcampaign.scheduler.delay=60000
 backend.api-prefix=/api
-facebook.ad-set.daily-budget=2000
-facebook.ad-set.billing-event=IMPRESSIONS
-facebook.ad-set.optimization-goal=LINK_CLICKS
-facebook.ad-set.destination-type=WEBSITE
-facebook.ad-set.bid-strategy=LOWEST_COST_WITHOUT_CAP
-facebook.ad-set.bid-amount=
-facebook.ad-set.target-country=BR
-facebook.page-id=
-facebook.instagram-actor-id=
-facebook.website-url=https://example.com
-facebook.creative.message-template=%s
-facebook.creative.call-to-action-type=LEARN_MORE
+facebook.graph-api.version=v23.0
 

--- a/frontend/src/api/facebookAccountMutations.ts
+++ b/frontend/src/api/facebookAccountMutations.ts
@@ -14,6 +14,20 @@ export interface FacebookAccountPayload {
   businessManagerAppId?: string | null;
   appSecret?: string | null;
   tokenRenewalEnabled?: boolean;
+  adAccountId?: string | null;
+  defaultPageId?: string | null;
+  defaultWebsiteUrl?: string | null;
+  defaultInstagramActorId?: string | null;
+  defaultCreativeMessageTemplate?: string | null;
+  defaultCallToActionType?: string | null;
+  adSetDailyBudget?: string | null;
+  adSetBillingEvent?: string | null;
+  adSetOptimizationGoal?: string | null;
+  adSetDestinationType?: string | null;
+  adSetBidStrategy?: string | null;
+  adSetBidAmount?: string | null;
+  adSetTargetCountry?: string | null;
+  workerEnabled?: boolean;
 }
 
 export function useCreateFacebookAccount() {

--- a/frontend/src/api/useFacebookAccounts.ts
+++ b/frontend/src/api/useFacebookAccounts.ts
@@ -22,6 +22,20 @@ export interface FacebookAccount {
   tokenRenewalLastAttemptAt?: string | null;
   tokenRenewedAt?: string | null;
   tokenRenewalLastError?: string | null;
+  adAccountId?: string | null;
+  defaultPageId?: string | null;
+  defaultWebsiteUrl?: string | null;
+  defaultInstagramActorId?: string | null;
+  defaultCreativeMessageTemplate?: string | null;
+  defaultCallToActionType?: string | null;
+  adSetDailyBudget?: string | null;
+  adSetBillingEvent?: string | null;
+  adSetOptimizationGoal?: string | null;
+  adSetDestinationType?: string | null;
+  adSetBidStrategy?: string | null;
+  adSetBidAmount?: string | null;
+  adSetTargetCountry?: string | null;
+  workerEnabled?: boolean;
 }
 
 export function useFacebookAccounts() {

--- a/frontend/src/pages/FacebookAccountsPage.tsx
+++ b/frontend/src/pages/FacebookAccountsPage.tsx
@@ -27,6 +27,20 @@ interface AccountFormState {
   businessManagerAppId: string;
   appSecret: string;
   tokenRenewalEnabled: boolean;
+  adAccountId: string;
+  defaultPageId: string;
+  defaultWebsiteUrl: string;
+  defaultInstagramActorId: string;
+  defaultCreativeMessageTemplate: string;
+  defaultCallToActionType: string;
+  adSetDailyBudget: string;
+  adSetBillingEvent: string;
+  adSetOptimizationGoal: string;
+  adSetDestinationType: string;
+  adSetBidStrategy: string;
+  adSetBidAmount: string;
+  adSetTargetCountry: string;
+  workerEnabled: boolean;
   clearAppSecret: boolean;
 }
 
@@ -49,6 +63,20 @@ const emptyAccountForm: AccountFormState = {
   businessManagerAppId: "",
   appSecret: "",
   tokenRenewalEnabled: false,
+  adAccountId: "",
+  defaultPageId: "",
+  defaultWebsiteUrl: "",
+  defaultInstagramActorId: "",
+  defaultCreativeMessageTemplate: "%s",
+  defaultCallToActionType: "LEARN_MORE",
+  adSetDailyBudget: "",
+  adSetBillingEvent: "IMPRESSIONS",
+  adSetOptimizationGoal: "LINK_CLICKS",
+  adSetDestinationType: "WEBSITE",
+  adSetBidStrategy: "LOWEST_COST_WITHOUT_CAP",
+  adSetBidAmount: "",
+  adSetTargetCountry: "BR",
+  workerEnabled: false,
   clearAppSecret: false,
 };
 const emptyPageForm: PageFormState = { pageId: "", name: "" };
@@ -200,6 +228,25 @@ export default function FacebookAccountsPage() {
       appId: accountForm.appId.trim() || null,
       businessManagerAppId: accountForm.businessManagerAppId.trim() || null,
       tokenRenewalEnabled: accountForm.tokenRenewalEnabled,
+      adAccountId: accountForm.adAccountId.trim() || null,
+      defaultPageId: accountForm.defaultPageId.trim() || null,
+      defaultWebsiteUrl: accountForm.defaultWebsiteUrl.trim() || null,
+      defaultInstagramActorId:
+        accountForm.defaultInstagramActorId.trim() || null,
+      defaultCreativeMessageTemplate:
+        accountForm.defaultCreativeMessageTemplate.trim() || "%s",
+      defaultCallToActionType:
+        accountForm.defaultCallToActionType.trim() || "LEARN_MORE",
+      adSetDailyBudget: accountForm.adSetDailyBudget.trim() || null,
+      adSetBillingEvent: accountForm.adSetBillingEvent.trim() || null,
+      adSetOptimizationGoal:
+        accountForm.adSetOptimizationGoal.trim() || null,
+      adSetDestinationType:
+        accountForm.adSetDestinationType.trim() || null,
+      adSetBidStrategy: accountForm.adSetBidStrategy.trim() || null,
+      adSetBidAmount: accountForm.adSetBidAmount.trim() || null,
+      adSetTargetCountry: accountForm.adSetTargetCountry.trim() || null,
+      workerEnabled: accountForm.workerEnabled,
     };
     if (accountForm.clearAppSecret) {
       payload.appSecret = null;
@@ -375,6 +422,26 @@ export default function FacebookAccountsPage() {
                                     account.businessManagerAppId ?? "",
                                   appSecret: "",
                                   tokenRenewalEnabled: Boolean(account.tokenRenewalEnabled),
+                                  adAccountId: account.adAccountId ?? "",
+                                  defaultPageId: account.defaultPageId ?? "",
+                                  defaultWebsiteUrl: account.defaultWebsiteUrl ?? "",
+                                  defaultInstagramActorId:
+                                    account.defaultInstagramActorId ?? "",
+                                  defaultCreativeMessageTemplate:
+                                    account.defaultCreativeMessageTemplate ?? "%s",
+                                  defaultCallToActionType:
+                                    account.defaultCallToActionType ?? "LEARN_MORE",
+                                  adSetDailyBudget: account.adSetDailyBudget ?? "",
+                                  adSetBillingEvent: account.adSetBillingEvent ?? "IMPRESSIONS",
+                                  adSetOptimizationGoal:
+                                    account.adSetOptimizationGoal ?? "LINK_CLICKS",
+                                  adSetDestinationType:
+                                    account.adSetDestinationType ?? "WEBSITE",
+                                  adSetBidStrategy:
+                                    account.adSetBidStrategy ?? "LOWEST_COST_WITHOUT_CAP",
+                                  adSetBidAmount: account.adSetBidAmount ?? "",
+                                  adSetTargetCountry: account.adSetTargetCountry ?? "BR",
+                                  workerEnabled: Boolean(account.workerEnabled),
                                   clearAppSecret: false,
                                 });
                               }}
@@ -567,6 +634,232 @@ export default function FacebookAccountsPage() {
                     Mantenha o App ID e o App Secret atualizados para que o worker consiga solicitar um novo token antes do
                     vencimento.
                   </div>
+                </div>
+                <div className="col-12">
+                  <div className="form-check form-switch">
+                    <input
+                      className="form-check-input"
+                      type="checkbox"
+                      id="worker-enabled"
+                      checked={accountForm.workerEnabled}
+                      onChange={(event) =>
+                        setAccountForm((current) => ({
+                          ...current,
+                          workerEnabled: event.target.checked,
+                        }))
+                      }
+                      disabled={isAccountMutationPending}
+                    />
+                    <label className="form-check-label" htmlFor="worker-enabled">
+                      Utilizar esta conta no Facebook Ads Worker
+                    </label>
+                  </div>
+                  <div className="form-text">
+                    Apenas uma conta pode estar ativa no worker. Ao marcar esta opção, as demais contas serão desativadas.
+                  </div>
+                </div>
+                <div className="col-12">
+                  <hr />
+                  <h3 className="h6">Parâmetros padrão para criação de campanhas</h3>
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">ID da conta de anúncios (act_)</label>
+                  <input
+                    className="form-control"
+                    placeholder="Ex.: 123456789012345"
+                    value={accountForm.adAccountId}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        adAccountId: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Página padrão (ID)</label>
+                  <input
+                    className="form-control"
+                    placeholder="ID numérico da página"
+                    value={accountForm.defaultPageId}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        defaultPageId: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                  <div className="form-text">
+                    Utilizamos este valor quando o experimento não informa uma página específica.
+                  </div>
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Instagram Actor ID (opcional)</label>
+                  <input
+                    className="form-control"
+                    placeholder="ID do perfil profissional no Instagram"
+                    value={accountForm.defaultInstagramActorId}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        defaultInstagramActorId: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">URL padrão do site</label>
+                  <input
+                    type="url"
+                    className="form-control"
+                    placeholder="https://www.exemplo.com/landing-page"
+                    value={accountForm.defaultWebsiteUrl}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        defaultWebsiteUrl: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Template da mensagem do criativo</label>
+                  <input
+                    className="form-control"
+                    placeholder="Use %s para inserir o nome do experimento"
+                    value={accountForm.defaultCreativeMessageTemplate}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        defaultCreativeMessageTemplate: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Call to Action padrão</label>
+                  <input
+                    className="form-control"
+                    placeholder="LEARN_MORE, SIGN_UP, APPLY_NOW..."
+                    value={accountForm.defaultCallToActionType}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        defaultCallToActionType: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Orçamento diário do conjunto (centavos)</label>
+                  <input
+                    className="form-control"
+                    placeholder="Ex.: 2000 para R$ 20,00"
+                    value={accountForm.adSetDailyBudget}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        adSetDailyBudget: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Evento de cobrança</label>
+                  <input
+                    className="form-control"
+                    placeholder="IMPRESSIONS, LINK_CLICKS..."
+                    value={accountForm.adSetBillingEvent}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        adSetBillingEvent: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Objetivo de otimização</label>
+                  <input
+                    className="form-control"
+                    placeholder="LINK_CLICKS, REACH..."
+                    value={accountForm.adSetOptimizationGoal}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        adSetOptimizationGoal: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Tipo de destino</label>
+                  <input
+                    className="form-control"
+                    placeholder="WEBSITE, APP, MESSENGER..."
+                    value={accountForm.adSetDestinationType}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        adSetDestinationType: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Estratégia de lance</label>
+                  <input
+                    className="form-control"
+                    placeholder="LOWEST_COST_WITHOUT_CAP, COST_CAP..."
+                    value={accountForm.adSetBidStrategy}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        adSetBidStrategy: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Valor do lance (centavos, opcional)</label>
+                  <input
+                    className="form-control"
+                    placeholder="Informe apenas quando usar estratégias com limite"
+                    value={accountForm.adSetBidAmount}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        adSetBidAmount: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
+                </div>
+                <div className="col-12 col-md-6">
+                  <label className="form-label">País de destino</label>
+                  <input
+                    className="form-control"
+                    placeholder="Ex.: BR"
+                    value={accountForm.adSetTargetCountry}
+                    onChange={(event) =>
+                      setAccountForm((current) => ({
+                        ...current,
+                        adSetTargetCountry: event.target.value,
+                      }))
+                    }
+                    disabled={isAccountMutationPending}
+                  />
                 </div>
                 <div className="col-12 col-md-6">
                   <label className="form-label">ID do usuário autorizado</label>


### PR DESCRIPTION
## Summary
- remove the legacy Facebook Ads worker property defaults for ad account credentials and campaign fallbacks
- update the worker README to point operators to the frontend form when adjusting bid strategy and bid amount

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf0d83a488321a524bd607fc0fc21