### PR TITLE
Melhora feedback de envio e contrato de posicionamento de imagens no pipeline

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -205,6 +205,9 @@ public class ExperimentPipelineOpenAiClient {
             13. Toda tag <img> permitida deve usar src absoluto válido (https://... ou data:image/...) e reutilizar altText do planejamento de imagens.
             14. Cada <img> deve declarar data-image-section-id e data-image-binding-key como binding canônico obrigatório do plano de imagens.
             15. Cada <img> também deve declarar data-image-role (semântico), data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion.
+            16. Aplicar posicionamento de imagem determinístico por layoutBinding: cada bloco com imagem deve renderizar data-image-desktop-placement e data-image-mobile-placement com os valores de layoutBinding, além de classes CSS explícitas para cada variação (left/right/center/background e above-copy/below-copy/inline/background).
+            17. No mobile (<=768px), respeitar sempre preferredMobilePlacement e impedir overlap de texto/imagem.
+            18. Após envio bem-sucedido do formulário, exibir mensagem clara orientando o usuário a aguardar o e-mail com a prévia.
 
             Formato obrigatório (JSON):
             - htmlDocument
@@ -244,6 +247,12 @@ public class ExperimentPipelineOpenAiClient {
               form.addEventListener('submit', async function (event) {
                 event.preventDefault();
                 event.stopImmediatePropagation();
+                var submitButton = form.querySelector('[type="submit"]');
+                var originalButtonText = submitButton ? submitButton.textContent : '';
+                if (submitButton) {
+                  submitButton.disabled = true;
+                  submitButton.textContent = 'Enviando...';
+                }
                 var pathname = window.location.pathname || '';
                 var slugMatch = pathname.match(/\\/flows\\/([^/?#]+)/i);
                 var slug = slugMatch && slugMatch[1] ? slugMatch[1] : '';
@@ -275,8 +284,40 @@ public class ExperimentPipelineOpenAiClient {
                   if (!response.ok) {
                     throw new Error('Falha ao enviar formulário: ' + response.status);
                   }
+                  var successMessage = document.getElementById('lead-capture-success-message');
+                  if (!successMessage) {
+                    successMessage = document.createElement('div');
+                    successMessage.id = 'lead-capture-success-message';
+                    successMessage.setAttribute('role', 'status');
+                    successMessage.style.marginTop = '12px';
+                    successMessage.style.padding = '12px';
+                    successMessage.style.borderRadius = '10px';
+                    successMessage.style.background = '#ecfdf3';
+                    successMessage.style.color = '#065f46';
+                    successMessage.style.fontWeight = '600';
+                    form.appendChild(successMessage);
+                  }
+                  successMessage.textContent = 'Recebemos seus dados com sucesso! Aguarde: em instantes você receberá a prévia no e-mail informado.';
+                  successMessage.style.display = 'block';
+                  form.reset();
                 } catch (error) {
                   console.error(error);
+                  var fallbackError = document.getElementById('lead-capture-error-message');
+                  if (!fallbackError) {
+                    fallbackError = document.createElement('div');
+                    fallbackError.id = 'lead-capture-error-message';
+                    fallbackError.setAttribute('role', 'alert');
+                    fallbackError.style.marginTop = '12px';
+                    fallbackError.style.color = '#b91c1c';
+                    fallbackError.textContent = 'Não foi possível enviar agora. Tente novamente em alguns instantes.';
+                    form.appendChild(fallbackError);
+                  }
+                  fallbackError.style.display = 'block';
+                } finally {
+                  if (submitButton) {
+                    submitButton.disabled = false;
+                    submitButton.textContent = originalButtonText || 'Enviar';
+                  }
                 }
               }, true);
             })();

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -531,6 +531,8 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(htmlDocument).contains("action=\"/api/flows/{slug}/submissions\"");
         assertThat(htmlDocument).contains("id=\"lead-capture-submit-contract\"");
         assertThat(htmlDocument).contains("var slugtoken = /\\{slug\\}|%7bslug%7d/i;");
+        assertThat(htmlDocument).contains("lead-capture-success-message");
+        assertThat(htmlDocument).contains("aguarde: em instantes você receberá a prévia no e-mail informado");
     }
 
     @Test
@@ -588,6 +590,8 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(htmlDocument).contains("action=\"/api/flows/{slug}/submissions\"");
         assertThat(htmlDocument).contains("id=\"lead-capture-submit-contract\"");
         assertThat(htmlDocument).contains("var slugtoken = /\\{slug\\}|%7bslug%7d/i;");
+        assertThat(htmlDocument).contains("lead-capture-success-message");
+        assertThat(htmlDocument).contains("aguarde: em instantes você receberá a prévia no e-mail informado");
     }
 
     @Test

--- a/docs/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/modelo-canonico-artefatos-pipeline-experimento.md
@@ -319,7 +319,8 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
         "successFeedback": {
           "inlineElementId": "string",
           "displayMode": "block|flex|inline-block",
-          "resetForm": "boolean"
+          "resetForm": "boolean",
+          "waitForEmailMessage": "string"
         },
         "errorFeedback": {
           "mode": "inline|alert",
@@ -348,10 +349,29 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
     },
     "successState": {
       "title": "string",
-      "message": "string"
+      "message": "string",
+      "nextStepHint": "string"
     }
   },
   "summary": "string",
+  "imagePlacementContract": {
+    "requiredDataAttributes": [
+      "data-image-desktop-placement",
+      "data-image-mobile-placement"
+    ],
+    "requiredDesktopClasses": [
+      "image-placement-left",
+      "image-placement-right",
+      "image-placement-center",
+      "image-placement-background"
+    ],
+    "requiredMobileClasses": [
+      "image-mobile-above-copy",
+      "image-mobile-below-copy",
+      "image-mobile-inline",
+      "image-mobile-background"
+    ]
+  },
   "consistencyChecks": [
     {
       "check": "CTA_MATCH | PROMISE_MATCH | IMAGE_PLAN_BINDING | SURFACE_SPEC_BINDING | FORM_SPEC_BINDING | FORM_USABILITY",


### PR DESCRIPTION
### Motivation
- Corrigir UX das landings geradas pelo pipeline para fornecer feedback de envio claro ao usuário e evitar dúvidas sobre receber a prévia por e-mail. 
- Garantir posicionamento determinístico de imagens geradas pelo pipeline alinhado ao `layoutBinding` do planejamento de imagens.

### Description
- Reforça o prompt `landing-page-html` em `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java` para exigir atributos de posicionamento (`data-image-desktop-placement`, `data-image-mobile-placement`) e regras de renderização mobile/desktop. 
- Altera o script injetado pelo worker (`STATIC_FORM_SUBMIT_SCRIPT`) para desabilitar o botão de envio enquanto a requisição está em andamento, mostrar texto de carregamento (`Enviando...`), exibir mensagem de sucesso orientando a aguardar o e-mail (`lead-capture-success-message`), resetar o formulário e exibir um fallback de erro inline; restaura o estado do botão no `finally`. 
- Atualiza testes em `ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java` adicionando asserts que validam a injeção da mensagem de sucesso no HTML gerado. 
- Atualiza o esquema canônico em `docs/modelo-canonico-artefatos-pipeline-experimento.md` adicionando `waitForEmailMessage` em `successFeedback`, `nextStepHint` em `successState` e um `imagePlacementContract` com classes e atributos obrigatórios para posicionamento de imagem em desktop/mobile.

### Testing
- Executado `cd ai-worker && mvn -s settings.xml -Dtest=ExperimentPipelineOpenAiClientTest test`; os testes unitários foram modificados para verificar a mensagem de sucesso, porém a execução falhou por limitação de ambiente devido a resolução de dependências Maven (rede/repositório inacessível), portanto os testes não foram concluídos com sucesso.  
- Arquivos alterados: `ai-worker/src/main/java/.../ExperimentPipelineOpenAiClient.java`, `ai-worker/src/test/java/.../ExperimentPipelineOpenAiClientTest.java`, e `docs/modelo-canonico-artefatos-pipeline-experimento.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce4374570832191a174e4c9708adc)