### PR TITLE
Fix scrollIntoView restoration in flow iframe bridge

### DIFF
--- a/lead-portal/frontend/src/pages/FlowPage.tsx
+++ b/lead-portal/frontend/src/pages/FlowPage.tsx
@@ -448,7 +448,7 @@ function attachCustomTemplateBridge(
   };
 
   const elementProto = win.Element?.prototype;
-  const originalScrollIntoView = elementProto?.scrollIntoView?.bind(elementProto);
+  const originalScrollIntoView = elementProto?.scrollIntoView;
   if (elementProto && typeof elementProto.scrollIntoView === "function") {
     elementProto.scrollIntoView = function scrollIntoViewOverride(arg?: boolean | ScrollIntoViewOptions) {
       const behavior = normalizeBehavior(arg);


### PR DESCRIPTION
### Motivation
- Prevent runtime `Illegal invocation` errors caused by restoring a `bind`ed `scrollIntoView` prototype when landing templates call `scrollIntoView` from async callbacks after form interactions.

### Description
- Replace saving a bound function with keeping the original method reference (`elementProto.scrollIntoView`) and restore it on cleanup in `lead-portal/frontend/src/pages/FlowPage.tsx` to avoid illegal-invocation issues.

### Testing
- Ran `npm ci`, `npm run lint`, and `npm run build` in `lead-portal/frontend`, and all steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da47de19608321b79677651fc20c58)