### PR TITLE
Handle associated Facebook page IDs

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -16,7 +16,9 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
 3. **Criativo** (`POST /adcreatives`) baseado em um `object_story_spec`
    contendo o `page_id` definido na conta selecionada no backend. Quando a conta
    não possui `defaultPageId`, o worker utiliza a página vinculada ao
-   experimento no backend e ignora o experimento caso nenhuma associação exista.
+   experimento no backend (exposta como `facebookPage`, `associatedFacebookPage`
+   ou `facebookPageAssociation`) e ignora o experimento caso nenhuma associação
+   exista.
    Opcionalmente o fluxo inclui `instagram_actor_id`, mensagem e
    call-to-action vindos do próprio criativo.
 4. **Anúncio** (`POST /ads`) que referencia o conjunto e o criativo recém

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.facebookadsworker.facebookcampaign;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.marketinghub.facebookadsworker.FacebookAccessTokenExpiredException;
 import com.marketinghub.facebookadsworker.FacebookAccessTokenManager;
 import com.marketinghub.facebookadsworker.FacebookAdsService;
@@ -362,18 +363,18 @@ public class FacebookCampaignService {
         String configPageId = config.defaultPageId();
         Experiment.FacebookPage associatedPage = experiment.associatedPage();
         String experimentPageId = associatedPage != null ? associatedPage.pageId() : null;
-        return coalesce(configPageId, experimentPageId);
+        return coalesce(configPageId, experimentPageId, experiment.pageId());
     }
 
     public record Experiment(
         long id,
         String name,
         String pageId,
-        FacebookPage page,
+        @JsonAlias({ "page", "associatedFacebookPage", "facebookPageAssociation" })
         FacebookPage facebookPage
     ) {
         public FacebookPage associatedPage() {
-            return page != null ? page : facebookPage;
+            return facebookPage;
         }
 
         public record FacebookPage(Long id, String pageId, String name) {}

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -522,6 +522,40 @@ class FacebookCampaignServiceTest {
     }
 
     @Test
+    void resolvesPageIdFromAssociatedFacebookPageAlias() throws Exception {
+        configurationClient.setConfiguration(configurationWithoutDefaultPageId("token"));
+
+        backend.enqueue(
+            new MockResponse()
+                .setBody("[{\"id\":1,\"name\":\"Exp\",\"associatedFacebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"}}]")
+                .addHeader("Content-Type", "application/json")
+        );
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"10\"}").addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"20\"}").addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"30\"}").addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"id\":\"40\"}").addHeader("Content-Type", "application/json"));
+        backend.enqueue(
+            new MockResponse()
+                .setBody(
+                    "[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]"
+                )
+                .addHeader("Content-Type", "application/json")
+        );
+        backend.enqueue(new MockResponse().setBody("{}").addHeader("Content-Type", "application/json"));
+
+        service.createCampaignsFromExperiments();
+
+        facebook.takeRequest();
+        RecordedRequest adSetRequest = facebook.takeRequest();
+        JsonNode adSetPayload = objectMapper.readTree(adSetRequest.getBody().inputStream());
+        assertEquals("84", adSetPayload.get("promoted_object").get("page_id").asText());
+
+        RecordedRequest creativeRequest = facebook.takeRequest();
+        JsonNode creativePayload = objectMapper.readTree(creativeRequest.getBody().inputStream());
+        assertEquals("84", creativePayload.get("object_story_spec").get("page_id").asText());
+    }
+
+    @Test
     void skipsExperimentWhenNoPageCanBeResolved() throws Exception {
         configurationClient.setConfiguration(configurationWithoutDefaultPageId("token"));
 


### PR DESCRIPTION
## Summary
- allow the Facebook campaign worker to resolve the page ID from the associated Facebook page returned by the backend
- support new backend aliases when deserializing the associated Facebook page and fall back to the experiment-level page ID
- document the accepted association keys and cover the new alias behaviour with a unit test

## Testing
- mvn -s settings.xml test *(fails: Network is unreachable when resolving the parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68e02fa4a96c8321b7819f17aff42301