### PR TITLE
Ensure Facebook creatives upload images before ad creation

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -13,7 +13,12 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    não se enquadram em categorias especiais.
 2. **Conjunto de anúncios** (`POST /adsets`) atrelado à campanha, também em
    `PAUSED`, com segmentação geográfica simples e destino `WEBSITE`.
-3. **Criativo** (`POST /adcreatives`) baseado em um `object_story_spec`
+3. **Upload da imagem** (`POST /adimages`) utilizando o campo `imageUrl`
+   retornado pelo backend. Quando o caminho é relativo (por exemplo,
+   `/uploads/arquivo.jpg`), o worker o normaliza para o domínio configurado em
+   `backend.base-url` antes de enviá-lo ao Facebook. O endpoint devolve o
+   `hash` utilizado para referenciar a imagem no criativo.
+4. **Criativo** (`POST /adcreatives`) baseado em um `object_story_spec`
    contendo o `page_id` definido na conta selecionada no backend. Quando a conta
    não possui `defaultPageId`, o worker utiliza a página vinculada ao
    experimento no backend (exposta como `facebookPage`, `associatedFacebookPage`
@@ -23,8 +28,11 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    com o código cadastrado na conta. Caso o experimento não esteja relacionado a
    uma conta do Instagram, o worker registra o aviso e pula a publicação.
    Opcionalmente o fluxo inclui mensagem e call-to-action vindos do próprio
-   criativo.
-4. **Anúncio** (`POST /ads`) que referencia o conjunto e o criativo recém
+   criativo. A imagem sempre é enviada via `link_data.image_hash`; caso o upload
+   falhe por motivos transitórios o worker mantém o processo, preenchendo
+   `link_data.picture` com o URL absoluto como fallback para evitar um anúncio
+   sem mídia.
+5. **Anúncio** (`POST /ads`) que referencia o conjunto e o criativo recém
    criados, mantido pausado até que o time operacional revise os detalhes no
    Gerenciador de Anúncios.
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -135,6 +135,11 @@ public class FacebookAdsService {
         if (request.description() != null && !request.description().isBlank()) {
             linkData.put("description", request.description());
         }
+        if (hasText(request.imageHash())) {
+            linkData.put("image_hash", request.imageHash());
+        } else if (hasText(request.imageUrl())) {
+            linkData.put("picture", request.imageUrl());
+        }
         if (request.callToActionType() != null && !request.callToActionType().isBlank()) {
             Map<String, Object> callToAction = new HashMap<>();
             callToAction.put("type", request.callToActionType());
@@ -167,6 +172,32 @@ public class FacebookAdsService {
 
         JsonNode response = executePost(path, body);
         return response.path("id").asText();
+    }
+
+    public String uploadAdImage(String adAccountId, String imageUrl) {
+        Objects.requireNonNull(adAccountId, "adAccountId");
+        if (!hasText(imageUrl)) {
+            throw new IllegalArgumentException("imageUrl must not be blank");
+        }
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("url", imageUrl);
+        body.put("access_token", requireAccessToken());
+
+        String path = buildVersionedPath("/act_" + adAccountId + "/adimages");
+        JsonNode response = executePost(path, body);
+        JsonNode imagesNode = response.path("images");
+        if (imagesNode.isMissingNode() || imagesNode.isNull()) {
+            throw new IllegalStateException("Facebook did not return any image hash");
+        }
+
+        for (JsonNode value : imagesNode) {
+            String hash = value.path("hash").asText(null);
+            if (hasText(hash)) {
+                return hash;
+            }
+        }
+        throw new IllegalStateException("Facebook image upload response did not contain a hash");
     }
 
     public String createAd(String adAccountId, AdRequest request) {
@@ -576,6 +607,8 @@ public class FacebookAdsService {
         String websiteUrl,
         String leadGenFormId,
         String message,
+        String imageHash,
+        String imageUrl,
         String callToActionType,
         String headline,
         String description

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -228,6 +228,7 @@ public class FacebookCampaignService {
                 config.adSetTargetCountry()
             );
             String adSetId = facebookAdsService.createAdSet(config.adAccountId(), adSetRequest);
+            String resolvedImageUrl = resolveCreativeImageUrl(creative.imageUrl());
             AdCreativeCreation adCreativeCreation = createAdCreativeWithFallback(
                 config.adAccountId(),
                 exp,
@@ -238,7 +239,8 @@ public class FacebookCampaignService {
                 resolvedMessage,
                 resolvedCallToAction,
                 creative.headline(),
-                creative.description()
+                creative.description(),
+                resolvedImageUrl
             );
             FacebookAdsService.AdCreativeRequest adCreativeRequest = adCreativeCreation.request();
             String creativeId = adCreativeCreation.id();
@@ -276,6 +278,8 @@ public class FacebookCampaignService {
                     adCreativeRequest.websiteUrl(),
                     adCreativeRequest.leadGenFormId(),
                     adCreativeRequest.message(),
+                    adCreativeRequest.imageHash(),
+                    adCreativeRequest.imageUrl(),
                     adCreativeRequest.callToActionType(),
                     adCreativeRequest.headline(),
                     adCreativeRequest.description()
@@ -430,6 +434,8 @@ public class FacebookCampaignService {
             String websiteUrl,
             String leadGenFormId,
             String message,
+            String imageHash,
+            String imageUrl,
             String callToActionType,
             String headline,
             String description
@@ -498,8 +504,30 @@ public class FacebookCampaignService {
         String message,
         String callToAction,
         String headline,
-        String description
+        String description,
+        String imageUrl
     ) {
+        String imageHash = null;
+        if (StringUtils.hasText(imageUrl)) {
+            try {
+                imageHash = facebookAdsService.uploadAdImage(adAccountId, imageUrl);
+            } catch (FacebookAccessTokenExpiredException | FacebookPermissionException ex) {
+                throw ex;
+            } catch (RuntimeException ex) {
+                LOGGER.warn(
+                    "Could not upload creative image to Facebook; continuing without hash: experimentId={}, imageUrl={}, message={}",
+                    experiment.id(),
+                    imageUrl,
+                    ex.getMessage()
+                );
+                LOGGER.debug(
+                    "Stacktrace while uploading creative image for experiment {}",
+                    experiment.id(),
+                    ex
+                );
+            }
+        }
+
         FacebookAdsService.AdCreativeRequest primaryRequest = new FacebookAdsService.AdCreativeRequest(
             experiment.name() + " - Creative",
             pageId,
@@ -507,6 +535,8 @@ public class FacebookCampaignService {
             websiteUrl,
             leadGenFormId,
             message,
+            imageHash,
+            imageUrl,
             callToAction,
             headline,
             description
@@ -535,6 +565,8 @@ public class FacebookCampaignService {
                 websiteUrl,
                 leadGenFormId,
                 message,
+                imageHash,
+                imageUrl,
                 callToAction,
                 headline,
                 description
@@ -606,6 +638,19 @@ public class FacebookCampaignService {
     }
 
     private record AdCreativeCreation(String id, FacebookAdsService.AdCreativeRequest request) {}
+
+    private String resolveCreativeImageUrl(String imageUrl) {
+        if (!StringUtils.hasText(imageUrl)) {
+            return null;
+        }
+        String trimmed = imageUrl.trim();
+        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+            return trimmed;
+        }
+        String base = backendBaseUrl.endsWith("/") ? backendBaseUrl.substring(0, backendBaseUrl.length() - 1) : backendBaseUrl;
+        String path = trimmed.startsWith("/") ? trimmed : "/" + trimmed;
+        return base + path;
+    }
 
     private void logAutomaticRenewalOutcome(FacebookAccessTokenManager.RenewalAttemptResult renewalResult) {
         if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.NOT_CONFIGURED) {

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -94,6 +94,8 @@ class FacebookAdsServiceTest {
             "https://example.com",
             null,
             "Mensagem",
+            "hash-123",
+            "https://cdn.example/img.jpg",
             "LEARN_MORE",
             "Headline",
             "Descrição"
@@ -110,6 +112,7 @@ class FacebookAdsServiceTest {
         assertEquals("Mensagem", linkData.get("message").asText());
         assertEquals("Headline", linkData.get("name").asText());
         assertEquals("Descrição", linkData.get("description").asText());
+        assertEquals("hash-123", linkData.get("image_hash").asText());
         assertEquals("LEARN_MORE", linkData.get("call_to_action").get("type").asText());
         assertEquals("https://example.com", linkData.get("call_to_action").get("value").get("link").asText());
         assertEquals("333", id);
@@ -126,6 +129,8 @@ class FacebookAdsServiceTest {
             null,
             "123456789012345",
             "Mensagem",
+            null,
+            null,
             "SIGN_UP",
             null,
             null
@@ -137,6 +142,48 @@ class FacebookAdsServiceTest {
         assertEquals("SIGN_UP", callToAction.get("type").asText());
         assertEquals("123456789012345", callToAction.get("value").get("lead_gen_form_id").asText());
         assertEquals("999", id);
+    }
+
+    @Test
+    void createAdCreativeFallsBackToPictureWhenHashMissing() throws Exception {
+        server.enqueue(new MockResponse().setBody("{\"id\":\"777\"}")
+            .addHeader("Content-Type", "application/json"));
+        FacebookAdsService.AdCreativeRequest request = new FacebookAdsService.AdCreativeRequest(
+            "Camp - Creative",
+            "42",
+            null,
+            "https://example.com",
+            null,
+            "Mensagem",
+            null,
+            "https://cdn.example/img.jpg",
+            "LEARN_MORE",
+            null,
+            null
+        );
+
+        service.createAdCreative("1", request);
+
+        RecordedRequest recorded = server.takeRequest();
+        JsonNode linkData = objectMapper
+            .readTree(recorded.getBody().inputStream())
+            .get("object_story_spec")
+            .get("link_data");
+        assertEquals("https://cdn.example/img.jpg", linkData.get("picture").asText());
+    }
+
+    @Test
+    void uploadAdImageReturnsFirstHash() throws Exception {
+        server.enqueue(new MockResponse().setBody("{\"images\":{\"image1\":{\"hash\":\"abc\"}}}")
+            .addHeader("Content-Type", "application/json"));
+
+        String hash = service.uploadAdImage("1", "https://cdn.example/img.jpg");
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("/v23.0/act_1/adimages", request.getPath());
+        JsonNode body = objectMapper.readTree(request.getBody().inputStream());
+        assertEquals("https://cdn.example/img.jpg", body.get("url").asText());
+        assertEquals("abc", hash);
     }
 
     @Test

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -98,6 +98,8 @@ class FacebookCampaignServiceTest {
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"20\"}")
             .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"images\":{\"image1\":{\"hash\":\"hash-xyz\"}}}")
+            .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"30\"}")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"40\"}")
@@ -129,6 +131,11 @@ class FacebookCampaignServiceTest {
         assertEquals("WEBSITE", adSetPayload.get("destination_type").asText());
         assertEquals("42", adSetPayload.get("promoted_object").get("page_id").asText());
 
+        RecordedRequest postImage = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/adimages", postImage.getPath());
+        JsonNode imagePayload = objectMapper.readTree(postImage.getBody().inputStream());
+        assertEquals("https://cdn.example/img.jpg", imagePayload.get("url").asText());
+
         RecordedRequest postCreative = facebook.takeRequest();
         assertEquals("/v23.0/act_1/adcreatives", postCreative.getPath());
         JsonNode creativePayload = objectMapper.readTree(postCreative.getBody().inputStream());
@@ -141,6 +148,7 @@ class FacebookCampaignServiceTest {
         assertEquals("SHOP_NOW", linkData.get("call_to_action").get("type").asText());
         assertEquals("HL", linkData.get("name").asText());
         assertEquals("Desc", linkData.get("description").asText());
+        assertEquals("hash-xyz", linkData.get("image_hash").asText());
 
         RecordedRequest postAd = facebook.takeRequest();
         assertEquals("/v23.0/act_1/ads", postAd.getPath());
@@ -181,6 +189,8 @@ class FacebookCampaignServiceTest {
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"20\"}")
             .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"images\":{\"image1\":{\"hash\":\"hash-lead\"}}}")
+            .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"30\"}")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"40\"}")
@@ -197,12 +207,16 @@ class FacebookCampaignServiceTest {
         JsonNode adSetPayload = objectMapper.readTree(adSetRequest.getBody().inputStream());
         assertEquals("LEAD_GENERATION", adSetPayload.get("destination_type").asText());
 
+        RecordedRequest imageRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/adimages", imageRequest.getPath());
+
         RecordedRequest creativeRequest = facebook.takeRequest();
         JsonNode creativePayload = objectMapper.readTree(creativeRequest.getBody().inputStream());
         JsonNode linkData = creativePayload.get("object_story_spec").get("link_data");
         JsonNode cta = linkData.get("call_to_action");
         assertEquals("SIGN_UP", cta.get("type").asText());
         assertEquals("321123321123321", cta.get("value").get("lead_gen_form_id").asText());
+        assertEquals("hash-lead", linkData.get("image_hash").asText());
 
         backend.takeRequest(); // experiments-ready
         backend.takeRequest(); // creatives fetch
@@ -372,6 +386,8 @@ class FacebookCampaignServiceTest {
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"20\"}")
             .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"images\":{\"image1\":{\"hash\":\"hash-renew\"}}}")
+            .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"30\"}")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"40\"}")
@@ -402,6 +418,8 @@ class FacebookCampaignServiceTest {
 
         RecordedRequest adSetRequest = facebook.takeRequest();
         assertEquals("/v23.0/act_1/adsets", adSetRequest.getPath());
+        RecordedRequest imageRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/adimages", imageRequest.getPath());
         RecordedRequest creativeRequest = facebook.takeRequest();
         assertEquals("/v23.0/act_1/adcreatives", creativeRequest.getPath());
         RecordedRequest adRequest = facebook.takeRequest();
@@ -456,6 +474,8 @@ class FacebookCampaignServiceTest {
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"20\"}")
             .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"images\":{\"image1\":{\"hash\":\"hash-renew-backend\"}}}")
+            .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"30\"}")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"40\"}")
@@ -482,7 +502,10 @@ class FacebookCampaignServiceTest {
         JsonNode renewedPayload = objectMapper.readTree(renewedCampaign.getBody().inputStream());
         assertEquals("renewed-by-backend", renewedPayload.get("access_token").asText());
 
-        facebook.takeRequest(); // ad set
+        RecordedRequest adSetRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/adsets", adSetRequest.getPath());
+        RecordedRequest imageRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/adimages", imageRequest.getPath());
         facebook.takeRequest(); // creative
         facebook.takeRequest(); // ad
 
@@ -500,6 +523,8 @@ class FacebookCampaignServiceTest {
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"20\"}")
             .addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"images\":{\"image1\":{\"hash\":\"hash-fallback\"}}}")
+            .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"30\"}")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"40\"}")
@@ -515,6 +540,9 @@ class FacebookCampaignServiceTest {
         RecordedRequest adSetRequest = facebook.takeRequest();
         JsonNode adSetPayload = objectMapper.readTree(adSetRequest.getBody().inputStream());
         assertEquals("84", adSetPayload.get("promoted_object").get("page_id").asText());
+
+        RecordedRequest imageRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/adimages", imageRequest.getPath());
 
         RecordedRequest creativeRequest = facebook.takeRequest();
         JsonNode creativePayload = objectMapper.readTree(creativeRequest.getBody().inputStream());
@@ -532,6 +560,7 @@ class FacebookCampaignServiceTest {
         );
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"10\"}").addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"20\"}").addHeader("Content-Type", "application/json"));
+        facebook.enqueue(new MockResponse().setBody("{\"images\":{\"image1\":{\"hash\":\"hash-associated\"}}}").addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"30\"}").addHeader("Content-Type", "application/json"));
         facebook.enqueue(new MockResponse().setBody("{\"id\":\"40\"}").addHeader("Content-Type", "application/json"));
         backend.enqueue(
@@ -549,6 +578,9 @@ class FacebookCampaignServiceTest {
         RecordedRequest adSetRequest = facebook.takeRequest();
         JsonNode adSetPayload = objectMapper.readTree(adSetRequest.getBody().inputStream());
         assertEquals("84", adSetPayload.get("promoted_object").get("page_id").asText());
+
+        RecordedRequest imageRequest = facebook.takeRequest();
+        assertEquals("/v23.0/act_1/adimages", imageRequest.getPath());
 
         RecordedRequest creativeRequest = facebook.takeRequest();
         JsonNode creativePayload = objectMapper.readTree(creativeRequest.getBody().inputStream());


### PR DESCRIPTION
## Summary
- upload creative assets to Facebook via /adimages and include the returned image hash when creating ad creatives
- fall back to using the absolute image URL when the image upload fails temporarily and persist the hash/url in backend reporting
- document the new image upload step and extend unit tests for both the Facebook API client and campaign flow

## Testing
- `mvn -s settings.xml test` *(fails: Network is unreachable while downloading parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68e47beffa108321ad4ed1829b24cfa1