### PR TITLE
Remove automatic/manual columns from experiment funnel table

### DIFF
--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -241,8 +241,6 @@ export default function ExperimentFunnelTab({
               <thead>
                 <tr>
                   <th style={{ minWidth: 220 }}>Etapa</th>
-                  <th>Automático</th>
-                  <th>Manuais</th>
                   <th>Total</th>
                   <th>Custo por conv.</th>
                   <th>Únicos</th>
@@ -257,8 +255,6 @@ export default function ExperimentFunnelTab({
                         {stage.order}. {stage.label}
                       </div>
                     </td>
-                    <td>{stage.autoCount}</td>
-                    <td>{stage.manualCount}</td>
                     <td>
                       <strong>{stage.totalCount}</strong>
                     </td>


### PR DESCRIPTION
### Motivation
- Simplify the experiment funnel UI by removing per-source breakdown columns which were redundant and improve table readability.

### Description
- Deleted the `Automático` and `Manuais` table columns and removed usages of `stage.autoCount` and `stage.manualCount` in `frontend/src/pages/experiment/ExperimentFunnelTab.tsx` so only the total counts are shown.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce67545048321a45a6105630d737b)