### PR TITLE
Refina regras de cardinalidade de imagens no prompt de landing HTML

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -199,9 +199,12 @@ public class ExperimentPipelineOpenAiClient {
             7. Cada seção renderizada deve incluir data-section-id e aplicar exatamente wireframe.sectionOrder[i].surfaceSpec usando data-surface-token, data-surface-style e data-surface-contrast.
             8. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.
             9. Não usar bibliotecas externas.
-            10. Toda tag <img> deve usar src absoluto válido (https://... ou data:image/...) e reutilizar altText do planejamento de imagens.
-            11. Cada <img> deve declarar data-image-section-id e data-image-binding-key como binding canônico obrigatório do plano de imagens.
-            12. Cada <img> também deve declarar data-image-role (semântico), data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion.
+            10. Renderizar imagens somente para itens listados em landingPageImagePlanning.images[].
+            11. É proibido adicionar qualquer tag <img> fora dessa lista, mesmo que o wireframe sugira mídia visual em outras seções.
+            12. Se uma seção tiver contentType=split e não existir imagem correspondente em landingPageImagePlanning.images[], renderizar o bloco sem <img>.
+            13. Toda tag <img> permitida deve usar src absoluto válido (https://... ou data:image/...) e reutilizar altText do planejamento de imagens.
+            14. Cada <img> deve declarar data-image-section-id e data-image-binding-key como binding canônico obrigatório do plano de imagens.
+            15. Cada <img> também deve declarar data-image-role (semântico), data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion.
 
             Formato obrigatório (JSON):
             - htmlDocument


### PR DESCRIPTION
### Motivation
- Evitar drift entre o wireframe e o planejamento de imagens, tornando explícito quem pode e não pode renderizar imagens na etapa `LANDING_PAGE_HTML` para preservar integridade do contrato de geração.

### Description
- Atualiza o sufixo de prompt `LANDING_HTML_PROMPT_SUFFIX` em `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java` para exigir que apenas imagens listadas em `landingPageImagePlanning.images[]` sejam renderizadas, proibir qualquer `<img>` fora dessa lista, definir que se uma seção `contentType=split` não tiver imagem planejada deve ser renderizada sem `<img>`, e manter os requisitos de binding e metadados (`data-image-section-id`, `data-image-binding-key`, `data-image-role`, `data-conversion-role`, etc.).

### Testing
- Executei o teste direcionado com `mvn -s settings.xml -Dtest=ExperimentPipelineOpenAiClientTest test` no diretório `ai-worker`, mas a execução falhou devido a resolução de dependências Maven (parent POM não resolvido por indisponibilidade de rede).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7bd90a7c83218825f95480dc29d0)