### PR TITLE
Surface Facebook automation diagnostics in UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookConfigurationController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookConfigurationController.java
@@ -1,24 +1,256 @@
 package com.marketinghub.facebookads.web;
 
+import com.marketinghub.ads.FacebookAccount;
+import com.marketinghub.ads.FacebookAccountRepository;
 import com.marketinghub.ads.FacebookPageRepository;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 @RestController
 @RequestMapping("/api/facebook")
 public class FacebookConfigurationController {
     private final FacebookPageRepository pageRepository;
+    private final FacebookAccountRepository accountRepository;
 
-    public FacebookConfigurationController(FacebookPageRepository pageRepository) {
+    public FacebookConfigurationController(
+        FacebookPageRepository pageRepository,
+        FacebookAccountRepository accountRepository
+    ) {
         this.pageRepository = pageRepository;
+        this.accountRepository = accountRepository;
     }
 
     @GetMapping("/configuration-status")
     public FacebookConfigurationStatus configurationStatus() {
         boolean hasConfiguredPages = pageRepository.count() > 0;
-        return new FacebookConfigurationStatus(hasConfiguredPages);
+        List<FacebookAccount> accounts = accountRepository.findAll();
+        FacebookConfigurationStatus.WorkerDiagnostics worker = buildWorkerDiagnostics(accounts);
+        FacebookConfigurationStatus.TokenRenewalDiagnostics tokenRenewal = buildTokenRenewalDiagnostics(accounts);
+        return new FacebookConfigurationStatus(hasConfiguredPages, worker, tokenRenewal);
     }
 
-    public record FacebookConfigurationStatus(boolean hasConfiguredPages) {}
+    private FacebookConfigurationStatus.WorkerDiagnostics buildWorkerDiagnostics(List<FacebookAccount> accounts) {
+        FacebookAccount workerAccount = accounts
+            .stream()
+            .filter(FacebookAccount::isWorkerEnabled)
+            .findFirst()
+            .orElse(null);
+
+        if (workerAccount == null) {
+            List<FacebookConfigurationStatus.DiagnosticMessage> messages = List.of(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "NO_WORKER_ACCOUNT",
+                    "Nenhuma conta está habilitada no Facebook Ads Worker. Acesse Contas do Facebook e marque a opção \"Utilizar esta conta no worker\"."
+                )
+            );
+            return new FacebookConfigurationStatus.WorkerDiagnostics(false, false, null, null, messages);
+        }
+
+        List<FacebookConfigurationStatus.DiagnosticMessage> messages = new ArrayList<>();
+        if (!StringUtils.hasText(workerAccount.getAccessToken())) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "ACCESS_TOKEN_MISSING",
+                    "Informe um token de acesso válido na conta selecionada para o worker."
+                )
+            );
+        }
+        if (!StringUtils.hasText(workerAccount.getAdAccountId())) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "AD_ACCOUNT_ID_MISSING",
+                    "Preencha o ID da conta de anúncios (act_...) na conta ativa do worker."
+                )
+            );
+        }
+        if (!StringUtils.hasText(workerAccount.getDefaultWebsiteUrl())) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "DEFAULT_WEBSITE_URL_MISSING",
+                    "Informe a URL padrão do site para que o worker possa criar anúncios."
+                )
+            );
+        }
+        if (!StringUtils.hasText(workerAccount.getAdSetDailyBudget())) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "AD_SET_DAILY_BUDGET_MISSING",
+                    "Defina o orçamento diário do conjunto de anúncios em centavos."
+                )
+            );
+        }
+        if (!StringUtils.hasText(workerAccount.getAdSetBillingEvent())) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "AD_SET_BILLING_EVENT_MISSING",
+                    "Informe o evento de cobrança padrão (por exemplo, IMPRESSIONS)."
+                )
+            );
+        }
+        if (!StringUtils.hasText(workerAccount.getAdSetOptimizationGoal())) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "AD_SET_OPTIMIZATION_GOAL_MISSING",
+                    "Defina o objetivo de otimização do conjunto (por exemplo, LINK_CLICKS)."
+                )
+            );
+        }
+        if (!StringUtils.hasText(workerAccount.getAdSetDestinationType())) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "AD_SET_DESTINATION_TYPE_MISSING",
+                    "Informe o tipo de destino padrão (WEBSITE, APP, MESSENGER...)."
+                )
+            );
+        }
+        if (!StringUtils.hasText(workerAccount.getAdSetTargetCountry())) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "AD_SET_TARGET_COUNTRY_MISSING",
+                    "Informe pelo menos um país de segmentação para o conjunto de anúncios."
+                )
+            );
+        }
+
+        boolean ready = messages.isEmpty();
+        return new FacebookConfigurationStatus.WorkerDiagnostics(
+            true,
+            ready,
+            workerAccount.getId(),
+            workerAccount.getName(),
+            messages
+        );
+    }
+
+    private FacebookConfigurationStatus.TokenRenewalDiagnostics buildTokenRenewalDiagnostics(List<FacebookAccount> accounts) {
+        List<FacebookAccount> enabledAccounts = accounts
+            .stream()
+            .filter(FacebookAccount::isTokenRenewalEnabled)
+            .toList();
+
+        List<FacebookConfigurationStatus.TokenRenewalAccountStatus> statuses = enabledAccounts
+            .stream()
+            .map(this::buildTokenRenewalAccountStatus)
+            .toList();
+
+        long eligibleCount = statuses
+            .stream()
+            .filter(FacebookConfigurationStatus.TokenRenewalAccountStatus::eligible)
+            .count();
+
+        return new FacebookConfigurationStatus.TokenRenewalDiagnostics(
+            enabledAccounts.size(),
+            (int) eligibleCount,
+            statuses
+        );
+    }
+
+    private FacebookConfigurationStatus.TokenRenewalAccountStatus buildTokenRenewalAccountStatus(
+        FacebookAccount account
+    ) {
+        List<FacebookConfigurationStatus.DiagnosticMessage> messages = new ArrayList<>();
+
+        boolean hasAccessToken = StringUtils.hasText(account.getAccessToken());
+        if (!hasAccessToken) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "ACCESS_TOKEN_MISSING",
+                    "Informe um token de acesso válido para permitir a renovação automática."
+                )
+            );
+        }
+
+        boolean hasAppId = StringUtils.hasText(account.getAppId());
+        if (!hasAppId) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "APP_ID_MISSING",
+                    "Cadastre o App ID do Facebook utilizado para gerar o token."
+                )
+            );
+        }
+
+        boolean hasAppSecret = account.hasAppSecret();
+        if (!hasAppSecret) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "APP_SECRET_MISSING",
+                    "Informe o App Secret para que possamos renovar o token automaticamente."
+                )
+            );
+        }
+
+        boolean renewalRequired = account.isTokenRenewalRequired();
+        boolean eligible = hasAccessToken && hasAppId && hasAppSecret && renewalRequired;
+
+        if (eligible) {
+            messages.add(
+                new FacebookConfigurationStatus.DiagnosticMessage(
+                    "READY",
+                    "Pronto para renovação automática. O worker atualizará este token quando necessário."
+                )
+            );
+        } else if (hasAccessToken && hasAppId && hasAppSecret && !renewalRequired) {
+            Long expiresInDays = account.getTokenExpiresInDays();
+            String detail;
+            if (expiresInDays == null) {
+                detail = "O token atual não possui data de expiração informada. O worker aguardará até que haja necessidade de renovação.";
+            } else if (expiresInDays > 1) {
+                detail = String.format(
+                    Locale.ROOT,
+                    "Token válido por mais %d dias. A renovação automática acontecerá quando estiver próximo do vencimento.",
+                    expiresInDays
+                );
+            } else if (expiresInDays == 1) {
+                detail = "Token válido por mais 1 dia. A renovação automática será tentada na próxima execução.";
+            } else if (expiresInDays == 0) {
+                detail = "Token vence hoje. A renovação automática será tentada na próxima execução.";
+            } else {
+                detail = "Token já expirado. O worker tentará renovar na próxima execução.";
+            }
+            messages.add(new FacebookConfigurationStatus.DiagnosticMessage("WAITING_THRESHOLD", detail));
+        }
+
+        return new FacebookConfigurationStatus.TokenRenewalAccountStatus(
+            account.getId(),
+            account.getName(),
+            eligible,
+            messages
+        );
+    }
+
+    public record FacebookConfigurationStatus(
+        boolean hasConfiguredPages,
+        WorkerDiagnostics worker,
+        TokenRenewalDiagnostics tokenRenewal
+    ) {
+        public record WorkerDiagnostics(
+            boolean hasAccount,
+            boolean ready,
+            Long accountId,
+            String accountName,
+            List<DiagnosticMessage> messages
+        ) {}
+
+        public record TokenRenewalDiagnostics(
+            int enabledAccounts,
+            int eligibleAccounts,
+            List<TokenRenewalAccountStatus> accounts
+        ) {}
+
+        public record TokenRenewalAccountStatus(
+            Long accountId,
+            String accountName,
+            boolean eligible,
+            List<DiagnosticMessage> messages
+        ) {}
+
+        public record DiagnosticMessage(String code, String message) {}
+    }
 }

--- a/frontend/src/api/useFacebookConfigurationStatus.ts
+++ b/frontend/src/api/useFacebookConfigurationStatus.ts
@@ -1,8 +1,36 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 
+export interface DiagnosticMessage {
+  code: string;
+  message: string;
+}
+
+export interface WorkerDiagnostics {
+  hasAccount: boolean;
+  ready: boolean;
+  accountId: number | null;
+  accountName: string | null;
+  messages: DiagnosticMessage[];
+}
+
+export interface TokenRenewalAccountStatus {
+  accountId: number;
+  accountName: string;
+  eligible: boolean;
+  messages: DiagnosticMessage[];
+}
+
+export interface TokenRenewalDiagnostics {
+  enabledAccounts: number;
+  eligibleAccounts: number;
+  accounts: TokenRenewalAccountStatus[];
+}
+
 export interface FacebookConfigurationStatus {
   hasConfiguredPages: boolean;
+  worker: WorkerDiagnostics;
+  tokenRenewal: TokenRenewalDiagnostics;
 }
 
 export function useFacebookConfigurationStatus() {

--- a/frontend/src/components/FacebookAutomationAlerts.tsx
+++ b/frontend/src/components/FacebookAutomationAlerts.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import type { FacebookConfigurationStatus } from "../api/useFacebookConfigurationStatus";
+
+interface FacebookAutomationAlertsProps {
+  status?: FacebookConfigurationStatus;
+}
+
+export default function FacebookAutomationAlerts({
+  status,
+}: FacebookAutomationAlertsProps) {
+  if (!status) {
+    return null;
+  }
+
+  const alerts: ReactNode[] = [];
+
+  const worker = status.worker;
+  const hasWorkerIssues = !worker.ready || !worker.hasAccount;
+  if (hasWorkerIssues) {
+    alerts.push(
+      <div
+        key="worker"
+        className="alert alert-warning d-flex align-items-start gap-2"
+        role="alert"
+      >
+        <AlertTriangle size={18} className="mt-1" aria-hidden="true" />
+        <div>
+          <div className="fw-semibold mb-1">
+            O Facebook Ads Worker está bloqueado
+          </div>
+          <ul className="mb-2 ps-3">
+            {worker.messages.map((message) => (
+              <li key={message.code}>{message.message}</li>
+            ))}
+          </ul>
+          <Link className="btn btn-sm btn-outline-primary" to="/accounts/facebook">
+            Revisar contas do Facebook
+          </Link>
+        </div>
+      </div>,
+    );
+  }
+
+  const tokenRenewal = status.tokenRenewal;
+  if (tokenRenewal.enabledAccounts === 0) {
+    alerts.push(
+      <div
+        key="token-renewal-disabled"
+        className="alert alert-warning d-flex align-items-start gap-2"
+        role="alert"
+      >
+        <AlertTriangle size={18} className="mt-1" aria-hidden="true" />
+        <div>
+          <div className="fw-semibold mb-1">
+            Renovação automática desativada
+          </div>
+          <p className="mb-2">
+            Nenhuma conta está com a renovação automática habilitada. Ative a opção
+            nas contas relevantes para que o worker atualize os tokens antes do
+            vencimento.
+          </p>
+          <Link className="btn btn-sm btn-outline-primary" to="/accounts/facebook">
+            Configurar renovação automática
+          </Link>
+        </div>
+      </div>,
+    );
+  } else if (tokenRenewal.eligibleAccounts === 0) {
+    const accountsWithIssues = tokenRenewal.accounts.filter(
+      (account) => !account.eligible,
+    );
+
+    if (accountsWithIssues.length > 0) {
+      alerts.push(
+        <div
+          key="token-renewal-issues"
+          className="alert alert-warning d-flex align-items-start gap-2"
+          role="alert"
+        >
+          <AlertTriangle size={18} className="mt-1" aria-hidden="true" />
+          <div>
+            <div className="fw-semibold mb-1">
+              Tokens não serão renovados automaticamente
+            </div>
+            <ul className="mb-2 ps-3">
+              {accountsWithIssues.map((account) => (
+                <li key={account.accountId}>
+                  <span className="fw-semibold">{account.accountName}:</span>
+                  <ul className="mb-1 ps-3">
+                    {account.messages.map((message) => (
+                      <li key={message.code}>{message.message}</li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+            <Link className="btn btn-sm btn-outline-primary" to="/accounts/facebook">
+              Ajustar dados de renovação
+            </Link>
+          </div>
+        </div>,
+      );
+    }
+  }
+
+  if (alerts.length === 0) {
+    return null;
+  }
+
+  return <div className="d-flex flex-column gap-3">{alerts}</div>;
+}

--- a/frontend/src/pages/FacebookAccountsPage.tsx
+++ b/frontend/src/pages/FacebookAccountsPage.tsx
@@ -15,6 +15,8 @@ import {
   useDeleteFacebookPage,
   useUpdateFacebookPage,
 } from "../api/facebookPageMutations";
+import { useFacebookConfigurationStatus } from "../api/useFacebookConfigurationStatus";
+import FacebookAutomationAlerts from "../components/FacebookAutomationAlerts";
 
 interface FinancialStrategyFormState {
   dailyBudget: string;
@@ -208,6 +210,8 @@ export default function FacebookAccountsPage() {
     [accounts],
   );
 
+  const { data: configuration } = useFacebookConfigurationStatus();
+
   const accountBeingEdited = useMemo(
     () =>
       typeof accountForm.id === "number"
@@ -331,6 +335,7 @@ export default function FacebookAccountsPage() {
   return (
     <div>
       <PageTitle>Contas do Facebook</PageTitle>
+      <FacebookAutomationAlerts status={configuration} />
       {accountsNeedingRenewal.length > 0 && (
         <div className="alert alert-warning" role="alert">
           <h2 className="h6 mb-2">Renovação de token necessária</h2>

--- a/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
+++ b/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, CheckCircle2 } from "lucide-react";
 import { useFacebookCampaignExperiments } from "../../api/useFacebookCampaignExperiments";
 import PageTitle from "../../components/PageTitle";
 import { useFacebookConfigurationStatus } from "../../api/useFacebookConfigurationStatus";
+import FacebookAutomationAlerts from "../../components/FacebookAutomationAlerts";
 import { getMissingConfigurationLabel } from "./missingConfigurationLabels";
 
 export default function FacebookCampaignExperimentsPage() {
@@ -24,6 +25,7 @@ export default function FacebookCampaignExperimentsPage() {
           </div>
         </div>
       ) : null}
+      <FacebookAutomationAlerts status={configuration} />
       <div className="btn-group mb-3">
         <button
           className={`btn btn-outline-primary${status === "PLANNED" ? " active" : ""}`}

--- a/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
+++ b/frontend/src/pages/facebook/FacebookExperimentsReadyPage.tsx
@@ -15,6 +15,7 @@ import {
 import PageTitle from "../../components/PageTitle";
 import { useFacebookReadyExperiments } from "../../api/useFacebookReadyExperiments";
 import { useFacebookConfigurationStatus } from "../../api/useFacebookConfigurationStatus";
+import FacebookAutomationAlerts from "../../components/FacebookAutomationAlerts";
 import "./FacebookExperimentsReadyPage.css";
 import { getMissingConfigurationLabel } from "./missingConfigurationLabels";
 
@@ -53,6 +54,7 @@ export default function FacebookExperimentsReadyPage() {
           </div>
         </div>
       ) : null}
+      <FacebookAutomationAlerts status={configuration} />
       <div className="experiments-ready-toolbar">
         <span className="experiments-ready-toolbar-title">
           <Flag size={18} className="text-primary" />


### PR DESCRIPTION
## Summary
- extend the Facebook configuration status endpoint with worker and token renewal diagnostics
- add a reusable frontend alert component to explain missing worker configuration and renewal issues
- surface these diagnostics on Facebook account and campaign pages so users can resolve automation blockers

## Testing
- mvn test | tail -n 20
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbff9ecd248321baaeaaa4b11c23d7