### PR TITLE
Add guideline for required field indicators

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,6 +1,7 @@
 # Frontend guidelines
 
 - Qualquer botão que dispare uma requisição assíncrona deve ficar desabilitado e exibir um indicador de carregamento (por exemplo, `spinner-border spinner-border-sm`) enquanto a operação estiver em andamento.
+- Campos de formulário obrigatórios devem exibir um asterisco (`*`) ao lado do rótulo para indicar a obrigatoriedade na interface.
 
 ## Menu lateral
 


### PR DESCRIPTION
## Summary
- document that required form fields must display an asterisk in the frontend guidelines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd02c3e6248321a60e7cb08c5eefba