### PR TITLE
Throttle repeated configuration warnings in Facebook worker

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -79,7 +79,14 @@ Em ambientes instáveis pode ocorrer do backend encerrar a conexão HTTP antes d
 enviar a resposta do endpoint `GET /api/accounts/facebook/worker-config`. Nessa
 situação o worker registra apenas um aviso indicando a falha de comunicação e
 prossegue normalmente com o ciclo agendado, tentando novamente na próxima
-execução sem interromper o processamento de campanhas.
+execução sem interromper o processamento de campanhas. Para evitar poluição dos
+logs, o aviso é emitido apenas uma vez enquanto a indisponibilidade persiste e é
+reabilitado automaticamente assim que o backend voltar a responder.
+
+Quando o backend ainda não possui uma conta marcada para o worker e responde
+`404 Not Found`, o serviço segue a mesma abordagem: registra o primeiro aviso e
+silencia tentativas subsequentes até que a configuração esteja disponível
+novamente.
 
 ## Configuração via backend
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
@@ -13,6 +13,7 @@ import reactor.core.publisher.Mono;
 import reactor.netty.http.client.PrematureCloseException;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Component
 public class FacebookWorkerConfigurationClient {
@@ -21,6 +22,8 @@ public class FacebookWorkerConfigurationClient {
     private final WebClient backendClient;
     private final String backendBaseUrl;
     private final String apiPrefix;
+    private final AtomicBoolean configurationNotFoundLogged;
+    private final AtomicBoolean prematureCloseWarningLogged;
 
     public FacebookWorkerConfigurationClient(
         WebClient.Builder builder,
@@ -30,6 +33,8 @@ public class FacebookWorkerConfigurationClient {
         this.backendClient = builder.build();
         this.backendBaseUrl = backendBaseUrl;
         this.apiPrefix = apiPrefix;
+        this.configurationNotFoundLogged = new AtomicBoolean(false);
+        this.prematureCloseWarningLogged = new AtomicBoolean(false);
     }
 
     public Optional<FacebookWorkerConfiguration> fetchConfiguration() {
@@ -41,10 +46,16 @@ public class FacebookWorkerConfigurationClient {
                 .retrieve()
                 .bodyToMono(FacebookWorkerConfiguration.class)
                 .onErrorResume(WebClientResponseException.NotFound.class, ex -> {
-                    LOGGER.warn("Facebook worker configuration not found in backend; skipping Facebook automation");
+                    if (configurationNotFoundLogged.compareAndSet(false, true)) {
+                        LOGGER.warn("Facebook worker configuration not found in backend; skipping Facebook automation");
+                    }
                     return Mono.empty();
                 })
                 .block();
+            if (configuration != null) {
+                configurationNotFoundLogged.set(false);
+                prematureCloseWarningLogged.set(false);
+            }
             return Optional.ofNullable(configuration);
         } catch (WebClientResponseException ex) {
             LOGGER.error(
@@ -56,10 +67,12 @@ public class FacebookWorkerConfigurationClient {
         } catch (WebClientRequestException ex) {
             Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(ex);
             if (rootCause instanceof PrematureCloseException) {
-                LOGGER.warn(
-                    "Failed to fetch Facebook worker configuration from backend: {}. Connection will be retried on the next cycle.",
-                    rootCause.getMessage()
-                );
+                if (prematureCloseWarningLogged.compareAndSet(false, true)) {
+                    LOGGER.warn(
+                        "Failed to fetch Facebook worker configuration from backend: {}. Connection will be retried on the next cycle.",
+                        rootCause.getMessage()
+                    );
+                }
             } else {
                 LOGGER.error("Failed to fetch Facebook worker configuration from backend: {}", ex.getMessage(), ex);
             }

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -40,6 +40,7 @@ public class FacebookCampaignService {
     private final AtomicBoolean accessTokenExpiryWarningLogged;
     private final AtomicReference<String> lastExpiredAccessToken;
     private final FacebookAccessTokenManager accessTokenManager;
+    private final AtomicBoolean configurationUnavailableWarningLogged;
 
     public FacebookCampaignService(FacebookAdsService facebookAdsService,
                                    FacebookAccessTokenManager accessTokenManager,
@@ -57,6 +58,7 @@ public class FacebookCampaignService {
         this.accessTokenExpired = new AtomicBoolean(false);
         this.accessTokenExpiryWarningLogged = new AtomicBoolean(false);
         this.lastExpiredAccessToken = new AtomicReference<>(null);
+        this.configurationUnavailableWarningLogged = new AtomicBoolean(false);
     }
 
     public void createCampaignsFromExperiments() {
@@ -93,9 +95,12 @@ public class FacebookCampaignService {
 
         var configuration = configurationClient.fetchConfiguration();
         if (configuration.isEmpty()) {
-            LOGGER.warn("Facebook worker configuration is unavailable; skipping campaign creation");
+            if (configurationUnavailableWarningLogged.compareAndSet(false, true)) {
+                LOGGER.warn("Facebook worker configuration is unavailable; skipping campaign creation");
+            }
             return;
         }
+        configurationUnavailableWarningLogged.set(false);
 
         FacebookWorkerConfiguration config = configuration.get();
         String configuredToken = config.accessToken();

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClientTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClientTest.java
@@ -1,5 +1,9 @@
 package com.marketinghub.facebookadsworker.configuration;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient.FacebookWorkerConfiguration;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -7,9 +11,11 @@ import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -46,6 +52,50 @@ class FacebookWorkerConfigurationClientTest {
         var recordedRequest = backend.takeRequest(1, TimeUnit.SECONDS);
         assertThat(recordedRequest).isNotNull();
         assertThat(recordedRequest.getPath()).isEqualTo("/api/accounts/facebook/worker-config");
+    }
+
+    @Test
+    void logsMissingConfigurationWarningOnlyOncePerOutage() {
+        backend.enqueue(new MockResponse().setResponseCode(404));
+        backend.enqueue(new MockResponse().setResponseCode(404));
+        backend.enqueue(new MockResponse()
+            .setBody("{\"accountId\":1,\"adAccountId\":\"act_1\",\"accessToken\":\"token\",\"appId\":\"app\",\"appSecret\":\"secret\","
+                + "\"defaultPageId\":\"42\",\"defaultInstagramActorId\":\"24\",\"defaultWebsiteUrl\":\"https://example.com\","
+                + "\"defaultCreativeMessageTemplate\":\"Conheça %s\",\"defaultCallToActionType\":\"LEARN_MORE\",\"adSetDailyBudget\":\"2000\","
+                + "\"adSetBillingEvent\":\"IMPRESSIONS\",\"adSetOptimizationGoal\":\"LINK_CLICKS\",\"adSetDestinationType\":\"WEBSITE\","
+                + "\"adSetBidStrategy\":\"LOWEST_COST_WITHOUT_CAP\",\"adSetBidAmount\":\"150\",\"adSetTargetCountry\":\"BR\"}")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueue(new MockResponse().setResponseCode(404));
+
+        FacebookWorkerConfigurationClient client = new FacebookWorkerConfigurationClient(
+            WebClient.builder(),
+            backend.url("/").toString(),
+            "/api"
+        );
+
+        Logger logger = (Logger) LoggerFactory.getLogger(FacebookWorkerConfigurationClient.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            assertThat(client.fetchConfiguration()).isEmpty();
+            assertThat(client.fetchConfiguration()).isEmpty();
+            assertThat(client.fetchConfiguration()).isPresent();
+            assertThat(client.fetchConfiguration()).isEmpty();
+
+            List<String> warnings = appender.list.stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+            assertThat(warnings)
+                .hasSize(2)
+                .allMatch(message -> message.equals("Facebook worker configuration not found in backend; skipping Facebook automation"));
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
     }
 }
 

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -1,5 +1,9 @@
 package com.marketinghub.facebookadsworker.facebookcampaign;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.facebookadsworker.FacebookAccessTokenManager;
@@ -13,10 +17,12 @@ import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 
@@ -139,6 +145,41 @@ class FacebookCampaignServiceTest {
 
         assertEquals(1, backend.getRequestCount());
         assertEquals(0, facebook.getRequestCount());
+    }
+
+    @Test
+    void logsConfigurationUnavailableWarningOnlyOncePerOutage() {
+        configurationClient.setConfiguration(null);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(FacebookCampaignService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            service.createCampaignsFromExperiments();
+            service.createCampaignsFromExperiments();
+
+            backend.enqueue(new MockResponse().setResponseCode(404));
+            configurationClient.setConfiguration(configurationWithAccessToken("token"));
+            service.createCampaignsFromExperiments();
+
+            configurationClient.setConfiguration(null);
+            service.createCampaignsFromExperiments();
+
+            List<ILoggingEvent> warnings = appender.list.stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .toList();
+
+            assertEquals(2, warnings.size());
+            warnings.forEach(event -> assertEquals(
+                "Facebook worker configuration is unavailable; skipping campaign creation",
+                event.getFormattedMessage()
+            ));
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- suppress repeated warnings when the backend configuration endpoint returns 404 or closes the connection so logs stay readable
- reset throttling once a configuration is retrieved successfully and update the documentation to reflect the behavior
- cover the new logging strategy with targeted unit tests for the client and campaign service

## Testing
- mvn -s settings.xml test *(fails: Network is unreachable when downloading org.springframework.boot:spring-boot-starter-parent from https://maven.pkg.github.com/paulofor/marketing-hub)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe0883eb4832192b1a68c1df2a9bb