### PR TITLE
Exibir passos detalhados no detalhe da jornada

### DIFF
--- a/frontend/src/api/journey/types.ts
+++ b/frontend/src/api/journey/types.ts
@@ -5,6 +5,32 @@ export type JourneyStatus =
   | "COMPLETED"
   | "ARCHIVED";
 
+export type JourneyPhase =
+  | "ATTENTION"
+  | "INTEREST"
+  | "DESIRE"
+  | "ACTION";
+
+export type JourneyStimulusType = "AD" | "EMAIL" | "WHATSAPP" | "LANDING_PAGE";
+
+export interface JourneyStep {
+  id: number;
+  templateId: number;
+  position: number;
+  name?: string | null;
+  description?: string | null;
+  phase: JourneyPhase;
+  stimulusType: JourneyStimulusType;
+  creativeId?: number | null;
+  angleId?: number | null;
+  visualProofId?: number | null;
+  emotionalTriggerId?: number | null;
+  entryCondition?: string | null;
+  exitCondition?: string | null;
+  delayMinutes?: number | null;
+  metadata: Record<string, string>;
+}
+
 export interface Journey {
   id: number;
   templateId: number;
@@ -47,6 +73,20 @@ export interface JourneyTemplateSummary {
   preferredChannel?: string | null;
   tags: string[];
   metadata: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JourneyTemplate {
+  id: number;
+  name: string;
+  description?: string | null;
+  objective?: string | null;
+  phases: JourneyPhase[];
+  preferredChannel?: string | null;
+  tags: string[];
+  metadata: Record<string, string>;
+  steps: JourneyStep[];
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/api/journey/useJourneyTemplate.ts
+++ b/frontend/src/api/journey/useJourneyTemplate.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { JourneyTemplate } from "./types";
+
+export function useJourneyTemplate(id?: number) {
+  return useQuery({
+    queryKey: ["journey-template", id],
+    enabled: typeof id === "number" && id > 0,
+    queryFn: async () => {
+      const { data } = await axios.get<JourneyTemplate>(`/api/journey-templates/${id}`);
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/journey/JourneyDetailPage.css
+++ b/frontend/src/pages/journey/JourneyDetailPage.css
@@ -46,12 +46,19 @@
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-.journey-detail__card {
+.journey-detail__card { 
   background: #ffffff;
   border-radius: 18px;
   border: 1px solid #e2e8f0;
   padding: 1.75rem;
   box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+}
+
+.journey-detail__card-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
 .journey-detail__card h2 {
@@ -99,7 +106,7 @@
   grid-column: 1 / -1;
 }
 
-.journey-detail__timeline {
+.journey-detail__timeline { 
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1.25rem;
@@ -177,7 +184,7 @@
   background: radial-gradient(circle at top, #f0fdf4 0%, #bbf7d0 55%, #86efac 100%);
 }
 
-.journey-detail__constellation {
+.journey-detail__constellation { 
   display: grid;
   gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -283,6 +290,159 @@
   margin: 0;
 }
 
+.journey-detail__loading--inline {
+  margin: 0;
+  padding: 1.5rem;
+  border-radius: 14px;
+  border-style: dashed;
+}
+
+.journey-detail__step-count {
+  background: rgba(59, 130, 246, 0.1);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+}
+
+.journey-detail__steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.journey-detail__step {
+  display: flex;
+  gap: 1.25rem;
+  align-items: flex-start;
+  background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+  border-radius: 18px;
+  border: 1px solid #cbd5f5;
+  padding: 1.5rem;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+.journey-detail__step-index {
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  gap: 0.35rem;
+  min-width: 72px;
+  max-width: 72px;
+  color: #312e81;
+  background: rgba(79, 70, 229, 0.12);
+  border-radius: 16px;
+  padding: 0.75rem 0.5rem;
+  border: 1px solid rgba(79, 70, 229, 0.2);
+}
+
+.journey-detail__step-number {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.journey-detail__step-phase {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.journey-detail__step-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.journey-detail__step-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.journey-detail__step-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.journey-detail__step-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.1);
+  color: #1d4ed8;
+}
+
+.journey-detail__step-pill--ads {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.journey-detail__step-pill--email {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.journey-detail__step-pill--whatsapp {
+  background: rgba(34, 197, 94, 0.14);
+  color: #047857;
+}
+
+.journey-detail__step-pill--landing {
+  background: rgba(168, 85, 247, 0.12);
+  color: #6b21a8;
+}
+
+.journey-detail__step-description {
+  margin: 0;
+  color: #1f2937;
+  line-height: 1.6;
+}
+
+.journey-detail__step-description--muted {
+  color: #64748b;
+  font-style: italic;
+}
+
+.journey-detail__step-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.journey-detail__step-meta strong {
+  font-weight: 700;
+  margin-right: 0.25rem;
+  color: #0f172a;
+}
+
+.journey-detail__step-annotations {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.journey-detail__step-chip {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.06);
+  color: #1f2937;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
 .journey-detail__loading {
   background: #f8fafc;
   border-radius: 16px;
@@ -344,5 +504,18 @@
 
   .journey-detail__timeline {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .journey-detail__step {
+    flex-direction: column;
+  }
+
+  .journey-detail__step-index {
+    width: 100%;
+    max-width: none;
+    flex-direction: row;
+    grid-auto-flow: column;
+    justify-content: flex-start;
+    padding: 0.5rem 1rem;
   }
 }

--- a/frontend/src/pages/journey/JourneyDetailPage.tsx
+++ b/frontend/src/pages/journey/JourneyDetailPage.tsx
@@ -4,7 +4,14 @@ import PageTitle from "../../components/PageTitle";
 import { useJourney } from "../../api/journey/useJourney";
 import JourneyStatusBadge from "./JourneyStatusBadge";
 import { useDeleteJourney } from "../../api/journey/useDeleteJourney";
-import type { Journey, JourneyStatus } from "../../api/journey/types";
+import { useJourneyTemplate } from "../../api/journey/useJourneyTemplate";
+import type {
+  Journey,
+  JourneyPhase,
+  JourneyStatus,
+  JourneyStep,
+  JourneyStimulusType,
+} from "../../api/journey/types";
 import "./JourneyDetailPage.css";
 
 type TimelineStageAccent = "start" | "milestone" | "segment" | "end";
@@ -33,6 +40,20 @@ const stageAccentIcons: Record<TimelineStageAccent, string> = {
   end: "🏁",
 };
 
+const phaseLabels: Record<JourneyPhase, string> = {
+  ATTENTION: "Atenção",
+  INTEREST: "Interesse",
+  DESIRE: "Desejo",
+  ACTION: "Ação",
+};
+
+const stimulusDescriptors: Record<JourneyStimulusType, { label: string; accent: string; icon: string }> = {
+  AD: { label: "Anúncio pago", accent: "ads", icon: "📢" },
+  EMAIL: { label: "Email marketing", accent: "email", icon: "✉️" },
+  WHATSAPP: { label: "WhatsApp", accent: "whatsapp", icon: "💬" },
+  LANDING_PAGE: { label: "Landing page", accent: "landing", icon: "🧭" },
+};
+
 const statusLabels: Record<JourneyStatus, string> = {
   DRAFT: "Rascunho",
   ACTIVE: "Ativa",
@@ -59,6 +80,7 @@ function beautifyMetadataKey(key: string, index: number) {
 function buildTimelineStages(
   journey: Journey,
   metadataEntries: Array<[string, string]>,
+  steps?: JourneyStep[],
 ): TimelineStage[] {
   const stages: TimelineStage[] = [];
 
@@ -73,28 +95,46 @@ function buildTimelineStages(
     detailType: "date",
   });
 
-  const stageKeywords = ["fase", "phase", "etapa", "stage", "momento", "step"];
-  const milestoneEntries = metadataEntries.filter(([key]) =>
-    stageKeywords.some((keyword) => key.toLowerCase().includes(keyword)),
-  );
+  if (steps?.length) {
+    steps.forEach((step, index) => {
+      const descriptor = stimulusDescriptors[step.stimulusType];
+      const summary = [phaseLabels[step.phase], descriptor?.label]
+        .filter(Boolean)
+        .join(" • ");
 
-  if (milestoneEntries.length) {
-    milestoneEntries.forEach(([key, value], index) => {
       stages.push({
-        id: `milestone-${key}-${index}`,
+        id: `step-${step.id ?? index}`,
         accent: "milestone",
-        title: beautifyMetadataKey(key, index + 1),
-        description: value?.trim() || "Adicione detalhes para esta etapa e deixe o mapa ainda mais completo.",
+        title: step.name?.trim() || `Passo ${index + 1}`,
+        description: step.description?.trim() || summary || "Aprofunde os detalhes deste ponto de contato.",
+        detail: step.description ? summary : undefined,
+        detailType: step.description ? "text" : undefined,
       });
     });
   } else {
-    stages.push({
-      id: "blueprint",
-      accent: "milestone",
-      title: `Blueprint "${journey.templateName}"`,
-      description:
-        "Este template orienta os pontos de contato e garante consistência na jornada. Personalize os marcos usando os metadados.",
-    });
+    const stageKeywords = ["fase", "phase", "etapa", "stage", "momento", "step"];
+    const milestoneEntries = metadataEntries.filter(([key]) =>
+      stageKeywords.some((keyword) => key.toLowerCase().includes(keyword)),
+    );
+
+    if (milestoneEntries.length) {
+      milestoneEntries.forEach(([key, value], index) => {
+        stages.push({
+          id: `milestone-${key}-${index}`,
+          accent: "milestone",
+          title: beautifyMetadataKey(key, index + 1),
+          description: value?.trim() || "Adicione detalhes para esta etapa e deixe o mapa ainda mais completo.",
+        });
+      });
+    } else {
+      stages.push({
+        id: "blueprint",
+        accent: "milestone",
+        title: `Blueprint "${journey.templateName}"`,
+        description:
+          "Este template orienta os pontos de contato e garante consistência na jornada. Personalize os marcos usando os metadados.",
+      });
+    }
   }
 
   if (journey.segmentReference || journey.segmentFilter || journey.marketNicheId) {
@@ -191,6 +231,33 @@ function formatDateTime(value?: string | null) {
   }
 }
 
+function formatDelay(minutes?: number | null) {
+  if (minutes == null || Number.isNaN(minutes)) {
+    return null;
+  }
+
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (hours < 24) {
+    return remainingMinutes ? `${hours}h ${remainingMinutes}min` : `${hours}h`;
+  }
+
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+
+  if (remainingHours) {
+    const readableMinutes = remainingMinutes ? ` ${remainingMinutes}min` : "";
+    return `${days}d ${remainingHours}h${readableMinutes}`;
+  }
+
+  return `${days}d`;
+}
+
 export default function JourneyDetailPage() {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -198,6 +265,7 @@ export default function JourneyDetailPage() {
   const { data: journey, isLoading } = useJourney(Number.isNaN(journeyId) ? undefined : journeyId);
   const deleteJourney = useDeleteJourney(journeyId);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const { data: template, isLoading: isTemplateLoading } = useJourneyTemplate(journey?.templateId);
 
   const metadataEntries = useMemo(
     () => Object.entries(journey?.metadata ?? {}),
@@ -205,14 +273,16 @@ export default function JourneyDetailPage() {
   );
 
   const timelineStages = useMemo(
-    () => (journey ? buildTimelineStages(journey, metadataEntries) : []),
-    [journey, metadataEntries],
+    () => (journey ? buildTimelineStages(journey, metadataEntries, template?.steps) : []),
+    [journey, metadataEntries, template?.steps],
   );
 
   const constellationNodes = useMemo(
     () => (journey ? buildConstellationNodes(journey) : []),
     [journey],
   );
+
+  const templateSteps = template?.steps ?? [];
 
   if (isLoading) {
     return <div className="journey-detail__loading">Carregando jornada...</div>;
@@ -345,6 +415,92 @@ export default function JourneyDetailPage() {
               </li>
             ))}
           </ol>
+        </article>
+
+        <article className="journey-detail__card journey-detail__card--full">
+          <div className="journey-detail__card-heading">
+            <h2>Roteiro de execução</h2>
+            {templateSteps.length ? (
+              <span className="journey-detail__step-count" aria-label={`${templateSteps.length} passos`}>
+                {templateSteps.length} passo{templateSteps.length > 1 ? "s" : ""}
+              </span>
+            ) : null}
+          </div>
+          <p className="journey-detail__card-intro">
+            Confira os pontos de contato planejados no template e alinhe sua operação com o que acontece na prática.
+          </p>
+          {isTemplateLoading ? (
+            <div className="journey-detail__loading journey-detail__loading--inline" role="status">
+              Carregando passos do template...
+            </div>
+          ) : templateSteps.length ? (
+            <ol className="journey-detail__steps">
+              {templateSteps.map((step, index) => {
+                const descriptor = stimulusDescriptors[step.stimulusType];
+                const delayLabel = formatDelay(step.delayMinutes);
+                const metadata = Object.entries(step.metadata ?? {});
+
+                return (
+                  <li key={step.id ?? `step-${index}`} className="journey-detail__step">
+                    <div className="journey-detail__step-index" aria-hidden="true">
+                      <span className="journey-detail__step-number">{index + 1}</span>
+                      <span className="journey-detail__step-phase">{phaseLabels[step.phase]}</span>
+                    </div>
+                    <div className="journey-detail__step-content">
+                      <div className="journey-detail__step-header">
+                        <h3>{step.name?.trim() || `Passo ${index + 1}`}</h3>
+                        {descriptor ? (
+                          <span
+                            className={`journey-detail__step-pill journey-detail__step-pill--${descriptor.accent}`}
+                          >
+                            <span aria-hidden="true">{descriptor.icon}</span> {descriptor.label}
+                          </span>
+                        ) : null}
+                      </div>
+                      {step.description ? (
+                        <p className="journey-detail__step-description">{step.description}</p>
+                      ) : (
+                        <p className="journey-detail__step-description journey-detail__step-description--muted">
+                          Acrescente uma descrição para orientar a execução deste momento.
+                        </p>
+                      )}
+                      <div className="journey-detail__step-meta" aria-label="Detalhes do passo">
+                        {delayLabel ? (
+                          <span>
+                            <strong>Espera:</strong> {delayLabel}
+                          </span>
+                        ) : null}
+                        {step.entryCondition ? (
+                          <span>
+                            <strong>Entrada:</strong> {step.entryCondition}
+                          </span>
+                        ) : null}
+                        {step.exitCondition ? (
+                          <span>
+                            <strong>Saída:</strong> {step.exitCondition}
+                          </span>
+                        ) : null}
+                      </div>
+                      {metadata.length ? (
+                        <div className="journey-detail__step-annotations" aria-label="Metadados do passo">
+                          {metadata.map(([key, value]) => (
+                            <span key={key} className="journey-detail__step-chip">
+                              <strong>{key}:</strong> {value || "—"}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          ) : (
+            <p className="journey-detail__empty">
+              Este template ainda não possui passos cadastrados. Acesse o blueprint para criar os pontos de contato e
+              automatizar a jornada.
+            </p>
+          )}
         </article>
 
         <article className="journey-detail__card journey-detail__card--full">


### PR DESCRIPTION
## Summary
- buscar o template da jornada e usar os passos reais na linha do tempo
- apresentar uma seção de roteiro com fase, canal, atrasos e metadados de cada passo
- ajustar os estilos para a nova hierarquia visual dos cards

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e612f443cc8321925493fb81f90c68