### PR TITLE
Fix JourneyServiceTest Spring context configuration

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/journey/JourneyServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/JourneyServiceTest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.journey;
 
+import com.marketinghub.ads.AdsServiceApplication;
 import com.marketinghub.journey.dto.JourneyMetricsResponse;
 import com.marketinghub.journey.model.Journey;
 import com.marketinghub.journey.model.JourneyStatus;
@@ -14,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+@SpringBootTest(classes = AdsServiceApplication.class)
 @Transactional
 class JourneyServiceTest {
 


### PR DESCRIPTION
## Summary
- load the Spring context for JourneyServiceTest using the main AdsServiceApplication configuration

## Testing
- `mvn -s ../settings.xml test` *(fails: unable to download parent POM because https://maven.pkg.github.com is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e54d3d58a883219e0f16057640682d