### PR TITLE
Link Facebook campaigns to experiment and account records

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsCampaign.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsCampaign.java
@@ -1,5 +1,7 @@
 package com.marketinghub.facebookads;
 
+import com.marketinghub.ads.FacebookAccount;
+import com.marketinghub.experiment.Experiment;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,6 +28,14 @@ public class FacebookAdsCampaign {
 
     @Column(name = "ad_account_id", nullable = false)
     private String adAccountId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "experiment_id", nullable = false)
+    private Experiment experiment;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "facebook_account_id", nullable = false)
+    private FacebookAccount facebookAccount;
 
     @Column(nullable = false)
     private String name;

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
@@ -1,28 +1,36 @@
 package com.marketinghub.facebookads.web;
 
+import com.marketinghub.ads.FacebookAccount;
+import com.marketinghub.ads.FacebookAccountRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.facebookads.BudgetMode;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.FacebookAdsCampaignRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @RestController
 @RequestMapping("/api/facebook-campaigns")
 public class FacebookAdsCampaignController {
     private final ExperimentService experimentService;
     private final FacebookAdsCampaignRepository campaignRepository;
+    private final FacebookAccountRepository accountRepository;
 
     public FacebookAdsCampaignController(ExperimentService experimentService,
-                                         FacebookAdsCampaignRepository campaignRepository) {
+                                         FacebookAdsCampaignRepository campaignRepository,
+                                         FacebookAccountRepository accountRepository) {
         this.experimentService = experimentService;
         this.campaignRepository = campaignRepository;
+        this.accountRepository = accountRepository;
     }
 
     @GetMapping("/experiments-ready")
@@ -44,12 +52,24 @@ public class FacebookAdsCampaignController {
 
     @PostMapping
     public FacebookAdsCampaign create(@RequestBody CreateCampaignRequest req) {
+        Experiment experiment;
+        try {
+            experiment = experimentService.get(req.experimentId());
+        } catch (NoSuchElementException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "Experiment not found: " + req.experimentId(), ex);
+        }
+        FacebookAccount account = accountRepository.findById(req.facebookAccountId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Facebook account not found: " + req.facebookAccountId()));
         FacebookAdsCampaign campaign = new FacebookAdsCampaign();
         campaign.setId(req.id());
         campaign.setAdAccountId(req.adAccountId());
         campaign.setName(req.name());
         campaign.setObjective(req.objective());
         campaign.setBudgetMode(req.budgetMode());
+        campaign.setExperiment(experiment);
+        campaign.setFacebookAccount(account);
         return campaignRepository.save(campaign);
     }
 
@@ -113,5 +133,7 @@ public class FacebookAdsCampaignController {
             String adAccountId,
             String name,
             String objective,
-            BudgetMode budgetMode) {}
+            BudgetMode budgetMode,
+            Long experimentId,
+            Long facebookAccountId) {}
 }

--- a/backend/ads-service/src/main/resources/db/changelog/V2026_04_05__link_facebook_ads_campaign_to_experiment_and_account.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2026_04_05__link_facebook_ads_campaign_to_experiment_and_account.sql
@@ -1,0 +1,23 @@
+--liquibase formatted sql
+--changeset marketinghub:2026-04-05-link-facebook-ads-campaign-relations dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'facebook_ads_campaign' AND column_name = 'experiment_id';
+ALTER TABLE facebook_ads_campaign
+  ADD COLUMN experiment_id BIGINT NULL,
+  ADD COLUMN facebook_account_id BIGINT NULL;
+
+UPDATE facebook_ads_campaign c
+JOIN experiment e ON e.name = c.name
+SET c.experiment_id = e.id
+WHERE c.experiment_id IS NULL;
+
+UPDATE facebook_ads_campaign c
+JOIN fb_account a ON a.ad_account_id = c.ad_account_id
+SET c.facebook_account_id = a.id
+WHERE c.facebook_account_id IS NULL;
+
+ALTER TABLE facebook_ads_campaign
+  MODIFY COLUMN experiment_id BIGINT NOT NULL,
+  MODIFY COLUMN facebook_account_id BIGINT NOT NULL,
+  ADD CONSTRAINT fk_facebook_ads_campaign_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id),
+  ADD CONSTRAINT fk_facebook_ads_campaign_account FOREIGN KEY (facebook_account_id) REFERENCES fb_account(id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -137,3 +137,6 @@ databaseChangeLog:
   - include:
       file: V2026_03_20__extend_fb_account_worker_config.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2026_04_05__link_facebook_ads_campaign_to_experiment_and_account.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.facebookads.web;
 
 import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.ads.FacebookAccountRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.funnel.SalesFunnel;
 import com.marketinghub.hypothesis.Hypothesis;
@@ -39,6 +40,8 @@ class FacebookAdsCampaignControllerTest {
     ExperimentService experimentService;
     @MockBean
     com.marketinghub.facebookads.FacebookAdsCampaignRepository campaignRepository;
+    @MockBean
+    FacebookAccountRepository facebookAccountRepository;
 
     @Test
     void listExperimentsByStatus() throws Exception {

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -325,6 +325,8 @@ allow variants to be created before an experiment is defined.
 - `id` CHAR(36) PRIMARY KEY
 - `external_id` VARCHAR(64)
 - `ad_account_id` VARCHAR(64) NOT NULL
+- `experiment_id` BIGINT NOT NULL → FK `experiment.id`
+- `facebook_account_id` BIGINT NOT NULL → FK `fb_account.id`
 - `name` VARCHAR(255) NOT NULL
 - `objective` VARCHAR(64) NOT NULL
 - `status` ENUM(PAUSED,ACTIVE,ARCHIVED,DELETED) DEFAULT "PAUSED"

--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -106,6 +106,8 @@ classDiagram
         +name : String
         +objective : String
         +budgetMode : BudgetMode
+        +experimentId : Long
+        +facebookAccountId : Long
     }
 
     class FacebookAdsCampaign {
@@ -120,6 +122,8 @@ classDiagram
         +dailyBudgetMinor : Long
         +lifetimeBudgetMinor : Long
         +apiVersion : String
+        +experiment : Experiment
+        +facebookAccount : FacebookAccount
         +specialAdCategories : Set<SpecialAdCategory>
         +specialAdCountries : Set<String>
         +createdAt : Instant
@@ -166,6 +170,8 @@ classDiagram
     FacebookAdsCampaign --> FacebookAdStatus
     FacebookAdsCampaign --> BudgetMode
     FacebookAdsCampaign --> SpecialAdCategory
+    FacebookAdsCampaign --> Experiment
+    FacebookAdsCampaign --> FacebookAccount
     FacebookCampaignService ..> UrlUtils : compõe URLs do backend
     FacebookTokenRenewalScheduler --> FacebookTokenRenewalService : agenda renovação
     FacebookTokenRenewalService --> FacebookAdsService : renova token
@@ -197,7 +203,9 @@ classDiagram
   `/api/accounts/facebook/worker-config`, permitindo que os serviços leiam as
   credenciais e parâmetros padrão preenchidos na interface web.
 * `CreateCampaignRequest` representa o payload enviado ao backend contendo os
-  campos mínimos para materializar a entidade de campanha.
+  campos mínimos para materializar a entidade de campanha, incluindo os
+  identificadores do experimento e da conta de Facebook responsáveis pela
+  geração automática.
 * `FacebookAdsCampaign` é a entidade JPA do backend responsável por armazenar a
   campanha criada com seus metadados básicos e enums auxiliares.
 * `UrlUtils` garante a composição correta das URLs ao concatenar `base-url`,

--- a/docs/facebook-ads-worker/input-output-mapping.md
+++ b/docs/facebook-ads-worker/input-output-mapping.md
@@ -123,9 +123,14 @@ para o backend.
 | `name` | `Experiment.name` | Replicado para manter rastreabilidade entre backend e Facebook |
 | `objective` | Constante | Valor fixo `OUTCOME_TRAFFIC` |
 | `budgetMode` | Constante | Valor fixo `CAMPAIGN` até que o backend passe a enviar planejamento detalhado |
+| `experimentId` | `Experiment.id` | Garante vínculo direto com o experimento que originou a campanha |
+| `facebookAccountId` | `worker-config.accountId` | Mantém rastreabilidade com a conta utilizada pelo worker |
 
 ## Observações
 
+* O payload enviado ao backend agora inclui `experimentId` e `facebookAccountId`,
+  permitindo que a tabela `facebook_ads_campaign` mantenha chaves estrangeiras
+  para rastreabilidade e auditoria do fluxo automatizado.
 * As tabelas `facebook_ads_ad_set`, `facebook_ads_ad` e entidades auxiliares já
   estão preparadas no backend, mas ainda não recebem dados adicionais além do
   identificador da campanha. O enriquecimento com segmentação detalhada, criativos

--- a/docs/facebook-ads-worker/meta-ads-campaign-coverage.md
+++ b/docs/facebook-ads-worker/meta-ads-campaign-coverage.md
@@ -11,6 +11,8 @@ para navegar entre as entidades citadas.
 - Alguns **pré-requisitos obrigatórios** (ID da conta de anúncios, token,
   página e CTA padrão etc.) não constam na lista original, mas são carregados a
   partir de `FacebookWorkerConfigurationClient` e das entidades `fb_account`.
+- O backend agora persiste chaves estrangeiras para o experimento e a conta de
+  Facebook que originaram cada campanha, viabilizando auditoria ponta a ponta.
 - Há **campos planejados** no documento que ainda não são enviados pelo worker
   nem possuem suporte completo no banco (ex.: teste A/B, limites de gasto,
   segmentações avançadas).
@@ -25,6 +27,7 @@ para navegar entre as entidades citadas.
 | --- | --- | --- |
 | Nome da campanha | Derivado de `Experiment.name` e replicado em campanha, conjunto, criativo e anúncio para rastreabilidade. | Persistido em `facebook_ads_campaign.name` (ver `FacebookAdsCampaign` no diagrama). |
 | Objetivo | Worker envia sempre `OUTCOME_TRAFFIC`; demais opções ainda não foram expostas. | `facebook_ads_campaign.objective`; origem em `CreateCampaignRequest.objective`. |
+| Vínculo com planejamento | Novo payload inclui `experimentId` e `facebookAccountId`, garantindo rastreabilidade de origem. | `facebook_ads_campaign.experiment_id` → `experiment.id`; `facebook_ads_campaign.facebook_account_id` → `fb_account.id`. |
 | Tipo de compra | Não enviado atualmente; ausência de coluna `buying_type`. | Não implementado em `FacebookAdsCampaign`. |
 | Categoria especial | Enviada como lista vazia; países especiais também não são coletados. | Tabelas/tipos `facebook_ads_campaign.specialAdCategories` e `specialAdCountries`. |
 | Limite de gasto da campanha | Não manipulado (`spending_limit` não enviado). | `dailyBudgetMinor` / `lifetimeBudgetMinor` permanecem nulos. |

--- a/docs/facebook-ads-worker/meta-ads-campaign-fields.md
+++ b/docs/facebook-ads-worker/meta-ads-campaign-fields.md
@@ -28,6 +28,12 @@ Opcional. Informe se a campanha fará parte de um experimento A/B e qual variant
 ### Status inicial
 Define se a campanha será criada como **Ativa**, **Em rascunho** ou **Pausada**. Útil para processos que exigem revisão antes da publicação.
 
+### Rastreabilidade com planejamento
+Ao automatizar a criação pelo `facebook-ads-worker`, registre o identificador do
+experimento aprovado e da conta de Facebook utilizada. Esses valores alimentam
+as colunas `facebook_ads_campaign.experiment_id` e
+`facebook_ads_campaign.facebook_account_id`, garantindo auditoria de origem.
+
 ## 2. Configurações no nível de Conjunto de Anúncios
 
 ### Nome do conjunto de anúncios

--- a/docs/facebook-ads-worker/pendencias.md
+++ b/docs/facebook-ads-worker/pendencias.md
@@ -15,6 +15,8 @@ e governança, ainda faltam os itens abaixo, agrupados por tema.
   (ex.: programada, ativa, pausada).
 - Alimentar o backend com os identificadores de ad set, criativo e anúncio para
   manter rastreabilidade completa no modelo de dados.
+- As campanhas já registram `experiment_id` e `facebook_account_id`, faltando
+  estender o mesmo nível de rastreabilidade para as demais entidades.
 - Versionar e auditar alterações na configuração do worker (`worker-config`),
   registrando quem atualizou parâmetros sensíveis (token, orçamento padrão,
   página fallback).

--- a/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
+++ b/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
@@ -70,10 +70,12 @@ consulta novamente o backend antes de atualizar o token em memória.
 ### 3. Persistência no backend
 
 Após concluir as chamadas à Graph API, o worker envia um
-`CreateCampaignRequest` para o backend com os campos mínimos necessários para
-registrar a campanha na tabela `facebook_ads_campaign`. A chamada utiliza o
-mesmo nome do experimento e preenche `objective` e `budgetMode` com constantes
-(`OUTCOME_TRAFFIC` e `CAMPAIGN`) ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L39-L57)).
+`CreateCampaignRequest` para o backend com os campos necessários para registrar
+a campanha na tabela `facebook_ads_campaign`. Além dos atributos já utilizados
+(`id`, `adAccountId`, `objective`, `budgetMode`), o payload agora leva o
+`experimentId` e o `facebookAccountId`, garantindo chaves estrangeiras para o
+planejamento que originou a campanha
+([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L136), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L39-L66)).
 
 ## Mapeamento de campos
 
@@ -91,6 +93,8 @@ mesmo nome do experimento e preenche `objective` e `budgetMode` com constantes
 | Resposta da Graph API (`id`) | `CreateCampaignRequest.id` | Persistido como identificador principal da campanha ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132)) |
 | Constante `OUTCOME_TRAFFIC` | `Graph API - objective` e `CreateCampaignRequest.objective` | Objetivo padrão até existir planejamento específico |
 | Constante `CAMPAIGN` | `CreateCampaignRequest.budgetMode` | Modo de orçamento usado atualmente pelo backend |
+| `Experiment.id` | `CreateCampaignRequest.experimentId` | Usado para preencher a FK `facebook_ads_campaign.experiment_id` |
+| `FacebookWorkerConfiguration.accountId` | `CreateCampaignRequest.facebookAccountId` | Alimenta a FK `facebook_ads_campaign.facebook_account_id` |
 
 ## Informações de experimento ainda não utilizadas
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -220,7 +220,15 @@ public class FacebookCampaignService {
                 adSetId,
                 creativeId
             ));
-            CreateCampaignRequest req = new CreateCampaignRequest(campaignId, config.adAccountId(), exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
+            CreateCampaignRequest req = new CreateCampaignRequest(
+                campaignId,
+                config.adAccountId(),
+                exp.name(),
+                "OUTCOME_TRAFFIC",
+                "CAMPAIGN",
+                exp.id(),
+                config.accountId()
+            );
             String createCampaignUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns");
             LOGGER.info(
                 "Reporting Facebook campaign creation to backend: url={}, params={}, payload={}",
@@ -310,7 +318,15 @@ public class FacebookCampaignService {
     }
 
     public record Experiment(long id, String name, String pageId) {}
-    public record CreateCampaignRequest(String id, String adAccountId, String name, String objective, String budgetMode) {}
+    public record CreateCampaignRequest(
+        String id,
+        String adAccountId,
+        String name,
+        String objective,
+        String budgetMode,
+        Long experimentId,
+        Long facebookAccountId
+    ) {}
 
     private Creative resolveCreative(long experimentId) {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/creatives");

--- a/schema.sql
+++ b/schema.sql
@@ -296,6 +296,8 @@ CREATE TABLE facebook_ads_campaign (
   id CHAR(36) NOT NULL,
   external_id VARCHAR(64),
   ad_account_id VARCHAR(64) NOT NULL,
+  experiment_id BIGINT NOT NULL,
+  facebook_account_id BIGINT NOT NULL,
   name VARCHAR(255) NOT NULL,
   objective VARCHAR(64) NOT NULL,
   status ENUM('PAUSED','ACTIVE','ARCHIVED','DELETED') NOT NULL DEFAULT 'PAUSED',
@@ -305,7 +307,9 @@ CREATE TABLE facebook_ads_campaign (
   api_version VARCHAR(16),
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  CONSTRAINT fk_facebook_ads_campaign_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id),
+  CONSTRAINT fk_facebook_ads_campaign_account FOREIGN KEY (facebook_account_id) REFERENCES fb_account(id)
 );
 
 CREATE TABLE facebook_ads_campaign_special_ad_category (


### PR DESCRIPTION
## Summary
- add Liquibase changelog to attach `facebook_ads_campaign` to its originating experiment and Facebook account, updating the schema snapshot and data model docs
- persist the experiment/account relationships in the backend entity and controller while adjusting the worker payload and documentation accordingly
- refresh all Facebook Ads worker guides to describe the new identifiers propagated throughout the flow

## Testing
- mvn test (backend/ads-service)
- mvn test (facebook-ads-worker)


------
https://chatgpt.com/codex/tasks/task_e_68dd03bcc63c83218653ea78dbe5379e