### PR TITLE
Fix iframe bridge initialization for custom lead-portal templates that load before listener attach

### DIFF
--- a/lead-portal/frontend/src/pages/FlowPage.tsx
+++ b/lead-portal/frontend/src/pages/FlowPage.tsx
@@ -346,6 +346,9 @@ function CustomFlowTemplate({
     };
 
     iframe.addEventListener("load", handleLoad);
+    if (iframe.contentDocument?.readyState === "complete") {
+      handleLoad();
+    }
     return () => {
       iframe.removeEventListener("load", handleLoad);
       cleanupObserver();


### PR DESCRIPTION
### Motivation
- Evitar que formulários HTML personalizados renderizados em `srcDoc` submetam nativamente (causando `POST /flows/:slug` que pode retornar 405) quando o iframe já terminou de carregar antes do efeito React anexar o listener de `load`.
- Corrigir a condição de corrida onde a função de inicialização do bridge (`handleLoad`) não era executada se o `iframe.contentDocument.readyState` já estivesse em `complete`.

### Description
- Ao registrar o listener de `load` no `CustomFlowTemplate`, o código agora também chama `handleLoad()` imediatamente quando `iframe.contentDocument?.readyState === "complete"` para garantir inicialização do bridge em ambos os casos (carregamento tardio ou já-completo).
- Alteração aplicada em `lead-portal/frontend/src/pages/FlowPage.tsx` dentro do efeito que monta o iframe e anexa o bridge de comunicação/controle do template.
- Mantém o comportamento existente para iframes que carregam depois do listener e adiciona cobertura para carregamentos rápidos do `srcDoc`.

### Testing
- `npm run build` (em `lead-portal/frontend`) falhou inicialmente devido a dependências não instaladas (`Cannot find module 'vite'`).
- `npm install` (em `lead-portal/frontend`) foi executado com sucesso para instalar dependências do projeto.
- `npm run build` (em `lead-portal/frontend`) foi executado novamente e completou com sucesso, confirmando que a alteração não quebrou a build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db052907f08321889a402cf095a06b)