### PR TITLE
Fix journey metrics test to account for seeded data

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/journey/JourneyServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/journey/JourneyServiceTest.java
@@ -34,6 +34,8 @@ class JourneyServiceTest {
                 .name("Onboarding Experience")
                 .build());
 
+        JourneyMetricsResponse initialMetrics = journeyService.metrics();
+
         journeyRepository.save(Journey.builder()
                 .template(template)
                 .name("Warm-up")
@@ -54,11 +56,11 @@ class JourneyServiceTest {
 
         JourneyMetricsResponse metrics = journeyService.metrics();
 
-        assertThat(metrics.totalJourneys()).isEqualTo(3);
+        assertThat(metrics.totalJourneys()).isEqualTo(initialMetrics.totalJourneys() + 3);
         assertThat(metrics.statusBreakdown())
-                .containsEntry(JourneyStatus.ACTIVE, 1L)
-                .containsEntry(JourneyStatus.DRAFT, 1L)
-                .containsEntry(JourneyStatus.PAUSED, 1L);
+                .containsEntry(JourneyStatus.ACTIVE, initialMetrics.statusBreakdown().getOrDefault(JourneyStatus.ACTIVE, 0L) + 1)
+                .containsEntry(JourneyStatus.DRAFT, initialMetrics.statusBreakdown().getOrDefault(JourneyStatus.DRAFT, 0L) + 1)
+                .containsEntry(JourneyStatus.PAUSED, initialMetrics.statusBreakdown().getOrDefault(JourneyStatus.PAUSED, 0L) + 1);
         for (JourneyStatus status : JourneyStatus.values()) {
             assertThat(metrics.statusBreakdown()).containsKey(status);
         }


### PR DESCRIPTION
## Summary
- capture existing journey metrics in the test before seeding additional data
- assert totals and per-status counts relative to the pre-existing seeded journeys

## Testing
- `mvn -s ../settings.xml test` *(fails: unable to resolve parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e58ee958ec8321acdfb94f34f8785a