### PR TITLE
Ensure Facebook app secret flag is exposed

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
@@ -1,5 +1,6 @@
 package com.marketinghub.ads;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -153,7 +154,8 @@ public class FacebookAccount {
     }
 
     @Transient
-    @JsonProperty("hasAppSecret")
+    @JsonGetter("hasAppSecret")
+    @JsonProperty(value = "hasAppSecret", access = JsonProperty.Access.READ_ONLY)
     public boolean hasAppSecret() {
         return appSecret != null && !appSecret.isBlank();
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -100,6 +100,23 @@ public class FacebookAccountControllerTest {
     }
 
     @Test
+    void shouldExposeHasAppSecretFlagAfterSavingSecret() throws Exception {
+        repository.deleteAll();
+
+        repository.save(FacebookAccount.builder()
+            .name("Conta com segredo")
+            .currency("BRL")
+            .appSecret("segredo-armazenado")
+            .build());
+
+        mockMvc.perform(get("/api/accounts/facebook"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].hasAppSecret").value(true));
+
+        repository.deleteAll();
+    }
+
+    @Test
     void shouldReturnAccountsEligibleForRenewal() throws Exception {
         FacebookAccount eligible = repository.save(FacebookAccount.builder()
             .name("Eligible")


### PR DESCRIPTION
## Summary
- expose the Facebook account `hasAppSecret` flag via a dedicated JSON getter so the frontend can detect stored secrets
- add a controller test that verifies the flag is returned after persisting an app secret

## Testing
- mvn -s ../settings.xml test -Dtest=FacebookAccountControllerTest#shouldPersistAppCredentialsOnCreate *(fails: unable to resolve Spring Boot parent due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0bb8f9ac8321b64741101e139660