### PR TITLE
Exigir conta do Instagram nos experimentos

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -7,6 +7,7 @@ import com.marketinghub.niche.MarketNiche;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import com.marketinghub.funnel.SalesFunnel;
+import com.marketinghub.ads.InstagramAccount;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -38,6 +39,10 @@ public class Experiment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "facebook_page_id")
     private FacebookPage facebookPage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instagram_account_id")
+    private InstagramAccount instagramAccount;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "hypothesis_id", nullable = false)

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
@@ -30,4 +30,5 @@ public class CreateExperimentRequest {
     private Integer creativesToGenerate;
     private String salesFunnelName;
     private Long facebookPageId;
+    private Long instagramAccountId;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -19,6 +19,7 @@ public class ExperimentDto {
     private String name;
     private String hypothesis;
     private FacebookPageDto facebookPage;
+    private InstagramAccountDto instagramAccount;
     @JsonProperty("kpiTarget")
     private BigDecimal kpiTargetCpl;
     private BigDecimal stopLossCpl;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/InstagramAccountDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/InstagramAccountDto.java
@@ -1,0 +1,14 @@
+package com.marketinghub.experiment.dto;
+
+import lombok.Data;
+
+/**
+ * DTO for InstagramAccount associated to experiments.
+ */
+@Data
+public class InstagramAccountDto {
+    private Long id;
+    private String name;
+    private String handle;
+    private String code;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
@@ -29,11 +29,20 @@ public class UpdateExperimentRequest {
     private Long facebookPageId;
     @JsonIgnore
     private boolean facebookPageIdPresent;
+    private Long instagramAccountId;
+    @JsonIgnore
+    private boolean instagramAccountIdPresent;
 
     @JsonSetter(value = "facebookPageId", nulls = Nulls.SET)
     public void setFacebookPageId(Long facebookPageId) {
         this.facebookPageId = facebookPageId;
         this.facebookPageIdPresent = true;
+    }
+
+    @JsonSetter(value = "instagramAccountId", nulls = Nulls.SET)
+    public void setInstagramAccountId(Long instagramAccountId) {
+        this.instagramAccountId = instagramAccountId;
+        this.instagramAccountIdPresent = true;
     }
 }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/mapper/ExperimentMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/mapper/ExperimentMapper.java
@@ -3,7 +3,9 @@ package com.marketinghub.experiment.mapper;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.dto.ExperimentDto;
 import com.marketinghub.ads.FacebookPage;
+import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.experiment.dto.FacebookPageDto;
+import com.marketinghub.experiment.dto.InstagramAccountDto;
 import org.mapstruct.Mapper;
 
 /**
@@ -20,4 +22,6 @@ public interface ExperimentMapper {
 
     @org.mapstruct.Mapping(target = "accountId", source = "account.id")
     FacebookPageDto toDto(FacebookPage page);
+
+    InstagramAccountDto toDto(InstagramAccount account);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 
 public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
     @Override
-    @EntityGraph(attributePaths = "facebookPage")
+    @EntityGraph(attributePaths = {"facebookPage", "instagramAccount"})
     Optional<Experiment> findById(Long id);
     List<Experiment> findByNicheId(Long nicheId);
     boolean existsByNicheAndName(MarketNiche niche, String name);
@@ -29,9 +29,11 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
             select e from Experiment e
             join fetch e.niche n
             join fetch e.hypothesisRef h
+            join fetch e.instagramAccount ig
             where e.status = :status
               and e.platform = :platform
               and e.creativeApproved = true
+              and ig is not null
               and exists (
                     select 1 from Audience a
                     where a.niche = e.niche

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -2,6 +2,8 @@ package com.marketinghub.experiment.service;
 
 import com.marketinghub.ads.FacebookPage;
 import com.marketinghub.ads.FacebookPageRepository;
+import com.marketinghub.ads.InstagramAccount;
+import com.marketinghub.ads.InstagramAccountRepository;
 import com.marketinghub.experiment.*;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.dto.UpdateExperimentRequest;
@@ -29,13 +31,15 @@ public class ExperimentService {
     private final EntityManager entityManager;
     private final SalesFunnelRepository salesFunnelRepository;
     private final FacebookPageRepository facebookPageRepository;
+    private final InstagramAccountRepository instagramAccountRepository;
 
     public ExperimentService(ExperimentRepository repository, MarketNicheRepository nicheRepository,
                              com.marketinghub.hypothesis.repository.HypothesisRepository hypothesisRepository,
                              MetricPresetService metricPresetService,
                              EntityManager entityManager,
                              SalesFunnelRepository salesFunnelRepository,
-                             FacebookPageRepository facebookPageRepository) {
+                             FacebookPageRepository facebookPageRepository,
+                             InstagramAccountRepository instagramAccountRepository) {
         this.repository = repository;
         this.nicheRepository = nicheRepository;
         this.hypothesisRepository = hypothesisRepository;
@@ -43,6 +47,7 @@ public class ExperimentService {
         this.entityManager = entityManager;
         this.salesFunnelRepository = salesFunnelRepository;
         this.facebookPageRepository = facebookPageRepository;
+        this.instagramAccountRepository = instagramAccountRepository;
     }
 
     /**
@@ -74,6 +79,16 @@ public class ExperimentService {
             throw new EntityNotFoundException("FacebookPage not found: " + facebookPageId);
         }
         return entityManager.getReference(FacebookPage.class, facebookPageId);
+    }
+
+    private InstagramAccount attachInstagramAccount(Long instagramAccountId) {
+        if (instagramAccountId == null) {
+            return null;
+        }
+        if (!instagramAccountRepository.existsById(instagramAccountId)) {
+            throw new EntityNotFoundException("InstagramAccount not found: " + instagramAccountId);
+        }
+        return entityManager.getReference(InstagramAccount.class, instagramAccountId);
     }
 
     private SalesFunnel resolveSalesFunnel(String name) {
@@ -109,6 +124,9 @@ public class ExperimentService {
         if (request.getMetricPresetId() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "metricPresetId required");
         }
+        if (request.getInstagramAccountId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "instagramAccountId required");
+        }
         MetricPreset preset = metricPresetService.get(request.getMetricPresetId());
         java.math.BigDecimal computedStopLoss = request.getKpiTargetCpl().multiply(preset.getStopLossFactor());
         if (request.getSampleSize() != null && request.getSampleSize() < 100) {
@@ -140,6 +158,7 @@ public class ExperimentService {
                 .platform(ExperimentPlatform.FACEBOOK)
                 .creativesToGenerate(request.getCreativesToGenerate())
                 .facebookPage(attachFacebookPage(request.getFacebookPageId()))
+                .instagramAccount(attachInstagramAccount(request.getInstagramAccountId()))
                 .salesFunnel(salesFunnel)
                 .build();
         return repository.save(exp);
@@ -195,6 +214,7 @@ public class ExperimentService {
                 .platform(original.getPlatform())
                 .creativesToGenerate(original.getCreativesToGenerate())
                 .facebookPage(original.getFacebookPage())
+                .instagramAccount(original.getInstagramAccount())
                 .salesFunnel(original.getSalesFunnel())
                 .build();
         return repository.save(copy);
@@ -277,6 +297,9 @@ public class ExperimentService {
         }
         if (request.isFacebookPageIdPresent()) {
             exp.setFacebookPage(attachFacebookPage(request.getFacebookPageId()));
+        }
+        if (request.isInstagramAccountIdPresent()) {
+            exp.setInstagramAccount(attachInstagramAccount(request.getInstagramAccountId()));
         }
         return exp;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/web/FacebookAdsCampaignController.java
@@ -235,7 +235,8 @@ public class FacebookAdsCampaignController {
                 experiment.getNiche() != null ? experiment.getNiche().getName() : null,
                 experiment.getHypothesisRef() != null ? experiment.getHypothesisRef().getTitle() : null,
                 computeMissingConfiguration(experiment),
-                toFacebookPageSummary(experiment));
+                toFacebookPageSummary(experiment),
+                toInstagramAccountSummary(experiment));
     }
 
     private List<String> computeMissingConfiguration(Experiment experiment) {
@@ -264,6 +265,9 @@ public class FacebookAdsCampaignController {
         if (!StringUtils.hasText(resolveExperimentPageId(experiment))) {
             missing.add("pageId");
         }
+        if (experiment.getInstagramAccount() == null) {
+            missing.add("instagramAccount");
+        }
         return missing;
     }
 
@@ -283,6 +287,14 @@ public class FacebookAdsCampaignController {
         return new FacebookPageSummary(page.getId(), accountId, page.getPageId(), page.getName());
     }
 
+    private InstagramAccountSummary toInstagramAccountSummary(Experiment experiment) {
+        if (experiment.getInstagramAccount() == null) {
+            return null;
+        }
+        var account = experiment.getInstagramAccount();
+        return new InstagramAccountSummary(account.getId(), account.getHandle(), account.getCode(), account.getName());
+    }
+
     public record ExperimentSummary(
             Long id,
             String name,
@@ -294,9 +306,12 @@ public class FacebookAdsCampaignController {
             String nicheName,
             String hypothesisTitle,
             List<String> missingConfiguration,
-            FacebookPageSummary facebookPage) {}
+            FacebookPageSummary facebookPage,
+            InstagramAccountSummary instagramAccount) {}
 
     public record FacebookPageSummary(Long id, Long accountId, String pageId, String name) {}
+
+    public record InstagramAccountSummary(Long id, String handle, String code, String name) {}
 
     public record CreateCampaignRequest(
             String id,

--- a/backend/ads-service/src/main/resources/db/changelog/V2026_08_20__add_instagram_account_to_experiment.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2026_08_20__add_instagram_account_to_experiment.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+--changeset marketinghub:2026-08-20-add-instagram-account-to-experiment dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'experiment' AND column_name = 'instagram_account_id';
+ALTER TABLE experiment
+  ADD COLUMN instagram_account_id BIGINT NULL;
+
+ALTER TABLE experiment
+  ADD CONSTRAINT fk_experiment_instagram_account FOREIGN KEY (instagram_account_id) REFERENCES ig_account(id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -158,3 +158,6 @@ databaseChangeLog:
   - include:
       file: V2026_07_05__simplify_instagram_account.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2026_08_20__add_instagram_account_to_experiment.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/FixtureUtils.java
@@ -9,6 +9,8 @@ import com.marketinghub.experiment.*;
 import com.marketinghub.experiment.repository.*;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.ads.InstagramAccount;
+import com.marketinghub.ads.InstagramAccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -26,6 +28,7 @@ public class FixtureUtils {
     private final com.marketinghub.creative.label.repository.AngleRepository angleRepository;
     private final com.marketinghub.hypothesis.repository.HypothesisRepository hypothesisRepository;
     private final com.marketinghub.experiment.repository.MetricPresetRepository metricPresetRepository;
+    private final InstagramAccountRepository instagramAccountRepository;
 
     public MarketNiche createAndSaveNiche() {
         MarketNiche niche = MarketNiche.builder()
@@ -74,8 +77,18 @@ public class FixtureUtils {
                 .status(ExperimentStatus.PLANNED)
                 .platform(ExperimentPlatform.FACEBOOK)
                 .creativesToGenerate(0)
+                .instagramAccount(createAndSaveInstagramAccount())
                 .build();
         return experimentRepository.save(exp);
+    }
+
+    public InstagramAccount createAndSaveInstagramAccount() {
+        InstagramAccount account = InstagramAccount.builder()
+                .name("Instagram Test")
+                .handle("@instagramtest")
+                .code("IG-TEST")
+                .build();
+        return instagramAccountRepository.save(account);
     }
 
     public Creative createAndSaveCreative(Experiment exp) {

--- a/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookPageControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/ads/FacebookPageControllerTest.java
@@ -18,6 +18,8 @@ import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.ads.InstagramAccount;
+import com.marketinghub.ads.InstagramAccountRepository;
 
 import java.math.BigDecimal;
 
@@ -58,6 +60,9 @@ class FacebookPageControllerTest {
     @Autowired
     ObjectMapper objectMapper;
 
+    @Autowired
+    InstagramAccountRepository instagramAccountRepository;
+
     FacebookAccount account;
 
     @BeforeEach
@@ -67,6 +72,7 @@ class FacebookPageControllerTest {
         nicheRepository.deleteAll();
         pageRepository.deleteAll();
         accountRepository.deleteAll();
+        instagramAccountRepository.deleteAll();
         account = accountRepository.save(FacebookAccount.builder()
                 .name("Account")
                 .currency("BRL")
@@ -132,6 +138,11 @@ class FacebookPageControllerTest {
                 .marketNiche(niche)
                 .title("Hypothesis " + page.getPageId())
                 .build());
+        InstagramAccount instagramAccount = instagramAccountRepository.save(InstagramAccount.builder()
+                .name("IG " + page.getPageId())
+                .handle("@" + page.getPageId())
+                .code("IG-" + page.getPageId())
+                .build());
         Experiment experiment = Experiment.builder()
                 .niche(niche)
                 .name("Experiment " + page.getPageId())
@@ -141,6 +152,7 @@ class FacebookPageControllerTest {
                 .platform(ExperimentPlatform.FACEBOOK)
                 .creativeApproved(true)
                 .facebookPage(page)
+                .instagramAccount(instagramAccount)
                 .build();
         experiment.setCreativesToGenerate(0);
         experiment.setKpiTargetCpl(BigDecimal.ONE);

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -11,6 +11,8 @@ import com.marketinghub.funnel.SalesFunnel;
 import com.marketinghub.funnel.SalesFunnelRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
+import com.marketinghub.ads.InstagramAccount;
+import com.marketinghub.ads.InstagramAccountRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -47,6 +49,17 @@ class ExperimentServiceTest {
     SalesFunnelRepository salesFunnelRepository;
     @Autowired
     AudienceRepository audienceRepository;
+    @Autowired
+    InstagramAccountRepository instagramAccountRepository;
+
+    private InstagramAccount createInstagramAccount() {
+        return instagramAccountRepository.save(
+                InstagramAccount.builder()
+                        .name("Conta Teste")
+                        .handle("@contateste")
+                        .code("IG-1")
+                        .build());
+    }
 
     @Test
     void createNewExperimentWithExistingNiche() {
@@ -80,6 +93,7 @@ class ExperimentServiceTest {
         req.setBaselineCvr(new BigDecimal("3"));
         req.setTargetCvr(new BigDecimal("5"));
         req.setMdePercent(new BigDecimal("40"));
+        req.setInstagramAccountId(createInstagramAccount().getId());
         var exp = service.create(req);
         assertThat(exp.getId()).isNotNull();
         assertThat(exp.getPlatform()).isEqualTo(ExperimentPlatform.FACEBOOK);
@@ -117,6 +131,7 @@ class ExperimentServiceTest {
         req.setMdePercent(new BigDecimal("40"));
         req.setStartDate(java.time.LocalDate.of(2024,2,1));
         req.setEndDate(java.time.LocalDate.of(2024,1,1));
+        req.setInstagramAccountId(createInstagramAccount().getId());
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
@@ -152,6 +167,7 @@ class ExperimentServiceTest {
         req.setBaselineCvr(new BigDecimal("3"));
         req.setTargetCvr(new BigDecimal("5"));
         req.setMdePercent(new BigDecimal("40"));
+        req.setInstagramAccountId(createInstagramAccount().getId());
         assertThatThrownBy(() -> service.create(req))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
@@ -185,6 +201,7 @@ class ExperimentServiceTest {
         req1.setHypothesis("H");
         req1.setKpiTargetCpl(new BigDecimal("45"));
         req1.setMetricPresetId("LEAN_150");
+        req1.setInstagramAccountId(createInstagramAccount().getId());
         var expApproved = service.create(req1);
         expApproved.setCreativeApproved(true);
         experimentRepository.save(expApproved);
@@ -209,6 +226,7 @@ class ExperimentServiceTest {
         req2.setHypothesis("H");
         req2.setKpiTargetCpl(new BigDecimal("45"));
         req2.setMetricPresetId("LEAN_150");
+        req2.setInstagramAccountId(createInstagramAccount().getId());
         var expNotApproved = service.create(req2);
         experimentRepository.save(expNotApproved);
 
@@ -248,6 +266,7 @@ class ExperimentServiceTest {
         req.setBaselineCvr(new BigDecimal("3"));
         req.setTargetCvr(new BigDecimal("5"));
         req.setMdePercent(new BigDecimal("40"));
+        req.setInstagramAccountId(createInstagramAccount().getId());
         var exp = service.create(req);
         exp.setStatus(ExperimentStatus.RUNNING);
         experimentRepository.save(exp);
@@ -286,6 +305,7 @@ class ExperimentServiceTest {
         req.setKpiTargetCpl(new BigDecimal("45"));
         req.setMetricPresetId("LEAN_150");
         req.setSalesFunnelName("Topo");
+        req.setInstagramAccountId(createInstagramAccount().getId());
 
         Experiment exp = service.create(req);
 
@@ -324,6 +344,7 @@ class ExperimentServiceTest {
         req.setKpiTargetCpl(new BigDecimal("45"));
         req.setMetricPresetId("LEAN_150");
         req.setSalesFunnelName(first.getName());
+        req.setInstagramAccountId(createInstagramAccount().getId());
         Experiment exp = service.create(req);
 
         UpdateExperimentRequest updateReq = new UpdateExperimentRequest();
@@ -369,6 +390,7 @@ class ExperimentServiceTest {
         req.setKpiTargetCpl(new BigDecimal("45"));
         req.setMetricPresetId("LEAN_150");
         req.setSalesFunnelName(funnel.getName());
+        req.setInstagramAccountId(createInstagramAccount().getId());
         Experiment exp = service.create(req);
 
         UpdateExperimentRequest updateReq = new UpdateExperimentRequest();

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/web/ExperimentControllerTest.java
@@ -13,6 +13,7 @@ import com.marketinghub.hypothesis.repository.HypothesisRepository;
 import com.marketinghub.FixtureUtils;
 import com.marketinghub.funnel.SalesFunnel;
 import com.marketinghub.funnel.SalesFunnelRepository;
+import com.marketinghub.ads.InstagramAccountRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,6 +68,8 @@ class ExperimentControllerTest {
     private SalesFunnelRepository salesFunnelRepository;
     @Autowired
     private AudienceRepository audienceRepository;
+    @Autowired
+    private InstagramAccountRepository instagramAccountRepository;
 
     Long nicheId;
 
@@ -76,6 +79,7 @@ class ExperimentControllerTest {
         repository.deleteAll();
         salesFunnelRepository.deleteAll();
         audienceRepository.deleteAll();
+        instagramAccountRepository.deleteAll();
         hypothesisRepository.deleteAll();
         angleRepository.deleteAll();
         nicheRepo.deleteAll();
@@ -104,6 +108,7 @@ class ExperimentControllerTest {
                 .defaultMdePp(new BigDecimal("12"))
                 .build());
         SalesFunnel funnel = salesFunnelRepository.save(SalesFunnel.builder().name("Topo").build());
+        var instagramAccount = fixtures.createAndSaveInstagramAccount();
         CreateExperimentRequest req = new CreateExperimentRequest();
         req.setName("Exp1");
         req.setHypothesisId(hyp.getId());
@@ -117,6 +122,7 @@ class ExperimentControllerTest {
         req.setStartDate(LocalDate.now());
         req.setEndDate(LocalDate.now().plusDays(5));
         req.setSalesFunnelName(funnel.getName());
+        req.setInstagramAccountId(instagramAccount.getId());
 
         mockMvc.perform(post("/api/niches/" + nicheId + "/experiments")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -6,6 +6,7 @@ import com.marketinghub.ads.AdsServiceApplication;
 import com.marketinghub.ads.FacebookAccount;
 import com.marketinghub.ads.FacebookAccountRepository;
 import com.marketinghub.ads.FacebookPage;
+import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.funnel.SalesFunnel;
 import com.marketinghub.hypothesis.Hypothesis;
@@ -87,6 +88,12 @@ class FacebookAdsCampaignControllerTest {
                 .id(55L)
                 .name("Conta Worker")
                 .build();
+        var instagramAccount = InstagramAccount.builder()
+                .id(91L)
+                .handle("@estudio")
+                .code("IG-ESTUDIO")
+                .name("Estúdio")
+                .build();
         var page = FacebookPage.builder()
                 .id(9L)
                 .account(account)
@@ -107,6 +114,7 @@ class FacebookAdsCampaignControllerTest {
                 .creativeApproved(true)
                 .salesFunnel(funnel)
                 .facebookPage(page)
+                .instagramAccount(instagramAccount)
                 .build();
         when(experimentService.listByStatusAndPlatform(
                 com.marketinghub.experiment.ExperimentStatus.PLANNED,
@@ -121,6 +129,8 @@ class FacebookAdsCampaignControllerTest {
                 .andExpect(jsonPath("$[0].pageId").value("84"))
                 .andExpect(jsonPath("$[0].facebookPage.pageId").value("84"))
                 .andExpect(jsonPath("$[0].facebookPage.name").value("Estúdio"))
+                .andExpect(jsonPath("$[0].instagramAccount.handle").value("@estudio"))
+                .andExpect(jsonPath("$[0].instagramAccount.code").value("IG-ESTUDIO"))
                 .andExpect(jsonPath("$[0].startDate").value("2024-01-01"))
                 .andExpect(jsonPath("$[0].endDate").value("2024-01-31"))
                 .andExpect(jsonPath("$[0].nicheName").value("Test Nicho"))
@@ -135,6 +145,12 @@ class FacebookAdsCampaignControllerTest {
                 .id(42L)
                 .name("Exp")
                 .creativeApproved(true)
+                .instagramAccount(InstagramAccount.builder()
+                        .id(5L)
+                        .handle("@acc")
+                        .code("IG-ACC")
+                        .name("Account")
+                        .build())
                 .build();
         when(experimentService.get(42L)).thenReturn(experiment);
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -162,6 +162,7 @@ triggering ad set generation.
 - `name` VARCHAR(255) NOT NULL
 - `hypothesis` VARCHAR(255)
 - `facebook_page_id` BIGINT
+- `instagram_account_id` BIGINT
 - `kpi_target_cpl` DECIMAL(10,2) DEFAULT 45.00
 - `stop_loss_cpl` DECIMAL(10,2) DEFAULT 90.00
 - `sample_size` INT DEFAULT 1500

--- a/docs/facebook-ads-worker/call-to-action-types.md
+++ b/docs/facebook-ads-worker/call-to-action-types.md
@@ -8,6 +8,11 @@ A Graph API expõe os tipos de call to action aceitos em campanhas via enumeraç
 > experimento quando não há `defaultPageId` configurado. Garanta que a página
 > exista antes de acionar o worker para publicar anúncios com os CTAs abaixo.
 
+> Atualização 2025-08-22: os experimentos precisam informar `instagramAccount`
+> no backend. O worker ignora CTAs de experimentos sem conta de Instagram
+> definida, garantindo que o `instagram_actor_id` enviado à Graph API seja
+> sempre válido.
+
 ## Lista completa (97 valores)
 
 - ADD_TO_CART

--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -5,6 +5,11 @@ criação de campanhas no Facebook Ads a partir de experimentos aprovados pelo
 backend. Estão incluídos o agendador, o serviço responsável por orquestrar as
 chamadas e o cliente usado para conversar com a Graph API do Facebook.
 
+> **Atualização:** Experimentos enviados pelo backend agora precisam informar o
+> campo `instagramAccount`. O `FacebookCampaignService` ignora qualquer
+> experimento sem essa associação para garantir que o criativo receba um
+> `instagram_actor_id` válido.
+
 ```mermaid
 classDiagram
     class FacebookCampaignScheduler {

--- a/docs/facebook-ads-worker/endpoint-flow.md
+++ b/docs/facebook-ads-worker/endpoint-flow.md
@@ -1,5 +1,9 @@
 # Fluxo de chamadas do Facebook Ads Worker
 
+> **Atualização 2025-08-22:** os experimentos retornados pelo backend devem
+> conter `instagramAccount`. O worker ignora qualquer item sem essa associação,
+> garantindo que o criativo seja criado com um `instagram_actor_id` válido.
+
 Este documento detalha como o **Facebook Ads Worker** conversa com o backend do
 Marketing Hub e com a **Facebook Graph API** em dois contextos principais:
 criação de campanhas e renovação automática de tokens. Sempre que possível os

--- a/docs/facebook-ads-worker/facebook-app-identifiers.md
+++ b/docs/facebook-ads-worker/facebook-app-identifiers.md
@@ -1,5 +1,10 @@
 # Identificador do aplicativo do Facebook
 
+> **Atualização 2025-08-22:** além de configurar App ID e App Secret, certifique-se
+> de que cada experimento retornado pelo backend tenha o campo
+> `instagramAccount`. O worker ignora experimentos sem essa associação para que
+> o `instagram_actor_id` enviado à Graph API seja válido.
+
 Este guia explica como localizar o campo obrigatório **ID do aplicativo (App ID)** na tela **Contas do Facebook**.
 
 ## ID do aplicativo (App ID)

--- a/docs/facebook-ads-worker/input-output-mapping.md
+++ b/docs/facebook-ads-worker/input-output-mapping.md
@@ -1,5 +1,10 @@
 # Mapeamento de Campos de Entrada e Saída do Facebook Ads Worker
 
+> **Atualização 2025-08-22:** o backend passou a enviar o campo
+> `instagramAccount` junto com cada experimento. O worker usa o código dessa
+> conta para preencher `instagram_actor_id` e ignora registros sem essa
+> informação.
+
 Este documento descreve como o **Facebook Ads Worker** converte os
 experimentos aprovados pelo backend em chamadas à Graph API do Facebook e em
 registros persistidos nas tabelas `facebook_ads_*`. O fluxo atual cria a

--- a/docs/facebook-ads-worker/meta-ads-campaign-coverage.md
+++ b/docs/facebook-ads-worker/meta-ads-campaign-coverage.md
@@ -6,6 +6,10 @@ e aponta onde cada informação é armazenada no modelo de dados. Utilize-o como
 complemento ao [diagrama de classes](class-diagram.md#diagrama-de-classes-do-facebook-ads-worker)
 para navegar entre as entidades citadas.
 
+> **Atualização 2025-08-22:** os experimentos retornados pelo backend precisam
+> informar o campo `instagramAccount`. O worker usa esse código como
+> `instagram_actor_id` e ignora experimentos sem a associação.
+
 ## Visão Geral
 
 - Alguns **pré-requisitos obrigatórios** (ID da conta de anúncios, token,

--- a/docs/facebook-ads-worker/meta-ads-campaign-fields.md
+++ b/docs/facebook-ads-worker/meta-ads-campaign-fields.md
@@ -6,6 +6,10 @@ Este documento descreve todos os campos que precisam ser coletados e preenchidos
 > quando a conta não informa `defaultPageId`. Revise os campos de campanha e
 > criativo considerando a nova obrigatoriedade.
 
+> Atualização 2025-08-22: os experimentos também precisam informar
+> `instagramAccount`. Sem essa conta o worker ignora o experimento para evitar
+> criativos sem `instagram_actor_id`.
+
 ## 1. Configurações no nível de Campanha
 
 ### Nome da campanha

--- a/docs/facebook-ads-worker/pendencias.md
+++ b/docs/facebook-ads-worker/pendencias.md
@@ -1,5 +1,9 @@
 # Pendências para campanha no Facebook Ads
 
+> **Atualização 2025-08-22:** vincule uma conta do Instagram em cada experimento
+> antes de liberar o worker. Sem essa informação o serviço ignora o experimento
+> ao montar o criativo.
+
 O worker já consulta o backend por experimentos aprovados, cria a campanha com
 objetivo `OUTCOME_TRAFFIC`, gera o ad set, criativo e anúncio correspondentes na
 Graph API e registra a campanha no backend. Para completar o fluxo de veiculação

--- a/docs/facebook-ads-worker/token-management.md
+++ b/docs/facebook-ads-worker/token-management.md
@@ -10,6 +10,10 @@ expiração automática.
 > associada (`fb_page`). Certifique-se de que o token gerado tenha acesso à
 > página vinculada ao experimento, caso contrário o worker ignorará a criação da
 > campanha.
+>
+> Atualização 2025-08-22: vincule uma `instagramAccount` a cada experimento.
+> Sem esse relacionamento o worker não consegue definir `instagram_actor_id` e
+> deixa o experimento fora da fila até que a conta esteja configurada.
 
 ## 1. Geração inicial do token
 

--- a/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
+++ b/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
@@ -4,6 +4,10 @@ Este documento descreve como o MarketingHub converte experimentos aprovados em
 campanhas no Facebook Ads, criando automaticamente conjuntos de anúncios,
 criativos e anúncios associados antes de registrar os dados no backend.
 
+> Atualização 2025-08-22: apenas experimentos com `instagramAccount`
+> configurada são elegíveis para transformação. O worker ignora qualquer item
+> sem esse vínculo para garantir o envio de um `instagram_actor_id` válido.
+
 A fila de trabalho usada aqui é a mesma exibida na tela "Experimentos para
 Campanha" do frontend, que lista os experimentos aprovados e prontos para serem
 transformados em campanhas.

--- a/docs/html/data-model.html
+++ b/docs/html/data-model.html
@@ -155,6 +155,8 @@
 <li><code>hypothesis_id</code> BINARY(16) NOT NULL</li>
 <li><code>name</code> VARCHAR(255) NOT NULL</li>
 <li><code>hypothesis</code> VARCHAR(255)</li>
+<li><code>facebook_page_id</code> BIGINT</li>
+<li><code>instagram_account_id</code> BIGINT</li>
 <li><code>kpi_target_cpl</code> DECIMAL(10,2) DEFAULT 45.00</li>
 <li><code>stop_loss_cpl</code> DECIMAL(10,2) DEFAULT 90.00</li>
 <li><code>sample_size</code> INT DEFAULT 1500</li>

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -18,9 +18,12 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    não possui `defaultPageId`, o worker utiliza a página vinculada ao
    experimento no backend (exposta como `facebookPage`, `associatedFacebookPage`
    ou `facebookPageAssociation`) e ignora o experimento caso nenhuma associação
-   exista.
-   Opcionalmente o fluxo inclui `instagram_actor_id`, mensagem e
-   call-to-action vindos do próprio criativo.
+   exista. A mesma regra vale para a identidade do Instagram: o worker consome o
+   campo `instagramAccount` retornado pelo backend e popula `instagram_actor_id`
+   com o código cadastrado na conta. Caso o experimento não esteja relacionado a
+   uma conta do Instagram, o worker registra o aviso e pula a publicação.
+   Opcionalmente o fluxo inclui mensagem e call-to-action vindos do próprio
+   criativo.
 4. **Anúncio** (`POST /ads`) que referencia o conjunto e o criativo recém
    criados, mantido pausado até que o time operacional revise os detalhes no
    Gerenciador de Anúncios.

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -176,6 +176,15 @@ public class FacebookCampaignService {
                 return;
             }
 
+            Experiment.InstagramAccount instagramAccount = exp.instagramAccount();
+            if (instagramAccount == null || !StringUtils.hasText(instagramAccount.code())) {
+                LOGGER.warn(
+                    "Skipping experiment {} because no Instagram account is configured",
+                    exp.id()
+                );
+                return;
+            }
+
             String resolvedPageId = resolvePageId(config, exp);
             if (!StringUtils.hasText(resolvedPageId)) {
                 LOGGER.warn("Skipping experiment {} because no Facebook page ID is configured", exp.id());
@@ -198,7 +207,11 @@ public class FacebookCampaignService {
                 ? creative.primaryText()
                 : formatCreativeMessage(exp.name(), config);
             String resolvedCallToAction = coalesce(creative.cta(), config.defaultCallToActionType());
-            String resolvedInstagramActorId = coalesce(creative.instagramUserId(), config.defaultInstagramActorId());
+            String resolvedInstagramActorId = coalesce(
+                creative.instagramUserId(),
+                instagramAccount.code(),
+                config.defaultInstagramActorId()
+            );
             String resolvedDestinationType = hasLeadFormDestination ? "LEAD_GENERATION" : config.adSetDestinationType();
 
             String campaignId = facebookAdsService.createCampaign(config.adAccountId(), exp.name());
@@ -374,13 +387,15 @@ public class FacebookCampaignService {
         String name,
         String pageId,
         @JsonAlias({ "page", "associatedFacebookPage", "facebookPageAssociation" })
-        FacebookPage facebookPage
+        FacebookPage facebookPage,
+        InstagramAccount instagramAccount
     ) {
         public FacebookPage associatedPage() {
             return facebookPage;
         }
 
         public record FacebookPage(Long id, String pageId, String name) {}
+        public record InstagramAccount(Long id, String handle, String code, String name) {}
     }
     public record CreateCampaignRequest(
         String id,

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -92,7 +92,7 @@ class FacebookCampaignServiceTest {
 
     @Test
     void createsCampaignHierarchyForEachExperiment() throws Exception {
-        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"}}]")
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"10\"}")
             .addHeader("Content-Type", "application/json"));
@@ -175,7 +175,7 @@ class FacebookCampaignServiceTest {
             "150",
             "BR"
         ));
-        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"}}]")
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"10\"}")
             .addHeader("Content-Type", "application/json"));
@@ -259,7 +259,7 @@ class FacebookCampaignServiceTest {
 
     @Test
     void marksExperimentAsFailedWhenFacebookReturnsPermissionError() throws Exception {
-        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"}}]")
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse()
             .setResponseCode(400)
@@ -293,7 +293,7 @@ class FacebookCampaignServiceTest {
 
     @Test
     void skipsExperimentAfterPermissionErrorEvenIfBackendKeepsReturningIt() throws Exception {
-        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"}}]")
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse()
             .setResponseCode(400)
@@ -355,7 +355,7 @@ class FacebookCampaignServiceTest {
             "/api"
         );
 
-        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"}}]")
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
             .addHeader("Content-Type", "application/json"));
         backend.enqueue(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
             .addHeader("Content-Type", "application/json"));
@@ -364,7 +364,7 @@ class FacebookCampaignServiceTest {
             .setBody("{\"error\":{\"message\":\"Error validating access token: Session has expired\",\"type\":\"OAuthException\",\"code\":190,\"error_subcode\":463}}")
             .addHeader("Content-Type", "application/json"));
 
-        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"}}]")
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
             .addHeader("Content-Type", "application/json"));
         backend.enqueue(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
             .addHeader("Content-Type", "application/json"));
@@ -434,7 +434,7 @@ class FacebookCampaignServiceTest {
             "/api"
         );
 
-        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"}}]")
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
             .addHeader("Content-Type", "application/json"));
         backend.enqueue(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
             .addHeader("Content-Type", "application/json"));
@@ -448,7 +448,7 @@ class FacebookCampaignServiceTest {
         adsService.updateAccessToken("renewed-by-backend");
         configurationClient.setConfiguration(configurationWithAccessToken("renewed-by-backend"));
 
-        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"}}]")
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
             .addHeader("Content-Type", "application/json"));
         backend.enqueue(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
             .addHeader("Content-Type", "application/json"));
@@ -494,7 +494,7 @@ class FacebookCampaignServiceTest {
     void fallsBackToExperimentFacebookPageWhenConfigurationDoesNotProvideOne() throws Exception {
         configurationClient.setConfiguration(configurationWithoutDefaultPageId("token"));
 
-        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"}}]")
+        backend.enqueue(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"10\"}")
             .addHeader("Content-Type", "application/json"));

--- a/frontend/src/__tests__/NicheFlow.test.tsx
+++ b/frontend/src/__tests__/NicheFlow.test.tsx
@@ -43,6 +43,7 @@ function mockApi() {
             platform: "FACEBOOK",
             createdAt: "",
             updatedAt: "",
+            instagramAccount: null,
           },
         ],
       });
@@ -65,6 +66,7 @@ function mockApi() {
           platform: "FACEBOOK",
           createdAt: "",
           updatedAt: "",
+          instagramAccount: null,
         },
       });
     }

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -16,6 +16,7 @@ export interface CreateExperiment {
   creativesToGenerate?: number;
   salesFunnelName?: string;
   facebookPageId?: number;
+  instagramAccountId: number;
 }
 
 export function useCreateExperiment() {

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -8,6 +8,13 @@ export interface FacebookPageSummary {
   name: string;
 }
 
+export interface InstagramAccountSummary {
+  id: number;
+  handle: string;
+  code: string;
+  name: string;
+}
+
 export interface Experiment {
   id: string;
   nicheId: number;
@@ -16,6 +23,7 @@ export interface Experiment {
   hypothesis: string;
   pageId?: string | null;
   facebookPage?: FacebookPageSummary | null;
+  instagramAccount?: InstagramAccountSummary | null;
   /**
    * KPI alvo em CPL. Mantém `kpiTarget` para compatibilidade com APIs
    * antigas que usavam este nome.

--- a/frontend/src/api/experiment/useUpdateExperiment.ts
+++ b/frontend/src/api/experiment/useUpdateExperiment.ts
@@ -14,6 +14,7 @@ export interface UpdateExperiment {
   creativesToGenerate?: number;
   salesFunnelName?: string | null;
   facebookPageId?: number | null;
+  instagramAccountId?: number | null;
 }
 
 export function useUpdateExperiment(id: string) {

--- a/frontend/src/api/useFacebookCampaignExperiments.ts
+++ b/frontend/src/api/useFacebookCampaignExperiments.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
+import type { InstagramAccountSummary } from "./experiment/useExperiments";
 
 export interface ExperimentSummary {
   id: number;
@@ -11,6 +12,7 @@ export interface ExperimentSummary {
   nicheName: string | null;
   hypothesisTitle: string | null;
   missingConfiguration: string[];
+  instagramAccount?: InstagramAccountSummary | null;
 }
 
 export function useFacebookCampaignExperiments(status: string) {

--- a/frontend/src/api/useFacebookReadyExperiments.ts
+++ b/frontend/src/api/useFacebookReadyExperiments.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
+import type { InstagramAccountSummary } from "./experiment/useExperiments";
 
 export interface FacebookReadyExperiment {
   id: number;
@@ -11,6 +12,7 @@ export interface FacebookReadyExperiment {
   nicheName: string | null;
   hypothesisTitle: string | null;
   missingConfiguration: string[];
+  instagramAccount?: InstagramAccountSummary | null;
 }
 
 export function useFacebookReadyExperiments() {

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -12,6 +12,7 @@ import { useRequestCreatives } from "../../api/experiment/useRequestCreatives";
 import { useExperiment } from "../../api/experiment/useExperiment";
 import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
 import { useAllFacebookPages } from "../../api/useAllFacebookPages";
+import { useInstagramAccounts } from "../../api/useInstagramAccounts";
 import InstagramAdPreview from "../../components/InstagramAdPreview";
 import { resolveAssetUrl } from "../../utils/resolveAssetUrl";
 import { FACEBOOK_CALL_TO_ACTIONS } from "../../constants/facebookCallToActions";
@@ -97,6 +98,8 @@ export default function CriativosTab({ experimentId }: Props) {
     status: "DRAFT",
   });
   const [experimentPageId, setExperimentPageId] = useState("");
+  const [experimentInstagramAccountId, setExperimentInstagramAccountId] =
+    useState("");
   const { handleSubmit: handleFormSubmit } = useForm<CreativeForm>();
   const { data: angles } = useAngles();
   const { data: proofs } = useVisualProofs();
@@ -118,6 +121,12 @@ export default function CriativosTab({ experimentId }: Props) {
   const requestCreatives = useRequestCreatives(experimentId);
   const { data: facebookPages, isLoading: isLoadingFacebookPages } =
     useAllFacebookPages();
+  const { data: instagramAccounts, isLoading: isLoadingInstagramAccounts } =
+    useInstagramAccounts();
+  const noInstagramAccounts =
+    !isLoadingInstagramAccounts &&
+    Array.isArray(instagramAccounts) &&
+    instagramAccounts.length === 0;
 
   useEffect(() => {
     if (!feedback) return;
@@ -137,6 +146,14 @@ export default function CriativosTab({ experimentId }: Props) {
     );
   }, [experiment?.facebookPage?.id]);
 
+  useEffect(() => {
+    setExperimentInstagramAccountId(
+      experiment?.instagramAccount?.id
+        ? String(experiment.instagramAccount.id)
+        : "",
+    );
+  }, [experiment?.instagramAccount?.id]);
+
   const handleSavePageId = async () => {
     if (!experiment) return;
     const kpiTargetValue = experiment.kpiTarget ?? experiment.kpiTargetCpl;
@@ -146,6 +163,24 @@ export default function CriativosTab({ experimentId }: Props) {
         title: "Não foi possível salvar a página",
         description:
           "Defina a meta de KPI e o preset de métricas antes de configurar a página do experimento.",
+      });
+      return;
+    }
+    if (noInstagramAccounts) {
+      setFeedback({
+        variant: "error",
+        title: "Cadastre uma conta do Instagram",
+        description:
+          "Cadastre uma conta de Instagram na tela Contas do Instagram antes de salvar as configurações.",
+      });
+      return;
+    }
+    if (!experimentInstagramAccountId) {
+      setFeedback({
+        variant: "error",
+        title: "Selecione a conta do Instagram",
+        description:
+          "Relacione uma conta de Instagram para que o worker possa publicar os criativos.",
       });
       return;
     }
@@ -172,17 +207,33 @@ export default function CriativosTab({ experimentId }: Props) {
         creativesToGenerate: experiment.creativesToGenerate ?? undefined,
         salesFunnelName: experiment.salesFunnelName ?? null,
         facebookPageId: parsedPageId,
+        instagramAccountId: Number(experimentInstagramAccountId),
       });
       const selectedPage =
         parsedPageId === null
           ? null
           : facebookPages?.find((page) => page.id === parsedPageId) ?? null;
+      const selectedInstagramAccount = Array.isArray(instagramAccounts)
+        ? instagramAccounts.find(
+            (account) => account.id === Number(experimentInstagramAccountId),
+          ) ?? null
+        : null;
+      const rawHandle =
+        selectedInstagramAccount?.handle ?? experiment.instagramAccount?.handle ?? "";
+      const formattedHandle = rawHandle
+        ? rawHandle.startsWith("@")
+          ? rawHandle
+          : `@${rawHandle}`
+        : null;
+      const instagramDescription = formattedHandle
+        ? `a conta ${formattedHandle}`
+        : "a conta do Instagram selecionada";
       setFeedback({
         variant: "success",
-        title: "Página atualizada",
+        title: "Configurações atualizadas",
         description: selectedPage
-          ? `Todos os criativos deste experimento usarão a página ${selectedPage.name}.`
-          : "Sem página definida o worker utilizará a página padrão configurada no worker.",
+          ? `Os criativos publicarão na página ${selectedPage.name} com ${instagramDescription}.`
+          : `Sem página definida o worker utilizará a página padrão do Facebook, mantendo ${instagramDescription}.`,
       });
     } catch {
       setFeedback({
@@ -548,6 +599,49 @@ export default function CriativosTab({ experimentId }: Props) {
         </div>
       )}
       <div className="mb-4">
+        <label className="form-label" htmlFor="experiment-instagram-id">
+          Conta do Instagram <span className="text-danger">*</span>
+        </label>
+        <select
+          id="experiment-instagram-id"
+          className="form-select mb-2"
+          value={experimentInstagramAccountId}
+          onChange={(e) => setExperimentInstagramAccountId(e.target.value)}
+          disabled={
+            isSavingPageId || isLoadingInstagramAccounts || noInstagramAccounts
+          }
+        >
+          <option value="">
+            {isLoadingInstagramAccounts
+              ? "Carregando contas cadastradas..."
+              : noInstagramAccounts
+                ? "Cadastre uma conta para continuar"
+                : "Selecione uma conta"}
+          </option>
+          {Array.isArray(instagramAccounts) &&
+            instagramAccounts.map((account) => (
+              <option key={account.id} value={account.id}>
+                {account.name} ({account.handle})
+              </option>
+            ))}
+        </select>
+        <div className="form-text mb-2">
+          O worker utilizará esta conta como identidade do Instagram nas campanhas.
+        </div>
+        {noInstagramAccounts && (
+          <div className="alert alert-warning" role="alert">
+            Nenhuma conta do Instagram está cadastrada. Cadastre uma conta antes
+            de publicar criativos neste experimento.
+            <div className="mt-2">
+              <a
+                className="btn btn-outline-primary btn-sm"
+                href="/accounts/instagram"
+              >
+                Abrir Contas do Instagram
+              </a>
+            </div>
+          </div>
+        )}
         <label className="form-label" htmlFor="experiment-page-id">
           Página do Facebook deste experimento
         </label>
@@ -575,7 +669,7 @@ export default function CriativosTab({ experimentId }: Props) {
             type="button"
             className="btn btn-primary d-flex align-items-center gap-2"
             onClick={handleSavePageId}
-            disabled={isSavingPageId || !experiment}
+            disabled={isSavingPageId || !experiment || noInstagramAccounts}
           >
             {isSavingPageId ? (
               <>

--- a/frontend/src/pages/experiment/EditExperimentPage.tsx
+++ b/frontend/src/pages/experiment/EditExperimentPage.tsx
@@ -6,6 +6,7 @@ import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
 import { useMetricPresets } from "../../api/experiment/useMetricPresets";
 import { useFunnels } from "../../api/funnel/useFunnels";
 import { useAllFacebookPages } from "../../api/useAllFacebookPages";
+import { useInstagramAccounts } from "../../api/useInstagramAccounts";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
 
@@ -15,6 +16,7 @@ interface FormData {
   metricPresetId: string;
   salesFunnelName: string;
   facebookPageId: string;
+  instagramAccountId: string;
 }
 
 export default function EditExperimentPage() {
@@ -28,6 +30,12 @@ export default function EditExperimentPage() {
   const { register, handleSubmit, reset } = useForm<FormData>();
   const { data: facebookPages, isLoading: isLoadingFacebookPages } =
     useAllFacebookPages();
+  const { data: instagramAccounts, isLoading: isLoadingInstagramAccounts } =
+    useInstagramAccounts();
+  const noInstagramAccounts =
+    !isLoadingInstagramAccounts &&
+    Array.isArray(instagramAccounts) &&
+    instagramAccounts.length === 0;
 
   useEffect(() => {
     if (data) {
@@ -39,6 +47,9 @@ export default function EditExperimentPage() {
         facebookPageId: data.facebookPage?.id
           ? String(data.facebookPage.id)
           : "",
+        instagramAccountId: data.instagramAccount?.id
+          ? String(data.instagramAccount.id)
+          : "",
       });
     }
   }, [data, reset]);
@@ -46,6 +57,16 @@ export default function EditExperimentPage() {
   const onSubmit = async (values: FormData) => {
     try {
       if (!data) return;
+      if (noInstagramAccounts) {
+        alert(
+          "Cadastre uma conta do Instagram em Contas do Instagram antes de salvar o experimento.",
+        );
+        return;
+      }
+      if (!values.instagramAccountId) {
+        alert("Selecione uma conta do Instagram");
+        return;
+      }
       await update.mutateAsync({
         name: values.name,
         hypothesis: data.hypothesis,
@@ -59,6 +80,7 @@ export default function EditExperimentPage() {
         facebookPageId: values.facebookPageId
           ? Number(values.facebookPageId)
           : null,
+        instagramAccountId: Number(values.instagramAccountId),
       });
       navigate(-1);
     } catch {
@@ -119,6 +141,43 @@ export default function EditExperimentPage() {
               </option>
             ))}
         </select>
+        <label className="form-label" htmlFor="instagramAccountId">
+          Conta do Instagram <span className="text-danger">*</span>
+        </label>
+        <select
+          id="instagramAccountId"
+          className="form-select mb-2"
+          {...register("instagramAccountId")}
+          disabled={isLoadingInstagramAccounts || noInstagramAccounts}
+        >
+          <option value="">
+            {isLoadingInstagramAccounts
+              ? "Carregando contas cadastradas..."
+              : noInstagramAccounts
+                ? "Cadastre uma conta para continuar"
+                : "Selecione uma conta"}
+          </option>
+          {Array.isArray(instagramAccounts) &&
+            instagramAccounts.map((account) => (
+              <option key={account.id} value={account.id}>
+                {account.name} ({account.handle})
+              </option>
+            ))}
+        </select>
+        {noInstagramAccounts && (
+          <div className="alert alert-warning" role="alert">
+            Nenhuma conta do Instagram está cadastrada. Cadastre uma conta antes
+            de editar o experimento.
+            <div className="mt-2">
+              <a
+                className="btn btn-outline-primary btn-sm"
+                href="/accounts/instagram"
+              >
+                Abrir Contas do Instagram
+              </a>
+            </div>
+          </div>
+        )}
         <label className="form-label" htmlFor="facebookPageId">
           Página do Facebook
         </label>
@@ -156,12 +215,23 @@ export default function EditExperimentPage() {
           <button
             type="button"
             className="btn btn-primary"
-            disabled={update.isPending}
+            disabled={update.isPending || noInstagramAccounts}
             onClick={handleSubmit(onSubmit, (errors) => {
               console.log("Validation errors", errors);
             })}
           >
-            Salvar
+            {update.isPending ? (
+              <>
+                <span
+                  className="spinner-border spinner-border-sm"
+                  role="status"
+                  aria-hidden
+                />
+                <span className="ms-2">Salvando...</span>
+              </>
+            ) : (
+              <span>Salvar</span>
+            )}
           </button>
         </div>
       </form>

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -79,6 +79,8 @@ export default function ExperimentDetailPage() {
   const hasConfiguredFacebookPage = facebookConfig?.hasConfiguredPages ?? false;
   const experimentPage = data.facebookPage;
   const hasExperimentPage = Boolean(experimentPage?.pageId);
+  const instagramAccount = data.instagramAccount;
+  const hasInstagramAccount = Boolean(instagramAccount);
   const readinessChecks = [
     {
       id: "facebook-page",
@@ -97,6 +99,16 @@ export default function ExperimentDetailPage() {
         !isLoadingFacebookConfig && !hasConfiguredFacebookPage
           ? "Abrir Contas do Facebook"
           : undefined,
+    },
+    {
+      id: "instagram-account",
+      title: "Conta de Instagram vinculada",
+      isMet: hasInstagramAccount,
+      hint: hasInstagramAccount
+        ? `Este experimento usa a conta ${instagramAccount?.handle}.`
+        : "Associe uma conta do Instagram ao experimento para liberar as campanhas.",
+      action: hasInstagramAccount ? undefined : () => navigate(`/experiments/${expId}/edit`),
+      actionLabel: hasInstagramAccount ? undefined : "Editar experimento",
     },
     {
       id: "experiment-page",
@@ -175,6 +187,12 @@ export default function ExperimentDetailPage() {
       label: "Página do Facebook",
       value: experimentPage
         ? `${experimentPage.name} (${experimentPage.pageId})`
+        : "—",
+    },
+    {
+      label: "Conta do Instagram",
+      value: instagramAccount
+        ? `${instagramAccount.name} (${instagramAccount.handle})`
         : "—",
     },
     ...(data.salesFunnelName

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -7,6 +7,7 @@ import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useMetricPresets } from "../../api/experiment/useMetricPresets";
 import { useFunnels } from "../../api/funnel/useFunnels";
 import { useAllFacebookPages } from "../../api/useAllFacebookPages";
+import { useInstagramAccounts } from "../../api/useInstagramAccounts";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
 
@@ -29,6 +30,7 @@ export default function NewExperimentPage() {
     endDate: "",
     salesFunnelName: "",
     facebookPageId: "",
+    instagramAccountId: "",
   });
   const { data: hypotheses } = useHypothesesByNiche(form.nicheId);
   const { data: selectedHypothesis } = useHypothesis(
@@ -42,6 +44,12 @@ export default function NewExperimentPage() {
   const { data: funnels } = useFunnels();
   const { data: facebookPages, isLoading: isLoadingFacebookPages } =
     useAllFacebookPages();
+  const { data: instagramAccounts, isLoading: isLoadingInstagramAccounts } =
+    useInstagramAccounts();
+  const noInstagramAccounts =
+    !isLoadingInstagramAccounts &&
+    Array.isArray(instagramAccounts) &&
+    instagramAccounts.length === 0;
   const showNicheSelect = nicheIdParam === "";
   const showHypSelect = hypothesisIdParam === "";
 
@@ -53,6 +61,16 @@ export default function NewExperimentPage() {
 
   const submit = async () => {
     try {
+      if (noInstagramAccounts) {
+        alert(
+          "Cadastre uma conta do Instagram em Contas do Instagram antes de criar o experimento.",
+        );
+        return;
+      }
+      if (!form.instagramAccountId) {
+        alert("Selecione uma conta do Instagram");
+        return;
+      }
       await create.mutateAsync({
         nicheId: Number(form.nicheId),
         hypothesisId: form.hypothesisId || undefined,
@@ -68,6 +86,7 @@ export default function NewExperimentPage() {
         facebookPageId: form.facebookPageId
           ? Number(form.facebookPageId)
           : undefined,
+        instagramAccountId: Number(form.instagramAccountId),
       });
       setForm({
         nicheId: nicheIdParam,
@@ -82,6 +101,7 @@ export default function NewExperimentPage() {
         endDate: "",
         salesFunnelName: "",
         facebookPageId: "",
+        instagramAccountId: "",
       });
       alert("Teste salvo!");
     } catch (errors) {
@@ -198,6 +218,49 @@ export default function NewExperimentPage() {
             </option>
           ))}
       </select>
+      <label className="form-label" htmlFor="instagramAccount">
+        Conta do Instagram <span className="text-danger">*</span>
+      </label>
+      <select
+        id="instagramAccount"
+        className="form-select mb-2"
+        value={form.instagramAccountId}
+        onChange={(e) =>
+          setForm({ ...form, instagramAccountId: e.target.value })
+        }
+        disabled={isLoadingInstagramAccounts || noInstagramAccounts}
+      >
+        <option value="">
+          {isLoadingInstagramAccounts
+            ? "Carregando contas cadastradas..."
+            : noInstagramAccounts
+              ? "Cadastre uma conta para continuar"
+              : "Selecione uma conta"}
+        </option>
+        {Array.isArray(instagramAccounts) &&
+          instagramAccounts.map((account) => (
+            <option key={account.id} value={account.id}>
+              {account.name} ({account.handle})
+            </option>
+          ))}
+      </select>
+      <div className="form-text mb-2">
+        Essa conta será usada como identidade do Instagram nas campanhas geradas.
+      </div>
+      {noInstagramAccounts && (
+        <div className="alert alert-warning" role="alert">
+          Nenhuma conta do Instagram está cadastrada. Cadastre uma conta antes de
+          criar novos experimentos.
+          <div className="mt-2">
+            <a
+              className="btn btn-outline-primary btn-sm"
+              href="/accounts/instagram"
+            >
+              Abrir Contas do Instagram
+            </a>
+          </div>
+        </div>
+      )}
       <label className="form-label" htmlFor="facebookPage">
         Página do Facebook
       </label>
@@ -249,8 +312,23 @@ export default function NewExperimentPage() {
         value={form.endDate}
         onChange={(e) => setForm({ ...form, endDate: e.target.value })}
       />
-      <button className="btn btn-primary" onClick={submit}>
-        Salvar
+      <button
+        className="btn btn-primary d-flex align-items-center gap-2"
+        onClick={submit}
+        disabled={create.isPending || noInstagramAccounts}
+      >
+        {create.isPending ? (
+          <>
+            <span
+              className="spinner-border spinner-border-sm"
+              role="status"
+              aria-hidden
+            />
+            <span>Salvando...</span>
+          </>
+        ) : (
+          <span>Salvar</span>
+        )}
       </button>
     </div>
   );

--- a/frontend/src/pages/facebook/missingConfigurationLabels.ts
+++ b/frontend/src/pages/facebook/missingConfigurationLabels.ts
@@ -6,6 +6,7 @@ export const missingConfigurationLabels: Record<string, string> = {
   startDate: "Definir a data de início",
   endDate: "Definir a data de término",
   salesFunnel: "Associar um funil de vendas",
+  instagramAccount: "Vincular uma conta do Instagram",
 };
 
 export function getMissingConfigurationLabel(key: string) {

--- a/schema.sql
+++ b/schema.sql
@@ -120,6 +120,7 @@ CREATE TABLE experiment (
     name VARCHAR(255) NOT NULL,
     hypothesis VARCHAR(255),
     facebook_page_id BIGINT,
+    instagram_account_id BIGINT,
     kpi_target_cpl DECIMAL(10,2) DEFAULT 45.00,
     stop_loss_cpl DECIMAL(10,2) DEFAULT 90.00,
     sample_size INT DEFAULT 1500,
@@ -135,7 +136,8 @@ CREATE TABLE experiment (
     sales_funnel_id BINARY(16),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    CONSTRAINT fk_experiment_facebook_page FOREIGN KEY (facebook_page_id) REFERENCES fb_page(id)
+    CONSTRAINT fk_experiment_facebook_page FOREIGN KEY (facebook_page_id) REFERENCES fb_page(id),
+    CONSTRAINT fk_experiment_instagram_account FOREIGN KEY (instagram_account_id) REFERENCES ig_account(id)
 );
 
 CREATE TABLE audience (


### PR DESCRIPTION
## Resumo
- atualiza a documentação do facebook-ads-worker para destacar que experimentos sem conta do Instagram são ignorados
- bloqueia ações de criação/edição quando não há contas de Instagram e orienta o usuário no frontend
- melhora o feedback da aba de criativos ao validar a conta de Instagram selecionada e ao salvar a página

## Testes
- `mvn -s ../settings.xml test` *(falhou: dependências corporativas indisponíveis no ambiente)*
- `npm test -- --run` *(falhou: suite existente apresenta erros no jsdom)*
- `mvn -s settings.xml test` *(falhou: dependências corporativas indisponíveis no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b92656483218d22ef7ad04d221b