### PR TITLE
fix(ai-worker-ci): prevent AI Worker CI test job from appearing stuck in loop

### DIFF
--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       mysql:
         image: mysql:5.7
@@ -48,7 +49,7 @@ jobs:
       - name: Run tests
         run: mvn -B -s settings.xml test
       - name: Build
-        run: mvn -B -s settings.xml package
+        run: mvn -B -s settings.xml package -DskipTests
 
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Prevent the AI Worker CI `test` job from hanging indefinitely and avoid running the test suite twice during the workflow.

### Description
- Added `timeout-minutes: 30` to the `test` job and changed the `package` step to `mvn -B -s settings.xml package -DskipTests` in `.github/workflows/ai-worker.yml` so tests run only in the dedicated `Run tests` step.

### Testing
- Attempted to run `cd ai-worker && mvn -s settings.xml test -DskipITs` locally and the Maven build failed due to an inability to resolve the parent POM from GitHub Packages (network unreachable), so the full test suite could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da52efeff88321a0ab64c9b1abdf99)