### PR TITLE
Propagate Facebook page updates to experiments

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookPageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookPageController.java
@@ -1,21 +1,27 @@
 package com.marketinghub.ads;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Objects;
 
 @RestController
 @RequestMapping("/api/accounts/facebook/{accountId}/pages")
 public class FacebookPageController {
     private final FacebookAccountRepository accountRepository;
     private final FacebookPageRepository pageRepository;
+    private final com.marketinghub.experiment.repository.ExperimentRepository experimentRepository;
 
     public FacebookPageController(FacebookAccountRepository accountRepository,
-                                  FacebookPageRepository pageRepository) {
+                                  FacebookPageRepository pageRepository,
+                                  com.marketinghub.experiment.repository.ExperimentRepository experimentRepository) {
         this.accountRepository = accountRepository;
         this.pageRepository = pageRepository;
+        this.experimentRepository = experimentRepository;
     }
 
     @GetMapping
@@ -27,18 +33,20 @@ public class FacebookPageController {
     }
 
     @PostMapping
+    @Transactional
     public FacebookPageDto create(@PathVariable Long accountId,
                                   @RequestBody UpsertFacebookPageRequest request) {
         FacebookAccount account = ensureAccountExists(accountId);
         FacebookPage page = FacebookPage.builder()
                 .account(account)
                 .name(request.name())
-                .pageId(request.pageId())
+                .pageId(normalize(request.pageId()))
                 .build();
         return toDto(pageRepository.save(page));
     }
 
     @PutMapping("/{pageRecordId}")
+    @Transactional
     public FacebookPageDto update(@PathVariable Long accountId,
                                   @PathVariable Long pageRecordId,
                                   @RequestBody UpsertFacebookPageRequest request) {
@@ -47,19 +55,36 @@ public class FacebookPageController {
                 .filter(existing -> existing.getAccount().getId().equals(accountId))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 
+        String previousPageId = page.getPageId();
+        String normalizedPageId = normalize(request.pageId());
         page.setName(request.name());
-        page.setPageId(request.pageId());
-        return toDto(pageRepository.save(page));
+        page.setPageId(normalizedPageId);
+        FacebookPage saved = pageRepository.save(page);
+
+        if (StringUtils.hasText(previousPageId) && !Objects.equals(previousPageId, normalizedPageId)) {
+            if (!StringUtils.hasText(normalizedPageId)) {
+                experimentRepository.clearPageIdByValue(previousPageId);
+            } else {
+                experimentRepository.updatePageIdByValue(previousPageId, normalizedPageId);
+            }
+        }
+
+        return toDto(saved);
     }
 
     @DeleteMapping("/{pageRecordId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Transactional
     public void delete(@PathVariable Long accountId, @PathVariable Long pageRecordId) {
         ensureAccountExists(accountId);
         FacebookPage page = pageRepository.findById(pageRecordId)
                 .filter(existing -> existing.getAccount().getId().equals(accountId))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        String previousPageId = page.getPageId();
         pageRepository.delete(page);
+        if (StringUtils.hasText(previousPageId)) {
+            experimentRepository.clearPageIdByValue(previousPageId);
+        }
     }
 
     private FacebookAccount ensureAccountExists(Long accountId) {
@@ -69,6 +94,14 @@ public class FacebookPageController {
 
     private static FacebookPageDto toDto(FacebookPage page) {
         return new FacebookPageDto(page.getId(), page.getAccount().getId(), page.getPageId(), page.getName());
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     public record FacebookPageDto(Long id, Long accountId, String pageId, String name) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -5,6 +5,7 @@ import com.marketinghub.experiment.ExperimentPlatform;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.niche.MarketNiche;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import java.util.List;
@@ -66,4 +67,13 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
             """)
     List<Experiment> findAllReadyForAdSets(@Param("platform") ExperimentPlatform platform,
                                            @Param("statuses") List<ExperimentStatus> statuses);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Experiment e set e.pageId = :newPageId where e.pageId = :oldPageId")
+    int updatePageIdByValue(@Param("oldPageId") String oldPageId,
+                            @Param("newPageId") String newPageId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Experiment e set e.pageId = null where e.pageId = :pageId")
+    int clearPageIdByValue(@Param("pageId") String pageId);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookPageControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookPageControllerTest.java
@@ -10,6 +10,18 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentPlatform;
+import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.repository.HypothesisRepository;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.repository.MarketNicheRepository;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -35,12 +47,24 @@ class FacebookPageControllerTest {
     FacebookPageRepository pageRepository;
 
     @Autowired
+    ExperimentRepository experimentRepository;
+
+    @Autowired
+    MarketNicheRepository nicheRepository;
+
+    @Autowired
+    HypothesisRepository hypothesisRepository;
+
+    @Autowired
     ObjectMapper objectMapper;
 
     FacebookAccount account;
 
     @BeforeEach
     void setup() {
+        experimentRepository.deleteAll();
+        hypothesisRepository.deleteAll();
+        nicheRepository.deleteAll();
         pageRepository.deleteAll();
         accountRepository.deleteAll();
         account = accountRepository.save(FacebookAccount.builder()
@@ -65,6 +89,8 @@ class FacebookPageControllerTest {
 
         FacebookPage saved = pageRepository.findAll().getFirst();
 
+        Experiment experiment = createExperiment("123456");
+
         FacebookPageController.UpsertFacebookPageRequest update = new FacebookPageController.UpsertFacebookPageRequest(
                 "654321",
                 "Página Atualizada"
@@ -82,11 +108,40 @@ class FacebookPageControllerTest {
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].pageId").value("654321"));
 
+        Experiment updatedExperiment = experimentRepository.findById(experiment.getId()).orElseThrow();
+        assertThat(updatedExperiment.getPageId()).isEqualTo("654321");
+
         mockMvc.perform(delete("/api/accounts/facebook/" + account.getId() + "/pages/" + saved.getId()))
                 .andExpect(status().isNoContent());
 
         mockMvc.perform(get("/api/accounts/facebook/" + account.getId() + "/pages"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(0));
+
+        Experiment clearedExperiment = experimentRepository.findById(experiment.getId()).orElseThrow();
+        assertThat(clearedExperiment.getPageId()).isNull();
+    }
+
+    private Experiment createExperiment(String pageId) {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder()
+                .name("Niche " + pageId)
+                .build());
+        Hypothesis hypothesis = hypothesisRepository.save(Hypothesis.builder()
+                .marketNiche(niche)
+                .title("Hypothesis " + pageId)
+                .build());
+        Experiment experiment = Experiment.builder()
+                .niche(niche)
+                .name("Experiment " + pageId)
+                .hypothesis("Hypothesis " + pageId)
+                .hypothesisRef(hypothesis)
+                .status(ExperimentStatus.PLANNED)
+                .platform(ExperimentPlatform.FACEBOOK)
+                .creativeApproved(true)
+                .pageId(pageId)
+                .build();
+        experiment.setCreativesToGenerate(0);
+        experiment.setKpiTargetCpl(BigDecimal.ONE);
+        return experimentRepository.save(experiment);
     }
 }


### PR DESCRIPTION
## Summary
- normalize stored Facebook page IDs and synchronize experiments when a page record is updated or deleted
- add repository helpers to update or clear experiment page references in bulk
- extend the Facebook page controller integration test to cover experiment synchronization

## Testing
- `mvn -s ../settings.xml test` *(fails: Non-resolvable parent POM because the Maven parent could not be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe02749888321abb7812bf0b3473a