### PR TITLE
Fix landing form submit button binding and document submit ownership

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1046,7 +1046,23 @@ public class ExperimentPipelineGenerationService {
         for (FormFieldContract field : formFields) {
             appendFieldMarkup(document, form, field);
         }
+        bindExternalSubmitButtonsToForm(document, form);
         return document.outerHtml();
+    }
+
+    private void bindExternalSubmitButtonsToForm(Document document, Element form) {
+        String formId = StringUtils.hasText(form.id()) ? form.id() : "lead-capture-primary";
+        form.attr("id", formId);
+        for (Element submitControl : document.select("button[type=submit],input[type=submit]")) {
+            Element ownerForm = submitControl.closest("form");
+            if (ownerForm == form) {
+                continue;
+            }
+            if (StringUtils.hasText(submitControl.attr("form"))) {
+                continue;
+            }
+            submitControl.attr("form", formId);
+        }
     }
 
     private void appendFieldMarkup(Document document, Element form, FormFieldContract field) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -255,6 +255,7 @@ class ExperimentPipelineGenerationServiceTest {
         assertTrue(html.contains("name=\"nome\""));
         assertTrue(html.contains("name=\"email\""));
         assertTrue(html.contains("name=\"whatsapp\""));
+        assertTrue(html.contains("button type=\"submit\" form=\"lead-capture-primary\""));
         assertFalse(html.contains("name=\"objetivo\""));
         assertFalse(html.contains("objetivo principal"));
         assertTrue(summary.contains("wireframe.formspec"));

--- a/docs/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/modelo-canonico-artefatos-pipeline-experimento.md
@@ -199,6 +199,7 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
     "title": "string",
     "submitLabel": "string",
     "submitTarget": "string",
+    "submitOwnership": "inside-form | external-with-form-attr",
     "fields": [
       {
         "name": "string",


### PR DESCRIPTION
### Motivation
- Orphaned submit controls placed outside the canonical form could be non-functional inside the Lead Portal iframe, breaking form submission for landing pages.  
- The landing HTML normalization needs to deterministically rebuild form markup while preserving expected submit behavior for both in-form and external submit buttons.  
- The canonical artifact schema should explicitly describe submit ownership to make the wireframe/form contract unambiguous.

### Description
- Added `bindExternalSubmitButtonsToForm` and invoked it from `rebuildFormFromSpec` to ensure the canonical form has an `id` and to add `form="lead-capture-primary"` to external `button[type=submit]` and `input[type=submit]` controls when appropriate.  
- Ensured the rebuilt form preserves in-form submit behavior and only binds external submit controls that are orphaned and lack a `form` attribute.  
- Extended `ExperimentPipelineGenerationServiceTest` to assert the normalized HTML contains a submit button bound to `lead-capture-primary`.  
- Updated the canonical artifact schema in `docs/modelo-canonico-artefatos-pipeline-experimento.md` to add `submitOwnership` in `landingPageWireframe.formSpec` to document ownership modes (`inside-form | external-with-form-attr`).

### Testing
- Updated unit test `ExperimentPipelineGenerationServiceTest` to cover the external-submit binding scenario and added an assertion for `button type="submit" form="lead-capture-primary"`.  
- Attempted to run the backend test with `cd backend/ads-service && mvn -s ../settings.xml -Dtest=ExperimentPipelineGenerationServiceTest test`, but Maven could not resolve the parent POM (network to Maven Central unavailable), so automated tests could not be executed in this environment.  
- Local/CI runs should validate `ExperimentPipelineGenerationServiceTest` and the landing HTML normalization behavior once dependencies are resolvable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabb0d69348321a61b5f6ad06e09a8)