### PR TITLE
Add playful diagrams to journey detail view

### DIFF
--- a/frontend/src/pages/journey/JourneyDetailPage.css
+++ b/frontend/src/pages/journey/JourneyDetailPage.css
@@ -60,6 +60,12 @@
   color: #0f172a;
 }
 
+.journey-detail__card-intro {
+  margin: -0.25rem 0 1.25rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
 .journey-detail__card dl {
   display: grid;
   gap: 1rem;
@@ -91,6 +97,155 @@
 
 .journey-detail__card--full {
   grid-column: 1 / -1;
+}
+
+.journey-detail__timeline {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.journey-detail__timeline-stage {
+  position: relative;
+  padding: 1.5rem;
+  border-radius: 18px;
+  border: 2px solid #cbd5f5;
+  background: radial-gradient(circle at top, #f8fafc 0%, #eef2ff 70%, #e0e7ff 100%);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  display: grid;
+  gap: 0.9rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.journey-detail__timeline-stage:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 42px rgba(15, 23, 42, 0.18);
+}
+
+.journey-detail__timeline-stage::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 14px;
+  border: 1px dashed rgba(99, 102, 241, 0.25);
+  pointer-events: none;
+}
+
+.journey-detail__timeline-icon {
+  font-size: 1.75rem;
+  filter: drop-shadow(0 8px 16px rgba(79, 70, 229, 0.25));
+}
+
+.journey-detail__timeline-content h3 {
+  font-size: 1.05rem;
+  margin: 0;
+  color: #0f172a;
+}
+
+.journey-detail__timeline-content p {
+  margin: 0;
+  color: #334155;
+  line-height: 1.5;
+}
+
+.journey-detail__timeline-detail {
+  font-size: 0.85rem;
+  color: #4338ca;
+  font-weight: 600;
+}
+
+.journey-detail__timeline-stage--start {
+  border-color: #38bdf8;
+  background: radial-gradient(circle at top, #ecfeff 0%, #bae6fd 55%, #7dd3fc 100%);
+}
+
+.journey-detail__timeline-stage--milestone {
+  border-color: #a855f7;
+  background: radial-gradient(circle at top, #f5f3ff 0%, #e0e7ff 55%, #c7d2fe 100%);
+}
+
+.journey-detail__timeline-stage--segment {
+  border-color: #f97316;
+  background: radial-gradient(circle at top, #fff7ed 0%, #fed7aa 55%, #fdba74 100%);
+}
+
+.journey-detail__timeline-stage--end {
+  border-color: #22c55e;
+  background: radial-gradient(circle at top, #f0fdf4 0%, #bbf7d0 55%, #86efac 100%);
+}
+
+.journey-detail__constellation {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.journey-detail__constellation-node {
+  position: relative;
+  padding: 1.5rem;
+  border-radius: 20px;
+  color: #0f172a;
+  border: 1px solid transparent;
+  background: linear-gradient(#ffffff, #ffffff) padding-box,
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.45), rgba(236, 72, 153, 0.25)) border-box;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+}
+
+.journey-detail__constellation-node::after {
+  content: "";
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(59, 130, 246, 0.2);
+  filter: blur(12px);
+  top: 16px;
+  right: 16px;
+}
+
+.journey-detail__constellation-label {
+  display: block;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.journey-detail__constellation-value {
+  display: block;
+  font-size: 1.1rem;
+  margin-top: 0.35rem;
+  color: #1e293b;
+}
+
+.journey-detail__constellation-hint {
+  display: block;
+  margin-top: 0.6rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.journey-detail__constellation-node--primary {
+  background: linear-gradient(#ffffff, #ffffff) padding-box,
+    radial-gradient(circle at top, rgba(56, 189, 248, 0.5), rgba(59, 130, 246, 0.2)) border-box;
+}
+
+.journey-detail__constellation-node--secondary {
+  background: linear-gradient(#ffffff, #ffffff) padding-box,
+    radial-gradient(circle at top, rgba(168, 85, 247, 0.4), rgba(129, 140, 248, 0.2)) border-box;
+}
+
+.journey-detail__constellation-node--tertiary {
+  background: linear-gradient(#ffffff, #ffffff) padding-box,
+    radial-gradient(circle at top, rgba(244, 114, 182, 0.45), rgba(236, 72, 153, 0.25)) border-box;
+}
+
+.journey-detail__constellation-node--quaternary {
+  background: linear-gradient(#ffffff, #ffffff) padding-box,
+    radial-gradient(circle at top, rgba(74, 222, 128, 0.45), rgba(34, 197, 94, 0.2)) border-box;
 }
 
 .journey-detail__metadata {
@@ -185,5 +340,9 @@
 
   .journey-detail__modal {
     padding: 1.5rem;
+  }
+
+  .journey-detail__timeline {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 }

--- a/frontend/src/pages/journey/JourneyDetailPage.tsx
+++ b/frontend/src/pages/journey/JourneyDetailPage.tsx
@@ -4,7 +4,178 @@ import PageTitle from "../../components/PageTitle";
 import { useJourney } from "../../api/journey/useJourney";
 import JourneyStatusBadge from "./JourneyStatusBadge";
 import { useDeleteJourney } from "../../api/journey/useDeleteJourney";
+import type { Journey, JourneyStatus } from "../../api/journey/types";
 import "./JourneyDetailPage.css";
+
+type TimelineStageAccent = "start" | "milestone" | "segment" | "end";
+
+interface TimelineStage {
+  id: string;
+  title: string;
+  description: string;
+  accent: TimelineStageAccent;
+  detail?: string;
+  detailType?: "date" | "text";
+}
+
+interface ConstellationNode {
+  id: string;
+  label: string;
+  value: string;
+  hint?: string;
+  accent: "primary" | "secondary" | "tertiary" | "quaternary";
+}
+
+const stageAccentIcons: Record<TimelineStageAccent, string> = {
+  start: "🚀",
+  milestone: "🧭",
+  segment: "🎯",
+  end: "🏁",
+};
+
+const statusLabels: Record<JourneyStatus, string> = {
+  DRAFT: "Rascunho",
+  ACTIVE: "Ativa",
+  PAUSED: "Pausada",
+  COMPLETED: "Concluída",
+  ARCHIVED: "Arquivada",
+};
+
+function beautifyMetadataKey(key: string, index: number) {
+  const cleaned = key
+    .replace(/_/g, " ")
+    .replace(/-/g, " ")
+    .replace(/\s+/g, " ")
+    .replace(/[0-9]+$/, "")
+    .trim();
+
+  if (!cleaned) {
+    return `Etapa ${index}`;
+  }
+
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+function buildTimelineStages(
+  journey: Journey,
+  metadataEntries: Array<[string, string]>,
+): TimelineStage[] {
+  const stages: TimelineStage[] = [];
+
+  stages.push({
+    id: "start",
+    accent: "start",
+    title: "Início da jornada",
+    description: journey.startAt
+      ? "Momento de largada planejado para ativar o plano de ação."
+      : "Defina uma data de início para visualizar a largada desta jornada.",
+    detail: journey.startAt || journey.createdAt,
+    detailType: "date",
+  });
+
+  const stageKeywords = ["fase", "phase", "etapa", "stage", "momento", "step"];
+  const milestoneEntries = metadataEntries.filter(([key]) =>
+    stageKeywords.some((keyword) => key.toLowerCase().includes(keyword)),
+  );
+
+  if (milestoneEntries.length) {
+    milestoneEntries.forEach(([key, value], index) => {
+      stages.push({
+        id: `milestone-${key}-${index}`,
+        accent: "milestone",
+        title: beautifyMetadataKey(key, index + 1),
+        description: value?.trim() || "Adicione detalhes para esta etapa e deixe o mapa ainda mais completo.",
+      });
+    });
+  } else {
+    stages.push({
+      id: "blueprint",
+      accent: "milestone",
+      title: `Blueprint "${journey.templateName}"`,
+      description:
+        "Este template orienta os pontos de contato e garante consistência na jornada. Personalize os marcos usando os metadados.",
+    });
+  }
+
+  if (journey.segmentReference || journey.segmentFilter || journey.marketNicheId) {
+    stages.push({
+      id: "segment",
+      accent: "segment",
+      title: "Segmentação em foco",
+      description:
+        journey.segmentFilter?.trim() ||
+        journey.segmentReference?.trim() ||
+        (journey.marketNicheId ? `Foco no nicho ${journey.marketNicheId}.` : "Direcione a jornada para um público específico."),
+      detail: journey.segmentReference || journey.segmentFilter || undefined,
+      detailType: journey.segmentReference || journey.segmentFilter ? "text" : undefined,
+    });
+  }
+
+  stages.push({
+    id: "end",
+    accent: "end",
+    title: "Grand finale",
+    description:
+      journey.endAt
+        ? "Momento previsto para consolidar resultados e celebrar os aprendizados."
+        : "Defina uma data de conclusão para acompanhar o encerramento com clareza.",
+    detail: journey.endAt ?? undefined,
+    detailType: journey.endAt ? "date" : undefined,
+  });
+
+  return stages;
+}
+
+function buildConstellationNodes(journey: Journey): ConstellationNode[] {
+  const nodes: ConstellationNode[] = [
+    {
+      id: "status",
+      accent: "primary",
+      label: "Status",
+      value: statusLabels[journey.status],
+      hint: "Situação atual da jornada.",
+    },
+    {
+      id: "template",
+      accent: "secondary",
+      label: "Template",
+      value: journey.templateName,
+      hint: "Arquitetura criativa que guia os marcos.",
+    },
+  ];
+
+  if (journey.experimentId != null) {
+    nodes.push({
+      id: "experiment",
+      accent: "tertiary",
+      label: "Experimento",
+      value: `Experimento #${journey.experimentId}`,
+      hint: "Hipótese testada nesta jornada.",
+    });
+  }
+
+  if (journey.marketNicheId != null) {
+    nodes.push({
+      id: "niche",
+      accent: "quaternary",
+      label: "Nicho",
+      value: `Nicho ${journey.marketNicheId}`,
+      hint: "Contexto de mercado priorizado.",
+    });
+  }
+
+  if (journey.segmentReference || journey.segmentFilter) {
+    nodes.push({
+      id: "segment",
+      accent: "primary",
+      label: "Segmento",
+      value: journey.segmentReference || journey.segmentFilter || "Segmento personalizado",
+      hint: "Critério usado para encontrar o público ideal.",
+    });
+  }
+
+  return nodes;
+}
 
 function formatDateTime(value?: string | null) {
   if (!value) {
@@ -31,6 +202,16 @@ export default function JourneyDetailPage() {
   const metadataEntries = useMemo(
     () => Object.entries(journey?.metadata ?? {}),
     [journey?.metadata],
+  );
+
+  const timelineStages = useMemo(
+    () => (journey ? buildTimelineStages(journey, metadataEntries) : []),
+    [journey, metadataEntries],
+  );
+
+  const constellationNodes = useMemo(
+    () => (journey ? buildConstellationNodes(journey) : []),
+    [journey],
   );
 
   if (isLoading) {
@@ -139,6 +320,47 @@ export default function JourneyDetailPage() {
               <dd>{journey.experimentId ?? "—"}</dd>
             </div>
           </dl>
+        </article>
+
+        <article className="journey-detail__card journey-detail__card--full">
+          <h2>Mapa lúdico da jornada</h2>
+          <p className="journey-detail__card-intro">
+            Uma visão em estilo storyboard destacando os principais marcos, desde o pontapé inicial até o grande final.
+          </p>
+          <ol className="journey-detail__timeline">
+            {timelineStages.map((stage) => (
+              <li key={stage.id} className={`journey-detail__timeline-stage journey-detail__timeline-stage--${stage.accent}`}>
+                <span className="journey-detail__timeline-icon" aria-hidden="true">
+                  {stageAccentIcons[stage.accent]}
+                </span>
+                <div className="journey-detail__timeline-content">
+                  <h3>{stage.title}</h3>
+                  <p>{stage.description}</p>
+                  {stage.detail ? (
+                    <span className="journey-detail__timeline-detail">
+                      {stage.detailType === "date" ? formatDateTime(stage.detail) : stage.detail}
+                    </span>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </article>
+
+        <article className="journey-detail__card journey-detail__card--full">
+          <h2>Constelação estratégica</h2>
+          <p className="journey-detail__card-intro">
+            Elementos que orbitam esta jornada e influenciam o roteiro criativo.
+          </p>
+          <div className="journey-detail__constellation">
+            {constellationNodes.map((node) => (
+              <div key={node.id} className={`journey-detail__constellation-node journey-detail__constellation-node--${node.accent}`}>
+                <span className="journey-detail__constellation-label">{node.label}</span>
+                <strong className="journey-detail__constellation-value">{node.value}</strong>
+                {node.hint ? <span className="journey-detail__constellation-hint">{node.hint}</span> : null}
+              </div>
+            ))}
+          </div>
         </article>
 
         <article className="journey-detail__card journey-detail__card--full">


### PR DESCRIPTION
## Summary
- add helper utilities to build a storyboard-like timeline and constellation from journey data
- render playful timeline and constellation sections in the journey detail page alongside metadata
- style the new diagram sections with gradients, icons, and responsive layouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5a90a475c832188e9f0c84c087e43