### PR TITLE
Simplify canonical `formSpec` and add `formSpec` to `landingPageHtml`

### DIFF
--- a/docs/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/modelo-canonico-artefatos-pipeline-experimento.md
@@ -199,33 +199,13 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
     "title": "string",
     "submitLabel": "string",
     "submitTarget": "string",
-    "submitMethod": "POST",
-    "submitEncoding": "multipart/form-data",
-    "submitPayloadContract": {
-      "endpoint": "/api/flows/{slug}/submissions",
-      "endpointResolution": "obrigatorio resolver {slug} a partir de /flows/{slug} em runtime e executar POST multipart/form-data",
-      "requiredMultipartFields": ["payload"],
-      "payloadJsonShape": {
-        "name": "string",
-        "email": "string",
-        "answers": {
-          "campo": "string | string[]"
-        },
-        "imageKey": "string",
-        "campaignCode": "string"
-      },
-      "optionalMultipartFields": ["image"]
-    },
     "fields": [
       {
-        "id": "string",
         "name": "string",
         "label": "string",
-        "type": "string",
+        "type": "text | email | tel",
         "required": "boolean",
-        "placeholder": "string",
-        "autocomplete": "string",
-        "helpText": "string"
+        "placeholder": "string"
       }
     ],
     "consent": {
@@ -312,6 +292,35 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 ```json
 {
   "htmlDocument": "string",
+  "formSpec": {
+    "formId": "string",
+    "title": "string",
+    "submitLabel": "string",
+    "submitTarget": "string",
+    "cta": {
+      "label": "string",
+      "target": "string",
+      "variant": "hero | mid | final | sticky | inline"
+    },
+    "fields": [
+      {
+        "name": "string",
+        "label": "string",
+        "type": "text | email | tel",
+        "required": "boolean",
+        "placeholder": "string"
+      }
+    ],
+    "consent": {
+      "enabled": "boolean",
+      "required": "boolean",
+      "label": "string"
+    },
+    "successState": {
+      "title": "string",
+      "message": "string"
+    }
+  },
   "summary": "string",
   "consistencyChecks": [
     {


### PR DESCRIPTION
### Motivation
- Simplify and standardize the canonical form specification to avoid exposing implementation-specific submission contracts and to keep payload details out of the schema. 
- Provide a consistent form representation within the `landingPageHtml` artifact so the HTML bundle can carry a bound form spec for rendering and validation.

### Description
- Removed `submitMethod`, `submitEncoding`, and the implementation-specific `submitPayloadContract` from the top-level `formSpec` to eliminate multipart/endpoint details. 
- Restricted `fields[].type` to the enum `text | email | tel` and removed `id`, `autocomplete`, and `helpText` from field entries to simplify the field schema. 
- Removed multipart/optional payload details such as `requiredMultipartFields`, `optionalMultipartFields`, and the `payloadJsonShape`. 
- Added a new `formSpec` object into the `landingPageHtml` schema that includes `formId`, `title`, `submitLabel`, `submitTarget`, `cta`, `fields`, `consent`, and `successState` to enable form binding in the HTML artifact.

### Testing
- No automated tests were run for this documentation/schema-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8148fc1c83219c7ae3ac8b68a935)