### PR TITLE
Add versioned Lead Portal submission engagement contract (v1) and wire through backend/frontend

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelEventRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelEventRepository.java
@@ -16,6 +16,12 @@ public interface ExperimentFunnelEventRepository extends JpaRepository<Experimen
     String RENDER_COMPLETE_SOURCE = "lead-portal-render-complete";
     String SUBMISSION_SOURCE = "lead_portal_submission";
 
+    boolean existsByExperimentIdAndStageAndSourceAndPayload(
+            Long experimentId,
+            ExperimentFunnelStage stage,
+            String source,
+            String payload);
+
     @Query("""
             select e.stage as stage,
                    count(e.id) as total,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -4,6 +4,7 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
 import com.marketinghub.experiment.funnel.dto.RegisterExperimentFunnelEventRequest;
 import com.marketinghub.experiment.funnel.ExperimentFunnelEventRepository.StageAggregation;
+import com.marketinghub.leadportal.dto.LeadPortalSubmissionEngagementContractV1;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.model.Lead;
 import com.marketinghub.repository.LeadRepository;
@@ -117,7 +118,7 @@ public class ExperimentFunnelService {
     }
 
     @Transactional
-    public void registerFormSubmission(String flowSlug, RegisterLeadPortalSubmissionRequest request) {
+    public boolean registerFormSubmission(String flowSlug, RegisterLeadPortalSubmissionRequest request) {
         if (flowSlug == null || flowSlug.isBlank()) {
             throw new IllegalArgumentException("Slug do fluxo é obrigatório");
         }
@@ -129,6 +130,14 @@ public class ExperimentFunnelService {
                 .orElseThrow(() -> new IllegalArgumentException("Fluxo não vinculado a experimento"));
 
         String payload = "submissionId=" + request.submissionId().trim();
+        boolean duplicated = eventRepository.existsByExperimentIdAndStageAndSourceAndPayload(
+                experiment.getId(),
+                ExperimentFunnelStage.ENVIO_FORM,
+                ExperimentFunnelEventRepository.SUBMISSION_SOURCE,
+                payload);
+        if (duplicated) {
+            return false;
+        }
         Instant occurredAt = Optional.ofNullable(request.submittedAt()).orElse(Instant.now());
 
         ExperimentFunnelEvent event = ExperimentFunnelEvent.builder()
@@ -140,6 +149,22 @@ public class ExperimentFunnelService {
                 .occurredAt(occurredAt)
                 .build();
         eventRepository.save(event);
+        return true;
+    }
+
+    @Transactional
+    public boolean registerFormSubmission(String flowSlug, LeadPortalSubmissionEngagementContractV1 request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Payload de submissão é obrigatório");
+        }
+        if (!LeadPortalSubmissionEngagementContractV1.VERSION.equals(request.contractVersion())) {
+            throw new IllegalArgumentException("Versão de contrato não suportada: " + request.contractVersion());
+        }
+        RegisterLeadPortalSubmissionRequest legacyRequest = new RegisterLeadPortalSubmissionRequest(
+                request.submissionId(),
+                request.submittedAt(),
+                request.campaignCode());
+        return registerFormSubmission(flowSlug, legacyRequest);
     }
 
     private Lead resolveLead(UUID leadId) {

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/LeadPortalSubmissionEngagementContractV1.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/LeadPortalSubmissionEngagementContractV1.java
@@ -1,0 +1,33 @@
+package com.marketinghub.leadportal.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+/**
+ * Contrato versionado para eventos públicos de submissão/engajamento do Lead Portal.
+ */
+public record LeadPortalSubmissionEngagementContractV1(
+        @NotBlank(message = "Versão do contrato é obrigatória") String contractVersion,
+        @NotBlank(message = "Slug do fluxo é obrigatório") String slug,
+        @NotBlank(message = "ID da submissão é obrigatório") String submissionId,
+        @NotNull(message = "Data/hora de submissão é obrigatória") Instant submittedAt,
+        @NotNull(message = "Contato é obrigatório") @Valid Contact contato,
+        String campaignCode,
+        @Valid Failure failure,
+        String idempotencyKey) {
+
+    public static final String VERSION = "lead-portal-submission-engagement.v1";
+
+    public record Contact(
+            @NotBlank(message = "Nome do contato é obrigatório") String nome,
+            @NotBlank(message = "E-mail do contato é obrigatório") @Email(message = "E-mail inválido") String email,
+            String telefone) {
+    }
+
+    public record Failure(String reason, String detail) {
+    }
+}
+

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublicationRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublicationRequest.java
@@ -22,6 +22,7 @@ public record LeadPortalFlowPublicationRequest(
         String name,
         String description,
         String customFormHtml,
+        EngagementContractMetadata engagementContract,
         String model,
         String prompt,
         String imagePromptModel,
@@ -53,6 +54,7 @@ public record LeadPortalFlowPublicationRequest(
                 flow.getName(),
                 flow.getDescription(),
                 flow.getCustomFormHtml(),
+                EngagementContractMetadata.defaultV1(),
                 flow.getModel(),
                 flow.getPrompt(),
                 flow.getImagePromptModel(),
@@ -182,5 +184,25 @@ public record LeadPortalFlowPublicationRequest(
             String name,
             LeadPortalSimpleFormStyleDefinition definition,
             String previewImageUrl) {
+    }
+
+    public record EngagementContractMetadata(
+            String version,
+            String renderCompleteEndpoint,
+            String submissionEndpoint,
+            String idempotencyField,
+            List<String> submissionRequiredFields) {
+
+        private static final String RENDER_ENDPOINT = "/api/public/lead-portal/flows/{slug}/render-complete";
+        private static final String SUBMISSION_ENDPOINT = "/api/public/lead-portal/flows/{slug}/submission";
+
+        public static EngagementContractMetadata defaultV1() {
+            return new EngagementContractMetadata(
+                    "lead-portal-submission-engagement.v1",
+                    RENDER_ENDPOINT,
+                    SUBMISSION_ENDPOINT,
+                    "submissionId",
+                    List.of("slug", "submissionId", "submittedAt", "contato"));
+        }
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalFlowEngagementController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalFlowEngagementController.java
@@ -1,9 +1,10 @@
 package com.marketinghub.leadportal.web;
 
 import com.marketinghub.experiment.funnel.ExperimentFunnelService;
+import com.marketinghub.leadportal.dto.LeadPortalSubmissionEngagementContractV1;
 import com.marketinghub.leadportal.dto.RegisterLeadPortalRenderCompleteRequest;
-import com.marketinghub.leadportal.dto.RegisterLeadPortalSubmissionRequest;
 import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,9 +33,34 @@ public class LeadPortalFlowEngagementController {
     }
 
     @PostMapping("/{slug}/submission")
-    public void registerSubmission(@PathVariable String slug,
-                                   @RequestBody @Valid RegisterLeadPortalSubmissionRequest request) {
-        experimentFunnelService.registerFormSubmission(slug, request);
+    public ResponseEntity<LeadPortalEngagementAckResponse> registerSubmission(@PathVariable String slug,
+                                                                               @RequestBody @Valid LeadPortalSubmissionEngagementContractV1 request) {
+        if (!slug.equals(request.slug())) {
+            throw new IllegalArgumentException("Slug da rota diverge do payload de submissão");
+        }
+        boolean accepted = experimentFunnelService.registerFormSubmission(slug, request);
+        if (!accepted) {
+            return ResponseEntity.ok(new LeadPortalEngagementAckResponse(
+                    LeadPortalSubmissionEngagementContractV1.VERSION,
+                    slug,
+                    request.submissionId(),
+                    "duplicate",
+                    "Evento de submissão já recebido anteriormente (idempotente)."));
+        }
+        return ResponseEntity.ok(new LeadPortalEngagementAckResponse(
+                LeadPortalSubmissionEngagementContractV1.VERSION,
+                slug,
+                request.submissionId(),
+                "accepted",
+                "Evento de submissão registrado com sucesso."));
+    }
+
+    public record LeadPortalEngagementAckResponse(
+            String contractVersion,
+            String slug,
+            String submissionId,
+            String status,
+            String message) {
     }
 
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalFlowEngagementControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalFlowEngagementControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -49,9 +50,18 @@ class LeadPortalFlowEngagementControllerTest {
 
     @Test
     void registerSubmissionForwardsPayload() throws Exception {
+        when(experimentFunnelService.registerFormSubmission(eq("flow-slug"), any())).thenReturn(true);
         mockMvc.perform(post("/api/public/lead-portal/flows/flow-slug/submission")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"submissionId\":\"abc-123\",\"submittedAt\":\"2024-05-01T12:34:56Z\"}"))
+                        .content("""
+                                {
+                                  "contractVersion":"lead-portal-submission-engagement.v1",
+                                  "slug":"flow-slug",
+                                  "submissionId":"abc-123",
+                                  "submittedAt":"2024-05-01T12:34:56Z",
+                                  "contato":{"nome":"Teste","email":"teste@contato.com"}
+                                }
+                                """))
                 .andExpect(status().isOk());
 
         verify(experimentFunnelService).registerFormSubmission(eq("flow-slug"), any());

--- a/docs/integrations/lead-portal-engagement-contract-v1.md
+++ b/docs/integrations/lead-portal-engagement-contract-v1.md
@@ -1,0 +1,62 @@
+# Contrato de submissão/engajamento — Lead Portal (v1)
+
+Versão: `lead-portal-submission-engagement.v1`
+
+## Objetivo
+
+Padronizar os eventos públicos enviados do runtime do portal para o backend de marketing, cobrindo:
+
+- render completo do formulário;
+- submit do formulário;
+- campos obrigatórios para submit;
+- comportamento idempotente e tratamento de falha.
+
+## Endpoints públicos
+
+- Render completo: `POST /api/public/lead-portal/flows/{slug}/render-complete`
+- Submit: `POST /api/public/lead-portal/flows/{slug}/submission`
+
+## Payload de submit (v1)
+
+```json
+{
+  "contractVersion": "lead-portal-submission-engagement.v1",
+  "slug": "flow-slug",
+  "submissionId": "f8fd3f64-e15b-4c61-b4cf-53f44a251001",
+  "submittedAt": "2026-04-11T10:15:30Z",
+  "contato": {
+    "nome": "Maria Silva",
+    "email": "maria@exemplo.com",
+    "telefone": "+55 11 99999-0000"
+  },
+  "campaignCode": "meta-campanha-001",
+  "idempotencyKey": "f8fd3f64-e15b-4c61-b4cf-53f44a251001"
+}
+```
+
+### Campos obrigatórios (submit)
+
+- `slug`
+- `submissionId`
+- `submittedAt`
+- `contato.nome`
+- `contato.email`
+
+## Idempotência e falhas
+
+- O backend trata `submissionId` como chave idempotente do evento de submit no funil.
+- Reenvios com o mesmo `submissionId` retornam `status=duplicate` sem duplicar evento.
+- Erros de validação retornam 4xx e precisam ser corrigidos pelo caller.
+- Erros transitórios (5xx/rede) devem usar retry com o mesmo `idempotencyKey`.
+
+## Metadados de publicação de fluxo
+
+Ao publicar o fluxo para o runtime público, o payload inclui:
+
+- `engagementContract.version`
+- `engagementContract.renderCompleteEndpoint`
+- `engagementContract.submissionEndpoint`
+- `engagementContract.idempotencyField`
+- `engagementContract.submissionRequiredFields`
+
+Esses metadados permitem o runtime validar versão e obrigatoriedade sem depender de JavaScript embarcado no HTML customizado.

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/ExperimentFunnelTrackingClient.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/ExperimentFunnelTrackingClient.java
@@ -26,6 +26,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class ExperimentFunnelTrackingClient {
 
     private static final Logger log = LoggerFactory.getLogger(ExperimentFunnelTrackingClient.class);
+    private static final String SUBMISSION_CONTRACT_VERSION = "lead-portal-submission-engagement.v1";
 
     public enum TrackingResult {
         FORWARDED,
@@ -67,7 +68,14 @@ public class ExperimentFunnelTrackingClient {
         return sendTrackingRequest(endpoint, entity, "render-complete", slug);
     }
 
-    public TrackingResult registerSubmission(String slug, UUID submissionId, Instant submittedAt, String campaignCode) {
+    public TrackingResult registerSubmission(
+            String slug,
+            UUID submissionId,
+            Instant submittedAt,
+            String campaignCode,
+            String contactName,
+            String contactEmail,
+            String contactPhone) {
         if (!StringUtils.hasText(slug)) {
             throw new IllegalArgumentException("O slug do fluxo é obrigatório");
         }
@@ -80,7 +88,14 @@ public class ExperimentFunnelTrackingClient {
                 .buildAndExpand(slug.trim())
                 .toUri();
 
-        HttpEntity<Map<String, Object>> entity = buildSubmissionPayload(submissionId, submittedAt, campaignCode);
+        HttpEntity<Map<String, Object>> entity = buildSubmissionPayload(
+                slug,
+                submissionId,
+                submittedAt,
+                campaignCode,
+                contactName,
+                contactEmail,
+                contactPhone);
         return sendTrackingRequest(endpoint, entity, "submission", slug);
     }
 
@@ -123,12 +138,27 @@ public class ExperimentFunnelTrackingClient {
         return new HttpEntity<>(body, headers);
     }
 
-    private HttpEntity<Map<String, Object>> buildSubmissionPayload(UUID submissionId, Instant submittedAt, String campaignCode) {
+    private HttpEntity<Map<String, Object>> buildSubmissionPayload(
+            String slug,
+            UUID submissionId,
+            Instant submittedAt,
+            String campaignCode,
+            String contactName,
+            String contactEmail,
+            String contactPhone) {
         Map<String, Object> body = new HashMap<>();
+        body.put("contractVersion", SUBMISSION_CONTRACT_VERSION);
+        body.put("slug", slug.trim());
         body.put("submissionId", submissionId.toString());
-        if (submittedAt != null) {
-            body.put("submittedAt", submittedAt.toString());
+        body.put("submittedAt", (submittedAt != null ? submittedAt : Instant.now()).toString());
+        body.put("idempotencyKey", submissionId.toString());
+        Map<String, String> contato = new HashMap<>();
+        contato.put("nome", contactName);
+        contato.put("email", contactEmail);
+        if (contactPhone != null && !contactPhone.trim().isEmpty()) {
+            contato.put("telefone", contactPhone.trim());
         }
+        body.put("contato", contato);
         if (campaignCode != null && !campaignCode.trim().isEmpty()) {
             body.put("campaignCode", campaignCode.trim());
         }

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowSubmissionService.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowSubmissionService.java
@@ -233,7 +233,13 @@ public class FlowSubmissionService {
         }
         try {
             ExperimentFunnelTrackingClient.TrackingResult result = trackingClient.registerSubmission(
-                    flow.slug(), submission.id(), submission.createdAt(), submission.campaignCode());
+                    flow.slug(),
+                    submission.id(),
+                    submission.createdAt(),
+                    submission.campaignCode(),
+                    submission.name(),
+                    submission.email(),
+                    extractContactPhone(submission.answers()));
             if (result == ExperimentFunnelTrackingClient.TrackingResult.FAILED) {
                 log.warn("Falha ao reenviar submission {} do fluxo {} para o Marketing Hub",
                         submission.id(), flow.slug());
@@ -243,6 +249,25 @@ public class FlowSubmissionService {
         } catch (RuntimeException ex) {
             log.warn("Erro ao reenviar submission {} do fluxo {} ao Marketing Hub", submission.id(), flow.slug(), ex);
         }
+    }
+
+    private String extractContactPhone(Map<String, Object> answers) {
+        if (answers == null || answers.isEmpty()) {
+            return null;
+        }
+        return answers.entrySet().stream()
+                .filter(entry -> entry.getKey() != null)
+                .filter(entry -> {
+                    String key = entry.getKey().toLowerCase();
+                    return key.contains("telefone") || key.contains("whatsapp") || key.contains("phone");
+                })
+                .map(Map.Entry::getValue)
+                .filter(value -> value != null)
+                .map(Object::toString)
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .findFirst()
+                .orElse(null);
     }
 
     private void registerImagePackage(Flow flow, FlowSubmission submission, boolean hasImage) {

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowSubmissionControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowSubmissionControllerTest.java
@@ -79,7 +79,7 @@ class FlowSubmissionControllerTest {
                         ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), "conteudo".getBytes()));
 
         Mockito.lenient()
-                .when(trackingClient.registerSubmission(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .when(trackingClient.registerSubmission(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(TrackingResult.FORWARDED);
 
         imagePackageRepository.deleteAll();

--- a/lead-portal/frontend/src/pages/FlowPage.tsx
+++ b/lead-portal/frontend/src/pages/FlowPage.tsx
@@ -368,7 +368,7 @@ function CustomFlowTemplate({
         className="flow-custom-template-frame"
         srcDoc={processedHtml}
         title="Conteúdo personalizado do fluxo"
-        sandbox="allow-same-origin allow-scripts allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-downloads allow-top-navigation-by-user-activation"
+        sandbox="allow-same-origin allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-downloads allow-top-navigation-by-user-activation"
       />
     </div>
   );
@@ -659,6 +659,8 @@ function parseTemplateSubmissionPayload(
     }
   });
 
+  ensureRequiredSubmissionContractFields(name, email);
+
   return {
     payload: {
       name,
@@ -669,6 +671,15 @@ function parseTemplateSubmissionPayload(
     },
     image,
   };
+}
+
+function ensureRequiredSubmissionContractFields(name: string, email: string) {
+  if (!name.trim()) {
+    throw new Error("Contrato de submissão v1 exige contato.nome preenchido.");
+  }
+  if (!email.trim()) {
+    throw new Error("Contrato de submissão v1 exige contato.email preenchido.");
+  }
 }
 
 function normalizeTemplateFieldKey(rawKey: string) {

--- a/lead-portal/frontend/src/types.ts
+++ b/lead-portal/frontend/src/types.ts
@@ -79,8 +79,17 @@ export interface LeadPortalFlow {
   name: string;
   description?: string | null;
   customFormHtml?: string | null;
+  engagementContract?: LeadPortalEngagementContract | null;
   questions: FlowQuestion[];
   simpleFormStyle?: LeadPortalSimpleFormStyle | null;
+}
+
+export interface LeadPortalEngagementContract {
+  version: string;
+  renderCompleteEndpoint: string;
+  submissionEndpoint: string;
+  idempotencyField?: string | null;
+  submissionRequiredFields?: string[];
 }
 
 export interface FlowSubmissionPayload {


### PR DESCRIPTION
### Motivation
- Standardize the public runtime → marketing backend engagement events with a versioned contract that enforces required fields and enables idempotent processing.
- Allow the publisher to convey contract/version and endpoints so the public runtime can validate submissions without relying on arbitrary JS embedded in custom HTML.
- Ensure contacts (nome/email) are always available for downstream tracking and that transient failures/duplicates are correctly handled.

### Description
- Add a new DTO `LeadPortalSubmissionEngagementContractV1` implementing the `lead-portal-submission-engagement.v1` contract with required `slug`, `submissionId`, `submittedAt`, and `contato` (`nome`/`email`) plus optional `failure` and `idempotencyKey` fields (`backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/LeadPortalSubmissionEngagementContractV1.java`).
- Update public controller to accept the new contract and return explicit ACKs (`accepted` / `duplicate`) after validating path/body slug consistency (`LeadPortalFlowEngagementController`).
- Implement idempotent handling in `ExperimentFunnelService` by checking existence via repository before saving submission events and add repository support method to detect duplicates (`ExperimentFunnelEventRepository`, `ExperimentFunnelService`).
- Extend flow publication payload with `engagementContract` metadata so the runtime can discover contract version and endpoints (`LeadPortalFlowPublicationRequest`).
- Wire the contract through the public runtime: `ExperimentFunnelTrackingClient` now builds and forwards the v1 payload (including `contato` and `idempotencyKey`), and `FlowSubmissionService` populates contact metadata (name/email and extracted phone when available).
- Make runtime/frontend changes to avoid embedding runtime JS in custom HTML by removing `allow-scripts` from the iframe sandbox and enforcing required contact fields before submit, and add the corresponding front-end types for `engagementContract` and internal documentation for v1 contract (`lead-portal/frontend` changes and `docs/integrations/lead-portal-engagement-contract-v1.md`).

### Testing
- Ran lead-portal backend tests with `cd lead-portal/backend && mvn test -Dtest=FlowSubmissionControllerTest,FlowEngagementControllerTest -DfailIfNoTests=false` and they passed successfully (unit/integration tests exercised the new tracking call signature). ✅
- Attempted `cd backend/ads-service && mvn -s ../settings.xml -Dtest=LeadPortalFlowEngagementControllerTest,ExperimentFunnelServiceSubmissionTest test` but the build failed in this environment due to network/unable-to-resolve the parent Spring Boot POM (transient network/registry issue), not due to the code changes. ⚠️
- Attempted the front-end build with `cd lead-portal/frontend && npm run build` but it failed in this environment because local Vite/development dependencies/types were not available, so a full production build could not be validated here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da875246e0832185e7964436eeaed4)