### PR TITLE
Remove Business Manager App ID field

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
@@ -44,9 +44,6 @@ public class FacebookAccount {
     private String authorizedUserEmail;
     private String appId;
 
-    @Column(name = "business_manager_app_id")
-    private String businessManagerAppId;
-
     @Column(name = "ad_account_id")
     private String adAccountId;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -61,7 +61,6 @@ public class FacebookAccountController {
         persisted.setAuthorizedUserName(account.getAuthorizedUserName());
         persisted.setAuthorizedUserEmail(account.getAuthorizedUserEmail());
         persisted.setAppId(account.getAppId());
-        persisted.setBusinessManagerAppId(account.getBusinessManagerAppId());
         persisted.setAdAccountId(account.getAdAccountId());
         persisted.setDefaultPageId(account.getDefaultPageId());
         persisted.setDefaultWebsiteUrl(account.getDefaultWebsiteUrl());
@@ -182,7 +181,6 @@ public class FacebookAccountController {
         account.setAuthorizedUserName(trimToNull(account.getAuthorizedUserName()));
         account.setAuthorizedUserEmail(trimToNull(account.getAuthorizedUserEmail()));
         account.setAppId(trimToNull(account.getAppId()));
-        account.setBusinessManagerAppId(trimToNull(account.getBusinessManagerAppId()));
         account.setAdAccountId(trimToNull(account.getAdAccountId()));
         account.setDefaultPageId(trimToNull(account.getDefaultPageId()));
         account.setDefaultWebsiteUrl(trimToNull(account.getDefaultWebsiteUrl()));

--- a/backend/ads-service/src/main/resources/db/changelog/V2026_04_10__drop_fb_account_business_manager_app_id.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2026_04_10__drop_fb_account_business_manager_app_id.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--changeset repo:2026-04-10-drop-fb-account-business-manager-app-id dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'fb_account' AND column_name = 'business_manager_app_id';
+ALTER TABLE fb_account
+  DROP COLUMN business_manager_app_id;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -140,3 +140,6 @@ databaseChangeLog:
   - include:
       file: V2026_04_05__link_facebook_ads_campaign_to_experiment_and_account.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2026_04_10__drop_fb_account_business_manager_app_id.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -80,7 +80,6 @@ public class FacebookAccountControllerTest {
             "\"name\":\"Conta BM\"," +
             "\"currency\":\"BRL\"," +
             "\"appId\":\" 123456 \"," +
-            "\"businessManagerAppId\":\" 654321 \"," +
             "\"appSecret\":\" segredo-super-seguro \"," +
             "\"tokenRenewalEnabled\":true" +
             "}";
@@ -92,7 +91,6 @@ public class FacebookAccountControllerTest {
 
         FacebookAccount saved = repository.findAll().stream().findFirst().orElseThrow();
         assertThat(saved.getAppId()).isEqualTo("123456");
-        assertThat(saved.getBusinessManagerAppId()).isEqualTo("654321");
         assertThat(saved.getAppSecret()).isEqualTo("segredo-super-seguro");
         assertThat(saved.isTokenRenewalEnabled()).isTrue();
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -428,7 +428,6 @@ allow variants to be created before an experiment is defined.
 - `authorized_user_name` VARCHAR(255)
 - `authorized_user_email` VARCHAR(320)
 - `app_id` VARCHAR(255)
-- `business_manager_app_id` VARCHAR(255)
 - `app_secret` LONGTEXT
 - `token_renewal_enabled` TINYINT(1) DEFAULT 0
 - `token_renewal_status` VARCHAR(40)

--- a/docs/facebook-ads-worker/facebook-app-identifiers.md
+++ b/docs/facebook-ads-worker/facebook-app-identifiers.md
@@ -1,8 +1,8 @@
-# Identificadores de aplicativos do Facebook
+# Identificador do aplicativo do Facebook
 
-Este guia explica como localizar os dois campos obrigatórios na tela **Contas do Facebook**: **ID do aplicativo (App ID)** e **ID do aplicativo vinculado ao Business Manager**.
+Este guia explica como localizar o campo obrigatório **ID do aplicativo (App ID)** na tela **Contas do Facebook**.
 
-## 1. ID do aplicativo (App ID)
+## ID do aplicativo (App ID)
 
 O App ID é o identificador público do aplicativo registrado no [Facebook for Developers](https://developers.facebook.com/).
 
@@ -12,22 +12,10 @@ O App ID é o identificador público do aplicativo registrado no [Facebook for D
 
 > O App ID também é usado em chamadas à Graph API, Login com Facebook e na renovação de tokens pelo worker.
 
-## 2. ID do aplicativo vinculado ao Business Manager
-
-Esse campo registra o identificador do aplicativo **dentro do Business Manager** responsável pelos ativos da conta.
-
-1. Entre em `https://business.facebook.com/` com o perfil que administra o ativo.
-2. No menu lateral, abra **Configurações do negócio → Contas → Aplicativos**.
-3. Selecione o aplicativo desejado. O painel de detalhes exibe o campo **ID do aplicativo do Business Manager** (ou apenas **ID** quando a interface estiver em português).
-4. Copie esse número e preencha o campo **ID do aplicativo vinculado ao Business Manager** no Marketing Hub.
-
-> Esse identificador é diferente do App ID público. Ele comprova que o aplicativo está vinculado ao Business Manager e facilita auditorias internas.
-
-## 3. Checklist rápido
+## Checklist rápido
 
 | Campo na UI | Onde localizar | Observações |
 |-------------|----------------|-------------|
 | **ID do aplicativo (App ID)** | Painel do app em developers.facebook.com → Configurações → Básico | Mesmo valor exibido no cabeçalho do portal de desenvolvedores. |
-| **ID do aplicativo vinculado ao Business Manager** | business.facebook.com → Configurações do negócio → Contas → Aplicativos | Disponível somente para usuários com acesso ao BM. |
 
-Sempre valide que ambos os IDs pertencem ao mesmo aplicativo antes de salvar a conta. Isso evita erros de autorização durante o disparo de campanhas e a renovação automática de tokens.
+Confirme que o número informado corresponde ao aplicativo autorizado a gerar tokens para a conta do Business Manager. Isso evita erros de autorização durante o disparo de campanhas e a renovação automática de tokens.

--- a/docs/postman/facebook-ads-worker.postman_collection.json
+++ b/docs/postman/facebook-ads-worker.postman_collection.json
@@ -49,7 +49,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Conta BM\",\n  \"currency\": \"BRL\",\n  \"accessToken\": \"EAAG...\",\n  \"appId\": \"1234567890\",\n  \"businessManagerAppId\": \"0987654321\",\n  \"defaultPageId\": \"123456789012345\",\n  \"defaultWebsiteUrl\": \"https://example.com\",\n  \"defaultCreativeMessageTemplate\": \"Campanha %s\",\n  \"defaultCallToActionType\": \"LEARN_MORE\",\n  \"adAccountId\": \"act_123456789012345\",\n  \"adSetDailyBudget\": \"2000\",\n  \"adSetBillingEvent\": \"IMPRESSIONS\",\n  \"adSetOptimizationGoal\": \"LINK_CLICKS\",\n  \"adSetDestinationType\": \"WEBSITE\",\n  \"adSetBidStrategy\": \"LOWEST_COST_WITHOUT_CAP\",\n  \"adSetTargetCountry\": \"BR\",\n  \"tokenRenewalEnabled\": true,\n  \"workerEnabled\": true\n}"
+              "raw": "{\n  \"name\": \"Conta BM\",\n  \"currency\": \"BRL\",\n  \"accessToken\": \"EAAG...\",\n  \"appId\": \"1234567890\",\n  \"defaultPageId\": \"123456789012345\",\n  \"defaultWebsiteUrl\": \"https://example.com\",\n  \"defaultCreativeMessageTemplate\": \"Campanha %s\",\n  \"defaultCallToActionType\": \"LEARN_MORE\",\n  \"adAccountId\": \"act_123456789012345\",\n  \"adSetDailyBudget\": \"2000\",\n  \"adSetBillingEvent\": \"IMPRESSIONS\",\n  \"adSetOptimizationGoal\": \"LINK_CLICKS\",\n  \"adSetDestinationType\": \"WEBSITE\",\n  \"adSetBidStrategy\": \"LOWEST_COST_WITHOUT_CAP\",\n  \"adSetTargetCountry\": \"BR\",\n  \"tokenRenewalEnabled\": true,\n  \"workerEnabled\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/accounts/facebook",
@@ -75,7 +75,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Conta BM\",\n  \"currency\": \"BRL\",\n  \"accessToken\": \"EAAG...\",\n  \"appId\": \"1234567890\",\n  \"businessManagerAppId\": \"0987654321\",\n  \"defaultPageId\": \"123456789012345\",\n  \"defaultWebsiteUrl\": \"https://example.com\",\n  \"defaultCreativeMessageTemplate\": \"Campanha %s\",\n  \"defaultCallToActionType\": \"LEARN_MORE\",\n  \"adAccountId\": \"act_123456789012345\",\n  \"adSetDailyBudget\": \"2000\",\n  \"adSetBillingEvent\": \"IMPRESSIONS\",\n  \"adSetOptimizationGoal\": \"LINK_CLICKS\",\n  \"adSetDestinationType\": \"WEBSITE\",\n  \"adSetBidStrategy\": \"LOWEST_COST_WITHOUT_CAP\",\n  \"adSetBidAmount\": null,\n  \"adSetTargetCountry\": \"BR\",\n  \"tokenRenewalEnabled\": true,\n  \"workerEnabled\": true\n}"
+              "raw": "{\n  \"name\": \"Conta BM\",\n  \"currency\": \"BRL\",\n  \"accessToken\": \"EAAG...\",\n  \"appId\": \"1234567890\",\n  \"defaultPageId\": \"123456789012345\",\n  \"defaultWebsiteUrl\": \"https://example.com\",\n  \"defaultCreativeMessageTemplate\": \"Campanha %s\",\n  \"defaultCallToActionType\": \"LEARN_MORE\",\n  \"adAccountId\": \"act_123456789012345\",\n  \"adSetDailyBudget\": \"2000\",\n  \"adSetBillingEvent\": \"IMPRESSIONS\",\n  \"adSetOptimizationGoal\": \"LINK_CLICKS\",\n  \"adSetDestinationType\": \"WEBSITE\",\n  \"adSetBidStrategy\": \"LOWEST_COST_WITHOUT_CAP\",\n  \"adSetBidAmount\": null,\n  \"adSetTargetCountry\": \"BR\",\n  \"tokenRenewalEnabled\": true,\n  \"workerEnabled\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/accounts/facebook/{{accountId}}",

--- a/frontend/src/api/facebookAccountMutations.ts
+++ b/frontend/src/api/facebookAccountMutations.ts
@@ -19,7 +19,6 @@ export interface FacebookAccountPayload {
   authorizedUserName?: string | null;
   authorizedUserEmail?: string | null;
   appId?: string | null;
-  businessManagerAppId?: string | null;
   appSecret?: string | null;
   tokenRenewalEnabled?: boolean;
   adAccountId?: string | null;

--- a/frontend/src/api/useFacebookAccounts.ts
+++ b/frontend/src/api/useFacebookAccounts.ts
@@ -25,7 +25,6 @@ export interface FacebookAccount {
   requiresTokenRenewal?: boolean;
   tokenExpiresInDays?: number | null;
   appId?: string | null;
-  businessManagerAppId?: string | null;
   hasAppSecret?: boolean;
   tokenRenewalEnabled?: boolean;
   tokenRenewalStatus?: string | null;

--- a/frontend/src/pages/FacebookAccountsPage.tsx
+++ b/frontend/src/pages/FacebookAccountsPage.tsx
@@ -34,7 +34,6 @@ interface AccountFormState {
   authorizedUserName: string;
   authorizedUserEmail: string;
   appId: string;
-  businessManagerAppId: string;
   appSecret: string;
   appSecretKept: boolean;
   tokenRenewalEnabled: boolean;
@@ -72,7 +71,6 @@ const emptyAccountForm: AccountFormState = {
   authorizedUserName: "",
   authorizedUserEmail: "",
   appId: "",
-  businessManagerAppId: "",
   appSecret: "",
   appSecretKept: false,
   tokenRenewalEnabled: false,
@@ -283,7 +281,6 @@ export default function FacebookAccountsPage() {
       authorizedUserName: accountForm.authorizedUserName.trim() || null,
       authorizedUserEmail: accountForm.authorizedUserEmail.trim() || null,
       appId: accountForm.appId.trim() || null,
-      businessManagerAppId: accountForm.businessManagerAppId.trim() || null,
       tokenRenewalEnabled: accountForm.tokenRenewalEnabled,
       adAccountId: accountForm.adAccountId.trim() || null,
       defaultWebsiteUrl: accountForm.defaultWebsiteUrl.trim() || null,
@@ -490,8 +487,6 @@ export default function FacebookAccountsPage() {
                                   authorizedUserName: account.authorizedUserName ?? "",
                                   authorizedUserEmail: account.authorizedUserEmail ?? "",
                                   appId: account.appId ?? "",
-                                  businessManagerAppId:
-                                    account.businessManagerAppId ?? "",
                                   appSecret: "",
                                   appSecretKept: Boolean(account.hasAppSecret),
                                   tokenRenewalEnabled: Boolean(account.tokenRenewalEnabled),
@@ -589,30 +584,12 @@ export default function FacebookAccountsPage() {
                   </label>
                   <input
                     className="form-control"
-                    placeholder="ID do aplicativo vinculado ao Business Manager"
+                    placeholder="ID do aplicativo registrado no Facebook for Developers"
                     value={accountForm.appId}
                     onChange={(event) =>
                       setAccountForm((current) => ({
                         ...current,
                         appId: event.target.value,
-                      }))
-                    }
-                    disabled={isAccountMutationPending}
-                  />
-                </div>
-                <div className="col-12 col-md-6">
-                  <label className="form-label">
-                    ID do aplicativo vinculado ao Business Manager
-                    <RequiredMark />
-                  </label>
-                  <input
-                    className="form-control"
-                    placeholder="ID do aplicativo no Business Manager"
-                    value={accountForm.businessManagerAppId}
-                    onChange={(event) =>
-                      setAccountForm((current) => ({
-                        ...current,
-                        businessManagerAppId: event.target.value,
                       }))
                     }
                     disabled={isAccountMutationPending}


### PR DESCRIPTION
## Summary
- remove the deprecated Business Manager App ID field from the backend entity, controller normalization, and tests while adding a Liquibase change to drop the column
- streamline the Facebook accounts frontend form and API types to capture only the App ID required by the platform
- update documentation and Postman examples to reflect the single App ID requirement for configuring Facebook accounts

## Testing
- `mvn -s ../settings.xml test` *(fails: dependency download blocked because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68dd577076808321893f8d52fe1a8682