### PR TITLE
Make Facebook page DTO public and eager load experiments

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -39,11 +39,3 @@ public class ExperimentDto {
     private java.util.UUID salesFunnelId;
     private String salesFunnelName;
 }
-
-@Data
-class FacebookPageDto {
-    private Long id;
-    private Long accountId;
-    private String pageId;
-    private String name;
-}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/FacebookPageDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/FacebookPageDto.java
@@ -1,0 +1,14 @@
+package com.marketinghub.experiment.dto;
+
+import lombok.Data;
+
+/**
+ * DTO representing a Facebook page linked to an experiment.
+ */
+@Data
+public class FacebookPageDto {
+    private Long id;
+    private Long accountId;
+    private String pageId;
+    private String name;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
@@ -30,7 +30,7 @@ public class UpdateExperimentRequest {
     @JsonIgnore
     private boolean facebookPageIdPresent;
 
-    @JsonSetter(value = "facebookPageId", nulls = Nulls.AS_NULL)
+    @JsonSetter(value = "facebookPageId", nulls = Nulls.SET)
     public void setFacebookPageId(Long facebookPageId) {
         this.facebookPageId = facebookPageId;
         this.facebookPageIdPresent = true;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -4,17 +4,23 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentPlatform;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.niche.MarketNiche;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
  * Repository for experiments.
  */
+
 public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
+    @Override
+    @EntityGraph(attributePaths = "facebookPage")
+    Optional<Experiment> findById(Long id);
     List<Experiment> findByNicheId(Long nicheId);
     boolean existsByNicheAndName(MarketNiche niche, String name);
     List<Experiment> findByStatus(ExperimentStatus status);


### PR DESCRIPTION
## Summary
- expose the Facebook page DTO as a top-level public class and update the experiment mapper to use it
- switch the update request to use `Nulls.SET` so `null` inputs are captured
- load the associated Facebook page when fetching experiments to avoid lazy initialization issues

## Testing
- mvn -s ../settings.xml test *(fails: repository parent POM download blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e01cfe67f483218d893110455429f0