### PR TITLE
Navigate to AI service list after creating service

### DIFF
--- a/frontend/src/pages/aiService/NewAiServicePage.tsx
+++ b/frontend/src/pages/aiService/NewAiServicePage.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useCreateAiService } from "../../api/aiService/useCreateAiService";
 import PageTitle from "../../components/PageTitle";
 
 export default function NewAiServicePage() {
   const create = useCreateAiService();
+  const navigate = useNavigate();
   const [form, setForm] = useState({
     name: "",
     objective: "",
@@ -15,12 +17,17 @@ export default function NewAiServicePage() {
   });
 
   const submit = () => {
-    create.mutate({
-      ...form,
-      price: Number(form.price),
-      cost: Number(form.cost),
-      observation: form.observation,
-    });
+    create.mutate(
+      {
+        ...form,
+        price: Number(form.price),
+        cost: Number(form.cost),
+        observation: form.observation,
+      },
+      {
+        onSuccess: () => navigate("/ai-services"),
+      },
+    );
   };
 
   return (


### PR DESCRIPTION
## Summary
- redirect the AI service creation flow back to the listing once the backend confirms persistence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6607eea3c8321b8f91676755c81a7