### PR TITLE
feat: add journeys management experience

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyMetricsResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyMetricsResponse.java
@@ -1,0 +1,14 @@
+package com.marketinghub.journey.dto;
+
+import com.marketinghub.journey.model.JourneyStatus;
+
+import java.util.Map;
+
+/**
+ * Aggregated metrics for journey instances exposed via the API.
+ */
+public record JourneyMetricsResponse(
+        long totalJourneys,
+        Map<JourneyStatus, Long> statusBreakdown
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/repository/JourneyRepository.java
@@ -15,4 +15,6 @@ public interface JourneyRepository extends JpaRepository<Journey, Long> {
     Page<Journey> findByStatus(JourneyStatus status, Pageable pageable);
 
     Page<Journey> findByTemplateIdAndStatus(Long templateId, JourneyStatus status, Pageable pageable);
+
+    long countByStatus(JourneyStatus status);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyService.java
@@ -2,6 +2,7 @@ package com.marketinghub.journey.service;
 
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.journey.dto.JourneyMetricsResponse;
 import com.marketinghub.journey.dto.JourneyRequest;
 import com.marketinghub.journey.dto.JourneyUpdateRequest;
 import com.marketinghub.journey.model.Journey;
@@ -18,9 +19,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Application service orchestrating journey lifecycle operations.
@@ -54,6 +57,17 @@ public class JourneyService {
             return journeyRepository.findByStatus(status, pageable);
         }
         return journeyRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public JourneyMetricsResponse metrics() {
+        long totalJourneys = journeyRepository.count();
+        Map<JourneyStatus, Long> statusBreakdown = Arrays.stream(JourneyStatus.values())
+                .collect(Collectors.toMap(status -> status,
+                        journeyRepository::countByStatus,
+                        (left, right) -> left,
+                        LinkedHashMap::new));
+        return new JourneyMetricsResponse(totalJourneys, statusBreakdown);
     }
 
     @Transactional(readOnly = true)

--- a/backend/ads-service/src/main/java/com/marketinghub/journey/web/JourneyController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/journey/web/JourneyController.java
@@ -1,5 +1,6 @@
 package com.marketinghub.journey.web;
 
+import com.marketinghub.journey.dto.JourneyMetricsResponse;
 import com.marketinghub.journey.dto.JourneyRequest;
 import com.marketinghub.journey.dto.JourneyResponse;
 import com.marketinghub.journey.dto.JourneyUpdateRequest;
@@ -33,6 +34,11 @@ public class JourneyController {
                                       @RequestParam(value = "status", required = false) JourneyStatus status,
                                       @PageableDefault(size = 20) Pageable pageable) {
         return journeyService.list(templateId, status, pageable).map(mapper::toJourneyResponse);
+    }
+
+    @GetMapping("/metrics")
+    public JourneyMetricsResponse metrics() {
+        return journeyService.metrics();
     }
 
     @PostMapping

--- a/backend/ads-service/src/test/java/com/marketinghub/journey/JourneyServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/JourneyServiceTest.java
@@ -1,0 +1,65 @@
+package com.marketinghub.journey;
+
+import com.marketinghub.journey.dto.JourneyMetricsResponse;
+import com.marketinghub.journey.model.Journey;
+import com.marketinghub.journey.model.JourneyStatus;
+import com.marketinghub.journey.model.JourneyTemplate;
+import com.marketinghub.journey.repository.JourneyRepository;
+import com.marketinghub.journey.repository.JourneyTemplateRepository;
+import com.marketinghub.journey.service.JourneyService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class JourneyServiceTest {
+
+    @Autowired
+    private JourneyService journeyService;
+
+    @Autowired
+    private JourneyRepository journeyRepository;
+
+    @Autowired
+    private JourneyTemplateRepository journeyTemplateRepository;
+
+    @Test
+    void metricsAggregatesCountsPerStatus() {
+        JourneyTemplate template = journeyTemplateRepository.save(JourneyTemplate.builder()
+                .name("Onboarding Experience")
+                .build());
+
+        journeyRepository.save(Journey.builder()
+                .template(template)
+                .name("Warm-up")
+                .status(JourneyStatus.DRAFT)
+                .build());
+
+        journeyRepository.save(Journey.builder()
+                .template(template)
+                .name("Activation")
+                .status(JourneyStatus.ACTIVE)
+                .build());
+
+        journeyRepository.save(Journey.builder()
+                .template(template)
+                .name("Re-engagement")
+                .status(JourneyStatus.PAUSED)
+                .build());
+
+        JourneyMetricsResponse metrics = journeyService.metrics();
+
+        assertThat(metrics.totalJourneys()).isEqualTo(3);
+        assertThat(metrics.statusBreakdown())
+                .containsEntry(JourneyStatus.ACTIVE, 1L)
+                .containsEntry(JourneyStatus.DRAFT, 1L)
+                .containsEntry(JourneyStatus.PAUSED, 1L);
+        for (JourneyStatus status : JourneyStatus.values()) {
+            assertThat(metrics.statusBreakdown()).containsKey(status);
+        }
+    }
+}

--- a/docs/journeys/orquestracao-jornadas.md
+++ b/docs/journeys/orquestracao-jornadas.md
@@ -29,9 +29,15 @@ Sobre esses modelos atua um motor de execução que avalia condições, respeita
 
 ## APIs expostas
 * **Templates de jornada** — CRUD completo em `/api/journey-templates` para blueprinting e manutenção de passos.【F:docs/openapi.yaml†L377-L606】
-* **Jornadas operacionais** — CRUD em `/api/journeys`, filtragem por template/status e vinculação a nichos/experimentos.【F:docs/openapi.yaml†L604-L724】
+* **Jornadas operacionais** — CRUD em `/api/journeys`, filtragem por template/status, métricas agregadas em `/api/journeys/metrics` e vinculação a nichos/experimentos.【F:docs/openapi.yaml†L604-L724】【F:docs/openapi.yaml†L724-L732】
 * **Atribuições** — Paginação e criação em lote de vínculos via `/api/journeys/{id}/assignments`, aceitando leads, segmentos e contexto serializado.【F:docs/openapi.yaml†L725-L806】【F:backend/ads-service/src/main/java/com/marketinghub/journey/dto/JourneyAssignmentRequest.java†L11-L18】
 * **Eventos multicanal** — Ingestão unificada em `/api/events`, validando jornada/passo e persistindo com `occurredAt` customizável.【F:docs/openapi.yaml†L808-L836】【F:backend/ads-service/src/main/java/com/marketinghub/journey/service/EventLogService.java†L40-L84】
+
+## Experiência no Marketing Hub
+* A nova navegação lateral traz o item "Jornadas" com acesso direto à visão geral, criação rápida e templates, reforçando a descoberta das funcionalidades de orquestração.【F:frontend/src/components/MainNavigation.tsx†L34-L118】
+* A lista de jornadas exibe cards responsivos com filtros por template/status, busca textual e indicadores de saúde (totais por status) consumindo o endpoint `/api/journeys/metrics`, além de atalhos para detalhamento, edição e remoção.【F:frontend/src/pages/journey/JourneyListPage.tsx†L1-L260】【F:frontend/src/pages/journey/JourneyListPage.css†L1-L167】
+* A tela de detalhes organiza timeline, metadados e contexto de segmentação em painéis visuais, com atalhos para edição e exclusão segura via modal de confirmação.【F:frontend/src/pages/journey/JourneyDetailPage.tsx†L1-L248】【F:frontend/src/pages/journey/JourneyDetailPage.css†L1-L168】
+* O formulário reutilizável de criação/edição possui validação, edição dinâmica de metadados e seleção assistida de nichos, experimentos e templates, entregando feedback imediato de carregamento/sucesso.【F:frontend/src/pages/journey/JourneyForm.tsx†L1-L330】【F:frontend/src/api/journey/useCreateJourney.ts†L1-L55】【F:frontend/src/api/journey/useUpdateJourney.ts†L1-L55】
 
 ## Tratamento de vínculos (assignments)
 * Atribuições podem ser criadas para leads individuais (verificação de existência) ou identificadores de segmento externos.【F:backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyAssignmentService.java†L49-L121】

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -659,6 +659,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemResponse'
+  /api/journeys/metrics:
+    get:
+      tags: [Journeys]
+      summary: Obter métricas agregadas das jornadas
+      responses:
+        '200':
+          description: Métricas consolidadas das jornadas
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JourneyMetrics'
   /api/journeys/{id}:
     get:
       tags: [Journeys]
@@ -1351,6 +1362,16 @@ components:
         updatedAt:
           type: string
           format: date-time
+    JourneyMetrics:
+      type: object
+      description: Métricas agregadas das jornadas operacionais.
+      properties:
+        totalJourneys:
+          type: integer
+        statusBreakdown:
+          type: object
+          additionalProperties:
+            type: integer
     JourneyAssignmentRequest:
       type: object
       properties:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,11 @@ import PromptEntitiesPage from "./pages/prompt/PromptEntitiesPage";
 import PromptAttributesPage from "./pages/prompt/PromptAttributesPage";
 import NewPromptEntityPage from "./pages/prompt/NewPromptEntityPage";
 import PromptEntityDescriptionPage from "./pages/prompt/PromptEntityDescriptionPage";
+import JourneyListPage from "./pages/journey/JourneyListPage";
+import JourneyDetailPage from "./pages/journey/JourneyDetailPage";
+import NewJourneyPage from "./pages/journey/NewJourneyPage";
+import EditJourneyPage from "./pages/journey/EditJourneyPage";
+import JourneyTemplatesPage from "./pages/journey/JourneyTemplatesPage";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import MainNavigation from "./components/MainNavigation";
@@ -167,6 +172,17 @@ export default function App() {
               <Route
                 path="/facebook-campaigns/ready"
                 element={<FacebookExperimentsReadyPage />}
+              />
+              <Route path="/journeys" element={<JourneyListPage />} />
+              <Route path="/journeys/new" element={<NewJourneyPage />} />
+              <Route path="/journeys/:id" element={<JourneyDetailPage />} />
+              <Route
+                path="/journeys/:id/edit"
+                element={<EditJourneyPage />}
+              />
+              <Route
+                path="/journey-templates"
+                element={<JourneyTemplatesPage />}
               />
               <Route path="*" element={<div>Início</div>} />
             </Routes>

--- a/frontend/src/api/journey/types.ts
+++ b/frontend/src/api/journey/types.ts
@@ -1,0 +1,65 @@
+export type JourneyStatus =
+  | "DRAFT"
+  | "ACTIVE"
+  | "PAUSED"
+  | "COMPLETED"
+  | "ARCHIVED";
+
+export interface Journey {
+  id: number;
+  templateId: number;
+  templateName: string;
+  name: string;
+  description?: string | null;
+  status: JourneyStatus;
+  marketNicheId?: number | null;
+  experimentId?: number | null;
+  segmentReference?: string | null;
+  segmentFilter?: string | null;
+  metadata: Record<string, string>;
+  startAt?: string | null;
+  endAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JourneyRequestPayload {
+  templateId: number;
+  name: string;
+  description?: string;
+  status?: JourneyStatus;
+  marketNicheId?: number;
+  experimentId?: number;
+  segmentReference?: string;
+  segmentFilter?: string;
+  startAt?: string | null;
+  endAt?: string | null;
+  metadata?: Record<string, string>;
+}
+
+export type JourneyUpdatePayload = Partial<JourneyRequestPayload>;
+
+export interface JourneyTemplateSummary {
+  id: number;
+  name: string;
+  objective?: string | null;
+  phases: string[];
+  preferredChannel?: string | null;
+  tags: string[];
+  metadata: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size?: number;
+}
+
+export interface JourneyMetrics {
+  totalJourneys: number;
+  statusBreakdown: Partial<Record<JourneyStatus, number>>;
+}

--- a/frontend/src/api/journey/useCreateJourney.ts
+++ b/frontend/src/api/journey/useCreateJourney.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { toast } from "react-toastify";
+import type { Journey, JourneyRequestPayload } from "./types";
+
+export function useCreateJourney() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: JourneyRequestPayload) => {
+      const { data } = await axios.post<Journey>("/api/journeys", payload);
+      return data;
+    },
+    onSuccess: (journey) => {
+      queryClient.invalidateQueries({ queryKey: ["journeys"] });
+      queryClient.invalidateQueries({ queryKey: ["journeys", "metrics"] });
+      toast.success(`Jornada "${journey.name}" criada com sucesso.`);
+    },
+    onError: () => {
+      toast.error("Não foi possível criar a jornada.");
+    },
+  });
+}

--- a/frontend/src/api/journey/useDeleteJourney.ts
+++ b/frontend/src/api/journey/useDeleteJourney.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { toast } from "react-toastify";
+
+export function useDeleteJourney(id: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      await axios.delete(`/api/journeys/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["journeys"] });
+      queryClient.invalidateQueries({ queryKey: ["journeys", "metrics"] });
+      toast.success("Jornada removida.");
+    },
+    onError: () => {
+      toast.error("Não foi possível remover a jornada.");
+    },
+  });
+}

--- a/frontend/src/api/journey/useJourney.ts
+++ b/frontend/src/api/journey/useJourney.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { Journey } from "./types";
+
+export function useJourney(id?: number) {
+  return useQuery({
+    queryKey: ["journeys", id],
+    enabled: typeof id === "number" && id > 0,
+    queryFn: async () => {
+      const { data } = await axios.get<Journey>(`/api/journeys/${id}`);
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/journey/useJourneyMetrics.ts
+++ b/frontend/src/api/journey/useJourneyMetrics.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { JourneyMetrics } from "./types";
+
+export function useJourneyMetrics() {
+  return useQuery({
+    queryKey: ["journeys", "metrics"],
+    queryFn: async () => {
+      const { data } = await axios.get<JourneyMetrics>("/api/journeys/metrics");
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/journey/useJourneyTemplates.ts
+++ b/frontend/src/api/journey/useJourneyTemplates.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type {
+  JourneyTemplateSummary,
+  PageResponse,
+} from "./types";
+
+export interface JourneyTemplateFilters {
+  page?: number;
+  size?: number;
+}
+
+export function useJourneyTemplates(filters: JourneyTemplateFilters = {}) {
+  const { page = 0, size = 100 } = filters;
+
+  return useQuery<PageResponse<JourneyTemplateSummary>>({
+    queryKey: ["journey-templates", page, size],
+    queryFn: async () => {
+      const { data } = await axios.get<PageResponse<JourneyTemplateSummary>>(
+        "/api/journey-templates",
+        {
+          params: { page, size },
+        },
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/journey/useJourneys.ts
+++ b/frontend/src/api/journey/useJourneys.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type {
+  Journey,
+  JourneyStatus,
+  PageResponse,
+} from "./types";
+
+export interface JourneyFilters {
+  page?: number;
+  size?: number;
+  templateId?: number;
+  status?: JourneyStatus;
+}
+
+export function useJourneys(filters: JourneyFilters = {}) {
+  const { page = 0, size = 12, templateId, status } = filters;
+
+  return useQuery<PageResponse<Journey>>({
+    queryKey: ["journeys", page, size, templateId ?? null, status ?? null],
+    queryFn: async () => {
+      const params: Record<string, unknown> = { page, size };
+      if (templateId) {
+        params.templateId = templateId;
+      }
+      if (status) {
+        params.status = status;
+      }
+      const { data } = await axios.get<PageResponse<Journey>>("/api/journeys", {
+        params,
+      });
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/journey/useUpdateJourney.ts
+++ b/frontend/src/api/journey/useUpdateJourney.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { toast } from "react-toastify";
+import type { Journey, JourneyUpdatePayload } from "./types";
+
+export function useUpdateJourney(id: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: JourneyUpdatePayload) => {
+      const { data } = await axios.patch<Journey>(`/api/journeys/${id}`, payload);
+      return data;
+    },
+    onSuccess: (journey) => {
+      queryClient.invalidateQueries({ queryKey: ["journeys"] });
+      queryClient.invalidateQueries({ queryKey: ["journeys", "metrics"] });
+      queryClient.invalidateQueries({ queryKey: ["journeys", id] });
+      toast.success(`Jornada "${journey.name}" atualizada.`);
+    },
+    onError: () => {
+      toast.error("Não foi possível atualizar a jornada.");
+    },
+  });
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -15,6 +15,9 @@ import {
   Package,
   PanelLeftClose,
   PanelLeftOpen,
+  Layers,
+  Map,
+  PlusCircle,
   Shapes,
   Sparkles,
   Trophy,
@@ -115,6 +118,34 @@ const NAV_SECTIONS: NavSection[] = [
         icon: ClipboardCheck,
       },
       { to: "/analytics", label: "Analytics", icon: BarChart3 },
+    ],
+  },
+  {
+    title: "Jornadas",
+    items: [
+      {
+        to: "/journeys",
+        label: "Jornadas",
+        icon: Map,
+        children: [
+          {
+            to: "/journeys",
+            label: "Visão geral",
+            icon: Compass,
+            end: true,
+          },
+          {
+            to: "/journeys/new",
+            label: "Nova jornada",
+            icon: PlusCircle,
+          },
+          {
+            to: "/journey-templates",
+            label: "Templates",
+            icon: Layers,
+          },
+        ],
+      },
     ],
   },
 ];

--- a/frontend/src/pages/journey/EditJourneyPage.tsx
+++ b/frontend/src/pages/journey/EditJourneyPage.tsx
@@ -1,0 +1,57 @@
+import { Link, useNavigate, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import JourneyForm from "./JourneyForm";
+import { useJourney } from "../../api/journey/useJourney";
+import { useUpdateJourney } from "../../api/journey/useUpdateJourney";
+import type { JourneyRequestPayload } from "../../api/journey/types";
+import "./JourneyPageShell.css";
+import "./JourneyDetailPage.css";
+
+export default function EditJourneyPage() {
+  const params = useParams<{ id: string }>();
+  const journeyId = Number(params.id);
+  const navigate = useNavigate();
+  const { data: journey, isLoading } = useJourney(Number.isNaN(journeyId) ? undefined : journeyId);
+  const updateJourney = useUpdateJourney(journeyId);
+
+  const handleSubmit = (payload: JourneyRequestPayload) => {
+    updateJourney.mutate(payload, {
+      onSuccess: () => {
+        navigate(`/journeys/${journeyId}`);
+      },
+    });
+  };
+
+  if (isLoading) {
+    return <div className="journey-detail__loading">Carregando jornada...</div>;
+  }
+
+  if (!journey) {
+    return (
+      <div className="journey-detail__loading">
+        Jornada não encontrada.
+        <div>
+          <Link to="/journeys" className="btn btn-link">
+            Voltar para jornadas
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="journey-page-shell">
+      <header className="journey-page-shell__header">
+        <PageTitle>Editar jornada</PageTitle>
+        <p>Atualize metas, metadados e segmentação para manter a jornada alinhada ao plano atual.</p>
+      </header>
+      <JourneyForm
+        initialJourney={journey}
+        submitLabel="Salvar alterações"
+        onSubmit={handleSubmit}
+        isSubmitting={updateJourney.isPending}
+        onCancel={() => navigate(`/journeys/${journeyId}`)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/journey/JourneyDetailPage.css
+++ b/frontend/src/pages/journey/JourneyDetailPage.css
@@ -1,0 +1,189 @@
+.journey-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.journey-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  background: linear-gradient(120deg, #0f172a, #1e3a8a);
+  color: #e2e8f0;
+  padding: 2rem;
+  border-radius: 20px;
+  box-shadow: 0 22px 44px rgba(15, 23, 42, 0.4);
+}
+
+.journey-detail__subtitle {
+  margin: 0.75rem 0 0;
+  color: rgba(226, 232, 240, 0.85);
+  max-width: 560px;
+}
+
+.journey-detail__status {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 1rem;
+}
+
+.journey-detail__status-meta {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.journey-detail__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.journey-detail__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.journey-detail__card {
+  background: #ffffff;
+  border-radius: 18px;
+  border: 1px solid #e2e8f0;
+  padding: 1.75rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+}
+
+.journey-detail__card h2 {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.journey-detail__card dl {
+  display: grid;
+  gap: 1rem;
+}
+
+.journey-detail__card dl div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.journey-detail__card dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.journey-detail__card dd {
+  margin: 0;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.journey-detail__arrow {
+  margin: 0 0.4rem;
+  color: #94a3b8;
+}
+
+.journey-detail__card--full {
+  grid-column: 1 / -1;
+}
+
+.journey-detail__metadata {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.journey-detail__metadata li {
+  background: #f8fafc;
+  border-radius: 14px;
+  padding: 1rem;
+  border: 1px solid #e2e8f0;
+}
+
+.journey-detail__metadata-key {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+  margin-bottom: 0.35rem;
+}
+
+.journey-detail__metadata-value {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.journey-detail__empty {
+  color: #64748b;
+  margin: 0;
+}
+
+.journey-detail__loading {
+  background: #f8fafc;
+  border-radius: 16px;
+  border: 2px dashed #cbd5f5;
+  padding: 2rem;
+  text-align: center;
+  color: #475569;
+}
+
+.journey-detail__modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 1000;
+}
+
+.journey-detail__modal-content {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 2rem;
+  max-width: 420px;
+  width: 100%;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
+}
+
+.journey-detail__modal-content h3 {
+  margin-top: 0;
+  font-size: 1.25rem;
+  color: #0f172a;
+}
+
+.journey-detail__modal-content p {
+  color: #475569;
+  margin: 1rem 0 2rem;
+}
+
+.journey-detail__modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .journey-detail__header {
+    flex-direction: column;
+  }
+
+  .journey-detail__actions {
+    width: 100%;
+  }
+
+  .journey-detail__modal {
+    padding: 1.5rem;
+  }
+}

--- a/frontend/src/pages/journey/JourneyDetailPage.tsx
+++ b/frontend/src/pages/journey/JourneyDetailPage.tsx
@@ -1,0 +1,202 @@
+import { useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useJourney } from "../../api/journey/useJourney";
+import JourneyStatusBadge from "./JourneyStatusBadge";
+import { useDeleteJourney } from "../../api/journey/useDeleteJourney";
+import "./JourneyDetailPage.css";
+
+function formatDateTime(value?: string | null) {
+  if (!value) {
+    return "—";
+  }
+  try {
+    return new Intl.DateTimeFormat("pt-BR", {
+      dateStyle: "long",
+      timeStyle: "short",
+    }).format(new Date(value));
+  } catch (error) {
+    return value;
+  }
+}
+
+export default function JourneyDetailPage() {
+  const params = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const journeyId = Number(params.id);
+  const { data: journey, isLoading } = useJourney(Number.isNaN(journeyId) ? undefined : journeyId);
+  const deleteJourney = useDeleteJourney(journeyId);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const metadataEntries = useMemo(
+    () => Object.entries(journey?.metadata ?? {}),
+    [journey?.metadata],
+  );
+
+  if (isLoading) {
+    return <div className="journey-detail__loading">Carregando jornada...</div>;
+  }
+
+  if (!journey) {
+    return (
+      <div className="journey-detail__loading">
+        Jornada não encontrada.
+        <div>
+          <Link to="/journeys" className="btn btn-link">
+            Voltar para jornadas
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const handleDelete = async () => {
+    await deleteJourney.mutateAsync();
+    navigate("/journeys");
+  };
+
+  return (
+    <div className="journey-detail">
+      <header className="journey-detail__header">
+        <div>
+          <PageTitle>{journey.name}</PageTitle>
+          {journey.description ? (
+            <p className="journey-detail__subtitle">{journey.description}</p>
+          ) : null}
+          <div className="journey-detail__status">
+            <JourneyStatusBadge status={journey.status} />
+            <span className="journey-detail__status-meta">
+              Atualizada em {formatDateTime(journey.updatedAt)}
+            </span>
+          </div>
+        </div>
+        <div className="journey-detail__actions">
+          <Link className="btn btn-secondary" to={`/journeys/${journey.id}/edit`}>
+            Editar jornada
+          </Link>
+          <button
+            type="button"
+            className="btn btn-outline-danger"
+            onClick={() => setIsConfirmOpen(true)}
+            disabled={deleteJourney.isPending}
+          >
+            {deleteJourney.isPending ? (
+              <>
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  role="status"
+                  aria-hidden="true"
+                />
+                Removendo...
+              </>
+            ) : (
+              "Excluir"
+            )}
+          </button>
+        </div>
+      </header>
+
+      <section className="journey-detail__grid">
+        <article className="journey-detail__card">
+          <h2>Resumo</h2>
+          <dl>
+            <div>
+              <dt>Template</dt>
+              <dd>{journey.templateName}</dd>
+            </div>
+            <div>
+              <dt>Janela</dt>
+              <dd>
+                {formatDateTime(journey.startAt)}
+                <span className="journey-detail__arrow">→</span>
+                {formatDateTime(journey.endAt)}
+              </dd>
+            </div>
+            <div>
+              <dt>Criado em</dt>
+              <dd>{formatDateTime(journey.createdAt)}</dd>
+            </div>
+          </dl>
+        </article>
+
+        <article className="journey-detail__card">
+          <h2>Segmentação</h2>
+          <dl>
+            <div>
+              <dt>Referência externa</dt>
+              <dd>{journey.segmentReference ?? "—"}</dd>
+            </div>
+            <div>
+              <dt>Filtro</dt>
+              <dd>{journey.segmentFilter ?? "—"}</dd>
+            </div>
+            <div>
+              <dt>Nicho de mercado</dt>
+              <dd>{journey.marketNicheId ?? "—"}</dd>
+            </div>
+            <div>
+              <dt>Experimento</dt>
+              <dd>{journey.experimentId ?? "—"}</dd>
+            </div>
+          </dl>
+        </article>
+
+        <article className="journey-detail__card journey-detail__card--full">
+          <h2>Metadados</h2>
+          {metadataEntries.length ? (
+            <ul className="journey-detail__metadata">
+              {metadataEntries.map(([key, value]) => (
+                <li key={key}>
+                  <span className="journey-detail__metadata-key">{key}</span>
+                  <span className="journey-detail__metadata-value">{value || "—"}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="journey-detail__empty">Nenhum metadado cadastrado.</p>
+          )}
+        </article>
+      </section>
+
+      {isConfirmOpen ? (
+        <div className="journey-detail__modal" role="dialog" aria-modal="true">
+          <div className="journey-detail__modal-content">
+            <h3>Confirmar exclusão</h3>
+            <p>
+              Esta ação removerá a jornada "{journey.name}" e todo o histórico associado.
+              Tem certeza de que deseja continuar?
+            </p>
+            <div className="journey-detail__modal-actions">
+              <button
+                type="button"
+                className="btn btn-outline-secondary"
+                onClick={() => setIsConfirmOpen(false)}
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                className="btn btn-danger"
+                onClick={handleDelete}
+                disabled={deleteJourney.isPending}
+              >
+                {deleteJourney.isPending ? (
+                  <>
+                    <span
+                      className="spinner-border spinner-border-sm me-2"
+                      role="status"
+                      aria-hidden="true"
+                    />
+                    Removendo...
+                  </>
+                ) : (
+                  "Excluir"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/journey/JourneyForm.css
+++ b/frontend/src/pages/journey/JourneyForm.css
@@ -1,0 +1,119 @@
+.journey-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.journey-form__section {
+  background: #ffffff;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  padding: 1.75rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+.journey-form__section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+  gap: 1rem;
+}
+
+.journey-form__section-header h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 0.25rem;
+}
+
+.journey-form__section-header p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.journey-form__grid {
+  display: grid;
+  gap: 1rem 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.journey-form__field--full {
+  grid-column: 1 / -1;
+}
+
+.journey-form__label {
+  display: block;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 0.35rem;
+}
+
+.journey-form__required {
+  color: #e11d48;
+  margin-left: 0.25rem;
+}
+
+.journey-form__help {
+  display: block;
+  margin-top: 0.35rem;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.journey-form__error {
+  display: block;
+  margin-top: 0.35rem;
+  color: #dc2626;
+  font-size: 0.85rem;
+}
+
+.journey-form__metadata {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.journey-form__metadata-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem;
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid #e2e8f0;
+}
+
+.journey-form__metadata-input {
+  flex: 1 1 220px;
+}
+
+.journey-form__metadata-remove {
+  align-self: center;
+  white-space: nowrap;
+}
+
+.journey-form__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.journey-form__footer-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .journey-form__section {
+    padding: 1.25rem;
+  }
+
+  .journey-form__section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/journey/JourneyForm.tsx
+++ b/frontend/src/pages/journey/JourneyForm.tsx
@@ -1,0 +1,397 @@
+import { useEffect } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import { useExperiments } from "../../api/experiment/useExperiments";
+import { useNiches } from "../../api/niche/useNiches";
+import {
+  type Journey,
+  type JourneyRequestPayload,
+  type JourneyStatus,
+} from "../../api/journey/types";
+import { useJourneyTemplates } from "../../api/journey/useJourneyTemplates";
+import JourneyStatusBadge from "./JourneyStatusBadge";
+import "./JourneyForm.css";
+
+const STATUS_OPTIONS: { value: JourneyStatus; label: string }[] = [
+  { value: "DRAFT", label: "Rascunho" },
+  { value: "ACTIVE", label: "Ativa" },
+  { value: "PAUSED", label: "Pausada" },
+  { value: "COMPLETED", label: "Concluída" },
+  { value: "ARCHIVED", label: "Arquivada" },
+];
+
+interface JourneyFormProps {
+  initialJourney?: Journey;
+  onSubmit: (payload: JourneyRequestPayload) => void;
+  isSubmitting?: boolean;
+  submitLabel: string;
+  onCancel?: () => void;
+}
+
+interface MetadataField {
+  key: string;
+  value: string;
+}
+
+interface JourneyFormValues {
+  templateId: string;
+  name: string;
+  description: string;
+  status: JourneyStatus;
+  marketNicheId: string;
+  experimentId: string;
+  segmentReference: string;
+  segmentFilter: string;
+  startAt: string;
+  endAt: string;
+  metadata: MetadataField[];
+}
+
+function toInputDate(value?: string | null) {
+  if (!value) {
+    return "";
+  }
+  const date = new Date(value);
+  const pad = (num: number) => num.toString().padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function normaliseMetadata(metadata: Record<string, string> | undefined) {
+  if (!metadata) {
+    return [];
+  }
+  return Object.entries(metadata).map(([key, value]) => ({ key, value }));
+}
+
+export default function JourneyForm({
+  initialJourney,
+  onSubmit,
+  isSubmitting,
+  submitLabel,
+  onCancel,
+}: JourneyFormProps) {
+  const navigate = useNavigate();
+  const { data: templatePage, isLoading: isTemplatesLoading } = useJourneyTemplates();
+  const templates = templatePage?.content ?? [];
+  const { data: niches } = useNiches();
+  const { data: experiments } = useExperiments();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    control,
+    watch,
+  } = useForm<JourneyFormValues>({
+    defaultValues: {
+      templateId: initialJourney?.templateId
+        ? String(initialJourney.templateId)
+        : "",
+      name: initialJourney?.name ?? "",
+      description: initialJourney?.description ?? "",
+      status: initialJourney?.status ?? "DRAFT",
+      marketNicheId: initialJourney?.marketNicheId
+        ? String(initialJourney.marketNicheId)
+        : "",
+      experimentId: initialJourney?.experimentId
+        ? String(initialJourney.experimentId)
+        : "",
+      segmentReference: initialJourney?.segmentReference ?? "",
+      segmentFilter: initialJourney?.segmentFilter ?? "",
+      startAt: toInputDate(initialJourney?.startAt),
+      endAt: toInputDate(initialJourney?.endAt),
+      metadata: normaliseMetadata(initialJourney?.metadata),
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "metadata",
+  });
+
+  useEffect(() => {
+    if (!fields.length) {
+      append({ key: "", value: "" });
+    }
+  }, [append, fields.length]);
+
+  const currentStatus = watch("status");
+
+  const submitHandler = handleSubmit((values) => {
+    const payload: JourneyRequestPayload = {
+      templateId: Number(values.templateId),
+      name: values.name.trim(),
+      description: values.description.trim() || undefined,
+      status: values.status,
+      marketNicheId: values.marketNicheId
+        ? Number(values.marketNicheId)
+        : undefined,
+      experimentId: values.experimentId
+        ? Number(values.experimentId)
+        : undefined,
+      segmentReference: values.segmentReference.trim() || undefined,
+      segmentFilter: values.segmentFilter.trim() || undefined,
+      startAt: values.startAt ? new Date(values.startAt).toISOString() : undefined,
+      endAt: values.endAt ? new Date(values.endAt).toISOString() : undefined,
+      metadata: values.metadata.reduce<Record<string, string>>((acc, entry) => {
+        const key = entry.key.trim();
+        if (!key) {
+          return acc;
+        }
+        acc[key] = entry.value.trim();
+        return acc;
+      }, {}),
+    };
+
+    onSubmit(payload);
+  });
+
+  return (
+    <form className="journey-form" onSubmit={submitHandler}>
+      <section className="journey-form__section">
+        <header className="journey-form__section-header">
+          <div>
+            <h2>Configuração básica</h2>
+            <p>Selecione o template e defina os principais atributos operacionais.</p>
+          </div>
+          <JourneyStatusBadge status={currentStatus} />
+        </header>
+        <div className="journey-form__grid">
+          <div className="journey-form__field">
+            <label className="journey-form__label">
+              Template <span className="journey-form__required" aria-hidden="true">*</span>
+            </label>
+            <select
+              className="form-select"
+              disabled={isTemplatesLoading}
+              aria-label="Template de jornada"
+              {...register("templateId", { required: "Selecione um template" })}
+            >
+              <option value="">Selecione um template</option>
+              {templates.map((template) => (
+                <option key={template.id} value={template.id}>
+                  {template.name}
+                </option>
+              ))}
+            </select>
+            {isTemplatesLoading ? (
+              <span className="journey-form__help">Carregando templates...</span>
+            ) : null}
+            {errors.templateId ? (
+              <span className="journey-form__error">{errors.templateId.message}</span>
+            ) : null}
+          </div>
+
+          <div className="journey-form__field">
+            <label className="journey-form__label">
+              Nome <span className="journey-form__required" aria-hidden="true">*</span>
+            </label>
+            <input
+              className="form-control"
+              placeholder="Ex.: Jornada de ativação do onboarding"
+              {...register("name", { required: "Informe um nome" })}
+            />
+            {errors.name ? (
+              <span className="journey-form__error">{errors.name.message}</span>
+            ) : null}
+          </div>
+
+          <div className="journey-form__field">
+            <label className="journey-form__label">
+              Status <span className="journey-form__required" aria-hidden="true">*</span>
+            </label>
+            <select
+              className="form-select"
+              {...register("status", { required: "Informe o status" })}
+            >
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            {errors.status ? (
+              <span className="journey-form__error">{errors.status.message}</span>
+            ) : null}
+          </div>
+
+          <div className="journey-form__field journey-form__field--full">
+            <label className="journey-form__label">Descrição</label>
+            <textarea
+              className="form-control"
+              rows={3}
+              placeholder="Contextualize objetivos, público e resultados esperados"
+              {...register("description")}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="journey-form__section">
+        <header className="journey-form__section-header">
+          <div>
+            <h2>Segmentação e escopo</h2>
+            <p>Conecte a jornada a nichos, experimentos e filtros externos.</p>
+          </div>
+        </header>
+        <div className="journey-form__grid">
+          <div className="journey-form__field">
+            <label className="journey-form__label">Nicho de mercado</label>
+            <select className="form-select" {...register("marketNicheId")}>
+              <option value="">Nenhum</option>
+              {niches?.map((niche) => (
+                <option key={niche.id} value={niche.id}>
+                  {niche.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="journey-form__field">
+            <label className="journey-form__label">Experimento associado</label>
+            <select className="form-select" {...register("experimentId")}>
+              <option value="">Nenhum</option>
+              {experiments?.map((experiment) => (
+                <option key={experiment.id} value={experiment.id}>
+                  {experiment.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="journey-form__field">
+            <label className="journey-form__label">Referência externa</label>
+            <input
+              className="form-control"
+              placeholder="Identificador da lista ou segmento no CRM"
+              {...register("segmentReference")}
+            />
+          </div>
+
+          <div className="journey-form__field journey-form__field--full">
+            <label className="journey-form__label">Filtro de segmentação</label>
+            <textarea
+              className="form-control"
+              rows={3}
+              placeholder="Ex.: atributos do público, condições de entrada"
+              {...register("segmentFilter")}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="journey-form__section">
+        <header className="journey-form__section-header">
+          <div>
+            <h2>Janela e metas</h2>
+            <p>Configure a duração da jornada e pontos de controle.</p>
+          </div>
+        </header>
+        <div className="journey-form__grid">
+          <div className="journey-form__field">
+            <label className="journey-form__label">Início</label>
+            <input type="datetime-local" className="form-control" {...register("startAt")}
+            />
+          </div>
+          <div className="journey-form__field">
+            <label className="journey-form__label">Término</label>
+            <input type="datetime-local" className="form-control" {...register("endAt")}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="journey-form__section">
+        <header className="journey-form__section-header">
+          <div>
+            <h2>Metadados operacionais</h2>
+            <p>Adicione chaves e valores utilizados pelos canais ou integrações.</p>
+          </div>
+        </header>
+        <div className="journey-form__metadata">
+          {fields.map((field, index) => (
+            <div key={field.id} className="journey-form__metadata-row">
+              <div className="journey-form__metadata-input">
+                <label className="journey-form__label" htmlFor={`metadata-key-${index}`}>
+                  Chave
+                </label>
+                <input
+                  id={`metadata-key-${index}`}
+                  className="form-control"
+                  placeholder="Ex.: templateName"
+                  {...register(`metadata.${index}.key` as const)}
+                />
+              </div>
+              <div className="journey-form__metadata-input">
+                <label className="journey-form__label" htmlFor={`metadata-value-${index}`}>
+                  Valor
+                </label>
+                <input
+                  id={`metadata-value-${index}`}
+                  className="form-control"
+                  placeholder="Conteúdo associado"
+                  {...register(`metadata.${index}.value` as const)}
+                />
+              </div>
+              <button
+                type="button"
+                className="btn btn-outline-danger journey-form__metadata-remove"
+                onClick={() => remove(index)}
+                title="Remover metadado"
+              >
+                Remover
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+            onClick={() => append({ key: "", value: "" })}
+          >
+            Adicionar metadado
+          </button>
+        </div>
+      </section>
+
+      <footer className="journey-form__footer">
+        <div className="journey-form__footer-actions">
+          {onCancel ? (
+            <button
+              type="button"
+              className="btn btn-outline-secondary"
+              onClick={onCancel}
+            >
+              Cancelar
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="btn btn-outline-secondary"
+              onClick={() => navigate(-1)}
+            >
+              Voltar
+            </button>
+          )}
+        </div>
+        <button
+          type="submit"
+          className="btn btn-primary"
+          disabled={isSubmitting || isTemplatesLoading}
+        >
+          {isSubmitting ? (
+            <>
+              <span
+                className="spinner-border spinner-border-sm me-2"
+                role="status"
+                aria-hidden="true"
+              />
+              Salvando...
+            </>
+          ) : (
+            submitLabel
+          )}
+        </button>
+      </footer>
+    </form>
+  );
+}

--- a/frontend/src/pages/journey/JourneyListPage.css
+++ b/frontend/src/pages/journey/JourneyListPage.css
@@ -1,0 +1,316 @@
+.journey-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.journey-page__hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  background: linear-gradient(135deg, #1d4ed8, #60a5fa);
+  color: #f8fafc;
+  padding: 2rem;
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(30, 64, 175, 0.35);
+}
+
+.journey-page__subtitle {
+  margin: 0.75rem 0 0;
+  max-width: 540px;
+  font-size: 1rem;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.journey-page__hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.journey-metrics {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.journey-metric-card {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 1.5rem;
+  border: 1px solid #e2e8f0;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+}
+
+.journey-metric-card::after {
+  content: "";
+  position: absolute;
+  inset: auto auto 0 0;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  opacity: 0.18;
+  transform: translate(-30%, 30%);
+}
+
+.journey-metric-card--primary::after {
+  background: #2563eb;
+}
+
+.journey-metric-card--active::after {
+  background: #16a34a;
+}
+
+.journey-metric-card--draft::after {
+  background: #f97316;
+}
+
+.journey-metric-card--paused::after {
+  background: #facc15;
+}
+
+.journey-metric-card--completed::after {
+  background: #0ea5e9;
+}
+
+.journey-metric-card--archived::after {
+  background: #94a3b8;
+}
+
+.journey-metric-card__label {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+  margin-bottom: 0.5rem;
+}
+
+.journey-metric-card__value {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 0.5rem;
+}
+
+.journey-metric-card__description {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.journey-filters {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.journey-filters__grid {
+  display: grid;
+  gap: 1rem 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.journey-filters__label {
+  display: block;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 0.35rem;
+}
+
+.journey-filters__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.journey-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.journey-card {
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 100%;
+}
+
+.journey-card__header {
+  padding: 1.5rem 1.5rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.journey-card__timestamp {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.journey-card__template {
+  text-align: right;
+}
+
+.journey-card__template-label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.journey-card__content {
+  padding: 1rem 1.5rem 1.5rem;
+}
+
+.journey-card__content h3 {
+  font-size: 1.3rem;
+  margin-bottom: 0.5rem;
+  color: #0f172a;
+}
+
+.journey-card__description {
+  color: #475569;
+  margin-bottom: 1rem;
+}
+
+.journey-card__details {
+  display: grid;
+  gap: 0.75rem 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin: 0 0 1rem;
+}
+
+.journey-card__details dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.journey-card__details dd {
+  margin: 0.25rem 0 0;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.journey-card__details-separator {
+  margin: 0 0.35rem;
+  color: #94a3b8;
+}
+
+.journey-card__metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.journey-card__metadata-chip {
+  background: #f1f5f9;
+  color: #1e293b;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.journey-card__metadata-chip strong {
+  margin-right: 0.35rem;
+  font-weight: 700;
+}
+
+.journey-card__footer {
+  padding: 1.25rem 1.5rem 1.5rem;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.journey-empty-state {
+  background: #f8fafc;
+  border: 2px dashed #cbd5f5;
+  border-radius: 16px;
+  padding: 2rem;
+  text-align: center;
+  color: #475569;
+}
+
+.journey-empty-state__hint {
+  margin: 0.5rem 0 0;
+  color: #64748b;
+}
+
+.journey-pagination {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  align-items: center;
+}
+
+.journey-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.journey-status-badge--draft {
+  background: rgba(251, 191, 36, 0.18);
+  color: #b45309;
+}
+
+.journey-status-badge--active {
+  background: rgba(34, 197, 94, 0.18);
+  color: #166534;
+}
+
+.journey-status-badge--paused {
+  background: rgba(250, 204, 21, 0.18);
+  color: #b45309;
+}
+
+.journey-status-badge--completed {
+  background: rgba(14, 165, 233, 0.18);
+  color: #0369a1;
+}
+
+.journey-status-badge--archived {
+  background: rgba(148, 163, 184, 0.22);
+  color: #475569;
+}
+
+@media (max-width: 768px) {
+  .journey-page__hero {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .journey-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .journey-card__template {
+    text-align: left;
+  }
+
+  .journey-card__footer {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/pages/journey/JourneyListPage.tsx
+++ b/frontend/src/pages/journey/JourneyListPage.tsx
@@ -1,0 +1,342 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useJourneys } from "../../api/journey/useJourneys";
+import { useJourneyTemplates } from "../../api/journey/useJourneyTemplates";
+import { useJourneyMetrics } from "../../api/journey/useJourneyMetrics";
+import type { Journey, JourneyStatus } from "../../api/journey/types";
+import JourneyStatusBadge from "./JourneyStatusBadge";
+import "./JourneyListPage.css";
+
+const STATUS_OPTIONS: { value: JourneyStatus; label: string }[] = [
+  { value: "ACTIVE", label: "Ativas" },
+  { value: "DRAFT", label: "Rascunhos" },
+  { value: "PAUSED", label: "Pausadas" },
+  { value: "COMPLETED", label: "Concluídas" },
+  { value: "ARCHIVED", label: "Arquivadas" },
+];
+
+function formatDateTime(value?: string | null) {
+  if (!value) {
+    return "—";
+  }
+  try {
+    return new Intl.DateTimeFormat("pt-BR", {
+      dateStyle: "short",
+      timeStyle: "short",
+    }).format(new Date(value));
+  } catch (error) {
+    return value;
+  }
+}
+
+function highlightMetadata(metadata: Record<string, string>) {
+  return Object.entries(metadata)
+    .filter(([key]) => Boolean(key))
+    .slice(0, 6);
+}
+
+function matchesSearch(journey: Journey, term: string) {
+  const normalised = term.trim().toLowerCase();
+  if (!normalised) {
+    return true;
+  }
+  return (
+    journey.name.toLowerCase().includes(normalised) ||
+    journey.templateName.toLowerCase().includes(normalised) ||
+    (journey.segmentReference ?? "").toLowerCase().includes(normalised)
+  );
+}
+
+export default function JourneyListPage() {
+  const [page, setPage] = useState(0);
+  const [statusFilter, setStatusFilter] = useState<JourneyStatus | "">("");
+  const [templateFilter, setTemplateFilter] = useState<number | "">("");
+  const [searchTerm, setSearchTerm] = useState("");
+  const pageSize = 12;
+
+  const { data: templatePage } = useJourneyTemplates();
+  const templates = templatePage?.content ?? [];
+
+  const journeysQuery = useJourneys({
+    page,
+    size: pageSize,
+    status: statusFilter || undefined,
+    templateId: templateFilter ? Number(templateFilter) : undefined,
+  });
+
+  const journeysPage = journeysQuery.data;
+  const isLoading = journeysQuery.isLoading;
+
+  const { data: metrics, isLoading: metricsLoading } = useJourneyMetrics();
+
+  const journeys: Journey[] = journeysPage?.content ?? [];
+
+  const filteredJourneys = useMemo(
+    () => journeys.filter((journey) => matchesSearch(journey, searchTerm)),
+    [journeys, searchTerm],
+  );
+
+  const totalPages = journeysPage?.totalPages ?? 0;
+  const canGoPrevious = page > 0;
+  const canGoNext = page + 1 < totalPages;
+
+  const statusBreakdown = metrics?.statusBreakdown ?? {};
+
+  return (
+    <div className="journey-page">
+      <header className="journey-page__hero">
+        <div>
+          <PageTitle>Jornadas</PageTitle>
+          <p className="journey-page__subtitle">
+            Monitore o progresso das jornadas de marketing, acompanhe metas e ajuste rapidamente cada etapa da orquestração.
+          </p>
+        </div>
+        <div className="journey-page__hero-actions">
+          <Link className="btn btn-outline-secondary" to="/journey-templates">
+            Ver templates
+          </Link>
+          <Link className="btn btn-primary" to="/journeys/new">
+            Criar nova jornada
+          </Link>
+        </div>
+      </header>
+
+      <section className="journey-metrics">
+        <div className="journey-metric-card journey-metric-card--primary">
+          <p className="journey-metric-card__label">Jornadas totais</p>
+          <p className="journey-metric-card__value">
+            {metricsLoading ? (
+              <span
+                className="spinner-border spinner-border-sm text-primary"
+                role="status"
+                aria-hidden="true"
+              />
+            ) : (
+              metrics?.totalJourneys ?? 0
+            )}
+          </p>
+          <p className="journey-metric-card__description">
+            Instâncias operacionais prontas para acompanhamento.
+          </p>
+        </div>
+        {STATUS_OPTIONS.map((option) => (
+          <div
+            key={option.value}
+            className={`journey-metric-card journey-metric-card--${option.value.toLowerCase()}`}
+          >
+            <p className="journey-metric-card__label">{option.label}</p>
+            <p className="journey-metric-card__value">
+              {metricsLoading ? (
+                <span
+                  className="spinner-border spinner-border-sm text-primary"
+                  role="status"
+                  aria-hidden="true"
+                />
+              ) : (
+                statusBreakdown[option.value] ?? 0
+              )}
+            </p>
+            <p className="journey-metric-card__description">
+              {option.value === "ACTIVE"
+                ? "Jornadas em execução com estímulos ativos."
+                : option.value === "DRAFT"
+                ? "Configurações em fase de alinhamento."
+                : option.value === "PAUSED"
+                ? "Instâncias aguardando retomada."
+                : option.value === "COMPLETED"
+                ? "Fluxos finalizados com sucesso."
+                : "Histórico arquivado para consulta."}
+            </p>
+          </div>
+        ))}
+      </section>
+
+      <section className="journey-filters">
+        <div className="journey-filters__grid">
+          <div>
+            <label className="journey-filters__label" htmlFor="journey-search">
+              Buscar por nome ou referência
+            </label>
+            <input
+              id="journey-search"
+              className="form-control"
+              placeholder="Digite um termo de busca"
+              value={searchTerm}
+              onChange={(event) => {
+                setSearchTerm(event.target.value);
+                setPage(0);
+              }}
+            />
+          </div>
+          <div>
+            <label className="journey-filters__label" htmlFor="journey-status">
+              Status
+            </label>
+            <select
+              id="journey-status"
+              className="form-select"
+              value={statusFilter}
+              onChange={(event) => {
+                setStatusFilter(event.target.value as JourneyStatus | "");
+                setPage(0);
+              }}
+            >
+              <option value="">Todos</option>
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="journey-filters__label" htmlFor="journey-template">
+              Template
+            </label>
+            <select
+              id="journey-template"
+              className="form-select"
+              value={templateFilter}
+              onChange={(event) => {
+                setTemplateFilter(event.target.value ? Number(event.target.value) : "");
+                setPage(0);
+              }}
+            >
+              <option value="">Todos</option>
+              {templates.map((template) => (
+                <option key={template.id} value={template.id}>
+                  {template.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="journey-filters__actions">
+          <button
+            type="button"
+            className="btn btn-outline-secondary"
+            onClick={() => {
+              setSearchTerm("");
+              setStatusFilter("");
+              setTemplateFilter("");
+              setPage(0);
+            }}
+          >
+            Limpar filtros
+          </button>
+        </div>
+      </section>
+
+      <section>
+        {isLoading ? (
+          <div className="journey-empty-state">Carregando jornadas...</div>
+        ) : filteredJourneys.length === 0 ? (
+          <div className="journey-empty-state">
+            <p>Nenhuma jornada encontrada com os filtros atuais.</p>
+            <p className="journey-empty-state__hint">
+              Ajuste os filtros ou crie uma nova jornada personalizada.
+            </p>
+          </div>
+        ) : (
+          <div className="journey-grid">
+            {filteredJourneys.map((journey) => {
+              const metadata = highlightMetadata(journey.metadata);
+              return (
+                <article key={journey.id} className="journey-card">
+                  <header className="journey-card__header">
+                    <div>
+                      <JourneyStatusBadge status={journey.status} />
+                      <p className="journey-card__timestamp">
+                        Atualizada em {formatDateTime(journey.updatedAt)}
+                      </p>
+                    </div>
+                    <div className="journey-card__template">
+                      <span className="journey-card__template-label">Template</span>
+                      <strong>{journey.templateName}</strong>
+                    </div>
+                  </header>
+                  <div className="journey-card__content">
+                    <h3>{journey.name}</h3>
+                    {journey.description ? (
+                      <p className="journey-card__description">{journey.description}</p>
+                    ) : null}
+                    <dl className="journey-card__details">
+                      <div>
+                        <dt>Janela</dt>
+                        <dd>
+                          {formatDateTime(journey.startAt)}
+                          <span className="journey-card__details-separator">→</span>
+                          {formatDateTime(journey.endAt)}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>Segmento</dt>
+                        <dd>{journey.segmentReference ?? "—"}</dd>
+                      </div>
+                      <div>
+                        <dt>Nicho</dt>
+                        <dd>{journey.marketNicheId ?? "—"}</dd>
+                      </div>
+                      <div>
+                        <dt>Experimento</dt>
+                        <dd>{journey.experimentId ?? "—"}</dd>
+                      </div>
+                    </dl>
+                    {metadata.length ? (
+                      <div className="journey-card__metadata">
+                        {metadata.map(([key, value]) => (
+                          <span key={key} className="journey-card__metadata-chip">
+                            <strong>{key}:</strong> {value || "—"}
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                  <footer className="journey-card__footer">
+                    <Link
+                      className="btn btn-outline-primary btn-sm"
+                      to={`/journeys/${journey.id}`}
+                    >
+                      Ver detalhes
+                    </Link>
+                    <Link
+                      className="btn btn-secondary btn-sm"
+                      to={`/journeys/${journey.id}/edit`}
+                    >
+                      Editar
+                    </Link>
+                  </footer>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {totalPages > 1 ? (
+        <nav className="journey-pagination" aria-label="Paginação de jornadas">
+          <button
+            type="button"
+            className="btn btn-outline-secondary"
+            onClick={() => setPage((current) => Math.max(current - 1, 0))}
+            disabled={!canGoPrevious}
+          >
+            Anterior
+          </button>
+          <span>
+            Página {page + 1} de {totalPages}
+          </span>
+          <button
+            type="button"
+            className="btn btn-outline-secondary"
+            onClick={() => setPage((current) => (canGoNext ? current + 1 : current))}
+            disabled={!canGoNext}
+          >
+            Próxima
+          </button>
+        </nav>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/journey/JourneyPageShell.css
+++ b/frontend/src/pages/journey/JourneyPageShell.css
@@ -1,0 +1,18 @@
+.journey-page-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.journey-page-shell__header {
+  background: #ffffff;
+  border-radius: 18px;
+  border: 1px solid #e2e8f0;
+  padding: 1.75rem;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
+}
+
+.journey-page-shell__header p {
+  margin: 0.75rem 0 0;
+  color: #475569;
+}

--- a/frontend/src/pages/journey/JourneyStatusBadge.tsx
+++ b/frontend/src/pages/journey/JourneyStatusBadge.tsx
@@ -1,0 +1,22 @@
+import type { JourneyStatus } from "../../api/journey/types";
+import "./JourneyListPage.css";
+
+const STATUS_LABELS: Record<JourneyStatus, string> = {
+  DRAFT: "Rascunho",
+  ACTIVE: "Ativa",
+  PAUSED: "Pausada",
+  COMPLETED: "Concluída",
+  ARCHIVED: "Arquivada",
+};
+
+interface JourneyStatusBadgeProps {
+  status: JourneyStatus;
+}
+
+export default function JourneyStatusBadge({ status }: JourneyStatusBadgeProps) {
+  return (
+    <span className={`journey-status-badge journey-status-badge--${status.toLowerCase()}`}>
+      {STATUS_LABELS[status] ?? status}
+    </span>
+  );
+}

--- a/frontend/src/pages/journey/JourneyTemplatesPage.css
+++ b/frontend/src/pages/journey/JourneyTemplatesPage.css
@@ -1,0 +1,108 @@
+.journey-templates {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.journey-templates__hero {
+  background: linear-gradient(140deg, #9333ea, #6366f1);
+  padding: 2rem;
+  border-radius: 20px;
+  color: #f8fafc;
+  box-shadow: 0 18px 36px rgba(76, 29, 149, 0.35);
+}
+
+.journey-templates__hero p {
+  margin: 0.75rem 0 0;
+  max-width: 560px;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.journey-templates__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.journey-template-card {
+  background: #ffffff;
+  border-radius: 18px;
+  border: 1px solid #e2e8f0;
+  padding: 1.75rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.journey-template-card h2 {
+  font-size: 1.3rem;
+  color: #0f172a;
+  margin: 0.5rem 0;
+}
+
+.journey-template-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #6366f1;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.journey-template-card__channel {
+  background: rgba(99, 102, 241, 0.15);
+  color: #3730a3;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.journey-template-card__phases {
+  color: #1e293b;
+  font-weight: 600;
+}
+
+.journey-template-card__objective {
+  color: #475569;
+  margin: 0;
+}
+
+.journey-template-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.journey-template-card__tag {
+  background: #f1f5f9;
+  color: #1e293b;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.journey-template-card__footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.journey-templates__empty {
+  background: #f8fafc;
+  border-radius: 16px;
+  border: 2px dashed #cbd5f5;
+  padding: 2rem;
+  text-align: center;
+  color: #475569;
+}
+
+@media (max-width: 768px) {
+  .journey-template-card__footer {
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+}

--- a/frontend/src/pages/journey/JourneyTemplatesPage.tsx
+++ b/frontend/src/pages/journey/JourneyTemplatesPage.tsx
@@ -1,0 +1,71 @@
+import PageTitle from "../../components/PageTitle";
+import { useJourneyTemplates } from "../../api/journey/useJourneyTemplates";
+import type { JourneyTemplateSummary } from "../../api/journey/types";
+import "./JourneyTemplatesPage.css";
+
+function formatChannel(template: JourneyTemplateSummary) {
+  if (template.preferredChannel) {
+    return template.preferredChannel;
+  }
+  return "Multicanal";
+}
+
+export default function JourneyTemplatesPage() {
+  const { data, isLoading } = useJourneyTemplates();
+  const templates = data?.content ?? [];
+
+  return (
+    <div className="journey-templates">
+      <header className="journey-templates__hero">
+        <div>
+          <PageTitle>Templates de jornada</PageTitle>
+          <p>
+            Explore modelos prontos de cadência e estímulos para acelerar a criação de novas jornadas, mantendo consistência na experiência.
+          </p>
+        </div>
+      </header>
+
+      {isLoading ? (
+        <div className="journey-templates__empty">Carregando templates...</div>
+      ) : templates.length === 0 ? (
+        <div className="journey-templates__empty">Nenhum template cadastrado até o momento.</div>
+      ) : (
+        <div className="journey-templates__grid">
+          {templates.map((template) => (
+            <article key={template.id} className="journey-template-card">
+              <header>
+                <div className="journey-template-card__meta">
+                  <span className="journey-template-card__channel">{formatChannel(template)}</span>
+                  <span className="journey-template-card__phases">
+                    {template.phases.join(" • ")}
+                  </span>
+                </div>
+                <h2>{template.name}</h2>
+                {template.objective ? (
+                  <p className="journey-template-card__objective">{template.objective}</p>
+                ) : null}
+              </header>
+              {template.tags.length ? (
+                <div className="journey-template-card__tags">
+                  {template.tags.map((tag) => (
+                    <span key={tag} className="journey-template-card__tag">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+              <footer className="journey-template-card__footer">
+                <span>
+                  Criado em {new Date(template.createdAt).toLocaleDateString("pt-BR")}
+                </span>
+                <span>
+                  Atualizado em {new Date(template.updatedAt).toLocaleDateString("pt-BR")}
+                </span>
+              </footer>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/journey/NewJourneyPage.tsx
+++ b/frontend/src/pages/journey/NewJourneyPage.tsx
@@ -1,0 +1,36 @@
+import { useNavigate } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import JourneyForm from "./JourneyForm";
+import { useCreateJourney } from "../../api/journey/useCreateJourney";
+import type { JourneyRequestPayload } from "../../api/journey/types";
+import "./JourneyPageShell.css";
+
+export default function NewJourneyPage() {
+  const navigate = useNavigate();
+  const createJourney = useCreateJourney();
+
+  const handleSubmit = (payload: JourneyRequestPayload) => {
+    createJourney.mutate(payload, {
+      onSuccess: (journey) => {
+        navigate(`/journeys/${journey.id}`);
+      },
+    });
+  };
+
+  return (
+    <div className="journey-page-shell">
+      <header className="journey-page-shell__header">
+        <PageTitle>Criar nova jornada</PageTitle>
+        <p>
+          Estruture uma jornada personalizada a partir de um template existente,
+          definindo público, janela de ativação e metadados operacionais.
+        </p>
+      </header>
+      <JourneyForm
+        submitLabel="Criar jornada"
+        onSubmit={handleSubmit}
+        isSubmitting={createJourney.isPending}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose aggregated journey metrics from the backend and document the new endpoint
- add a dedicated Journeys area in the navigation with list, detail and form experiences
- include a templates showcase and rich styling/filters for the journeys workspace

## Testing
- npm run build
- mvn -s ../settings.xml test *(fails: cannot resolve spring-boot-starter-parent because GitHub Packages is unreachable from the runner)*

------
https://chatgpt.com/codex/tasks/task_e_68e53e52395083218d7f18b2ae00360e