### PR TITLE
Clarify Facebook worker requirements

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -1,5 +1,7 @@
 package com.marketinghub.ads;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
@@ -12,6 +14,7 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/accounts/facebook")
 public class FacebookAccountController {
+    private static final Logger log = LoggerFactory.getLogger(FacebookAccountController.class);
     private final FacebookAccountRepository repository;
 
     public FacebookAccountController(FacebookAccountRepository repository) {
@@ -251,30 +254,52 @@ public class FacebookAccountController {
     }
 
     private void validateWorkerConfiguration(FacebookAccount account) {
-        if (!StringUtils.hasText(account.getAccessToken())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing access token");
+        requireField(account, account.getAccessToken(), "access token", "Facebook worker account is missing access token");
+        requireField(account, account.getAdAccountId(), "ad account id", "Facebook worker account is missing ad account id");
+        requireField(
+            account,
+            account.getDefaultWebsiteUrl(),
+            "default website URL",
+            "Facebook worker account is missing default website URL"
+        );
+        requireField(
+            account,
+            account.getAdSetDailyBudget(),
+            "ad set daily budget",
+            "Facebook worker account is missing ad set daily budget"
+        );
+        requireField(
+            account,
+            account.getAdSetBillingEvent(),
+            "ad set billing event",
+            "Facebook worker account is missing ad set billing event"
+        );
+        requireField(
+            account,
+            account.getAdSetOptimizationGoal(),
+            "ad set optimization goal",
+            "Facebook worker account is missing ad set optimization goal"
+        );
+        requireField(
+            account,
+            account.getAdSetDestinationType(),
+            "ad set destination type",
+            "Facebook worker account is missing ad set destination type"
+        );
+        requireField(account, account.getAdSetTargetCountry(), "target country", "Facebook worker account is missing target country");
+    }
+
+    private void requireField(FacebookAccount account, String value, String fieldDescription, String errorMessage) {
+        if (StringUtils.hasText(value)) {
+            return;
         }
-        if (!StringUtils.hasText(account.getAdAccountId())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing ad account id");
-        }
-        if (!StringUtils.hasText(account.getDefaultWebsiteUrl())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing default website URL");
-        }
-        if (!StringUtils.hasText(account.getAdSetDailyBudget())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing ad set daily budget");
-        }
-        if (!StringUtils.hasText(account.getAdSetBillingEvent())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing ad set billing event");
-        }
-        if (!StringUtils.hasText(account.getAdSetOptimizationGoal())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing ad set optimization goal");
-        }
-        if (!StringUtils.hasText(account.getAdSetDestinationType())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing ad set destination type");
-        }
-        if (!StringUtils.hasText(account.getAdSetTargetCountry())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook worker account is missing target country");
-        }
+        log.warn(
+            "Facebook worker configuration validation failed for account id={} name='{}': missing {}.",
+            account.getId(),
+            StringUtils.hasText(account.getName()) ? account.getName() : "(unnamed)",
+            fieldDescription
+        );
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errorMessage);
     }
 
     private static String trim(String value) {

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -19,8 +19,8 @@ server.port=8000
 
 # Enable detailed Hibernate logging
 logging.level.org.hibernate.SQL=DEBUG
-logging.level.org.hibernate.orm.jdbc.bind=TRACE
-logging.level.org.hibernate.type=TRACE
+logging.level.org.hibernate.orm.jdbc.bind=INFO
+logging.level.org.hibernate.type=INFO
 
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 # Enable detailed Liquibase logging

--- a/frontend/src/pages/FacebookAccountsPage.tsx
+++ b/frontend/src/pages/FacebookAccountsPage.tsx
@@ -95,6 +95,15 @@ function createEmptyAccountForm(): AccountFormState {
   };
 }
 
+function RequiredMark() {
+  return (
+    <span className="ms-1 text-danger">
+      <span aria-hidden="true">*</span>
+      <span className="visually-hidden">Campo obrigatório</span>
+    </span>
+  );
+}
+
 function toFinancialStrategyForm(
   account?: RemoteFacebookAccount,
 ): FinancialStrategyFormState {
@@ -336,6 +345,22 @@ export default function FacebookAccountsPage() {
     <div>
       <PageTitle>Contas do Facebook</PageTitle>
       <FacebookAutomationAlerts status={configuration} />
+      <div className="alert alert-info" role="alert">
+        <h2 className="h6 mb-2">Campos obrigatórios para o Facebook Ads Worker</h2>
+        <p className="mb-2">
+          Para liberar o worker, mantenha os seguintes campos preenchidos na conta ativa:
+        </p>
+        <ul className="mb-0 ps-3">
+          <li>Token de acesso (gerado automaticamente pelo Marketing Hub)</li>
+          <li>ID da conta de anúncios (act_)</li>
+          <li>URL padrão do site</li>
+          <li>Orçamento diário do conjunto</li>
+          <li>Evento de cobrança</li>
+          <li>Objetivo de otimização</li>
+          <li>Tipo de destino</li>
+          <li>País de destino do conjunto (BR)</li>
+        </ul>
+      </div>
       {accountsNeedingRenewal.length > 0 && (
         <div className="alert alert-warning" role="alert">
           <h2 className="h6 mb-2">Renovação de token necessária</h2>
@@ -671,7 +696,10 @@ export default function FacebookAccountsPage() {
                   </div>
                 </div>
                 <div className="col-12 col-md-6">
-                  <label className="form-label">ID da conta de anúncios (act_)</label>
+                  <label className="form-label">
+                    ID da conta de anúncios (act_)
+                    <RequiredMark />
+                  </label>
                   <input
                     className="form-control"
                     placeholder="Ex.: 123456789012345"
@@ -686,7 +714,10 @@ export default function FacebookAccountsPage() {
                   />
                 </div>
                 <div className="col-12 col-md-6">
-                  <label className="form-label">URL padrão do site</label>
+                  <label className="form-label">
+                    URL padrão do site
+                    <RequiredMark />
+                  </label>
                   <input
                     type="url"
                     className="form-control"
@@ -736,7 +767,10 @@ export default function FacebookAccountsPage() {
                     <h3 className="h6 mb-3">Estratégia financeira</h3>
                     <div className="row g-3">
                       <div className="col-12 col-md-6">
-                        <label className="form-label">Orçamento diário do conjunto (centavos)</label>
+                        <label className="form-label">
+                          Orçamento diário do conjunto (centavos)
+                          <RequiredMark />
+                        </label>
                         <input
                           className="form-control"
                           placeholder="Ex.: 2000 para R$ 20,00"
@@ -754,7 +788,10 @@ export default function FacebookAccountsPage() {
                         />
                       </div>
                       <div className="col-12 col-md-6">
-                        <label className="form-label">Evento de cobrança</label>
+                        <label className="form-label">
+                          Evento de cobrança
+                          <RequiredMark />
+                        </label>
                         <input
                           className="form-control"
                           placeholder="IMPRESSIONS, LINK_CLICKS..."
@@ -772,7 +809,10 @@ export default function FacebookAccountsPage() {
                         />
                       </div>
                       <div className="col-12 col-md-6">
-                        <label className="form-label">Objetivo de otimização</label>
+                        <label className="form-label">
+                          Objetivo de otimização
+                          <RequiredMark />
+                        </label>
                         <input
                           className="form-control"
                           placeholder="LINK_CLICKS, REACH..."
@@ -790,7 +830,10 @@ export default function FacebookAccountsPage() {
                         />
                       </div>
                       <div className="col-12 col-md-6">
-                        <label className="form-label">Tipo de destino</label>
+                        <label className="form-label">
+                          Tipo de destino
+                          <RequiredMark />
+                        </label>
                         <input
                           className="form-control"
                           placeholder="WEBSITE, APP, MESSENGER..."


### PR DESCRIPTION
## Summary
- log which required Facebook worker field is missing before returning HTTP 400
- reduce backend noise by lowering Hibernate bind/type log levels from TRACE to INFO
- highlight the required worker fields on the Facebook accounts page so operators know what to fill

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc9c992ae083219e9e32979f13e349