### PR TITLE
Corrige exibição de templates de jornada sem timestamps válidos

### DIFF
--- a/frontend/src/pages/journey/JourneyTemplatesPage.test.tsx
+++ b/frontend/src/pages/journey/JourneyTemplatesPage.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import JourneyTemplatesPage from "./JourneyTemplatesPage";
+
+vi.mock("../../api/journey/useJourneyTemplates", () => ({
+  useJourneyTemplates: () => ({
+    data: {
+      content: [
+        {
+          id: 1,
+          name: "Lifecycle Pós-Clique Lead Ads 14d",
+          objective: "Converter curiosidade em relacionamento contínuo",
+          phases: ["ATTENTION", "INTEREST", "DESIRE", "ACTION"],
+          preferredChannel: null,
+          tags: ["facebook", "lifecycle"],
+          metadata: {},
+          createdAt: null,
+          updatedAt: undefined,
+        },
+      ],
+      totalElements: 1,
+      totalPages: 1,
+      number: 0,
+    },
+    isLoading: false,
+  }),
+}));
+
+describe("JourneyTemplatesPage", () => {
+  it("exibe templates mesmo quando timestamps não estão disponíveis", () => {
+    render(<JourneyTemplatesPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "Lifecycle Pós-Clique Lead Ads 14d",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Multicanal")).toBeInTheDocument();
+    expect(screen.getByText("ATTENTION • INTEREST • DESIRE • ACTION")).toBeInTheDocument();
+    expect(screen.getByText(/Criado em\s+—/)).toBeInTheDocument();
+    expect(screen.getByText(/Atualizado em\s+—/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/journey/JourneyTemplatesPage.tsx
+++ b/frontend/src/pages/journey/JourneyTemplatesPage.tsx
@@ -10,6 +10,27 @@ function formatChannel(template: JourneyTemplateSummary) {
   return "Multicanal";
 }
 
+function formatDate(value?: string | null) {
+  if (!value) {
+    return "—";
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "—";
+  }
+
+  return parsed.toLocaleDateString("pt-BR");
+}
+
+function formatPhases(phases?: string[]) {
+  if (!phases || phases.length === 0) {
+    return "Fases não cadastradas";
+  }
+
+  return phases.join(" • ");
+}
+
 export default function JourneyTemplatesPage() {
   const { data, isLoading } = useJourneyTemplates();
   const templates = data?.content ?? [];
@@ -37,7 +58,7 @@ export default function JourneyTemplatesPage() {
                 <div className="journey-template-card__meta">
                   <span className="journey-template-card__channel">{formatChannel(template)}</span>
                   <span className="journey-template-card__phases">
-                    {template.phases.join(" • ")}
+                    {formatPhases(template.phases)}
                   </span>
                 </div>
                 <h2>{template.name}</h2>
@@ -45,7 +66,7 @@ export default function JourneyTemplatesPage() {
                   <p className="journey-template-card__objective">{template.objective}</p>
                 ) : null}
               </header>
-              {template.tags.length ? (
+              {Array.isArray(template.tags) && template.tags.length ? (
                 <div className="journey-template-card__tags">
                   {template.tags.map((tag) => (
                     <span key={tag} className="journey-template-card__tag">
@@ -56,10 +77,10 @@ export default function JourneyTemplatesPage() {
               ) : null}
               <footer className="journey-template-card__footer">
                 <span>
-                  Criado em {new Date(template.createdAt).toLocaleDateString("pt-BR")}
+                  Criado em {formatDate(template.createdAt)}
                 </span>
                 <span>
-                  Atualizado em {new Date(template.updatedAt).toLocaleDateString("pt-BR")}
+                  Atualizado em {formatDate(template.updatedAt)}
                 </span>
               </footer>
             </article>


### PR DESCRIPTION
## Resumo
- evita que datas ausentes nos templates quebrem a renderização da página
- adiciona teste cobrindo o fallback de datas para garantir que o card continue visível

## Testes
- npm test -- --run JourneyTemplatesPage

------
https://chatgpt.com/codex/tasks/task_e_68e6649416f483218db9a11a87b8bbfe