### PR TITLE
Improve funnel builder card contrast

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -35,3 +35,20 @@
     padding: clamp(1rem, 4vw, 1.5rem);
   }
 }
+
+.funnel-card {
+  background: linear-gradient(135deg, #f7f9ff 0%, #f4f7ff 100%);
+  border: 1px solid rgba(88, 102, 242, 0.12);
+}
+
+.funnel-step-card {
+  background: linear-gradient(135deg, #f8faff 0%, #eef3ff 100%);
+  border: 1px solid rgba(88, 102, 242, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.funnel-step-card:hover,
+.funnel-step-card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 0.75rem 2rem -1rem rgba(88, 102, 242, 0.45);
+}

--- a/frontend/src/components/FunnelBuilder.tsx
+++ b/frontend/src/components/FunnelBuilder.tsx
@@ -173,7 +173,7 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
 
       <div className="row g-4">
         <div className="col-12 col-lg-4">
-          <section className="card shadow-sm border-0 h-100">
+          <section className="card shadow-sm border-0 h-100 funnel-card">
             <div className="card-body">
               <h2 className="h5 mb-2">Nova etapa</h2>
               <p className="text-muted small mb-4">
@@ -255,7 +255,7 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
           </section>
         </div>
         <div className="col-12 col-lg-8">
-          <section className="card shadow-sm border-0 mb-4">
+          <section className="card shadow-sm border-0 mb-4 funnel-card">
             <div className="card-body">
               <label className="form-label fw-semibold" htmlFor="funnel_name">
                 Nome do funil *
@@ -273,7 +273,7 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
             </div>
           </section>
 
-          <section className="card shadow-sm border-0">
+          <section className="card shadow-sm border-0 funnel-card">
             <div className="card-body">
               <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-4">
                 <div>
@@ -312,7 +312,7 @@ export default function FunnelBuilder({ funnel }: FunnelProps) {
                             <div
                               ref={prov.innerRef}
                               {...prov.draggableProps}
-                              className="card border-0 shadow-sm"
+                              className="card border-0 shadow-sm funnel-step-card"
                             >
                               <div className="card-body p-4">
                                 <div className="d-flex align-items-start justify-content-between gap-3 mb-3">


### PR DESCRIPTION
## Summary
- apply a pastel gradient background to funnel builder panels to create contrast with the page backdrop
- style individual funnel step cards with a tinted background and hover feedback for better visual separation

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dec7d7f5188321ae942ce7a8449b3e