### PR TITLE
Trata payload multipart como JSON e alinha contrato do AI Worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -266,7 +266,10 @@ public class ExperimentPipelineOpenAiClient {
                 if (campaignCode) {
                   payload.campaignCode = campaignCode;
                 }
-                formData.set('payload', JSON.stringify(payload));
+                formData.set(
+                  'payload',
+                  new Blob([JSON.stringify(payload)], { type: 'application/json' })
+                );
                 try {
                   var response = await fetch(endpoint, { method: 'POST', body: formData });
                   if (!response.ok) {

--- a/docs/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/modelo-canonico-artefatos-pipeline-experimento.md
@@ -307,7 +307,9 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
         "request": {
           "urlSource": "form.action",
           "methodSource": "form.method.toUpperCase()",
-          "bodySource": "new FormData(form)"
+          "bodySource": "new FormData(form)",
+          "payloadPartName": "payload",
+          "payloadPartContentType": "application/json"
         },
         "buttonState": {
           "disableDuringRequest": "boolean",

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/FlowSubmissionController.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/FlowSubmissionController.java
@@ -5,8 +5,9 @@ import com.marketinghub.leadportal.dto.FlowSubmissionRequest;
 import com.marketinghub.leadportal.dto.FlowSubmissionResponse;
 import com.marketinghub.leadportal.model.FlowSubmission;
 import com.marketinghub.leadportal.service.FlowSubmissionService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.Valid;
 import jakarta.validation.Validator;
 import java.net.URI;
 import java.util.UUID;
@@ -36,23 +37,26 @@ public class FlowSubmissionController {
     private final FlowSubmissionService submissionService;
     private final FormDataSubmissionRequestFactory formDataFactory;
     private final Validator validator;
+    private final ObjectMapper objectMapper;
 
     public FlowSubmissionController(
             FlowSubmissionService submissionService,
             FormDataSubmissionRequestFactory formDataFactory,
-            Validator validator) {
+            Validator validator,
+            ObjectMapper objectMapper) {
         this.submissionService = submissionService;
         this.formDataFactory = formDataFactory;
         this.validator = validator;
+        this.objectMapper = objectMapper;
     }
 
     @PostMapping(value = "/{slug}/submissions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<FlowSubmissionResponse> submit(
             @PathVariable("slug") String slug,
-            @RequestPart(value = "payload", required = false) @Valid FlowSubmissionRequest payload,
+            @RequestPart(value = "payload", required = false) String payloadRaw,
             @RequestParam MultiValueMap<String, String> formFields,
             @RequestPart(value = "image", required = false) MultipartFile imageFile) {
-        FlowSubmissionRequest request = payload != null ? payload : fromFormData(slug, formFields);
+        FlowSubmissionRequest request = resolveRequest(slug, payloadRaw, formFields);
         FlowSubmission submission = submissionService.create(slug, request, imageFile);
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{id}")
@@ -103,5 +107,24 @@ public class FlowSubmissionController {
                         .path(submission.id().toString())
                         .path("/image")
                         .toUriString());
+    }
+
+    private FlowSubmissionRequest resolveRequest(
+            String slug,
+            String payloadRaw,
+            MultiValueMap<String, String> formFields) {
+        if (payloadRaw == null || payloadRaw.isBlank()) {
+            return fromFormData(slug, formFields);
+        }
+        try {
+            FlowSubmissionRequest request = objectMapper.readValue(payloadRaw, FlowSubmissionRequest.class);
+            var violations = validator.validate(request);
+            if (!violations.isEmpty()) {
+                throw new ConstraintViolationException(violations);
+            }
+            return request;
+        } catch (JsonProcessingException ex) {
+            throw new IllegalArgumentException("Payload inválido para submissão.", ex);
+        }
     }
 }

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowSubmissionControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowSubmissionControllerTest.java
@@ -241,6 +241,33 @@ class FlowSubmissionControllerTest {
                 .isEqualTo("meta-campanha-42");
     }
 
+    @Test
+    void acceptsPayloadPartSentAsPlainTextJson() throws Exception {
+        String payload = """
+                {
+                  "name": "Cliente Script",
+                  "email": "cliente.script@example.com",
+                  "imageKey": "referencia",
+                  "answers": {
+                    "nome": "Cliente Script",
+                    "email": "cliente.script@example.com",
+                    "objetivo": "Aumentar conversão"
+                  }
+                }
+                """;
+
+        MockMultipartFile payloadPart = new MockMultipartFile(
+                "payload", "payload", MediaType.TEXT_PLAIN_VALUE, payload.getBytes());
+        MockMultipartFile imagePart = new MockMultipartFile(
+                "image", "referencia.png", MediaType.IMAGE_PNG_VALUE, "conteudo".getBytes());
+
+        mockMvc.perform(multipart("/api/flows/planejamento-acao-21-dias/submissions")
+                        .file(payloadPart)
+                        .file(imagePart))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.flowSlug").value("planejamento-acao-21-dias"));
+    }
+
 
     @Test
     void missingRequiredImageReturnsBadRequest() throws Exception {
@@ -363,4 +390,3 @@ class FlowSubmissionControllerTest {
                 .andExpect(jsonPath("$.flowSlug").value("fluxo-custom-html"));
     }
 }
-


### PR DESCRIPTION
### Motivation
- Corrigir erro 500 ao receber `payload` em `multipart/form-data` quando páginas publicadas enviam o campo como texto JSON em vez de um `Blob` JSON. 
- Tornar o endpoint `POST /api/flows/{slug}/submissions` mais resiliente aceitando variantes comuns do `payload` sem mudar a rota.
- Alinhar o runtime gerado pelo `ai-worker` com o contrato do backend e documentar o formato esperado no esquema canônico.

### Description
- Atualiza `FlowSubmissionController` para injetar `ObjectMapper` e aceitar um `payload` multipart como texto (`String`), fazendo parse via `objectMapper.readValue(...)` em `FlowSubmissionRequest` com validação (`Validator`).
- Remove a expectativa rígida de um `@RequestPart` tipado e adiciona a função `resolveRequest(...)` que converte `payload` texto JSON ou monta a requisição a partir de `formFields` quando `payload` está ausente.
- Ajusta o script estático em `ExperimentPipelineOpenAiClient` (ai-worker) para anexar `payload` como `new Blob([JSON.stringify(payload)], { type: 'application/json' })` em vez de uma string crua.
- Documenta no `docs/modelo-canonico-artefatos-pipeline-experimento.md` os campos `payloadPartName` e `payloadPartContentType` dentro de `landingPageHtml.formSpec.submissionRuntime.request`.
- Adiciona teste `acceptsPayloadPartSentAsPlainTextJson` em `FlowSubmissionControllerTest` cobrindo envio de `payload` como `text/plain` no multipart.

### Testing
- Executado `cd lead-portal/backend && mvn -q -Dtest=FlowSubmissionControllerTest test`, todos os testes da classe `FlowSubmissionControllerTest` passaram ✅.
- Executado `cd ai-worker && mvn -q -Dtest=ExperimentPipelineOpenAiClientTest test`, os testes do `ai-worker` falharam por dependência externa não resolvível (`com.marketinghub:ads-service` retornando `401 Unauthorized` no GitHub Packages) ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dafaae513483219c5fb0ba167d96ac)