### PR TITLE
Add Postman collection for Facebook Ads worker endpoints

### DIFF
--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -5,7 +5,7 @@ Esta pasta concentra collections prontas para importar no Postman e exercitar os
 ## Como usar
 1. Abra o Postman e escolha **Import**.
 2. Faça o upload do arquivo `facebook-ads-worker.postman_collection.json`.
-3. Ajuste a variável `baseUrl` para apontar para a instância do backend que deseja testar (por padrão `http://191.252.92.222/api`).
+3. Ajuste a variável `baseUrl` para apontar para a instância do backend que deseja testar (por padrão `http://191.252.92.222:8000/api`).
 4. Defina a variável `accountId` com o identificador da conta que deseja atualizar, renovar ou excluir.
 
 A collection inclui requisições para listar, criar, atualizar e remover contas, consultar o `worker-config` ativo e registrar tentativas de renovação de token do Facebook Ads Worker.

--- a/docs/postman/facebook-ads-worker.postman_collection.json
+++ b/docs/postman/facebook-ads-worker.postman_collection.json
@@ -7,7 +7,7 @@
   "variable": [
     {
       "key": "baseUrl",
-      "value": "http://191.252.92.222/api",
+      "value": "http://191.252.92.222:8000/api",
       "type": "string"
     },
     {


### PR DESCRIPTION
## Summary
- add a Postman collection covering the Facebook account management and worker-config endpoints
- document how to import and configure the new collection

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dd32b4096083218788e7bf3b639ef0