### PR TITLE
Standardize AI Worker image model to gpt-image-1.5 and normalize legacy gpt-image-1

### DIFF
--- a/ai-worker/docker-compose.yml
+++ b/ai-worker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       OPENAI_API_KEY_FILE: ${OPENAI_API_KEY_FILE:-/run/secrets/openai_api_key}
       OPENAI_MODEL: ${OPENAI_MODEL:-o3}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
-      OPENAI_IMAGE_MODEL: ${OPENAI_IMAGE_MODEL:-gpt-image-1}
+      OPENAI_IMAGE_MODEL: ${OPENAI_IMAGE_MODEL:-gpt-image-1.5}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
       GOOGLE_SEARCH_ID: ${GOOGLE_SEARCH_ID:-}
       LOGGING_FILE_NAME: ${AI_WORKER_LOG_FILE:-/var/log/ai-worker/application.log}

--- a/ai-worker/src/main/java/com/marketinghub/worker/frameworkimage/FrameworkImageOpenAiBatchClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/frameworkimage/FrameworkImageOpenAiBatchClient.java
@@ -113,7 +113,7 @@ public class FrameworkImageOpenAiBatchClient {
 
     private Map<String, Object> buildGenerationPayload(FrameworkImageJobDto job) {
         Map<String, Object> payload = new LinkedHashMap<>();
-        String selectedModel = StringUtils.hasText(job.model()) ? job.model().trim() : defaultModel;
+        String selectedModel = resolveModel(job.model());
         payload.put("model", selectedModel);
         payload.put("prompt", job.prompt());
         if (supportsResponseFormat(selectedModel)) {
@@ -231,7 +231,7 @@ public class FrameworkImageOpenAiBatchClient {
                 }
 
                 ImageGenerationResponse response = mapper.convertValue(output.response().body(), ImageGenerationResponse.class);
-                String model = StringUtils.hasText(response.model()) ? response.model() : defaultModel;
+                String model = resolveModel(response.model());
                 String prompt = response.prompt();
                 ImageData imageData = response.firstImageData();
                 if (imageData == null) {
@@ -297,6 +297,19 @@ public class FrameworkImageOpenAiBatchClient {
             return fallback;
         }
         return candidate;
+    }
+
+    private String resolveModel(String requestedModel) {
+        String normalizedDefaultModel = StringUtils.hasText(defaultModel) ? defaultModel.trim() : "gpt-image-1.5";
+        if (!StringUtils.hasText(requestedModel)) {
+            return normalizedDefaultModel;
+        }
+
+        String trimmed = requestedModel.trim();
+        if ("gpt-image-1".equalsIgnoreCase(trimmed) || "gpt-image-1.0".equalsIgnoreCase(trimmed)) {
+            return normalizedDefaultModel;
+        }
+        return trimmed;
     }
 
     private boolean supportsResponseFormat(String selectedModel) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/leadportal/image/LeadPortalOpenAiImageClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/leadportal/image/LeadPortalOpenAiImageClient.java
@@ -67,7 +67,7 @@ public class LeadPortalOpenAiImageClient {
             CreativeImageOptimizer imageOptimizer,
             @Value("${openai.api-key:}") String apiKey,
             @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
-            @Value("${openai.image-model:gpt-image-1}") String model,
+            @Value("${openai.image-model:gpt-image-1.5}") String model,
             @Value("${openai.batch-poll-interval:PT0.5S}") Duration batchPollInterval,
             @Value("${openai.batch-timeout:PT5M}") Duration batchTimeout) {
         this.imageOptimizer = imageOptimizer;


### PR DESCRIPTION
### Motivation
- Logs showed the Worker AI still generating images with `gpt-image-1`, so the project needs to standardize on `gpt-image-1.5` to avoid mixed-version processing. 
- The change ensures new deployments default to the 1.5 image model and that legacy job records requesting `gpt-image-1` are migrated to the new model at runtime.

### Description
- Update the `ai-worker` docker defaults by changing `OPENAI_IMAGE_MODEL` to `gpt-image-1.5` in `ai-worker/docker-compose.yml`.
- Change the `LeadPortalOpenAiImageClient` fallback to `@Value("${openai.image-model:gpt-image-1.5}")` so lead-portal image flows use `gpt-image-1.5` by default.
- Add a `resolveModel(String)` method in `FrameworkImageOpenAiBatchClient` and use it when building batch payloads and parsing batch responses to map empty/legacy values (including `gpt-image-1` and `gpt-image-1.0`) to the configured default model, preventing old jobs from being processed as version 1.

### Testing
- Attempted to run targeted unit tests with `mvn -s settings.xml -Dtest=FrameworkImageServiceTest,LeadPortalOpenAiImageClientTest test` in the `ai-worker` module. 
- The Maven run failed due to an external network issue preventing resolution of the Spring Boot parent POM from the configured Maven repository, so automated tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8252bb0c483219e5d1cf98391bb62)