### PR TITLE
Persist Facebook ad hierarchy metadata from worker

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
@@ -2,7 +2,15 @@ package com.marketinghub.facebookads.web;
 
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.service.ExperimentService;
+import com.marketinghub.facebookads.AdCreativeKind;
 import com.marketinghub.facebookads.BudgetMode;
+import com.marketinghub.facebookads.FacebookAdStatus;
+import com.marketinghub.facebookads.FacebookAdsAd;
+import com.marketinghub.facebookads.FacebookAdsAdCreative;
+import com.marketinghub.facebookads.FacebookAdsAdCreativeRepository;
+import com.marketinghub.facebookads.FacebookAdsAdRepository;
+import com.marketinghub.facebookads.FacebookAdsAdSet;
+import com.marketinghub.facebookads.FacebookAdsAdSetRepository;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.FacebookAdsCampaignRepository;
 import org.springframework.util.StringUtils;
@@ -12,17 +20,27 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/facebook-campaigns")
 public class FacebookAdsCampaignController {
     private final ExperimentService experimentService;
     private final FacebookAdsCampaignRepository campaignRepository;
+    private final FacebookAdsAdSetRepository adSetRepository;
+    private final FacebookAdsAdCreativeRepository adCreativeRepository;
+    private final FacebookAdsAdRepository adRepository;
 
     public FacebookAdsCampaignController(ExperimentService experimentService,
-                                         FacebookAdsCampaignRepository campaignRepository) {
+                                         FacebookAdsCampaignRepository campaignRepository,
+                                         FacebookAdsAdSetRepository adSetRepository,
+                                         FacebookAdsAdCreativeRepository adCreativeRepository,
+                                         FacebookAdsAdRepository adRepository) {
         this.experimentService = experimentService;
         this.campaignRepository = campaignRepository;
+        this.adSetRepository = adSetRepository;
+        this.adCreativeRepository = adCreativeRepository;
+        this.adRepository = adRepository;
     }
 
     @GetMapping("/experiments-ready")
@@ -50,7 +68,75 @@ public class FacebookAdsCampaignController {
         campaign.setName(req.name());
         campaign.setObjective(req.objective());
         campaign.setBudgetMode(req.budgetMode());
-        return campaignRepository.save(campaign);
+        FacebookAdsCampaign savedCampaign = campaignRepository.save(campaign);
+
+        FacebookAdsAdSet savedAdSet = saveAdSet(req.adSet(), savedCampaign);
+        FacebookAdsAdCreative savedCreative = saveAdCreative(req.adCreative());
+        saveAd(req.ad(), savedAdSet, savedCreative);
+
+        return savedCampaign;
+    }
+
+    private FacebookAdsAdSet saveAdSet(CreateCampaignRequest.AdSetPayload payload, FacebookAdsCampaign campaign) {
+        if (payload == null) {
+            return null;
+        }
+        FacebookAdsAdSet adSet = new FacebookAdsAdSet();
+        adSet.setId(payload.id());
+        adSet.setCampaign(campaign);
+        adSet.setName(payload.name());
+        adSet.setStatus(Optional.ofNullable(payload.status()).orElse(FacebookAdStatus.PAUSED));
+        adSet.setDailyBudgetMinor(payload.dailyBudgetMinor());
+        adSet.setLifetimeBudgetMinor(payload.lifetimeBudgetMinor());
+        adSet.setBillingEvent(payload.billingEvent());
+        adSet.setOptimizationGoal(payload.optimizationGoal());
+        adSet.setBidStrategy(Optional.ofNullable(payload.bidStrategy()).orElse("LOWEST_COST_WITHOUT_CAP"));
+        adSet.setBidAmountMinor(payload.bidAmountMinor());
+        adSet.setPromotedObjectJson(payload.promotedObjectJson());
+        adSet.setTargetingJson(Optional.ofNullable(payload.targetingJson()).orElse("{}"));
+        return adSetRepository.save(adSet);
+    }
+
+    private FacebookAdsAdCreative saveAdCreative(CreateCampaignRequest.AdCreativePayload payload) {
+        if (payload == null) {
+            return null;
+        }
+        FacebookAdsAdCreative creative = new FacebookAdsAdCreative();
+        creative.setId(payload.id());
+        creative.setPageId(payload.pageId());
+        creative.setInstagramUserId(payload.instagramUserId());
+        creative.setKind(Optional.ofNullable(payload.kind()).orElse(AdCreativeKind.LINK));
+        creative.setLinkDataJson(payload.linkDataJson());
+        creative.setVideoDataJson(payload.videoDataJson());
+        creative.setCarouselDataJson(payload.carouselDataJson());
+        creative.setLastPreviewUrl(payload.lastPreviewUrl());
+        return adCreativeRepository.save(creative);
+    }
+
+    private void saveAd(CreateCampaignRequest.AdPayload payload,
+                         FacebookAdsAdSet adSet,
+                         FacebookAdsAdCreative creative) {
+        if (payload == null) {
+            return;
+        }
+        FacebookAdsAdSet targetAdSet = adSet;
+        if (targetAdSet == null && payload.adSetId() != null) {
+            targetAdSet = adSetRepository.findById(payload.adSetId()).orElse(null);
+        }
+        FacebookAdsAdCreative targetCreative = creative;
+        if (targetCreative == null && payload.creativeId() != null) {
+            targetCreative = adCreativeRepository.findById(payload.creativeId()).orElse(null);
+        }
+        if (targetAdSet == null || targetCreative == null) {
+            return;
+        }
+        FacebookAdsAd ad = new FacebookAdsAd();
+        ad.setId(payload.id());
+        ad.setName(payload.name());
+        ad.setStatus(Optional.ofNullable(payload.status()).orElse(FacebookAdStatus.PAUSED));
+        ad.setAdSet(targetAdSet);
+        ad.setCreative(targetCreative);
+        adRepository.save(ad);
     }
 
     private ExperimentSummary toSummary(Experiment experiment) {
@@ -113,5 +199,39 @@ public class FacebookAdsCampaignController {
             String adAccountId,
             String name,
             String objective,
-            BudgetMode budgetMode) {}
+            BudgetMode budgetMode,
+            AdSetPayload adSet,
+            AdCreativePayload adCreative,
+            AdPayload ad) {
+
+        public record AdSetPayload(
+                String id,
+                String name,
+                FacebookAdStatus status,
+                Long dailyBudgetMinor,
+                Long lifetimeBudgetMinor,
+                String billingEvent,
+                String optimizationGoal,
+                String bidStrategy,
+                Long bidAmountMinor,
+                String promotedObjectJson,
+                String targetingJson) {}
+
+        public record AdCreativePayload(
+                String id,
+                String pageId,
+                String instagramUserId,
+                AdCreativeKind kind,
+                String linkDataJson,
+                String videoDataJson,
+                String carouselDataJson,
+                String lastPreviewUrl) {}
+
+        public record AdPayload(
+                String id,
+                String name,
+                FacebookAdStatus status,
+                String adSetId,
+                String creativeId) {}
+    }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -6,6 +6,9 @@ import com.marketinghub.funnel.SalesFunnel;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.experiment.service.ExperimentService;
+import com.marketinghub.facebookads.AdCreativeKind;
+import com.marketinghub.facebookads.BudgetMode;
+import com.marketinghub.facebookads.FacebookAdStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -18,6 +21,8 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -35,10 +40,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class FacebookAdsCampaignControllerTest {
     @Autowired
     MockMvc mockMvc;
+    @Autowired
+    FacebookAdsCampaignController controller;
     @MockBean
     ExperimentService experimentService;
     @MockBean
     com.marketinghub.facebookads.FacebookAdsCampaignRepository campaignRepository;
+    @MockBean
+    com.marketinghub.facebookads.FacebookAdsAdSetRepository adSetRepository;
+    @MockBean
+    com.marketinghub.facebookads.FacebookAdsAdCreativeRepository adCreativeRepository;
+    @MockBean
+    com.marketinghub.facebookads.FacebookAdsAdRepository adRepository;
 
     @Test
     void listExperimentsByStatus() throws Exception {
@@ -86,5 +99,66 @@ class FacebookAdsCampaignControllerTest {
                 .andExpect(jsonPath("$[0].hypothesisTitle").value("Hipótese do Nicho"))
                 .andExpect(jsonPath("$[0].missingConfiguration").isArray())
                 .andExpect(jsonPath("$[0].missingConfiguration").isEmpty());
+    }
+
+    @Test
+    void persistsHierarchyWhenCampaignIsReported() {
+        when(campaignRepository.save(org.mockito.ArgumentMatchers.any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(adSetRepository.save(org.mockito.ArgumentMatchers.any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(adCreativeRepository.save(org.mockito.ArgumentMatchers.any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        FacebookAdsCampaignController.CreateCampaignRequest request =
+                new FacebookAdsCampaignController.CreateCampaignRequest(
+                        "10",
+                        "act_1",
+                        "Campanha",
+                        "OUTCOME_TRAFFIC",
+                        BudgetMode.CAMPAIGN,
+                        new FacebookAdsCampaignController.CreateCampaignRequest.AdSetPayload(
+                                "20",
+                                "Campanha - Ad Set",
+                                FacebookAdStatus.PAUSED,
+                                2000L,
+                                null,
+                                "IMPRESSIONS",
+                                "LINK_CLICKS",
+                                "LOWEST_COST_WITHOUT_CAP",
+                                150L,
+                                "{\"page_id\":\"84\"}",
+                                "{\"geo_locations\":{\"countries\":[\"BR\"]}}"
+                        ),
+                        new FacebookAdsCampaignController.CreateCampaignRequest.AdCreativePayload(
+                                "30",
+                                "84",
+                                "11",
+                                AdCreativeKind.LINK,
+                                "{}",
+                                null,
+                                null,
+                                null
+                        ),
+                        new FacebookAdsCampaignController.CreateCampaignRequest.AdPayload(
+                                "40",
+                                "Campanha - Ad",
+                                FacebookAdStatus.PAUSED,
+                                "20",
+                                "30"
+                        )
+                );
+
+        controller.create(request);
+
+        verify(adSetRepository).save(argThat(adSet ->
+                adSet.getId().equals("20") && adSet.getCampaign() != null && "10".equals(adSet.getCampaign().getId())));
+        verify(adCreativeRepository).save(argThat(creative -> creative.getId().equals("30")));
+        verify(adRepository).save(argThat(ad ->
+                ad.getId().equals("40")
+                        && ad.getAdSet() != null
+                        && ad.getAdSet().getId().equals("20")
+                        && ad.getCreative() != null
+                        && ad.getCreative().getId().equals("30")));
     }
 }

--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -106,6 +106,41 @@ classDiagram
         +name : String
         +objective : String
         +budgetMode : BudgetMode
+        +adSet : AdSetPayload
+        +adCreative : AdCreativePayload
+        +ad : AdPayload
+    }
+
+    class AdSetPayload {
+        <<record>>
+        +id : String
+        +name : String
+        +status : String
+        +dailyBudgetMinor : Long
+        +billingEvent : String
+        +optimizationGoal : String
+        +bidStrategy : String
+        +bidAmountMinor : Long
+        +promotedObjectJson : String
+        +targetingJson : String
+    }
+
+    class AdCreativePayload {
+        <<record>>
+        +id : String
+        +pageId : String
+        +instagramUserId : String
+        +kind : String
+        +linkDataJson : String
+    }
+
+    class AdPayload {
+        <<record>>
+        +id : String
+        +name : String
+        +status : String
+        +adSetId : String
+        +creativeId : String
     }
 
     class FacebookAdsCampaign {
@@ -162,6 +197,12 @@ classDiagram
     FacebookAdsService --> AdCreativeRequest
     FacebookAdsService --> AdRequest
     FacebookCampaignService --> CreateCampaignRequest : monta payload do backend
+    CreateCampaignRequest --> AdSetPayload
+    CreateCampaignRequest --> AdCreativePayload
+    CreateCampaignRequest --> AdPayload
+    AdSetPayload ..> FacebookAdsAdSet
+    AdCreativePayload ..> FacebookAdsAdCreative
+    AdPayload ..> FacebookAdsAd
     CreateCampaignRequest ..> FacebookAdsCampaign : persiste entidade
     FacebookAdsCampaign --> FacebookAdStatus
     FacebookAdsCampaign --> BudgetMode
@@ -197,7 +238,8 @@ classDiagram
   `/api/accounts/facebook/worker-config`, permitindo que os serviços leiam as
   credenciais e parâmetros padrão preenchidos na interface web.
 * `CreateCampaignRequest` representa o payload enviado ao backend contendo os
-  campos mínimos para materializar a entidade de campanha.
+  dados necessários para materializar a campanha e registrar os identificadores
+  do conjunto, do criativo e do anúncio gerados na Graph API.
 * `FacebookAdsCampaign` é a entidade JPA do backend responsável por armazenar a
   campanha criada com seus metadados básicos e enums auxiliares.
 * `UrlUtils` garante a composição correta das URLs ao concatenar `base-url`,

--- a/docs/facebook-ads-worker/input-output-mapping.md
+++ b/docs/facebook-ads-worker/input-output-mapping.md
@@ -106,7 +106,7 @@ flowchart TD
 | `status` | Constante | `PAUSED` |
 | `access_token` | Conta configurada (`worker-config.accessToken`) | Token com permissão para o Ad Account |
 
-* **Resposta tratada:** o identificador é armazenado apenas para auditoria de execução (não é persistido no backend ainda).
+* **Resposta tratada:** o identificador do anúncio agora é enviado ao backend para persistência junto ao conjunto e ao criativo correspondentes.
 
 ## 6. Persistência da campanha no backend
 
@@ -123,13 +123,17 @@ para o backend.
 | `name` | `Experiment.name` | Replicado para manter rastreabilidade entre backend e Facebook |
 | `objective` | Constante | Valor fixo `OUTCOME_TRAFFIC` |
 | `budgetMode` | Constante | Valor fixo `CAMPAIGN` até que o backend passe a enviar planejamento detalhado |
+| `adSet` | Resposta da Graph API + configuração da conta | Inclui `id`, status `PAUSED`, orçamento diário, estratégia de lance e `targeting_json` com o país configurado |
+| `adCreative` | Resposta da Graph API + dados do criativo aprovado | Transporta `id`, `pageId`, `instagramUserId`, `kind = LINK` e `linkDataJson` utilizado na criação |
+| `ad` | Resposta da Graph API | Contém `id`, nome com sufixo “- Ad”, status `PAUSED`, além dos vínculos com `adSetId` e `creativeId` |
 
 ## Observações
 
-* As tabelas `facebook_ads_ad_set`, `facebook_ads_ad` e entidades auxiliares já
-  estão preparadas no backend, mas ainda não recebem dados adicionais além do
-  identificador da campanha. O enriquecimento com segmentação detalhada, criativos
-  aprovados pelo usuário e UTMs permanece listado em [pendencias.md](./pendencias.md).
+* As tabelas `facebook_ads_ad_set`, `facebook_ads_ad_creative` e `facebook_ads_ad`
+  passam a receber os identificadores e metadados básicos (targeting, promoted
+  object e `object_story_spec`) enviados pelo worker. O enriquecimento com
+  segmentação detalhada, criativos alternativos aprovados pelo usuário e UTMs
+  permanece listado em [pendencias.md](./pendencias.md).
 * A composição das URLs dos endpoints do backend utiliza `UrlUtils.joinPath`
   para garantir que `backend.base-url`, `backend.api-prefix` e o caminho do
   recurso não gerem barras duplicadas.

--- a/docs/facebook-ads-worker/meta-ads-campaign-coverage.md
+++ b/docs/facebook-ads-worker/meta-ads-campaign-coverage.md
@@ -45,13 +45,13 @@ para navegar entre as entidades citadas.
 | Campo (documento) | Tratamento atual no worker | Entidades / Propriedades relacionadas |
 | --- | --- | --- |
 | Nome do conjunto | Usa `Experiment.name` com sufixo “- Ad Set”. | `facebook_ads_ad_set.name` (`FacebookAdsAdSet` no diagrama). |
-| Evento de conversão / Meta | `promoted_object_json` permanece vazio; pixel/evento ainda não configurados. | `facebook_ads_ad_set.promoted_object_json`. |
+| Evento de conversão / Meta | `promoted_object_json` recebe `page_id` quando disponível; pixel/evento ainda não configurados. | `facebook_ads_ad_set.promoted_object_json`. |
 | Estratégia de otimização | Valor padrão da conta (`fb_account.ad_set_optimization_goal`). | `facebook_ads_ad_set.optimization_goal`. |
 | Estratégia de lance | `bid_strategy` e `bid_amount` herdados da conta; podem ficar em branco. | `facebook_ads_ad_set.bid_strategy`, `bid_amount_minor`. |
 | Orçamento (sem CBO) | Envia `daily_budget` a partir de `fb_account.ad_set_daily_budget`. | `facebook_ads_ad_set.daily_budget_minor` / `lifetime_budget_minor`. |
 | Período de veiculação | `start_time`/`end_time` não configurados. | Colunas homônimas no ad set. |
-| Públicos personalizados / semelhantes | Planejado para `targeting_json`; ainda não serializado. | `facebook_ads_ad_set.targeting_json`. |
-| Segmentação detalhada | Não implementada. | Mesmo `targeting_json`. |
+| Públicos personalizados / semelhantes | Estrutura `targeting_json` criada, porém preenchida apenas com o país alvo padrão. | `facebook_ads_ad_set.targeting_json`. |
+| Segmentação detalhada | Ainda não preenchida além de `geo_locations`. | Mesmo `targeting_json`. |
 | Localizações | Apenas país padrão (`adSetTargetCountry`) incluído. | `targeting_json.geo_locations`. |
 | Faixa etária, gênero, idiomas, posicionamentos, dispositivos | Ainda não expostos na UI nem enviados. | `targeting_json` aguardando evolução. |
 | Limite de frequência | Sem suporte; exigiria nova coluna. | Não existente no modelo atual. |
@@ -64,7 +64,7 @@ para navegar entre as entidades citadas.
 | --- | --- | --- |
 | Nome do anúncio | Derivado de `Experiment.name` com sufixo “- Ad”. | `facebook_ads_ad.name`. |
 | Identidade (Página/Instagram) | Resolve `pageId` e `instagram_user_id` a partir do experimento ou defaults da conta. | `facebook_ads_ad_creative.page_id`, `instagram_user_id`. |
-| Formato do anúncio | Apenas link ads; valor armazenado em `Creative.format`, não enviado ainda. | `facebook_ads_ad_creative.kind`. |
+| Formato do anúncio | Apenas link ads; valor enviado como `LINK` no payload do criativo. | `facebook_ads_ad_creative.kind`. |
 | Mídia principal | Dados do criativo aprovado (`imageUrl`, `imageHash`, `videoId`); assets futuros usarão `facebook_ads_media_asset`. | `facebook_ads_media_asset` e JSON do criativo. |
 | Mídias adicionais | Carrossel/coleção não suportados. | `facebook_ads_ad_creative.carousel_data_json` / `video_data_json`. |
 | Texto primário | `Creative.primaryText` ou fallback da conta. | `facebook_ads_ad_creative.link_data_json.message`. |

--- a/docs/facebook-ads-worker/pendencias.md
+++ b/docs/facebook-ads-worker/pendencias.md
@@ -13,8 +13,6 @@ e governança, ainda faltam os itens abaixo, agrupados por tema.
   de constantes.
 - Suportar janelas de veiculação (datas de início/fim) e status da campanha
   (ex.: programada, ativa, pausada).
-- Alimentar o backend com os identificadores de ad set, criativo e anúncio para
-  manter rastreabilidade completa no modelo de dados.
 - Versionar e auditar alterações na configuração do worker (`worker-config`),
   registrando quem atualizou parâmetros sensíveis (token, orçamento padrão,
   página fallback).

--- a/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
+++ b/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
@@ -70,10 +70,14 @@ consulta novamente o backend antes de atualizar o token em memória.
 ### 3. Persistência no backend
 
 Após concluir as chamadas à Graph API, o worker envia um
-`CreateCampaignRequest` para o backend com os campos mínimos necessários para
-registrar a campanha na tabela `facebook_ads_campaign`. A chamada utiliza o
-mesmo nome do experimento e preenche `objective` e `budgetMode` com constantes
-(`OUTCOME_TRAFFIC` e `CAMPAIGN`) ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L39-L57)).
+`CreateCampaignRequest` para o backend contendo a campanha e os identificadores
+do ad set, do criativo e do anúncio recém-gerados. O payload também leva os
+metadados utilizados para criação (orçamento, segmentação e `object_story_spec`),
+permitindo que o backend materialize toda a hierarquia nas tabelas
+`facebook_ads_campaign`, `facebook_ads_ad_set`, `facebook_ads_ad_creative` e
+`facebook_ads_ad`. A chamada utiliza o mesmo nome do experimento e preenche
+`objective` e `budgetMode` com constantes (`OUTCOME_TRAFFIC` e `CAMPAIGN`)
+([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L202-L245), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L63-L140)).
 
 ## Mapeamento de campos
 
@@ -88,7 +92,12 @@ mesmo nome do experimento e preenche `objective` e `budgetMode` com constantes
 | `worker-config.defaultInstagramActorId` | `Graph API - object_story_spec.instagram_actor_id` | Opcional, incluído apenas quando configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L118)) |
 | `worker-config.defaultCreativeMessageTemplate` | `Graph API - object_story_spec.link_data.message` | Template com suporte a `%s` para o nome do experimento ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L134-L141)) |
 | `worker-config.defaultWebsiteUrl` | `Graph API - link_data.link` e `call_to_action.value.link` | URL padrão de destino ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L118)) |
-| Resposta da Graph API (`id`) | `CreateCampaignRequest.id` | Persistido como identificador principal da campanha ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132)) |
+| Resposta da Graph API (`id`) | `CreateCampaignRequest.id` | Persistido como identificador principal da campanha ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L202-L245)) |
+| Resposta da Graph API (`adset.id`) | `CreateCampaignRequest.adSet.id` | Garante rastreabilidade do conjunto no backend ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L202-L246), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L80-L98)) |
+| Parâmetros do ad set (budget, targeting, promoted object) | `CreateCampaignRequest.adSet.*` | Serializados para manter histórico das configurações utilizadas na Graph API ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L442-L528), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L80-L98)) |
+| Resposta da Graph API (`adcreative.id`) | `CreateCampaignRequest.adCreative.id` | Rastreia o criativo gerado na Graph API ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L218-L245), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L100-L114)) |
+| `object_story_spec` utilizado na criação | `CreateCampaignRequest.adCreative.linkDataJson` | Persistido como JSON para auditoria ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L481-L516), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L100-L114)) |
+| Resposta da Graph API (`ad.id`) | `CreateCampaignRequest.ad.id` | Permite mapear o anúncio às métricas futuras ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L230-L245), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L116-L140)) |
 | Constante `OUTCOME_TRAFFIC` | `Graph API - objective` e `CreateCampaignRequest.objective` | Objetivo padrão até existir planejamento específico |
 | Constante `CAMPAIGN` | `CreateCampaignRequest.budgetMode` | Modo de orçamento usado atualmente pelo backend |
 

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -26,8 +26,9 @@ As chamadas ao backend utilizam o prefixo `/api`. O worker consome
 "nenhum experimento disponível" para evitar falhas no agendamento. Falhas de
 conexão ao recuperar os experimentos são registradas em log e ignoradas para
 que o agendamento continue saudável. Após criar campanha, conjunto, criativo e
-anúncio, o worker persiste o identificador da campanha via
-`POST /api/facebook-campaigns`. Todas as chamadas HTTP ao backend devem
+anúncio, o worker envia para o backend os identificadores da campanha, do ad set,
+do criativo e do anúncio (incluindo os metadados necessários para rastreabilidade)
+via `POST /api/facebook-campaigns`. Todas as chamadas HTTP ao backend devem
 registrar a URL completa, parâmetros, payload e resposta recebida para
 acelerar o diagnóstico de incidentes em produção.
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -1,5 +1,7 @@
 package com.marketinghub.facebookadsworker.facebookcampaign;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.facebookadsworker.FacebookAccessTokenExpiredException;
 import com.marketinghub.facebookadsworker.FacebookAccessTokenManager;
 import com.marketinghub.facebookadsworker.FacebookAdsService;
@@ -19,7 +21,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,13 +45,15 @@ public class FacebookCampaignService {
     private final AtomicReference<String> lastExpiredAccessToken;
     private final FacebookAccessTokenManager accessTokenManager;
     private final AtomicBoolean configurationUnavailableWarningLogged;
+    private final ObjectMapper objectMapper;
 
     public FacebookCampaignService(FacebookAdsService facebookAdsService,
                                    FacebookAccessTokenManager accessTokenManager,
                                    WebClient.Builder builder,
                                    FacebookWorkerConfigurationClient configurationClient,
                                    @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
-                                   @Value("${backend.api-prefix:/api}") String apiPrefix) {
+                                   @Value("${backend.api-prefix:/api}") String apiPrefix,
+                                   ObjectMapper objectMapper) {
         this.facebookAdsService = facebookAdsService;
         this.accessTokenManager = accessTokenManager;
         this.backendClient = builder.build();
@@ -59,6 +65,7 @@ public class FacebookCampaignService {
         this.accessTokenExpiryWarningLogged = new AtomicBoolean(false);
         this.lastExpiredAccessToken = new AtomicReference<>(null);
         this.configurationUnavailableWarningLogged = new AtomicBoolean(false);
+        this.objectMapper = objectMapper;
     }
 
     public void createCampaignsFromExperiments() {
@@ -193,7 +200,8 @@ public class FacebookCampaignService {
             String resolvedInstagramActorId = coalesce(creative.instagramUserId(), config.defaultInstagramActorId());
 
             String campaignId = facebookAdsService.createCampaign(config.adAccountId(), exp.name());
-            String adSetId = facebookAdsService.createAdSet(config.adAccountId(), new FacebookAdsService.AdSetRequest(
+
+            FacebookAdsService.AdSetRequest adSetRequest = new FacebookAdsService.AdSetRequest(
                 exp.name() + " - Ad Set",
                 campaignId,
                 config.adSetDailyBudget(),
@@ -204,8 +212,10 @@ public class FacebookCampaignService {
                 config.adSetBidAmount(),
                 resolvedPageId,
                 config.adSetTargetCountry()
-            ));
-            String creativeId = facebookAdsService.createAdCreative(config.adAccountId(), new FacebookAdsService.AdCreativeRequest(
+            );
+            String adSetId = facebookAdsService.createAdSet(config.adAccountId(), adSetRequest);
+
+            FacebookAdsService.AdCreativeRequest adCreativeRequest = new FacebookAdsService.AdCreativeRequest(
                 exp.name() + " - Creative",
                 resolvedPageId,
                 resolvedInstagramActorId,
@@ -214,13 +224,26 @@ public class FacebookCampaignService {
                 resolvedCallToAction,
                 creative.headline(),
                 creative.description()
-            ));
-            facebookAdsService.createAd(config.adAccountId(), new FacebookAdsService.AdRequest(
+            );
+            String creativeId = facebookAdsService.createAdCreative(config.adAccountId(), adCreativeRequest);
+
+            FacebookAdsService.AdRequest adRequest = new FacebookAdsService.AdRequest(
                 exp.name() + " - Ad",
                 adSetId,
                 creativeId
-            ));
-            CreateCampaignRequest req = new CreateCampaignRequest(campaignId, config.adAccountId(), exp.name(), "OUTCOME_TRAFFIC", "CAMPAIGN");
+            );
+            String adId = facebookAdsService.createAd(config.adAccountId(), adRequest);
+
+            CreateCampaignRequest req = new CreateCampaignRequest(
+                campaignId,
+                config.adAccountId(),
+                exp.name(),
+                "OUTCOME_TRAFFIC",
+                "CAMPAIGN",
+                buildAdSetPayload(adSetId, adSetRequest),
+                buildAdCreativePayload(creativeId, adCreativeRequest),
+                buildAdPayload(adId, adRequest)
+            );
             String createCampaignUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns");
             LOGGER.info(
                 "Reporting Facebook campaign creation to backend: url={}, params={}, payload={}",
@@ -310,7 +333,49 @@ public class FacebookCampaignService {
     }
 
     public record Experiment(long id, String name, String pageId) {}
-    public record CreateCampaignRequest(String id, String adAccountId, String name, String objective, String budgetMode) {}
+    public record CreateCampaignRequest(
+        String id,
+        String adAccountId,
+        String name,
+        String objective,
+        String budgetMode,
+        AdSetPayload adSet,
+        AdCreativePayload adCreative,
+        AdPayload ad
+    ) {
+        public record AdSetPayload(
+            String id,
+            String name,
+            String status,
+            Long dailyBudgetMinor,
+            Long lifetimeBudgetMinor,
+            String billingEvent,
+            String optimizationGoal,
+            String bidStrategy,
+            Long bidAmountMinor,
+            String promotedObjectJson,
+            String targetingJson
+        ) {}
+
+        public record AdCreativePayload(
+            String id,
+            String pageId,
+            String instagramUserId,
+            String kind,
+            String linkDataJson,
+            String videoDataJson,
+            String carouselDataJson,
+            String lastPreviewUrl
+        ) {}
+
+        public record AdPayload(
+            String id,
+            String name,
+            String status,
+            String adSetId,
+            String creativeId
+        ) {}
+    }
 
     private Creative resolveCreative(long experimentId) {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/creatives");
@@ -371,6 +436,114 @@ public class FacebookCampaignService {
                 ex.getMessage(),
                 ex
             );
+        }
+    }
+
+    private CreateCampaignRequest.AdSetPayload buildAdSetPayload(
+        String adSetId,
+        FacebookAdsService.AdSetRequest request
+    ) {
+        Long dailyBudgetMinor = parseLongOrNull(request.dailyBudget());
+        Long bidAmountMinor = parseLongOrNull(request.bidAmount());
+        String bidStrategy = StringUtils.hasText(request.bidStrategy())
+            ? request.bidStrategy()
+            : "LOWEST_COST_WITHOUT_CAP";
+
+        Map<String, Object> targeting = new HashMap<>();
+        Map<String, Object> geoLocations = new HashMap<>();
+        if (StringUtils.hasText(request.targetCountry())) {
+            geoLocations.put("countries", List.of(request.targetCountry()));
+        } else {
+            geoLocations.put("countries", List.of());
+        }
+        targeting.put("geo_locations", geoLocations);
+
+        String targetingJson = writeJson(targeting);
+        String promotedObjectJson = StringUtils.hasText(request.pageId())
+            ? writeJson(Map.of("page_id", request.pageId()))
+            : null;
+
+        return new CreateCampaignRequest.AdSetPayload(
+            adSetId,
+            request.name(),
+            "PAUSED",
+            dailyBudgetMinor,
+            null,
+            request.billingEvent(),
+            request.optimizationGoal(),
+            bidStrategy,
+            bidAmountMinor,
+            promotedObjectJson,
+            targetingJson
+        );
+    }
+
+    private CreateCampaignRequest.AdCreativePayload buildAdCreativePayload(
+        String creativeId,
+        FacebookAdsService.AdCreativeRequest request
+    ) {
+        Map<String, Object> callToActionValue = Map.of("link", request.websiteUrl());
+        Map<String, Object> callToAction = Map.of(
+            "type",
+            request.callToActionType(),
+            "value",
+            callToActionValue
+        );
+
+        Map<String, Object> linkData = new HashMap<>();
+        linkData.put("link", request.websiteUrl());
+        linkData.put("message", request.message());
+        if (StringUtils.hasText(request.headline())) {
+            linkData.put("name", request.headline());
+        }
+        if (StringUtils.hasText(request.description())) {
+            linkData.put("description", request.description());
+        }
+        linkData.put("call_to_action", callToAction);
+
+        String linkDataJson = writeJson(linkData);
+
+        return new CreateCampaignRequest.AdCreativePayload(
+            creativeId,
+            request.pageId(),
+            request.instagramActorId(),
+            "LINK",
+            linkDataJson,
+            null,
+            null,
+            null
+        );
+    }
+
+    private CreateCampaignRequest.AdPayload buildAdPayload(
+        String adId,
+        FacebookAdsService.AdRequest request
+    ) {
+        return new CreateCampaignRequest.AdPayload(
+            adId,
+            request.name(),
+            "PAUSED",
+            request.adSetId(),
+            request.creativeId()
+        );
+    }
+
+    private String writeJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Failed to serialize payload for backend tracking", ex);
+        }
+    }
+
+    private static Long parseLongOrNull(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException ex) {
+            return null;
         }
     }
 

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -65,7 +65,8 @@ class FacebookCampaignServiceTest {
             WebClient.builder(),
             configurationClient,
             backend.url("/").toString(),
-            "/api"
+            "/api",
+            objectMapper
         );
     }
 
@@ -135,6 +136,32 @@ class FacebookCampaignServiceTest {
 
         RecordedRequest postBackend = backend.takeRequest();
         assertEquals("/api/facebook-campaigns", postBackend.getPath());
+        JsonNode backendPayload = objectMapper.readTree(postBackend.getBody().inputStream());
+        assertEquals("10", backendPayload.get("id").asText());
+        assertEquals("1", backendPayload.get("adAccountId").asText());
+        assertEquals("OUTCOME_TRAFFIC", backendPayload.get("objective").asText());
+        JsonNode adSetNode = backendPayload.get("adSet");
+        assertEquals("20", adSetNode.get("id").asText());
+        assertEquals("Exp - Ad Set", adSetNode.get("name").asText());
+        assertEquals("PAUSED", adSetNode.get("status").asText());
+        assertEquals(2000L, adSetNode.get("dailyBudgetMinor").asLong());
+        assertEquals("IMPRESSIONS", adSetNode.get("billingEvent").asText());
+        assertEquals("LINK_CLICKS", adSetNode.get("optimizationGoal").asText());
+        assertEquals("LOWEST_COST_WITHOUT_CAP", adSetNode.get("bidStrategy").asText());
+        assertEquals(150L, adSetNode.get("bidAmountMinor").asLong());
+        assertEquals("{\"page_id\":\"84\"}", adSetNode.get("promotedObjectJson").asText());
+        assertEquals("{\"geo_locations\":{\"countries\":[\"BR\"]}}", adSetNode.get("targetingJson").asText());
+        JsonNode creativeNode = backendPayload.get("adCreative");
+        assertEquals("30", creativeNode.get("id").asText());
+        assertEquals("84", creativeNode.get("pageId").asText());
+        assertEquals("11", creativeNode.get("instagramUserId").asText());
+        assertEquals("LINK", creativeNode.get("kind").asText());
+        JsonNode adNode = backendPayload.get("ad");
+        assertEquals("40", adNode.get("id").asText());
+        assertEquals("Exp - Ad", adNode.get("name").asText());
+        assertEquals("PAUSED", adNode.get("status").asText());
+        assertEquals("20", adNode.get("adSetId").asText());
+        assertEquals("30", adNode.get("creativeId").asText());
     }
 
     @Test
@@ -277,7 +304,8 @@ class FacebookCampaignServiceTest {
             WebClient.builder(),
             configurationClient,
             backend.url("/").toString(),
-            "/api"
+            "/api",
+            objectMapper
         );
 
         backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"pageId\":\"84\"}]")
@@ -356,7 +384,8 @@ class FacebookCampaignServiceTest {
             WebClient.builder(),
             configurationClient,
             backend.url("/").toString(),
-            "/api"
+            "/api",
+            objectMapper
         );
 
         backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"pageId\":\"84\"}]")


### PR DESCRIPTION
## Summary
- Extend the Facebook Ads worker to send the ad set, creative, and ad identifiers plus related metadata when reporting campaign creation to the backend
- Persist the received hierarchy in the backend, saving the ad set, creative, and ad entities alongside the campaign and covering the behavior with unit tests
- Refresh the Facebook Ads worker documentation to describe the richer payload and updated data coverage

## Testing
- `mvn -s settings.xml test` *(fails: GitHub Packages is unreachable in the execution environment)*
- `mvn -s ../settings.xml test` *(fails: GitHub Packages is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd049dd6988321b2bb33deb7226ef4