### PR TITLE
Fix pipeline image replacement when applying landing HTML to Lead Portal form

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/LandingPageImageInjector.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/LandingPageImageInjector.java
@@ -6,10 +6,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marketinghub.experiment.frameworkimage.FrameworkImageGenerationJob;
 import com.marketinghub.experiment.frameworkimage.repository.FrameworkImageGenerationJobRepository;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -119,24 +123,93 @@ public class LandingPageImageInjector {
         try {
             Document document = Jsoup.parse(html, "", Parser.htmlParser());
             document.outputSettings().prettyPrint(false);
+            List<ImageCandidate> availableImages = sectionImages.entrySet().stream()
+                    .map(entry -> new ImageCandidate(normalizeMatchValue(entry.getKey()), entry.getValue()))
+                    .filter(candidate -> StringUtils.hasText(candidate.url()))
+                    .toList();
+            if (availableImages.isEmpty()) {
+                return html;
+            }
+
+            Set<Integer> consumedIndexes = new HashSet<>();
             boolean changed = false;
-            for (Map.Entry<String, String> entry : sectionImages.entrySet()) {
-                Element section = document.getElementById(entry.getKey());
-                if (section == null) {
-                    continue;
+            for (Element imageElement : document.select("img")) {
+                ImageCandidate matched = consumeFirstAvailable(availableImages, consumedIndexes,
+                        candidate -> collectMatchCandidates(imageElement).stream()
+                                .anyMatch(value -> value.equals(candidate.matchKey())
+                                        || value.contains(candidate.matchKey())));
+
+                if (matched == null && shouldFallbackToNextImage(imageElement)) {
+                    matched = consumeFirstAvailable(availableImages, consumedIndexes, candidate -> true);
                 }
-                Element image = section.selectFirst("img");
-                if (image == null) {
-                    log.debug("No <img> found inside section {} while injecting framework images", entry.getKey());
-                    continue;
+
+                if (matched != null && !Objects.equals(imageElement.attr("src"), matched.url())) {
+                    imageElement.attr("src", matched.url());
+                    changed = true;
                 }
-                image.attr("src", entry.getValue());
-                changed = true;
             }
             return changed ? document.outerHtml() : html;
         } catch (Exception ex) {
             log.warn("Failed to inject framework images into landing page HTML", ex);
             return html;
         }
+    }
+
+    private List<String> collectMatchCandidates(Element imageElement) {
+        List<String> candidates = new ArrayList<>();
+        addCandidate(candidates, imageElement.attr("data-planning-item-key"));
+        addCandidate(candidates, imageElement.attr("data-section-id"));
+        addCandidate(candidates, imageElement.attr("data-section-name"));
+        addCandidate(candidates, imageElement.attr("data-image-key"));
+        addCandidate(candidates, imageElement.id());
+        addCandidate(candidates, imageElement.attr("alt"));
+        addCandidate(candidates, imageElement.className());
+        Element closestSection = imageElement.closest("section");
+        if (closestSection != null) {
+            addCandidate(candidates, closestSection.id());
+            addCandidate(candidates, closestSection.attr("data-section-id"));
+            addCandidate(candidates, closestSection.attr("data-planning-item-key"));
+            addCandidate(candidates, closestSection.className());
+        }
+        return candidates;
+    }
+
+    private void addCandidate(List<String> candidates, String rawValue) {
+        String normalized = normalizeMatchValue(rawValue);
+        if (StringUtils.hasText(normalized)) {
+            candidates.add(normalized);
+        }
+    }
+
+    private String normalizeMatchValue(String rawValue) {
+        return rawValue == null ? "" : rawValue.trim().toLowerCase();
+    }
+
+    private boolean shouldFallbackToNextImage(Element imageElement) {
+        String src = normalizeMatchValue(imageElement.attr("src"));
+        return !StringUtils.hasText(src)
+                || src.startsWith("about:blank")
+                || src.contains("placehold.co")
+                || src.contains("placeholder");
+    }
+
+    private ImageCandidate consumeFirstAvailable(List<ImageCandidate> availableImages,
+                                                 Set<Integer> consumedIndexes,
+                                                 Predicate<ImageCandidate> matcher) {
+        for (int index = 0; index < availableImages.size(); index++) {
+            if (consumedIndexes.contains(index)) {
+                continue;
+            }
+            ImageCandidate candidate = availableImages.get(index);
+            if (!matcher.test(candidate)) {
+                continue;
+            }
+            consumedIndexes.add(index);
+            return candidate;
+        }
+        return null;
+    }
+
+    private record ImageCandidate(String matchKey, String url) {
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/LandingPageImageInjectorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/LandingPageImageInjectorTest.java
@@ -62,6 +62,44 @@ class LandingPageImageInjectorTest {
     }
 
     @Test
+    void injectsByDataPlanningItemKeyWhenSectionIdDoesNotMatch() {
+        String html = """
+                <!doctype html>
+                <html><body>
+                  <section id="hero-top">
+                    <img src="https://placehold.co/1600x900/png?text=Hero" data-planning-item-key="s0-hero" />
+                  </section>
+                </body></html>
+                """;
+        when(jobRepository.findByExperimentIdOrderByCreatedAtDesc(anyLong()))
+                .thenReturn(List.of(completedJob("s0-hero", "https://cdn.example.com/hero-final.jpg", null)));
+
+        String enriched = injector.injectImages(123L, html);
+
+        assertThat(enriched).contains("https://cdn.example.com/hero-final.jpg");
+        assertThat(enriched).doesNotContain("placehold.co");
+    }
+
+    @Test
+    void replacesPlaceholderWithNextGeneratedImageWhenNoDirectMatchExists() {
+        String html = """
+                <!doctype html>
+                <html><body>
+                  <section id="intro">
+                    <img src="https://placehold.co/1600x1000/png?text=Timeline" alt="Timeline visual" />
+                  </section>
+                </body></html>
+                """;
+        when(jobRepository.findByExperimentIdOrderByCreatedAtDesc(anyLong()))
+                .thenReturn(List.of(completedJob("s9-proof", "https://cdn.example.com/timeline-final.jpg", null)));
+
+        String enriched = injector.injectImages(987L, html);
+
+        assertThat(enriched).contains("https://cdn.example.com/timeline-final.jpg");
+        assertThat(enriched).doesNotContain("placehold.co");
+    }
+
+    @Test
     void keepsOriginalPayloadWhenNoImagesAreAvailable() {
         String payload = "{}";
         when(jobRepository.findByExperimentIdOrderByCreatedAtDesc(anyLong())).thenReturn(List.of());


### PR DESCRIPTION
### Motivation

- Avoid public Lead Portal flows showing placeholder images after the user clicks `Usar como formulário do experimento` by making image injection robust to real HTML structure and metadata.
- Honor the canonical artifact model for landing image planning so generated pipeline images are correctly bound to the landing HTML when applied to the lead portal.

### Description

- Enhanced `LandingPageImageInjector` to match generated images not only by `<section id="...">` but also by HTML metadata such as `data-planning-item-key`, `data-section-id`, `data-section-name`, `data-image-key`, `id`, `alt`, `class`, and nearest `section` attributes.
- Added a safe fallback that replaces explicit placeholders (`placehold.co`, `placeholder`, `about:blank` or empty `src`) with the next available generated image when no direct key match is found, and ensured each generated image is consumed only once to avoid reuse.
- Implemented helper methods (`collectMatchCandidates`, `normalizeMatchValue`, `consumeFirstAvailable`) and a small `ImageCandidate` record to structure matching logic.
- Added unit tests in `LandingPageImageInjectorTest` covering `data-planning-item-key` matching and placeholder fallback replacement, and updated `LandingPageImageInjector` implementation in `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/LandingPageImageInjector.java`.

### Testing

- Added unit tests `injectsByDataPlanningItemKeyWhenSectionIdDoesNotMatch` and `replacesPlaceholderWithNextGeneratedImageWhenNoDirectMatchExists` in `backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/LandingPageImageInjectorTest.java`.
- Attempted to run `cd backend/ads-service && mvn -s ../settings.xml -Dtest=LandingPageImageInjectorTest,ExperimentPipelineGenerationServiceTest test`, but the Maven build failed due to network restrictions resolving the parent POM (`Network is unreachable`), so tests could not be executed in this environment.
- Local unit test additions are in place and should pass in CI or a developer environment with network access to Maven Central.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95c9c87ac8321901f0152cd7301d6)