### PR TITLE
AI Hub: **Resumo**
- Identifiquei no log do Worker AI (job `95d8df0d-2e99-4890-af3f-a2d9c1d14b00`) o 422 vindo do backend ao finalizar a etapa `LANDING_PAGE_HTML`. As consultas SQL (`SELECT landing_page_wireframe, landing_page_html FROM experiment WHERE i…

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -205,6 +207,29 @@ public class ExperimentPipelineOpenAiClient {
             - summary
             - consistencyChecks[] com CTA_MATCH, PROMISE_MATCH, IMAGE_PLAN_BINDING, SURFACE_SPEC_BINDING, FORM_SPEC_BINDING e FORM_USABILITY
             """;
+    private static final Pattern FORM_FIELD_BLOCK_PATTERN = Pattern.compile(
+            "(?is)<div\\b[^>]*class\\s*=\\s*\"[^\"]*field[^\"]*\"[^>]*>.*?</div>");
+    private static final String STATIC_FORM_FIELDS_HTML = """
+            <div class="field">
+              <label for="field_nome">Nome</label>
+              <input type="text" id="field_nome" name="nome" placeholder="Seu nome" required aria-required="true" autocomplete="name" />
+              <div class="help">Só para personalizar o envio.</div>
+              <div class="error" id="field_nome_error" style="display:none" role="alert"></div>
+            </div>
+            <div class="field">
+              <label for="field_email">E-mail</label>
+              <input type="email" id="field_email" name="email" placeholder="voce@exemplo.com" required aria-required="true" autocomplete="email" />
+              <div class="help">Vamos enviar a prévia diretamente para o seu e-mail.</div>
+              <div class="error" id="field_email_error" style="display:none" role="alert"></div>
+            </div>
+            <div class="field">
+              <label for="field_whatsapp">WhatsApp (opcional)</label>
+              <input type="tel" id="field_whatsapp" name="whatsapp" placeholder="(DDD) 9XXXX-XXXX" aria-required="false" autocomplete="tel" />
+              <div class="help">Opcional. Se preencher, podemos enviar a prévia também por lá.</div>
+              <div class="error" id="field_whatsapp_error" style="display:none" role="alert"></div>
+            </div>
+            """;
+
     private static final String LANDING_IMAGE_PLANNING_PROMPT_SUFFIX = """
             Objetivo:
             Planejar as imagens da landing antes da geração final do HTML, usando o ângulo da campanha, os textos da landing e o layout já aprovado.
@@ -291,7 +316,7 @@ public class ExperimentPipelineOpenAiClient {
             }
             log.info("OpenAI content for job {}: {}", job.id(), content);
             Map<String, Object> parsed = objectMapper.readValue(content, new TypeReference<>() {});
-            ensureLandingHtmlHasStaticFormContract(parsed, job.section());
+            ensureLandingHtmlHasStaticFormContract(parsed, job);
             String sectionContent = objectMapper.writeValueAsString(parsed);
             Integer inputTokens = response.usage() != null ? response.usage().effectiveInputTokens() : null;
             Integer outputTokens = response.usage() != null ? response.usage().effectiveOutputTokens() : null;
@@ -309,8 +334,8 @@ public class ExperimentPipelineOpenAiClient {
 
 
     @SuppressWarnings("unchecked")
-    private void ensureLandingHtmlHasStaticFormContract(Map<String, Object> parsed, String section) {
-        if (!"landing-page-html".equalsIgnoreCase(section) || parsed == null) {
+    private void ensureLandingHtmlHasStaticFormContract(Map<String, Object> parsed, ExperimentPipelineJobDto job) {
+        if (!isLandingHtmlSection(job) || parsed == null) {
             return;
         }
 
@@ -324,43 +349,54 @@ public class ExperimentPipelineOpenAiClient {
             return;
         }
 
-        String normalizedHtml = htmlDocument.toLowerCase(Locale.ROOT);
-        if (normalizedHtml.contains("name=\"nome\"")
-                && normalizedHtml.contains("name=\"email\"")
-                && normalizedHtml.contains("name=\"whatsapp\"")) {
-            return;
-        }
-
-        String staticFields = """
-                <div class="field">
-                  <label for="field_nome">Nome</label>
-                  <input type="text" id="field_nome" name="nome" placeholder="Seu nome" required aria-required="true" autocomplete="name" />
-                  <div class="error" id="field_nome_error" style="display:none" role="alert"></div>
-                </div>
-                <div class="field">
-                  <label for="field_email">E-mail</label>
-                  <input type="email" id="field_email" name="email" placeholder="voce@exemplo.com" required aria-required="true" autocomplete="email" />
-                  <div class="error" id="field_email_error" style="display:none" role="alert"></div>
-                </div>
-                <div class="field">
-                  <label for="field_whatsapp">WhatsApp (opcional)</label>
-                  <input type="tel" id="field_whatsapp" name="whatsapp" placeholder="(DDD) 9XXXX-XXXX" aria-required="false" autocomplete="tel" />
-                  <div class="help">Opcional. Se preencher, podemos enviar o acesso também por lá.</div>
-                  <div class="error" id="field_whatsapp_error" style="display:none" role="alert"></div>
-                </div>
-                """.trim();
-
-        String marker = "<div id=\"form-fields\"></div>";
-        if (htmlDocument.contains(marker)) {
-            payload.put("htmlDocument", htmlDocument.replace(marker, "<div id=\"form-fields\">\n" + staticFields + "\n</div>"));
-            return;
-        }
-
-        String fallbackMarker = "</form>";
-        if (htmlDocument.contains(fallbackMarker)) {
-            payload.put("htmlDocument", htmlDocument.replace(fallbackMarker, "<div id=\"form-fields\" style=\"display:none\">\n" + staticFields + "\n</div>\n</form>"));
+        String updatedDocument = enforceStaticFormContract(htmlDocument);
+        if (!htmlDocument.equals(updatedDocument)) {
+            payload.put("htmlDocument", updatedDocument);
         }
     }
+
+    private String enforceStaticFormContract(String htmlDocument) {
+        String lowerDocument = htmlDocument.toLowerCase(Locale.ROOT);
+        int formStart = lowerDocument.indexOf("<form");
+        if (formStart < 0) {
+            return htmlDocument;
+        }
+        int formOpenEnd = htmlDocument.indexOf('>', formStart);
+        if (formOpenEnd < 0) {
+            return htmlDocument;
+        }
+        int formClose = lowerDocument.indexOf("</form>", formOpenEnd);
+        if (formClose < 0) {
+            return htmlDocument;
+        }
+
+        String beforeForm = htmlDocument.substring(0, formStart);
+        String formOpenTag = htmlDocument.substring(formStart, formOpenEnd + 1);
+        String formInner = htmlDocument.substring(formOpenEnd + 1, formClose);
+        String afterForm = htmlDocument.substring(formClose);
+
+        String sanitizedInner = stripDynamicFormFields(formInner);
+        if (StringUtils.hasText(sanitizedInner)) {
+            sanitizedInner = sanitizedInner.stripLeading();
+        }
+
+        StringBuilder rebuiltForm = new StringBuilder(formOpenTag.length() + STATIC_FORM_FIELDS_HTML.length() + sanitizedInner.length() + 32);
+        rebuiltForm.append(formOpenTag).append('\n').append(STATIC_FORM_FIELDS_HTML);
+        if (StringUtils.hasText(sanitizedInner)) {
+            rebuiltForm.append('\n').append(sanitizedInner);
+        }
+
+        return beforeForm + rebuiltForm + afterForm;
+    }
+
+    private String stripDynamicFormFields(String formInner) {
+        if (!StringUtils.hasText(formInner)) {
+            return "";
+        }
+        Matcher matcher = FORM_FIELD_BLOCK_PATTERN.matcher(formInner);
+        return matcher.replaceAll("");
+    }
+
 
     private String enforceRequiredModel(Map<String, Object> payload, ExperimentPipelineJobDto job) {
         if (payload == null) {


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Estou tomando esse erro no Worker AI, geração do HTML da landing page.

Último erro: 422 Unprocessable Entity from POST http://191.252.181.168:8000/api/internal/experiment-pipeline/jobs/95d8df0d-2e99-4890-af3f-a2d9c1d14b00/complete

Experimento com ID : 10

use a tool de banco de dados para pesquisar as informações necessárias
Teste a compilação dos módulos alterados
use a tool de web search para pesquisar documentação na internet se necessário
Faça os testes necessários para garantir que a solicitação está realmente atendida.
Voce pode usar a tool de web search para acessar o log do modulo AI Worker na url : http://191.252.120.96:4567/worker-observability/logfile
Voce pode usar a tool de web search para acessar o log do Backend na url : http://191.252.181.168:8000/ops-mh-observability-v2/backend-log-stream-x9k
O modelo de dados do experimento e seus relacionamentos você encontra em: docs/modelo-dados-experimento.md
Se fizer alterações ajuste o modelo.
Todo o conhecimento relacionado aos pipelines orientados a artefatos estão no diretorio /arquitetura-prompts leia eles.
Lembrando que o nosso banco de dados principal de produção é o MySql 5.7
Sabendo que o dominio oportunidadebrasil.shop está apontando para 191.252.120.96

**Resumo das alterações:**
**Resumo**
- Identifiquei no log do Worker AI (job `95d8df0d-2e99-4890-af3f-a2d9c1d14b00`) o 422 vindo do backend ao finalizar a etapa `LANDING_PAGE_HTML`. As consultas SQL (`SELECT landing_page_wireframe, landing_page_html FROM experiment WHERE id=10`) mostraram que o wireframe aprovou apenas três campos (nome, e-mail, WhatsApp), enquanto o HTML armazenado não tinha o campo de e-mail e ainda adicionava um `<select name="objetivo">`, causando a validação negativa em `ExperimentPipelineGenerationService.validateLandingHtmlFormConsistency`.
- Ajustei `ExperimentPipelineOpenAiClient` no ai-worker para garantir que a resposta para `landing-page-html` siga exatamente o contrato do formulário:
  - Passei a reutilizar a lógica de detecção de seção (`isLandingHtmlSection`) para que jobs nomeados como `LANDING_PAGE_HTML` com underscores também ativem o pós-processamento.
  - Introduzi `FORM_FIELD_BLOCK_PATTERN` e `STATIC_FORM_FIELDS_HTML`. Antes de enviar o payload ao backend, o Worker remove agora todos os blocos `.field` devolvidos pelo modelo e reinjeta o markup padronizado (nome, e-mail, WhatsApp), preservando os demais elementos (botões, microcopy, mensagens de sucesso/erro).
  - Adicionei `enforceStaticFormContract` e `stripDynamicFormFields`, garantindo que não sobrem campos extras e que sempre haja os três campos obrigatórios descritos no wireframe.

**Testes**
- `mvn test` (na pasta `ai-worker`): **falhou**. O build compila nossas alterações, porém a fase de compile para por uma dependência pré-existente (`ExperimentCreativeService` referencia `Hypothesis#getImageFilterTitle()`, que não existe). Log relevante:
  ```
  ...ExperimentCreativeService.java:[400,64] cannot find symbol
    symbol:   method getImageFilterTitle()
    location: class com.marketinghub.hypothesis.Hypothesis
  ```
  Também há warnings de acesso ao registry GitHub (401) por falta de credenciais, mas o erro que impede o teste é o `cannot find symbol`.

**Observações adicionais**
- Os logs do Worker e do backend (via `curl` nas URLs fornecidas) confirmam o 422 exato e o payload recebido pelo OpenAI, reforçando que o backend valida a estrutura do formulário antes de persistir o HTML. Depois deste ajuste o Worker sempre entregará o contrato estático, então a mesma situação não deve se repetir para outros experimentos enquanto o wireframe continuar especificando esses três campos.
- Assim que o backend disponibilizar `Hypothesis#getImageFilterTitle()` (ou o código que o referencia for ajustado), reexecute `mvn test` no módulo `ai-worker` para registrar o sucesso dos testes automatizados.