### PR TITLE
Add schema-first lead portal fallback and unified submission IDs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -71,6 +71,10 @@ public class Experiment {
     @Column(name = "lead_portal_flow_model", length = 191)
     private String leadPortalFlowModel;
 
+    @Builder.Default
+    @Column(name = "schema_first_lead_portal_enabled", nullable = false)
+    private boolean schemaFirstLeadPortalEnabled = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "lead_portal_flow_id")
     private LeadPortalFlow leadPortalFlow;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
@@ -50,6 +50,7 @@ public class CreateExperimentRequest {
     private Long instagramAccountId;
     private String followUpActionUrl;
     private String leadPortalFlowModel;
+    private Boolean schemaFirstLeadPortalEnabled;
     private Long leadPortalFlowId;
     private Long imageModelId;
     private Long imageModelQualityId;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -25,6 +25,7 @@ public class ExperimentDto {
     private FacebookInstantFormDto facebookInstantForm;
     private String followUpActionUrl;
     private String leadPortalFlowModel;
+    private boolean schemaFirstLeadPortalEnabled;
     private String creativeTextPrompt;
     private String creativeImagePrompt;
     private String campaignAngle;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/UpdateExperimentRequest.java
@@ -69,6 +69,9 @@ public class UpdateExperimentRequest {
     private String leadPortalFlowModel;
     @JsonIgnore
     private boolean leadPortalFlowModelPresent;
+    private Boolean schemaFirstLeadPortalEnabled;
+    @JsonIgnore
+    private boolean schemaFirstLeadPortalEnabledPresent;
     @JsonIgnore
     private boolean dailyBudgetPresent;
     private Long leadPortalFlowId;
@@ -122,6 +125,12 @@ public class UpdateExperimentRequest {
     public void setLeadPortalFlowModel(String leadPortalFlowModel) {
         this.leadPortalFlowModel = leadPortalFlowModel;
         this.leadPortalFlowModelPresent = true;
+    }
+
+    @JsonSetter(value = "schemaFirstLeadPortalEnabled", nulls = Nulls.SET)
+    public void setSchemaFirstLeadPortalEnabled(Boolean schemaFirstLeadPortalEnabled) {
+        this.schemaFirstLeadPortalEnabled = schemaFirstLeadPortalEnabled;
+        this.schemaFirstLeadPortalEnabledPresent = true;
     }
 
     @JsonSetter(value = "openImagesPerPackage", nulls = Nulls.SET)

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -246,11 +246,23 @@ public class ExperimentFunnelService {
                         SELECT COUNT(*) AS total,
                                COUNT(DISTINCT lead_id) AS unique_count,
                                MAX(submitted_at) AS last_event
-                        FROM lead_portal_submission
-                        WHERE experiment_id = ?
-                          AND (? IS NULL OR submitted_at >= ?)
-                        """, experimentId, baseline, baseline),
-                "Envios do formulário (lead_portal_submission)");
+                        FROM (
+                            SELECT CONCAT('legacy:', lps.id) AS canonical_submission_id,
+                                   lps.lead_id,
+                                   lps.submitted_at
+                            FROM lead_portal_submission lps
+                            WHERE lps.experiment_id = ?
+                            UNION
+                            SELECT CAST(fs.id AS CHAR(64)) AS canonical_submission_id,
+                                   NULL AS lead_id,
+                                   fs.created_at AS submitted_at
+                            FROM flow_submissions fs
+                            JOIN lead_portal_flow f ON f.slug = fs.flow_slug
+                            WHERE %s
+                        ) submissions
+                        WHERE (? IS NULL OR submitted_at >= ?)
+                        """.formatted(FLOW_SCOPE_CONDITION), experimentId, experimentId, experimentId, baseline, baseline),
+                "Envios do formulário (lead_portal_submission + flow_submissions)");
 
         mergeMetric(stages, ExperimentFunnelStage.ABERTURA_EMAIL_AMOSTRA,
                 fetchSingleMetric("""

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -202,6 +202,8 @@ public class ExperimentPipelineGenerationService {
                 experiment.getId(),
                 experiment.getLandingPageHtml());
         flow.setCustomFormHtml(payloadWithImages != null ? payloadWithImages.trim() : null);
+        flow.setSchemaFirst(true);
+        experiment.setSchemaFirstLeadPortalEnabled(true);
         LeadPortalFlow saved = leadPortalFlowRepository.save(flow);
         if (saved.isApproved()) {
             try {
@@ -223,6 +225,7 @@ public class ExperimentPipelineGenerationService {
                 .description("Fluxo criado automaticamente a partir do HTML da landing page do experimento " + experimentId)
                 .model(DEFAULT_MODEL)
                 .prompt("Pipeline: landing-page-html/apply-to-form")
+                .schemaFirst(true)
                 .approved(true)
                 .approvedAt(Instant.now())
                 .marketNiche(experiment.getNiche())
@@ -230,6 +233,7 @@ public class ExperimentPipelineGenerationService {
                 .build();
         LeadPortalFlow saved = leadPortalFlowRepository.save(flow);
         experiment.setLeadPortalFlow(saved);
+        experiment.setSchemaFirstLeadPortalEnabled(true);
         experimentRepository.save(experiment);
         return saved;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -311,6 +311,7 @@ public class ExperimentService {
                 .instagramAccount(attachInstagramAccount(request.getInstagramAccountId()))
                 .journeyTemplate(journeyTemplate)
                 .leadPortalFlowModel(request.getLeadPortalFlowModel())
+                .schemaFirstLeadPortalEnabled(Boolean.TRUE.equals(request.getSchemaFirstLeadPortalEnabled()))
                 .leadPortalFlow(leadPortalFlow)
                 .imageGenerationModel(imageSelection.model())
                 .imageGenerationQuality(imageSelection.quality())
@@ -402,6 +403,7 @@ public class ExperimentService {
                 .facebookInstantForm(original.getFacebookInstantForm())
                 .journeyTemplate(original.getJourneyTemplate())
                 .leadPortalFlowModel(original.getLeadPortalFlowModel())
+                .schemaFirstLeadPortalEnabled(original.isSchemaFirstLeadPortalEnabled())
                 .leadPortalFlow(original.getLeadPortalFlow())
                 .imageGenerationModel(original.getImageGenerationModel())
                 .imageGenerationQuality(original.getImageGenerationQuality())
@@ -555,6 +557,9 @@ public class ExperimentService {
         }
         if (request.isLeadPortalFlowModelPresent()) {
             exp.setLeadPortalFlowModel(request.getLeadPortalFlowModel());
+        }
+        if (request.isSchemaFirstLeadPortalEnabledPresent()) {
+            exp.setSchemaFirstLeadPortalEnabled(Boolean.TRUE.equals(request.getSchemaFirstLeadPortalEnabled()));
         }
         if (request.isCreativeTextPromptPresent()) {
             exp.setCreativeTextPrompt(normalizePrompt(request.getCreativeTextPrompt()));

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/LeadPortalFlow.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/LeadPortalFlow.java
@@ -54,6 +54,10 @@ public class LeadPortalFlow {
     @Column(name = "custom_form_html", columnDefinition = "LONGTEXT")
     private String customFormHtml;
 
+    @Builder.Default
+    @Column(name = "schema_first", nullable = false)
+    private boolean schemaFirst = false;
+
     @Column(name = "image_prompt_batch_size")
     private Integer imagePromptBatchSize;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/CreateLeadPortalFlowRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/CreateLeadPortalFlowRequest.java
@@ -13,6 +13,7 @@ public class CreateLeadPortalFlowRequest {
     private String slug;
     private String description;
     private String customFormHtml;
+    private Boolean schemaFirst;
     private Long marketNicheId;
     private Long experimentId;
     private String model;

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/LeadPortalFlowDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/LeadPortalFlowDto.java
@@ -17,6 +17,7 @@ public class LeadPortalFlowDto {
     private String publicUrl;
     private String description;
     private String customFormHtml;
+    private boolean schemaFirst;
     private String model;
     private String prompt;
     private String imagePromptModel;

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/UpdateLeadPortalFlowRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/UpdateLeadPortalFlowRequest.java
@@ -13,6 +13,7 @@ public class UpdateLeadPortalFlowRequest {
     private String slug;
     private String description;
     private String customFormHtml;
+    private Boolean schemaFirst;
     private Long marketNicheId;
     private Long experimentId;
     private String model;

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublicationRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublicationRequest.java
@@ -22,6 +22,9 @@ public record LeadPortalFlowPublicationRequest(
         String name,
         String description,
         String customFormHtml,
+        String legacyPreviewHtml,
+        String renderMode,
+        FormSpec formSpec,
         EngagementContractMetadata engagementContract,
         String model,
         String prompt,
@@ -54,16 +57,26 @@ public record LeadPortalFlowPublicationRequest(
                 flow.getName(),
                 flow.getDescription(),
                 flow.getCustomFormHtml(),
+                flow.getCustomFormHtml(),
+                resolveRenderMode(flow),
+                new FormSpec(flow.getQuestions().stream()
+                        .map(LeadPortalFlowPublicationRequest::toQuestion)
+                        .toList()),
                 EngagementContractMetadata.defaultV1(),
                 flow.getModel(),
                 flow.getPrompt(),
                 flow.getImagePromptModel(),
                 flow.getImagePromptTemplate(),
                 flow.getImagePromptBatchSize(),
-                flow.getQuestions().stream()
-                        .map(LeadPortalFlowPublicationRequest::toQuestion)
-                        .toList(),
+                flow.getQuestions().stream().map(LeadPortalFlowPublicationRequest::toQuestion).toList(),
                 stylePayload);
+    }
+
+    private static String resolveRenderMode(LeadPortalFlow flow) {
+        if (flow.isSchemaFirst()) {
+            return "schema-first";
+        }
+        return flow.getQuestions() == null || flow.getQuestions().isEmpty() ? "legacy-html" : "fallback";
     }
 
     private static LeadPortalSimpleFormStyleDefinition mergeDefinitionWithExperimentImage(
@@ -177,6 +190,9 @@ public record LeadPortalFlowPublicationRequest(
             String description,
             String placeholder,
             List<String> options) {
+    }
+
+    public record FormSpec(List<Question> questions) {
     }
 
     public record SimpleFormStylePayload(

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/service/LeadPortalFlowService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/service/LeadPortalFlowService.java
@@ -121,6 +121,7 @@ public class LeadPortalFlowService {
                 .slug(slug)
                 .description(trimToNull(request.getDescription()))
                 .customFormHtml(trimToNull(request.getCustomFormHtml()))
+                .schemaFirst(Boolean.TRUE.equals(request.getSchemaFirst()))
                 .model(trimToNull(request.getModel()))
                 .imagePromptModel(trimToNull(request.getImagePromptModel()))
                 .imagePromptTemplate(trimToNull(request.getImagePromptTemplate()))
@@ -152,6 +153,9 @@ public class LeadPortalFlowService {
         }
         if (request.getCustomFormHtml() != null) {
             flow.setCustomFormHtml(trimToNull(request.getCustomFormHtml()));
+        }
+        if (request.getSchemaFirst() != null) {
+            flow.setSchemaFirst(Boolean.TRUE.equals(request.getSchemaFirst()));
         }
         if (request.getMarketNicheId() != null) {
             flow.setMarketNiche(attachMarketNiche(request.getMarketNicheId()));

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/service/LeadPortalMetricsService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/service/LeadPortalMetricsService.java
@@ -76,7 +76,7 @@ public class LeadPortalMetricsService {
                 FROM experiment e
                 LEFT JOIN (
                     SELECT lps.experiment_id,
-                           lps.id AS submission_id,
+                           CONCAT('legacy:', lps.id) AS submission_id,
                            lps.lead_id,
                            lps.primary_contact_name,
                            lps.primary_contact_email,
@@ -93,7 +93,7 @@ public class LeadPortalMetricsService {
                              lps.primary_contact_phone
                     UNION ALL
                     SELECT exp.id AS experiment_id,
-                           fs.id AS submission_id,
+                           CAST(fs.id AS CHAR(64)) AS submission_id,
                            NULL AS lead_id,
                            fs.name AS primary_contact_name,
                            fs.email AS primary_contact_email,

--- a/backend/ads-service/src/main/resources/db/changelog/V2037_04_11__lead_portal_schema_first_flags_mysql5.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2037_04_11__lead_portal_schema_first_flags_mysql5.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+--changeset repo:2037-04-11-lead-portal-schema-first-flags dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'lead_portal_flow' AND column_name = 'schema_first';
+ALTER TABLE lead_portal_flow
+    ADD COLUMN schema_first TINYINT(1) NOT NULL DEFAULT 0;
+
+--changeset repo:2037-04-11-experiment-schema-first-lead-portal-enabled dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'experiment' AND column_name = 'schema_first_lead_portal_enabled';
+ALTER TABLE experiment
+    ADD COLUMN schema_first_lead_portal_enabled TINYINT(1) NOT NULL DEFAULT 0;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -611,3 +611,6 @@ databaseChangeLog:
   - include:
       file: V2036_03_27__hypothesis_framework_generation_job_mysql5.sql
       relativeToChangelogFile: true
+  - include:
+      file: V2037_04_11__lead_portal_schema_first_flags_mysql5.sql
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublicationRequestTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublicationRequestTest.java
@@ -45,6 +45,7 @@ class LeadPortalFlowPublicationRequestTest {
         LeadPortalFlowPublicationRequest payload = LeadPortalFlowPublicationRequest.from(flow);
 
         assertThat(payload.simpleFormStyle()).isNotNull();
+        assertThat(payload.renderMode()).isEqualTo("legacy-html");
         assertThat(payload.simpleFormStyle().definition()).isNotNull();
         assertThat(payload.simpleFormStyle().definition().heroImageUrl()).isEqualTo(pipelineImage);
     }
@@ -74,6 +75,7 @@ class LeadPortalFlowPublicationRequestTest {
         LeadPortalFlowPublicationRequest payload = LeadPortalFlowPublicationRequest.from(flow);
 
         assertThat(payload.simpleFormStyle()).isNotNull();
+        assertThat(payload.renderMode()).isEqualTo("legacy-html");
         assertThat(payload.simpleFormStyle().definition()).isNotNull();
         assertThat(payload.simpleFormStyle().definition().heroImageUrl()).isEqualTo(styleImage);
     }
@@ -103,6 +105,7 @@ class LeadPortalFlowPublicationRequestTest {
         LeadPortalFlowPublicationRequest payload = LeadPortalFlowPublicationRequest.from(flow, overrideImage);
 
         assertThat(payload.simpleFormStyle()).isNotNull();
+        assertThat(payload.renderMode()).isEqualTo("legacy-html");
         assertThat(payload.simpleFormStyle().definition()).isNotNull();
         assertThat(payload.simpleFormStyle().definition().heroImageUrl()).isEqualTo(overrideImage);
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
@@ -72,6 +72,8 @@ class LeadPortalPublicFlowControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.slug").value("exp-10-landing"))
                 .andExpect(jsonPath("$.name").value("Fluxo Landing"))
+                .andExpect(jsonPath("$.renderMode").value("fallback"))
+                .andExpect(jsonPath("$.formSpec.questions[0].dataKey").value("nome"))
                 .andExpect(jsonPath("$.questions[0].dataKey").value("nome"));
     }
 

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -32,6 +32,7 @@ export interface CreateExperiment {
   instagramAccountId: number;
   imageModelId?: number;
   imageModelQualityId?: number;
+  schemaFirstLeadPortalEnabled?: boolean;
   creativeTextPrompt?: string;
   creativeImagePrompt?: string;
 }

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -66,6 +66,7 @@ export interface Experiment {
   facebookReleaseRequestedAt?: string | null;
   followUpActionUrl?: string | null;
   leadPortalFlowModel?: string | null;
+  schemaFirstLeadPortalEnabled?: boolean;
   creativeTextPrompt?: string | null;
   campaignAngle?: string | null;
   adCopy?: string | null;

--- a/frontend/src/api/experiment/useUpdateExperiment.ts
+++ b/frontend/src/api/experiment/useUpdateExperiment.ts
@@ -31,6 +31,7 @@ export interface UpdateExperiment {
   facebookInstantFormId?: number | null;
   instagramAccountId?: number | null;
   followUpActionUrl?: string | null;
+  schemaFirstLeadPortalEnabled?: boolean;
   creativeTextPrompt?: string | null;
   creativeImagePrompt?: string | null;
   leadPortalFlowId?: number | null;

--- a/frontend/src/api/leadPortal/useCreateLeadPortalFlow.ts
+++ b/frontend/src/api/leadPortal/useCreateLeadPortalFlow.ts
@@ -27,6 +27,7 @@ export interface CreateLeadPortalFlowRequest {
   slug: string;
   description?: string;
   customFormHtml?: string | null;
+  schemaFirst?: boolean;
   experimentId?: number | string | null;
   marketNicheId: number | string;
   model?: string;

--- a/frontend/src/api/leadPortal/useLeadPortalFlows.ts
+++ b/frontend/src/api/leadPortal/useLeadPortalFlows.ts
@@ -24,6 +24,7 @@ export interface LeadPortalFlow {
   publicUrl?: string | null;
   description?: string | null;
   customFormHtml?: string | null;
+  schemaFirst?: boolean;
   model?: string | null;
   prompt?: string | null;
   imagePromptModel?: string | null;

--- a/frontend/src/api/leadPortal/useUpdateLeadPortalFlow.ts
+++ b/frontend/src/api/leadPortal/useUpdateLeadPortalFlow.ts
@@ -8,6 +8,7 @@ export interface UpdateLeadPortalFlowRequest {
   slug?: string;
   description?: string | null;
   customFormHtml?: string | null;
+  schemaFirst?: boolean;
   marketNicheId?: number | string | null;
   model?: string | null;
   simpleFormStyleId?: number | string | null;

--- a/frontend/src/pages/experiment/LeadPortalFlowTab.tsx
+++ b/frontend/src/pages/experiment/LeadPortalFlowTab.tsx
@@ -312,6 +312,7 @@ export default function LeadPortalFlowTab({
                       <LeadFlowPreview
                         flowName={flow.name}
                         questions={flow.questions}
+                        customFormHtml={flow.customFormHtml}
                         viewport={activeViewport}
                       />
                     </div>
@@ -392,15 +393,19 @@ interface LeadFlowPreviewProps {
     options: string[];
     placeholder?: string | null;
   }>;
+  customFormHtml?: string | null;
   viewport: PreviewViewport;
 }
 
 function LeadFlowPreview({
   flowName,
   questions,
+  customFormHtml,
   viewport,
 }: LeadFlowPreviewProps) {
   const isMobile = viewport === "mobile";
+  const hasQuestionSchema = questions.length > 0;
+  const hasLegacyHtml = Boolean(customFormHtml?.trim());
   return (
     <div className="d-flex justify-content-center">
       <div
@@ -416,23 +421,33 @@ function LeadFlowPreview({
             Assim o lead verá o formulário no portal.
           </p>
         </div>
-        <form
-          className="d-flex flex-column gap-3"
-          onSubmit={(event) => event.preventDefault()}
-        >
-          {questions.map((question) => (
-            <div key={question.id}>
-              <label className="form-label fw-semibold">
-                {question.title}
-                {question.required ? " *" : ""}
-              </label>
-              {renderPreviewField(question)}
-            </div>
-          ))}
-          <button type="button" className="btn btn-primary" disabled>
-            Enviar respostas
-          </button>
-        </form>
+        {hasQuestionSchema ? (
+          <form
+            className="d-flex flex-column gap-3"
+            onSubmit={(event) => event.preventDefault()}
+          >
+            {questions.map((question) => (
+              <div key={question.id}>
+                <label className="form-label fw-semibold">
+                  {question.title}
+                  {question.required ? " *" : ""}
+                </label>
+                {renderPreviewField(question)}
+              </div>
+            ))}
+            <button type="button" className="btn btn-primary" disabled>
+              Enviar respostas
+            </button>
+          </form>
+        ) : hasLegacyHtml ? (
+          <div className="alert alert-secondary mb-0 small">
+            Fluxo legado: este preview usa <code>customFormHtml</code> apenas para referência.
+          </div>
+        ) : (
+          <div className="alert alert-light mb-0 small">
+            Nenhum schema de formulário disponível.
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Migrar progressivamente o lead portal para um modelo `schema-first` mantendo `customFormHtml` apenas como preview legado para compatibilidade.
- Permitir rollout controlado por experimento através de uma flag que ativa o comportamento `schema-first` por experimento.
- Garantir que consultas de métricas/funil utilizem um identificador de submissão canônico para unificar envios vindos do fluxo antigo e do novo pipeline.

### Description
- Adicionadas colunas e flags: `schema_first` em `lead_portal_flow` e `schema_first_lead_portal_enabled` em `experiment`, com migration Liquibase `V2037_04_11__lead_portal_schema_first_flags_mysql5.sql` e inclusão no `db.changelog-master.yaml`.
- Propagados campos para contratos/DTO/requests (backend + frontend) e usado `schemaFirst` ao criar/atualizar fluxos gerados pelo pipeline para marcar fluxos novos como `schema-first` (`ExperimentPipelineGenerationService`, `LeadPortalFlowService`, `ExperimentService`).
- Publicação progressiva: payload público agora inclui `renderMode`, `formSpec` e `legacyPreviewHtml` mantendo `customFormHtml`; `LeadPortalFlowPublicationRequest.from` decide `renderMode` por `schemaFirst`/existência de `questions`.
- Frontend preview atualizado em `LeadPortalFlowTab.tsx` para renderizar o formulário padronizado quando há `questions` e exibir `customFormHtml` apenas como preview legado quando não houver schema.
- Normalização de identificadores de submissão nas consultas de métricas e funil (prefixo `legacy:` para `lead_portal_submission` e `CAST(fs.id AS CHAR)` para `flow_submissions`) em `ExperimentFunnelService` e `LeadPortalMetricsService` para assegurar consistência entre caminhos antigo/novo.
- Ajustados testes de integração do payload público para verificar `renderMode` e `formSpec` (`LeadPortalFlowPublicationRequestTest`, `LeadPortalPublicFlowControllerTest`).

### Testing
- Executei a suíte de testes alvo com Maven: `mvn -s ../settings.xml -Dtest=LeadPortalFlowPublicationRequestTest,LeadPortalPublicFlowControllerTest test`, que não completou devido a resolução de dependências externa falhando por restrição de rede no ambiente (erro: download do parent POM falhou); portanto os testes JVM não puderam ser executados aqui.
- Foram atualizados/adiados testes de unidade relevantes no backend para validar `renderMode`/`formSpec` e a publicação pública; esses testes estão inclusos no repositório e devem ser executados em CI com acesso a repositórios Maven.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8cd8c87c83219b6bc66696b80348)