### PR TITLE
Preserve Facebook account token and hidden fields during updates

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -6,3 +6,5 @@
 - Liquibase: nunca altere arquivos de changelog já aplicados para evitar erros de checksum. Em vez disso, crie um novo changelog incremental e, se necessário, atualize os `include` do master.
 - Liquibase (MySQL 5): ao escrever `preConditions`, utilize apenas SQL válida no MySQL 5 (testando as consultas antes de incluí-las) e configure `dbms="mysql"` quando a condição depender do banco para evitar erros de sintaxe.
 - Liquibase (SQL formatado): mantenha os atributos (`expectedResult`, `dbms`, etc.) na mesma linha do `--precondition-sql-check` junto com a consulta SQL (`SELECT ...`) exatamente como suportado pelo Liquibase para evitar falhas de parsing.
+
+- Ao atualizar entidades `FacebookAccount`, preserve tokens e demais campos não exibidos na interface quando o payload não os enviar explicitamente; nunca limpe o token salvo a menos que o cliente solicite isso de forma direta.

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
@@ -35,6 +35,7 @@ public class FacebookAccount {
     private String name;
     private String currency;
 
+    @Setter(AccessLevel.NONE)
     @Column(columnDefinition = "LONGTEXT")
     private String accessToken;
     private LocalDateTime tokenExpiresAt;
@@ -47,12 +48,14 @@ public class FacebookAccount {
     @Column(name = "ad_account_id")
     private String adAccountId;
 
+    @Setter(AccessLevel.NONE)
     @Column(name = "default_page_id")
     private String defaultPageId;
 
     @Column(name = "default_website_url", length = 512)
     private String defaultWebsiteUrl;
 
+    @Setter(AccessLevel.NONE)
     @Column(name = "default_instagram_actor_id")
     private String defaultInstagramActorId;
 
@@ -117,6 +120,21 @@ public class FacebookAccount {
     private boolean appSecretProvided;
 
     @Transient
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private boolean accessTokenProvided;
+
+    @Transient
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private boolean defaultPageIdProvided;
+
+    @Transient
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private boolean defaultInstagramActorIdProvided;
+
+    @Transient
     @JsonProperty("tokenExpired")
     public boolean isTokenExpired() {
         return tokenExpiresAt != null && tokenExpiresAt.isBefore(LocalDateTime.now());
@@ -156,10 +174,58 @@ public class FacebookAccount {
         this.appSecret = appSecret;
     }
 
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    @JsonSetter("accessToken")
+    public void jsonAccessTokenSetter(String accessToken) {
+        this.accessToken = accessToken;
+        this.accessTokenProvided = true;
+    }
+
     @Transient
     @JsonIgnore
     public boolean isAppSecretProvided() {
         return appSecretProvided;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isAccessTokenProvided() {
+        return accessTokenProvided;
+    }
+
+    public void setDefaultPageId(String defaultPageId) {
+        this.defaultPageId = defaultPageId;
+    }
+
+    @JsonSetter("defaultPageId")
+    public void jsonDefaultPageIdSetter(String defaultPageId) {
+        this.defaultPageId = defaultPageId;
+        this.defaultPageIdProvided = true;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isDefaultPageIdProvided() {
+        return defaultPageIdProvided;
+    }
+
+    public void setDefaultInstagramActorId(String defaultInstagramActorId) {
+        this.defaultInstagramActorId = defaultInstagramActorId;
+    }
+
+    @JsonSetter("defaultInstagramActorId")
+    public void jsonDefaultInstagramActorIdSetter(String defaultInstagramActorId) {
+        this.defaultInstagramActorId = defaultInstagramActorId;
+        this.defaultInstagramActorIdProvided = true;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isDefaultInstagramActorIdProvided() {
+        return defaultInstagramActorIdProvided;
     }
 
     @Transient

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -67,9 +67,13 @@ public class FacebookAccountController {
         persisted.setAuthorizedUserEmail(account.getAuthorizedUserEmail());
         persisted.setAppId(account.getAppId());
         persisted.setAdAccountId(account.getAdAccountId());
-        persisted.setDefaultPageId(account.getDefaultPageId());
+        if (account.isDefaultPageIdProvided()) {
+            persisted.setDefaultPageId(account.getDefaultPageId());
+        }
         persisted.setDefaultWebsiteUrl(account.getDefaultWebsiteUrl());
-        persisted.setDefaultInstagramActorId(account.getDefaultInstagramActorId());
+        if (account.isDefaultInstagramActorIdProvided()) {
+            persisted.setDefaultInstagramActorId(account.getDefaultInstagramActorId());
+        }
         persisted.setDefaultCreativeMessageTemplate(account.getDefaultCreativeMessageTemplate());
         persisted.setDefaultCallToActionType(account.getDefaultCallToActionType());
         persisted.setAdSetDailyBudget(account.getAdSetDailyBudget());
@@ -82,21 +86,23 @@ public class FacebookAccountController {
         persisted.setTokenRenewalEnabled(account.isTokenRenewalEnabled());
         persisted.setWorkerEnabled(account.isWorkerEnabled());
 
-        String newToken = account.getAccessToken();
-        if (newToken == null) {
-            persisted.setAccessToken(null);
-            persisted.setTokenExpiresAt(null);
-            persisted.setTokenLastRefreshedAt(null);
-            persisted.setTokenRenewalStatus(FacebookTokenRenewalStatus.NEVER_ATTEMPTED.name());
-            persisted.setTokenRenewalLastAttemptAt(null);
-            persisted.setTokenRenewedAt(null);
-            persisted.setTokenRenewalLastError(null);
-        } else {
-            if (!newToken.equals(persisted.getAccessToken())) {
-                persisted.setTokenLastRefreshedAt(LocalDateTime.now());
+        if (account.isAccessTokenProvided()) {
+            String newToken = account.getAccessToken();
+            if (newToken == null) {
+                persisted.setAccessToken(null);
+                persisted.setTokenExpiresAt(null);
+                persisted.setTokenLastRefreshedAt(null);
+                persisted.setTokenRenewalStatus(FacebookTokenRenewalStatus.NEVER_ATTEMPTED.name());
+                persisted.setTokenRenewalLastAttemptAt(null);
+                persisted.setTokenRenewedAt(null);
+                persisted.setTokenRenewalLastError(null);
+            } else {
+                if (!newToken.equals(persisted.getAccessToken())) {
+                    persisted.setTokenLastRefreshedAt(LocalDateTime.now());
+                }
+                persisted.setAccessToken(newToken);
+                persisted.setTokenExpiresAt(account.getTokenExpiresAt());
             }
-            persisted.setAccessToken(newToken);
-            persisted.setTokenExpiresAt(account.getTokenExpiresAt());
         }
 
         if (account.isAppSecretProvided()) {
@@ -196,15 +202,21 @@ public class FacebookAccountController {
     private void normalizeAccount(FacebookAccount account) {
         account.setName(trim(account.getName()));
         account.setCurrency(trim(account.getCurrency()));
-        account.setAccessToken(trimToNull(account.getAccessToken()));
+        if (account.isAccessTokenProvided()) {
+            account.setAccessToken(trimToNull(account.getAccessToken()));
+        }
         account.setAuthorizedUserId(trimToNull(account.getAuthorizedUserId()));
         account.setAuthorizedUserName(trimToNull(account.getAuthorizedUserName()));
         account.setAuthorizedUserEmail(trimToNull(account.getAuthorizedUserEmail()));
         account.setAppId(trimToNull(account.getAppId()));
         account.setAdAccountId(trimToNull(account.getAdAccountId()));
-        account.setDefaultPageId(trimToNull(account.getDefaultPageId()));
+        if (account.isDefaultPageIdProvided()) {
+            account.setDefaultPageId(trimToNull(account.getDefaultPageId()));
+        }
         account.setDefaultWebsiteUrl(trimToNull(account.getDefaultWebsiteUrl()));
-        account.setDefaultInstagramActorId(trimToNull(account.getDefaultInstagramActorId()));
+        if (account.isDefaultInstagramActorIdProvided()) {
+            account.setDefaultInstagramActorId(trimToNull(account.getDefaultInstagramActorId()));
+        }
         account.setDefaultCreativeMessageTemplate(trimToNull(account.getDefaultCreativeMessageTemplate()));
         account.setDefaultCallToActionType(trimToNull(account.getDefaultCallToActionType()));
         account.setAdSetDailyBudget(trimToNull(account.getAdSetDailyBudget()));

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -96,6 +97,106 @@ public class FacebookAccountControllerTest {
         assertThat(saved.isTokenRenewalEnabled()).isTrue();
 
         repository.deleteAll();
+    }
+
+    @Test
+    void shouldPreserveTokenAndHiddenFieldsWhenUpdatingWithoutThem() throws Exception {
+        LocalDateTime expiresAt = LocalDateTime.of(2030, 1, 1, 12, 0);
+        FacebookAccount existing = repository.save(FacebookAccount.builder()
+            .name("Conta original")
+            .currency("BRL")
+            .accessToken("token-atual")
+            .tokenExpiresAt(expiresAt)
+            .defaultPageId("1234567890")
+            .defaultInstagramActorId("ig-actor-1")
+            .defaultWebsiteUrl("https://example.com")
+            .defaultCreativeMessageTemplate("Mensagem %s")
+            .defaultCallToActionType("LEARN_MORE")
+            .adSetDailyBudget("1000")
+            .adSetBillingEvent("IMPRESSIONS")
+            .adSetOptimizationGoal("LINK_CLICKS")
+            .adSetDestinationType("WEBSITE")
+            .adSetBidStrategy("LOWEST_COST_WITHOUT_CAP")
+            .adSetBidAmount("500")
+            .adSetTargetCountry("BR")
+            .tokenRenewalEnabled(true)
+            .workerEnabled(true)
+            .build());
+
+        String payload = """
+            {
+              "name": "Conta atualizada",
+              "currency": "BRL",
+              "authorizedUserId": "123",
+              "authorizedUserName": "Marketing Hub",
+              "authorizedUserEmail": "contato@example.com",
+              "appId": "app-123",
+              "adAccountId": "act_123",
+              "defaultWebsiteUrl": "https://atualizado.example.com",
+              "defaultCreativeMessageTemplate": "Atualizada %s",
+              "defaultCallToActionType": "LEARN_MORE",
+              "adSetDailyBudget": "2000",
+              "adSetBillingEvent": "IMPRESSIONS",
+              "adSetOptimizationGoal": "LINK_CLICKS",
+              "adSetDestinationType": "WEBSITE",
+              "adSetBidStrategy": "LOWEST_COST_WITHOUT_CAP",
+              "adSetBidAmount": "800",
+              "adSetTargetCountry": "BR",
+              "tokenRenewalEnabled": true,
+              "workerEnabled": true
+            }
+            """;
+
+        mockMvc.perform(put("/api/accounts/facebook/" + existing.getId())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(payload))
+            .andExpect(status().isOk());
+
+        FacebookAccount updated = repository.findById(existing.getId()).orElseThrow();
+        assertThat(updated.getAccessToken()).isEqualTo("token-atual");
+        assertThat(updated.getTokenExpiresAt()).isEqualTo(expiresAt);
+        assertThat(updated.getDefaultPageId()).isEqualTo("1234567890");
+        assertThat(updated.getDefaultInstagramActorId()).isEqualTo("ig-actor-1");
+        assertThat(updated.getDefaultWebsiteUrl()).isEqualTo("https://atualizado.example.com");
+        assertThat(updated.getAdSetBidAmount()).isEqualTo("800");
+    }
+
+    @Test
+    void shouldClearTokenWhenNullIsExplicitlyProvidedOnUpdate() throws Exception {
+        FacebookAccount existing = repository.save(FacebookAccount.builder()
+            .name("Conta com token")
+            .currency("BRL")
+            .accessToken("token-antigo")
+            .tokenExpiresAt(LocalDateTime.of(2030, 1, 1, 0, 0))
+            .tokenRenewalStatus(FacebookTokenRenewalStatus.SUCCESS.name())
+            .tokenRenewalLastError("erro antigo")
+            .tokenRenewalLastAttemptAt(LocalDateTime.of(2029, 12, 31, 23, 0))
+            .tokenRenewedAt(LocalDateTime.of(2029, 12, 31, 23, 0))
+            .build());
+
+        String payload = """
+            {
+              "name": "Conta com token",
+              "currency": "BRL",
+              "accessToken": null,
+              "tokenRenewalEnabled": false,
+              "workerEnabled": false
+            }
+            """;
+
+        mockMvc.perform(put("/api/accounts/facebook/" + existing.getId())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(payload))
+            .andExpect(status().isOk());
+
+        FacebookAccount updated = repository.findById(existing.getId()).orElseThrow();
+        assertThat(updated.getAccessToken()).isNull();
+        assertThat(updated.getTokenExpiresAt()).isNull();
+        assertThat(updated.getTokenLastRefreshedAt()).isNull();
+        assertThat(updated.getTokenRenewalStatus()).isEqualTo(FacebookTokenRenewalStatus.NEVER_ATTEMPTED.name());
+        assertThat(updated.getTokenRenewalLastAttemptAt()).isNull();
+        assertThat(updated.getTokenRenewalLastError()).isNull();
+        assertThat(updated.getTokenRenewedAt()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ensure Facebook account updates keep the stored access token and hidden configuration fields unless the payload explicitly changes them
- cover the new behaviour with controller tests for preserving and clearing tokens
- document the preservation rule for FacebookAccount entities in the backend agent guidelines

## Testing
- `mvn -s ../settings.xml test` *(fails: network is unreachable while downloading spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68deda6fbe888321b634a0e388770bc3