### PR TITLE
AI Hub: Resumo das mudanças:
- Ajustei o builder de requisições do pipeline no backend para enviar as mensagens no formato esperado pela Responses API (conteúdo como lista de partes `input_text`).
- No worker, normalizei todo o `input` antes de chamar a O…

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.OpenAiCostEstimator;
 import com.marketinghub.worker.openai.OpenAiResponse;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -492,16 +493,61 @@ public class ExperimentPipelineOpenAiClient {
                 continue;
             }
             Map<String, Object> message = (Map<String, Object>) messageRaw;
-            Object role = message.get("role");
-            if (!(role instanceof String roleValue) || !"user".equalsIgnoreCase(roleValue)) {
-                continue;
+            String roleValue = message.get("role") instanceof String role ? role : null;
+            boolean prependPipelinePrompt = roleValue != null && "user".equalsIgnoreCase(roleValue);
+            List<Object> normalizedContent = normalizeMessageContent(message.get("content"), job, prependPipelinePrompt);
+            if (normalizedContent != null) {
+                message.put("content", normalizedContent);
             }
-            Object contentNode = message.get("content");
-            if (!(contentNode instanceof String content)) {
-                continue;
-            }
-            message.put("content", withPipelinePrompt(content, job));
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Object> normalizeMessageContent(Object contentNode,
+                                                 ExperimentPipelineJobDto job,
+                                                 boolean prependPipelinePrompt) {
+        if (contentNode instanceof List<?> contentList) {
+            List<Object> normalized = new ArrayList<>();
+            for (Object part : contentList) {
+                normalized.add(normalizeContentPart(part, job, prependPipelinePrompt));
+            }
+            return normalized;
+        }
+        if (contentNode == null) {
+            return null;
+        }
+        return List.of(normalizeContentPart(contentNode, job, prependPipelinePrompt));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object normalizeContentPart(Object part,
+                                        ExperimentPipelineJobDto job,
+                                        boolean prependPipelinePrompt) {
+        if (part instanceof Map<?, ?> mapPart) {
+            Map<String, Object> mutable = new LinkedHashMap<>((Map<String, Object>) mapPart);
+            Object typeNode = mutable.get("type");
+            String type = typeNode instanceof String typeValue && StringUtils.hasText(typeValue)
+                    ? typeValue
+                    : "input_text";
+            mutable.put("type", type);
+            if ("input_text".equals(type)) {
+                Object textNode = mutable.get("text");
+                String textValue = textNode != null ? String.valueOf(textNode) : "";
+                mutable.put("text", withMaybePipelinePrompt(textValue, job, prependPipelinePrompt));
+            }
+            return mutable;
+        }
+        if (part instanceof String textPart) {
+            return Map.of("type", "input_text", "text", withMaybePipelinePrompt(textPart, job, prependPipelinePrompt));
+        }
+        return Map.of("type", "input_text", "text", withMaybePipelinePrompt(String.valueOf(part), job, prependPipelinePrompt));
+    }
+
+    private String withMaybePipelinePrompt(String text, ExperimentPipelineJobDto job, boolean prependPipelinePrompt) {
+        if (!prependPipelinePrompt) {
+            return text;
+        }
+        return withPipelinePrompt(text, job);
     }
 
     private String withPipelinePrompt(String prompt, ExperimentPipelineJobDto job) {

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -57,7 +57,10 @@ class ExperimentPipelineOpenAiClientTest {
         Map<String, Object> payload = payloadRef.get();
         @SuppressWarnings("unchecked")
         var input = (java.util.List<Map<String, Object>>) payload.get("input");
-        String userPrompt = String.valueOf(input.get(1).get("content"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> contentPart = (Map<String, Object>) ((java.util.List<?>) input.get(1).get("content")).get(0);
+        assertThat(contentPart.get("type")).isEqualTo("input_text");
+        String userPrompt = firstInputText((Map<String, Object>) input.get(1));
         assertThat(userPrompt).startsWith("Você cria ativos de campanha para o Marketing Hub.");
         assertThat(userPrompt).contains("Prompt original de angulo");
         assertThat(userPrompt).contains("Crie a base estratégica de uma campanha Meta Ads + landing page para este produto.");
@@ -98,7 +101,7 @@ class ExperimentPipelineOpenAiClientTest {
         Map<String, Object> payload = payloadRef.get();
         @SuppressWarnings("unchecked")
         var input = (java.util.List<Map<String, Object>>) payload.get("input");
-        String userPrompt = String.valueOf(input.get(0).get("content"));
+        String userPrompt = firstInputText((Map<String, Object>) input.get(0));
         assertThat(userPrompt).startsWith("Você cria ativos de campanha para o Marketing Hub.");
         assertThat(userPrompt).contains("Prompt de anuncio");
         assertThat(userPrompt).doesNotContain("proofSummary,");
@@ -134,7 +137,7 @@ class ExperimentPipelineOpenAiClientTest {
         Map<String, Object> payload = payloadRef.get();
         @SuppressWarnings("unchecked")
         var input = (java.util.List<Map<String, Object>>) payload.get("input");
-        String userPrompt = String.valueOf(input.get(0).get("content"));
+        String userPrompt = firstInputText((Map<String, Object>) input.get(0));
         assertThat(userPrompt).startsWith("Você cria ativos de campanha para o Marketing Hub.");
         assertThat(userPrompt).contains("Prompt da landing");
         assertThat(userPrompt).contains("Continuar exatamente a promessa do anúncio clicado");
@@ -176,7 +179,7 @@ class ExperimentPipelineOpenAiClientTest {
         Map<String, Object> payload = payloadRef.get();
         @SuppressWarnings("unchecked")
         var input = (java.util.List<Map<String, Object>>) payload.get("input");
-        String userPrompt = String.valueOf(input.get(0).get("content"));
+        String userPrompt = firstInputText((Map<String, Object>) input.get(0));
         assertThat(userPrompt).startsWith("Você cria ativos de campanha para o Marketing Hub.");
         assertThat(userPrompt).contains("Prompt do wireframe");
         assertThat(userPrompt).contains("variantLayoutId");
@@ -610,6 +613,20 @@ class ExperimentPipelineOpenAiClientTest {
 
         Map<String, Object> payload = payloadRef.get();
         assertThat(payload.get("model")).isEqualTo("gpt-5.2");
+    }
+
+    @SuppressWarnings("unchecked")
+    private String firstInputText(Map<String, Object> message) {
+        Object contentNode = message.get("content");
+        if (contentNode instanceof java.util.List<?> list && !list.isEmpty()) {
+            Object first = list.get(0);
+            if (first instanceof Map<?, ?> contentMap) {
+                Object text = ((Map<String, Object>) contentMap).get("text");
+                return text != null ? text.toString() : null;
+            }
+            return first != null ? first.toString() : null;
+        }
+        return contentNode != null ? contentNode.toString() : null;
     }
 
     private ExchangeFunction capturePayloadExchange(AtomicReference<Map<String, Object>> payloadRef) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -468,8 +468,8 @@ public class ExperimentPipelineGenerationService {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", model);
         body.put("input", List.of(
-                Map.of("role", "system", "content", buildSystemPrompt(section)),
-                Map.of("role", "user", "content", userPrompt)
+                inputMessage("system", buildSystemPrompt(section)),
+                inputMessage("user", userPrompt)
         ));
         body.put("text", Map.of(
                 "format", Map.of(
@@ -480,6 +480,20 @@ public class ExperimentPipelineGenerationService {
                 )
         ));
         return body;
+    }
+
+    private Map<String, Object> inputMessage(String role, String text) {
+        return Map.of(
+                "role", role,
+                "content", List.of(inputTextContent(text))
+        );
+    }
+
+    private Map<String, Object> inputTextContent(String text) {
+        return Map.of(
+                "type", "input_text",
+                "text", text
+        );
     }
 
     private String buildSystemPrompt(ExperimentPipelineSection section) {


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
tomei esse erro:

2026-04-10T17:25:08.602Z  INFO 1 --- [scheduling-1] xperimentPipelineGenerationWorkerService : Experiment pipeline worker found 1 pending job(s)
2026-04-10T17:25:08.606Z  INFO 1 --- [scheduling-1] xperimentPipelineGenerationWorkerService : Attempting to claim experiment pipeline job 433f399c-7c4c-4cfc-95f6-12f34c8bef83 (experimentId=10, section=LANDING_PAGE_HTML)
2026-04-10T17:25:10.173Z  INFO 1 --- [scheduling-1] xperimentPipelineGenerationWorkerService : Job 433f399c-7c4c-4cfc-95f6-12f34c8bef83 claimed by worker experiment-pipeline-609262bb0469. Sending to OpenAI (section=LANDING_PAGE_HTML)
2026-04-10T17:25:10.482Z  INFO 1 --- [scheduling-1] c.m.w.e.ExperimentPipelineOpenAiClient   : Sending experiment pipeline job 433f399c-7c4c-4cfc-95f6-12f34c8bef83 to OpenAI (experimentId=10, section=LANDING_PAGE_HTML, model=gpt-5.2)
2026-04-10T17:25:10.556Z  INFO 1 --- [scheduling-1] c.m.w.e.ExperimentPipelineOpenAiClient   : OpenAI payload completo para job 433f399c-7c4c-4cfc-95f6-12f34c8bef83: {"model":"gpt-5.2","input":[{"role":"system","content":"Você é especialista em marketing direto e criação de ativos para performance. Escreva em português do Brasil, de forma clara e vendável. Seção atual: landing-page-html. Considere as dependências anteriores já geradas e mantenha consistência entre elas."},{"role":"user","content":"Você cria ativos de campanha para o Marketing Hub.\n\nRegras globais:\n1. O anúncio e a landing devem ter a mesma promessa central.\n2. O CTA do anúncio deve combinar com a ação principal da landing.\n3. O material precisa caber no envelope real do produto:\n   - pode entregar ativos digitais gerados por IA\n   - não pode prometer consultoria, call, gestão humana ou acompanhamento manual\n4. Priorize clareza comercial:\n   DOR → RESULTADO → MECANISMO → PROVA → AÇÃO\n5. Não transforme mecanismo em promessa principal.\n6. Não use jargão técnico desnecessário.\n7. O público é geral dentro do nicho, com baixa a moderada maturidade em marketing.\n8. Sempre escreva pensando em alta escala e geração automatizada.\n9. O anúncio deve ser rápido de entender.\n10. A landing deve aprofundar a promessa e reduzir ceticismo.\n\nExperimento #10\nNome do experimento: Experimento 4\nHipótese resumida: Agenda Cheia Sem Desconto (8 Semanas)\nTítulo da hipótese: Agenda Cheia Sem Desconto (8 Semanas)\nProblema: Falta um processo simples e repetível que funcione todo mês (sem depender de indicação) para: (1) deixar claro, antes da conversa virar ‘quanto custa?’, por que seu acompanhamento é diferente e vale o investimento; e (2) fazer o aluno sentir progresso e cuidado logo nas primeiras semanas, quando ele ainda não tem hábito e é mais fácil desistir. Sem uma sequência clara de comunicação + primeiros marcos de evolução + check-ins, o aluno não percebe valor rápido, a conversa vira briga de preço e a renovação vira loteria.\nPromessa: Ter uma agenda cheia com constância e tranquilidade no fim do mês, porque os alunos certos chegam entendendo o valor do seu acompanhamento (não só perguntando preço) e, principalmente, continuam engajados nas primeiras semanas por sentirem cuidado e progresso rápido — deixando de ser uma loteria de indicação e virando um negócio sob controle. ([glofox.com](https://www.glofox.com/blog/member-onboarding-first-30-days/?utm_source=openai))\nMetadados obrigatórios do experimento:\n- primary_variable: Dor vs Resultado\n- variant_id: variant-10\n- stage: AD\n- control_or_treatment: treatment\n- asset_role: landing-page-html\n\nTarefa alvo: landing-page-html\n\nÂngulo da campanha:\n{\"campaignAngle\":{\"singleMindedPromise\":\"Encha sua agenda em até 8 semanas sem dar desconto — com alunos que já chegam entendendo o valor do seu acompanhamento e seguem engajados nas primeiras semanas.\",\"primaryPain\":\"A conversa vira “quanto custa?” e os alunos somem nas primeiras semanas porque não enxergam valor rápido — aí sua agenda depende de indicação e o mês vira loteria.\",\"primaryPromise\":\"Ter agenda cheia com constância em até 8 semanas, sem desconto, com alunos que chegam mais qualificados (entendendo o valor) e permanecem engajados no início.\",\"cta\":\"Desbloquear o kit de “Agenda Cheia Sem Desconto (8 semanas)”\",\"tone\":\"Direto, prático e confiante (sem hype), com foco em clareza e controle do resultado.\",\"mechanismSummary\":\"Um kit de ativos gerados por IA com uma sequência pronta de comunicação + primeiros marcos de evolução (primeiras semanas) + check-ins automáticos para (1) posicionar seu diferencial antes do preço e (2) fazer o aluno sentir progresso e cuidado rápido.\",\"primaryCTA\":\"Desbloquear o kit\",\"landingMatchLine\":\"Desbloqueie o kit “Agenda Cheia Sem Desconto (8 semanas)” para atrair alunos que entendem seu valor e manter engajamento nas primeiras semanas — sem depender de indicação.\",\"funnelStage\":\"Topo/Meio (aquisição + pré-qualificação)\",\"proofSummary\":\"Baseado em boas práticas de onboarding e retenção nos primeiros 30 dias (reduz desistência, aumenta percepção de valor e melhora renovação), transformadas em sequência pronta e replicável em ativos digitais.\"},\"experimentMetadata\":{\"variant_id\":\"variant-10\",\"control_or_treatment\":\"treatment\",\"primary_variable\":\"Dor vs Resultado\",\"stage\":\"AD\",\"asset_role\":\"campaign-angle\"}}\n\nTexto do anúncio:\n{\"adCopy\":{\"primaryTextVariants\":[{\"label\":\"dor\",\"openingHookType\":\"dor\",\"headline\":\"Agenda cheia sem desconto (8 semanas)\",\"placementHint\":\"feed\",\"lengthVariants\":{\"curta\":\"A conversa vira “quanto custa?” e o aluno some na 2ª semana?\\n\\nEncha sua agenda em até 8 semanas sem dar desconto — com alunos que chegam entendendo o valor do seu acompanhamento e seguem engajados no começo.\\n\\nDesbloquear o Kit (receber a prévia gerada por IA)\",\"longa\":\"A conversa vira “quanto custa?” cedo demais.\\nO aluno fecha, treina 1–2 semanas… e some porque não sente valor rápido.\\nNo fim, sua agenda depende de indicação e o mês vira loteria.\\n\\nA meta é ter constância: encha sua agenda em até 8 semanas sem dar desconto — com alunos que já chegam entendendo o valor do seu acompanhamento e seguem engajados nas primeiras semanas.\\n\\nComo você aplica isso:\\n• sequência pronta de mensagens (WhatsApp/DM/e-mail)\\n• roteiro curto pra conduzir a conversa sem cair no preço cedo\\n• marcos iniciais + check-ins para o aluno sentir cuidado e progresso no começo\\n\\nEntrega 100% digital, gerada por IA. Sem call e sem consultoria.\\n\\nDesbloquear o Kit (receber a prévia gerada por IA)\",\"media\":\"O aluno pergunta preço, fecha… e some no começo?\\n\\nEncha sua agenda em até 8 semanas sem dar desconto — com alunos entendendo seu valor e ficando engajados nas primeiras semanas.\\n\\nDesbloqueie a prévia do kit gerado por IA com mensagens prontas, roteiro de conversa e check-ins iniciais.\\n\\nDesbloquear o Kit (receber a prévia gerada por IA)\"},\"compliance\":{\"semPromessaIndividual\":true,\"semGarantiaAbsoluta\":true,\"semLinguagemDeConsultoria\":true},\"description\":\"Prévia do kit (IA): mensagens + roteiro + check-ins.\",\"primaryText\":\"\",\"ctaText\":\"Desbloquear o Kit (receber a prévia gerada por IA)\"},{\"label\":\"resultado\",\"openingHookType\":\"resultado\",\"headline\":\"Mais alunos certos. Menos briga de preço.\",\"placementHint\":\"stories/reels\",\"lengthVariants\":{\"curta\":\"Encha sua agenda em até 8 semanas sem dar desconto.\\n\\nAlunos chegam entendendo seu valor e seguem engajados no começo.\\n\\nDesbloquear o Kit (receber a prévia gerada por IA)\",\"longa\":\"Encha sua agenda em até 8 semanas sem dar desconto — com alunos que já chegam entendendo o valor do seu acompanhamento e seguem engajados nas primeiras semanas.\\n\\nEm vez de depender de indicação, você usa uma sequência simples para:\\n1) deixar seu diferencial claro antes do preço\\n2) criar progresso perceptível logo no começo (quando muita gente desiste)\\n\\nDesbloqueie a prévia do kit gerado por IA:\\n• mensagens prontas (WhatsApp/DM/e-mail)\\n• roteiro curto de conversa\\n• marcos iniciais + check-ins das primeiras semanas\\n\\nEntrega digital. Sem call. Sem consultoria.\\n\\nDesbloquear o Kit (receber a prévia gerada por IA)\",\"media\":\"Encha sua agenda em até 8 semanas sem dar desconto.\\n\\nCom alunos que chegam entendendo seu valor e continuam engajados nas primeiras semanas.\\n\\nDesbloqueie a prévia do kit gerado por IA (mensagens + roteiro + check-ins).\\n\\nDesbloquear o Kit (receber a prévia gerada por IA)\"},\"compliance\":{\"semPromessaIndividual\":true,\"semGarantiaAbsoluta\":true,\"semLinguagemDeConsultoria\":true},\"description\":\"Prévia do kit (IA) para captar e engajar no início.\",\"primaryText\":\"\",\"ctaText\":\"Desbloquear o Kit (receber a prévia gerada por IA)\"},{\"label\":\"prova\",\"openingHookType\":\"prova\",\"headline\":\"O começo decide a permanência\",\"placementHint\":\"feed\",\"lengthVariants\":{\"curta\":\"Os primeiros 30 dias costumam decidir se o aluno engaja ou some.\\n\\nEncha sua agenda em até 8 semanas sem dar desconto — com valor claro antes do preço e marcos iniciais.\\n\\nDesbloquear o Kit (receber a prévia gerada por IA)\",\"longa\":\"Boas práticas de onboarding mostram um padrão: quando o aluno entende o caminho e tem pequenas vitórias no começo, a percepção de valor sobe e o engajamento tende a aumentar — especialmente nos primeiros 30 dias.\\n\\nPor isso a promessa é direta: encha sua agenda em até 8 semanas sem dar desconto — com alunos que já chegam entendendo o valor do seu acompanhamento e seguem engajados nas primeiras semanas.\\n\\nDesbloqueie a prévia do kit gerado por IA com:\\n• mensagens prontas (WhatsApp/DM/e-mail)\\n• roteiro curto para conduzir a conversa antes do preço\\n• marcos iniciais + check-ins para o aluno sentir progresso e cuidado\\n\\nEntrega digital. Sem call. Sem consultoria.\\n\\nDesbloquear o Kit (receber a prévia gerada por IA)\",\"media\":\"Primeiros 30 dias bem guiados costumam aumentar a percepção de valor.\\n\\nEncha sua agenda em até 8 semanas sem dar desconto — com uma sequência pronta de comunicação + marcos + check-ins.\\n\\nDesbloqueie a prévia do kit gerado por IA.\\n\\nDesbloquear o Kit (receber a prévia gerada por IA)\"},\"compliance\":{\"semPromessaIndividual\":true,\"semGarantiaAbsoluta\":true,\"semLinguagemDeConsultoria\":true},\"description\":\"Baseado em boas práticas dos primeiros 30 dias (prévia).\",\"primaryText\":\"\",\"ctaText\":\"Desbloquear o Kit (receber a prévia gerada por IA)\"}]},\"experimentMetadata\":{\"variant_id\":\"variant-10\",\"control_or_treatment\":\"treatment\",\"primary_variable\":\"Dor vs Resultado\",\"stage\":\"AD\",\"asset_role\":\"ad-copy\"}}\n\nBriefing da imagem:\n{\"adImageBriefing\":{\"briefings\":[{\"complianceNotes\":\"Evitar garantias e absolutos (ex.: “garantido”, “100%”, “infalível”). Tratar “em até 8 semanas” como objetivo/estrutura de processo, não como promessa individual. Não citar consultoria/call/mentoria/gestão humana. Não usar números de resultados (R$, alunos) nem depoimentos. Não insinuar suporte humano. Pode incluir microcopy “Kit IA • entrega digital” sem sugerir acompanhamento.\",\"visualBriefing\":\"Conceito (DOR): a conversa vira “quanto custa?” e depois silêncio.\\nCena/estilo: Foto realista em estúdio/academia. Personal trainer (uniforme dry-fit) em pé ao lado de um banco/halteres, olhando o celular com frustração contida (expressão natural, não teatral).\\nTela do celular: bolhas de chat genéricas (sem marcas), com a mensagem “Quanto custa?” em destaque e, abaixo, duas mensagens do personal em cinza claro com indicador de “visualizado”/sem resposta (representar sumiço sem usar logos).\\nComposição: personal no terço direito, celular em primeiro plano (mão próxima à câmera). Fundo desfocado com equipamentos de treino.\\nOverlay de texto (curto e grande): topo: “Cansou do ‘quanto custa?’”\\nLinha secundária menor: “sem desconto • 8 semanas”\\nSelo discreto no rodapé: “Kit I... [truncated 71281 chars]

**Resumo das alterações:**
Resumo das mudanças:
- Ajustei o builder de requisições do pipeline no backend para enviar as mensagens no formato esperado pela Responses API (conteúdo como lista de partes `input_text`).
- No worker, normalizei todo o `input` antes de chamar a OpenAI: converto qualquer conteúdo para partes `input_text`, mantenho tipos já existentes e aplico o prefixo do pipeline apenas no texto do usuário.
- Atualizei os testes do cliente do pipeline para refletir o novo formato de mensagem e facilitar a leitura do texto normalizado.

Testes:
- `mvn test` (na pasta `ai-worker`) **falhou na compilação pré-existente**: `ExperimentCreativeService` não compila por método ausente `Hypothesis.getImageFilterTitle()`. Não consegui avançar para a execução dos testes por conta desse erro de base.