### PR TITLE
Fix Facebook account update lead form handling

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
@@ -63,6 +63,10 @@ public class FacebookAccount {
 
     @Column(name = "default_lead_gen_form_id")
     private String defaultLeadGenFormId;
+    @Transient
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private boolean defaultLeadGenFormIdProvided;
 
     @Column(name = "default_instagram_actor_id")
     private String defaultInstagramActorId;
@@ -207,6 +211,18 @@ public class FacebookAccount {
     @JsonIgnore
     public boolean isDefaultInstagramActorIdProvided() {
         return defaultInstagramActorIdProvided;
+    }
+
+    @JsonSetter("defaultLeadGenFormId")
+    public void jsonDefaultLeadGenFormIdSetter(String defaultLeadGenFormId) {
+        this.defaultLeadGenFormIdProvided = true;
+        this.defaultLeadGenFormId = defaultLeadGenFormId;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isDefaultLeadGenFormIdProvided() {
+        return defaultLeadGenFormIdProvided;
     }
 
     @JsonSetter("appSecret")

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -86,6 +86,9 @@ public class FacebookAccountController {
         if (account.isDefaultInstagramActorIdProvided()) {
             persisted.setDefaultInstagramActorId(account.getDefaultInstagramActorId());
         }
+        if (account.isDefaultLeadGenFormIdProvided()) {
+            persisted.setDefaultLeadGenFormId(account.getDefaultLeadGenFormId());
+        }
 
         if (account.isAccessTokenProvided()) {
             String newToken = account.getAccessToken();


### PR DESCRIPTION
## Summary
- track whether the Facebook lead gen form id field was provided in requests so optional updates are preserved
- update the Facebook account controller to only overwrite the stored lead gen form id when the caller explicitly sends a new value

## Testing
- mvn -Dtest=FacebookAccountControllerTest test

------
https://chatgpt.com/codex/tasks/task_e_68def2124d2883219ad26a3da7a51e20