### PR TITLE
Corrige filtro de baseline do reset do funil (>= → >)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelAttributionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelAttributionService.java
@@ -50,7 +50,7 @@ public class ExperimentFunnelAttributionService {
                   AND stage = 'VISUALIZACAO_FORM'
                   AND source = ?
                   AND campaign_code IS NOT NULL
-                  AND (? IS NULL OR occurred_at >= ?)
+                  AND (? IS NULL OR occurred_at > ?)
                 GROUP BY campaign_code
                 """;
         queryByCampaignCode(sql, ExperimentFunnelStage.VISUALIZACAO_FORM, target,
@@ -64,7 +64,7 @@ public class ExperimentFunnelAttributionService {
                 JOIN lead_portal_flow f ON f.slug = s.flow_slug
                 WHERE s.campaign_code IS NOT NULL
                   AND %s
-                  AND (? IS NULL OR s.created_at >= ?)
+                  AND (? IS NULL OR s.created_at > ?)
                 GROUP BY s.campaign_code
                 """.formatted(ExperimentFunnelService.FLOW_SCOPE_CONDITION);
         queryByCampaignCode(sql, ExperimentFunnelStage.ENVIO_FORM, target,
@@ -80,7 +80,7 @@ public class ExperimentFunnelAttributionService {
                 WHERE s.campaign_code IS NOT NULL
                   AND %s
                   AND p.email_opened_at IS NOT NULL
-                  AND (? IS NULL OR p.email_opened_at >= ?)
+                  AND (? IS NULL OR p.email_opened_at > ?)
                 GROUP BY s.campaign_code
                 """.formatted(ExperimentFunnelService.FLOW_SCOPE_CONDITION);
         queryByCampaignCode(sql, ExperimentFunnelStage.ABERTURA_EMAIL_AMOSTRA, target,
@@ -96,7 +96,7 @@ public class ExperimentFunnelAttributionService {
                 WHERE s.campaign_code IS NOT NULL
                   AND %s
                   AND p.checkout_accessed_at IS NOT NULL
-                  AND (? IS NULL OR p.checkout_accessed_at >= ?)
+                  AND (? IS NULL OR p.checkout_accessed_at > ?)
                 GROUP BY s.campaign_code
                 """.formatted(ExperimentFunnelService.FLOW_SCOPE_CONDITION);
         queryByCampaignCode(sql, ExperimentFunnelStage.ACESSO_CHECKOUT, target,
@@ -112,7 +112,7 @@ public class ExperimentFunnelAttributionService {
                 WHERE s.campaign_code IS NOT NULL
                   AND %s
                   AND (p.payment_approved_at IS NOT NULL OR p.mp_status = 'approved')
-                  AND (? IS NULL OR COALESCE(p.payment_approved_at, p.updated_at) >= ?)
+                  AND (? IS NULL OR COALESCE(p.payment_approved_at, p.updated_at) > ?)
                 GROUP BY s.campaign_code
                 """.formatted(ExperimentFunnelService.FLOW_SCOPE_CONDITION);
         queryByCampaignCode(sql, ExperimentFunnelStage.COMPRA, target,
@@ -130,7 +130,7 @@ public class ExperimentFunnelAttributionService {
                   AND %s
                   AND d.email_request_id IS NOT NULL
                   AND el.opened_at IS NOT NULL
-                  AND (? IS NULL OR el.opened_at >= ?)
+                  AND (? IS NULL OR el.opened_at > ?)
                 GROUP BY s.campaign_code
                 """.formatted(ExperimentFunnelService.FLOW_SCOPE_CONDITION);
         queryByCampaignCode(sql, ExperimentFunnelStage.ABERTURA_EMAIL_COMPRA, target,
@@ -147,7 +147,7 @@ public class ExperimentFunnelAttributionService {
                   AND %s
                   AND p.payment_purchase_id IS NOT NULL
                   AND p.images_viewed_at IS NOT NULL
-                  AND (? IS NULL OR p.images_viewed_at >= ?)
+                  AND (? IS NULL OR p.images_viewed_at > ?)
                 GROUP BY s.campaign_code
                 """.formatted(ExperimentFunnelService.FLOW_SCOPE_CONDITION);
         queryByCampaignCode(sql, ExperimentFunnelStage.DOWNLOAD_MATERIAL_PAGO, target,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelEventRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelEventRepository.java
@@ -30,7 +30,7 @@ public interface ExperimentFunnelEventRepository extends JpaRepository<Experimen
             from ExperimentFunnelEvent e
             where e.experiment.id = :experimentId
               and (e.source is null or e.source <> :excludedSource)
-              and (:baseline is null or e.occurredAt >= :baseline)
+              and (:baseline is null or e.occurredAt > :baseline)
             group by e.stage
             """)
     List<StageAggregation> aggregateByExperiment(@Param("experimentId") Long experimentId,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -213,7 +213,7 @@ public class ExperimentFunnelService {
                                MAX(updated_at) AS last_event
                         FROM experiment_campaign_metric
                         WHERE experiment_id = ?
-                          AND (? IS NULL OR updated_at >= ?)
+                          AND (? IS NULL OR updated_at > ?)
                         """, experimentId, baseline, baseline),
                 "Impressões vindas do Facebook Ads (experiment_campaign_metric)");
 
@@ -224,7 +224,7 @@ public class ExperimentFunnelService {
                                MAX(updated_at) AS last_event
                         FROM experiment_campaign_metric
                         WHERE experiment_id = ?
-                          AND (? IS NULL OR updated_at >= ?)
+                          AND (? IS NULL OR updated_at > ?)
                         """, experimentId, baseline, baseline),
                 "Cliques do anúncio para o formulário (experiment_campaign_metric)");
 
@@ -237,7 +237,7 @@ public class ExperimentFunnelService {
                         WHERE experiment_id = ?
                           AND stage = 'VISUALIZACAO_FORM'
                           AND source = ?
-                          AND (? IS NULL OR occurred_at >= ?)
+                          AND (? IS NULL OR occurred_at > ?)
                         """, experimentId, ExperimentFunnelEventRepository.RENDER_COMPLETE_SOURCE, baseline, baseline),
                 "Renderização completa registrada pelo Lead Portal (evento lead-portal-render-complete)");
 
@@ -260,7 +260,7 @@ public class ExperimentFunnelService {
                             JOIN lead_portal_flow f ON f.slug = fs.flow_slug
                             WHERE %s
                         ) submissions
-                        WHERE (? IS NULL OR submitted_at >= ?)
+                        WHERE (? IS NULL OR submitted_at > ?)
                         """.formatted(FLOW_SCOPE_CONDITION), experimentId, experimentId, experimentId, baseline, baseline),
                 "Envios do formulário (lead_portal_submission + flow_submissions)");
 
@@ -274,7 +274,7 @@ public class ExperimentFunnelService {
                         JOIN lead_portal_flow f ON f.slug = s.flow_slug
                         WHERE %s
                           AND p.email_opened_at IS NOT NULL
-                          AND (? IS NULL OR p.email_opened_at >= ?)
+                          AND (? IS NULL OR p.email_opened_at > ?)
                         """.formatted(FLOW_SCOPE_CONDITION), experimentId, experimentId, baseline, baseline),
                 "Aberturas de e-mail de amostra (flow_submission_image_package.email_opened_at)");
 
@@ -288,7 +288,7 @@ public class ExperimentFunnelService {
                         JOIN lead_portal_flow f ON f.slug = s.flow_slug
                         WHERE %s
                           AND p.checkout_accessed_at IS NOT NULL
-                          AND (? IS NULL OR p.checkout_accessed_at >= ?)
+                          AND (? IS NULL OR p.checkout_accessed_at > ?)
                         """.formatted(FLOW_SCOPE_CONDITION), experimentId, experimentId, baseline, baseline),
                 "Acessos ao checkout registrados via tracking público (lead_portal_purchase.checkout_accessed_at)");
 
@@ -302,7 +302,7 @@ public class ExperimentFunnelService {
                         JOIN lead_portal_flow f ON f.slug = s.flow_slug
                         WHERE %s
                           AND (p.payment_approved_at IS NOT NULL OR p.mp_status = 'approved')
-                          AND (? IS NULL OR COALESCE(p.payment_approved_at, p.updated_at) >= ?)
+                          AND (? IS NULL OR COALESCE(p.payment_approved_at, p.updated_at) > ?)
                         """.formatted(FLOW_SCOPE_CONDITION), experimentId, experimentId, baseline, baseline),
                 "Pagamentos aprovados (lead_portal_purchase)");
 
@@ -318,7 +318,7 @@ public class ExperimentFunnelService {
                         WHERE %s
                           AND d.email_request_id IS NOT NULL
                           AND el.opened_at IS NOT NULL
-                          AND (? IS NULL OR el.opened_at >= ?)
+                          AND (? IS NULL OR el.opened_at > ?)
                         """.formatted(FLOW_SCOPE_CONDITION), experimentId, experimentId, baseline, baseline),
                 "Abertura do e-mail de entrega (lead_portal_premium_delivery -> email_log)");
 
@@ -333,7 +333,7 @@ public class ExperimentFunnelService {
                         WHERE %s
                           AND p.payment_purchase_id IS NOT NULL
                           AND p.images_viewed_at IS NOT NULL
-                          AND (? IS NULL OR p.images_viewed_at >= ?)
+                          AND (? IS NULL OR p.images_viewed_at > ?)
                         """.formatted(FLOW_SCOPE_CONDITION), experimentId, experimentId, baseline, baseline),
                 "Downloads/visualizações do material pago (flow_submission_image_package.images_viewed_at)");
     }


### PR DESCRIPTION
### Motivation
- O botão “Zerar contagens” não limpava totalmente o funil porque comparações inclusivas (`>=`) faziam eventos ocorridos exatamente no instante do `resetAt` ainda serem contados.
- Mudar para comparação estrita evita que eventos no mesmo timestamp do reset “vazem” para a nova janela de contagem.

### Description
- Substituí comparações inclusivas (`>=`) por exclusivas (`>`) nas condições de baseline usadas para filtrar eventos e métricas do funil em SQL nas consultas do backend.
- Arquivos modificados: `backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java`, `backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelAttributionService.java`, e `backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelEventRepository.java`.
- Mudança aplicada em agregação de eventos manuais (`aggregateByExperiment`), nas consultas de métricas automáticas (impressões, cliques, renders, envios, e‑mails, checkout, compra, downloads) e nas queries de atribuição por `campaign_code` para manter consistência entre resumo do funil e dados de atribuição.
- A lógica de fallback para `NULL` no baseline foi preservada (continua permitindo `:baseline is null`), apenas a comparação temporal mudou para ser estrita.

### Testing
- Tentei executar testes direcionados com `cd backend/ads-service && mvn -s ../settings.xml -Dtest=ExperimentFunnelServiceResetTest,ExperimentFunnelServiceRenderCompleteTest,ExperimentFunnelServiceSubmissionTest test`.
- A execução dos testes não pôde ser completada devido a falha de ambiente (Maven não conseguiu baixar dependências, `Network is unreachable`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce65735b08321b55cee081b8a9701)