### PR TITLE
Fix compile error by importing Objects in FacebookAdsService

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -176,6 +176,14 @@ repetidamente, o log registra uma mensagem de erro com os detalhes retornados
 pela Graph API, orientando a atualizar o token manualmente na interface e
 reiniciar o serviço após a substituição.
 
+### Erro de compilação `cannot find symbol: variable Objects`
+
+Ao adicionar novos métodos no `FacebookAdsService`, certifique-se de importar
+`java.util.Objects` quando utilizar `Objects.requireNonNull`. A ausência do
+import impede a compilação do módulo e exibe a mensagem acima. Após sincronizar
+o import, execute `mvn -s settings.xml compile` para validar o projeto antes de
+publicar o pacote.
+
 ## Build
 ```
 mvn -s settings.xml package

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
## Summary
- add the missing java.util.Objects import required by FacebookAdsService
- document the compilation failure pattern in the worker README for quick troubleshooting

## Testing
- mvn -q -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68dbb127496c83218e837b50a0a224be