### PR TITLE
Allow Facebook worker config when default website missing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -274,12 +274,13 @@ public class FacebookAccountController {
     private void validateWorkerConfiguration(FacebookAccount account) {
         requireField(account, account.getAccessToken(), "access token", FacebookWorkerValidationError.ACCESS_TOKEN_MISSING);
         requireField(account, account.getAdAccountId(), "ad account id", FacebookWorkerValidationError.AD_ACCOUNT_ID_MISSING);
-        requireField(
-            account,
-            account.getDefaultWebsiteUrl(),
-            "default website URL",
-            FacebookWorkerValidationError.DEFAULT_WEBSITE_URL_MISSING
-        );
+        if (!StringUtils.hasText(account.getDefaultWebsiteUrl())) {
+            log.warn(
+                "Facebook worker configuration for account id={} name='{}' is missing default website URL; continuing with null value.",
+                account.getId(),
+                StringUtils.hasText(account.getName()) ? account.getName() : "(unnamed)"
+            );
+        }
         requireField(
             account,
             account.getAdSetDailyBudget(),

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -231,6 +232,36 @@ public class FacebookAccountControllerTest {
             .andExpect(jsonPath("$.adSetBillingEvent").value("IMPRESSIONS"))
             .andExpect(jsonPath("$.defaultCallToActionType").value("SIGN_UP"))
             .andExpect(jsonPath("$.defaultCreativeMessageTemplate").value("Campanha %s"));
+    }
+
+    @Test
+    void shouldExposeWorkerConfigurationWhenDefaultWebsiteMissing() throws Exception {
+        repository.deleteAll();
+        FacebookAccount account = repository.save(FacebookAccount.builder()
+            .name("Worker Account")
+            .currency("BRL")
+            .accessToken("worker-token")
+            .adAccountId("1234567890")
+            .defaultCreativeMessageTemplate("Campanha %s")
+            .defaultCallToActionType("SIGN_UP")
+            .adSetDailyBudget("2000")
+            .adSetBillingEvent("IMPRESSIONS")
+            .adSetOptimizationGoal("LINK_CLICKS")
+            .adSetDestinationType("WEBSITE")
+            .adSetBidStrategy("LOWEST_COST_WITHOUT_CAP")
+            .adSetTargetCountry("BR")
+            .workerEnabled(true)
+            .build());
+
+        mockMvc.perform(get("/api/accounts/facebook/worker-config"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accountId").value(account.getId()))
+            .andExpect(jsonPath("$.defaultWebsiteUrl").value(nullValue()));
+
+        FacebookAccount persisted = repository.findById(account.getId()).orElseThrow();
+        assertThat(persisted.getWorkerLastValidationAt()).isNotNull();
+        assertThat(persisted.getWorkerLastValidationErrorCode()).isNull();
+        assertThat(persisted.getWorkerLastValidationErrorDetail()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- allow the Facebook worker configuration endpoint to tolerate accounts without a default website URL
- add a regression test ensuring the configuration still clears validation errors when the website is absent

## Testing
- mvn -s ../settings.xml test *(fails: Non-resolvable parent POM due to network is unreachable when downloading org.springframework.boot:spring-boot-starter-parent:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd1dc212083219d1da9c76d2deb03