### PR TITLE
Add directional markers to Facebook Ads Worker endpoint logs

### DIFF
--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -12,6 +12,8 @@
 - Endpoints do backend devem ser acessados com o prefixo configurado em `backend.api-prefix` (default `/api`).
 - Sempre que chamar o backend registre logs com **URL completa**, parâmetros, payload enviado (quando existir) e a resposta recebida
   para facilitar troubleshooting.
+- Prefixe os valores de URL nos logs de integração com endpoints usando `==>` para requisições e `<==` para respostas (incluindo
+  erros), garantindo um padrão visual consistente em todo o módulo.
 - Em caso de erro de permissão do Facebook, o worker bloqueia o experimento em memória até que o serviço seja reiniciado.
 
 ## Serviços existentes

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -31,7 +31,10 @@ anúncio, o worker envia um `CreateCampaignRequest` para o backend via
 hierarquia para manter rastreabilidade completa (`facebook_ads_campaign`,
 `facebook_ads_ad_set`, `facebook_ads_ad_creative` e `facebook_ads_ad`). Todas as
 chamadas HTTP ao backend devem registrar a URL completa, parâmetros, payload e
-resposta recebida para acelerar o diagnóstico de incidentes em produção.
+resposta recebida para acelerar o diagnóstico de incidentes em produção. Os logs
+seguem o padrão visual `==>` para requisições (por exemplo, `url==>https://...`)
+e `<==` para respostas, inclusive em cenários de erro, permitindo identificar
+rapidamente a direção do tráfego durante uma análise.
 
 Todas as chamadas à Graph API são logadas detalhadamente para facilitar
 investigações de erros (por exemplo, respostas `400 Bad Request`). Os logs

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -175,7 +175,7 @@ public class FacebookAdsService {
     public JsonNode getCampaignMetrics(String campaignId) {
         String path = buildVersionedPath("/" + campaignId + "/insights?access_token=" + requireAccessToken());
         String maskedPath = maskAccessTokenInPath(path);
-        LOGGER.info("Sending GET request to Facebook API: path={}", maskedPath);
+        LOGGER.info("Sending GET request to Facebook API: path==>{}", maskedPath);
         try {
             FacebookApiResponse apiResponse = webClient
                 .get()
@@ -198,7 +198,7 @@ public class FacebookAdsService {
             String responseBody = ex.getResponseBodyAsString();
             ObjectNode errorDetails = extractErrorDetails(responseBody);
             LOGGER.error(
-                "Facebook API GET request failed: path={}, status={}, responseBody={}, errorDetails={}",
+                "Facebook API GET request failed: path<=={}, status={}, responseBody={}, errorDetails={}",
                 maskedPath,
                 ex.getRawStatusCode(),
                 maskAccessToken(responseBody),
@@ -210,7 +210,12 @@ public class FacebookAdsService {
             }
             throw ex;
         } catch (WebClientRequestException ex) {
-            LOGGER.error("Facebook API GET request could not be completed: path={}, message={}", maskedPath, ex.getMessage(), ex);
+            LOGGER.error(
+                "Facebook API GET request could not be completed: path==>{}, message={}",
+                maskedPath,
+                ex.getMessage(),
+                ex
+            );
             throw ex;
         }
     }
@@ -218,7 +223,7 @@ public class FacebookAdsService {
     private JsonNode executePost(String path, Map<String, Object> body) {
         Map<String, Object> sanitizedBody = sanitizeBody(body);
         String maskedPath = maskAccessTokenInPath(path);
-        LOGGER.info("Sending POST request to Facebook API: path={}, body={}", maskedPath, sanitizedBody);
+        LOGGER.info("Sending POST request to Facebook API: path==>{}, body={}", maskedPath, sanitizedBody);
         try {
             FacebookApiResponse apiResponse = webClient
                 .post()
@@ -242,7 +247,7 @@ public class FacebookAdsService {
             String responseBody = ex.getResponseBodyAsString();
             ObjectNode errorDetails = extractErrorDetails(responseBody);
             LOGGER.error(
-                "Facebook API POST request failed: path={}, status={}, responseBody={}, errorDetails={}, headers={}",
+                "Facebook API POST request failed: path<=={}, status={}, responseBody={}, errorDetails={}, headers={}",
                 maskedPath,
                 ex.getRawStatusCode(),
                 maskAccessToken(responseBody),
@@ -259,7 +264,7 @@ public class FacebookAdsService {
             throw ex;
         } catch (WebClientRequestException ex) {
             LOGGER.error(
-                "Facebook API POST request could not be completed: path={}, message={}",
+                "Facebook API POST request could not be completed: path==>{}, message={}",
                 maskedPath,
                 ex.getMessage(),
                 ex
@@ -270,7 +275,7 @@ public class FacebookAdsService {
 
     private void logSuccessfulResponse(String method, String maskedPath, FacebookApiResponse response) {
         LOGGER.info(
-            "Facebook API response received: method={}, path={}, status={}, headers={}, body={}",
+            "Facebook API response received: method={}, path<=={}, status={}, headers={}, body={}",
             method,
             maskedPath,
             formatStatus(response.statusCode()),

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
@@ -41,7 +41,7 @@ public class FacebookWorkerConfigurationClient {
     public Optional<FacebookWorkerConfiguration> fetchConfiguration() {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/accounts/facebook/worker-config");
         LOGGER.info(
-            "Requesting Facebook worker configuration from backend: url={}, params={}",
+            "Requesting Facebook worker configuration from backend: url==>{}, params={}",
             url,
             Collections.emptyMap()
         );
@@ -56,7 +56,7 @@ public class FacebookWorkerConfigurationClient {
                         LOGGER.warn("Facebook worker configuration not found in backend; skipping Facebook automation");
                     }
                     LOGGER.info(
-                        "Backend responded with HTTP 404 when fetching Facebook worker configuration: url={}, response={}",
+                        "Backend responded with HTTP 404 when fetching Facebook worker configuration: url<=={}, response={}",
                         url,
                         ex.getResponseBodyAsString()
                     );
@@ -64,7 +64,7 @@ public class FacebookWorkerConfigurationClient {
                 })
                 .block();
             LOGGER.info(
-                "Received Facebook worker configuration response from backend: url={}, response={}",
+                "Received Facebook worker configuration response from backend: url<=={}, response={}",
                 url,
                 configuration
             );

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -121,7 +121,7 @@ public class FacebookCampaignService {
         List<Experiment> experiments = Collections.emptyList();
         String experimentsUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/experiments-ready");
         LOGGER.info(
-            "Requesting experiments ready for Facebook campaigns from backend: url={}, params={}",
+            "Requesting experiments ready for Facebook campaigns from backend: url==>{}, params={}",
             experimentsUrl,
             Collections.emptyMap()
         );
@@ -142,12 +142,12 @@ public class FacebookCampaignService {
                 .collectList()
                 .block();
             LOGGER.info(
-                "Received experiments response from backend: url={}, response={}",
+                "Received experiments response from backend: url<=={}, response={}",
                 experimentsUrl,
                 experiments
             );
         } catch (WebClientRequestException ex) {
-            LOGGER.warn("Failed to fetch experiments from backend: url={}", experimentsUrl, ex);
+            LOGGER.warn("Failed to fetch experiments from backend: url==>{}", experimentsUrl, ex);
         }
 
         if (experiments == null || experiments.isEmpty()) {
@@ -263,7 +263,7 @@ public class FacebookCampaignService {
             );
             String createCampaignUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns");
             LOGGER.info(
-                "Reporting Facebook campaign creation to backend: url={}, params={}, payload={}",
+                "Reporting Facebook campaign creation to backend: url==>{}, params={}, payload={}",
                 createCampaignUrl,
                 Collections.emptyMap(),
                 req
@@ -275,7 +275,7 @@ public class FacebookCampaignService {
                 .toBodilessEntity()
                 .block();
             LOGGER.info(
-                "Successfully reported Facebook campaign creation to backend: url={}, experimentId={}, campaignId={}",
+                "Successfully reported Facebook campaign creation to backend: url<=={}, experimentId={}, campaignId={}",
                 createCampaignUrl,
                 exp.id(),
                 campaignId
@@ -398,7 +398,7 @@ public class FacebookCampaignService {
     private Creative resolveCreative(long experimentId) {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/creatives");
         LOGGER.info(
-            "Requesting creatives for experiment from backend: url={}, params={}",
+            "Requesting creatives for experiment from backend: url==>{}, params={}",
             url,
             Collections.emptyMap()
         );
@@ -410,7 +410,7 @@ public class FacebookCampaignService {
                 .collectList()
                 .block();
             LOGGER.info(
-                "Received creatives response from backend: url={}, response={}",
+                "Received creatives response from backend: url<=={}, response={}",
                 url,
                 creatives
             );
@@ -422,7 +422,7 @@ public class FacebookCampaignService {
                 .findFirst()
                 .orElse(creatives.get(0));
         } catch (Exception ex) {
-            LOGGER.warn("Failed to fetch creatives for experiment {} from backend: url={}, message={}", experimentId, url, ex.getMessage());
+            LOGGER.warn("Failed to fetch creatives for experiment {} from backend: url==>{}, message={}", experimentId, url, ex.getMessage());
             LOGGER.debug("Stacktrace while fetching creatives for experiment {}", experimentId, ex);
             return null;
         }
@@ -435,7 +435,7 @@ public class FacebookCampaignService {
     private void markExperimentAsFailed(long experimentId) {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/status?status=FAILED");
         LOGGER.info(
-            "Marking experiment as FAILED in backend: url={}, params={}",
+            "Marking experiment as FAILED in backend: url==>{}, params={}",
             url,
             Collections.emptyMap()
         );
@@ -448,7 +448,7 @@ public class FacebookCampaignService {
             LOGGER.info("Marked experiment {} as FAILED after Facebook permission error", experimentId);
         } catch (Exception ex) {
             LOGGER.warn(
-                "Could not mark experiment {} as FAILED after Facebook permission error: url={}, message={}",
+                "Could not mark experiment {} as FAILED after Facebook permission error: url==>{}, message={}",
                 experimentId,
                 url,
                 ex.getMessage(),

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
@@ -52,7 +52,7 @@ public class FacebookTokenRenewalService {
     private List<FacebookAccountRenewalCandidate> fetchEligibleAccounts() {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/accounts/facebook/renewal/eligible");
         LOGGER.info(
-            "Requesting Facebook accounts eligible for token renewal from backend: url={}, params={}",
+            "Requesting Facebook accounts eligible for token renewal from backend: url==>{}, params={}",
             url,
             Collections.emptyMap()
         );
@@ -66,14 +66,14 @@ public class FacebookTokenRenewalService {
                 .blockOptional()
                 .orElse(Collections.emptyList());
             LOGGER.info(
-                "Received eligible Facebook accounts response from backend: url={}, response={}",
+                "Received eligible Facebook accounts response from backend: url<=={}, response={}",
                 url,
                 response
             );
             return response;
         } catch (WebClientResponseException | WebClientRequestException ex) {
             LOGGER.error(
-                "Failed to fetch Facebook accounts for token renewal: url={}, status={}, message={}",
+                "Failed to fetch Facebook accounts for token renewal: url<=={}, status={}, message={}",
                 url,
                 ex instanceof WebClientResponseException responseException ? responseException.getRawStatusCode() : "N/A",
                 ex.getMessage(),

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRevalidationClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRevalidationClient.java
@@ -34,7 +34,7 @@ public class FacebookTokenRevalidationClient {
         String path = "/accounts/facebook/" + accountId + "/token/revalidation";
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, path);
         LOGGER.info(
-            "Requesting Facebook token revalidation from backend: url={}, params={}",
+            "Requesting Facebook token revalidation from backend: url==>{}, params={}",
             url,
             Collections.emptyMap()
         );
@@ -46,14 +46,14 @@ public class FacebookTokenRevalidationClient {
                 .bodyToMono(TokenRevalidationResponse.class)
                 .block();
             LOGGER.info(
-                "Received Facebook token revalidation response from backend: url={}, response={}",
+                "Received Facebook token revalidation response from backend: url<=={}, response={}",
                 url,
                 response
             );
             return Optional.ofNullable(response);
         } catch (WebClientResponseException | WebClientRequestException ex) {
             LOGGER.error(
-                "Failed to revalidate Facebook token via backend: url={}, status={}, message={}",
+                "Failed to revalidate Facebook token via backend: url<=={}, status={}, message={}",
                 url,
                 ex instanceof WebClientResponseException responseException ? responseException.getRawStatusCode() : "N/A",
                 ex.getMessage(),


### PR DESCRIPTION
## Summary
- prefix Facebook Ads Worker outbound endpoint log entries with `==>` and inbound entries with `<==`
- document the logging convention in `AGENTS.md` and the module README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde8b397a48321b432752560e13e12