### PR TITLE
Fix Instagram account test setup

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/ads/CampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/CampaignControllerTest.java
@@ -43,6 +43,8 @@ public class CampaignControllerTest {
 
         InstagramAccount ig = igRepo.save(InstagramAccount.builder()
                 .name("IG Account")
+                .handle("@ig.account")
+                .code("IG-001")
                 .build());
 
         mockMvc.perform(post("/api/accounts/" + fb.getId() + "/campaigns?platform=facebook")


### PR DESCRIPTION
## Summary
- provide required handle and code when creating the Instagram account in CampaignControllerTest

## Testing
- mvn -s ../settings.xml test *(fails: network is unreachable when resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68e285a1c56883218bfb0305ed3c3afe