### PR TITLE
Include readable AI output and raw JSON in experiment report; wrap long lines

### DIFF
--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -766,6 +766,56 @@ function tryFormatJsonBlock(raw: string): string | undefined {
   }
 }
 
+function extractReadableResult(rawResponse?: string): string | undefined {
+  const trimmed = rawResponse?.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      output_text?: unknown;
+      output?: Array<{
+        content?: Array<{
+          type?: string;
+          text?: unknown;
+        }>;
+      }>;
+    };
+
+    if (typeof parsed.output_text === "string" && parsed.output_text.trim()) {
+      return parsed.output_text.trim();
+    }
+
+    const outputTextCandidate = parsed.output
+      ?.flatMap((item) => item.content ?? [])
+      .find((contentItem) => contentItem.type === "output_text");
+    if (
+      outputTextCandidate &&
+      typeof outputTextCandidate.text === "string" &&
+      outputTextCandidate.text.trim()
+    ) {
+      return outputTextCandidate.text.trim();
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function wrapLongLines(content: string, maxLength = 88): string {
+  return content
+    .split("\n")
+    .map((line) => {
+      if (line.length <= maxLength) return line;
+      const chunks: string[] = [];
+      for (let index = 0; index < line.length; index += maxLength) {
+        chunks.push(line.slice(index, index + maxLength));
+      }
+      return chunks.join("\n");
+    })
+    .join("\n");
+}
+
 interface PromptLineItem {
   kind: "text" | "title" | "json";
   content: string;
@@ -1528,9 +1578,19 @@ export default function ExperimentContentGenerationTab({
                 generation.prompt?.trim() || "Sem prompt registrado.",
                 "```",
                 "",
-                "**Resultado**",
+                "**Resultado (legível)**",
                 "```text",
-                generation.rawResponse?.trim() || "Sem resposta registrada.",
+                extractReadableResult(generation.rawResponse) ??
+                  "Não foi possível extrair um resumo legível desta resposta.",
+                "```",
+                "",
+                "**Resposta bruta (JSON)**",
+                "```json",
+                wrapLongLines(
+                  tryFormatJsonBlock(generation.rawResponse ?? "") ??
+                    generation.rawResponse?.trim() ??
+                    "Sem resposta registrada.",
+                ),
                 "```",
                 "",
                 "**Persistido no sistema**",


### PR DESCRIPTION
### Motivation
- Improve the experiment pipeline report by presenting a human-readable AI output summary in addition to the raw model JSON, so reports are easier to inspect.

### Description
- Added `extractReadableResult` to parse and extract readable output from common model response shapes (e.g. `output_text` or `output[].content` entries).
- Added `wrapLongLines` to wrap long lines to a default width of 88 characters when embedding raw JSON in the report.
- Updated report generation to include a "**Resultado (legível)**" block populated from `extractReadableResult`, and a separate "**Resposta bruta (JSON)**" block that formats and wraps the raw response using `tryFormatJsonBlock` and `wrapLongLines`.
- Kept existing fallbacks for missing responses and preserved persisted payload output, and adjusted user-facing labels/messages in the generated markdown.

### Testing
- No automated tests were added or modified for this change.
- Verified the frontend build completes successfully via the project build (`yarn build`) after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d852e879908321887d4a8363453e38)