### PR TITLE
Include backgroundColorStrategy and textImageBalanceNotes in landing layout prompt

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -152,8 +152,9 @@ public class ExperimentPipelineOpenAiClient {
             15. Se a estrutura puder servir para qualquer nicho, reescreva até ficar específica para o nicho informado.
             16. Cada bloco deve preencher surfaceSpec com surfaceToken, style, contrastMode e notes para contrato explícito de superfície visual por seção.
             17. Alternar surfaceToken entre surface-base e surface-alt-* para reforçar escaneabilidade e hierarquia visual entre seções consecutivas.
-            18. Garantir equilíbrio visual entre texto e imagem em cada bloco, explicando como mediaSlot e copy dividem atenção sem competir entre si.
-            19. Definir formSpec como contrato único do formulário com:
+            18. Garantir variação intencional de cores de fundo entre seções, explicando a estratégia em backgroundColorStrategy.
+            19. Garantir equilíbrio visual entre texto e imagem em cada bloco, explicando como mediaSlot e copy dividem atenção sem competir entre si e detalhando em textImageBalanceNotes.
+            20. Definir formSpec como contrato único do formulário com:
                 - formId: lead-capture-primary
                 - title: Receber a prévia do Kit (IA)
                 - submitLabel: Desbloquear o Kit (receber a prévia gerada por IA)
@@ -173,6 +174,8 @@ public class ExperimentPipelineOpenAiClient {
             - mobilePriorityNotes
             - ctaPlacementNotes
             - formPlacementNotes
+            - backgroundColorStrategy
+            - textImageBalanceNotes
             - formSpec
             - consistencyChecks[]
             """;


### PR DESCRIPTION
### Motivation
- A unit test expected the landing-layout prompt to include guidance about intentional background color variation and text/image balance, so the prompt must be aligned with the test assertions.

### Description
- Updated `LANDING_LAYOUT_PROMPT_SUFFIX` in `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java` to add the guidance: `Garantir variação intencional de cores de fundo entre seções, explicando a estratégia em backgroundColorStrategy` and to reference `textImageBalanceNotes` for text/image balance details.
- Added `backgroundColorStrategy` and `textImageBalanceNotes` to the required JSON output list so the generated prompt explicitly demands those fields.
- Adjusted rule numbering to keep the prompt text consistent after inserting the new guidance lines.

### Testing
- Attempted to run the specific unit test with `cd ai-worker && mvn -s settings.xml -Dtest=ExperimentPipelineOpenAiClientTest test`, but the build could not proceed due to Maven dependency resolution failure (network unreachable while resolving parent POM), so tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d857232ff08321b3ff4c5757bf479f)