### PR TITLE
fix(ai-worker): cap OpenAI tool-call rounds to prevent infinite loop

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java
@@ -31,6 +31,7 @@ public class OpenAiChatGptClient implements ChatGptClient {
 
     private static final Logger log = LoggerFactory.getLogger(OpenAiChatGptClient.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final int MAX_TOOL_CALL_ROUNDS = 8;
 
     private final HttpClient httpClient;
     private final String apiKey;
@@ -98,6 +99,7 @@ public class OpenAiChatGptClient implements ChatGptClient {
 
             OpenAiResponse response = executeResponseRequest(payload);
 
+            int toolCallRounds = 0;
             while (true) {
                 if (response == null) {
                     log.error("OpenAI returned null response for product {}", product.getId());
@@ -110,6 +112,14 @@ public class OpenAiChatGptClient implements ChatGptClient {
 
                 List<OpenAiResponse.OpenAiToolCall> toolCalls = response.firstToolCalls();
                 if (!toolCalls.isEmpty()) {
+                    if (toolCallRounds >= MAX_TOOL_CALL_ROUNDS) {
+                        log.error(
+                                "OpenAI exceeded maximum tool-call rounds ({}) for product {}",
+                                MAX_TOOL_CALL_ROUNDS,
+                                product.getId());
+                        return product;
+                    }
+                    toolCallRounds++;
                     OpenAiResponse.OpenAiToolCall toolCall = toolCalls.get(0);
                     String functionName = toolCall.function() != null ? toolCall.function().name() : null;
                     if (log.isInfoEnabled()) {


### PR DESCRIPTION
### Motivation

- Prevent the AI Worker from getting stuck in a non-terminating loop if the OpenAI model keeps emitting function/tool calls without ever producing final textual output.

### Description

- Add a defensive cap `MAX_TOOL_CALL_ROUNDS = 8` to limit how many successive tool-call follow-ups are processed in `OpenAiChatGptClient.enrich(...)`.
- Introduce a `toolCallRounds` counter and return early with an error log when the limit is exceeded, avoiding infinite blocking behavior (file: `ai-worker/src/main/java/com/marketinghub/worker/OpenAiChatGptClient.java`).

### Testing

- Attempted to run AI Worker unit tests with `cd ai-worker && mvn -s settings.xml test`, but the run failed due to inability to resolve the parent POM caused by network/repository access errors, so test suite could not complete.
- The change is small and localized and no additional automated test failures were observed in this environment because the full test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db1f9fba408321878238cc0300a434)