### PR TITLE
Generalize experiment relation preservation

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -2,6 +2,7 @@
 
 - Qualquer botão que dispare uma requisição assíncrona deve ficar desabilitado e exibir um indicador de carregamento (por exemplo, `spinner-border spinner-border-sm`) enquanto a operação estiver em andamento.
 - Campos de formulário obrigatórios devem exibir um asterisco (`*`) ao lado do rótulo para indicar a obrigatoriedade na interface.
+- Ao editar formulários que referenciam entidades relacionadas (funis, páginas, contas etc.), preserve as associações existentes quando o usuário não interagir com o campo. Utilize o utilitário `preserveLinkedValue` (`frontend/src/utils/preserveLinkedValue.ts`) para evitar que relacionamentos previamente salvos sejam removidos de maneira involuntária.
 
 ## Menu lateral
 

--- a/frontend/src/pages/experiment/EditExperimentPage.tsx
+++ b/frontend/src/pages/experiment/EditExperimentPage.tsx
@@ -2,20 +2,24 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate, useParams } from "react-router-dom";
 import { useExperiment } from "../../api/experiment/useExperiment";
-import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
+import {
+  type UpdateExperiment,
+  useUpdateExperiment,
+} from "../../api/experiment/useUpdateExperiment";
 import { useMetricPresets } from "../../api/experiment/useMetricPresets";
 import { useFunnels } from "../../api/funnel/useFunnels";
 import { useAllFacebookPages } from "../../api/useAllFacebookPages";
 import { useInstagramAccounts } from "../../api/useInstagramAccounts";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
+import { preserveLinkedValue } from "../../utils/preserveLinkedValue";
 
 interface FormData {
   name: string;
   kpiTarget: string;
   metricPresetId: string;
-  salesFunnelName: string;
-  facebookPageId: string;
+  salesFunnelName?: string | null;
+  facebookPageId?: string | null;
   instagramAccountId: string;
 }
 
@@ -67,7 +71,7 @@ export default function EditExperimentPage() {
         alert("Selecione uma conta do Instagram");
         return;
       }
-      await update.mutateAsync({
+      const payload: UpdateExperiment = {
         name: values.name,
         hypothesis: data.hypothesis,
         kpiTarget: Number(values.kpiTarget),
@@ -76,12 +80,29 @@ export default function EditExperimentPage() {
         mde: data.mdePercent ?? undefined,
         startDate: data.startDate ?? undefined,
         endDate: data.endDate ?? undefined,
-        salesFunnelName: values.salesFunnelName,
-        facebookPageId: values.facebookPageId
-          ? Number(values.facebookPageId)
-          : null,
         instagramAccountId: Number(values.instagramAccountId),
+      };
+
+      const salesFunnelName = preserveLinkedValue({
+        input: values.salesFunnelName,
+        persisted: data.salesFunnelName ?? null,
+        emptyInputs: [""],
       });
+      if (salesFunnelName !== undefined) {
+        payload.salesFunnelName = salesFunnelName;
+      }
+
+      const facebookPageId = preserveLinkedValue({
+        input: values.facebookPageId,
+        persisted: data.facebookPage?.id ?? null,
+        emptyInputs: [""],
+        parse: (value: string) => Number(value),
+      });
+      if (facebookPageId !== undefined) {
+        payload.facebookPageId = facebookPageId;
+      }
+
+      await update.mutateAsync(payload);
       navigate(-1);
     } catch {
       alert("Erro ao salvar Experimento");

--- a/frontend/src/utils/preserveLinkedValue.ts
+++ b/frontend/src/utils/preserveLinkedValue.ts
@@ -1,0 +1,33 @@
+export interface PreserveLinkedValueOptions<TInput, TValue> {
+  input: TInput | null | undefined;
+  persisted: TValue | null | undefined;
+  parse?: (value: TInput) => TValue;
+  emptyInputs?: Array<TInput | null | undefined>;
+}
+
+/**
+ * Keeps the association with a linked entity intact when the user does not interact with the
+ * corresponding field in the form. Explicit empty selections (for example selecting "Nenhum")
+ * still nullify the relationship, while untouched fields reuse the previously persisted value.
+ */
+export function preserveLinkedValue<TInput, TValue>({
+  input,
+  persisted,
+  parse,
+  emptyInputs = ["" as unknown as TInput],
+}: PreserveLinkedValueOptions<TInput, TValue>): TValue | null | undefined {
+  if (input === undefined) {
+    return persisted;
+  }
+
+  if (input === null) {
+    return null;
+  }
+
+  if (emptyInputs.some((value) => value === input)) {
+    return null;
+  }
+
+  const parser = parse ?? ((value: TInput) => value as unknown as TValue);
+  return parser(input);
+}


### PR DESCRIPTION
## Summary
- extract the `preserveLinkedValue` helper to keep linked entity selections intact when form fields are not touched
- update the experiment edition flow to rely on the helper so Facebook page and sales funnel references persist correctly
- document the guideline in the frontend AGENTS file to avoid future regressions on other screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a363e56483219075b2e1c4dad41f