### PR TITLE
Persist Facebook ad hierarchy identifiers

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
@@ -1,16 +1,27 @@
 package com.marketinghub.facebookads.web;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marketinghub.ads.FacebookAccount;
 import com.marketinghub.ads.FacebookAccountRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.service.ExperimentService;
+import com.marketinghub.facebookads.AdCreativeKind;
 import com.marketinghub.facebookads.BudgetMode;
+import com.marketinghub.facebookads.FacebookAdsAd;
+import com.marketinghub.facebookads.FacebookAdsAdCreative;
+import com.marketinghub.facebookads.FacebookAdsAdCreativeRepository;
+import com.marketinghub.facebookads.FacebookAdsAdRepository;
+import com.marketinghub.facebookads.FacebookAdsAdSet;
+import com.marketinghub.facebookads.FacebookAdsAdSetRepository;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.FacebookAdsCampaignRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -24,13 +35,25 @@ public class FacebookAdsCampaignController {
     private final ExperimentService experimentService;
     private final FacebookAdsCampaignRepository campaignRepository;
     private final FacebookAccountRepository accountRepository;
+    private final FacebookAdsAdSetRepository adSetRepository;
+    private final FacebookAdsAdCreativeRepository adCreativeRepository;
+    private final FacebookAdsAdRepository adRepository;
+    private final ObjectMapper objectMapper;
 
     public FacebookAdsCampaignController(ExperimentService experimentService,
                                          FacebookAdsCampaignRepository campaignRepository,
-                                         FacebookAccountRepository accountRepository) {
+                                         FacebookAccountRepository accountRepository,
+                                         FacebookAdsAdSetRepository adSetRepository,
+                                         FacebookAdsAdCreativeRepository adCreativeRepository,
+                                         FacebookAdsAdRepository adRepository,
+                                         ObjectMapper objectMapper) {
         this.experimentService = experimentService;
         this.campaignRepository = campaignRepository;
         this.accountRepository = accountRepository;
+        this.adSetRepository = adSetRepository;
+        this.adCreativeRepository = adCreativeRepository;
+        this.adRepository = adRepository;
+        this.objectMapper = objectMapper;
     }
 
     @GetMapping("/experiments-ready")
@@ -51,6 +74,7 @@ public class FacebookAdsCampaignController {
     }
 
     @PostMapping
+    @Transactional
     public FacebookAdsCampaign create(@RequestBody CreateCampaignRequest req) {
         Experiment experiment;
         try {
@@ -70,7 +94,122 @@ public class FacebookAdsCampaignController {
         campaign.setBudgetMode(req.budgetMode());
         campaign.setExperiment(experiment);
         campaign.setFacebookAccount(account);
-        return campaignRepository.save(campaign);
+        FacebookAdsCampaign savedCampaign = campaignRepository.save(campaign);
+
+        FacebookAdsAdSet savedAdSet = null;
+        if (req.adSet() != null) {
+            savedAdSet = adSetRepository.save(mapAdSet(req.adSet(), savedCampaign));
+        }
+
+        FacebookAdsAdCreative savedCreative = null;
+        if (req.adCreative() != null) {
+            savedCreative = adCreativeRepository.save(mapAdCreative(req.adCreative()));
+        }
+
+        if (req.ad() != null) {
+            if (savedAdSet == null || savedCreative == null) {
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "Ad set and ad creative must be provided when reporting an ad"
+                );
+            }
+            adRepository.save(mapAd(req.ad(), savedAdSet, savedCreative));
+        }
+
+        return savedCampaign;
+    }
+
+    private FacebookAdsAdSet mapAdSet(CreateCampaignRequest.AdSet adSetReq, FacebookAdsCampaign campaign) {
+        FacebookAdsAdSet adSet = new FacebookAdsAdSet();
+        adSet.setId(adSetReq.id());
+        adSet.setCampaign(campaign);
+        adSet.setName(adSetReq.name());
+        adSet.setBillingEvent(adSetReq.billingEvent());
+        adSet.setOptimizationGoal(adSetReq.optimizationGoal());
+        adSet.setBidStrategy(resolveBidStrategy(adSetReq.bidStrategy()));
+        adSet.setDailyBudgetMinor(parseLong(adSetReq.dailyBudget()));
+        adSet.setLifetimeBudgetMinor(parseLong(adSetReq.lifetimeBudget()));
+        adSet.setBidAmountMinor(parseLong(adSetReq.bidAmount()));
+        adSet.setPromotedObjectJson(buildPromotedObjectJson(adSetReq.pageId()));
+        adSet.setTargetingJson(buildTargetingJson(adSetReq.targetCountry()));
+        return adSet;
+    }
+
+    private FacebookAdsAdCreative mapAdCreative(CreateCampaignRequest.AdCreative creativeReq) {
+        FacebookAdsAdCreative creative = new FacebookAdsAdCreative();
+        creative.setId(creativeReq.id());
+        creative.setPageId(creativeReq.pageId());
+        creative.setInstagramUserId(creativeReq.instagramActorId());
+        creative.setKind(AdCreativeKind.LINK);
+        creative.setLinkDataJson(buildLinkDataJson(creativeReq));
+        return creative;
+    }
+
+    private FacebookAdsAd mapAd(CreateCampaignRequest.Ad adReq,
+                                 FacebookAdsAdSet adSet,
+                                 FacebookAdsAdCreative creative) {
+        FacebookAdsAd ad = new FacebookAdsAd();
+        ad.setId(adReq.id());
+        ad.setName(adReq.name());
+        ad.setAdSet(adSet);
+        ad.setCreative(creative);
+        return ad;
+    }
+
+    private String resolveBidStrategy(String bidStrategy) {
+        if (StringUtils.hasText(bidStrategy)) {
+            return bidStrategy.trim();
+        }
+        return "LOWEST_COST_WITHOUT_CAP";
+    }
+
+    private Long parseLong(String numeric) {
+        if (!StringUtils.hasText(numeric)) {
+            return null;
+        }
+        try {
+            return Long.parseLong(numeric.trim());
+        } catch (NumberFormatException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid numeric value: " + numeric, ex);
+        }
+    }
+
+    private String buildPromotedObjectJson(String pageId) {
+        if (!StringUtils.hasText(pageId)) {
+            return null;
+        }
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("page_id", pageId);
+        return node.toString();
+    }
+
+    private String buildTargetingJson(String targetCountry) {
+        ObjectNode node = objectMapper.createObjectNode();
+        ObjectNode geoLocations = node.putObject("geo_locations");
+        ArrayNode countries = geoLocations.putArray("countries");
+        if (StringUtils.hasText(targetCountry)) {
+            countries.add(targetCountry);
+        }
+        return node.toString();
+    }
+
+    private String buildLinkDataJson(CreateCampaignRequest.AdCreative creativeReq) {
+        ObjectNode linkData = objectMapper.createObjectNode();
+        linkData.put("link", creativeReq.websiteUrl());
+        linkData.put("message", creativeReq.message());
+        if (StringUtils.hasText(creativeReq.headline())) {
+            linkData.put("name", creativeReq.headline());
+        }
+        if (StringUtils.hasText(creativeReq.description())) {
+            linkData.put("description", creativeReq.description());
+        }
+        if (StringUtils.hasText(creativeReq.callToActionType())) {
+            ObjectNode callToAction = linkData.putObject("call_to_action");
+            callToAction.put("type", creativeReq.callToActionType());
+            ObjectNode value = callToAction.putObject("value");
+            value.put("link", creativeReq.websiteUrl());
+        }
+        return linkData.toString();
     }
 
     private ExperimentSummary toSummary(Experiment experiment) {
@@ -135,5 +274,38 @@ public class FacebookAdsCampaignController {
             String objective,
             BudgetMode budgetMode,
             Long experimentId,
-            Long facebookAccountId) {}
+            Long facebookAccountId,
+            AdSet adSet,
+            AdCreative adCreative,
+            Ad ad) {
+
+        public record AdSet(
+                String id,
+                String name,
+                String billingEvent,
+                String optimizationGoal,
+                String bidStrategy,
+                String bidAmount,
+                String dailyBudget,
+                String lifetimeBudget,
+                String targetCountry,
+                String destinationType,
+                String pageId) {}
+
+        public record AdCreative(
+                String id,
+                String pageId,
+                String instagramActorId,
+                String websiteUrl,
+                String message,
+                String callToActionType,
+                String headline,
+                String description) {}
+
+        public record Ad(
+                String id,
+                String name,
+                String adSetId,
+                String creativeId) {}
+    }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -1,12 +1,21 @@
 package com.marketinghub.facebookads.web;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.ads.FacebookAccount;
 import com.marketinghub.ads.FacebookAccountRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.funnel.SalesFunnel;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.experiment.service.ExperimentService;
+import com.marketinghub.facebookads.FacebookAdsAd;
+import com.marketinghub.facebookads.FacebookAdsAdCreative;
+import com.marketinghub.facebookads.FacebookAdsAdCreativeRepository;
+import com.marketinghub.facebookads.FacebookAdsAdRepository;
+import com.marketinghub.facebookads.FacebookAdsAdSet;
+import com.marketinghub.facebookads.FacebookAdsAdSetRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -14,13 +23,21 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.MediaType;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest(classes = AdsServiceApplication.class)
@@ -36,12 +53,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class FacebookAdsCampaignControllerTest {
     @Autowired
     MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
     @MockBean
     ExperimentService experimentService;
     @MockBean
     com.marketinghub.facebookads.FacebookAdsCampaignRepository campaignRepository;
     @MockBean
     FacebookAccountRepository facebookAccountRepository;
+    @MockBean
+    FacebookAdsAdSetRepository adSetRepository;
+    @MockBean
+    FacebookAdsAdCreativeRepository adCreativeRepository;
+    @MockBean
+    FacebookAdsAdRepository adRepository;
 
     @Test
     void listExperimentsByStatus() throws Exception {
@@ -89,5 +114,101 @@ class FacebookAdsCampaignControllerTest {
                 .andExpect(jsonPath("$[0].hypothesisTitle").value("Hipótese do Nicho"))
                 .andExpect(jsonPath("$[0].missingConfiguration").isArray())
                 .andExpect(jsonPath("$[0].missingConfiguration").isEmpty());
+    }
+
+    @Test
+    void createCampaignPersistsHierarchy() throws Exception {
+        var experiment = Experiment.builder()
+                .id(42L)
+                .name("Exp")
+                .creativeApproved(true)
+                .build();
+        when(experimentService.get(42L)).thenReturn(experiment);
+
+        FacebookAccount account = new FacebookAccount();
+        account.setId(77L);
+        when(facebookAccountRepository.findById(77L)).thenReturn(Optional.of(account));
+
+        when(campaignRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(adSetRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(adCreativeRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(adRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        String payload = """
+            {
+              "id": "cmp123",
+              "adAccountId": "act_555",
+              "name": "Exp",
+              "objective": "OUTCOME_TRAFFIC",
+              "budgetMode": "CAMPAIGN",
+              "experimentId": 42,
+              "facebookAccountId": 77,
+              "adSet": {
+                "id": "adset123",
+                "name": "Exp - Ad Set",
+                "billingEvent": "IMPRESSIONS",
+                "optimizationGoal": "LINK_CLICKS",
+                "bidStrategy": "LOWEST_COST_WITHOUT_CAP",
+                "bidAmount": "1000",
+                "dailyBudget": "5000",
+                "lifetimeBudget": null,
+                "targetCountry": "BR",
+                "destinationType": "WEBSITE",
+                "pageId": "12345"
+              },
+              "adCreative": {
+                "id": "creative123",
+                "pageId": "12345",
+                "instagramActorId": "6789",
+                "websiteUrl": "https://example.com",
+                "message": "Mensagem",
+                "callToActionType": "LEARN_MORE",
+                "headline": "Headline",
+                "description": "Description"
+              },
+              "ad": {
+                "id": "ad987",
+                "name": "Exp - Ad",
+                "adSetId": "adset123",
+                "creativeId": "creative123"
+              }
+            }
+            """;
+
+        mockMvc.perform(post("/api/facebook-campaigns")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("cmp123"))
+                .andExpect(jsonPath("$.adAccountId").value("act_555"))
+                .andExpect(jsonPath("$.experiment.id").value(42));
+
+        ArgumentCaptor<FacebookAdsAdSet> adSetCaptor = ArgumentCaptor.forClass(FacebookAdsAdSet.class);
+        verify(adSetRepository).save(adSetCaptor.capture());
+        FacebookAdsAdSet savedAdSet = adSetCaptor.getValue();
+        assertThat(savedAdSet.getId()).isEqualTo("adset123");
+        assertThat(savedAdSet.getCampaign().getId()).isEqualTo("cmp123");
+        JsonNode targetingJson = objectMapper.readTree(savedAdSet.getTargetingJson());
+        assertThat(targetingJson.path("geo_locations").path("countries").get(0).asText()).isEqualTo("BR");
+        JsonNode promotedObject = savedAdSet.getPromotedObjectJson() != null
+                ? objectMapper.readTree(savedAdSet.getPromotedObjectJson())
+                : objectMapper.nullNode();
+        assertThat(promotedObject.path("page_id").asText()).isEqualTo("12345");
+
+        ArgumentCaptor<FacebookAdsAdCreative> creativeCaptor = ArgumentCaptor.forClass(FacebookAdsAdCreative.class);
+        verify(adCreativeRepository).save(creativeCaptor.capture());
+        FacebookAdsAdCreative savedCreative = creativeCaptor.getValue();
+        assertThat(savedCreative.getId()).isEqualTo("creative123");
+        assertThat(savedCreative.getPageId()).isEqualTo("12345");
+        JsonNode linkData = objectMapper.readTree(savedCreative.getLinkDataJson());
+        assertThat(linkData.path("link").asText()).isEqualTo("https://example.com");
+        assertThat(linkData.path("call_to_action").path("type").asText()).isEqualTo("LEARN_MORE");
+
+        ArgumentCaptor<FacebookAdsAd> adCaptor = ArgumentCaptor.forClass(FacebookAdsAd.class);
+        verify(adRepository).save(adCaptor.capture());
+        FacebookAdsAd savedAd = adCaptor.getValue();
+        assertThat(savedAd.getId()).isEqualTo("ad987");
+        assertThat(savedAd.getAdSet().getId()).isEqualTo("adset123");
+        assertThat(savedAd.getCreative().getId()).isEqualTo("creative123");
     }
 }

--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -43,6 +43,8 @@ classDiagram
         +billingEvent : String
         +optimizationGoal : String
         +destinationType : String
+        +bidStrategy : String
+        +bidAmount : String
         +pageId : String
         +targetCountry : String
     }
@@ -55,6 +57,8 @@ classDiagram
         +websiteUrl : String
         +message : String
         +callToActionType : String
+        +headline : String
+        +description : String
     }
 
     class AdRequest {
@@ -108,6 +112,44 @@ classDiagram
         +budgetMode : BudgetMode
         +experimentId : Long
         +facebookAccountId : Long
+        +adSet : AdSetPayload
+        +adCreative : AdCreativePayload
+        +ad : AdPayload
+    }
+
+    class AdSetPayload {
+        <<record>>
+        +id : String
+        +name : String
+        +billingEvent : String
+        +optimizationGoal : String
+        +bidStrategy : String
+        +bidAmount : String
+        +dailyBudget : String
+        +lifetimeBudget : String
+        +targetCountry : String
+        +destinationType : String
+        +pageId : String
+    }
+
+    class AdCreativePayload {
+        <<record>>
+        +id : String
+        +pageId : String
+        +instagramActorId : String
+        +websiteUrl : String
+        +message : String
+        +callToActionType : String
+        +headline : String
+        +description : String
+    }
+
+    class AdPayload {
+        <<record>>
+        +id : String
+        +name : String
+        +adSetId : String
+        +creativeId : String
     }
 
     class FacebookAdsCampaign {
@@ -128,6 +170,37 @@ classDiagram
         +specialAdCountries : Set<String>
         +createdAt : Instant
         +updatedAt : Instant
+    }
+
+    class FacebookAdsAdSet {
+        <<entity>>
+        +id : String
+        +campaign : FacebookAdsCampaign
+        +name : String
+        +billingEvent : String
+        +optimizationGoal : String
+        +bidStrategy : String
+        +bidAmountMinor : Long
+        +dailyBudgetMinor : Long
+        +targetingJson : String
+        +promotedObjectJson : String
+    }
+
+    class FacebookAdsAdCreative {
+        <<entity>>
+        +id : String
+        +pageId : String
+        +instagramUserId : String
+        +kind : AdCreativeKind
+        +linkDataJson : String
+    }
+
+    class FacebookAdsAd {
+        <<entity>>
+        +id : String
+        +adSet : FacebookAdsAdSet
+        +creative : FacebookAdsAdCreative
+        +name : String
     }
 
     class FacebookAdStatus {
@@ -166,12 +239,20 @@ classDiagram
     FacebookAdsService --> AdCreativeRequest
     FacebookAdsService --> AdRequest
     FacebookCampaignService --> CreateCampaignRequest : monta payload do backend
-    CreateCampaignRequest ..> FacebookAdsCampaign : persiste entidade
+    CreateCampaignRequest --> AdSetPayload
+    CreateCampaignRequest --> AdCreativePayload
+    CreateCampaignRequest --> AdPayload
+    CreateCampaignRequest ..> FacebookAdsCampaign : persiste campanha
+    CreateCampaignRequest ..> FacebookAdsAdSet : persiste ad set
+    CreateCampaignRequest ..> FacebookAdsAdCreative : persiste criativo
+    CreateCampaignRequest ..> FacebookAdsAd : persiste anúncio
     FacebookAdsCampaign --> FacebookAdStatus
     FacebookAdsCampaign --> BudgetMode
     FacebookAdsCampaign --> SpecialAdCategory
     FacebookAdsCampaign --> Experiment
     FacebookAdsCampaign --> FacebookAccount
+    FacebookAdsAd --> FacebookAdsAdSet
+    FacebookAdsAd --> FacebookAdsAdCreative
     FacebookCampaignService ..> UrlUtils : compõe URLs do backend
     FacebookTokenRenewalScheduler --> FacebookTokenRenewalService : agenda renovação
     FacebookTokenRenewalService --> FacebookAdsService : renova token
@@ -185,9 +266,10 @@ classDiagram
   a configuração ativa (`worker-config`), sincroniza o token em memória e cria a
   hierarquia de campanha na Graph API. O serviço resolve o `pageId` a partir do
   experimento, utilizando o fallback da conta quando necessário, e registra o
-  resultado da campanha no backend. Quando o Facebook devolve erro de permissão,
-  o serviço adiciona o experimento a uma lista de bloqueio em memória para evitar
-  novas tentativas até que o worker seja reiniciado.
+  resultado completo (campanha, ad set, criativo e anúncio) no backend. Quando o
+  Facebook devolve erro de permissão, o serviço adiciona o experimento a uma
+  lista de bloqueio em memória para evitar novas tentativas até que o worker
+  seja reiniciado.
 * `FacebookAdsService` encapsula as chamadas à Graph API (criação da hierarquia
   de mídia, consulta de métricas e renovação de tokens de longa duração).
 * `FacebookTokenRenewalScheduler` agenda o fluxo periódico de renovação de token

--- a/docs/facebook-ads-worker/input-output-mapping.md
+++ b/docs/facebook-ads-worker/input-output-mapping.md
@@ -106,7 +106,8 @@ flowchart TD
 | `status` | Constante | `PAUSED` |
 | `access_token` | Conta configurada (`worker-config.accessToken`) | Token com permissão para o Ad Account |
 
-* **Resposta tratada:** o identificador é armazenado apenas para auditoria de execução (não é persistido no backend ainda).
+* **Resposta tratada:** o identificador alimenta o payload enviado ao backend,
+  mantendo o vínculo entre anúncio, conjunto e criativo na base própria.
 
 ## 6. Persistência da campanha no backend
 
@@ -125,16 +126,21 @@ para o backend.
 | `budgetMode` | Constante | Valor fixo `CAMPAIGN` até que o backend passe a enviar planejamento detalhado |
 | `experimentId` | `Experiment.id` | Garante vínculo direto com o experimento que originou a campanha |
 | `facebookAccountId` | `worker-config.accountId` | Mantém rastreabilidade com a conta utilizada pelo worker |
+| `adSet.id` | Resposta da Graph API (ad set) | Persistido como `facebook_ads_ad_set.id` |
+| `adSet.targetCountry` | `worker-config.adSetTargetCountry` | Serializado para JSON em `facebook_ads_ad_set.targeting_json` |
+| `adSet.pageId` | `worker-config.defaultPageId` ou `Experiment.pageId` | Serializado como `promoted_object_json` |
+| `adCreative.id` | Resposta da Graph API (criativo) | Persistido como `facebook_ads_ad_creative.id` |
+| `adCreative.websiteUrl` | Configuração do worker ou criativo aprovado | Serializado em `link_data_json` |
+| `ad.id` | Resposta da Graph API (anúncio) | Persistido como `facebook_ads_ad.id` e vinculado ao ad set/criativo salvos |
 
 ## Observações
 
-* O payload enviado ao backend agora inclui `experimentId` e `facebookAccountId`,
-  permitindo que a tabela `facebook_ads_campaign` mantenha chaves estrangeiras
-  para rastreabilidade e auditoria do fluxo automatizado.
-* As tabelas `facebook_ads_ad_set`, `facebook_ads_ad` e entidades auxiliares já
-  estão preparadas no backend, mas ainda não recebem dados adicionais além do
-  identificador da campanha. O enriquecimento com segmentação detalhada, criativos
-  aprovados pelo usuário e UTMs permanece listado em [pendencias.md](./pendencias.md).
+* O payload enviado ao backend inclui `experimentId`, `facebookAccountId` e as
+  estruturas completas de `adSet`, `adCreative` e `ad`, garantindo que todas as
+  tabelas `facebook_ads_*` recebam os identificadores gerados na Graph API.
+* A persistência do ad set replica a segmentação simplificada utilizada hoje
+  (`geo_locations.countries`) e o `page_id` promovido. Evoluções futuras podem
+  complementar esse JSON com segmentações ricas e planejamento de orçamento.
 * A composição das URLs dos endpoints do backend utiliza `UrlUtils.joinPath`
   para garantir que `backend.base-url`, `backend.api-prefix` e o caminho do
   recurso não gerem barras duplicadas.

--- a/docs/facebook-ads-worker/meta-ads-campaign-coverage.md
+++ b/docs/facebook-ads-worker/meta-ads-campaign-coverage.md
@@ -12,7 +12,9 @@ para navegar entre as entidades citadas.
   página e CTA padrão etc.) não constam na lista original, mas são carregados a
   partir de `FacebookWorkerConfigurationClient` e das entidades `fb_account`.
 - O backend agora persiste chaves estrangeiras para o experimento e a conta de
-  Facebook que originaram cada campanha, viabilizando auditoria ponta a ponta.
+  Facebook que originaram cada campanha, bem como os identificadores dos ad
+  sets, criativos e anúncios correspondentes, viabilizando auditoria ponta a
+  ponta.
 - Há **campos planejados** no documento que ainda não são enviados pelo worker
   nem possuem suporte completo no banco (ex.: teste A/B, limites de gasto,
   segmentações avançadas).
@@ -48,9 +50,9 @@ para navegar entre as entidades citadas.
 | Campo (documento) | Tratamento atual no worker | Entidades / Propriedades relacionadas |
 | --- | --- | --- |
 | Nome do conjunto | Usa `Experiment.name` com sufixo “- Ad Set”. | `facebook_ads_ad_set.name` (`FacebookAdsAdSet` no diagrama). |
-| Evento de conversão / Meta | `promoted_object_json` permanece vazio; pixel/evento ainda não configurados. | `facebook_ads_ad_set.promoted_object_json`. |
+| Evento de conversão / Meta | `promoted_object_json` armazena o `page_id` promovido; pixel/evento ainda não configurados. | `facebook_ads_ad_set.promoted_object_json`. |
 | Estratégia de otimização | Valor padrão da conta (`fb_account.ad_set_optimization_goal`). | `facebook_ads_ad_set.optimization_goal`. |
-| Estratégia de lance | `bid_strategy` e `bid_amount` herdados da conta; podem ficar em branco. | `facebook_ads_ad_set.bid_strategy`, `bid_amount_minor`. |
+| Estratégia de lance | `bid_strategy` e `bid_amount` herdados da conta; quando ausentes, o backend assume `LOWEST_COST_WITHOUT_CAP`. | `facebook_ads_ad_set.bid_strategy`, `bid_amount_minor`. |
 | Orçamento (sem CBO) | Envia `daily_budget` a partir de `fb_account.ad_set_daily_budget`. | `facebook_ads_ad_set.daily_budget_minor` / `lifetime_budget_minor`. |
 | Período de veiculação | `start_time`/`end_time` não configurados. | Colunas homônimas no ad set. |
 | Públicos personalizados / semelhantes | Planejado para `targeting_json`; ainda não serializado. | `facebook_ads_ad_set.targeting_json`. |
@@ -67,7 +69,7 @@ para navegar entre as entidades citadas.
 | --- | --- | --- |
 | Nome do anúncio | Derivado de `Experiment.name` com sufixo “- Ad”. | `facebook_ads_ad.name`. |
 | Identidade (Página/Instagram) | Resolve `pageId` e `instagram_user_id` a partir do experimento ou defaults da conta. | `facebook_ads_ad_creative.page_id`, `instagram_user_id`. |
-| Formato do anúncio | Apenas link ads; valor armazenado em `Creative.format`, não enviado ainda. | `facebook_ads_ad_creative.kind`. |
+| Formato do anúncio | Apenas link ads; backend registra `AdCreativeKind.LINK` em todos os criativos. | `facebook_ads_ad_creative.kind`. |
 | Mídia principal | Dados do criativo aprovado (`imageUrl`, `imageHash`, `videoId`); assets futuros usarão `facebook_ads_media_asset`. | `facebook_ads_media_asset` e JSON do criativo. |
 | Mídias adicionais | Carrossel/coleção não suportados. | `facebook_ads_ad_creative.carousel_data_json` / `video_data_json`. |
 | Texto primário | `Creative.primaryText` ou fallback da conta. | `facebook_ads_ad_creative.link_data_json.message`. |

--- a/docs/facebook-ads-worker/pendencias.md
+++ b/docs/facebook-ads-worker/pendencias.md
@@ -13,10 +13,9 @@ e governança, ainda faltam os itens abaixo, agrupados por tema.
   de constantes.
 - Suportar janelas de veiculação (datas de início/fim) e status da campanha
   (ex.: programada, ativa, pausada).
-- Alimentar o backend com os identificadores de ad set, criativo e anúncio para
-  manter rastreabilidade completa no modelo de dados.
-- As campanhas já registram `experiment_id` e `facebook_account_id`, faltando
-  estender o mesmo nível de rastreabilidade para as demais entidades.
+- Enriquecer `facebook_ads_ad_set`, `facebook_ads_ad_creative` e `facebook_ads_ad`
+  com planejamento completo (orçamento detalhado, segmentações avançadas e UTMs)
+  além dos identificadores básicos já persistidos.
 - Versionar e auditar alterações na configuração do worker (`worker-config`),
   registrando quem atualizou parâmetros sensíveis (token, orçamento padrão,
   página fallback).

--- a/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
+++ b/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
@@ -47,19 +47,19 @@ montar a hierarquia completa:
 
 1. **Campanha**: `POST /campaigns` com objetivo `OUTCOME_TRAFFIC`, status
    `PAUSED` e `special_ad_categories = NONE`. O identificador retornado alimenta
-   as etapas seguintes ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L101-L105)).
+   as etapas seguintes ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L195-L205)).
 2. **Conjunto de anúncios**: `POST /adsets` com orçamento diário, billing event,
    objetivo de otimização e destino (`WEBSITE`) vindos da conta configurada no
    backend (`worker-config`). A segmentação inicial utiliza apenas o país padrão
    enquanto o backend não envia dados mais ricos. O `id` retornado é usado na
-   criação do anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L111)).
+   criação do anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L196-L208)).
 3. **Criativo**: `POST /adcreatives` baseado em um `object_story_spec` que inclui
    `page_id`, `instagram_actor_id` opcional, template de mensagem com o nome do
    experimento e call-to-action vindos da mesma configuração. O `id` retornado
-   alimenta o anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L119)).
+   alimenta o anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L209-L219)).
 4. **Anúncio**: `POST /ads` referenciando o ad set e o criativo recém-criados, em
    status `PAUSED` para permitir revisão manual antes da ativação
-   ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L120-L124)).
+   ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L220-L225)).
 
 Todos os pontos de contato com a Graph API reutilizam o `access_token` exposto
 pelo `worker-config`. Quando a Graph API responde com `(#190) OAuthException`
@@ -71,26 +71,28 @@ consulta novamente o backend antes de atualizar o token em memória.
 
 Após concluir as chamadas à Graph API, o worker envia um
 `CreateCampaignRequest` para o backend com os campos necessários para registrar
-a campanha na tabela `facebook_ads_campaign`. Além dos atributos já utilizados
-(`id`, `adAccountId`, `objective`, `budgetMode`), o payload agora leva o
-`experimentId` e o `facebookAccountId`, garantindo chaves estrangeiras para o
-planejamento que originou a campanha
-([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L136), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L39-L66)).
+a campanha, o conjunto, o criativo e o anúncio gerados. O payload replica os
+identificadores retornados pela Graph API, os parâmetros de segmentação
+utilizados (`targetCountry`, `pageId`) e os metadados do criativo (`websiteUrl`,
+`message`, `callToActionType`), garantindo rastreabilidade completa nas tabelas
+`facebook_ads_campaign`, `facebook_ads_ad_set`, `facebook_ads_ad_creative` e
+`facebook_ads_ad`
+([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L195-L269), [FacebookAdsCampaignController.java](../../backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java#L39-L196)).
 
 ## Mapeamento de campos
 
 | Fonte | Destino | Observações |
 | --- | --- | --- |
-| `Experiment.name` | `Graph API - name` | Nome base para campanha, ad set, criativo e anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L101-L124)) |
-| `Experiment.name` | `CreateCampaignRequest.name` | Mantém rastreabilidade entre backend e Facebook ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132)) |
+| `Experiment.name` | `Graph API - name` | Nome base para campanha, ad set, criativo e anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L169-L224)) |
+| `Experiment.name` | `CreateCampaignRequest.name` | Mantém rastreabilidade entre backend e Facebook ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L226-L263)) |
 | `worker-config.adAccountId` | `Graph API - URLs` | Define o Ad Account usado em todas as chamadas `POST` ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L38-L67)) |
-| `worker-config.accessToken` | `Graph API - access_token` | Token reutilizado em campanha, ad set, criativo e anúncio ([FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L18-L132)) |
-| `worker-config.adSet*` | `Graph API - adsets` | Define orçamento, otimização e país padrão ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L111)) |
-| `worker-config.defaultPageId` | `Graph API - promoted_object` / `object_story_spec.page_id` | Necessário para ad sets e criativos ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L102-L119)) |
-| `worker-config.defaultInstagramActorId` | `Graph API - object_story_spec.instagram_actor_id` | Opcional, incluído apenas quando configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L118)) |
-| `worker-config.defaultCreativeMessageTemplate` | `Graph API - object_story_spec.link_data.message` | Template com suporte a `%s` para o nome do experimento ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L134-L141)) |
-| `worker-config.defaultWebsiteUrl` | `Graph API - link_data.link` e `call_to_action.value.link` | URL padrão de destino ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L112-L118)) |
-| Resposta da Graph API (`id`) | `CreateCampaignRequest.id` | Persistido como identificador principal da campanha ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L125-L132)) |
+| `worker-config.accessToken` | `Graph API - access_token` | Token reutilizado em campanha, ad set, criativo e anúncio ([FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L18-L208)) |
+| `worker-config.adSet*` | `Graph API - adsets` e `CreateCampaignRequest.adSet` | Define orçamento, otimização e país padrão, replicados no backend ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L196-L245)) |
+| `worker-config.defaultPageId` | `Graph API - promoted_object` / `object_story_spec.page_id` / `CreateCampaignRequest.adSet.pageId` | Necessário para ad sets e criativos, persistido em `promoted_object_json` ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L177-L245)) |
+| `worker-config.defaultInstagramActorId` | `Graph API - object_story_spec.instagram_actor_id` / `CreateCampaignRequest.adCreative.instagramActorId` | Opcional, incluído apenas quando configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L209-L255)) |
+| `worker-config.defaultCreativeMessageTemplate` | `Graph API - object_story_spec.link_data.message` | Template com suporte a `%s` para o nome do experimento ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L189-L193)) |
+| `worker-config.defaultWebsiteUrl` | `Graph API - link_data.link`/`call_to_action.value.link` e `CreateCampaignRequest.adCreative.websiteUrl` | URL padrão de destino persistida no backend ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L209-L255)) |
+| Resposta da Graph API (`id`) | `CreateCampaignRequest.id`/`adSet.id`/`adCreative.id`/`ad.id` | Identificadores de campanha, ad set, criativo e anúncio persistidos nas respectivas tabelas |
 | Constante `OUTCOME_TRAFFIC` | `Graph API - objective` e `CreateCampaignRequest.objective` | Objetivo padrão até existir planejamento específico |
 | Constante `CAMPAIGN` | `CreateCampaignRequest.budgetMode` | Modo de orçamento usado atualmente pelo backend |
 | `Experiment.id` | `CreateCampaignRequest.experimentId` | Usado para preencher a FK `facebook_ads_campaign.experiment_id` |
@@ -113,6 +115,6 @@ para completar a configuração avançada da campanha:
 - `landing_page` e `metric_snapshot` (rastreio de performance e destino de
   tráfego). ([data-model.md](../data-model.md#landing_page), [data-model.md](../data-model.md#metric_snapshot))
 
-As pendências registradas para o Facebook Ads Worker agora se concentram em
-alimentar essas entidades com dados reais, gerar UTMs e sincronizar métricas
+Com a hierarquia básica persistida, as próximas evoluções se concentram em
+enriquecer os registros com segmentações detalhadas, UTMs e métricas periódicas
 ([pendencias.md](./pendencias.md)).

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -26,10 +26,12 @@ As chamadas ao backend utilizam o prefixo `/api`. O worker consome
 "nenhum experimento disponível" para evitar falhas no agendamento. Falhas de
 conexão ao recuperar os experimentos são registradas em log e ignoradas para
 que o agendamento continue saudável. Após criar campanha, conjunto, criativo e
-anúncio, o worker persiste o identificador da campanha via
-`POST /api/facebook-campaigns`. Todas as chamadas HTTP ao backend devem
-registrar a URL completa, parâmetros, payload e resposta recebida para
-acelerar o diagnóstico de incidentes em produção.
+anúncio, o worker envia um `CreateCampaignRequest` para o backend via
+`POST /api/facebook-campaigns`, preenchendo os identificadores de cada nível da
+hierarquia para manter rastreabilidade completa (`facebook_ads_campaign`,
+`facebook_ads_ad_set`, `facebook_ads_ad_creative` e `facebook_ads_ad`). Todas as
+chamadas HTTP ao backend devem registrar a URL completa, parâmetros, payload e
+resposta recebida para acelerar o diagnóstico de incidentes em produção.
 
 Todas as chamadas à Graph API são logadas detalhadamente para facilitar
 investigações de erros (por exemplo, respostas `400 Bad Request`). Os logs

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -193,7 +193,7 @@ public class FacebookCampaignService {
             String resolvedInstagramActorId = coalesce(creative.instagramUserId(), config.defaultInstagramActorId());
 
             String campaignId = facebookAdsService.createCampaign(config.adAccountId(), exp.name());
-            String adSetId = facebookAdsService.createAdSet(config.adAccountId(), new FacebookAdsService.AdSetRequest(
+            FacebookAdsService.AdSetRequest adSetRequest = new FacebookAdsService.AdSetRequest(
                 exp.name() + " - Ad Set",
                 campaignId,
                 config.adSetDailyBudget(),
@@ -204,8 +204,9 @@ public class FacebookCampaignService {
                 config.adSetBidAmount(),
                 resolvedPageId,
                 config.adSetTargetCountry()
-            ));
-            String creativeId = facebookAdsService.createAdCreative(config.adAccountId(), new FacebookAdsService.AdCreativeRequest(
+            );
+            String adSetId = facebookAdsService.createAdSet(config.adAccountId(), adSetRequest);
+            FacebookAdsService.AdCreativeRequest adCreativeRequest = new FacebookAdsService.AdCreativeRequest(
                 exp.name() + " - Creative",
                 resolvedPageId,
                 resolvedInstagramActorId,
@@ -214,12 +215,14 @@ public class FacebookCampaignService {
                 resolvedCallToAction,
                 creative.headline(),
                 creative.description()
-            ));
-            facebookAdsService.createAd(config.adAccountId(), new FacebookAdsService.AdRequest(
+            );
+            String creativeId = facebookAdsService.createAdCreative(config.adAccountId(), adCreativeRequest);
+            FacebookAdsService.AdRequest adRequest = new FacebookAdsService.AdRequest(
                 exp.name() + " - Ad",
                 adSetId,
                 creativeId
-            ));
+            );
+            String adId = facebookAdsService.createAd(config.adAccountId(), adRequest);
             CreateCampaignRequest req = new CreateCampaignRequest(
                 campaignId,
                 config.adAccountId(),
@@ -227,7 +230,36 @@ public class FacebookCampaignService {
                 "OUTCOME_TRAFFIC",
                 "CAMPAIGN",
                 exp.id(),
-                config.accountId()
+                config.accountId(),
+                new CreateCampaignRequest.AdSet(
+                    adSetId,
+                    adSetRequest.name(),
+                    adSetRequest.billingEvent(),
+                    adSetRequest.optimizationGoal(),
+                    adSetRequest.bidStrategy(),
+                    adSetRequest.bidAmount(),
+                    adSetRequest.dailyBudget(),
+                    null,
+                    adSetRequest.targetCountry(),
+                    adSetRequest.destinationType(),
+                    adSetRequest.pageId()
+                ),
+                new CreateCampaignRequest.AdCreative(
+                    creativeId,
+                    adCreativeRequest.pageId(),
+                    adCreativeRequest.instagramActorId(),
+                    adCreativeRequest.websiteUrl(),
+                    adCreativeRequest.message(),
+                    adCreativeRequest.callToActionType(),
+                    adCreativeRequest.headline(),
+                    adCreativeRequest.description()
+                ),
+                new CreateCampaignRequest.Ad(
+                    adId,
+                    adRequest.name(),
+                    adRequest.adSetId(),
+                    adRequest.creativeId()
+                )
             );
             String createCampaignUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns");
             LOGGER.info(
@@ -325,8 +357,43 @@ public class FacebookCampaignService {
         String objective,
         String budgetMode,
         Long experimentId,
-        Long facebookAccountId
-    ) {}
+        Long facebookAccountId,
+        AdSet adSet,
+        AdCreative adCreative,
+        Ad ad
+    ) {
+        public record AdSet(
+            String id,
+            String name,
+            String billingEvent,
+            String optimizationGoal,
+            String bidStrategy,
+            String bidAmount,
+            String dailyBudget,
+            String lifetimeBudget,
+            String targetCountry,
+            String destinationType,
+            String pageId
+        ) {}
+
+        public record AdCreative(
+            String id,
+            String pageId,
+            String instagramActorId,
+            String websiteUrl,
+            String message,
+            String callToActionType,
+            String headline,
+            String description
+        ) {}
+
+        public record Ad(
+            String id,
+            String name,
+            String adSetId,
+            String creativeId
+        ) {}
+    }
 
     private Creative resolveCreative(long experimentId) {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/creatives");


### PR DESCRIPTION
## Summary
- report Facebook ad set, creative, and ad identifiers from the worker when creating campaigns
- persist the full hierarchy in the backend, building minimal targeting and creative payloads for storage and validating ad relationships
- update unit tests and documentation to reflect the new traceability flow

## Testing
- `cd backend/ads-service && mvn -s ../settings.xml test` *(fails: repository parent POM unavailable in the offline environment)*
- `cd facebook-ads-worker && mvn -s settings.xml test` *(fails: repository parent POM unavailable in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2c7abee08321b29ce8f15470882c