### PR TITLE
Handle backend disconnects when loading Facebook config

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -73,6 +73,14 @@ Caso a chamada à Graph API falhe, o backend recebe o status `FAILED` com a
 mensagem de erro no campo `tokenRenewalLastError`, mantendo o token anterior e
 exigindo uma ação manual.
 
+### Falha momentânea ao consultar a configuração do backend
+
+Em ambientes instáveis pode ocorrer do backend encerrar a conexão HTTP antes de
+enviar a resposta do endpoint `GET /api/accounts/facebook/worker-config`. Nessa
+situação o worker registra apenas um aviso indicando a falha de comunicação e
+prossegue normalmente com o ciclo agendado, tentando novamente na próxima
+execução sem interromper o processamento de campanhas.
+
 ## Configuração via backend
 
 O worker não lê mais variáveis de ambiente para parametrizar o Facebook. Todas

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
@@ -4,11 +4,13 @@ import com.marketinghub.facebookadsworker.util.UrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.PrematureCloseException;
 
 import java.util.Optional;
 
@@ -52,7 +54,15 @@ public class FacebookWorkerConfigurationClient {
                 ex
             );
         } catch (WebClientRequestException ex) {
-            LOGGER.error("Failed to fetch Facebook worker configuration from backend: {}", ex.getMessage(), ex);
+            Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(ex);
+            if (rootCause instanceof PrematureCloseException) {
+                LOGGER.warn(
+                    "Failed to fetch Facebook worker configuration from backend: {}. Connection will be retried on the next cycle.",
+                    rootCause.getMessage()
+                );
+            } else {
+                LOGGER.error("Failed to fetch Facebook worker configuration from backend: {}", ex.getMessage(), ex);
+            }
         }
         return Optional.empty();
     }

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClientTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClientTest.java
@@ -1,0 +1,51 @@
+package com.marketinghub.facebookadsworker.configuration;
+
+import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient.FacebookWorkerConfiguration;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FacebookWorkerConfigurationClientTest {
+
+    private MockWebServer backend;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        backend = new MockWebServer();
+        backend.start();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        backend.shutdown();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenBackendClosesConnectionBeforeResponding() throws InterruptedException {
+        backend.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
+
+        FacebookWorkerConfigurationClient client = new FacebookWorkerConfigurationClient(
+            WebClient.builder(),
+            backend.url("/").toString(),
+            "/api"
+        );
+
+        Optional<FacebookWorkerConfiguration> configuration = client.fetchConfiguration();
+
+        assertThat(configuration).isEmpty();
+        var recordedRequest = backend.takeRequest(1, TimeUnit.SECONDS);
+        assertThat(recordedRequest).isNotNull();
+        assertThat(recordedRequest.getPath()).isEqualTo("/api/accounts/facebook/worker-config");
+    }
+}
+


### PR DESCRIPTION
## Summary
- downgrade the log level when the backend closes the configuration endpoint connection prematurely and keep retrying normally
- add a regression test that simulates the backend disconnecting before sending a response
- document the new behaviour in the Facebook Ads Worker README

## Testing
- mvn -s settings.xml test *(fails: unable to reach GitHub-hosted Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd0b42f208321a8e3a1fdae3a9845