### PR TITLE
Switch Instagram creative payload to instagram_user_id

### DIFF
--- a/docs/facebook-ads-worker/call-to-action-types.md
+++ b/docs/facebook-ads-worker/call-to-action-types.md
@@ -10,7 +10,7 @@ A Graph API expõe os tipos de call to action aceitos em campanhas via enumeraç
 
 > Atualização 2025-08-22: os experimentos precisam informar `instagramAccount`
 > no backend. O worker ignora CTAs de experimentos sem conta de Instagram
-> definida, garantindo que o `instagram_actor_id` enviado à Graph API seja
+> definida, garantindo que o `instagram_user_id` enviado à Graph API seja
 > sempre válido.
 
 ## Lista completa (97 valores)

--- a/docs/facebook-ads-worker/class-diagram.md
+++ b/docs/facebook-ads-worker/class-diagram.md
@@ -8,7 +8,7 @@ chamadas e o cliente usado para conversar com a Graph API do Facebook.
 > **Atualização:** Experimentos enviados pelo backend agora precisam informar o
 > campo `instagramAccount`. O `FacebookCampaignService` ignora qualquer
 > experimento sem essa associação para garantir que o criativo receba um
-> `instagram_actor_id` válido.
+> `instagram_user_id` válido.
 
 ```mermaid
 classDiagram

--- a/docs/facebook-ads-worker/endpoint-flow.md
+++ b/docs/facebook-ads-worker/endpoint-flow.md
@@ -2,7 +2,7 @@
 
 > **Atualização 2025-08-22:** os experimentos retornados pelo backend devem
 > conter `instagramAccount`. O worker ignora qualquer item sem essa associação,
-> garantindo que o criativo seja criado com um `instagram_actor_id` válido.
+> garantindo que o criativo seja criado com um `instagram_user_id` válido.
 
 Este documento detalha como o **Facebook Ads Worker** conversa com o backend do
 Marketing Hub e com a **Facebook Graph API** em dois contextos principais:
@@ -65,7 +65,7 @@ sequenceDiagram
    status `READY` (ou o primeiro da lista quando não há aprovados). Falhas nessa
    etapa impedem a criação da campanha específica, mas não interrompem o ciclo.
 5. **Resolver página, destino e mensagens** – Antes de falar com a Graph API o
-   worker calcula página do Facebook, Instagram actor ID, URL/lead form e CTA,
+   worker calcula página do Facebook, Instagram user ID, URL/lead form e CTA,
    combinando valores vindos do experimento com os defaults da conta.
 6. **Criar a hierarquia na Graph API** – A sequência de chamadas `POST` cria a
    campanha (`/campaigns`), conjunto (`/adsets`), criativo (`/adcreatives`) e
@@ -104,7 +104,7 @@ sequenceDiagram
 | --- | --- | --- | --- | --- |
 | POST | `/v23.0/act_<adAccountId>/campaigns` | `FacebookAdsService.createCampaign` | Nome, objetivo `OUTCOME_TRAFFIC`, `special_ad_categories=[]`, `status=PAUSED` | Usado tanto para campanhas Facebook quanto Instagram |
 | POST | `/v23.0/act_<adAccountId>/adsets` | `FacebookAdsService.createAdSet` | Daily budget, billing event, optimization goal, destination type, targeting por país, promoted page | Inclui `bid_strategy` e `bid_amount` quando configurados |
-| POST | `/v23.0/act_<adAccountId>/adcreatives` | `FacebookAdsService.createAdCreative` | `object_story_spec` com `page_id`, `instagram_actor_id`, mensagem, CTA, link ou lead form | CTA só envia `value` quando há URL ou formulário |
+| POST | `/v23.0/act_<adAccountId>/adcreatives` | `FacebookAdsService.createAdCreative` | `object_story_spec` com `page_id`, `instagram_user_id`, mensagem, CTA, link ou lead form | CTA só envia `value` quando há URL ou formulário |
 | POST | `/v23.0/act_<adAccountId>/ads` | `FacebookAdsService.createAd` | Nome, `adset_id`, `creative_id`, `status=PAUSED` | Mantido pausado para revisão manual |
 | GET | `/v23.0/{campaignId}/insights` | `FacebookAdsService.getCampaignMetrics` | Retorna métricas agregadas da campanha | Trata `(#190)` como token expirado |
 | GET | `/v23.0/oauth/access_token` | `FacebookAdsService.renewLongLivedToken` | Query com `grant_type=fb_exchange_token`, `client_id`, `client_secret`, `fb_exchange_token` | Logs mascaram o token e retornam `expires_in` |

--- a/docs/facebook-ads-worker/facebook-app-identifiers.md
+++ b/docs/facebook-ads-worker/facebook-app-identifiers.md
@@ -3,7 +3,7 @@
 > **Atualização 2025-08-22:** além de configurar App ID e App Secret, certifique-se
 > de que cada experimento retornado pelo backend tenha o campo
 > `instagramAccount`. O worker ignora experimentos sem essa associação para que
-> o `instagram_actor_id` enviado à Graph API seja válido.
+> o `instagram_user_id` enviado à Graph API seja válido.
 
 Este guia explica como localizar o campo obrigatório **ID do aplicativo (App ID)** na tela **Contas do Facebook**.
 

--- a/docs/facebook-ads-worker/input-output-mapping.md
+++ b/docs/facebook-ads-worker/input-output-mapping.md
@@ -2,7 +2,7 @@
 
 > **Atualização 2025-08-22:** o backend passou a enviar o campo
 > `instagramAccount` junto com cada experimento. O worker usa o código dessa
-> conta para preencher `instagram_actor_id` e ignora registros sem essa
+> conta para preencher `instagram_user_id` e ignora registros sem essa
 > informação.
 
 Este documento descreve como o **Facebook Ads Worker** converte os
@@ -89,7 +89,7 @@ flowchart TD
 | --- | --- | --- |
 | `name` | `Experiment.name` + sufixo | Nome amigável para o criativo |
 | `object_story_spec.page_id` | Conta configurada (`worker-config.defaultPageId`) ou página associada ao experimento | Página responsável pelo anúncio |
-| `object_story_spec.instagram_actor_id` | Conta configurada (`worker-config.defaultInstagramActorId`) | Opcional; usado quando há Instagram vinculado |
+| `object_story_spec.instagram_user_id` | Conta configurada (`worker-config.defaultInstagramActorId`) | Opcional; usado quando há Instagram vinculado |
 | `object_story_spec.link_data.message` | Template (`worker-config.defaultCreativeMessageTemplate`) | Substitui `%s` pelo nome do experimento |
 | `object_story_spec.link_data.link` | Conta configurada (`worker-config.defaultWebsiteUrl`) ou `Creative.destinationUrl` | O worker envia apenas quando existe URL; formulários de leads funcionam sem este campo |
 | `object_story_spec.link_data.call_to_action.type` | Conta configurada (`worker-config.defaultCallToActionType`) ou `Creative.cta` | Lista completa documentada em [call-to-action-types.md](call-to-action-types.md) |

--- a/docs/facebook-ads-worker/meta-ads-campaign-coverage.md
+++ b/docs/facebook-ads-worker/meta-ads-campaign-coverage.md
@@ -8,7 +8,7 @@ para navegar entre as entidades citadas.
 
 > **Atualização 2025-08-22:** os experimentos retornados pelo backend precisam
 > informar o campo `instagramAccount`. O worker usa esse código como
-> `instagram_actor_id` e ignora experimentos sem a associação.
+> `instagram_user_id` e ignora experimentos sem a associação.
 
 ## Visão Geral
 

--- a/docs/facebook-ads-worker/meta-ads-campaign-fields.md
+++ b/docs/facebook-ads-worker/meta-ads-campaign-fields.md
@@ -8,7 +8,7 @@ Este documento descreve todos os campos que precisam ser coletados e preenchidos
 
 > Atualização 2025-08-22: os experimentos também precisam informar
 > `instagramAccount`. Sem essa conta o worker ignora o experimento para evitar
-> criativos sem `instagram_actor_id`.
+> criativos sem `instagram_user_id`.
 
 ## 1. Configurações no nível de Campanha
 

--- a/docs/facebook-ads-worker/token-management.md
+++ b/docs/facebook-ads-worker/token-management.md
@@ -12,7 +12,7 @@ expiração automática.
 > campanha.
 >
 > Atualização 2025-08-22: vincule uma `instagramAccount` a cada experimento.
-> Sem esse relacionamento o worker não consegue definir `instagram_actor_id` e
+> Sem esse relacionamento o worker não consegue definir `instagram_user_id` e
 > deixa o experimento fora da fila até que a conta esteja configurada.
 
 ## 1. Geração inicial do token

--- a/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
+++ b/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
@@ -6,7 +6,7 @@ criativos e anúncios associados antes de registrar os dados no backend.
 
 > Atualização 2025-08-22: apenas experimentos com `instagramAccount`
 > configurada são elegíveis para transformação. O worker ignora qualquer item
-> sem esse vínculo para garantir o envio de um `instagram_actor_id` válido.
+> sem esse vínculo para garantir o envio de um `instagram_user_id` válido.
 
 A fila de trabalho usada aqui é a mesma exibida na tela "Experimentos para
 Campanha" do frontend, que lista os experimentos aprovados e prontos para serem
@@ -59,7 +59,7 @@ montar a hierarquia completa:
    A segmentação inicial utiliza apenas o país padrão enquanto o backend não
    envia dados mais ricos. O `id` retornado é usado na criação do anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L196-L208)).
 3. **Criativo**: `POST /adcreatives` baseado em um `object_story_spec` que inclui
-   `page_id`, `instagram_actor_id` opcional, template de mensagem com o nome do
+   `page_id`, `instagram_user_id` opcional, template de mensagem com o nome do
    experimento e call-to-action vindos da mesma configuração. Quando o criativo
    ou a conta informam `leadGenFormId`, o worker adiciona `call_to_action.value.lead_gen_form_id`
    e torna o campo `link` opcional, habilitando formulários instantâneos no
@@ -96,7 +96,7 @@ utilizados (`targetCountry`, `pageId`) e os metadados do criativo (`websiteUrl`,
 | `worker-config.accessToken` | `Graph API - access_token` | Token reutilizado em campanha, ad set, criativo e anúncio ([FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L18-L208)) |
 | `worker-config.adSet*` | `Graph API - adsets` e `CreateCampaignRequest.adSet` | Define orçamento, otimização e país padrão, replicados no backend ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L196-L245)) |
 | `worker-config.defaultPageId` | `Graph API - promoted_object` / `object_story_spec.page_id` / `CreateCampaignRequest.adSet.pageId` | Necessário para ad sets e criativos; caso ausente, o worker usa a página associada ao experimento e ignora o experimento quando nenhuma estiver configurada ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L177-L245)) |
-| `worker-config.defaultInstagramActorId` | `Graph API - object_story_spec.instagram_actor_id` / `CreateCampaignRequest.adCreative.instagramActorId` | Opcional, incluído apenas quando configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L209-L255)) |
+| `worker-config.defaultInstagramActorId` | `Graph API - object_story_spec.instagram_user_id` / `CreateCampaignRequest.adCreative.instagramActorId` | Opcional, incluído apenas quando configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L209-L255)) |
 | `worker-config.defaultCreativeMessageTemplate` | `Graph API - object_story_spec.link_data.message` | Template com suporte a `%s` para o nome do experimento ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L189-L193)) |
 | `worker-config.defaultWebsiteUrl` | `Graph API - link_data.link`/`call_to_action.value.link` e `CreateCampaignRequest.adCreative.websiteUrl` | URL padrão de destino persistida no backend; opcional quando há formulário configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L209-L255)) |
 | `worker-config.defaultLeadGenFormId` | `Graph API - call_to_action.value.lead_gen_form_id` e `CreateCampaignRequest.adCreative.leadGenFormId` | Fallback para formulários Instant/Lead Ads quando o criativo não define `leadGenFormId` |

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -19,7 +19,7 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    experimento no backend (exposta como `facebookPage`, `associatedFacebookPage`
    ou `facebookPageAssociation`) e ignora o experimento caso nenhuma associação
    exista. A mesma regra vale para a identidade do Instagram: o worker consome o
-   campo `instagramAccount` retornado pelo backend e popula `instagram_actor_id`
+   campo `instagramAccount` retornado pelo backend e popula `instagram_user_id`
    com o código cadastrado na conta. Caso o experimento não esteja relacionado a
    uma conta do Instagram, o worker registra o aviso e pula a publicação.
    Opcionalmente o fluxo inclui mensagem e call-to-action vindos do próprio
@@ -160,7 +160,7 @@ de [códigos de erro da Marketing API](https://developers.facebook.com/docs/mark
 para confirmar os requisitos de permissão. Quando o erro vem acompanhado do
 `error_subcode = 1815199` ("A conta de anúncios não tem acesso a esta conta do
 Instagram"), o worker tenta novamente criar o criativo sem enviar o
-`instagram_actor_id`, permitindo que a campanha prossiga apenas com o Facebook
+`instagram_user_id`, permitindo que a campanha prossiga apenas com o Facebook
 quando a conta não possui acesso ao Instagram informado pelo backend. Caso o
 Facebook ainda rejeite a requisição — seja por outras permissões ausentes ou
 por continuar exigindo o Instagram — o worker marca automaticamente o

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -154,7 +154,7 @@ public class FacebookAdsService {
         Map<String, Object> objectStorySpec = new HashMap<>();
         objectStorySpec.put("page_id", request.pageId());
         if (request.instagramActorId() != null && !request.instagramActorId().isBlank()) {
-            objectStorySpec.put("instagram_actor_id", request.instagramActorId());
+            objectStorySpec.put("instagram_user_id", request.instagramActorId());
         }
         objectStorySpec.put("link_data", linkData);
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -521,7 +521,7 @@ public class FacebookCampaignService {
             }
 
             LOGGER.warn(
-                "Retrying Facebook ad creative creation without Instagram actor ID after permission error: experimentId={}, instagramActorId={}, message={}, details={}",
+                "Retrying Facebook ad creative creation without Instagram user ID after permission error: experimentId={}, instagramActorId={}, message={}, details={}",
                 experiment.id(),
                 instagramActorId,
                 ex.getMessage(),
@@ -542,7 +542,7 @@ public class FacebookCampaignService {
 
             String creativeId = facebookAdsService.createAdCreative(adAccountId, fallbackRequest);
             LOGGER.info(
-                "Created Facebook ad creative without Instagram actor ID after permission error: experimentId={}, creativeId={}",
+                "Created Facebook ad creative without Instagram user ID after permission error: experimentId={}, creativeId={}",
                 experiment.id(),
                 creativeId
             );

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -104,7 +104,7 @@ class FacebookAdsServiceTest {
         JsonNode body = objectMapper.readTree(recorded.getBody().inputStream());
         JsonNode storySpec = body.get("object_story_spec");
         assertEquals("42", storySpec.get("page_id").asText());
-        assertEquals("11", storySpec.get("instagram_actor_id").asText());
+        assertEquals("11", storySpec.get("instagram_user_id").asText());
         JsonNode linkData = storySpec.get("link_data");
         assertEquals("https://example.com", linkData.get("link").asText());
         assertEquals("Mensagem", linkData.get("message").asText());


### PR DESCRIPTION
## Summary
- send `instagram_user_id` when creating Instagram ad creatives to match Graph API v23 expectations
- refresh Facebook Ads Worker logs and tests to reflect the new Instagram identifier field
- update Facebook Ads Worker documentation so references now point to `instagram_user_id`

## Testing
- `mvn -s settings.xml test` *(fails: unable to download parent POM because the GitHub Maven registry is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3bda50dec83219d754f9c75a5d4ae