### PR TITLE
Fix lead portal form slug placeholder resolution (handle URL-encoded %7Bslug%7D)

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -248,8 +248,9 @@ public class ExperimentPipelineOpenAiClient {
                 var slugMatch = pathname.match(/\\/flows\\/([^/?#]+)/i);
                 var slug = slugMatch && slugMatch[1] ? slugMatch[1] : '';
                 var endpointTemplate = form.getAttribute('action') || '/api/flows/{slug}/submissions';
-                var endpoint = endpointTemplate.indexOf('{slug}') >= 0
-                  ? endpointTemplate.replace('{slug}', slug || 'formpersonal')
+                var slugToken = /\\{slug\\}|%7Bslug%7D/i;
+                var endpoint = slugToken.test(endpointTemplate)
+                  ? endpointTemplate.replace(slugToken, slug || 'formpersonal')
                   : endpointTemplate;
                 var formData = new FormData(form);
                 var nome = (formData.get('nome') || '').toString().trim();

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -530,6 +530,7 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(htmlDocument).contains("enctype=\"multipart/form-data\"");
         assertThat(htmlDocument).contains("action=\"/api/flows/{slug}/submissions\"");
         assertThat(htmlDocument).contains("id=\"lead-capture-submit-contract\"");
+        assertThat(htmlDocument).contains("var slugtoken = /\\{slug\\}|%7bslug%7d/i;");
     }
 
     @Test
@@ -586,6 +587,7 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(htmlDocument).doesNotContain("<select name=\"objetivo\"");
         assertThat(htmlDocument).contains("action=\"/api/flows/{slug}/submissions\"");
         assertThat(htmlDocument).contains("id=\"lead-capture-submit-contract\"");
+        assertThat(htmlDocument).contains("var slugtoken = /\\{slug\\}|%7bslug%7d/i;");
     }
 
     @Test

--- a/docs/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/modelo-canonico-artefatos-pipeline-experimento.md
@@ -298,6 +298,7 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
     "title": "string",
     "submitLabel": "string",
     "submitTarget": "string",
+    "submitTargetTemplateRule": "Quando usar placeholder de slug, manter exatamente {slug} (sem codificar para %7Bslug%7D).",
     "cta": {
       "label": "string",
       "target": "string",


### PR DESCRIPTION
### Motivation
- HTML produced by the experiment pipeline could contain a URL-encoded slug placeholder (`%7Bslug%7D`), causing form submissions to POST to `/api/flows/%7Bslug%7D/submissions` and return 404 instead of resolving to the real flow slug. 
- The canonical artifact schema should explicitly require the `submitTarget` placeholder to use the literal `{slug}` pattern to avoid ambiguity.

### Description
- Updated `ExperimentPipelineOpenAiClient` to detect and replace both literal `{slug}` and URL-encoded `%7Bslug%7D` in the injected submit script by adding a `slugToken` regex and using it to build the resolved `endpoint` before `fetch`ing the form (`ai-worker/src/main/java/.../ExperimentPipelineOpenAiClient.java`).
- Added regression assertions in `ExperimentPipelineOpenAiClientTest` to verify the normalized HTML contains the slug replacement regex token (checks for the presence of the slug-token pattern in the injected script) (`ai-worker/src/test/java/.../ExperimentPipelineOpenAiClientTest.java`).
- Documented the `submitTarget` template rule in the canonical pipeline artifact schema to require the literal `{slug}` placeholder (no URL-encoding) (`docs/modelo-canonico-artefatos-pipeline-experimento.md`).

### Testing
- Attempted to run the unit test `ExperimentPipelineOpenAiClientTest` with `cd ai-worker && mvn -s settings.xml -Dtest=ExperimentPipelineOpenAiClientTest test`, however the execution failed in this environment due to Maven dependency resolution/network errors (`Network is unreachable`), so tests could not complete here.
- The change includes added test assertions that should pass in CI when Maven can resolve dependencies and run the test suite successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad4cda3508321a6c196d289073e75)