### PR TITLE
Preserve hidden Facebook account fields on update

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -6,3 +6,4 @@
 - Liquibase: nunca altere arquivos de changelog já aplicados para evitar erros de checksum. Em vez disso, crie um novo changelog incremental e, se necessário, atualize os `include` do master.
 - Liquibase (MySQL 5): ao escrever `preConditions`, utilize apenas SQL válida no MySQL 5 (testando as consultas antes de incluí-las) e configure `dbms="mysql"` quando a condição depender do banco para evitar erros de sintaxe.
 - Liquibase (SQL formatado): mantenha os atributos (`expectedResult`, `dbms`, etc.) na mesma linha do `--precondition-sql-check` junto com a consulta SQL (`SELECT ...`) exatamente como suportado pelo Liquibase para evitar falhas de parsing.
+- Os endpoints de contas do Facebook não podem descartar valores que não aparecem na UI (por exemplo, tokens de acesso ou IDs padrão). Ao atualizar um registro existente, preserve qualquer campo que não tenha sido enviado explicitamente na requisição.

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
@@ -37,6 +37,10 @@ public class FacebookAccount {
 
     @Column(columnDefinition = "LONGTEXT")
     private String accessToken;
+    @Transient
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private boolean accessTokenProvided;
     private LocalDateTime tokenExpiresAt;
     private LocalDateTime tokenLastRefreshedAt;
     private String authorizedUserId;
@@ -49,6 +53,10 @@ public class FacebookAccount {
 
     @Column(name = "default_page_id")
     private String defaultPageId;
+    @Transient
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private boolean defaultPageIdProvided;
 
     @Column(name = "default_website_url", length = 512)
     private String defaultWebsiteUrl;
@@ -58,6 +66,10 @@ public class FacebookAccount {
 
     @Column(name = "default_instagram_actor_id")
     private String defaultInstagramActorId;
+    @Transient
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private boolean defaultInstagramActorIdProvided;
 
     @Column(name = "default_creative_message_template")
     private String defaultCreativeMessageTemplate;
@@ -147,6 +159,54 @@ public class FacebookAccount {
         }
         long days = ChronoUnit.DAYS.between(LocalDateTime.now(), tokenExpiresAt);
         return days;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    @JsonSetter("accessToken")
+    public void jsonAccessTokenSetter(String accessToken) {
+        this.accessTokenProvided = true;
+        this.accessToken = accessToken;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isAccessTokenProvided() {
+        return accessTokenProvided;
+    }
+
+    public void setDefaultPageId(String defaultPageId) {
+        this.defaultPageId = defaultPageId;
+    }
+
+    @JsonSetter("defaultPageId")
+    public void jsonDefaultPageIdSetter(String defaultPageId) {
+        this.defaultPageIdProvided = true;
+        this.defaultPageId = defaultPageId;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isDefaultPageIdProvided() {
+        return defaultPageIdProvided;
+    }
+
+    public void setDefaultInstagramActorId(String defaultInstagramActorId) {
+        this.defaultInstagramActorId = defaultInstagramActorId;
+    }
+
+    @JsonSetter("defaultInstagramActorId")
+    public void jsonDefaultInstagramActorIdSetter(String defaultInstagramActorId) {
+        this.defaultInstagramActorIdProvided = true;
+        this.defaultInstagramActorId = defaultInstagramActorId;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isDefaultInstagramActorIdProvided() {
+        return defaultInstagramActorIdProvided;
     }
 
     @JsonSetter("appSecret")

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -67,9 +67,7 @@ public class FacebookAccountController {
         persisted.setAuthorizedUserEmail(account.getAuthorizedUserEmail());
         persisted.setAppId(account.getAppId());
         persisted.setAdAccountId(account.getAdAccountId());
-        persisted.setDefaultPageId(account.getDefaultPageId());
         persisted.setDefaultWebsiteUrl(account.getDefaultWebsiteUrl());
-        persisted.setDefaultInstagramActorId(account.getDefaultInstagramActorId());
         persisted.setDefaultCreativeMessageTemplate(account.getDefaultCreativeMessageTemplate());
         persisted.setDefaultCallToActionType(account.getDefaultCallToActionType());
         persisted.setAdSetDailyBudget(account.getAdSetDailyBudget());
@@ -82,21 +80,30 @@ public class FacebookAccountController {
         persisted.setTokenRenewalEnabled(account.isTokenRenewalEnabled());
         persisted.setWorkerEnabled(account.isWorkerEnabled());
 
-        String newToken = account.getAccessToken();
-        if (newToken == null) {
-            persisted.setAccessToken(null);
-            persisted.setTokenExpiresAt(null);
-            persisted.setTokenLastRefreshedAt(null);
-            persisted.setTokenRenewalStatus(FacebookTokenRenewalStatus.NEVER_ATTEMPTED.name());
-            persisted.setTokenRenewalLastAttemptAt(null);
-            persisted.setTokenRenewedAt(null);
-            persisted.setTokenRenewalLastError(null);
-        } else {
-            if (!newToken.equals(persisted.getAccessToken())) {
-                persisted.setTokenLastRefreshedAt(LocalDateTime.now());
+        if (account.isDefaultPageIdProvided()) {
+            persisted.setDefaultPageId(account.getDefaultPageId());
+        }
+        if (account.isDefaultInstagramActorIdProvided()) {
+            persisted.setDefaultInstagramActorId(account.getDefaultInstagramActorId());
+        }
+
+        if (account.isAccessTokenProvided()) {
+            String newToken = account.getAccessToken();
+            if (newToken == null) {
+                persisted.setAccessToken(null);
+                persisted.setTokenExpiresAt(null);
+                persisted.setTokenLastRefreshedAt(null);
+                persisted.setTokenRenewalStatus(FacebookTokenRenewalStatus.NEVER_ATTEMPTED.name());
+                persisted.setTokenRenewalLastAttemptAt(null);
+                persisted.setTokenRenewedAt(null);
+                persisted.setTokenRenewalLastError(null);
+            } else {
+                if (!newToken.equals(persisted.getAccessToken())) {
+                    persisted.setTokenLastRefreshedAt(LocalDateTime.now());
+                }
+                persisted.setAccessToken(newToken);
+                persisted.setTokenExpiresAt(account.getTokenExpiresAt());
             }
-            persisted.setAccessToken(newToken);
-            persisted.setTokenExpiresAt(account.getTokenExpiresAt());
         }
 
         if (account.isAppSecretProvided()) {

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookAccountControllerTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -200,6 +201,101 @@ public class FacebookAccountControllerTest {
 
         mockMvc.perform(post("/api/accounts/facebook/" + account.getId() + "/token/revalidation"))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldPreserveTokenAndHiddenFieldsWhenUpdatingAccountWithoutExplicitValues() throws Exception {
+        FacebookAccount account = repository.save(FacebookAccount.builder()
+            .name("Original")
+            .currency("BRL")
+            .accessToken("original-token")
+            .tokenExpiresAt(LocalDateTime.parse("2024-01-05T10:00:00"))
+            .tokenLastRefreshedAt(LocalDateTime.parse("2024-01-01T08:00:00"))
+            .tokenRenewalStatus(FacebookTokenRenewalStatus.SUCCESS.name())
+            .tokenRenewalLastAttemptAt(LocalDateTime.parse("2023-12-31T12:00:00"))
+            .tokenRenewedAt(LocalDateTime.parse("2023-12-30T15:00:00"))
+            .tokenRenewalLastError("previous-error")
+            .defaultPageId("page-123")
+            .defaultInstagramActorId("ig-456")
+            .defaultWebsiteUrl("https://old.example.com")
+            .defaultLeadGenFormId("form-old")
+            .defaultCreativeMessageTemplate("Campanha antiga %s")
+            .defaultCallToActionType("SIGN_UP")
+            .adAccountId("act_old")
+            .adSetDailyBudget("1500")
+            .adSetBillingEvent("IMPRESSIONS")
+            .adSetOptimizationGoal("LINK_CLICKS")
+            .adSetDestinationType("WEBSITE")
+            .adSetBidStrategy("LOWEST_COST_WITHOUT_CAP")
+            .adSetBidAmount("500")
+            .adSetTargetCountry("BR")
+            .tokenRenewalEnabled(true)
+            .workerEnabled(true)
+            .authorizedUserId("auth-1")
+            .authorizedUserName("Original User")
+            .authorizedUserEmail("original@example.com")
+            .appId("old-app")
+            .build());
+
+        String payload = ("{" +
+            "\"id\":" + account.getId() + ',' +
+            "\"name\":\"Atualizada\"," +
+            "\"currency\":\"BRL\"," +
+            "\"authorizedUserId\":\"auth-2\"," +
+            "\"authorizedUserName\":\"Usuário Atualizado\"," +
+            "\"authorizedUserEmail\":\"updated@example.com\"," +
+            "\"appId\":\"new-app\"," +
+            "\"tokenRenewalEnabled\":false," +
+            "\"adAccountId\":\"act_new\"," +
+            "\"defaultWebsiteUrl\":\"https://new.example.com\"," +
+            "\"defaultLeadGenFormId\":\"form-new\"," +
+            "\"defaultCreativeMessageTemplate\":\"Nova campanha %s\"," +
+            "\"defaultCallToActionType\":\"LEARN_MORE\"," +
+            "\"adSetDailyBudget\":\"2000\"," +
+            "\"adSetBillingEvent\":\"IMPRESSIONS\"," +
+            "\"adSetOptimizationGoal\":\"LINK_CLICKS\"," +
+            "\"adSetDestinationType\":\"WEBSITE\"," +
+            "\"adSetBidStrategy\":\"LOWEST_COST_WITHOUT_CAP\"," +
+            "\"adSetBidAmount\":\"600\"," +
+            "\"adSetTargetCountry\":\"BR\"," +
+            "\"workerEnabled\":false" +
+            "}");
+
+        mockMvc.perform(put("/api/accounts/facebook/" + account.getId())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(payload))
+            .andExpect(status().isOk());
+
+        FacebookAccount updated = repository.findById(account.getId()).orElseThrow();
+        assertThat(updated.getAccessToken()).isEqualTo("original-token");
+        assertThat(updated.getTokenExpiresAt()).isEqualTo(LocalDateTime.parse("2024-01-05T10:00:00"));
+        assertThat(updated.getTokenLastRefreshedAt()).isEqualTo(LocalDateTime.parse("2024-01-01T08:00:00"));
+        assertThat(updated.getTokenRenewalStatus()).isEqualTo(FacebookTokenRenewalStatus.SUCCESS.name());
+        assertThat(updated.getTokenRenewalLastAttemptAt()).isEqualTo(LocalDateTime.parse("2023-12-31T12:00:00"));
+        assertThat(updated.getTokenRenewedAt()).isEqualTo(LocalDateTime.parse("2023-12-30T15:00:00"));
+        assertThat(updated.getTokenRenewalLastError()).isEqualTo("previous-error");
+        assertThat(updated.getDefaultPageId()).isEqualTo("page-123");
+        assertThat(updated.getDefaultInstagramActorId()).isEqualTo("ig-456");
+
+        assertThat(updated.getName()).isEqualTo("Atualizada");
+        assertThat(updated.getAuthorizedUserId()).isEqualTo("auth-2");
+        assertThat(updated.getAuthorizedUserName()).isEqualTo("Usuário Atualizado");
+        assertThat(updated.getAuthorizedUserEmail()).isEqualTo("updated@example.com");
+        assertThat(updated.getAppId()).isEqualTo("new-app");
+        assertThat(updated.isTokenRenewalEnabled()).isFalse();
+        assertThat(updated.getAdAccountId()).isEqualTo("act_new");
+        assertThat(updated.getDefaultWebsiteUrl()).isEqualTo("https://new.example.com");
+        assertThat(updated.getDefaultLeadGenFormId()).isEqualTo("form-new");
+        assertThat(updated.getDefaultCreativeMessageTemplate()).isEqualTo("Nova campanha %s");
+        assertThat(updated.getDefaultCallToActionType()).isEqualTo("LEARN_MORE");
+        assertThat(updated.getAdSetDailyBudget()).isEqualTo("2000");
+        assertThat(updated.getAdSetBillingEvent()).isEqualTo("IMPRESSIONS");
+        assertThat(updated.getAdSetOptimizationGoal()).isEqualTo("LINK_CLICKS");
+        assertThat(updated.getAdSetDestinationType()).isEqualTo("WEBSITE");
+        assertThat(updated.getAdSetBidStrategy()).isEqualTo("LOWEST_COST_WITHOUT_CAP");
+        assertThat(updated.getAdSetBidAmount()).isEqualTo("600");
+        assertThat(updated.getAdSetTargetCountry()).isEqualTo("BR");
+        assertThat(updated.isWorkerEnabled()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- prevent Facebook account updates from clearing tokens or other hidden configuration values
- track whether sensitive fields were provided in the payload before mutating persisted records
- add a regression test covering the non-destructive update flow and document the rule in the backend agent guide

## Testing
- `mvn -s ../settings.xml test` *(fails: cannot resolve org.springframework.boot:spring-boot-starter-parent due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68dedd23cd8c832196ea3191bd74ef24