### PR TITLE
Add backend token revalidation endpoint and update worker integration

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -16,9 +16,14 @@ import java.util.stream.Collectors;
 public class FacebookAccountController {
     private static final Logger log = LoggerFactory.getLogger(FacebookAccountController.class);
     private final FacebookAccountRepository repository;
+    private final FacebookTokenRevalidationService tokenRevalidationService;
 
-    public FacebookAccountController(FacebookAccountRepository repository) {
+    public FacebookAccountController(
+        FacebookAccountRepository repository,
+        FacebookTokenRevalidationService tokenRevalidationService
+    ) {
         this.repository = repository;
+        this.tokenRevalidationService = tokenRevalidationService;
     }
 
     @GetMapping
@@ -166,6 +171,21 @@ public class FacebookAccountController {
         }
 
         return repository.save(account);
+    }
+
+    @PostMapping("/{id}/token/revalidation")
+    public FacebookTokenRevalidationResponse revalidateToken(@PathVariable Long id) {
+        FacebookAccount account = repository.findById(id).orElseThrow();
+        validateRevalidationPrerequisites(account);
+        FacebookTokenRevalidationService.RevalidationResult result = tokenRevalidationService.revalidate(account);
+        return new FacebookTokenRevalidationResponse(
+            result.status(),
+            result.accessToken(),
+            result.tokenExpiresAt(),
+            result.renewedAt(),
+            result.attemptedAt(),
+            result.errorMessage()
+        );
     }
 
     @DeleteMapping("/{id}")
@@ -346,6 +366,18 @@ public class FacebookAccountController {
         return trimmed.isEmpty() ? null : trimmed;
     }
 
+    private void validateRevalidationPrerequisites(FacebookAccount account) {
+        if (!StringUtils.hasText(account.getAccessToken())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Conta sem token configurado para revalidação");
+        }
+        if (!StringUtils.hasText(account.getAppId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe o App ID antes de revalidar o token");
+        }
+        if (!StringUtils.hasText(account.getAppSecret())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe o App Secret antes de revalidar o token");
+        }
+    }
+
     public record FacebookAccountRenewalCandidate(
         Long id,
         String name,
@@ -359,6 +391,15 @@ public class FacebookAccountController {
     ) {}
 
     public record FacebookTokenRenewalRequest(
+        FacebookTokenRenewalStatus status,
+        String accessToken,
+        LocalDateTime tokenExpiresAt,
+        LocalDateTime renewedAt,
+        LocalDateTime attemptedAt,
+        String errorMessage
+    ) {}
+
+    public record FacebookTokenRevalidationResponse(
         FacebookTokenRenewalStatus status,
         String accessToken,
         LocalDateTime tokenExpiresAt,

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookTokenRevalidationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookTokenRevalidationService.java
@@ -1,0 +1,179 @@
+package com.marketinghub.ads;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.LocalDateTime;
+
+@Service
+public class FacebookTokenRevalidationService {
+    private static final Logger log = LoggerFactory.getLogger(FacebookTokenRevalidationService.class);
+
+    private final RestTemplate restTemplate;
+    private final FacebookAccountRepository repository;
+    private final String graphApiBaseUrl;
+    private final String graphApiVersion;
+
+    public FacebookTokenRevalidationService(
+        RestTemplateBuilder restTemplateBuilder,
+        FacebookAccountRepository repository,
+        @Value("${facebook.graph-api.base-url:https://graph.facebook.com}") String graphApiBaseUrl,
+        @Value("${facebook.graph-api.version:v23.0}") String graphApiVersion
+    ) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.repository = repository;
+        this.graphApiBaseUrl = trimTrailingSlash(graphApiBaseUrl);
+        this.graphApiVersion = trimSlashes(graphApiVersion);
+    }
+
+    public RevalidationResult revalidate(FacebookAccount account) {
+        LocalDateTime attemptedAt = LocalDateTime.now();
+        String url = buildTokenExchangeUrl(account);
+        log.info(
+            "Requesting Facebook token revalidation via Graph API: accountId={}, url={}",
+            account.getId(),
+            url
+        );
+
+        try {
+            GraphTokenResponse response = restTemplate.getForObject(url, GraphTokenResponse.class);
+            if (response == null || !StringUtils.hasText(response.accessToken())) {
+                throw new IllegalStateException("Facebook returned an empty token while revalidating the access token");
+            }
+
+            LocalDateTime renewedAt = attemptedAt;
+            LocalDateTime expiresAt = response.expiresIn() != null
+                ? attemptedAt.plusSeconds(Math.max(response.expiresIn(), 0))
+                : null;
+
+            account.setAccessToken(response.accessToken());
+            account.setTokenExpiresAt(expiresAt);
+            account.setTokenLastRefreshedAt(renewedAt);
+            account.setTokenRenewedAt(renewedAt);
+            account.setTokenRenewalStatus(FacebookTokenRenewalStatus.SUCCESS.name());
+            account.setTokenRenewalLastAttemptAt(attemptedAt);
+            account.setTokenRenewalLastError(null);
+
+            repository.save(account);
+
+            log.info(
+                "Facebook token revalidation succeeded: accountId={}, expiresAt={}",
+                account.getId(),
+                expiresAt
+            );
+
+            return new RevalidationResult(
+                FacebookTokenRenewalStatus.SUCCESS,
+                response.accessToken(),
+                expiresAt,
+                renewedAt,
+                attemptedAt,
+                null
+            );
+        } catch (RestClientResponseException ex) {
+            String message = String.format(
+                "HTTP %d: %s",
+                ex.getRawStatusCode(),
+                ex.getResponseBodyAsString()
+            );
+            log.error(
+                "Facebook token revalidation failed: accountId={}, status={}, response={}",
+                account.getId(),
+                ex.getRawStatusCode(),
+                ex.getResponseBodyAsString(),
+                ex
+            );
+            return registerFailure(account, attemptedAt, message);
+        } catch (RestClientException ex) {
+            log.error(
+                "Facebook token revalidation failed: accountId={}, message={}",
+                account.getId(),
+                ex.getMessage(),
+                ex
+            );
+            return registerFailure(account, attemptedAt, ex.getMessage());
+        } catch (RuntimeException ex) {
+            log.error(
+                "Facebook token revalidation failed: accountId={}, message={}",
+                account.getId(),
+                ex.getMessage(),
+                ex
+            );
+            return registerFailure(account, attemptedAt, ex.getMessage());
+        }
+    }
+
+    private RevalidationResult registerFailure(FacebookAccount account, LocalDateTime attemptedAt, String errorMessage) {
+        account.setTokenRenewalStatus(FacebookTokenRenewalStatus.FAILED.name());
+        account.setTokenRenewalLastAttemptAt(attemptedAt);
+        account.setTokenRenewalLastError(StringUtils.hasText(errorMessage) ? errorMessage : null);
+        repository.save(account);
+        return new RevalidationResult(
+            FacebookTokenRenewalStatus.FAILED,
+            null,
+            null,
+            null,
+            attemptedAt,
+            errorMessage
+        );
+    }
+
+    private String buildTokenExchangeUrl(FacebookAccount account) {
+        return UriComponentsBuilder
+            .fromHttpUrl(graphApiBaseUrl)
+            .pathSegment(graphApiVersion)
+            .pathSegment("oauth")
+            .pathSegment("access_token")
+            .queryParam("grant_type", "fb_exchange_token")
+            .queryParam("client_id", account.getAppId())
+            .queryParam("client_secret", account.getAppSecret())
+            .queryParam("fb_exchange_token", account.getAccessToken())
+            .build()
+            .toUriString();
+    }
+
+    private String trimTrailingSlash(String value) {
+        if (value == null || value.isBlank()) {
+            return "https://graph.facebook.com";
+        }
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    private String trimSlashes(String value) {
+        if (value == null || value.isBlank()) {
+            return "v23.0";
+        }
+        String trimmed = value;
+        if (trimmed.startsWith("/")) {
+            trimmed = trimmed.substring(1);
+        }
+        if (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+
+    public record RevalidationResult(
+        FacebookTokenRenewalStatus status,
+        String accessToken,
+        LocalDateTime tokenExpiresAt,
+        LocalDateTime renewedAt,
+        LocalDateTime attemptedAt,
+        String errorMessage
+    ) {}
+
+    private record GraphTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("expires_in") Long expiresIn
+    ) {}
+}

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -27,6 +27,10 @@ spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 logging.level.liquibase=DEBUG
 spring.config.import=optional:metrics.yml
 
+# Facebook Graph API configuration for token revalidation
+facebook.graph-api.base-url=https://graph.facebook.com
+facebook.graph-api.version=v23.0
+
 # Expose Swagger UI at /swagger-ui.html for quick API inspection
 springdoc.swagger-ui.enabled=true
 springdoc.swagger-ui.path=/swagger-ui.html

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -177,6 +177,31 @@ public class FacebookAccountControllerTest {
     }
 
     @Test
+    void shouldRejectRevalidationWhenTokenMissing() throws Exception {
+        FacebookAccount account = repository.save(FacebookAccount.builder()
+            .name("Missing token")
+            .currency("USD")
+            .appId("app-1")
+            .appSecret("secret")
+            .build());
+
+        mockMvc.perform(post("/api/accounts/facebook/" + account.getId() + "/token/revalidation"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldRejectRevalidationWhenAppCredentialsMissing() throws Exception {
+        FacebookAccount account = repository.save(FacebookAccount.builder()
+            .name("Missing app id")
+            .currency("USD")
+            .accessToken("token")
+            .build());
+
+        mockMvc.perform(post("/api/accounts/facebook/" + account.getId() + "/token/revalidation"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void shouldExposeWorkerConfigurationWhenAccountEnabled() throws Exception {
         repository.deleteAll();
         FacebookAccount account = repository.save(FacebookAccount.builder()

--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -255,8 +255,9 @@ classDiagram
     FacebookAdsAd --> FacebookAdsAdCreative
     FacebookCampaignService ..> UrlUtils : compõe URLs do backend
     FacebookTokenRenewalScheduler --> FacebookTokenRenewalService : agenda renovação
-    FacebookTokenRenewalService --> FacebookAdsService : renova token
+    FacebookTokenRenewalService --> FacebookTokenRevalidationClient : solicita revalidação
     FacebookAccessTokenManager --> FacebookWorkerConfigurationClient : lê credenciais do backend
+    FacebookAccessTokenManager --> FacebookTokenRevalidationClient : revalida token expirado
     FacebookTokenRenewalService ..> UrlUtils : reutiliza composição de URLs
 ```
 
@@ -271,16 +272,18 @@ classDiagram
   lista de bloqueio em memória para evitar novas tentativas até que o worker
   seja reiniciado.
 * `FacebookAdsService` encapsula as chamadas à Graph API (criação da hierarquia
-  de mídia, consulta de métricas e renovação de tokens de longa duração).
+  de mídia e consulta de métricas). A revalidação de tokens de longa duração é
+  realizada pelo backend através do `FacebookTokenRevalidationClient`.
 * `FacebookTokenRenewalScheduler` agenda o fluxo periódico de renovação de token
   e delega para `FacebookTokenRenewalService`.
-* `FacebookTokenRenewalService` busca as contas elegíveis no backend, chama a
-  Graph API para obter um novo token e registra o resultado por meio do endpoint
-  `/api/accounts/facebook/{id}/token/renewal`.
+* `FacebookTokenRenewalService` busca as contas elegíveis no backend, solicita a
+  revalidação automática via `POST /api/accounts/facebook/{id}/token/revalidation`
+  e sincroniza o token em memória quando a resposta pertence à conta configurada
+  no worker.
 * `FacebookAccessTokenManager` encapsula a renovação imediata de tokens quando o
   `FacebookCampaignService` detecta expiração durante a criação de campanhas,
-  consultando novamente o backend para reutilizar as credenciais e atualizar o
-  `access_token` em memória.
+  consultando o backend pelo mesmo endpoint para atualizar o `access_token` em
+  memória.
 * `FacebookWorkerConfigurationClient` fornece acesso ao endpoint
   `/api/accounts/facebook/worker-config`, permitindo que os serviços leiam as
   credenciais e parâmetros padrão preenchidos na interface web.

--- a/docs/facebook-ads-worker/token-management.md
+++ b/docs/facebook-ads-worker/token-management.md
@@ -32,18 +32,16 @@ expiração automática.
    `GET /api/accounts/facebook/renewal/eligible` para descobrir quais contas
    possuem `tokenRenewalEnabled = true`, credenciais completas e expiração
    iminente.
-2. Para cada conta elegível, o `FacebookTokenRenewalService` chama a Graph API na
-   rota `/{version}/oauth/access_token` com `grant_type=fb_exchange_token`,
-   reaproveitando `appId`, `appSecret` e o token atual para solicitar um novo
-   token de longa duração.
-3. Se a resposta indicar sucesso, o worker atualiza seu `FacebookAdsService` em
-   memória quando o token renovado pertence à mesma conta configurada e, em
-   seguida, informa o backend via `POST /api/accounts/facebook/{id}/token/renewal`
-   com o novo token, data de expiração calculada e o instante de renovação.
-4. Em caso de erro (por exemplo, `(#190) OAuthException`), o worker envia o mesmo
-   endpoint com `status=FAILED` e a mensagem retornada pela Graph API. O token
-   antigo permanece em uso até uma intervenção manual ou uma nova tentativa bem
-   sucedida.
+2. Para cada conta elegível, o `FacebookTokenRenewalService` aciona o endpoint
+   `POST /api/accounts/facebook/{id}/token/revalidation`. O backend reutiliza o
+   `appId`, o `appSecret` e o token atual armazenados na conta para trocar o
+   token diretamente na Graph API.
+3. Ao receber `status=SUCCESS`, o worker atualiza seu `FacebookAdsService` em
+   memória quando o token renovado pertence à mesma conta configurada. O backend
+   já registra o novo token, a data de expiração e o horário da tentativa.
+4. Em caso de falha (por exemplo, `(#190) OAuthException`), o backend devolve
+   `status=FAILED` com a mensagem da Graph API, mantendo o token anterior até que
+   uma intervenção manual ou nova tentativa automática seja bem-sucedida.
 
 ## 3. Comportamento do backend
 
@@ -52,15 +50,16 @@ expiração automática.
   `appId`, `appSecret`, renovação automática ativada e que estão dentro da janela
   configurada para expiração. O backend devolve a lista de candidatos contendo
   identificador, nome, credenciais e a data atual de expiração.
-- **Registro da tentativa** – Ao receber `POST /api/accounts/facebook/{id}/token/renewal`
-  o backend atualiza `tokenRenewalStatus` e `tokenRenewalLastAttemptAt` com o
-  horário informado (ou o horário da requisição quando ausente).
-- **Sucesso** – Quando `status=SUCCESS`, o backend exige `accessToken`
-  preenchido, atualiza `tokenExpiresAt`, `tokenLastRefreshedAt` e `tokenRenewedAt`
-  e limpa `tokenRenewalLastError`. O novo token passa a ser utilizado pelo
-  frontend e por futuras execuções do worker.
+- **Registro da tentativa** – O endpoint `POST /api/accounts/facebook/{id}/token/revalidation`
+  atualiza `tokenRenewalStatus`, `tokenRenewalLastAttemptAt`, `tokenRenewedAt` e
+  `tokenExpiresAt` automaticamente após consultar a Graph API, registrando o
+  token recebido ou a mensagem de erro.
+- **Sucesso** – Quando `status=SUCCESS`, o backend salva o novo `accessToken`,
+  atualiza `tokenExpiresAt`, `tokenLastRefreshedAt` e `tokenRenewedAt` e limpa
+  `tokenRenewalLastError`. O novo token passa a ser utilizado pelo frontend e por
+  futuras execuções do worker.
 - **Falha** – Quando `status=FAILED`, o backend mantém o token anterior e grava a
-  mensagem recebida em `tokenRenewalLastError`, permitindo que o frontend
+  mensagem retornada em `tokenRenewalLastError`, permitindo que o frontend
   exiba o motivo da falha e que operadores decidam por uma nova tentativa ou
   substituição manual do token.
 

--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -8,4 +8,4 @@ Esta pasta concentra collections prontas para importar no Postman e exercitar os
 3. Ajuste a variável `baseUrl` para apontar para a instância do backend que deseja testar (por padrão `http://191.252.92.222:8000/api`).
 4. Defina a variável `accountId` com o identificador da conta que deseja atualizar, renovar ou excluir.
 
-A collection inclui requisições para listar, criar, atualizar e remover contas, consultar o `worker-config` ativo e registrar tentativas de renovação de token do Facebook Ads Worker.
+A collection inclui requisições para listar, criar, atualizar e remover contas, consultar o `worker-config` ativo, solicitar a revalidação automática de tokens e registrar tentativas manualmente quando necessário.

--- a/docs/postman/facebook-ads-worker.postman_collection.json
+++ b/docs/postman/facebook-ads-worker.postman_collection.json
@@ -156,6 +156,26 @@
           }
         },
         {
+          "name": "Disparar revalidação automática",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/accounts/facebook/{{accountId}}/token/revalidation",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "accounts",
+                "facebook",
+                "{{accountId}}",
+                "token",
+                "revalidation"
+              ]
+            }
+          }
+        },
+        {
           "name": "Registrar tentativa de renovação",
           "request": {
             "method": "POST",

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -52,17 +52,15 @@ O fluxo funciona da seguinte forma:
    consulta o endpoint `/api/accounts/facebook/renewal/eligible`, que devolve
    apenas as contas com `tokenRenewalEnabled = true`, token prestes a expirar e
    credenciais completas (`appId`, `appSecret`).
-2. Para cada conta elegível, o serviço `FacebookTokenRenewalService` chama a
-   rota `/{version}/oauth/access_token` da Graph API utilizando o `appId`,
-   `appSecret` e o token atual, seguindo o mesmo fluxo utilizado no script em
-   PowerShell (grant type `fb_exchange_token`).
-3. O backend é notificado com `POST /api/accounts/facebook/{id}/token/renewal`,
-   atualizando o token, a nova data de expiração e registrando o status da
-   tentativa (`SUCCESS` ou `FAILED`).
-4. Quando a Graph API devolve `(#190) OAuthException` o `FacebookCampaignService`
+2. Para cada conta elegível, o serviço `FacebookTokenRenewalService` chama o
+   endpoint `POST /api/accounts/facebook/{id}/token/revalidation`, que executa a
+   troca do token diretamente no backend utilizando as credenciais já
+   persistidas (App ID, App Secret e token atual). O backend devolve o novo
+   token e a data de expiração calculada.
+3. Quando a Graph API devolve `(#190) OAuthException` o `FacebookCampaignService`
    intercepta a exceção, pausa o processamento de experimentos e delega para o
-   `FacebookAccessTokenManager` revalidar o token atual utilizando o mesmo fluxo
-   descrito acima. Caso o aplicativo (`facebook.app-id`/`facebook.app-secret`)
+   `FacebookAccessTokenManager` revalidar o token atual através do mesmo
+   endpoint do backend. Caso o aplicativo (`facebook.app-id`/`facebook.app-secret`)
    esteja configurado, o novo token é aplicado em memória e a fila de
    experimentos volta a ser processada sem necessidade de reiniciar o serviço.
    Quando as credenciais não estão configuradas, o agendador de renovação do
@@ -70,12 +68,12 @@ O fluxo funciona da seguinte forma:
    configurado foi trocado por esse processo externo, o worker aplica a nova
    credencial em memória e retoma automaticamente o processamento, eliminando a
    necessidade de reinicialização manual após a renovação via backend.
-5. Esses dados são exibidos na tela de contas do frontend, permitindo acompanhar
+4. Esses dados são exibidos na tela de contas do frontend, permitindo acompanhar
    a última tentativa, o último sucesso e eventuais mensagens de erro.
 
-Caso a chamada à Graph API falhe, o backend recebe o status `FAILED` com a
-mensagem de erro no campo `tokenRenewalLastError`, mantendo o token anterior e
-exigindo uma ação manual.
+Caso a revalidação dispare um erro da Graph API, o backend registra o status
+`FAILED` com a mensagem retornada em `tokenRenewalLastError`, mantendo o token
+anterior até que uma nova tentativa (manual ou automática) seja bem-sucedida.
 
 ### Falha momentânea ao consultar a configuração do backend
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAccessTokenManager.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAccessTokenManager.java
@@ -1,6 +1,7 @@
 package com.marketinghub.facebookadsworker;
 
 import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient;
+import com.marketinghub.facebookadsworker.facebooktokenrenewal.FacebookTokenRevalidationClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -12,13 +13,16 @@ public class FacebookAccessTokenManager {
 
     private final FacebookAdsService facebookAdsService;
     private final FacebookWorkerConfigurationClient configurationClient;
+    private final FacebookTokenRevalidationClient tokenRevalidationClient;
 
     public FacebookAccessTokenManager(
         FacebookAdsService facebookAdsService,
-        FacebookWorkerConfigurationClient configurationClient
+        FacebookWorkerConfigurationClient configurationClient,
+        FacebookTokenRevalidationClient tokenRevalidationClient
     ) {
         this.facebookAdsService = facebookAdsService;
         this.configurationClient = configurationClient;
+        this.tokenRevalidationClient = tokenRevalidationClient;
     }
 
     public RenewalAttemptResult tryRenewAccessTokenIfPossible() {
@@ -28,10 +32,9 @@ public class FacebookAccessTokenManager {
             return new RenewalAttemptResult(RenewalOutcome.NOT_CONFIGURED, null, null);
         }
 
-        String appId = normalize(configuration.get().appId());
-        String appSecret = normalize(configuration.get().appSecret());
-        if (!StringUtils.hasText(appId) || !StringUtils.hasText(appSecret)) {
-            LOGGER.debug("Skipping automatic Facebook token renewal because app credentials are missing in the worker configuration");
+        Long accountId = configuration.get().accountId();
+        if (accountId == null) {
+            LOGGER.debug("Skipping automatic Facebook token renewal because the worker configuration is missing the account identifier");
             return new RenewalAttemptResult(RenewalOutcome.NOT_CONFIGURED, null, null);
         }
 
@@ -42,25 +45,32 @@ public class FacebookAccessTokenManager {
         }
 
         try {
-            FacebookAdsService.TokenRenewalResponse response = facebookAdsService.renewLongLivedToken(
-                appId,
-                appSecret,
-                currentToken
-            );
-            facebookAdsService.updateAccessToken(response.accessToken());
-            LOGGER.info(
-                "Facebook access token renewed successfully via Graph API; expiresInSeconds={}",
-                response.expiresInSeconds()
-            );
-            return new RenewalAttemptResult(RenewalOutcome.SUCCESS, response.accessToken(), null);
+            FacebookTokenRevalidationClient.TokenRevalidationResponse response = tokenRevalidationClient
+                .revalidate(accountId)
+                .orElse(null);
+
+            if (response == null) {
+                LOGGER.error("Failed to renew Facebook access token automatically: backend returned an empty response");
+                return new RenewalAttemptResult(RenewalOutcome.FAILED, null, "Empty response from backend");
+            }
+
+            if (response.status() == FacebookTokenRevalidationClient.TokenRevalidationStatus.SUCCESS) {
+                if (StringUtils.hasText(response.accessToken())) {
+                    facebookAdsService.updateAccessToken(response.accessToken());
+                }
+                LOGGER.info("Facebook access token renewed successfully via backend revalidation");
+                return new RenewalAttemptResult(RenewalOutcome.SUCCESS, response.accessToken(), null);
+            }
+
+            String errorMessage = StringUtils.hasText(response.errorMessage())
+                ? response.errorMessage()
+                : "unknown error";
+            LOGGER.error("Failed to renew Facebook access token automatically: {}", errorMessage);
+            return new RenewalAttemptResult(RenewalOutcome.FAILED, null, errorMessage);
         } catch (Exception ex) {
             LOGGER.error("Failed to renew Facebook access token automatically: {}", ex.getMessage(), ex);
             return new RenewalAttemptResult(RenewalOutcome.FAILED, null, ex.getMessage());
         }
-    }
-
-    private String normalize(String value) {
-        return value == null ? null : value.trim();
     }
 
     public enum RenewalOutcome {

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
@@ -21,17 +21,20 @@ public class FacebookTokenRenewalService {
 
     private final WebClient backendClient;
     private final FacebookAdsService facebookAdsService;
+    private final FacebookTokenRevalidationClient tokenRevalidationClient;
     private final String backendBaseUrl;
     private final String apiPrefix;
 
     public FacebookTokenRenewalService(
         WebClient.Builder builder,
         FacebookAdsService facebookAdsService,
+        FacebookTokenRevalidationClient tokenRevalidationClient,
         @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
         @Value("${backend.api-prefix:/api}") String apiPrefix
     ) {
         this.backendClient = builder.build();
         this.facebookAdsService = facebookAdsService;
+        this.tokenRevalidationClient = tokenRevalidationClient;
         this.backendBaseUrl = backendBaseUrl;
         this.apiPrefix = apiPrefix;
     }
@@ -89,97 +92,47 @@ public class FacebookTokenRenewalService {
             candidate.tokenExpiresAt()
         );
 
-        try {
-            FacebookAdsService.TokenRenewalResponse response = facebookAdsService.renewLongLivedToken(
-                candidate.appId(),
-                candidate.appSecret(),
-                candidate.accessToken()
+        FacebookTokenRevalidationClient.TokenRevalidationResponse response = tokenRevalidationClient
+            .revalidate(candidate.id())
+            .orElse(null);
+
+        if (response == null) {
+            LOGGER.error(
+                "Token revalidation request did not return a response: accountId={}, name={}",
+                candidate.id(),
+                candidate.name()
             );
+            return;
+        }
 
-            LocalDateTime renewedAt = attemptTime;
-            LocalDateTime expiresAt = attemptTime.plusSeconds(Math.max(response.expiresInSeconds(), 0));
-
+        if (response.status() == FacebookTokenRevalidationClient.TokenRevalidationStatus.SUCCESS) {
             boolean matchesCurrentToken = Objects.equals(
                 candidate.accessToken(),
                 facebookAdsService.getCurrentAccessToken()
             );
-            if (matchesCurrentToken) {
+            if (matchesCurrentToken && response.accessToken() != null) {
                 facebookAdsService.updateAccessToken(response.accessToken());
                 LOGGER.info(
-                    "Updated in-memory Facebook access token after backend renewal for account id={}",
+                    "Updated in-memory Facebook access token after backend revalidation for account id={}",
                     candidate.id()
                 );
-            } else {
+            } else if (!matchesCurrentToken) {
                 LOGGER.debug(
                     "Skipping in-memory Facebook token update because candidate token does not match the worker configuration: accountId={}",
                     candidate.id()
                 );
             }
-
-            reportResult(candidate.id(), new RenewalResultPayload(
-                TokenRenewalStatus.SUCCESS,
-                response.accessToken(),
-                expiresAt,
-                renewedAt,
-                attemptTime,
-                null
-            ));
-        } catch (Exception ex) {
+            LOGGER.info(
+                "Facebook token revalidation succeeded for account id={} via backend", candidate.id()
+            );
+        } else {
             LOGGER.error(
-                "Token renewal failed for Facebook account id={}, name={}: {}",
+                "Token revalidation failed for Facebook account id={}, name={}: {}",
                 candidate.id(),
                 candidate.name(),
-                ex.getMessage(),
-                ex
-            );
-            reportResult(candidate.id(), new RenewalResultPayload(
-                TokenRenewalStatus.FAILED,
-                null,
-                null,
-                null,
-                attemptTime,
-                ex.getMessage()
-            ));
-        }
-    }
-
-    private void reportResult(Long accountId, RenewalResultPayload payload) {
-        String path = "/accounts/facebook/" + accountId + "/token/renewal";
-        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, path);
-        LOGGER.info(
-            "Reporting Facebook token renewal result to backend: url={}, params={}, payload={}",
-            url,
-            Collections.emptyMap(),
-            payload
-        );
-        try {
-            backendClient
-                .post()
-                .uri(url)
-                .bodyValue(payload)
-                .retrieve()
-                .toBodilessEntity()
-                .block();
-            LOGGER.info(
-                "Successfully reported Facebook token renewal result to backend: url={}, accountId={}",
-                url,
-                accountId
-            );
-        } catch (WebClientResponseException | WebClientRequestException ex) {
-            LOGGER.error(
-                "Failed to report token renewal result to backend for account {}: url={}, status={}, message={}",
-                accountId,
-                url,
-                ex instanceof WebClientResponseException responseException ? responseException.getRawStatusCode() : "N/A",
-                ex.getMessage(),
-                ex
+                response.errorMessage()
             );
         }
-    }
-
-    public enum TokenRenewalStatus {
-        SUCCESS,
-        FAILED
     }
 
     public record FacebookAccountRenewalCandidate(
@@ -189,14 +142,5 @@ public class FacebookTokenRenewalService {
         String appSecret,
         String accessToken,
         LocalDateTime tokenExpiresAt
-    ) {}
-
-    public record RenewalResultPayload(
-        TokenRenewalStatus status,
-        String accessToken,
-        LocalDateTime tokenExpiresAt,
-        LocalDateTime renewedAt,
-        LocalDateTime attemptedAt,
-        String errorMessage
     ) {}
 }

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRevalidationClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRevalidationClient.java
@@ -1,0 +1,79 @@
+package com.marketinghub.facebookadsworker.facebooktokenrenewal;
+
+import com.marketinghub.facebookadsworker.util.UrlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.Collections;
+import java.util.Optional;
+
+@Component
+public class FacebookTokenRevalidationClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FacebookTokenRevalidationClient.class);
+
+    private final WebClient backendClient;
+    private final String backendBaseUrl;
+    private final String apiPrefix;
+
+    public FacebookTokenRevalidationClient(
+        WebClient.Builder builder,
+        @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
+        @Value("${backend.api-prefix:/api}") String apiPrefix
+    ) {
+        this.backendClient = builder.build();
+        this.backendBaseUrl = backendBaseUrl;
+        this.apiPrefix = apiPrefix;
+    }
+
+    public Optional<TokenRevalidationResponse> revalidate(Long accountId) {
+        String path = "/accounts/facebook/" + accountId + "/token/revalidation";
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, path);
+        LOGGER.info(
+            "Requesting Facebook token revalidation from backend: url={}, params={}",
+            url,
+            Collections.emptyMap()
+        );
+        try {
+            TokenRevalidationResponse response = backendClient
+                .post()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(TokenRevalidationResponse.class)
+                .block();
+            LOGGER.info(
+                "Received Facebook token revalidation response from backend: url={}, response={}",
+                url,
+                response
+            );
+            return Optional.ofNullable(response);
+        } catch (WebClientResponseException | WebClientRequestException ex) {
+            LOGGER.error(
+                "Failed to revalidate Facebook token via backend: url={}, status={}, message={}",
+                url,
+                ex instanceof WebClientResponseException responseException ? responseException.getRawStatusCode() : "N/A",
+                ex.getMessage(),
+                ex
+            );
+            return Optional.empty();
+        }
+    }
+
+    public enum TokenRevalidationStatus {
+        SUCCESS,
+        FAILED
+    }
+
+    public record TokenRevalidationResponse(
+        TokenRevalidationStatus status,
+        String accessToken,
+        java.time.LocalDateTime tokenExpiresAt,
+        java.time.LocalDateTime renewedAt,
+        java.time.LocalDateTime attemptedAt,
+        String errorMessage
+    ) {}
+}

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -10,6 +10,7 @@ import com.marketinghub.facebookadsworker.FacebookAccessTokenManager;
 import com.marketinghub.facebookadsworker.FacebookAdsService;
 import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient;
 import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient.FacebookWorkerConfiguration;
+import com.marketinghub.facebookadsworker.facebooktokenrenewal.FacebookTokenRevalidationClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -55,9 +56,15 @@ class FacebookCampaignServiceTest {
             objectMapper
         );
         adsService.updateAccessToken("token");
+        FacebookTokenRevalidationClient tokenRevalidationClient = new FacebookTokenRevalidationClient(
+            WebClient.builder(),
+            backend.url("/").toString(),
+            "/api"
+        );
         FacebookAccessTokenManager accessTokenManager = new FacebookAccessTokenManager(
             adsService,
-            configurationClient
+            configurationClient,
+            tokenRevalidationClient
         );
         service = new FacebookCampaignService(
             adsService,
@@ -462,7 +469,11 @@ class FacebookCampaignServiceTest {
             FacebookAdsService adsService,
             FacebookWorkerConfigurationClient configurationClient
         ) {
-            super(adsService, configurationClient);
+            super(
+                adsService,
+                configurationClient,
+                new FacebookTokenRevalidationClient(WebClient.builder(), "http://localhost", "/api")
+            );
             this.adsService = adsService;
         }
 


### PR DESCRIPTION
## Summary
- add a backend service and controller endpoint that revalidates Facebook tokens through the Graph API and exposes new configuration properties
- cover the new endpoint with validation tests and document the revalidation flow across the backend and Facebook Ads worker artifacts
- update the Facebook Ads worker to trigger the new backend revalidation endpoint, refresh in-memory tokens, and extend the Postman collection

## Testing
- `mvn -s ../settings.xml test` *(fails: Network is unreachable while downloading org.springframework.boot:spring-boot-starter-parent)*
- `mvn -s settings.xml test` *(fails: Network is unreachable while downloading org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68dda5ce1dcc8321b36fbd4643efada2