### PR TITLE
Formalize and enforce section surfaceSpec contract between landing wireframe and HTML

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -150,9 +150,10 @@ public class ExperimentPipelineOpenAiClient {
             13. Não transformar o layout em HTML final; esta etapa define apenas ordem, hierarquia e slots de mídia.
             14. Não usar linguagem de consultoria e não criar estrutura genérica para qualquer mercado.
             15. Se a estrutura puder servir para qualquer nicho, reescreva até ficar específica para o nicho informado.
-            16. Orientar uiNotes/compositionNotes com variação intencional de cores de fundo entre seções para sinalizar mudança de assunto e facilitar escaneabilidade.
-            17. Garantir equilíbrio visual entre texto e imagem em cada bloco, explicando como mediaSlot e copy dividem atenção sem competir entre si.
-            18. Definir formSpec como contrato único do formulário com:
+            16. Cada bloco deve preencher surfaceSpec com surfaceToken, style, contrastMode e notes para contrato explícito de superfície visual por seção.
+            17. Alternar surfaceToken entre surface-base e surface-alt-* para reforçar escaneabilidade e hierarquia visual entre seções consecutivas.
+            18. Garantir equilíbrio visual entre texto e imagem em cada bloco, explicando como mediaSlot e copy dividem atenção sem competir entre si.
+            19. Definir formSpec como contrato único do formulário com:
                 - formId: lead-capture-primary
                 - title: Receber a prévia do Kit (IA)
                 - submitLabel: Desbloquear o Kit (receber a prévia gerada por IA)
@@ -173,8 +174,6 @@ public class ExperimentPipelineOpenAiClient {
             - ctaPlacementNotes
             - formPlacementNotes
             - formSpec
-            - backgroundColorStrategy
-            - textImageBalanceNotes
             - consistencyChecks[]
             """;
     private static final String LANDING_HTML_PROMPT_SUFFIX = """
@@ -192,14 +191,15 @@ public class ExperimentPipelineOpenAiClient {
                - wireframe para ordem/hierarquia e mediaSlot;
                - planejamento de imagens para placement e altText;
                - wireframe.formSpec para contrato de campos e obrigatoriedade do formulário.
-            7. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.
-            8. Não usar bibliotecas externas.
-            9. Toda tag <img> deve usar src absoluto válido (https://... ou data:image/...) e reutilizar altText do planejamento de imagens.
+            7. Cada seção renderizada deve incluir data-section-id e aplicar exatamente wireframe.sectionOrder[i].surfaceSpec usando data-surface-token, data-surface-style e data-surface-contrast.
+            8. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.
+            9. Não usar bibliotecas externas.
+            10. Toda tag <img> deve usar src absoluto válido (https://... ou data:image/...) e reutilizar altText do planejamento de imagens.
 
             Formato obrigatório (JSON):
             - htmlDocument
             - summary
-            - consistencyChecks[] com CTA_MATCH, PROMISE_MATCH, IMAGE_PLAN_BINDING, FORM_SPEC_BINDING e FORM_USABILITY
+            - consistencyChecks[] com CTA_MATCH, PROMISE_MATCH, IMAGE_PLAN_BINDING, SURFACE_SPEC_BINDING, FORM_SPEC_BINDING e FORM_USABILITY
             """;
     private static final String LANDING_IMAGE_PLANNING_PROMPT_SUFFIX = """
             Objetivo:

--- a/arquitetura-prompts/registro_alteracoes_workflow_orientado_artefatos.md
+++ b/arquitetura-prompts/registro_alteracoes_workflow_orientado_artefatos.md
@@ -16,6 +16,19 @@ As alterações serão adicionadas conforme forem implementadas, incluindo:
 
 ## Histórico
 
+
+### 2026-04-10 — Contrato explícito de superfícies entre `landing-page-wireframe` e `landing-page-html`
+
+- **Item alterado:** `landing-page-wireframe` e `landing-page-html` no pipeline de experimento.
+  - **O que mudou:** cada item de `sectionOrder` passou a exigir `surfaceSpec` estruturado (`surfaceToken`, `style`, `contrastMode`, `notes`) para formalizar a intenção visual de superfície por seção.
+  - **Impacto esperado:** alternância de fundos/superfícies deixa de ser implícita e passa a ser um contrato explícito antes da etapa de HTML.
+  - **Arquivos relacionados:** `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx`, `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`, `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java`.
+
+- **Item alterado:** validação determinística de superfícies no `landing-page-html`.
+  - **O que mudou:** backend agora valida de forma determinística se o `htmlDocument` aplica exatamente o `surfaceSpec` do wireframe por `sectionId`, exigindo `data-section-id`, `data-surface-token`, `data-surface-style` e `data-surface-contrast`.
+  - **Impacto esperado:** bloqueia deriva visual no HTML final e impede reinterpretar superfícies fora do contrato do wireframe.
+  - **Arquivos relacionados:** `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`.
+
 ### 2026-04-10 — Consistência determinística de formulário entre `landing-page-wireframe` e `landing-page-html`
 
 - **Item alterado:** `landing-page-wireframe` e `landing-page-html` no pipeline de experimento.

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -53,6 +53,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class ExperimentPipelineGenerationService {
     private static final Pattern FORM_CONTROL_TAG_PATTERN = Pattern.compile("(?is)<(input|textarea|select)\\b[^>]*>");
     private static final Pattern ATTRIBUTE_PATTERN = Pattern.compile("(?is)([a-zA-Z_:][-a-zA-Z0-9_:.]*)\\s*=\\s*([\"'])(.*?)\\2");
+    private static final Pattern OPENING_TAG_PATTERN = Pattern.compile("(?is)<([a-z0-9:-]+)\\b[^>]*>");
     private static final String DEFAULT_MODEL = "gpt-5.2";
     private static final Duration STALE_PENDING_TIMEOUT = Duration.ofMinutes(10);
     private static final Duration STALE_PROCESSING_TIMEOUT = Duration.ofMinutes(20);
@@ -702,10 +703,12 @@ public class ExperimentPipelineGenerationService {
             sb.append("10. mobilePriorityNotes deve destacar o que precisa aparecer antes da rolagem.\n");
             sb.append("11. Cada sectionOrder[i] deve preencher mediaSlot com: none, image, illustration, chart, icon-set ou video-thumb.\n");
             sb.append("12. Cada sectionOrder[i] deve preencher compositionNotes explicando hierarquia visual, densidade de conteúdo e leitura mobile-first.\n");
-            sb.append("13. Não transformar o layout em HTML final; esta etapa deve decidir ordem, hierarquia e slots de mídia.\n");
-            sb.append("14. Não usar linguagem de consultoria e não criar estrutura que pareça página genérica para qualquer mercado.\n");
-            sb.append("15. Se a estrutura puder servir para qualquer nicho, reescreva até ficar específica para ").append(niche).append(".\n");
-            sb.append("16. Definir formSpec como contrato estruturado do formulário com esta configuração:\n");
+            sb.append("13. Cada sectionOrder[i] deve preencher surfaceSpec com surfaceToken, style, contrastMode e notes para formalizar a superfície visual da seção.\n");
+            sb.append("14. Use surfaceToken alternando entre surface-base e surface-alt-* para reforçar escaneabilidade entre seções consecutivas.\n");
+            sb.append("15. Não transformar o layout em HTML final; esta etapa deve decidir ordem, hierarquia e slots de mídia.\n");
+            sb.append("16. Não usar linguagem de consultoria e não criar estrutura que pareça página genérica para qualquer mercado.\n");
+            sb.append("17. Se a estrutura puder servir para qualquer nicho, reescreva até ficar específica para ").append(niche).append(".\n");
+            sb.append("18. Definir formSpec como contrato estruturado do formulário com esta configuração:\n");
             sb.append("   - formId: lead-capture-primary\n");
             sb.append("   - title: Receber a prévia do Kit (IA)\n");
             sb.append("   - submitLabel: Desbloquear o Kit (receber a prévia gerada por IA)\n");
@@ -716,7 +719,7 @@ public class ExperimentPipelineGenerationService {
             sb.append("   - successState: title e message preenchidos.\n\n");
             sb.append("Formato obrigatório:\n");
             sb.append("- Preencher sectionOrder respeitando a ordem real da landing e referenciando sectionId de bodySections quando existir.\n");
-            sb.append("- Preencher mediaSlot e compositionNotes em todas as seções.\n");
+            sb.append("- Preencher mediaSlot, compositionNotes e surfaceSpec em todas as seções.\n");
             sb.append("- Preencher formSpec completo como fonte única da verdade para campos e obrigatoriedade do formulário.\n");
             sb.append("- Preencher ctaSlot dentro das seções com CTA.\n");
             sb.append("- Preencher consistencyChecks e observações finais (mobilePriorityNotes, ctaPlacementNotes, formPlacementNotes).\n");
@@ -780,13 +783,14 @@ public class ExperimentPipelineGenerationService {
             sb.append("   - wireframe para ordem/hierarquia e mediaSlot;\n");
             sb.append("   - planejamento de imagens para placement, prioridade e altText;\n");
             sb.append("   - wireframe.formSpec para renderização exata dos campos do formulário.\n");
-            sb.append("9. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.\n");
-            sb.append("10. O código deve ser limpo, legível e pronto para ser renderizado em iframe.\n");
-            sb.append("11. Toda tag <img> deve usar src absoluto válido (https://... ou data:image/...) e reaproveitar altText do planejamento de imagens.\n\n");
+            sb.append("9. Renderizar cada seção com data-section-id e aplicar exatamente wireframe.sectionOrder[i].surfaceSpec via data-surface-token, data-surface-style e data-surface-contrast.\n");
+            sb.append("10. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.\n");
+            sb.append("11. O código deve ser limpo, legível e pronto para ser renderizado em iframe.\n");
+            sb.append("12. Toda tag <img> deve usar src absoluto válido (https://... ou data:image/...) e reaproveitar altText do planejamento de imagens.\n\n");
             sb.append("Formato obrigatório:\n");
             sb.append("- htmlDocument: string com o documento completo final.\n");
             sb.append("- summary: resumo curto das decisões de implementação.\n");
-            sb.append("- consistencyChecks: checks com CTA_MATCH, PROMISE_MATCH, IMAGE_PLAN_BINDING, FORM_SPEC_BINDING e FORM_USABILITY.\n");
+            sb.append("- consistencyChecks: checks com CTA_MATCH, PROMISE_MATCH, IMAGE_PLAN_BINDING, SURFACE_SPEC_BINDING, FORM_SPEC_BINDING e FORM_USABILITY.\n");
             return;
         }
     }
@@ -830,6 +834,7 @@ public class ExperimentPipelineGenerationService {
             case LANDING_PAGE_IMAGE_PLANNING -> experiment.setLandingPageImagePlanning(normalized);
             case LANDING_PAGE_HTML -> {
                 validateLandingHtmlFormConsistency(experiment, normalized);
+                validateLandingHtmlSurfaceConsistency(experiment, normalized);
                 experiment.setLandingPageHtml(normalized);
             }
         }
@@ -1422,6 +1427,17 @@ public class ExperimentPipelineGenerationService {
                 ),
                 "required", List.of("formId", "title", "submitLabel", "submitTarget", "fields", "consent", "successState")
         );
+        Map<String, Object> surfaceSpecSchema = Map.of(
+                "type", "object",
+                "additionalProperties", false,
+                "properties", Map.ofEntries(
+                        Map.entry("surfaceToken", stringSchema()),
+                        Map.entry("style", Map.of("type", "string", "enum", List.of("band", "solid", "gradient-soft", "image-tint"))),
+                        Map.entry("contrastMode", Map.of("type", "string", "enum", List.of("normal", "high", "soft"))),
+                        Map.entry("notes", stringSchema())
+                ),
+                "required", List.of("surfaceToken", "style", "contrastMode", "notes")
+        );
         Map<String, Object> ctaSlotSchema = Map.of(
                 "type", "object",
                 "additionalProperties", false,
@@ -1454,9 +1470,10 @@ public class ExperimentPipelineGenerationService {
                         Map.entry("sectionDependsOn", stringSchema()),
                         Map.entry("mobilePriorityScore", integerSchema(1, 10)),
                         Map.entry("dropOffRisk", Map.of("type", "string", "enum", List.of("baixo", "medio", "alto"))),
+                        Map.entry("surfaceSpec", surfaceSpecSchema),
                         Map.entry("ctaSlot", ctaSlotSchema)
                 ),
-                "required", List.of("sectionId", "sectionName", "objective", "contentType", "mobilePriorityScore", "dropOffRisk")
+                "required", List.of("sectionId", "sectionName", "objective", "contentType", "mobilePriorityScore", "dropOffRisk", "surfaceSpec")
         );
         return Map.of(
                 "type", "object",
@@ -1570,6 +1587,92 @@ public class ExperimentPipelineGenerationService {
         return fields;
     }
 
+
+
+    @SuppressWarnings("unchecked")
+    private void validateLandingHtmlSurfaceConsistency(Experiment experiment, String landingHtmlContent) {
+        if (!StringUtils.hasText(landingHtmlContent) || !StringUtils.hasText(experiment.getLandingPageWireframe())) {
+            return;
+        }
+
+        Map<String, Object> wireframeRoot = readObject(experiment.getLandingPageWireframe(), "Wireframe da landing inválido");
+        Map<String, Object> wireframePayload = unwrapSectionPayload(wireframeRoot, "landingPageWireframe");
+        List<SectionSurfaceContract> expectedSurfaces = extractExpectedSectionSurfaces(wireframePayload);
+        if (expectedSurfaces.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Wireframe da landing sem sectionOrder.surfaceSpec estruturado");
+        }
+
+        Map<String, Object> htmlRoot = readObject(landingHtmlContent, "Payload da landing HTML inválido");
+        Map<String, Object> htmlPayload = unwrapSectionPayload(htmlRoot, "landingPageHtml");
+        String htmlDocument = asTrimmedString(htmlPayload.get("htmlDocument"));
+        if (!StringUtils.hasText(htmlDocument)) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "landingPageHtml.htmlDocument não encontrado");
+        }
+
+        List<SectionSurfaceContract> actualSurfaces = extractSectionSurfacesFromHtmlDocument(htmlDocument);
+        List<SectionSurfaceContract> expectedSorted = expectedSurfaces.stream()
+                .sorted(Comparator.comparing(SectionSurfaceContract::sectionId))
+                .toList();
+        List<SectionSurfaceContract> actualSorted = actualSurfaces.stream()
+                .sorted(Comparator.comparing(SectionSurfaceContract::sectionId))
+                .toList();
+
+        if (!expectedSorted.equals(actualSorted)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Divergência de superfície: landing-page-html deve reproduzir exatamente landing-page-wireframe.sectionOrder.surfaceSpec");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<SectionSurfaceContract> extractExpectedSectionSurfaces(Map<String, Object> wireframePayload) {
+        if (!(wireframePayload.get("sectionOrder") instanceof List<?> rawSections)) {
+            return List.of();
+        }
+        List<SectionSurfaceContract> surfaces = new ArrayList<>();
+        for (Object rawSection : rawSections) {
+            if (!(rawSection instanceof Map<?, ?> rawSectionMap)) {
+                continue;
+            }
+            Map<String, Object> section = (Map<String, Object>) rawSectionMap;
+            String sectionId = normalizeHtmlAttr(asTrimmedString(section.get("sectionId")));
+            if (!(section.get("surfaceSpec") instanceof Map<?, ?> rawSurfaceMap)) {
+                continue;
+            }
+            Map<String, Object> surfaceSpec = (Map<String, Object>) rawSurfaceMap;
+            String surfaceToken = normalizeHtmlAttr(asTrimmedString(surfaceSpec.get("surfaceToken")));
+            String style = normalizeHtmlAttr(asTrimmedString(surfaceSpec.get("style")));
+            String contrastMode = normalizeHtmlAttr(asTrimmedString(surfaceSpec.get("contrastMode")));
+            if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(surfaceToken)
+                    || !StringUtils.hasText(style) || !StringUtils.hasText(contrastMode)) {
+                continue;
+            }
+            surfaces.add(new SectionSurfaceContract(sectionId, surfaceToken, style, contrastMode));
+        }
+        return surfaces;
+    }
+
+    private List<SectionSurfaceContract> extractSectionSurfacesFromHtmlDocument(String htmlDocument) {
+        Map<String, SectionSurfaceContract> contractsBySectionId = new LinkedHashMap<>();
+        Matcher tagMatcher = OPENING_TAG_PATTERN.matcher(htmlDocument);
+        while (tagMatcher.find()) {
+            String tag = tagMatcher.group();
+            Map<String, String> attrs = parseHtmlAttributes(tag);
+            String sectionId = normalizeHtmlAttr(attrs.get("data-section-id"));
+            if (!StringUtils.hasText(sectionId)) {
+                continue;
+            }
+            String surfaceToken = normalizeHtmlAttr(attrs.get("data-surface-token"));
+            String style = normalizeHtmlAttr(attrs.get("data-surface-style"));
+            String contrastMode = normalizeHtmlAttr(attrs.get("data-surface-contrast"));
+            if (!StringUtils.hasText(surfaceToken) || !StringUtils.hasText(style) || !StringUtils.hasText(contrastMode)) {
+                continue;
+            }
+            contractsBySectionId.put(sectionId, new SectionSurfaceContract(sectionId, surfaceToken, style, contrastMode));
+        }
+        return new ArrayList<>(contractsBySectionId.values());
+    }
+
     private Map<String, String> parseHtmlAttributes(String tag) {
         Map<String, String> attrs = new LinkedHashMap<>();
         Matcher matcher = ATTRIBUTE_PATTERN.matcher(tag);
@@ -1629,6 +1732,9 @@ public class ExperimentPipelineGenerationService {
         public int hashCode() {
             return Objects.hash(name, type, required);
         }
+    }
+
+    private record SectionSurfaceContract(String sectionId, String surfaceToken, String style, String contrastMode) {
     }
 
     private Map<String, Object> consistencyCheckSchema() {

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -407,9 +407,11 @@ Regras:
 14. Não criar seções desnecessárias.
 15. Cada seção deve declarar mediaSlot (none, image, illustration, chart, icon-set ou video-thumb) com a função visual esperada.
 16. Cada seção deve declarar compositionNotes com instruções de composição e hierarquia visual para guiar a etapa de HTML.
-17. Não transformar o layout em HTML final; foque apenas em ordem, hierarquia, slots e leitura mobile-first.
-18. Se a estrutura puder servir para qualquer nicho, reescreva até ficar específica para {nicho}.
-19. Defina formSpec como contrato estruturado único do formulário com:
+17. Cada seção deve declarar surfaceSpec com: surfaceToken, style, contrastMode e notes para formalizar a superfície visual.
+18. Use surfaceToken alternando entre surface-base e surface-alt-* para melhorar escaneabilidade entre seções consecutivas.
+19. Não transformar o layout em HTML final; foque apenas em ordem, hierarquia, slots e leitura mobile-first.
+20. Se a estrutura puder servir para qualquer nicho, reescreva até ficar específica para {nicho}.
+21. Defina formSpec como contrato estruturado único do formulário com:
     - formId: "lead-capture-primary"
     - title: "Receber a prévia do Kit (IA)"
     - submitLabel: "Desbloquear o Kit (receber a prévia gerada por IA)"
@@ -441,7 +443,13 @@ artifact {
     "compositionNotes": "",
     "mobilePriorityScore": 0,
     "dropOffRisk": "baixo|médio|alto",
-    "sectionDependsOn": ""
+    "sectionDependsOn": "",
+    "surfaceSpec": {
+      "surfaceToken": "surface-alt-1",
+      "style": "band",
+      "contrastMode": "normal",
+      "notes": "Seção com fundo alternado para contraste sutil com a anterior"
+    }
       }
     ],
     mobilePriorityNotes,
@@ -467,9 +475,10 @@ Regras:
    - layout da landing para ordem/hierarquia e mediaSlot;
    - planejamento de imagens para posicionamento visual e altText;
    - wireframe.formSpec para renderizar exatamente os campos e obrigatoriedade do formulário.
-7. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.
-8. É proibido inventar/remover/renomear campos do formulário fora do formSpec.
-9. Não usar dependências externas.
+7. Aplicar cada wireframe.sectionOrder[i].surfaceSpec sem reinterpretar, usando data-section-id + data-surface-token + data-surface-style + data-surface-contrast na seção correspondente.
+8. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.
+9. É proibido inventar/remover/renomear campos do formulário fora do formSpec.
+10. Não usar dependências externas.
 
 Formato esperado:
 JSON com:


### PR DESCRIPTION
### Motivation

- Restore and formalize the visual intent to alternate surfaces/backgrounds between landing sections so the decision does not get lost or reinterpreted during HTML generation.  
- Prevent drift between `landing-page-wireframe` and `landing-page-html` by establishing a deterministic contract and validation step for section surfaces.  

### Description

- Require a `surfaceSpec` object (`surfaceToken`, `style`, `contrastMode`, `notes`) on every `sectionOrder` item in the `landing-page-wireframe` schema and prompt envelopes (frontend/backend/ai-worker).  
- Update HTML-generation prompts to force the `landing-page-html` to apply `surfaceSpec` exactly, instructing the HTML to render sections with `data-section-id` and the attributes `data-surface-token`, `data-surface-style`, and `data-surface-contrast`.  
- Extend backend schema and validation: add `surfaceSpec` schema, require it in section schema, add `OPENING_TAG_PATTERN`, new `SectionSurfaceContract` record, and deterministic validation methods (`validateLandingHtmlSurfaceConsistency`, `extractExpectedSectionSurfaces`, `extractSectionSurfacesFromHtmlDocument`) that compare wireframe `surfaceSpec` vs HTML attributes and block publication on mismatch.  
- Propagate prompt/text changes to `ai-worker` and `frontend` templates and record the change in `arquitetura-prompts/registro_alteracoes_workflow_orientado_artefatos.md`.

### Testing

- Attempted `cd backend/ads-service && mvn -s ../settings.xml -DskipTests compile`, which failed due to environment network restrictions preventing Maven from resolving parent dependencies (build did not complete).  
- Attempted `cd frontend && npm run test -- ExperimentContentGenerationTab.report.test.ts`, which failed in this environment because `vitest` is not available.  
- No automated tests were run to completion in this container; changes include schema updates and deterministic backend validation that should be covered by the project's normal CI (recommended: run backend `mvn test` and frontend `npm run test` in a networked environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84b1ed5c88321b55393da851b2c62)