### PR TITLE
Fix sandboxed flow iframe script blocking

### DIFF
--- a/lead-portal/frontend/src/pages/FlowPage.tsx
+++ b/lead-portal/frontend/src/pages/FlowPage.tsx
@@ -368,7 +368,7 @@ function CustomFlowTemplate({
         className="flow-custom-template-frame"
         srcDoc={processedHtml}
         title="Conteúdo personalizado do fluxo"
-        sandbox="allow-same-origin allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-downloads allow-top-navigation-by-user-activation"
+        sandbox="allow-same-origin allow-scripts allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-downloads allow-top-navigation-by-user-activation"
       />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Browsers were blocking script execution inside `about:srcdoc` for custom flow pages because the iframe in `lead-portal/frontend/src/pages/FlowPage.tsx` did not include the `allow-scripts` sandbox permission.

### Description
- Added `allow-scripts` to the iframe `sandbox` attribute in `lead-portal/frontend/src/pages/FlowPage.tsx` so embedded `srcDoc` content can execute scripts when intended.

### Testing
- Ran `npm install` and `npm run build` in `lead-portal/frontend` and the build completed successfully; no automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf6ccb70883219a0ceed1c957c32d)