### PR TITLE
Generate new long-lived Facebook tokens

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -381,13 +381,13 @@ public class FacebookAccountController {
 
     private void validateRevalidationPrerequisites(FacebookAccount account) {
         if (!StringUtils.hasText(account.getAccessToken())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Conta sem token configurado para revalidação");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Conta sem token configurado para gerar um novo acesso");
         }
         if (!StringUtils.hasText(account.getAppId())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe o App ID antes de revalidar o token");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe o App ID antes de gerar um novo token");
         }
         if (!StringUtils.hasText(account.getAppSecret())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe o App Secret antes de revalidar o token");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe o App Secret antes de gerar um novo token");
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookTokenRevalidationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookTokenRevalidationService.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 @Service
 public class FacebookTokenRevalidationService {
     private static final Logger log = LoggerFactory.getLogger(FacebookTokenRevalidationService.class);
+    private static final long LONG_LIVED_TOKEN_VALIDITY_DAYS = 60L;
 
     private final RestTemplate restTemplate;
     private final FacebookAccountRepository repository;
@@ -44,13 +45,13 @@ public class FacebookTokenRevalidationService {
         LocalDateTime attemptedAt = LocalDateTime.now();
         String url = buildTokenExchangeUrl(account);
         log.info(
-            "Requesting Facebook token revalidation via Graph API: accountId={}, endpoint={}/{}",
+            "Requesting Facebook long-lived token via Graph API: accountId={}, endpoint={}/{}",
             account.getId(),
             graphApiBaseUrl,
             graphApiVersion
         );
         log.debug(
-            "Facebook token revalidation parameters: accountId={}, appId={}, accessToken={}, tokenRenewalEnabled={}",
+            "Facebook token generation parameters: accountId={}, appId={}, accessToken={}, tokenRenewalEnabled={}",
             account.getId(),
             maskForLogs(account.getAppId()),
             maskForLogs(account.getAccessToken()),
@@ -60,13 +61,11 @@ public class FacebookTokenRevalidationService {
         try {
             GraphTokenResponse response = restTemplate.getForObject(url, GraphTokenResponse.class);
             if (response == null || !StringUtils.hasText(response.accessToken())) {
-                throw new IllegalStateException("Facebook returned an empty token while revalidating the access token");
+                throw new IllegalStateException("Facebook returned an empty token while generating a new access token");
             }
 
             LocalDateTime renewedAt = attemptedAt;
-            LocalDateTime expiresAt = response.expiresIn() != null
-                ? attemptedAt.plusSeconds(Math.max(response.expiresIn(), 0))
-                : null;
+            LocalDateTime expiresAt = attemptedAt.plusDays(LONG_LIVED_TOKEN_VALIDITY_DAYS);
 
             account.setAccessToken(response.accessToken());
             account.setTokenExpiresAt(expiresAt);
@@ -78,16 +77,13 @@ public class FacebookTokenRevalidationService {
 
             repository.save(account);
 
-            log.info(
-                "Facebook token revalidation succeeded: accountId={}, expiresAt={}",
-                account.getId(),
-                expiresAt
-            );
+            log.info("Generated new Facebook access token: accountId={}, expiresAt={}", account.getId(), expiresAt);
             log.debug(
-                "Facebook token revalidation updated credentials: accountId={}, renewedAt={}, expiresInSeconds={}",
+                "Facebook token generation updated credentials: accountId={}, renewedAt={}, expiresInSeconds={}, configuredValidityDays={}",
                 account.getId(),
                 renewedAt,
-                response.expiresIn()
+                response.expiresIn(),
+                LONG_LIVED_TOKEN_VALIDITY_DAYS
             );
 
             return new RevalidationResult(
@@ -104,7 +100,7 @@ public class FacebookTokenRevalidationService {
             if (error != null && error.error() != null) {
                 GraphError graphError = error.error();
                 log.error(
-                    "Facebook token revalidation failed: accountId={}, status={}, type={}, code={}, subCode={}, transient={}, fbtraceId={}, message={}",
+                    "Facebook token generation failed: accountId={}, status={}, type={}, code={}, subCode={}, transient={}, fbtraceId={}, message={}",
                     account.getId(),
                     ex.getRawStatusCode(),
                     graphError.type(),
@@ -117,7 +113,7 @@ public class FacebookTokenRevalidationService {
                 );
             } else {
                 log.error(
-                    "Facebook token revalidation failed: accountId={}, status={}, response={}",
+                    "Facebook token generation failed: accountId={}, status={}, response={}",
                     account.getId(),
                     ex.getRawStatusCode(),
                     sanitizeBody(ex.getResponseBodyAsString()),
@@ -127,7 +123,7 @@ public class FacebookTokenRevalidationService {
             return registerFailure(account, attemptedAt, message);
         } catch (RestClientException ex) {
             log.error(
-                "Facebook token revalidation failed: accountId={}, message={}",
+                "Facebook token generation failed: accountId={}, message={}",
                 account.getId(),
                 ex.getMessage(),
                 ex
@@ -135,7 +131,7 @@ public class FacebookTokenRevalidationService {
             return registerFailure(account, attemptedAt, ex.getMessage());
         } catch (RuntimeException ex) {
             log.error(
-                "Facebook token revalidation failed: accountId={}, message={}",
+                "Facebook token generation failed: accountId={}, message={}",
                 account.getId(),
                 ex.getMessage(),
                 ex
@@ -162,7 +158,7 @@ public class FacebookTokenRevalidationService {
     private String buildFailureMessage(RestClientResponseException ex, GraphErrorResponse error) {
         if (error != null && error.error() != null) {
             GraphError graphError = error.error();
-            StringBuilder builder = new StringBuilder("Graph API error");
+            StringBuilder builder = new StringBuilder("Graph API error during token generation");
             if (StringUtils.hasText(graphError.type())) {
                 builder.append(" (type=").append(graphError.type()).append(')');
             }

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -27,7 +27,7 @@ spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 logging.level.liquibase=DEBUG
 spring.config.import=optional:metrics.yml
 
-# Facebook Graph API configuration for token revalidation
+# Facebook Graph API configuration for long-lived token generation
 facebook.graph-api.base-url=https://graph.facebook.com
 facebook.graph-api.version=v23.0
 

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookTokenRevalidationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookTokenRevalidationServiceTest.java
@@ -1,0 +1,74 @@
+package com.marketinghub.ads;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class FacebookTokenRevalidationServiceTest {
+
+    @Test
+    void shouldGenerateNewTokenWithSixtyDayExpiration() {
+        RestTemplate restTemplate = new RestTemplate();
+        RestTemplateBuilder builder = mock(RestTemplateBuilder.class);
+        when(builder.build()).thenReturn(restTemplate);
+
+        FacebookAccountRepository repository = mock(FacebookAccountRepository.class);
+        when(repository.save(any(FacebookAccount.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        FacebookTokenRevalidationService service = new FacebookTokenRevalidationService(
+            builder,
+            repository,
+            new ObjectMapper(),
+            "https://graph.facebook.com",
+            "v18.0"
+        );
+
+        MockRestServiceServer server = MockRestServiceServer
+            .bindTo(restTemplate)
+            .ignoreExpectOrder(true)
+            .build();
+
+        server
+            .expect(requestTo("https://graph.facebook.com/v18.0/oauth/access_token?grant_type=fb_exchange_token&client_id=app-id&client_secret=secret&fb_exchange_token=old-token"))
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withSuccess("{\"access_token\":\"new-token\",\"expires_in\":3600}", MediaType.APPLICATION_JSON));
+
+        FacebookAccount account = FacebookAccount
+            .builder()
+            .id(1L)
+            .name("Test")
+            .accessToken("old-token")
+            .appId("app-id")
+            .appSecret("secret")
+            .tokenRenewalEnabled(true)
+            .build();
+
+        LocalDateTime before = LocalDateTime.now();
+        FacebookTokenRevalidationService.RevalidationResult result = service.revalidate(account);
+        LocalDateTime after = LocalDateTime.now();
+
+        server.verify();
+
+        assertThat(result.status()).isEqualTo(FacebookTokenRenewalStatus.SUCCESS);
+        assertThat(result.accessToken()).isEqualTo("new-token");
+        assertThat(result.tokenExpiresAt()).isNotNull();
+        assertThat(result.tokenExpiresAt()).isBetween(before.plusDays(60), after.plusDays(60));
+        assertThat(account.getTokenExpiresAt()).isBetween(before.plusDays(60), after.plusDays(60));
+        assertThat(account.getTokenLastRefreshedAt()).isBetween(before, after);
+        assertThat(account.getTokenRenewedAt()).isBetween(before, after);
+    }
+}

--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -257,9 +257,9 @@ classDiagram
     FacebookAdsAd --> FacebookAdsAdCreative
     FacebookCampaignService ..> UrlUtils : compõe URLs do backend
     FacebookTokenRenewalScheduler --> FacebookTokenRenewalService : agenda renovação
-    FacebookTokenRenewalService --> FacebookTokenRevalidationClient : solicita revalidação
+    FacebookTokenRenewalService --> FacebookTokenRevalidationClient : solicita geração de novo token
     FacebookAccessTokenManager --> FacebookWorkerConfigurationClient : lê credenciais do backend
-    FacebookAccessTokenManager --> FacebookTokenRevalidationClient : revalida token expirado
+    FacebookAccessTokenManager --> FacebookTokenRevalidationClient : solicita novo token após expiração
     FacebookTokenRenewalService ..> UrlUtils : reutiliza composição de URLs
 ```
 
@@ -274,18 +274,19 @@ classDiagram
   lista de bloqueio em memória para evitar novas tentativas até que o worker
   seja reiniciado.
 * `FacebookAdsService` encapsula as chamadas à Graph API (criação da hierarquia
-  de mídia e consulta de métricas). A revalidação de tokens de longa duração é
-  realizada pelo backend através do `FacebookTokenRevalidationClient`.
+  de mídia e consulta de métricas). A geração automática de novos tokens de
+  longa duração é realizada pelo backend através do
+  `FacebookTokenRevalidationClient`.
 * `FacebookTokenRenewalScheduler` agenda o fluxo periódico de renovação de token
   e delega para `FacebookTokenRenewalService`.
 * `FacebookTokenRenewalService` busca as contas elegíveis no backend, solicita a
-  revalidação automática via `POST /api/accounts/facebook/{id}/token/revalidation`
-  e sincroniza o token em memória quando a resposta pertence à conta configurada
-  no worker.
+  geração automática do novo token de 60 dias via
+  `POST /api/accounts/facebook/{id}/token/revalidation` e sincroniza o token em
+  memória quando a resposta pertence à conta configurada no worker.
 * `FacebookAccessTokenManager` encapsula a renovação imediata de tokens quando o
   `FacebookCampaignService` detecta expiração durante a criação de campanhas,
   consultando o backend pelo mesmo endpoint para atualizar o `access_token` em
-  memória.
+  memória com o novo valor gerado.
 * `FacebookWorkerConfigurationClient` fornece acesso ao endpoint
   `/api/accounts/facebook/worker-config`, permitindo que os serviços leiam as
   credenciais e parâmetros padrão preenchidos na interface web.

--- a/docs/facebook-ads-worker/token-management.md
+++ b/docs/facebook-ads-worker/token-management.md
@@ -22,9 +22,9 @@ expiração automática.
    no frontend. O backend persiste esses valores em `facebook_account` e inicia o
    controle de expiração (`tokenExpiresAt`, `tokenLastRefreshedAt`).
 
-> O worker também executa essa mesma chamada quando precisa transformar um token
-> recém renovado em memória, garantindo que a lógica seja idêntica ao processo
-> manual descrito acima.
+> O worker também executa essa mesma chamada quando precisa gerar um novo token
+> automaticamente, garantindo que a lógica seja idêntica ao processo manual
+> descrito acima.
 
 ## 2. Como o Facebook Ads Worker monitora o token
 
@@ -34,11 +34,12 @@ expiração automática.
    iminente.
 2. Para cada conta elegível, o `FacebookTokenRenewalService` aciona o endpoint
    `POST /api/accounts/facebook/{id}/token/revalidation`. O backend reutiliza o
-   `appId`, o `appSecret` e o token atual armazenados na conta para trocar o
-   token diretamente na Graph API.
+   `appId`, o `appSecret` e o token atual armazenados na conta para gerar um
+   novo token de 60 dias diretamente na Graph API.
 3. Ao receber `status=SUCCESS`, o worker atualiza seu `FacebookAdsService` em
-   memória quando o token renovado pertence à mesma conta configurada. O backend
-   já registra o novo token, a data de expiração e o horário da tentativa.
+   memória quando o token recém-gerado pertence à mesma conta configurada. O
+   backend já registra o novo token, a data de expiração (60 dias a partir da
+   tentativa) e o horário da execução.
 4. Em caso de falha (por exemplo, `(#190) OAuthException`), o backend devolve
    `status=FAILED` com a mensagem da Graph API, mantendo o token anterior até que
    uma intervenção manual ou nova tentativa automática seja bem-sucedida.
@@ -55,9 +56,10 @@ expiração automática.
   `tokenExpiresAt` automaticamente após consultar a Graph API, registrando o
   token recebido ou a mensagem de erro.
 - **Sucesso** – Quando `status=SUCCESS`, o backend salva o novo `accessToken`,
-  atualiza `tokenExpiresAt`, `tokenLastRefreshedAt` e `tokenRenewedAt` e limpa
-  `tokenRenewalLastError`. O novo token passa a ser utilizado pelo frontend e por
-  futuras execuções do worker.
+  atualiza `tokenExpiresAt` para 60 dias após a tentativa, bem como
+  `tokenLastRefreshedAt` e `tokenRenewedAt`, e limpa `tokenRenewalLastError`. O
+  novo token passa a ser utilizado pelo frontend e por futuras execuções do
+  worker.
 - **Falha** – Quando `status=FAILED`, o backend mantém o token anterior e grava a
   mensagem retornada em `tokenRenewalLastError`, permitindo que o frontend
   exiba o motivo da falha e que operadores decidam por uma nova tentativa ou

--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -8,4 +8,4 @@ Esta pasta concentra collections prontas para importar no Postman e exercitar os
 3. Ajuste a variável `baseUrl` para apontar para a instância do backend que deseja testar (por padrão `http://191.252.92.222:8000/api`).
 4. Defina a variável `accountId` com o identificador da conta que deseja atualizar, renovar ou excluir.
 
-A collection inclui requisições para listar, criar, atualizar e remover contas, consultar o `worker-config` ativo, solicitar a revalidação automática de tokens e registrar tentativas manualmente quando necessário.
+A collection inclui requisições para listar, criar, atualizar e remover contas, consultar o `worker-config` ativo, solicitar a geração automática de novos tokens (60 dias) e registrar tentativas manualmente quando necessário.

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -56,14 +56,15 @@ O fluxo funciona da seguinte forma:
    apenas as contas com `tokenRenewalEnabled = true`, token prestes a expirar e
    credenciais completas (`appId`, `appSecret`).
 2. Para cada conta elegível, o serviço `FacebookTokenRenewalService` chama o
-   endpoint `POST /api/accounts/facebook/{id}/token/revalidation`, que executa a
-   troca do token diretamente no backend utilizando as credenciais já
-   persistidas (App ID, App Secret e token atual). O backend devolve o novo
-   token e a data de expiração calculada.
+   endpoint `POST /api/accounts/facebook/{id}/token/revalidation`, que agora
+   gera um novo token de longa duração (60 dias) diretamente no backend
+   utilizando as credenciais já persistidas (App ID, App Secret e token atual).
+   O backend devolve o token recém-gerado e a data de expiração calculada a
+   partir da tentativa.
 3. Quando a Graph API devolve `(#190) OAuthException` o `FacebookCampaignService`
    intercepta a exceção, pausa o processamento de experimentos e delega para o
-   `FacebookAccessTokenManager` revalidar o token atual através do mesmo
-   endpoint do backend. Caso o aplicativo (`facebook.app-id`/`facebook.app-secret`)
+   `FacebookAccessTokenManager` solicitar a geração de um novo token através do
+   mesmo endpoint do backend. Caso o aplicativo (`facebook.app-id`/`facebook.app-secret`)
    esteja configurado, o novo token é aplicado em memória e a fila de
    experimentos volta a ser processada sem necessidade de reiniciar o serviço.
    Quando as credenciais não estão configuradas, o agendador de renovação do
@@ -74,9 +75,10 @@ O fluxo funciona da seguinte forma:
 4. Esses dados são exibidos na tela de contas do frontend, permitindo acompanhar
    a última tentativa, o último sucesso e eventuais mensagens de erro.
 
-Caso a revalidação dispare um erro da Graph API, o backend registra o status
-`FAILED` com a mensagem retornada em `tokenRenewalLastError`, mantendo o token
-anterior até que uma nova tentativa (manual ou automática) seja bem-sucedida.
+Caso a geração do token dispare um erro da Graph API, o backend registra o
+status `FAILED` com a mensagem retornada em `tokenRenewalLastError`, mantendo o
+token anterior até que uma nova tentativa (manual ou automática) seja
+bem-sucedida.
 
 ### Falha momentânea ao consultar a configuração do backend
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAccessTokenManager.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAccessTokenManager.java
@@ -58,7 +58,7 @@ public class FacebookAccessTokenManager {
                 if (StringUtils.hasText(response.accessToken())) {
                     facebookAdsService.updateAccessToken(response.accessToken());
                 }
-                LOGGER.info("Facebook access token renewed successfully via backend revalidation");
+                LOGGER.info("Facebook access token renewed successfully via backend token generation");
                 return new RenewalAttemptResult(RenewalOutcome.SUCCESS, response.accessToken(), null);
             }
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRenewalService.java
@@ -98,7 +98,7 @@ public class FacebookTokenRenewalService {
 
         if (response == null) {
             LOGGER.error(
-                "Token revalidation request did not return a response: accountId={}, name={}",
+                "Token generation request did not return a response: accountId={}, name={}",
                 candidate.id(),
                 candidate.name()
             );
@@ -113,7 +113,7 @@ public class FacebookTokenRenewalService {
             if (matchesCurrentToken && response.accessToken() != null) {
                 facebookAdsService.updateAccessToken(response.accessToken());
                 LOGGER.info(
-                    "Updated in-memory Facebook access token after backend revalidation for account id={}",
+                    "Updated in-memory Facebook access token after backend generation for account id={}",
                     candidate.id()
                 );
             } else if (!matchesCurrentToken) {
@@ -123,11 +123,11 @@ public class FacebookTokenRenewalService {
                 );
             }
             LOGGER.info(
-                "Facebook token revalidation succeeded for account id={} via backend", candidate.id()
+                "Facebook token generation succeeded for account id={} via backend", candidate.id()
             );
         } else {
             LOGGER.error(
-                "Token revalidation failed for Facebook account id={}, name={}: {}",
+                "Token generation failed for Facebook account id={}, name={}: {}",
                 candidate.id(),
                 candidate.name(),
                 response.errorMessage()

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRevalidationClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktokenrenewal/FacebookTokenRevalidationClient.java
@@ -34,7 +34,7 @@ public class FacebookTokenRevalidationClient {
         String path = "/accounts/facebook/" + accountId + "/token/revalidation";
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, path);
         LOGGER.info(
-            "Requesting Facebook token revalidation from backend: url==>{}, params={}",
+            "Requesting new Facebook access token from backend: url==>{}, params={}",
             url,
             Collections.emptyMap()
         );
@@ -46,14 +46,14 @@ public class FacebookTokenRevalidationClient {
                 .bodyToMono(TokenRevalidationResponse.class)
                 .block();
             LOGGER.info(
-                "Received Facebook token revalidation response from backend: url<=={}, response={}",
+                "Received Facebook token generation response from backend: url<=={}, response={}",
                 url,
                 response
             );
             return Optional.ofNullable(response);
         } catch (WebClientResponseException | WebClientRequestException ex) {
             LOGGER.error(
-                "Failed to revalidate Facebook token via backend: url<=={}, status={}, message={}",
+                "Failed to generate new Facebook access token via backend: url<=={}, status={}, message={}",
                 url,
                 ex instanceof WebClientResponseException responseException ? responseException.getRawStatusCode() : "N/A",
                 ex.getMessage(),


### PR DESCRIPTION
## Summary
- update the backend Facebook token service to create fresh 60-day tokens and refresh validation messaging
- align the worker logs and documentation with the new token generation flow
- add a focused unit test covering the new expiry calculation and update supporting docs (including Postman guidance)

## Testing
- mvn -Dtest=FacebookTokenRevalidationServiceTest test

------
https://chatgpt.com/codex/tasks/task_e_68df12301bbc8321a12bd3fc8c4f2d3a