### PR TITLE
Introduce canonical imageBindingKey and validate landing HTML image bindings

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -200,7 +200,8 @@ public class ExperimentPipelineOpenAiClient {
             8. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.
             9. Não usar bibliotecas externas.
             10. Toda tag <img> deve usar src absoluto válido (https://... ou data:image/...) e reutilizar altText do planejamento de imagens.
-            11. Cada <img> deve declarar data-image-section-id, data-image-role, data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion conforme o plano de imagens.
+            11. Cada <img> deve declarar data-image-section-id e data-image-binding-key como binding canônico obrigatório do plano de imagens.
+            12. Cada <img> também deve declarar data-image-role (semântico), data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion.
 
             Formato obrigatório (JSON):
             - htmlDocument
@@ -242,7 +243,7 @@ public class ExperimentPipelineOpenAiClient {
 
             Regras:
             1. Entregar images[] com no mínimo 4 itens ligados a sectionId/sectionName reais do wireframe.
-            2. Cada item deve incluir objective, placement, priority, hierarchyLevel, imagePrompt, messageMatchNotes, imageRole, conversionRole, emotionalJob e sectionVisualGoal.
+            2. Cada item deve incluir imageBindingKey (curto/canônico), objective, placement, priority, hierarchyLevel, imagePrompt, messageMatchNotes, imageRole, conversionRole, emotionalJob e sectionVisualGoal.
             3. imagePrompt deve ser específico para o contexto da seção (não genérico).
             4. Definir dimensions.desktop e dimensions.mobile para orientar implementação responsiva.
             5. Incluir safeMargins e textOverlayGuidance quando houver texto sobre imagem.

--- a/arquitetura-prompts/registro_alteracoes_workflow_orientado_artefatos.md
+++ b/arquitetura-prompts/registro_alteracoes_workflow_orientado_artefatos.md
@@ -16,6 +16,23 @@ As alterações serão adicionadas conforme forem implementadas, incluindo:
 
 ## Histórico
 
+### 2026-04-10 — Binding canônico de imagem no `landing-page-html` com fallback legado
+
+- **Item alterado:** contrato mínimo `landing-page-image-planning -> landing-page-html -> validação /complete`.
+  - **O que mudou:** foi introduzido `imageBindingKey` (curto/canônico) no contrato de `landing-page-image-planning` e no binding obrigatório do HTML (`data-image-binding-key`), mantendo `imageRole` apenas como campo semântico auxiliar.
+  - **Impacto esperado:** reduz drift por texto semântico livre e torna a validação estrutural deterministicamente ancorada em `sectionId + imageBindingKey`.
+  - **Arquivos relacionados:** `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`, `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java`, `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx`.
+
+- **Item alterado:** validação determinística de aderência de imagem no backend (`/complete` do `landing-page-html`).
+  - **O que mudou:** a comparação backend passou a priorizar `sectionId + imageBindingKey` com fallback incremental para legado (`imageRole` quando `imageBindingKey` estiver ausente), mantendo verificação dos demais atributos críticos (`conversionRole`, `attentionPriority`, `visualWeight`, `distanceToCTA`, `supportsFormConversion`).
+  - **Impacto esperado:** corrige a causa raiz do 422 por divergência de binding frágil e preserva compatibilidade com payloads anteriores.
+  - **Arquivos relacionados:** `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`.
+
+- **Item alterado:** cobertura de testes para cenário real de 422 e caminho canônico/legado.
+  - **O que mudou:** foram adicionados testes cobrindo falha por binding key incorreto, falha por binding textual aproximado, reprodução do 422 real por drift, sucesso com binding canônico exato e sucesso com fallback legado.
+  - **Impacto esperado:** proteção contra regressão no contrato de binding entre planejamento de imagens e HTML final.
+  - **Arquivos relacionados:** `backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java`.
+
 ### 2026-04-10 — Correção incremental do `landing-page-html` para evitar 422 no `/complete`
 
 - **Item alterado:** normalização final de `landing-page-html` no fechamento do job.

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -755,7 +755,7 @@ public class ExperimentPipelineGenerationService {
             sb.append("Regras:\n");
             sb.append("1. images[] deve ter no mínimo 4 itens com sectionId e sectionName existentes no wireframe.\n");
             sb.append("2. Cada item precisa trazer imagePrompt, objective, visualStyle, composition, focalPoint, supportingElements e mood.\n");
-            sb.append("3. Cada item precisa incluir imageRole, conversionRole, emotionalJob e sectionVisualGoal para explicitar função visual e contribuição para conversão.\n");
+            sb.append("3. Cada item precisa incluir imageBindingKey (curto/canônico), imageRole, conversionRole, emotionalJob e sectionVisualGoal para explicitar função visual e contribuição para conversão.\n");
             sb.append("4. Definir placement (hero, benefit, mechanism, proof, offer, faq, cta), priority (high, medium, low), hierarchyLevel (primary, secondary, support), attentionPriority (high, medium, low), visualWeight (primary, secondary, support) e distanceToCTA (near, medium, far).\n");
             sb.append("5. Cada item precisa informar dimensions (desktop e mobile), safeMargins, textOverlayGuidance, altText e layoutBinding (preferredDesktopPlacement, preferredMobilePlacement, desktopAspectRatio, mobileAspectRatio, allowCrop, safeCropZones).\n");
             sb.append("6. supportsFormConversion deve indicar explicitamente se a imagem ajuda o envio do lead e formRelationNotes deve explicar como empurra leitura para CTA/form sem competir com ele.\n");
@@ -802,7 +802,8 @@ public class ExperimentPipelineGenerationService {
             sb.append("10. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.\n");
             sb.append("11. O código deve ser limpo, legível e pronto para ser renderizado em iframe.\n");
             sb.append("12. Toda tag <img> deve usar src absoluto válido (https://... ou data:image/...) e reaproveitar altText do planejamento de imagens.\n\n");
-            sb.append("13. Cada <img> deve incluir binding explícito com o plano usando data-image-section-id, data-image-role, data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion.\n\n");
+            sb.append("13. Cada <img> deve incluir binding explícito canônico com o plano usando data-image-section-id + data-image-binding-key como chave primária de aderência.\n");
+            sb.append("14. Também preencher data-image-role (semântico/humano), data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion.\n\n");
             sb.append("Formato obrigatório:\n");
             sb.append("- htmlDocument: string com o documento completo final.\n");
             sb.append("- summary: resumo curto das decisões de implementação.\n");
@@ -1397,6 +1398,7 @@ public class ExperimentPipelineGenerationService {
                 "properties", Map.ofEntries(
                         Map.entry("sectionId", stringSchema()),
                         Map.entry("sectionName", stringSchema()),
+                        Map.entry("imageBindingKey", Map.of("type", "string", "pattern", "^[a-z0-9_\\-]{3,64}$")),
                         Map.entry("imageRole", stringSchema()),
                         Map.entry("conversionRole", stringSchema()),
                         Map.entry("emotionalJob", stringSchema()),
@@ -1450,6 +1452,7 @@ public class ExperimentPipelineGenerationService {
                 "required", List.of(
                         "sectionId",
                         "sectionName",
+                        "imageBindingKey",
                         "imageRole",
                         "conversionRole",
                         "emotionalJob",
@@ -1938,11 +1941,16 @@ public class ExperimentPipelineGenerationService {
         }
 
         List<ImagePlanBindingContract> actualBindings = extractImagePlanBindingsFromHtmlDocument(htmlDocument);
+        log.info("Validação landing HTML image binding (experimentId={}): plannedCount={}, expectedPairs={}, foundPairs={}",
+                experiment.getId(),
+                expectedBindings.size(),
+                summarizeImageBindingPairs(expectedBindings),
+                summarizeImageBindingPairs(actualBindings));
         List<ImagePlanBindingContract> expectedSorted = expectedBindings.stream()
-                .sorted(Comparator.comparing(ImagePlanBindingContract::sectionId).thenComparing(ImagePlanBindingContract::imageRole))
+                .sorted(Comparator.comparing(ImagePlanBindingContract::sectionId).thenComparing(ImagePlanBindingContract::imageBindingKey))
                 .toList();
         List<ImagePlanBindingContract> actualSorted = actualBindings.stream()
-                .sorted(Comparator.comparing(ImagePlanBindingContract::sectionId).thenComparing(ImagePlanBindingContract::imageRole))
+                .sorted(Comparator.comparing(ImagePlanBindingContract::sectionId).thenComparing(ImagePlanBindingContract::imageBindingKey))
                 .toList();
 
         if (!expectedSorted.equals(actualSorted)) {
@@ -1950,9 +1958,13 @@ public class ExperimentPipelineGenerationService {
                     experiment.getId(),
                     expectedSorted,
                     actualSorted);
+            log.warn("Validação landing HTML (experimentId={}): divergência específica de pares expected={} actual={}",
+                    experiment.getId(),
+                    summarizeImageBindingPairs(expectedSorted),
+                    summarizeImageBindingPairs(actualSorted));
             throw new ResponseStatusException(
                     HttpStatus.UNPROCESSABLE_ENTITY,
-                    "Divergência de imagens: landing-page-html deve reproduzir o binding explícito do landing-page-image-planning por sectionId/imageRole");
+                    "Divergência de imagens: landing-page-html deve reproduzir o binding explícito canônico do landing-page-image-planning por sectionId/imageBindingKey");
         }
     }
 
@@ -1968,6 +1980,7 @@ public class ExperimentPipelineGenerationService {
             }
             Map<String, Object> image = (Map<String, Object>) rawImageMap;
             String sectionId = normalizeHtmlAttr(asTrimmedString(image.get("sectionId")));
+            String imageBindingKey = normalizeHtmlAttr(resolveBindingKeyFromPlanning(image));
             String imageRole = normalizeHtmlAttr(asTrimmedString(image.get("imageRole")));
             String conversionRole = normalizeHtmlAttr(asTrimmedString(image.get("conversionRole")));
             String attentionPriority = normalizeHtmlAttr(asTrimmedString(image.get("attentionPriority")));
@@ -1976,11 +1989,11 @@ public class ExperimentPipelineGenerationService {
             if (!(image.get("supportsFormConversion") instanceof Boolean supportsFormConversion)) {
                 continue;
             }
-            if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(imageRole) || !StringUtils.hasText(conversionRole)
+            if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(imageBindingKey) || !StringUtils.hasText(imageRole) || !StringUtils.hasText(conversionRole)
                     || !StringUtils.hasText(attentionPriority) || !StringUtils.hasText(visualWeight) || !StringUtils.hasText(distanceToCta)) {
                 continue;
             }
-            bindings.add(new ImagePlanBindingContract(sectionId, imageRole, conversionRole, attentionPriority, visualWeight, distanceToCta, supportsFormConversion));
+            bindings.add(new ImagePlanBindingContract(sectionId, imageBindingKey, imageRole, conversionRole, attentionPriority, visualWeight, distanceToCta, supportsFormConversion));
         }
         return bindings;
     }
@@ -1992,21 +2005,48 @@ public class ExperimentPipelineGenerationService {
             String tag = tagMatcher.group();
             Map<String, String> attrs = parseHtmlAttributes(tag);
             String sectionId = normalizeHtmlAttr(attrs.get("data-image-section-id"));
+            String imageBindingKey = resolveBindingKeyFromHtmlAttrs(attrs);
             String imageRole = normalizeHtmlAttr(attrs.get("data-image-role"));
             String conversionRole = normalizeHtmlAttr(attrs.get("data-conversion-role"));
             String attentionPriority = normalizeHtmlAttr(attrs.get("data-attention-priority"));
             String visualWeight = normalizeHtmlAttr(attrs.get("data-visual-weight"));
             String distanceToCta = normalizeHtmlAttr(attrs.get("data-distance-to-cta"));
             String supportsFormConversionRaw = normalizeHtmlAttr(attrs.get("data-supports-form-conversion"));
-            if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(imageRole) || !StringUtils.hasText(conversionRole)
+            if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(imageBindingKey) || !StringUtils.hasText(imageRole) || !StringUtils.hasText(conversionRole)
                     || !StringUtils.hasText(attentionPriority) || !StringUtils.hasText(visualWeight)
                     || !StringUtils.hasText(distanceToCta) || !StringUtils.hasText(supportsFormConversionRaw)) {
                 continue;
             }
             boolean supportsFormConversion = "true".equalsIgnoreCase(supportsFormConversionRaw);
-            bindings.add(new ImagePlanBindingContract(sectionId, imageRole, conversionRole, attentionPriority, visualWeight, distanceToCta, supportsFormConversion));
+            bindings.add(new ImagePlanBindingContract(sectionId, imageBindingKey, imageRole, conversionRole, attentionPriority, visualWeight, distanceToCta, supportsFormConversion));
         }
         return bindings;
+    }
+
+    private String resolveBindingKeyFromPlanning(Map<String, Object> image) {
+        String bindingKey = asTrimmedString(image.get("imageBindingKey"));
+        if (StringUtils.hasText(bindingKey)) {
+            return bindingKey;
+        }
+        return asTrimmedString(image.get("imageRole"));
+    }
+
+    private String resolveBindingKeyFromHtmlAttrs(Map<String, String> attrs) {
+        String bindingKey = normalizeHtmlAttr(attrs.get("data-image-binding-key"));
+        if (StringUtils.hasText(bindingKey)) {
+            return bindingKey;
+        }
+        return normalizeHtmlAttr(attrs.get("data-image-role"));
+    }
+
+    private String summarizeImageBindingPairs(List<ImagePlanBindingContract> bindings) {
+        if (bindings == null || bindings.isEmpty()) {
+            return "[]";
+        }
+        return bindings.stream()
+                .map(binding -> binding.sectionId() + "/" + binding.imageBindingKey())
+                .toList()
+                .toString();
     }
 
     private Map<String, String> parseHtmlAttributes(String tag) {
@@ -2074,6 +2114,7 @@ public class ExperimentPipelineGenerationService {
     }
 
     private record ImagePlanBindingContract(String sectionId,
+                                            String imageBindingKey,
                                             String imageRole,
                                             String conversionRole,
                                             String attentionPriority,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -30,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.atLeastOnce;
@@ -254,5 +256,234 @@ class ExperimentPipelineGenerationServiceTest {
         assertFalse(html.contains("objetivo principal"));
         assertTrue(summary.contains("wireframe.formspec"));
         assertTrue(checks.stream().anyMatch(check -> "FORM_USABILITY".equals(check.get("check"))));
+    }
+
+    @Test
+    void completeJobRejectsLandingHtmlWhenSectionMatchesButBindingKeyIsWrong() {
+        Experiment experiment = buildLandingHtmlValidationExperiment(201L);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> service.completeJob(createLandingHtmlJob(experiment).getId(), landingHtmlCompletionRequest("""
+                        <!doctype html><html><body>
+                        <section data-section-id='hero' data-surface-token='surface-base' data-surface-style='band' data-surface-contrast='normal'>
+                          <img src='https://cdn.example.com/hero.jpg' alt='Hero'
+                               data-image-section-id='hero'
+                               data-image-binding-key='hero_wrong_key'
+                               data-image-role='Hero Pain Anchor'
+                               data-conversion-role='grab-attention'
+                               data-attention-priority='high'
+                               data-visual-weight='primary'
+                               data-distance-to-cta='near'
+                               data-supports-form-conversion='true' />
+                          <form id='lead-capture-primary'><input type='text' name='nome' required /><input type='email' name='email' required /><input type='tel' name='whatsapp' /></form>
+                        </section></body></html>
+                        """)));
+        assertTrue(exception.getReason().contains("sectionId/imageBindingKey"));
+    }
+
+    @Test
+    void completeJobRejectsLandingHtmlWhenUsingApproximateTextualRoleInsteadOfCanonicalBinding() {
+        Experiment experiment = buildLandingHtmlValidationExperiment(202L);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> service.completeJob(createLandingHtmlJob(experiment).getId(), landingHtmlCompletionRequest("""
+                        <!doctype html><html><body>
+                        <section data-section-id='hero' data-surface-token='surface-base' data-surface-style='band' data-surface-contrast='normal'>
+                          <img src='https://cdn.example.com/hero.jpg' alt='Hero'
+                               data-image-section-id='hero'
+                               data-image-role='Hero Pain Anchor Approx'
+                               data-conversion-role='grab-attention'
+                               data-attention-priority='high'
+                               data-visual-weight='primary'
+                               data-distance-to-cta='near'
+                               data-supports-form-conversion='true' />
+                          <form id='lead-capture-primary'><input type='text' name='nome' required /><input type='email' name='email' required /><input type='tel' name='whatsapp' /></form>
+                        </section></body></html>
+                        """)));
+        assertTrue(exception.getReason().contains("sectionId/imageBindingKey"));
+    }
+
+    @Test
+    void completeJobReproducesCurrent422ScenarioWhenHtmlDriftsFromImagePlanningBinding() {
+        Experiment experiment = buildLandingHtmlValidationExperiment(203L);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> service.completeJob(createLandingHtmlJob(experiment).getId(), landingHtmlCompletionRequest("""
+                        <!doctype html><html><body>
+                        <section data-section-id='hero' data-surface-token='surface-base' data-surface-style='band' data-surface-contrast='normal'>
+                          <img src='https://cdn.example.com/hero.jpg' alt='Hero'
+                               data-image-section-id='hero'
+                               data-image-binding-key='hero_pain_anchor'
+                               data-image-role='Hero Pain Anchor'
+                               data-conversion-role='wrong-conversion'
+                               data-attention-priority='high'
+                               data-visual-weight='primary'
+                               data-distance-to-cta='near'
+                               data-supports-form-conversion='true' />
+                          <form id='lead-capture-primary'><input type='text' name='nome' required /><input type='email' name='email' required /><input type='tel' name='whatsapp' /></form>
+                        </section></body></html>
+                        """)));
+        assertTrue(exception.getReason().contains("sectionId/imageBindingKey"));
+    }
+
+    @Test
+    void completeJobSucceedsWhenCanonicalImageBindingMatchesPlanningExactly() {
+        Experiment experiment = buildLandingHtmlValidationExperiment(204L);
+        ExperimentPipelineGenerationJob job = createLandingHtmlJob(experiment);
+
+        service.completeJob(job.getId(), landingHtmlCompletionRequest("""
+                <!doctype html><html><body>
+                <section data-section-id='hero' data-surface-token='surface-base' data-surface-style='band' data-surface-contrast='normal'>
+                  <img src='https://cdn.example.com/hero.jpg' alt='Hero'
+                       data-image-section-id='hero'
+                       data-image-binding-key='hero_pain_anchor'
+                       data-image-role='Hero Pain Anchor'
+                       data-conversion-role='grab-attention'
+                       data-attention-priority='high'
+                       data-visual-weight='primary'
+                       data-distance-to-cta='near'
+                       data-supports-form-conversion='true' />
+                  <form id='lead-capture-primary'><input type='text' name='nome' required /><input type='email' name='email' required /><input type='tel' name='whatsapp' /></form>
+                </section></body></html>
+                """));
+
+        assertNotNull(experiment.getLandingPageHtml());
+    }
+
+    @Test
+    void completeJobSupportsLegacyFallbackWhenPlanningAndHtmlDoNotSendBindingKey() {
+        Experiment experiment = buildLandingHtmlValidationExperiment(205L);
+        experiment.setLandingPageImagePlanning("""
+                {
+                  "landingPageImagePlanning": {
+                    "images": [
+                      {
+                        "sectionId": "hero",
+                        "imageRole": "Hero Pain Anchor",
+                        "conversionRole": "grab-attention",
+                        "attentionPriority": "high",
+                        "visualWeight": "primary",
+                        "distanceToCTA": "near",
+                        "supportsFormConversion": true
+                      }
+                    ]
+                  }
+                }
+                """);
+        ExperimentPipelineGenerationJob job = createLandingHtmlJob(experiment);
+
+        service.completeJob(job.getId(), landingHtmlCompletionRequest("""
+                <!doctype html><html><body>
+                <section data-section-id='hero' data-surface-token='surface-base' data-surface-style='band' data-surface-contrast='normal'>
+                  <img src='https://cdn.example.com/hero.jpg' alt='Hero'
+                       data-image-section-id='hero'
+                       data-image-role='Hero Pain Anchor'
+                       data-conversion-role='grab-attention'
+                       data-attention-priority='high'
+                       data-visual-weight='primary'
+                       data-distance-to-cta='near'
+                       data-supports-form-conversion='true' />
+                  <form id='lead-capture-primary'><input type='text' name='nome' required /><input type='email' name='email' required /><input type='tel' name='whatsapp' /></form>
+                </section></body></html>
+                """));
+
+        assertNotNull(experiment.getLandingPageHtml());
+    }
+
+    private Experiment buildLandingHtmlValidationExperiment(long experimentId) {
+        Experiment experiment = new Experiment();
+        experiment.setId(experimentId);
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {
+                        "sectionId": "hero",
+                        "surfaceSpec": {
+                          "surfaceToken": "surface-base",
+                          "style": "band",
+                          "contrastMode": "normal",
+                          "notes": "hero"
+                        }
+                      }
+                    ],
+                    "formSpec": {
+                      "formId": "lead-capture-primary",
+                      "title": "Receber a prévia do Kit (IA)",
+                      "submitLabel": "Desbloquear o Kit (receber a prévia gerada por IA)",
+                      "submitTarget": "#desbloquear",
+                      "fields": [
+                        {"name": "nome", "type": "text", "required": true},
+                        {"name": "email", "type": "email", "required": true},
+                        {"name": "whatsapp", "type": "tel", "required": false}
+                      ],
+                      "consent": {"enabled": true, "required": false, "label": "ok"},
+                      "successState": {"title": "ok", "message": "ok"}
+                    }
+                  }
+                }
+                """);
+        experiment.setLandingPageImagePlanning("""
+                {
+                  "landingPageImagePlanning": {
+                    "images": [
+                      {
+                        "sectionId": "hero",
+                        "imageBindingKey": "hero_pain_anchor",
+                        "imageRole": "Hero Pain Anchor",
+                        "conversionRole": "grab-attention",
+                        "attentionPriority": "high",
+                        "visualWeight": "primary",
+                        "distanceToCTA": "near",
+                        "supportsFormConversion": true
+                      }
+                    ]
+                  }
+                }
+                """);
+        return experiment;
+    }
+
+    private ExperimentPipelineGenerationJob createLandingHtmlJob(Experiment experiment) {
+        UUID jobId = UUID.randomUUID();
+        ExperimentPipelineGenerationJob job = ExperimentPipelineGenerationJob.builder()
+                .id(jobId)
+                .experiment(experiment)
+                .section(ExperimentPipelineSection.LANDING_PAGE_HTML)
+                .status(ExperimentPipelineGenerationJobStatus.PROCESSING)
+                .stage(ExperimentPipelineGenerationJobStage.SENT_TO_OPENAI)
+                .model("gpt-5.2")
+                .prompt("prompt")
+                .build();
+        when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
+        return job;
+    }
+
+    private ExperimentPipelineGenerationJobCompletionRequest landingHtmlCompletionRequest(String htmlDocument) {
+        return new ExperimentPipelineGenerationJobCompletionRequest(
+                """
+                        {
+                          "landingPageHtml": {
+                            "htmlDocument": %s,
+                            "summary": "ok",
+                            "consistencyChecks": [
+                              {"check":"FORM_USABILITY","status":"PASS","details":"ok"}
+                            ]
+                          }
+                        }
+                        """.formatted(quoteJsonString(htmlDocument)),
+                "{\"id\":\"resp_html\"}",
+                "{\"model\":\"gpt-5.2\"}",
+                120,
+                80,
+                null);
+    }
+
+    private String quoteJsonString(String value) {
+        return "\"" + value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r") + "\"";
     }
 }

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -497,7 +497,8 @@ artifact {
 Regra obrigatória de imagens:
 - Toda tag <img> deve ter src absoluto válido (https://... ou data:image/...).
 - Toda tag <img> deve reutilizar altText e placement definidos no planejamento de imagens.
-- Toda tag <img> deve declarar data-image-section-id, data-image-role, data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion conforme o planejamento.
+- Toda tag <img> deve declarar data-image-section-id e data-image-binding-key como binding canônico obrigatório do planejamento.
+- Toda tag <img> também deve declarar data-image-role (semântico), data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion.
 - Nunca use caminhos relativos como "/assets/..." ou "./imagem.jpg" no htmlDocument.
 - Se não houver imagem final disponível, renderize placeholder visual no CSS sem quebrar layout.`;
 
@@ -510,6 +511,7 @@ Regras:
 1. Entregar images[] com no mínimo 4 imagens planejadas para seções reais da landing.
 2. Cada imagem precisa incluir:
    - sectionId e sectionName
+   - imageBindingKey (curto, estável e canônico)
    - imageRole
    - conversionRole
    - emotionalJob

--- a/frontend/src/pages/experiment/landingImagePlanningParser.ts
+++ b/frontend/src/pages/experiment/landingImagePlanningParser.ts
@@ -8,6 +8,7 @@ import {
 export interface LandingPlannedImage {
   sectionId?: string;
   sectionName?: string;
+  imageBindingKey?: string;
   imageRole?: string;
   conversionRole?: string;
   emotionalJob?: string;
@@ -97,6 +98,7 @@ function parseImage(value: unknown): LandingPlannedImage | undefined {
   const parsed: LandingPlannedImage = {
     sectionId: pickText(payload.sectionId),
     sectionName: pickText(payload.sectionName),
+    imageBindingKey: pickText(payload.imageBindingKey),
     imageRole: pickText(payload.imageRole),
     conversionRole: pickText(payload.conversionRole),
     emotionalJob: pickText(payload.emotionalJob),


### PR DESCRIPTION
### Motivation
- The `/complete` for `landing-page-html` was returning 422 because backend validation relied on fragile semantic `imageRole` text for binding, allowing drift between `landing-page-image-planning` and the final HTML.
- Make the image binding deterministic and robust with a short, stable key while preserving legacy compatibility.

### Description
- Add a canonical `imageBindingKey` to the `landing-page-image-planning` contract and prompt guidance, and require `data-image-binding-key` in the `landing-page-html` prompt as the primary binding alongside `data-image-section-id`.
- Update backend validation in `ExperimentPipelineGenerationService` to compare `sectionId + imageBindingKey` (with fallback to `imageRole` when `imageBindingKey` is absent), to extract/compare bindings from both planning and HTML, and add low-risk logs summarizing planned vs found pairs.
- Update worker prompt text to instruct generation of `data-image-binding-key` and to include `imageBindingKey` in the image planning prompt suffix.
- Update frontend prompt/help text and the image planning parser to read `imageBindingKey` from the planning artifact.
- Add unit tests covering: failure when binding key is wrong, failure when only approximate textual role is used, reproduction of the 422 drift scenario, success when canonical binding matches exactly, and success when legacy fallback is used.
- Update `arquitetura-prompts/registro_alteracoes_workflow_orientado_artefatos.md` with an incremental record of the change.

Modified files (key): `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`, `backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java`, `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java`, `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx`, `frontend/src/pages/experiment/landingImagePlanningParser.ts`, `arquitetura-prompts/registro_alteracoes_workflow_orientado_artefatos.md`.

### Testing
- Added backend unit tests in `ExperimentPipelineGenerationServiceTest` covering the 5 required scenarios; they are included in the change set.
- Attempted to run `cd backend/ads-service && mvn -s ../settings.xml -Dtest=ExperimentPipelineGenerationServiceTest test`, but the Maven run failed in the current environment due to inability to resolve parent dependencies (network unavailable), so tests could not be executed here.
- Recommended: run the added tests in CI or a developer environment with Maven network access; they should validate the fix and guard against regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93f89b468832192de34ed8ba8d515)