### PR TITLE
Simplify Instagram account model to basic fields

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccount.java
@@ -1,19 +1,14 @@
 package com.marketinghub.ads;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonSetter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Transient;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity(name = "ig_account")
 @Data
@@ -27,44 +22,9 @@ public class InstagramAccount {
 
     private String name;
 
-    @Builder.Default
-    private String currency = "BRL";
-    private String avatarUrl;
+    @Column(name = "handle", nullable = false)
+    private String handle;
 
-    @Column(name = "instagram_user_id")
-    private String instagramUserId;
-
-    @Column(name = "facebook_page_id")
-    private String facebookPageId;
-
-    @Column(name = "ad_account_id")
-    private String adAccountId;
-
-    @Column(columnDefinition = "LONGTEXT")
-    private String accessToken;
-
-    @Transient
-    @JsonIgnore
-    @Setter(AccessLevel.NONE)
-    private boolean accessTokenProvided;
-
-    public void setCurrency(String currency) {
-        this.currency = currency == null || currency.isBlank() ? "BRL" : currency;
-    }
-
-    public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
-    }
-
-    @JsonSetter("accessToken")
-    public void jsonAccessTokenSetter(String accessToken) {
-        this.accessTokenProvided = true;
-        this.accessToken = accessToken;
-    }
-
-    @Transient
-    @JsonIgnore
-    public boolean isAccessTokenProvided() {
-        return accessTokenProvided;
-    }
+    @Column(name = "account_code", nullable = false)
+    private String code;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/InstagramAccountController.java
@@ -24,7 +24,6 @@ public class InstagramAccountController {
     @PostMapping
     public InstagramAccount create(@RequestBody InstagramAccount account) {
         validateRequiredFields(account);
-        account.setCurrency("BRL");
         return repository.save(account);
     }
 
@@ -36,15 +35,8 @@ public class InstagramAccountController {
         validateRequiredFields(account);
 
         existing.setName(account.getName());
-        existing.setAvatarUrl(account.getAvatarUrl());
-        existing.setInstagramUserId(account.getInstagramUserId());
-        existing.setFacebookPageId(account.getFacebookPageId());
-        existing.setAdAccountId(account.getAdAccountId());
-        existing.setCurrency("BRL");
-
-        if (account.isAccessTokenProvided()) {
-            existing.setAccessToken(account.getAccessToken());
-        }
+        existing.setHandle(account.getHandle());
+        existing.setCode(account.getCode());
 
         return repository.save(existing);
     }
@@ -58,14 +50,11 @@ public class InstagramAccountController {
         if (!StringUtils.hasText(account.getName())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Nome é obrigatório");
         }
-        if (!StringUtils.hasText(account.getInstagramUserId())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Instagram user ID é obrigatório");
+        if (!StringUtils.hasText(account.getHandle())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Usuário (@) é obrigatório");
         }
-        if (!StringUtils.hasText(account.getAdAccountId())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Ad account ID é obrigatório");
-        }
-        if (!StringUtils.hasText(account.getFacebookPageId())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Facebook Page ID é obrigatório");
+        if (!StringUtils.hasText(account.getCode())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Código é obrigatório");
         }
     }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/V2026_07_05__simplify_instagram_account.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2026_07_05__simplify_instagram_account.sql
@@ -1,0 +1,31 @@
+--liquibase formatted sql
+--changeset marketinghub:2026-07-05-simplify-instagram-account dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'ig_account' AND column_name = 'handle';
+ALTER TABLE ig_account
+  ADD COLUMN handle VARCHAR(255) NULL,
+  ADD COLUMN account_code VARCHAR(255) NULL;
+
+UPDATE ig_account
+SET handle = CASE
+    WHEN name IS NULL OR TRIM(name) = '' THEN CONCAT('@conta', id)
+    WHEN LOCATE('@', name) = 1 THEN name
+    ELSE CONCAT('@', REPLACE(LOWER(name), ' ', ''))
+  END
+WHERE handle IS NULL OR TRIM(handle) = '';
+
+UPDATE ig_account
+SET account_code = COALESCE(account_code, instagram_user_id, CONCAT('IG-', id))
+WHERE account_code IS NULL OR TRIM(account_code) = '';
+
+ALTER TABLE ig_account
+  MODIFY COLUMN handle VARCHAR(255) NOT NULL,
+  MODIFY COLUMN account_code VARCHAR(255) NOT NULL;
+
+ALTER TABLE ig_account
+  DROP COLUMN currency,
+  DROP COLUMN avatar_url,
+  DROP COLUMN instagram_user_id,
+  DROP COLUMN facebook_page_id,
+  DROP COLUMN ad_account_id,
+  DROP COLUMN access_token;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -155,3 +155,6 @@ databaseChangeLog:
   - include:
       file: V2026_06_01__extend_instagram_account.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2026_07_05__simplify_instagram_account.sql
+      relativeToChangelogFile: true

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -482,21 +482,14 @@ de anúncios, token, App ID/Secret, página fallback, orçamento diário etc.).
 
 - `id` BIGINT AUTO_INCREMENT PRIMARY KEY
 - `name` VARCHAR(255)
-- `currency` VARCHAR(8) DEFAULT "BRL"
-- `avatar_url` VARCHAR(255)
-- `instagram_user_id` VARCHAR(64)
-- `facebook_page_id` VARCHAR(64)
-- `ad_account_id` VARCHAR(64)
-- `access_token` LONGTEXT
+- `handle` VARCHAR(255)
+- `account_code` VARCHAR(255)
 
-Centraliza as informações mínimas para operar contas do Instagram dentro do
-Marketing Hub. O identificador `instagram_user_id` alimenta campanhas no Meta
-Ads e também habilita a coleta/organização automática de posts. O campo
-`facebook_page_id` vincula a página responsável pelos posts impulsionados, enquanto
-`ad_account_id` permite relacionar a conta de anúncios usada para promover o
-conteúdo. O token armazenado em `access_token` precisa ter escopos para leitura e
-publicação em Instagram/Facebook e é mantido sempre em Real brasileiro
-(`currency = 'BRL'`).
+Centraliza as informações essenciais da conta de Instagram que são exibidas na
+interface administrativa. O campo `handle` armazena o nome de usuário exibido
+com o símbolo `@`, enquanto `account_code` guarda o identificador interno usado
+pelas equipes de atendimento ou suporte. Informações adicionais de campanhas
+devem ser fornecidas diretamente nos objetos responsáveis por cada fluxo.
 
 ## Diagram
 

--- a/frontend/src/api/instagramAccountMutations.ts
+++ b/frontend/src/api/instagramAccountMutations.ts
@@ -2,17 +2,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 export interface CreateInstagramAccountPayload {
   name: string;
-  instagramUserId: string;
-  facebookPageId: string;
-  adAccountId: string;
-  avatarUrl?: string;
-  accessToken?: string;
+  handle: string;
+  code: string;
 }
 
 export interface UpdateInstagramAccountPayload
   extends CreateInstagramAccountPayload {
   id: number;
-  accessToken?: string;
 }
 
 export function useCreateInstagramAccount() {

--- a/frontend/src/api/useInstagramAccounts.ts
+++ b/frontend/src/api/useInstagramAccounts.ts
@@ -4,12 +4,8 @@ import axios from "axios";
 export interface InstagramAccount {
   id: number;
   name: string;
-  avatarUrl?: string | null;
-  currency: string;
-  instagramUserId: string;
-  facebookPageId: string;
-  adAccountId: string;
-  accessToken?: string | null;
+  handle: string;
+  code: string;
 }
 
 export function useInstagramAccounts() {

--- a/frontend/src/pages/InstagramAccountsPage.tsx
+++ b/frontend/src/pages/InstagramAccountsPage.tsx
@@ -10,20 +10,14 @@ import PageTitle from "../components/PageTitle";
 
 interface FormState {
   name: string;
-  instagramUserId: string;
-  facebookPageId: string;
-  adAccountId: string;
-  accessToken: string;
-  avatarUrl: string;
+  handle: string;
+  code: string;
 }
 
 const emptyForm: FormState = {
   name: "",
-  instagramUserId: "",
-  facebookPageId: "",
-  adAccountId: "",
-  accessToken: "",
-  avatarUrl: "",
+  handle: "",
+  code: "",
 };
 
 export default function InstagramAccountsPage() {
@@ -60,18 +54,9 @@ export default function InstagramAccountsPage() {
   const buildPayload = (): CreateInstagramAccountPayload => {
     const payload: CreateInstagramAccountPayload = {
       name: form.name.trim(),
-      instagramUserId: form.instagramUserId.trim(),
-      facebookPageId: form.facebookPageId.trim(),
-      adAccountId: form.adAccountId.trim(),
+      handle: form.handle.trim(),
+      code: form.code.trim(),
     };
-
-    if (form.avatarUrl.trim()) {
-      payload.avatarUrl = form.avatarUrl.trim();
-    }
-
-    if (form.accessToken.trim()) {
-      payload.accessToken = form.accessToken.trim();
-    }
 
     return payload;
   };
@@ -99,11 +84,8 @@ export default function InstagramAccountsPage() {
     setEditingId(account.id);
     setForm({
       name: account.name ?? "",
-      instagramUserId: account.instagramUserId ?? "",
-      facebookPageId: account.facebookPageId ?? "",
-      adAccountId: account.adAccountId ?? "",
-      avatarUrl: account.avatarUrl ?? "",
-      accessToken: "",
+      handle: account.handle ?? "",
+      code: account.code ?? "",
     });
   };
 
@@ -118,10 +100,8 @@ export default function InstagramAccountsPage() {
             <tr>
               <th scope="col">ID</th>
               <th scope="col">Nome</th>
-              <th scope="col">Instagram Business ID</th>
-              <th scope="col">Página do Facebook</th>
-              <th scope="col">Conta de Anúncios</th>
-              <th scope="col">Token</th>
+              <th scope="col">Usuário (@)</th>
+              <th scope="col">Código</th>
               <th scope="col" className="text-end">
                 Ações
               </th>
@@ -131,30 +111,9 @@ export default function InstagramAccountsPage() {
             {accounts.map((account) => (
               <tr key={account.id}>
                 <td>{account.id}</td>
-                <td>
-                  <div className="d-flex align-items-center gap-2">
-                    {account.avatarUrl && (
-                      <img
-                        src={account.avatarUrl}
-                        alt={account.name}
-                        className="rounded-circle"
-                        width={32}
-                        height={32}
-                      />
-                    )}
-                    <span>{account.name}</span>
-                  </div>
-                </td>
-                <td>{account.instagramUserId}</td>
-                <td>{account.facebookPageId}</td>
-                <td>{account.adAccountId}</td>
-                <td>
-                  {account.accessToken ? (
-                    <span className="badge bg-success">Configurado</span>
-                  ) : (
-                    <span className="badge bg-warning text-dark">Pendente</span>
-                  )}
-                </td>
+                <td>{account.name}</td>
+                <td>{account.handle}</td>
+                <td>{account.code}</td>
                 <td className="text-end">
                   <div className="btn-group" role="group" aria-label="Ações">
                     <a
@@ -219,101 +178,39 @@ export default function InstagramAccountsPage() {
               />
             </div>
             <div className="col-md-6">
-              <label className="form-label" htmlFor="instagramUserId">
-                Instagram Business ID <span className="text-danger">*</span>
+              <label className="form-label" htmlFor="instagramHandle">
+                Usuário (@) <span className="text-danger">*</span>
               </label>
               <input
-                id="instagramUserId"
+                id="instagramHandle"
                 className="form-control"
-                placeholder="ex.: 17841400000000000"
-                value={form.instagramUserId}
+                placeholder="ex.: @minhaempresa"
+                value={form.handle}
                 onChange={(event) =>
                   setForm((current) => ({
                     ...current,
-                    instagramUserId: event.target.value,
+                    handle: event.target.value,
                   }))
                 }
                 required
               />
             </div>
             <div className="col-md-6">
-              <label className="form-label" htmlFor="facebookPageId">
-                Página do Facebook <span className="text-danger">*</span>
+              <label className="form-label" htmlFor="instagramCode">
+                Código <span className="text-danger">*</span>
               </label>
               <input
-                id="facebookPageId"
+                id="instagramCode"
                 className="form-control"
-                placeholder="ID numérico da página conectada"
-                value={form.facebookPageId}
+                placeholder="Código interno ou identificador"
+                value={form.code}
                 onChange={(event) =>
                   setForm((current) => ({
                     ...current,
-                    facebookPageId: event.target.value,
+                    code: event.target.value,
                   }))
                 }
                 required
-              />
-            </div>
-            <div className="col-md-6">
-              <label className="form-label" htmlFor="adAccountId">
-                Conta de anúncios <span className="text-danger">*</span>
-              </label>
-              <input
-                id="adAccountId"
-                className="form-control"
-                placeholder="ex.: act_0000000000"
-                value={form.adAccountId}
-                onChange={(event) =>
-                  setForm((current) => ({
-                    ...current,
-                    adAccountId: event.target.value,
-                  }))
-                }
-                required
-              />
-            </div>
-            <div className="col-md-6">
-              <label className="form-label" htmlFor="accessToken">
-                Token de acesso <span className="text-danger">*</span>
-              </label>
-              <input
-                id="accessToken"
-                className="form-control"
-                placeholder="Use um token com permissões de leitura e publicação"
-                value={form.accessToken}
-                onChange={(event) =>
-                  setForm((current) => ({
-                    ...current,
-                    accessToken: event.target.value,
-                  }))
-                }
-                required={!editingId}
-              />
-              {editingId ? (
-                <small className="form-text text-muted">
-                  Deixe em branco para manter o token atual.
-                </small>
-              ) : (
-                <small className="form-text text-muted">
-                  O token será armazenado com a moeda padrão em BRL.
-                </small>
-              )}
-            </div>
-            <div className="col-md-6">
-              <label className="form-label" htmlFor="avatarUrl">
-                Avatar (opcional)
-              </label>
-              <input
-                id="avatarUrl"
-                className="form-control"
-                placeholder="URL da foto do perfil"
-                value={form.avatarUrl}
-                onChange={(event) =>
-                  setForm((current) => ({
-                    ...current,
-                    avatarUrl: event.target.value,
-                  }))
-                }
               />
             </div>
           </div>
@@ -329,9 +226,7 @@ export default function InstagramAccountsPage() {
               Cancelar edição
             </button>
           ) : (
-            <span className="text-muted">
-              Todas as contas usam Real brasileiro (BRL) como moeda padrão.
-            </span>
+            <span className="text-muted">Preencha os dados obrigatórios para salvar.</span>
           )}
           <button
             type="submit"


### PR DESCRIPTION
## Summary
- streamline the InstagramAccount entity to expose only name, handle and code while tightening controller validation
- add a Liquibase changelog that introduces the new columns, migrates legacy data and drops unused Instagram account columns
- align frontend APIs, Instagram accounts screen and documentation with the simplified model

## Testing
- mvn -s ../settings.xml test *(fails: unable to resolve parent POM due to network restrictions)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e27ebf18e08321ba93765ef0a40f8f