### PR TITLE
Allow creating experiments without Instagram account

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -124,9 +124,6 @@ public class ExperimentService {
         if (request.getMetricPresetId() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "metricPresetId required");
         }
-        if (request.getInstagramAccountId() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "instagramAccountId required");
-        }
         MetricPreset preset = metricPresetService.get(request.getMetricPresetId());
         java.math.BigDecimal computedStopLoss = request.getKpiTargetCpl().multiply(preset.getStopLossFactor());
         if (request.getSampleSize() != null && request.getSampleSize() < 100) {


### PR DESCRIPTION
## Summary
- remove the validation that required instagramAccountId when creating an experiment so requests without it succeed

## Testing
- `mvn -s ../settings.xml -Dtest=ExperimentControllerTest test` *(fails: unable to download parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e294d17f648321b2d2fbfa09428a45