### PR TITLE
Add journey screen wireframes to orchestration guide

### DIFF
--- a/docs/journeys/images/journey-detail.svg
+++ b/docs/journeys/images/journey-detail.svg
@@ -1,0 +1,32 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" fill="#020617"/>
+  <rect x="48" y="48" width="1184" height="624" rx="24" fill="#0F172A" stroke="#1E293B" stroke-width="2"/>
+  <text x="96" y="116" font-family="'Inter', sans-serif" font-size="34" fill="#E2E8F0" font-weight="600">Campanha de Nutrição • Jornada ativa</text>
+  <rect x="96" y="144" width="696" height="232" rx="20" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="120" y="190" font-family="'Inter', sans-serif" font-size="24" fill="#FACC15" font-weight="600">Timeline de estímulos</text>
+  <line x1="160" y1="220" x2="160" y2="348" stroke="#2563EB" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="160" cy="228" r="12" fill="#38BDF8"/>
+  <circle cx="160" cy="276" r="12" fill="#38BDF8"/>
+  <circle cx="160" cy="324" r="12" fill="#38BDF8"/>
+  <text x="200" y="236" font-family="'Inter', sans-serif" font-size="20" fill="#E2E8F0">Email de boas-vindas • Enviado</text>
+  <text x="200" y="284" font-family="'Inter', sans-serif" font-size="20" fill="#E2E8F0">WhatsApp • Agendado para 2h</text>
+  <text x="200" y="332" font-family="'Inter', sans-serif" font-size="20" fill="#E2E8F0">Anúncio • Segmento Lookalike</text>
+  <rect x="824" y="144" width="360" height="232" rx="20" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="856" y="190" font-family="'Inter', sans-serif" font-size="22" fill="#38BDF8" font-weight="600">Segmentação</text>
+  <text x="856" y="224" font-family="'Inter', sans-serif" font-size="18" fill="#94A3B8">Nichos, experimentos e filtros externos alinhados com o template ativo.</text>
+  <text x="856" y="268" font-family="'Inter', sans-serif" font-size="18" fill="#94A3B8">• Nicho: Cursos Tech</text>
+  <text x="856" y="300" font-family="'Inter', sans-serif" font-size="18" fill="#94A3B8">• Experimento: Onboarding Beta</text>
+  <text x="856" y="332" font-family="'Inter', sans-serif" font-size="18" fill="#94A3B8">• Público: Leads MQL 2024</text>
+  <rect x="96" y="400" width="520" height="240" rx="20" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="120" y="444" font-family="'Inter', sans-serif" font-size="22" fill="#38BDF8" font-weight="600">Métricas em tempo real</text>
+  <text x="120" y="484" font-family="'Inter', sans-serif" font-size="18" fill="#CBD5F5">• Disparos concluídos</text>
+  <text x="120" y="516" font-family="'Inter', sans-serif" font-size="18" fill="#CBD5F5">• Conversões atribuídas</text>
+  <text x="120" y="548" font-family="'Inter', sans-serif" font-size="18" fill="#CBD5F5">• Frequência média</text>
+  <rect x="640" y="400" width="544" height="240" rx="20" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="668" y="444" font-family="'Inter', sans-serif" font-size="22" fill="#38BDF8" font-weight="600">Ações rápidas</text>
+  <text x="668" y="484" font-family="'Inter', sans-serif" font-size="18" fill="#CBD5F5">Editar jornada • Pausar execução • Excluir com confirmação</text>
+  <rect x="668" y="512" width="220" height="44" rx="12" fill="#2563EB"/>
+  <text x="692" y="540" font-family="'Inter', sans-serif" font-size="20" fill="#F8FAFC" font-weight="600">Editar jornada</text>
+  <rect x="912" y="512" width="220" height="44" rx="12" fill="#DC2626"/>
+  <text x="936" y="540" font-family="'Inter', sans-serif" font-size="20" fill="#F8FAFC" font-weight="600">Excluir</text>
+</svg>

--- a/docs/journeys/images/journey-form.svg
+++ b/docs/journeys/images/journey-form.svg
@@ -1,0 +1,21 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" fill="#031626"/>
+  <rect x="80" y="60" width="1120" height="600" rx="24" fill="#0F172A" stroke="#1E293B" stroke-width="2"/>
+  <text x="128" y="128" font-family="'Inter', sans-serif" font-size="34" fill="#E2E8F0" font-weight="600">Criar jornada</text>
+  <rect x="128" y="164" width="960" height="88" rx="18" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="156" y="214" font-family="'Inter', sans-serif" font-size="22" fill="#FACC15" font-weight="600">Nome e template</text>
+  <text x="156" y="246" font-family="'Inter', sans-serif" font-size="18" fill="#94A3B8">Seleção assistida com busca incremental e pré-visualização das fases.</text>
+  <rect x="128" y="272" width="960" height="120" rx="18" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="156" y="320" font-family="'Inter', sans-serif" font-size="22" fill="#38BDF8" font-weight="600">Janela e metas</text>
+  <text x="156" y="352" font-family="'Inter', sans-serif" font-size="18" fill="#94A3B8">Datas, orçamento e objetivo de conversão com feedback imediato.</text>
+  <rect x="128" y="404" width="448" height="180" rx="18" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="156" y="452" font-family="'Inter', sans-serif" font-size="22" fill="#38BDF8" font-weight="600">Segmentação</text>
+  <text x="156" y="484" font-family="'Inter', sans-serif" font-size="18" fill="#94A3B8">Nichos, experimentos, listas externas e validação de consistência.</text>
+  <rect x="608" y="404" width="480" height="180" rx="18" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="636" y="452" font-family="'Inter', sans-serif" font-size="22" fill="#38BDF8" font-weight="600">Metadados e automações</text>
+  <text x="636" y="484" font-family="'Inter', sans-serif" font-size="18" fill="#94A3B8">Campos dinâmicos, webhooks, políticas de frequência e observações.</text>
+  <rect x="128" y="608" width="220" height="48" rx="14" fill="#2563EB"/>
+  <text x="152" y="640" font-family="'Inter', sans-serif" font-size="22" fill="#F8FAFC" font-weight="600">Salvar jornada</text>
+  <rect x="368" y="608" width="220" height="48" rx="14" fill="#1E293B" stroke="#475569" stroke-width="2"/>
+  <text x="392" y="640" font-family="'Inter', sans-serif" font-size="22" fill="#E2E8F0" font-weight="600">Salvar como rascunho</text>
+</svg>

--- a/docs/journeys/images/journey-list.svg
+++ b/docs/journeys/images/journey-list.svg
@@ -1,0 +1,28 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" fill="#0F172A"/>
+  <rect x="40" y="40" width="240" height="640" rx="16" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="80" y="96" font-family="'Inter', sans-serif" font-size="28" fill="#F1F5F9" font-weight="600">Jornadas</text>
+  <rect x="320" y="40" width="920" height="80" rx="14" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="348" y="92" font-family="'Inter', sans-serif" font-size="26" fill="#E2E8F0">Filtros e métricas</text>
+  <rect x="320" y="144" width="440" height="160" rx="18" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <rect x="780" y="144" width="440" height="160" rx="18" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <rect x="320" y="324" width="440" height="160" rx="18" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <rect x="780" y="324" width="440" height="160" rx="18" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <rect x="320" y="504" width="440" height="160" rx="18" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <rect x="780" y="504" width="440" height="160" rx="18" fill="#111827" stroke="#1E293B" stroke-width="2"/>
+  <text x="344" y="190" font-family="'Inter', sans-serif" font-size="24" fill="#38BDF8" font-weight="600">Campanha de Nutrição</text>
+  <text x="344" y="224" font-family="'Inter', sans-serif" font-size="18" fill="#CBD5F5">Status • Conversões • Último disparo</text>
+  <text x="804" y="190" font-family="'Inter', sans-serif" font-size="24" fill="#38BDF8" font-weight="600">Onboarding Pro</text>
+  <text x="804" y="224" font-family="'Inter', sans-serif" font-size="18" fill="#CBD5F5">Status • Conversões • Último disparo</text>
+  <text x="60" y="164" font-family="'Inter', sans-serif" font-size="20" fill="#94A3B8">Visão geral</text>
+  <text x="60" y="212" font-family="'Inter', sans-serif" font-size="20" fill="#94A3B8">Templates</text>
+  <text x="60" y="260" font-family="'Inter', sans-serif" font-size="20" fill="#FACC15">Jornadas</text>
+  <text x="60" y="308" font-family="'Inter', sans-serif" font-size="20" fill="#94A3B8">Criativos</text>
+  <rect x="60" y="340" width="200" height="2" fill="#1E293B"/>
+  <text x="60" y="388" font-family="'Inter', sans-serif" font-size="18" fill="#CBD5E1">Filtros rápidos</text>
+  <text x="60" y="424" font-family="'Inter', sans-serif" font-size="16" fill="#64748B">• Template</text>
+  <text x="60" y="456" font-family="'Inter', sans-serif" font-size="16" fill="#64748B">• Status</text>
+  <text x="60" y="488" font-family="'Inter', sans-serif" font-size="16" fill="#64748B">• Período</text>
+  <rect x="320" y="640" width="220" height="40" rx="12" fill="#2563EB"/>
+  <text x="344" y="668" font-family="'Inter', sans-serif" font-size="20" fill="#F8FAFC" font-weight="600">Criar jornada</text>
+</svg>

--- a/docs/journeys/orquestracao-jornadas.md
+++ b/docs/journeys/orquestracao-jornadas.md
@@ -35,9 +35,21 @@ Sobre esses modelos atua um motor de execução que avalia condições, respeita
 
 ## Experiência no Marketing Hub
 * A nova navegação lateral traz o item "Jornadas" com acesso direto à visão geral, criação rápida e templates, reforçando a descoberta das funcionalidades de orquestração.【F:frontend/src/components/MainNavigation.tsx†L34-L118】
-* A lista de jornadas exibe cards responsivos com filtros por template/status, busca textual e indicadores de saúde (totais por status) consumindo o endpoint `/api/journeys/metrics`, além de atalhos para detalhamento, edição e remoção.【F:frontend/src/pages/journey/JourneyListPage.tsx†L1-L260】【F:frontend/src/pages/journey/JourneyListPage.css†L1-L167】
-* A tela de detalhes organiza timeline, metadados e contexto de segmentação em painéis visuais, com atalhos para edição e exclusão segura via modal de confirmação.【F:frontend/src/pages/journey/JourneyDetailPage.tsx†L1-L248】【F:frontend/src/pages/journey/JourneyDetailPage.css†L1-L168】
-* O formulário reutilizável de criação/edição possui validação, edição dinâmica de metadados e seleção assistida de nichos, experimentos e templates, entregando feedback imediato de carregamento/sucesso.【F:frontend/src/pages/journey/JourneyForm.tsx†L1-L330】【F:frontend/src/api/journey/useCreateJourney.ts†L1-L55】【F:frontend/src/api/journey/useUpdateJourney.ts†L1-L55】
+
+### Lista de jornadas
+A listagem apresenta cards responsivos com filtros por template, status e período, busca textual e indicadores de saúde consolidados pelo endpoint `/api/journeys/metrics`. Atalhos permitem abrir o detalhamento em uma nova aba, duplicar ou excluir a jornada com confirmação, enquanto o botão "Criar jornada" permanece visível para incentivar novos fluxos.【F:frontend/src/pages/journey/JourneyListPage.tsx†L1-L260】【F:frontend/src/pages/journey/JourneyListPage.css†L1-L167】
+
+![Wireframe da lista de jornadas destacando filtros, cards e ações rápidas.](images/journey-list.svg)
+
+### Detalhe da jornada
+O detalhamento organiza timeline, métricas em tempo real e contexto de segmentação em painéis independentes, facilitando a identificação de gargalos no fluxo. Ações rápidas permitem editar a jornada, pausar a execução ou removê-la com modal de confirmação, enquanto o histórico de estímulos evidencia o status de cada passo e os identificadores registrados na telemetria.【F:frontend/src/pages/journey/JourneyDetailPage.tsx†L1-L248】【F:frontend/src/pages/journey/JourneyDetailPage.css†L1-L168】
+
+![Wireframe da tela de detalhes mostrando timeline, segmentação e métricas.](images/journey-detail.svg)
+
+### Formulário de criação e edição
+O formulário reutilizável é dividido em seções para nome/template, janela e metas, segmentação e metadados avançados. Cada campo exibe validações inline e loaders contextuais, garantindo feedback imediato durante operações de salvar como rascunho ou publicar. A seleção assistida de nichos/experimentos oferece busca incremental e garante coerência com o template escolhido via hooks de criação e atualização.【F:frontend/src/pages/journey/JourneyForm.tsx†L1-L330】【F:frontend/src/api/journey/useCreateJourney.ts†L1-L55】【F:frontend/src/api/journey/useUpdateJourney.ts†L1-L55】
+
+![Wireframe do formulário de jornada com seções de template, metas e segmentação.](images/journey-form.svg)
 
 ## Tratamento de vínculos (assignments)
 * Atribuições podem ser criadas para leads individuais (verificação de existência) ou identificadores de segmento externos.【F:backend/ads-service/src/main/java/com/marketinghub/journey/service/JourneyAssignmentService.java†L49-L121】


### PR DESCRIPTION
## Summary
- detalha as telas da experiência de jornadas com seções dedicadas para lista, detalhe e formulário
- adiciona wireframes ilustrativos para apoiar o entendimento visual do fluxo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5a7b2f08c83219b20b7b61e4a451b