### PR TITLE
Normalize landing HTML form contract and inject deterministic submit script

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -230,6 +230,51 @@ public class ExperimentPipelineOpenAiClient {
               <div class="error" id="field_whatsapp_error" style="display:none" role="alert"></div>
             </div>
             """;
+    private static final String STATIC_FORM_SUBMIT_SCRIPT = """
+            <script id="lead-capture-submit-contract">
+            (function () {
+              var form = document.getElementById('lead-capture-primary');
+              if (!form || form.dataset.staticSubmitContractApplied === 'true') {
+                return;
+              }
+              form.dataset.staticSubmitContractApplied = 'true';
+              form.addEventListener('submit', async function (event) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                var pathname = window.location.pathname || '';
+                var slugMatch = pathname.match(/\\/flows\\/([^/?#]+)/i);
+                var slug = slugMatch && slugMatch[1] ? slugMatch[1] : '';
+                var endpointTemplate = form.getAttribute('action') || '/api/flows/{slug}/submissions';
+                var endpoint = endpointTemplate.indexOf('{slug}') >= 0
+                  ? endpointTemplate.replace('{slug}', slug || 'formpersonal')
+                  : endpointTemplate;
+                var formData = new FormData(form);
+                var nome = (formData.get('nome') || '').toString().trim();
+                var email = (formData.get('email') || '').toString().trim();
+                var whatsapp = (formData.get('whatsapp') || '').toString().trim();
+                var answers = {};
+                if (whatsapp) {
+                  answers.whatsapp = whatsapp;
+                }
+                var campaignCode = new URLSearchParams(window.location.search).get('campaign')
+                  || new URLSearchParams(window.location.search).get('utm_campaign');
+                var payload = { name: nome, email: email, answers: answers };
+                if (campaignCode) {
+                  payload.campaignCode = campaignCode;
+                }
+                formData.set('payload', JSON.stringify(payload));
+                try {
+                  var response = await fetch(endpoint, { method: 'POST', body: formData });
+                  if (!response.ok) {
+                    throw new Error('Falha ao enviar formulário: ' + response.status);
+                  }
+                } catch (error) {
+                  console.error(error);
+                }
+              }, true);
+            })();
+            </script>
+            """;
 
     private static final String LANDING_IMAGE_PLANNING_PROMPT_SUFFIX = """
             Objetivo:
@@ -396,13 +441,14 @@ public class ExperimentPipelineOpenAiClient {
             sanitizedInner = sanitizedInner.stripLeading();
         }
 
-        StringBuilder rebuiltForm = new StringBuilder(formOpenTag.length() + STATIC_FORM_FIELDS_HTML.length() + sanitizedInner.length() + 32);
-        rebuiltForm.append(formOpenTag).append('\n').append(STATIC_FORM_FIELDS_HTML);
+        String normalizedFormOpenTag = normalizeFormOpenTag(formOpenTag);
+        StringBuilder rebuiltForm = new StringBuilder(normalizedFormOpenTag.length() + STATIC_FORM_FIELDS_HTML.length() + sanitizedInner.length() + 32);
+        rebuiltForm.append(normalizedFormOpenTag).append('\n').append(STATIC_FORM_FIELDS_HTML);
         if (StringUtils.hasText(sanitizedInner)) {
             rebuiltForm.append('\n').append(sanitizedInner);
         }
-
-        return beforeForm + rebuiltForm + afterForm;
+        String normalizedDocument = beforeForm + rebuiltForm + afterForm;
+        return ensureStaticSubmitScript(normalizedDocument);
     }
 
     private String stripDynamicFormFields(String formInner) {
@@ -411,6 +457,39 @@ public class ExperimentPipelineOpenAiClient {
         }
         Matcher matcher = FORM_FIELD_BLOCK_PATTERN.matcher(formInner);
         return matcher.replaceAll("");
+    }
+
+    private String normalizeFormOpenTag(String formOpenTag) {
+        String updated = upsertAttribute(formOpenTag, "id", "lead-capture-primary");
+        updated = upsertAttribute(updated, "method", "post");
+        updated = upsertAttribute(updated, "enctype", "multipart/form-data");
+        return upsertAttribute(updated, "action", "/api/flows/{slug}/submissions");
+    }
+
+    private String upsertAttribute(String tag, String attributeName, String value) {
+        Pattern pattern = Pattern.compile("(?i)\\s+" + Pattern.quote(attributeName) + "\\s*=\\s*(['\"]).*?\\1");
+        Matcher matcher = pattern.matcher(tag);
+        String replacement = " " + attributeName + "=\"" + value + "\"";
+        if (matcher.find()) {
+            return matcher.replaceFirst(replacement);
+        }
+        int closeIdx = tag.lastIndexOf('>');
+        if (closeIdx < 0) {
+            return tag;
+        }
+        return tag.substring(0, closeIdx) + replacement + tag.substring(closeIdx);
+    }
+
+    private String ensureStaticSubmitScript(String htmlDocument) {
+        if (!StringUtils.hasText(htmlDocument) || htmlDocument.contains("id=\"lead-capture-submit-contract\"")) {
+            return htmlDocument;
+        }
+        String lower = htmlDocument.toLowerCase(Locale.ROOT);
+        int bodyClose = lower.lastIndexOf("</body>");
+        if (bodyClose >= 0) {
+            return htmlDocument.substring(0, bodyClose) + STATIC_FORM_SUBMIT_SCRIPT + "\n" + htmlDocument.substring(bodyClose);
+        }
+        return htmlDocument + "\n" + STATIC_FORM_SUBMIT_SCRIPT;
     }
 
 

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -525,6 +525,11 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(htmlDocument).contains("name=\"nome\"");
         assertThat(htmlDocument).contains("name=\"email\"");
         assertThat(htmlDocument).contains("name=\"whatsapp\"");
+        assertThat(htmlDocument).contains("id=\"lead-capture-primary\"");
+        assertThat(htmlDocument).contains("method=\"post\"");
+        assertThat(htmlDocument).contains("enctype=\"multipart/form-data\"");
+        assertThat(htmlDocument).contains("action=\"/api/flows/{slug}/submissions\"");
+        assertThat(htmlDocument).contains("id=\"lead-capture-submit-contract\"");
     }
 
     @Test
@@ -579,6 +584,8 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(htmlDocument).contains("name=\"whatsapp\"");
         assertThat(htmlDocument).doesNotContain("name=\"objetivo\"");
         assertThat(htmlDocument).doesNotContain("<select name=\"objetivo\"");
+        assertThat(htmlDocument).contains("action=\"/api/flows/{slug}/submissions\"");
+        assertThat(htmlDocument).contains("id=\"lead-capture-submit-contract\"");
     }
 
     @Test

--- a/docs/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/modelo-canonico-artefatos-pipeline-experimento.md
@@ -203,6 +203,7 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
     "submitEncoding": "multipart/form-data",
     "submitPayloadContract": {
       "endpoint": "/api/flows/{slug}/submissions",
+      "endpointResolution": "obrigatorio resolver {slug} a partir de /flows/{slug} em runtime e executar POST multipart/form-data",
       "requiredMultipartFields": ["payload"],
       "payloadJsonShape": {
         "name": "string",


### PR DESCRIPTION
### Motivation
- Prevent generated landing forms from missing the submission POST to `/api/flows/{slug}/submissions` by enforcing a stable client-side contract for the form produced by the pipeline.
- Provide a deterministic fallback that resolves `{slug}` from the public URL so pages like `https://oportunidadebrasil.shop/flows/exp-10-landing` will actually post submissions instead of silently doing nothing.

### Description
- Enforce form attributes in `ExperimentPipelineOpenAiClient` by normalizing the `<form>` to include `id="lead-capture-primary"`, `method="post"`, `enctype="multipart/form-data"` and `action="/api/flows/{slug}/submissions"` before returning `landingPageHtml`.
- Add a deterministic inline fallback script (`id="lead-capture-submit-contract"`) that resolves the `slug` from the runtime path and submits a multipart `payload` JSON to the resolved endpoint when the form is submitted.
- Implement helper functions `normalizeFormOpenTag`, `upsertAttribute` and `ensureStaticSubmitScript` and reuse existing form-field stripping to keep deterministic fields only.
- Update unit tests in `ExperimentPipelineOpenAiClientTest` to assert the normalized attributes and the presence of the injected script, and update the canonical schema in `docs/modelo-canonico-artefatos-pipeline-experimento.md` to document runtime `{slug}` resolution for the pipeline form endpoint.

### Testing
- Updated `ai-worker` unit tests: `ExperimentPipelineOpenAiClientTest` was extended to validate normalization and script injection (tests added to repository).
- Attempted to run the tests with `cd ai-worker && mvn -s settings.xml test -Dtest=ExperimentPipelineOpenAiClientTest`, but the build failed in this environment due to Maven dependency resolution/network restrictions when fetching the parent Spring Boot POM; no test run completed here.
- Repository changes were committed and include the modified source, tests and the docs update; CI should run the full test suite where network and artifact resolution are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4da848f08321b566f0132cf7e233)