### PR TITLE
Invalidate Facebook configuration status after Facebook account updates

### DIFF
--- a/frontend/src/api/facebookAccountMutations.ts
+++ b/frontend/src/api/facebookAccountMutations.ts
@@ -42,8 +42,10 @@ export function useCreateFacebookAccount() {
   return useMutation({
     mutationFn: (account: FacebookAccountPayload) =>
       axios.post("/api/accounts/facebook", account),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] });
+      queryClient.invalidateQueries({ queryKey: ["facebook-configuration-status"] });
+    },
   });
 }
 
@@ -52,8 +54,10 @@ export function useUpdateFacebookAccount() {
   return useMutation({
     mutationFn: (account: FacebookAccountPayload) =>
       axios.put(`/api/accounts/facebook/${account.id}`, account),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] });
+      queryClient.invalidateQueries({ queryKey: ["facebook-configuration-status"] });
+    },
   });
 }
 
@@ -62,7 +66,9 @@ export function useDeleteFacebookAccount() {
   return useMutation({
     mutationFn: (id: number) =>
       axios.delete(`/api/accounts/facebook/${id}`),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["facebook-accounts"] });
+      queryClient.invalidateQueries({ queryKey: ["facebook-configuration-status"] });
+    },
   });
 }

--- a/frontend/src/api/facebookPageMutations.ts
+++ b/frontend/src/api/facebookPageMutations.ts
@@ -26,6 +26,7 @@ export function useUpdateFacebookPage(accountId: string | number | undefined) {
       axios.put(`/api/accounts/facebook/${accountId}/pages/${page.id}`, page),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["facebook-pages", accountId] });
+      queryClient.invalidateQueries({ queryKey: ["facebook-configuration-status"] });
     },
   });
 }


### PR DESCRIPTION
## Summary
- invalidate the facebook configuration status query after account mutations so worker diagnostics refresh immediately
- refresh the configuration status diagnostics after editing facebook pages as well

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd30a947488321b9e755abac7f3ec7