### PR TITLE
Add logging for backend requests in Facebook Ads worker

### DIFF
--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -10,6 +10,8 @@
 - A versão da Graph API é configurável via propriedade `facebook.graph-api.version` (default `v23.0`) e deve estar alinhada com a recomendação oficial.
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.
 - Endpoints do backend devem ser acessados com o prefixo configurado em `backend.api-prefix` (default `/api`).
+- Sempre que chamar o backend registre logs com **URL completa**, parâmetros, payload enviado (quando existir) e a resposta recebida
+  para facilitar troubleshooting.
 - Em caso de erro de permissão do Facebook, o worker bloqueia o experimento em memória até que o serviço seja reiniciado.
 
 ## Serviços existentes

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -27,7 +27,9 @@ As chamadas ao backend utilizam o prefixo `/api`. O worker consome
 conexão ao recuperar os experimentos são registradas em log e ignoradas para
 que o agendamento continue saudável. Após criar campanha, conjunto, criativo e
 anúncio, o worker persiste o identificador da campanha via
-`POST /api/facebook-campaigns`.
+`POST /api/facebook-campaigns`. Todas as chamadas HTTP ao backend devem
+registrar a URL completa, parâmetros, payload e resposta recebida para
+acelerar o diagnóstico de incidentes em produção.
 
 Todas as chamadas à Graph API são logadas detalhadamente para facilitar
 investigações de erros (por exemplo, respostas `400 Bad Request`). Os logs

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.PrematureCloseException;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -39,6 +40,11 @@ public class FacebookWorkerConfigurationClient {
 
     public Optional<FacebookWorkerConfiguration> fetchConfiguration() {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/accounts/facebook/worker-config");
+        LOGGER.info(
+            "Requesting Facebook worker configuration from backend: url={}, params={}",
+            url,
+            Collections.emptyMap()
+        );
         try {
             FacebookWorkerConfiguration configuration = backendClient
                 .get()
@@ -49,9 +55,19 @@ public class FacebookWorkerConfigurationClient {
                     if (configurationNotFoundLogged.compareAndSet(false, true)) {
                         LOGGER.warn("Facebook worker configuration not found in backend; skipping Facebook automation");
                     }
+                    LOGGER.info(
+                        "Backend responded with HTTP 404 when fetching Facebook worker configuration: url={}, response={}",
+                        url,
+                        ex.getResponseBodyAsString()
+                    );
                     return Mono.empty();
                 })
                 .block();
+            LOGGER.info(
+                "Received Facebook worker configuration response from backend: url={}, response={}",
+                url,
+                configuration
+            );
             if (configuration != null) {
                 configurationNotFoundLogged.set(false);
                 prematureCloseWarningLogged.set(false);

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -119,10 +119,15 @@ public class FacebookCampaignService {
         }
 
         List<Experiment> experiments = Collections.emptyList();
-
+        String experimentsUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/experiments-ready");
+        LOGGER.info(
+            "Requesting experiments ready for Facebook campaigns from backend: url={}, params={}",
+            experimentsUrl,
+            Collections.emptyMap()
+        );
         try {
             experiments = backendClient.get()
-                .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/experiments-ready"))
+                .uri(experimentsUrl)
                 .exchangeToFlux(response -> {
                     if (response.statusCode().value() == HttpStatus.NOT_FOUND.value()) {
                         return Flux.empty();
@@ -136,8 +141,13 @@ public class FacebookCampaignService {
                 })
                 .collectList()
                 .block();
+            LOGGER.info(
+                "Received experiments response from backend: url={}, response={}",
+                experimentsUrl,
+                experiments
+            );
         } catch (WebClientRequestException ex) {
-            LOGGER.warn("Failed to fetch experiments from backend", ex);
+            LOGGER.warn("Failed to fetch experiments from backend: url={}", experimentsUrl, ex);
         }
 
         if (experiments == null || experiments.isEmpty()) {
@@ -211,12 +221,25 @@ public class FacebookCampaignService {
                 creativeId
             ));
             CreateCampaignRequest req = new CreateCampaignRequest(campaignId, config.adAccountId(), exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
+            String createCampaignUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns");
+            LOGGER.info(
+                "Reporting Facebook campaign creation to backend: url={}, params={}, payload={}",
+                createCampaignUrl,
+                Collections.emptyMap(),
+                req
+            );
             backendClient.post()
-                .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns"))
+                .uri(createCampaignUrl)
                 .bodyValue(req)
                 .retrieve()
                 .toBodilessEntity()
                 .block();
+            LOGGER.info(
+                "Successfully reported Facebook campaign creation to backend: url={}, experimentId={}, campaignId={}",
+                createCampaignUrl,
+                exp.id(),
+                campaignId
+            );
         } catch (FacebookPermissionException ex) {
             experimentsBlockedByPermissions.add(exp.id());
             LOGGER.warn(
@@ -291,6 +314,11 @@ public class FacebookCampaignService {
 
     private Creative resolveCreative(long experimentId) {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/creatives");
+        LOGGER.info(
+            "Requesting creatives for experiment from backend: url={}, params={}",
+            url,
+            Collections.emptyMap()
+        );
         try {
             List<Creative> creatives = backendClient.get()
                 .uri(url)
@@ -298,6 +326,11 @@ public class FacebookCampaignService {
                 .bodyToFlux(Creative.class)
                 .collectList()
                 .block();
+            LOGGER.info(
+                "Received creatives response from backend: url={}, response={}",
+                url,
+                creatives
+            );
             if (creatives == null || creatives.isEmpty()) {
                 return null;
             }
@@ -306,7 +339,7 @@ public class FacebookCampaignService {
                 .findFirst()
                 .orElse(creatives.get(0));
         } catch (Exception ex) {
-            LOGGER.warn("Failed to fetch creatives for experiment {}: {}", experimentId, ex.getMessage());
+            LOGGER.warn("Failed to fetch creatives for experiment {} from backend: url={}, message={}", experimentId, url, ex.getMessage());
             LOGGER.debug("Stacktrace while fetching creatives for experiment {}", experimentId, ex);
             return null;
         }
@@ -318,6 +351,11 @@ public class FacebookCampaignService {
 
     private void markExperimentAsFailed(long experimentId) {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/status?status=FAILED");
+        LOGGER.info(
+            "Marking experiment as FAILED in backend: url={}, params={}",
+            url,
+            Collections.emptyMap()
+        );
         try {
             backendClient.patch()
                 .uri(url)
@@ -326,7 +364,13 @@ public class FacebookCampaignService {
                 .block();
             LOGGER.info("Marked experiment {} as FAILED after Facebook permission error", experimentId);
         } catch (Exception ex) {
-            LOGGER.warn("Could not mark experiment {} as FAILED after Facebook permission error: {}", experimentId, ex.getMessage(), ex);
+            LOGGER.warn(
+                "Could not mark experiment {} as FAILED after Facebook permission error: url={}, message={}",
+                experimentId,
+                url,
+                ex.getMessage(),
+                ex
+            );
         }
     }
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
@@ -47,18 +47,31 @@ public class FacebookTokenRenewalService {
     }
 
     private List<FacebookAccountRenewalCandidate> fetchEligibleAccounts() {
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/accounts/facebook/renewal/eligible");
+        LOGGER.info(
+            "Requesting Facebook accounts eligible for token renewal from backend: url={}, params={}",
+            url,
+            Collections.emptyMap()
+        );
         try {
-            return backendClient
+            List<FacebookAccountRenewalCandidate> response = backendClient
                 .get()
-                .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/accounts/facebook/renewal/eligible"))
+                .uri(url)
                 .retrieve()
                 .bodyToFlux(FacebookAccountRenewalCandidate.class)
                 .collectList()
                 .blockOptional()
                 .orElse(Collections.emptyList());
+            LOGGER.info(
+                "Received eligible Facebook accounts response from backend: url={}, response={}",
+                url,
+                response
+            );
+            return response;
         } catch (WebClientResponseException | WebClientRequestException ex) {
             LOGGER.error(
-                "Failed to fetch Facebook accounts for token renewal: status={}, message={}",
+                "Failed to fetch Facebook accounts for token renewal: url={}, status={}, message={}",
+                url,
                 ex instanceof WebClientResponseException responseException ? responseException.getRawStatusCode() : "N/A",
                 ex.getMessage(),
                 ex
@@ -132,18 +145,31 @@ public class FacebookTokenRenewalService {
 
     private void reportResult(Long accountId, RenewalResultPayload payload) {
         String path = "/accounts/facebook/" + accountId + "/token/renewal";
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, path);
+        LOGGER.info(
+            "Reporting Facebook token renewal result to backend: url={}, params={}, payload={}",
+            url,
+            Collections.emptyMap(),
+            payload
+        );
         try {
             backendClient
                 .post()
-                .uri(UrlUtils.joinPath(backendBaseUrl, apiPrefix, path))
+                .uri(url)
                 .bodyValue(payload)
                 .retrieve()
                 .toBodilessEntity()
                 .block();
+            LOGGER.info(
+                "Successfully reported Facebook token renewal result to backend: url={}, accountId={}",
+                url,
+                accountId
+            );
         } catch (WebClientResponseException | WebClientRequestException ex) {
             LOGGER.error(
-                "Failed to report token renewal result to backend for account {}: status={}, message={}",
+                "Failed to report token renewal result to backend for account {}: url={}, status={}, message={}",
                 accountId,
+                url,
                 ex instanceof WebClientResponseException responseException ? responseException.getRawStatusCode() : "N/A",
                 ex.getMessage(),
                 ex


### PR DESCRIPTION
## Summary
- log backend URL, parameters, payload and responses across Facebook Ads worker clients and services
- document the logging requirement for backend calls in the module guidelines and README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf84fcf2c8321b7c7a6f9baeac25d