### PR TITLE
Improve Instagram account management

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccount.java
@@ -1,13 +1,19 @@
 package com.marketinghub.ads;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity(name = "ig_account")
 @Data
@@ -20,6 +26,45 @@ public class InstagramAccount {
     private Long id;
 
     private String name;
-    private String currency;
+
+    @Builder.Default
+    private String currency = "BRL";
     private String avatarUrl;
+
+    @Column(name = "instagram_user_id")
+    private String instagramUserId;
+
+    @Column(name = "facebook_page_id")
+    private String facebookPageId;
+
+    @Column(name = "ad_account_id")
+    private String adAccountId;
+
+    @Column(columnDefinition = "LONGTEXT")
+    private String accessToken;
+
+    @Transient
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private boolean accessTokenProvided;
+
+    public void setCurrency(String currency) {
+        this.currency = currency == null || currency.isBlank() ? "BRL" : currency;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    @JsonSetter("accessToken")
+    public void jsonAccessTokenSetter(String accessToken) {
+        this.accessTokenProvided = true;
+        this.accessToken = accessToken;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isAccessTokenProvided() {
+        return accessTokenProvided;
+    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccountController.java
@@ -1,6 +1,9 @@
 package com.marketinghub.ads;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -20,17 +23,49 @@ public class InstagramAccountController {
 
     @PostMapping
     public InstagramAccount create(@RequestBody InstagramAccount account) {
+        validateRequiredFields(account);
+        account.setCurrency("BRL");
         return repository.save(account);
     }
 
     @PutMapping("/{id}")
     public InstagramAccount update(@PathVariable Long id, @RequestBody InstagramAccount account) {
-        account.setId(id);
-        return repository.save(account);
+        InstagramAccount existing = repository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        validateRequiredFields(account);
+
+        existing.setName(account.getName());
+        existing.setAvatarUrl(account.getAvatarUrl());
+        existing.setInstagramUserId(account.getInstagramUserId());
+        existing.setFacebookPageId(account.getFacebookPageId());
+        existing.setAdAccountId(account.getAdAccountId());
+        existing.setCurrency("BRL");
+
+        if (account.isAccessTokenProvided()) {
+            existing.setAccessToken(account.getAccessToken());
+        }
+
+        return repository.save(existing);
     }
 
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         repository.deleteById(id);
+    }
+
+    private void validateRequiredFields(InstagramAccount account) {
+        if (!StringUtils.hasText(account.getName())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Nome é obrigatório");
+        }
+        if (!StringUtils.hasText(account.getInstagramUserId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Instagram user ID é obrigatório");
+        }
+        if (!StringUtils.hasText(account.getAdAccountId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Ad account ID é obrigatório");
+        }
+        if (!StringUtils.hasText(account.getFacebookPageId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook Page ID é obrigatório");
+        }
     }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/V2026_06_01__extend_instagram_account.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2026_06_01__extend_instagram_account.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+--changeset marketinghub:2026-06-01-extend-instagram-account dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ig_account' AND column_name = 'instagram_user_id';
+ALTER TABLE ig_account
+  ADD COLUMN instagram_user_id VARCHAR(64) NULL,
+  ADD COLUMN facebook_page_id VARCHAR(64) NULL,
+  ADD COLUMN ad_account_id VARCHAR(64) NULL,
+  ADD COLUMN access_token LONGTEXT NULL,
+  MODIFY COLUMN currency VARCHAR(8) NOT NULL DEFAULT 'BRL';
+
+UPDATE ig_account
+SET currency = 'BRL'
+WHERE currency IS NULL OR currency <> 'BRL';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -152,3 +152,6 @@ databaseChangeLog:
   - include:
       file: V2026_05_20__link_experiment_to_fb_page.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2026_06_01__extend_instagram_account.sql
+      relativeToChangelogFile: true

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -478,6 +478,26 @@ em `token_renewal_last_error` quando a renovação falha. A conta marcada como
 e fornece os parâmetros padrão utilizados pelo `facebook-ads-worker` (ID da conta
 de anúncios, token, App ID/Secret, página fallback, orçamento diário etc.).
 
+### ig_account
+
+- `id` BIGINT AUTO_INCREMENT PRIMARY KEY
+- `name` VARCHAR(255)
+- `currency` VARCHAR(8) DEFAULT "BRL"
+- `avatar_url` VARCHAR(255)
+- `instagram_user_id` VARCHAR(64)
+- `facebook_page_id` VARCHAR(64)
+- `ad_account_id` VARCHAR(64)
+- `access_token` LONGTEXT
+
+Centraliza as informações mínimas para operar contas do Instagram dentro do
+Marketing Hub. O identificador `instagram_user_id` alimenta campanhas no Meta
+Ads e também habilita a coleta/organização automática de posts. O campo
+`facebook_page_id` vincula a página responsável pelos posts impulsionados, enquanto
+`ad_account_id` permite relacionar a conta de anúncios usada para promover o
+conteúdo. O token armazenado em `access_token` precisa ter escopos para leitura e
+publicação em Instagram/Facebook e é mantido sempre em Real brasileiro
+(`currency = 'BRL'`).
+
 ## Diagram
 
 ```mermaid

--- a/frontend/src/api/instagramAccountMutations.ts
+++ b/frontend/src/api/instagramAccountMutations.ts
@@ -1,11 +1,24 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
-import { InstagramAccount } from "./useInstagramAccounts";
+export interface CreateInstagramAccountPayload {
+  name: string;
+  instagramUserId: string;
+  facebookPageId: string;
+  adAccountId: string;
+  avatarUrl?: string;
+  accessToken?: string;
+}
+
+export interface UpdateInstagramAccountPayload
+  extends CreateInstagramAccountPayload {
+  id: number;
+  accessToken?: string;
+}
 
 export function useCreateInstagramAccount() {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (account: InstagramAccount) =>
+  return useMutation<void, unknown, CreateInstagramAccountPayload>({
+    mutationFn: (account: CreateInstagramAccountPayload) =>
       axios.post("/api/accounts/instagram", account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["instagram-accounts"] }),
@@ -14,8 +27,8 @@ export function useCreateInstagramAccount() {
 
 export function useUpdateInstagramAccount() {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (account: InstagramAccount) =>
+  return useMutation<void, unknown, UpdateInstagramAccountPayload>({
+    mutationFn: (account: UpdateInstagramAccountPayload) =>
       axios.put(`/api/accounts/instagram/${account.id}`, account),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["instagram-accounts"] }),
@@ -24,8 +37,8 @@ export function useUpdateInstagramAccount() {
 
 export function useDeleteInstagramAccount() {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (id: string) =>
+  return useMutation<void, unknown, number>({
+    mutationFn: (id: number) =>
       axios.delete(`/api/accounts/instagram/${id}`),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ["instagram-accounts"] }),

--- a/frontend/src/api/useInstagramAccounts.ts
+++ b/frontend/src/api/useInstagramAccounts.ts
@@ -2,9 +2,14 @@ import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 
 export interface InstagramAccount {
-  id: string;
+  id: number;
   name: string;
+  avatarUrl?: string | null;
   currency: string;
+  instagramUserId: string;
+  facebookPageId: string;
+  adAccountId: string;
+  accessToken?: string | null;
 }
 
 export function useInstagramAccounts() {

--- a/frontend/src/pages/InstagramAccountsPage.tsx
+++ b/frontend/src/pages/InstagramAccountsPage.tsx
@@ -1,113 +1,354 @@
-import { useState } from "react";
+import { FormEvent, useMemo, useState } from "react";
 import { useInstagramAccounts } from "../api/useInstagramAccounts";
 import {
   useCreateInstagramAccount,
   useUpdateInstagramAccount,
   useDeleteInstagramAccount,
+  CreateInstagramAccountPayload,
 } from "../api/instagramAccountMutations";
 import PageTitle from "../components/PageTitle";
 
+interface FormState {
+  name: string;
+  instagramUserId: string;
+  facebookPageId: string;
+  adAccountId: string;
+  accessToken: string;
+  avatarUrl: string;
+}
+
+const emptyForm: FormState = {
+  name: "",
+  instagramUserId: "",
+  facebookPageId: "",
+  adAccountId: "",
+  accessToken: "",
+  avatarUrl: "",
+};
+
 export default function InstagramAccountsPage() {
   const { data, isLoading, error } = useInstagramAccounts();
-  const accounts = Array.isArray(data) ? data : [];
+  const accounts = useMemo(
+    () => (Array.isArray(data) ? data : []),
+    [data],
+  );
   const createMutation = useCreateInstagramAccount();
   const updateMutation = useUpdateInstagramAccount();
   const deleteMutation = useDeleteInstagramAccount();
 
-  const [form, setForm] = useState({ id: "", name: "", currency: "" });
-  const [editing, setEditing] = useState<boolean | string>(false);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [editingId, setEditingId] = useState<number | null>(null);
 
-  if (isLoading) return <p>Carregando...</p>;
-  if (error) return <p>Erro ao carregar contas</p>;
+  const isSaving = createMutation.isPending || updateMutation.isPending;
+  const deletingId = deleteMutation.isPending ? deleteMutation.variables ?? null : null;
 
-  const submit = () => {
-    if (editing) {
-      updateMutation.mutate(form);
-    } else {
-      createMutation.mutate(form);
+  if (isLoading) {
+    return <p>Carregando...</p>;
+  }
+
+  const loadError = error ? (
+    <div className="alert alert-danger" role="alert">
+      Não foi possível carregar as contas do Instagram.
+    </div>
+  ) : null;
+
+  const resetForm = () => {
+    setForm(emptyForm);
+    setEditingId(null);
+  };
+
+  const buildPayload = (): CreateInstagramAccountPayload => {
+    const payload: CreateInstagramAccountPayload = {
+      name: form.name.trim(),
+      instagramUserId: form.instagramUserId.trim(),
+      facebookPageId: form.facebookPageId.trim(),
+      adAccountId: form.adAccountId.trim(),
+    };
+
+    if (form.avatarUrl.trim()) {
+      payload.avatarUrl = form.avatarUrl.trim();
     }
-    setForm({ id: "", name: "", currency: "" });
-    setEditing(false);
+
+    if (form.accessToken.trim()) {
+      payload.accessToken = form.accessToken.trim();
+    }
+
+    return payload;
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const payload = buildPayload();
+
+    if (editingId) {
+      updateMutation.mutate(
+        { id: editingId, ...payload },
+        { onSuccess: resetForm },
+      );
+    } else {
+      createMutation.mutate(payload, { onSuccess: resetForm });
+    }
+  };
+
+  const handleEdit = (accountId: number) => {
+    const account = accounts.find((item) => item.id === accountId);
+    if (!account) {
+      return;
+    }
+
+    setEditingId(account.id);
+    setForm({
+      name: account.name ?? "",
+      instagramUserId: account.instagramUserId ?? "",
+      facebookPageId: account.facebookPageId ?? "",
+      adAccountId: account.adAccountId ?? "",
+      avatarUrl: account.avatarUrl ?? "",
+      accessToken: "",
+    });
   };
 
   return (
     <div>
       <PageTitle>Contas do Instagram</PageTitle>
+      {loadError}
+
       <div className="table-responsive">
-        <table className="table table-striped">
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Nome</th>
-            <th>Moeda</th>
-            <th>Ações</th>
-          </tr>
-        </thead>
-        <tbody>
-          {accounts.map(({ id, name, currency }) => (
-            <tr key={id}>
-              <td>{id}</td>
-              <td>{name}</td>
-              <td>{currency}</td>
-              <td>
-                <a
-                  className="btn btn-sm btn-outline-secondary me-2"
-                  href={`/accounts/instagram/${id}/posts`}
-                >
-                  Posts
-                </a>
-                <button
-                  className="btn btn-sm btn-outline-primary me-2"
-                  onClick={() => {
-                    setForm({ id, name, currency });
-                    setEditing(id);
-                  }}
-                >
-                  Editar
-                </button>
-                <button
-                  className="btn btn-sm btn-outline-danger"
-                  onClick={() => deleteMutation.mutate(id)}
-                >
-                  Excluir
-                </button>
-              </td>
+        <table className="table table-striped align-middle">
+          <thead>
+            <tr>
+              <th scope="col">ID</th>
+              <th scope="col">Nome</th>
+              <th scope="col">Instagram Business ID</th>
+              <th scope="col">Página do Facebook</th>
+              <th scope="col">Conta de Anúncios</th>
+              <th scope="col">Token</th>
+              <th scope="col" className="text-end">
+                Ações
+              </th>
             </tr>
-          ))}
-        </tbody>
+          </thead>
+          <tbody>
+            {accounts.map((account) => (
+              <tr key={account.id}>
+                <td>{account.id}</td>
+                <td>
+                  <div className="d-flex align-items-center gap-2">
+                    {account.avatarUrl && (
+                      <img
+                        src={account.avatarUrl}
+                        alt={account.name}
+                        className="rounded-circle"
+                        width={32}
+                        height={32}
+                      />
+                    )}
+                    <span>{account.name}</span>
+                  </div>
+                </td>
+                <td>{account.instagramUserId}</td>
+                <td>{account.facebookPageId}</td>
+                <td>{account.adAccountId}</td>
+                <td>
+                  {account.accessToken ? (
+                    <span className="badge bg-success">Configurado</span>
+                  ) : (
+                    <span className="badge bg-warning text-dark">Pendente</span>
+                  )}
+                </td>
+                <td className="text-end">
+                  <div className="btn-group" role="group" aria-label="Ações">
+                    <a
+                      className="btn btn-sm btn-outline-secondary"
+                      href={`/accounts/instagram/${account.id}/posts`}
+                    >
+                      Posts
+                    </a>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-primary"
+                      onClick={() => handleEdit(account.id)}
+                    >
+                      Editar
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-danger"
+                      disabled={deleteMutation.isPending && deletingId === account.id}
+                      onClick={() => deleteMutation.mutate(account.id)}
+                    >
+                      {deleteMutation.isPending && deletingId === account.id ? (
+                        <>
+                          <span
+                            className="spinner-border spinner-border-sm me-1"
+                            role="status"
+                            aria-hidden="true"
+                          ></span>
+                          Excluindo...
+                        </>
+                      ) : (
+                        "Excluir"
+                      )}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
         </table>
       </div>
-      <div className="row g-2">
-        <div className="col-md-2">
-          <input
-            className="form-control"
-            placeholder="id"
-            value={form.id}
-            onChange={(e) => setForm({ ...form, id: e.target.value })}
-          />
+
+      <form className="card mt-4" onSubmit={handleSubmit}>
+        <div className="card-body">
+          <h2 className="h5 mb-3">
+            {editingId ? "Editar conta do Instagram" : "Cadastrar nova conta"}
+          </h2>
+          <div className="row g-3">
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="instagramName">
+                Nome <span className="text-danger">*</span>
+              </label>
+              <input
+                id="instagramName"
+                className="form-control"
+                placeholder="Nome público do perfil"
+                value={form.name}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, name: event.target.value }))
+                }
+                required
+              />
+            </div>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="instagramUserId">
+                Instagram Business ID <span className="text-danger">*</span>
+              </label>
+              <input
+                id="instagramUserId"
+                className="form-control"
+                placeholder="ex.: 17841400000000000"
+                value={form.instagramUserId}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    instagramUserId: event.target.value,
+                  }))
+                }
+                required
+              />
+            </div>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="facebookPageId">
+                Página do Facebook <span className="text-danger">*</span>
+              </label>
+              <input
+                id="facebookPageId"
+                className="form-control"
+                placeholder="ID numérico da página conectada"
+                value={form.facebookPageId}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    facebookPageId: event.target.value,
+                  }))
+                }
+                required
+              />
+            </div>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="adAccountId">
+                Conta de anúncios <span className="text-danger">*</span>
+              </label>
+              <input
+                id="adAccountId"
+                className="form-control"
+                placeholder="ex.: act_0000000000"
+                value={form.adAccountId}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    adAccountId: event.target.value,
+                  }))
+                }
+                required
+              />
+            </div>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="accessToken">
+                Token de acesso <span className="text-danger">*</span>
+              </label>
+              <input
+                id="accessToken"
+                className="form-control"
+                placeholder="Use um token com permissões de leitura e publicação"
+                value={form.accessToken}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    accessToken: event.target.value,
+                  }))
+                }
+                required={!editingId}
+              />
+              {editingId ? (
+                <small className="form-text text-muted">
+                  Deixe em branco para manter o token atual.
+                </small>
+              ) : (
+                <small className="form-text text-muted">
+                  O token será armazenado com a moeda padrão em BRL.
+                </small>
+              )}
+            </div>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="avatarUrl">
+                Avatar (opcional)
+              </label>
+              <input
+                id="avatarUrl"
+                className="form-control"
+                placeholder="URL da foto do perfil"
+                value={form.avatarUrl}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    avatarUrl: event.target.value,
+                  }))
+                }
+              />
+            </div>
+          </div>
         </div>
-        <div className="col-md-4">
-          <input
-            className="form-control"
-            placeholder="nome"
-            value={form.name}
-            onChange={(e) => setForm({ ...form, name: e.target.value })}
-          />
-        </div>
-        <div className="col-md-2">
-          <input
-            className="form-control"
-            placeholder="moeda"
-            value={form.currency}
-            onChange={(e) => setForm({ ...form, currency: e.target.value })}
-          />
-        </div>
-        <div className="col-md-2">
-          <button className="btn btn-primary w-100" onClick={submit}>
-            {editing ? "Atualizar" : "Criar"}
+        <div className="card-footer d-flex justify-content-between">
+          {editingId ? (
+            <button
+              type="button"
+              className="btn btn-outline-secondary"
+              onClick={resetForm}
+              disabled={isSaving}
+            >
+              Cancelar edição
+            </button>
+          ) : (
+            <span className="text-muted">
+              Todas as contas usam Real brasileiro (BRL) como moeda padrão.
+            </span>
+          )}
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={isSaving}
+          >
+            {isSaving && (
+              <span
+                className="spinner-border spinner-border-sm me-2"
+                role="status"
+                aria-hidden="true"
+              ></span>
+            )}
+            {editingId ? "Salvar alterações" : "Cadastrar conta"}
           </button>
         </div>
-      </div>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add instagram business identifiers, page binding, ad account and token handling to Instagram accounts while enforcing BRL as currency
- document and migrate the ig_account table to persist the new attributes
- redesign the Instagram accounts page with required field indicators, loading states and better actions for creating, editing and deleting accounts

## Testing
- npm run build
- mvn -s ../settings.xml test *(fails: unable to download spring-boot-starter-parent from github.com due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ad8d62608321a52247aa0d5b503d