### PR TITLE
docs: detalha campos e validações de Texto da Landing (`LANDING_PAGE_COPY`)

### DIFF
--- a/docs/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/modelo-canonico-artefatos-pipeline-experimento.md
@@ -12,10 +12,44 @@ Este documento define o **modelo canônico** dos artefatos do pipeline de experi
 | `mechanismSpec` | Definição do mecanismo/solução proposta | `problem`, `causalModel`, `intervention`, `proofBase`, `limitations` | LLM |
 | `offerSpec` | Definição estruturada da oferta/produto | `promise`, `scope`, `deliverables`, `constraints`, `pricingIdea` | LLM |
 | `campaignAngle` | Ângulo estratégico por variação de comunicação | `visualAngle`, `hook`, `promise`, `objections`, `messageMatch` | LLM |
-| `landingPageCopy` | Texto da landing por seção | `sectionId`, `headline`, `body`, `proof`, `cta`, `visualGoal` | LLM |
+| `landingPageCopy` | Texto da landing estruturado para validação e renderização | `pageGoal`, `messageMatchSource`, `messageMatchNotes`, `primaryCTA`, `complianceNotes`, `hero`, `bodySections`, `ctaBlocks`, `faq`, `consistencyChecks` | LLM |
 | `landingPageLayout` | Estrutura/layout por seção | `layoutType`, `order`, `mediaSlot`, `hierarchy`, `ratio` | LLM |
 | `landingImagePlan` | Plano visual e pacote de prompt de imagem por seção | `sectionId`, `imageRole`, `promptPackage`, `altText`, `priority` | LLM |
 | `landingCodeBundle` | Entrega final da página renderizada/publicável | `html`, `css`, `js`, `imageRefs`, `metadata` | Builder |
+
+## Artefato do item **Texto da Landing** (`LANDING_PAGE_COPY`)
+
+No pipeline operacional, o item visual **Texto da Landing** corresponde ao artefato `landingPageCopy`, persistido em `experiment.landing_page_copy` e gerado na seção `LANDING_PAGE_COPY`.
+
+### Campos canônicos obrigatórios
+
+- Raiz de `landingPageCopy`:
+  - `pageGoal`
+  - `messageMatchSource`
+  - `messageMatchNotes`
+  - `primaryCTA`
+  - `complianceNotes`
+- Bloco `hero`:
+  - `eyebrow`, `headline`, `subheadline`, `promise`, `supportingCopy`
+  - `proofBadge`, `microcopy`, `ctaLabel`, `ctaUrl`, `ctaMatchNotes`
+- Bloco `bodySections[]` (mínimo 4 itens):
+  - `sectionId`, `sectionType`, `title`, `summary`, `bullets`, `copy`
+  - `ctaSupport`, `sectionDependsOn`, `messageMatchNotes`
+- Bloco `ctaBlocks[]` (mínimo 2 itens):
+  - `placement`, `ctaVariant`, `ctaLabel`, `ctaUrl`, `matchAdCta`
+  - `ctaSupport`, `messageMatchNotes`
+- Bloco `faq[]` (mínimo 3 itens):
+  - `question`, `answer`, `objectionTag`
+- Bloco `consistencyChecks[]` (mínimo 2 itens):
+  - `check`, `status`, `details`
+
+### Regras de validação críticas do item
+
+1. `hero.ctaLabel`, `primaryCTA`, `ctaBlocks[].ctaLabel` e `ctaBlocks[].matchAdCta` devem manter igualdade com o CTA oficial do anúncio.
+2. `messageMatchSource` deve citar a headline do anúncio de origem.
+3. `bodySections[].sectionDependsOn` deve usar apenas: `primaryPromise`, `mechanismSummary`, `proofSummary` ou `primaryCTA`.
+4. `consistencyChecks[]` deve incluir explicitamente: `CTA_MATCH`, `PROMISE_MATCH` e `GOOGLE_LANDING_BEST_PRACTICES`.
+5. `complianceNotes` deve deixar explícito que a entrega é digital/automatizada.
 
 ## Dependência lógica sugerida
 
@@ -87,16 +121,125 @@ flowchart LR
     "objections": ["já tentei antes"],
     "messageMatch": "alto"
   },
-  "landingPageCopy": [
-    {
-      "sectionId": "hero",
+  "landingPageCopy": {
+    "pageGoal": "Capturar leads qualificados para diagnóstico",
+    "messageMatchSource": "headline_ad: Pare de desperdiçar clique",
+    "messageMatchNotes": "Promessa e CTA mantidos do anúncio",
+    "primaryCTA": "Quero minha landing",
+    "complianceNotes": "Entrega 100% digital e automatizada",
+    "hero": {
+      "eyebrow": "Para PMEs com tráfego pago",
       "headline": "Converta mais com consistência",
-      "body": "...",
-      "proof": "+120 projetos",
-      "cta": "Quero minha landing",
-      "visualGoal": "clareza"
-    }
-  ],
+      "subheadline": "Organize promessa, prova e CTA sem fricção",
+      "promise": "Mais aproveitamento do tráfego pago",
+      "supportingCopy": "Aplicação rápida com foco em resultado",
+      "proofBadge": "+120 projetos",
+      "microcopy": "Sem consultoria presencial",
+      "ctaLabel": "Quero minha landing",
+      "ctaUrl": "/formulario",
+      "ctaMatchNotes": "Mesmo CTA do anúncio"
+    },
+    "bodySections": [
+      {
+        "sectionId": "pain-01",
+        "sectionType": "pain",
+        "title": "Pare de perder cliques",
+        "summary": "Seu tráfego existe, mas não converte",
+        "bullets": ["mensagem desalinhada", "falta de prova"],
+        "copy": "...",
+        "ctaSupport": "Ajuste em poucos dias",
+        "sectionDependsOn": "primaryPromise",
+        "messageMatchNotes": "Conecta com dor do anúncio"
+      },
+      {
+        "sectionId": "mechanism-01",
+        "sectionType": "mechanism",
+        "title": "Como funciona",
+        "summary": "Processo guiado por dados",
+        "bullets": ["copy", "layout", "publicação"],
+        "copy": "...",
+        "ctaSupport": "Fluxo padronizado",
+        "sectionDependsOn": "mechanismSummary",
+        "messageMatchNotes": "Mesma promessa, mais profundidade"
+      },
+      {
+        "sectionId": "proof-01",
+        "sectionType": "proof",
+        "title": "Provas objetivas",
+        "summary": "Resultados em cenários similares",
+        "bullets": ["cases", "métricas"],
+        "copy": "...",
+        "ctaSupport": "Confiança para avançar",
+        "sectionDependsOn": "proofSummary",
+        "messageMatchNotes": "Reforça credibilidade"
+      },
+      {
+        "sectionId": "cta-01",
+        "sectionType": "cta",
+        "title": "Pronto para aplicar",
+        "summary": "Comece hoje",
+        "bullets": ["setup rápido"],
+        "copy": "...",
+        "ctaSupport": "Sem complexidade",
+        "sectionDependsOn": "primaryCTA",
+        "messageMatchNotes": "Fechamento com CTA oficial"
+      }
+    ],
+    "ctaBlocks": [
+      {
+        "placement": "hero",
+        "ctaVariant": "primary",
+        "ctaLabel": "Quero minha landing",
+        "ctaUrl": "/formulario",
+        "matchAdCta": "Quero minha landing",
+        "ctaSupport": "Comece agora",
+        "messageMatchNotes": "Match total"
+      },
+      {
+        "placement": "final",
+        "ctaVariant": "sticky",
+        "ctaLabel": "Quero minha landing",
+        "ctaUrl": "/formulario",
+        "matchAdCta": "Quero minha landing",
+        "ctaSupport": "Última chamada",
+        "messageMatchNotes": "Match total"
+      }
+    ],
+    "faq": [
+      {
+        "question": "Preciso de equipe técnica interna?",
+        "answer": "Não, o fluxo já entrega os blocos prontos.",
+        "objectionTag": "execucao"
+      },
+      {
+        "question": "Quanto tempo para publicar?",
+        "answer": "Normalmente em poucos dias.",
+        "objectionTag": "prazo"
+      },
+      {
+        "question": "Funciona para nichos diferentes?",
+        "answer": "Sim, ajustando copy e prova por contexto.",
+        "objectionTag": "aderencia"
+      }
+    ],
+    "consistencyChecks": [
+      {
+        "check": "CTA_MATCH",
+        "status": "PASS",
+        "details": "CTA alinhado entre anúncio e landing"
+      },
+      {
+        "check": "PROMISE_MATCH",
+        "status": "PASS",
+        "details": "Promessa do anúncio refletida no hero"
+      },
+      {
+        "check": "GOOGLE_LANDING_BEST_PRACTICES",
+        "status": "PASS",
+        "details": "Oferta clara e continuidade pós-clique"
+      }
+    ]
+  },
   "landingPageLayout": [
     {
       "sectionId": "hero",


### PR DESCRIPTION
### Motivation

- Tornar o documento canônico compatível com o formato real usado pelo pipeline para o item **Texto da Landing** e reduzir ambiguidade entre geração, validação e persistência.
- Facilitar a integração entre Worker IA, frontend e backend ao deixar explícitos os campos obrigatórios, regras críticas e o mapeamento para a coluna `experiment.landing_page_copy`.

### Description

- Atualiza a entrada `landingPageCopy` na tabela canônica de `docs/modelo-canonico-artefatos-pipeline-experimento.md` para listar os campos estruturados reais (por exemplo `pageGoal`, `messageMatchSource`, `primaryCTA`, `hero`, `bodySections`, `ctaBlocks`, `faq`, `consistencyChecks`).
- Adiciona a seção `Artefato do item Texto da Landing (LANDING_PAGE_COPY)` que documenta o vínculo com `experiment.landing_page_copy` e descreve os campos canônicos obrigatórios (raiz, `hero`, `bodySections[]`, `ctaBlocks[]`, `faq[]`, `consistencyChecks[]`).
- Inclui regras de validação críticas para garantir `CTA_MATCH`, `PROMISE_MATCH`, `GOOGLE_LANDING_BEST_PRACTICES`, restrições em `sectionDependsOn` e obrigação de `complianceNotes` explicitar entrega digital/automatizada.
- Atualiza o exemplo JSON do documento para o formato completo de `landingPageCopy` (objeto com `hero`, `bodySections`, `ctaBlocks`, `faq` e `consistencyChecks`) usado pelo pipeline.

### Testing

- Executei `git diff --check` para checar conflitos de formatação e problemas de diff, e não foram reportados erros.
- Não foram executadas builds ou testes de integração neste PR de documentação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94ea455a0832183dbb4b9ff7bed31)