### PR TITLE
Padroniza landing com formSpec explícito e runtime fixo no portal público

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -788,11 +788,11 @@ public class ExperimentPipelineGenerationService {
             sb.append("\nObjetivo:\n");
             sb.append("Unificar copy + wireframe + planejamento de imagens e entregar uma landing final pronta para uso em formulário do experimento.\n\n");
             sb.append("Regras:\n");
-            sb.append("1. Entregar HTML completo com <style> e <script> internos (sem dependências externas).\n");
+            sb.append("1. Entregar HTML completo com estrutura visual e campos do formulário (sem lógica de submit acoplada no HTML/JS gerado).\n");
             sb.append("2. Garantir mobile-first e acessibilidade básica (labels, aria, foco visível).\n");
             sb.append("3. Repetir o CTA principal exatamente como no anúncio e nas seções anteriores.\n");
             sb.append("4. O formulário deve ser renderizado a partir de wireframe.formSpec como fonte única da verdade (sem inventar, remover, renomear ou trocar required).\n");
-            sb.append("5. Incluir validação de campos obrigatórios no JavaScript.\n");
+            sb.append("5. Não implementar fetch/XHR/form.submit/onSubmit customizado nem redirecionamento de submit no HTML/JS gerado; o runtime oficial fará a submissão.\n");
             sb.append("6. Não usar claims absolutos, nem linguagem de consultoria.\n");
             sb.append("7. Incluir bloco de compliance reforçando entrega digital via IA.\n");
             sb.append("8. Consumir explicitamente os artefatos anteriores:\n");
@@ -809,6 +809,7 @@ public class ExperimentPipelineGenerationService {
             appendImageBindingSummary(sb, experiment);
             sb.append("Formato obrigatório:\n");
             sb.append("- htmlDocument: string com o documento completo final.\n");
+            sb.append("- formSpec: contrato explícito do formulário contendo fields/required e metadados de CTA para runtime oficial.\n");
             sb.append("- summary: resumo curto das decisões de implementação.\n");
             sb.append("- consistencyChecks: checks com CTA_MATCH, PROMISE_MATCH, IMAGE_PLAN_BINDING, SURFACE_SPEC_BINDING, FORM_SPEC_BINDING e FORM_USABILITY.\n");
             return;
@@ -1011,6 +1012,7 @@ public class ExperimentPipelineGenerationService {
             }
             String normalizedHtml = rebuildFormFromSpec(htmlDocument, formFields);
             htmlPayload.put("htmlDocument", normalizedHtml);
+            htmlPayload.put("formSpec", buildLandingHtmlFormSpec((Map<String, Object>) rawFormSpec));
             htmlPayload.put("summary", summarizeNormalizedForm(formFields, submitLabel));
             htmlPayload.put("consistencyChecks", buildLandingHtmlConsistencyChecks(formFields, submitLabel));
             log.info("Normalização determinística de formulário aplicada no LANDING_PAGE_HTML (experimentId={}, fields={})",
@@ -1577,11 +1579,69 @@ public class ExperimentPipelineGenerationService {
     }
 
     private Map<String, Object> landingPageHtmlFieldSchema() {
+        Map<String, Object> formFieldSchema = Map.of(
+                "type", "object",
+                "additionalProperties", false,
+                "properties", Map.ofEntries(
+                        Map.entry("name", stringSchema()),
+                        Map.entry("type", Map.of("type", "string", "enum", List.of("text", "email", "tel"))),
+                        Map.entry("label", stringSchema()),
+                        Map.entry("required", Map.of("type", "boolean")),
+                        Map.entry("placeholder", stringSchema())
+                ),
+                "required", List.of("name", "type", "label", "required", "placeholder")
+        );
+        Map<String, Object> formSpecSchema = Map.of(
+                "type", "object",
+                "additionalProperties", false,
+                "properties", Map.ofEntries(
+                        Map.entry("formId", stringSchema()),
+                        Map.entry("title", stringSchema()),
+                        Map.entry("submitLabel", stringSchema()),
+                        Map.entry("submitTarget", stringSchema()),
+                        Map.entry("cta", Map.of(
+                                "type", "object",
+                                "additionalProperties", false,
+                                "properties", Map.of(
+                                        "label", stringSchema(),
+                                        "target", stringSchema(),
+                                        "variant", stringSchema()
+                                ),
+                                "required", List.of("label", "target", "variant")
+                        )),
+                        Map.entry("fields", Map.of(
+                                "type", "array",
+                                "minItems", 1,
+                                "items", formFieldSchema
+                        )),
+                        Map.entry("consent", Map.of(
+                                "type", "object",
+                                "additionalProperties", false,
+                                "properties", Map.of(
+                                        "enabled", Map.of("type", "boolean"),
+                                        "required", Map.of("type", "boolean"),
+                                        "label", stringSchema()
+                                ),
+                                "required", List.of("enabled", "required", "label")
+                        )),
+                        Map.entry("successState", Map.of(
+                                "type", "object",
+                                "additionalProperties", false,
+                                "properties", Map.of(
+                                        "title", stringSchema(),
+                                        "message", stringSchema()
+                                ),
+                                "required", List.of("title", "message")
+                        ))
+                ),
+                "required", List.of("formId", "submitLabel", "submitTarget", "cta", "fields")
+        );
         return Map.of(
                 "type", "object",
                 "additionalProperties", false,
                 "properties", Map.ofEntries(
                         Map.entry("htmlDocument", stringSchema()),
+                        Map.entry("formSpec", formSpecSchema),
                         Map.entry("summary", stringSchema()),
                         Map.entry("consistencyChecks", Map.of(
                                 "type", "array",
@@ -1589,8 +1649,27 @@ public class ExperimentPipelineGenerationService {
                                 "items", consistencyCheckSchema()
                         ))
                 ),
-                "required", List.of("htmlDocument", "summary", "consistencyChecks")
+                "required", List.of("htmlDocument", "formSpec", "summary", "consistencyChecks")
         );
+    }
+
+    private Map<String, Object> buildLandingHtmlFormSpec(Map<String, Object> wireframeFormSpec) {
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        normalized.put("formId", asTrimmedString(wireframeFormSpec.get("formId")));
+        normalized.put("title", asTrimmedString(wireframeFormSpec.get("title")));
+        String submitLabel = asTrimmedString(wireframeFormSpec.get("submitLabel"));
+        String submitTarget = asTrimmedString(wireframeFormSpec.get("submitTarget"));
+        normalized.put("submitLabel", submitLabel);
+        normalized.put("submitTarget", submitTarget);
+        normalized.put("fields", wireframeFormSpec.getOrDefault("fields", List.of()));
+        normalized.put("consent", wireframeFormSpec.getOrDefault("consent", Map.of()));
+        normalized.put("successState", wireframeFormSpec.getOrDefault("successState", Map.of()));
+        normalized.put("cta", Map.of(
+                "label", submitLabel,
+                "target", submitTarget,
+                "variant", "primary"
+        ));
+        return normalized;
     }
 
     private Map<String, Object> landingPageCopyFieldSchema() {

--- a/lead-portal/frontend/src/pages/FlowPage.tsx
+++ b/lead-portal/frontend/src/pages/FlowPage.tsx
@@ -9,7 +9,11 @@ import {
 } from "../api";
 import FlowForm from "../components/FlowForm";
 import { resolveAssetUrl } from "../utils/resolveAssetUrl";
-import { normalizeCustomTemplateHtml } from "../utils/customTemplateHtml";
+import {
+  normalizeCustomTemplatePayload,
+  type CustomTemplateFormFieldSpec,
+  type CustomTemplateFormSpec,
+} from "../utils/customTemplateHtml";
 import { getVisitorIdCookie } from "../utils/visitorCookie";
 import { useCampaignCode } from "../hooks/useCampaignCode";
 import type { FlowQuestion, LeadPortalFlow, LeadPortalSimpleFormStyleDefinition } from "../types";
@@ -42,10 +46,12 @@ export default function FlowPage() {
     () => extractSimpleFormMetadata(flow?.questions ?? []),
     [flow?.questions],
   );
-  const customTemplateHtml = useMemo(
-    () => normalizeCustomTemplateHtml(flow?.customFormHtml),
+  const customTemplatePayload = useMemo(
+    () => normalizeCustomTemplatePayload(flow?.customFormHtml),
     [flow?.customFormHtml],
   );
+  const customTemplateHtml = customTemplatePayload?.html;
+  const customTemplateFormSpec = customTemplatePayload?.formSpec;
   const hasCustomTemplate = Boolean(customTemplateHtml);
   const customTemplateVariables = useMemo(() => {
     if (!hasCustomTemplate || !flow) {
@@ -63,6 +69,14 @@ export default function FlowPage() {
     registerFlowRenderComplete(resolvedFlowSlug, getVisitorIdCookie(), campaignCode)
       .then(() => {
         if (!cancelled) {
+          window.dispatchEvent(
+            new CustomEvent("lead-portal-render-complete", {
+              detail: {
+                flowSlug: resolvedFlowSlug,
+                campaignCode: campaignCode ?? null,
+              },
+            }),
+          );
           setHasTrackedRenderComplete(true);
         }
       })
@@ -115,6 +129,7 @@ export default function FlowPage() {
         html={customTemplateHtml}
         variables={templateVariables}
         flowSlug={flow.slug}
+        formSpec={customTemplateFormSpec}
         campaignCode={campaignCode}
         onSubmitted={() => setHasSubmitted(true)}
       />
@@ -236,6 +251,7 @@ interface CustomFlowTemplateProps {
   html: string;
   variables: Map<string, string>;
   flowSlug: string;
+  formSpec?: CustomTemplateFormSpec;
   campaignCode?: string | null;
   onSubmitted?: () => void;
 }
@@ -246,6 +262,7 @@ function CustomFlowTemplate({
   html,
   variables,
   flowSlug,
+  formSpec,
   campaignCode,
   onSubmitted,
 }: CustomFlowTemplateProps) {
@@ -306,6 +323,7 @@ function CustomFlowTemplate({
       }
       const newBridgeCleanup = attachCustomTemplateBridge(iframe, {
         flowSlug,
+        formSpec,
         campaignCode,
         onSubmitted,
       });
@@ -333,7 +351,7 @@ function CustomFlowTemplate({
       cleanupObserver();
       cleanupBridge();
     };
-  }, [processedHtml, flowSlug, campaignCode, onSubmitted]);
+  }, [processedHtml, flowSlug, formSpec, campaignCode, onSubmitted]);
 
   if (!processedHtml) {
     return (
@@ -359,6 +377,7 @@ function CustomFlowTemplate({
 
 interface CustomTemplateBridgeOptions {
   flowSlug: string;
+  formSpec?: CustomTemplateFormSpec;
   campaignCode?: string | null;
   onSubmitted?: () => void;
 }
@@ -371,6 +390,9 @@ function attachCustomTemplateBridge(
   const win = iframe.contentWindow;
   if (!doc || !win) {
     return null;
+  }
+  if (options.formSpec) {
+    renderManagedTemplateForm(doc, options.formSpec);
   }
 
   const handleAnchorClick = (event: MouseEvent) => {
@@ -416,8 +438,23 @@ function attachCustomTemplateBridge(
       const parsed = parseTemplateSubmissionPayload(target, options.campaignCode);
       await submitFlowSubmission(options.flowSlug, parsed.payload, parsed.image);
       target.dataset.leadPortalSubmitted = "true";
+      writeManagedTemplateFeedback(
+        target,
+        "success",
+        options.formSpec?.successState?.title ?? "Tudo certo!",
+        options.formSpec?.successState?.message ?? "Recebemos seus dados com sucesso.",
+      );
       target.dispatchEvent(
         new CustomEvent("leadportal:submission-success", { bubbles: true }),
+      );
+      window.dispatchEvent(
+        new CustomEvent("lead_portal_submission", {
+          detail: {
+            flowSlug: options.flowSlug,
+            campaignCode: options.campaignCode ?? null,
+            mode: "managed-runtime",
+          },
+        }),
       );
       options.onSubmitted?.();
     } catch (error) {
@@ -426,6 +463,7 @@ function attachCustomTemplateBridge(
           ? error.message
           : "Não foi possível enviar suas respostas.";
       target.dataset.leadPortalSubmitError = message;
+      writeManagedTemplateFeedback(target, "error", "Erro ao enviar", message);
       target.dispatchEvent(
         new CustomEvent("leadportal:submission-error", {
           bubbles: true,
@@ -474,6 +512,104 @@ function toggleTemplateSubmitButtons(form: HTMLFormElement, isSubmitting: boolea
     button.disabled = isSubmitting;
     button.setAttribute("aria-busy", isSubmitting ? "true" : "false");
   });
+}
+
+function renderManagedTemplateForm(doc: Document, formSpec: CustomTemplateFormSpec) {
+  const target =
+    (doc.getElementById(formSpec.formId) as HTMLFormElement | null) ??
+    (doc.querySelector("form") as HTMLFormElement | null);
+  if (!target) {
+    return;
+  }
+  target.id = formSpec.formId;
+  target.setAttribute("novalidate", "novalidate");
+  target.setAttribute("data-lead-portal-managed", "true");
+  target.removeAttribute("action");
+  target.removeAttribute("method");
+  target.querySelectorAll("[data-runtime-node='true']").forEach((node) => node.remove());
+
+  const fragment = doc.createDocumentFragment();
+  if (formSpec.title) {
+    const title = doc.createElement("h2");
+    title.textContent = formSpec.title;
+    title.setAttribute("data-runtime-node", "true");
+    fragment.appendChild(title);
+  }
+
+  formSpec.fields.forEach((field) => {
+    fragment.appendChild(buildManagedField(doc, field));
+  });
+
+  if (formSpec.consent?.enabled && formSpec.consent.label) {
+    const consentWrapper = doc.createElement("label");
+    consentWrapper.setAttribute("data-runtime-node", "true");
+    consentWrapper.style.display = "flex";
+    consentWrapper.style.gap = "0.5rem";
+    const consentInput = doc.createElement("input");
+    consentInput.type = "checkbox";
+    consentInput.name = "consentimento";
+    if (formSpec.consent.required) {
+      consentInput.required = true;
+    }
+    const consentText = doc.createElement("span");
+    consentText.textContent = formSpec.consent.label;
+    consentWrapper.appendChild(consentInput);
+    consentWrapper.appendChild(consentText);
+    fragment.appendChild(consentWrapper);
+  }
+
+  const submitButton = doc.createElement("button");
+  submitButton.type = "submit";
+  submitButton.textContent = formSpec.submitLabel;
+  submitButton.setAttribute("data-runtime-node", "true");
+  submitButton.className = "lead-portal-runtime-submit";
+  fragment.appendChild(submitButton);
+
+  const feedback = doc.createElement("div");
+  feedback.setAttribute("data-runtime-node", "true");
+  feedback.setAttribute("data-runtime-feedback", "true");
+  feedback.setAttribute("role", "status");
+  feedback.setAttribute("aria-live", "polite");
+  feedback.style.marginTop = "0.75rem";
+  fragment.appendChild(feedback);
+
+  target.replaceChildren(fragment);
+}
+
+function buildManagedField(doc: Document, field: CustomTemplateFormFieldSpec) {
+  const wrapper = doc.createElement("div");
+  wrapper.setAttribute("data-runtime-node", "true");
+  wrapper.className = "lead-portal-runtime-field";
+
+  const label = doc.createElement("label");
+  label.htmlFor = `field_${field.name}`;
+  label.textContent = field.required ? `${field.label} *` : field.label;
+
+  const input = doc.createElement("input");
+  input.id = `field_${field.name}`;
+  input.name = field.name;
+  input.type = field.type;
+  input.required = field.required;
+  input.placeholder = field.placeholder ?? "";
+  input.autocomplete = field.type === "email" ? "email" : field.type === "tel" ? "tel" : "name";
+
+  wrapper.appendChild(label);
+  wrapper.appendChild(input);
+  return wrapper;
+}
+
+function writeManagedTemplateFeedback(
+  form: HTMLFormElement,
+  status: "success" | "error",
+  title: string,
+  message: string,
+) {
+  const container = form.querySelector<HTMLElement>("[data-runtime-feedback='true']");
+  if (!container) {
+    return;
+  }
+  container.dataset.status = status;
+  container.textContent = `${title} ${message}`.trim();
 }
 
 function parseTemplateSubmissionPayload(

--- a/lead-portal/frontend/src/utils/customTemplateHtml.ts
+++ b/lead-portal/frontend/src/utils/customTemplateHtml.ts
@@ -1,7 +1,46 @@
 const HTML_HINT = /<\s*!doctype|<\s*html|<\s*body|<\s*(?:main|section|div|header|footer)/i;
 const FENCED_JSON = /```(?:json)?\s*([\s\S]*?)```/i;
 
+export interface CustomTemplateFormFieldSpec {
+  name: string;
+  type: "text" | "email" | "tel";
+  label: string;
+  required: boolean;
+  placeholder?: string;
+}
+
+export interface CustomTemplateFormSpec {
+  formId: string;
+  title?: string;
+  submitLabel: string;
+  submitTarget?: string;
+  fields: CustomTemplateFormFieldSpec[];
+  consent?: {
+    enabled?: boolean;
+    required?: boolean;
+    label?: string;
+  };
+  successState?: {
+    title?: string;
+    message?: string;
+  };
+  cta?: {
+    label?: string;
+    target?: string;
+    variant?: string;
+  };
+}
+
+export interface CustomTemplatePayload {
+  html: string;
+  formSpec?: CustomTemplateFormSpec;
+}
+
 export function normalizeCustomTemplateHtml(raw?: string | null): string | undefined {
+  return normalizeCustomTemplatePayload(raw)?.html;
+}
+
+export function normalizeCustomTemplatePayload(raw?: string | null): CustomTemplatePayload | undefined {
   if (typeof raw !== "string") {
     return undefined;
   }
@@ -10,27 +49,27 @@ export function normalizeCustomTemplateHtml(raw?: string | null): string | undef
     return undefined;
   }
   if (looksLikeHtml(trimmed)) {
-    return trimmed;
+    return { html: trimmed };
   }
   return extractFromJson(trimmed);
 }
 
-function extractFromJson(text: string): string | undefined {
+function extractFromJson(text: string): CustomTemplatePayload | undefined {
   const parsed = tryParseJson(text) ?? tryParseJson(extractEmbeddedJson(text) ?? "");
   if (!parsed) {
     return undefined;
   }
-  return findHtmlInValue(parsed);
+  return findPayloadInValue(parsed);
 }
 
-function findHtmlInValue(value: unknown): string | undefined {
+function findPayloadInValue(value: unknown): CustomTemplatePayload | undefined {
   if (typeof value === "string") {
     const trimmed = value.trim();
     if (!trimmed) {
       return undefined;
     }
     if (looksLikeHtml(trimmed)) {
-      return trimmed;
+      return { html: trimmed };
     }
     if (looksLikeJsonCandidate(trimmed)) {
       return extractFromJson(trimmed);
@@ -39,9 +78,9 @@ function findHtmlInValue(value: unknown): string | undefined {
   }
   if (Array.isArray(value)) {
     for (const entry of value) {
-      const html = findHtmlInValue(entry);
-      if (html) {
-        return html;
+      const payload = findPayloadInValue(entry);
+      if (payload) {
+        return payload;
       }
     }
     return undefined;
@@ -49,17 +88,122 @@ function findHtmlInValue(value: unknown): string | undefined {
   if (value && typeof value === "object") {
     const record = value as Record<string, unknown>;
     if (record.htmlDocument) {
-      const html = findHtmlInValue(record.htmlDocument);
-      if (html) {
-        return html;
+      const htmlPayload = findPayloadInValue(record.htmlDocument);
+      if (htmlPayload) {
+        return {
+          html: htmlPayload.html,
+          formSpec: normalizeFormSpec(record.formSpec),
+        };
       }
     }
     for (const entry of Object.values(record)) {
-      const html = findHtmlInValue(entry);
-      if (html) {
-        return html;
+      const payload = findPayloadInValue(entry);
+      if (payload) {
+        return payload;
       }
     }
+  }
+  return undefined;
+}
+
+function normalizeFormSpec(raw: unknown): CustomTemplateFormSpec | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const record = raw as Record<string, unknown>;
+  const formId = asNonEmptyString(record.formId);
+  const submitLabel = asNonEmptyString(record.submitLabel);
+  const fields = normalizeFields(record.fields);
+  if (!formId || !submitLabel || fields.length === 0) {
+    return undefined;
+  }
+  return {
+    formId,
+    title: asNonEmptyString(record.title),
+    submitLabel,
+    submitTarget: asNonEmptyString(record.submitTarget),
+    fields,
+    consent: normalizeConsent(record.consent),
+    successState: normalizeSuccessState(record.successState),
+    cta: normalizeCta(record.cta),
+  };
+}
+
+function normalizeFields(raw: unknown): CustomTemplateFormFieldSpec[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+      const field = entry as Record<string, unknown>;
+      const name = asNonEmptyString(field.name);
+      const type = asFieldType(field.type);
+      const label = asNonEmptyString(field.label);
+      const required = typeof field.required === "boolean" ? field.required : false;
+      if (!name || !type || !label) {
+        return null;
+      }
+      return {
+        name,
+        type,
+        label,
+        required,
+        placeholder: asNonEmptyString(field.placeholder),
+      };
+    })
+    .filter((entry): entry is CustomTemplateFormFieldSpec => Boolean(entry));
+}
+
+function normalizeConsent(raw: unknown) {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const consent = raw as Record<string, unknown>;
+  return {
+    enabled: typeof consent.enabled === "boolean" ? consent.enabled : undefined,
+    required: typeof consent.required === "boolean" ? consent.required : undefined,
+    label: asNonEmptyString(consent.label),
+  };
+}
+
+function normalizeSuccessState(raw: unknown) {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const successState = raw as Record<string, unknown>;
+  return {
+    title: asNonEmptyString(successState.title),
+    message: asNonEmptyString(successState.message),
+  };
+}
+
+function normalizeCta(raw: unknown) {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const cta = raw as Record<string, unknown>;
+  return {
+    label: asNonEmptyString(cta.label),
+    target: asNonEmptyString(cta.target),
+    variant: asNonEmptyString(cta.variant),
+  };
+}
+
+function asNonEmptyString(raw: unknown): string | undefined {
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asFieldType(raw: unknown): "text" | "email" | "tel" | undefined {
+  const normalized = asNonEmptyString(raw)?.toLowerCase();
+  if (normalized === "text" || normalized === "email" || normalized === "tel") {
+    return normalized;
   }
   return undefined;
 }


### PR DESCRIPTION
### Motivation
- Separar responsabilidade entre o HTML gerado por IA (apenas estrutura visual e campos) e a lógica de submissão, para evitar variantes JS inseguras e não padronizadas.
- Fornecer um contrato claro de formulário (`formSpec`) como fonte única da verdade para renderização e validação no runtime do portal público.

### Description
- Backend: atualizei as instruções e o schema da seção `LANDING_PAGE_HTML` para exigir `formSpec` no payload e para proibir lógica de submit acoplada no HTML/JS gerado; a normalização agora injeta deterministically `formSpec` a partir de `wireframe.formSpec` (arquivo modificado: `ExperimentPipelineGenerationService.java`).
- Frontend: estendi o parser de templates customizados para extrair `html` + `formSpec` (novos tipos e normalizadores em `lead-portal/frontend/src/utils/customTemplateHtml.ts`).
- Frontend: implementei um runtime gerenciado no `FlowPage` para templates customizados que renderiza campos a partir do `formSpec`, remove `action/method`, envia via `submitFlowSubmission`, exibe feedback padronizado e emite eventos de tracking (`lead-portal-render-complete` e `lead_portal_submission`) (arquivo modificado: `lead-portal/frontend/src/pages/FlowPage.tsx`).
- Pontos técnicos adicionais: o runtime marca elementos gerados com `data-runtime-node`, substitui o conteúdo do form quando `formSpec` está presente, e fornece mensagens de sucesso/erro a partir de `formSpec.successState` quando disponível.

### Testing
- Executado `cd backend/ads-service && mvn -s ../settings.xml -DskipTests compile` — falhou devido à indisponibilidade de rede para baixar dependências Maven (não relacionado às mudanças de código).
- Executado `cd lead-portal/frontend && npm run build` — falhou por dependências locais ausentes (`vite` e `@vitejs/plugin-react`) no ambiente atual; lints/compilação não puderam ser verificados.
- Código commitado e testes locais não concluídos por restrições de ambiente; revisão de diffs e execução parcial das validações de payload foram feitas durante o desenvolvimento.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da83580b84832186b3c5ee229574d0)