### PR TITLE
Add landing HTML diagnostics and enhanced HTTP/error logging for experiment pipeline

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineBackendClient.java
@@ -6,6 +6,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +21,8 @@ import reactor.core.publisher.Mono;
 @Component
 public class ExperimentPipelineBackendClient {
     private static final Logger log = LoggerFactory.getLogger(ExperimentPipelineBackendClient.class);
+    private static final Pattern FORM_CONTROL_TAG_PATTERN = Pattern.compile("(?is)<(input|textarea|select)\\b[^>]*>");
+    private static final Pattern ATTRIBUTE_PATTERN = Pattern.compile("(?is)([a-zA-Z_:][-a-zA-Z0-9_:.]*)\\s*=\\s*([\"'])(.*?)\\2");
 
     private final WebClient webClient;
     private final String backendBaseUrl;
@@ -61,7 +65,11 @@ public class ExperimentPipelineBackendClient {
 
     public void complete(UUID jobId, ExperimentPipelineJobCompletionPayload payload) {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/experiment-pipeline/jobs/", jobId.toString(), "/complete");
-        log.info("POST /complete do pipeline (jobId={}, keys={})", jobId, summarizeCompletionPayloadKeys(payload));
+        log.info("POST /complete do pipeline (jobId={}, url={}, keys={}, landingHtmlDiag={})",
+                jobId,
+                url,
+                summarizeCompletionPayloadKeys(payload),
+                summarizeLandingHtmlDiagnostic(payload));
         try {
             webClient.post()
                     .uri(url)
@@ -72,7 +80,12 @@ public class ExperimentPipelineBackendClient {
         } catch (WebClientResponseException ex) {
             String summarizedBody = summarizeErrorBody(ex.getResponseBodyAsString());
             if (ex.getStatusCode().value() == 422) {
-                log.error("Erro 422 ao completar job de pipeline {}: {}", jobId, summarizedBody);
+                log.error("Erro 422 ao completar job de pipeline {} (url={}, keys={}, landingHtmlDiag={}): {}",
+                        jobId,
+                        url,
+                        summarizeCompletionPayloadKeys(payload),
+                        summarizeLandingHtmlDiagnostic(payload),
+                        summarizedBody);
             } else {
                 log.error("Erro HTTP {} ao completar job de pipeline {}: {}",
                         ex.getStatusCode().value(), jobId, summarizedBody);
@@ -133,5 +146,56 @@ public class ExperimentPipelineBackendClient {
         }
         String compact = rawBody.replaceAll("\\s+", " ").trim();
         return compact.length() > 300 ? compact.substring(0, 300) + "..." : compact;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String summarizeLandingHtmlDiagnostic(ExperimentPipelineJobCompletionPayload payload) {
+        if (payload == null || payload.responseContent() == null) {
+            return "[sem-payload]";
+        }
+        try {
+            Map<String, Object> parsed = objectMapper.readValue(payload.responseContent(), Map.class);
+            Object node = parsed.containsKey("landingPageHtml") ? parsed.get("landingPageHtml") : parsed;
+            if (!(node instanceof Map<?, ?> rawMap)) {
+                return "[landingPageHtml-ausente]";
+            }
+            Map<String, Object> landingPayload = (Map<String, Object>) rawMap;
+            Object htmlNode = landingPayload.get("htmlDocument");
+            if (!(htmlNode instanceof String htmlDocument) || htmlDocument.isBlank()) {
+                return "[htmlDocument-ausente]";
+            }
+            return "htmlLength=" + htmlDocument.length() + ", formFields=" + extractFieldSnapshot(htmlDocument);
+        } catch (Exception ignored) {
+            return "[landing-html-nao-processavel]";
+        }
+    }
+
+    private String extractFieldSnapshot(String htmlDocument) {
+        Matcher matcher = FORM_CONTROL_TAG_PATTERN.matcher(htmlDocument);
+        List<String> fields = new java.util.ArrayList<>();
+        while (matcher.find()) {
+            String tag = matcher.group();
+            Map<String, String> attrs = parseAttributes(tag);
+            String name = attrs.get("name");
+            if (name == null || name.isBlank()) {
+                continue;
+            }
+            String type = attrs.get("type");
+            if (type == null || type.isBlank()) {
+                type = "text";
+            }
+            boolean required = attrs.containsKey("required") || tag.toLowerCase().contains(" required");
+            fields.add(name + ":" + type + ":" + required);
+        }
+        return fields.isEmpty() ? "[]" : fields.toString();
+    }
+
+    private Map<String, String> parseAttributes(String tag) {
+        Map<String, String> attrs = new java.util.LinkedHashMap<>();
+        Matcher matcher = ATTRIBUTE_PATTERN.matcher(tag);
+        while (matcher.find()) {
+            attrs.put(matcher.group(1).toLowerCase(), matcher.group(3));
+        }
+        return attrs;
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineGenerationWorkerService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineGenerationWorkerService.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @Service
@@ -77,6 +78,10 @@ public class ExperimentPipelineGenerationWorkerService {
         WebClientResponseException httpError = findHttpError(ex);
         if (httpError != null) {
             HttpStatus status = HttpStatus.resolve(httpError.getStatusCode().value());
+            if (status == HttpStatus.UNPROCESSABLE_ENTITY) {
+                return "Rejeitado pelo backend ao completar o job (422). Motivo: "
+                        + summarizeHttpErrorBody(httpError.getResponseBodyAsString());
+            }
             if (status == HttpStatus.BAD_GATEWAY
                     || status == HttpStatus.SERVICE_UNAVAILABLE
                     || status == HttpStatus.GATEWAY_TIMEOUT
@@ -90,6 +95,14 @@ public class ExperimentPipelineGenerationWorkerService {
             return "Falha desconhecida";
         }
         return message.length() > 500 ? message.substring(0, 500) : message;
+    }
+
+    private String summarizeHttpErrorBody(String responseBody) {
+        if (!StringUtils.hasText(responseBody)) {
+            return "backend não retornou detalhes";
+        }
+        String compact = responseBody.replaceAll("\\s+", " ").trim();
+        return compact.length() > 500 ? compact.substring(0, 500) + "..." : compact;
     }
 
     private WebClientResponseException findHttpError(Throwable throwable) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1743,11 +1743,13 @@ public class ExperimentPipelineGenerationService {
         Map<String, Object> wireframeRoot = readObject(experiment.getLandingPageWireframe(), "Wireframe da landing inválido");
         Map<String, Object> wireframePayload = unwrapSectionPayload(wireframeRoot, "landingPageWireframe");
         if (!(wireframePayload.get("formSpec") instanceof Map<?, ?> rawFormSpec)) {
+            log.warn("Validação landing HTML (experimentId={}): wireframe sem formSpec estruturado", experiment.getId());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Wireframe da landing sem formSpec estruturado");
         }
 
         List<FormFieldContract> expectedFields = extractExpectedFormFields((Map<String, Object>) rawFormSpec);
         if (expectedFields.isEmpty()) {
+            log.warn("Validação landing HTML (experimentId={}): formSpec.fields vazio", experiment.getId());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Wireframe da landing sem campos em formSpec.fields");
         }
 
@@ -1755,6 +1757,7 @@ public class ExperimentPipelineGenerationService {
         Map<String, Object> htmlPayload = unwrapSectionPayload(htmlRoot, "landingPageHtml");
         String htmlDocument = asTrimmedString(htmlPayload.get("htmlDocument"));
         if (!StringUtils.hasText(htmlDocument)) {
+            log.warn("Validação landing HTML (experimentId={}): htmlDocument ausente no payload", experiment.getId());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "landingPageHtml.htmlDocument não encontrado");
         }
 
@@ -1767,6 +1770,10 @@ public class ExperimentPipelineGenerationService {
                 .toList();
 
         if (!expectedSorted.equals(actualSorted)) {
+            log.warn("Validação landing HTML (experimentId={}): divergência de formulário detectada. expected={}, actual={}",
+                    experiment.getId(),
+                    expectedSorted,
+                    actualSorted);
             throw new ResponseStatusException(
                     HttpStatus.UNPROCESSABLE_ENTITY,
                     "Divergência de formulário: landing-page-html deve reproduzir exatamente landing-page-wireframe.formSpec");
@@ -1829,6 +1836,7 @@ public class ExperimentPipelineGenerationService {
         Map<String, Object> wireframePayload = unwrapSectionPayload(wireframeRoot, "landingPageWireframe");
         List<SectionSurfaceContract> expectedSurfaces = extractExpectedSectionSurfaces(wireframePayload);
         if (expectedSurfaces.isEmpty()) {
+            log.warn("Validação landing HTML (experimentId={}): wireframe sem sectionOrder.surfaceSpec", experiment.getId());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Wireframe da landing sem sectionOrder.surfaceSpec estruturado");
         }
 
@@ -1836,6 +1844,7 @@ public class ExperimentPipelineGenerationService {
         Map<String, Object> htmlPayload = unwrapSectionPayload(htmlRoot, "landingPageHtml");
         String htmlDocument = asTrimmedString(htmlPayload.get("htmlDocument"));
         if (!StringUtils.hasText(htmlDocument)) {
+            log.warn("Validação landing HTML (experimentId={}): htmlDocument ausente para validação de surfaceSpec", experiment.getId());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "landingPageHtml.htmlDocument não encontrado");
         }
 
@@ -1848,6 +1857,10 @@ public class ExperimentPipelineGenerationService {
                 .toList();
 
         if (!expectedSorted.equals(actualSorted)) {
+            log.warn("Validação landing HTML (experimentId={}): divergência de surfaceSpec detectada. expected={}, actual={}",
+                    experiment.getId(),
+                    expectedSorted,
+                    actualSorted);
             throw new ResponseStatusException(
                     HttpStatus.UNPROCESSABLE_ENTITY,
                     "Divergência de superfície: landing-page-html deve reproduzir exatamente landing-page-wireframe.sectionOrder.surfaceSpec");
@@ -1920,6 +1933,7 @@ public class ExperimentPipelineGenerationService {
         Map<String, Object> htmlPayload = unwrapSectionPayload(htmlRoot, "landingPageHtml");
         String htmlDocument = asTrimmedString(htmlPayload.get("htmlDocument"));
         if (!StringUtils.hasText(htmlDocument)) {
+            log.warn("Validação landing HTML (experimentId={}): htmlDocument ausente para validação de image plan", experiment.getId());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "landingPageHtml.htmlDocument não encontrado");
         }
 
@@ -1932,6 +1946,10 @@ public class ExperimentPipelineGenerationService {
                 .toList();
 
         if (!expectedSorted.equals(actualSorted)) {
+            log.warn("Validação landing HTML (experimentId={}): divergência de image plan detectada. expected={}, actual={}",
+                    experiment.getId(),
+                    expectedSorted,
+                    actualSorted);
             throw new ResponseStatusException(
                     HttpStatus.UNPROCESSABLE_ENTITY,
                     "Divergência de imagens: landing-page-html deve reproduzir o binding explícito do landing-page-image-planning por sectionId/imageRole");


### PR DESCRIPTION
### Motivation
- Improve observability when completing experiment pipeline jobs by including a compact diagnostic summary of landing page HTML and more informative HTTP error context.
- Provide clearer failure messages for worker retries when the backend returns `422 Unprocessable Entity` and avoid swallowing diagnostic details.
- Improve backend validation feedback for landing-page HTML consistency checks by emitting warnings with contextual identifiers when expectations are missing or diverge.

### Description
- Added HTML diagnostics to `ExperimentPipelineBackendClient` including `summarizeLandingHtmlDiagnostic`, `extractFieldSnapshot`, and a simple attribute parser using regex to report `htmlLength` and `formFields` when logging completion payloads.
- Enhanced the `complete` call logging in `ExperimentPipelineBackendClient` to include the completion URL, payload keys, and the landing HTML diagnostic, and improved `422` error logging to include this context and a compacted error body via `summarizeErrorBody`.
- Updated `ExperimentPipelineGenerationWorkerService` to special-case `422` responses in `buildFailureReason` and added `summarizeHttpErrorBody` to compact backend response bodies for error messages, plus a `StringUtils` import.
- Added multiple `log.warn` statements in backend validation functions in `ExperimentPipelineGenerationService` to surface missing or divergent landing-page artifacts during `validateLandingHtmlFormConsistency`, `validateLandingHtmlSurfaceConsistency`, and `validateLandingHtmlImagePlanConsistency`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d935e459cc8321bbe70d030f570fa9)