### PR TITLE
AI Hub: **Resumo das alterações**
- Consultei os dados no banco (`lead_portal_flow` e `experiment`) para entender o estado atual do fluxo `exp-10-landing` e confirmar o HTML com placeholders.
- Criei o componente reutilizável `SubmissionSuccessCard` e o a…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/LandingPageImageInjector.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/LandingPageImageInjector.java
@@ -161,6 +161,10 @@ public class LandingPageImageInjector {
         addCandidate(candidates, imageElement.attr("data-section-id"));
         addCandidate(candidates, imageElement.attr("data-section-name"));
         addCandidate(candidates, imageElement.attr("data-image-key"));
+        addCandidate(candidates, imageElement.attr("data-image-section-id"));
+        addCandidate(candidates, imageElement.attr("data-image-binding-key"));
+        addCandidate(candidates, imageElement.attr("data-image-role"));
+        addCandidate(candidates, imageElement.attr("data-conversion-role"));
         addCandidate(candidates, imageElement.id());
         addCandidate(candidates, imageElement.attr("alt"));
         addCandidate(candidates, imageElement.className());

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/LandingPageImageInjectorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/LandingPageImageInjectorTest.java
@@ -100,6 +100,30 @@ class LandingPageImageInjectorTest {
     }
 
     @Test
+    void injectsImageByImageSectionAttributes() {
+        String html = """
+                <!doctype html>
+                <html><body>
+                  <section id=\"hero\">
+                    <img
+                      src=\"https://images.unsplash.com/photo-placeholder?auto=format&fit=crop&w=1600&q=70\"
+                      data-image-section-id=\"s0-hero-pt-variant10-v1\"
+                      data-image-binding-key=\"hero-dor-quanto-custa\"
+                    />
+                  </section>
+                </body></html>
+                """;
+        when(jobRepository.findByExperimentIdOrderByCreatedAtDesc(anyLong()))
+                .thenReturn(List.of(completedJob("s0-hero-pt-variant10-v1",
+                        "https://cdn.example.com/hero-runtime.jpg", null)));
+
+        String enriched = injector.injectImages(42L, html);
+
+        assertThat(enriched).contains("https://cdn.example.com/hero-runtime.jpg");
+        assertThat(enriched).doesNotContain("images.unsplash.com/photo-placeholder");
+    }
+
+    @Test
     void keepsOriginalPayloadWhenNoImagesAreAvailable() {
         String payload = "{}";
         when(jobRepository.findByExperimentIdOrderByCreatedAtDesc(anyLong())).thenReturn(List.of());

--- a/docs/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/modelo-canonico-artefatos-pipeline-experimento.md
@@ -290,6 +290,11 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 
 ## `landingPageHtml`
 
+> Cada documento HTML gerado pela etapa `landingPageHtml` traz atributos de dados para vincular os visuais planejados aos ativos finais.
+> Os principais atributos são `data-image-section-id` (mapeia o `planning_item_key`), `data-image-binding-key` (chave semântica)
+> e `data-image-role`/`data-conversion-role` (indicam o papel do ativo). Esses marcadores permitem que o pipeline substitua
+> placeholders genéricos por imagens aprovadas automaticamente durante a publicação das landings.
+
 ```json
 {
   "htmlDocument": "string",

--- a/lead-portal/frontend/src/components/FlowForm.tsx
+++ b/lead-portal/frontend/src/components/FlowForm.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from "react";
 import { submitFlowSubmission } from "../api";
+import SubmissionSuccessCard from "./SubmissionSuccessCard";
 import {
   FlowQuestion,
   FlowQuestionType,
@@ -207,7 +208,7 @@ export default function FlowForm({
 
   if (submissionResult) {
     return (
-      <ThankYouPanel
+      <SubmissionSuccessCard
         name={submissionResult.name}
         email={submissionResult.email}
       />
@@ -362,29 +363,6 @@ function resolveContactFollowUpConfig(
   return Object.keys(followUpByOption).length > 0
     ? { contactQuestionKey: contactQuestion.dataKey, followUpByOption }
     : null;
-}
-
-function ThankYouPanel({ name, email }: { name: string; email: string }) {
-  const isGmailAddress = /@gmail\.com$/i.test(email.trim());
-
-  return (
-    <div className="thank-you-card">
-      <h2>Respostas enviadas!</h2>
-      <p>
-        Obrigado, {name || "cliente"}. Recebemos suas respostas e em breve
-        entraremos em contato pelo e-mail
-        <strong> {email}</strong>.
-      </p>
-      {isGmailAddress ? (
-        <p className="gmail-tip">
-          Se você usa Gmail, confira também a pasta <strong>Todos os e-mails</strong>
-          ou a aba de <strong>Promoções</strong>, pois nossa mensagem pode ser
-          direcionada para lá.
-        </p>
-      ) : null}
-      <p>Você pode fechar esta página com segurança.</p>
-    </div>
-  );
 }
 
 interface QuestionFieldProps {

--- a/lead-portal/frontend/src/components/SubmissionSuccessCard.tsx
+++ b/lead-portal/frontend/src/components/SubmissionSuccessCard.tsx
@@ -1,0 +1,38 @@
+interface SubmissionSuccessCardProps {
+  name?: string | null;
+  email?: string | null;
+  title?: string | null;
+  message?: string | null;
+  showGmailTip?: boolean;
+}
+
+export default function SubmissionSuccessCard({
+  name,
+  email,
+  title,
+  message,
+  showGmailTip = true,
+}: SubmissionSuccessCardProps) {
+  const normalizedName = name?.trim() || "cliente";
+  const normalizedEmail = email?.trim() ?? "";
+  const finalTitle = title?.trim() || "Respostas enviadas!";
+  const fallbackMessage = normalizedEmail
+    ? `Obrigado, ${normalizedName}. Recebemos suas respostas e em breve entraremos em contato pelo e-mail ${normalizedEmail}.`
+    : `Obrigado, ${normalizedName}. Recebemos suas respostas e em breve entraremos em contato.`;
+  const finalMessage = message?.trim() || fallbackMessage;
+  const isGmailAddress = showGmailTip && /@gmail\.com$/i.test(normalizedEmail);
+
+  return (
+    <div className="thank-you-card">
+      <h2>{finalTitle}</h2>
+      <p>{finalMessage}</p>
+      {isGmailAddress ? (
+        <p className="gmail-tip">
+          Se você usa Gmail, confira também a pasta <strong>Todos os e-mails</strong> ou a aba de
+          <strong> Promoções</strong>, pois nossa mensagem pode ser direcionada para lá.
+        </p>
+      ) : null}
+      <p>Você pode fechar esta página com segurança.</p>
+    </div>
+  );
+}

--- a/lead-portal/frontend/src/pages/FlowPage.tsx
+++ b/lead-portal/frontend/src/pages/FlowPage.tsx
@@ -8,6 +8,7 @@ import {
   submitFlowSubmission,
 } from "../api";
 import FlowForm from "../components/FlowForm";
+import SubmissionSuccessCard from "../components/SubmissionSuccessCard";
 import { resolveAssetUrl } from "../utils/resolveAssetUrl";
 import {
   normalizeCustomTemplatePayload,
@@ -16,18 +17,30 @@ import {
 } from "../utils/customTemplateHtml";
 import { getVisitorIdCookie } from "../utils/visitorCookie";
 import { useCampaignCode } from "../hooks/useCampaignCode";
-import type { FlowQuestion, LeadPortalFlow, LeadPortalSimpleFormStyleDefinition } from "../types";
+import type {
+  FlowQuestion,
+  FlowSubmissionResponse,
+  LeadPortalFlow,
+  LeadPortalSimpleFormStyleDefinition,
+} from "../types";
 
 export default function FlowPage() {
   const { slug } = useParams<{ slug: string }>();
   const campaignCode = useCampaignCode();
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [hasTrackedRenderComplete, setHasTrackedRenderComplete] = useState(false);
+  const [submissionResult, setSubmissionResult] = useState<FlowSubmissionResponse | null>(null);
 
   useEffect(() => {
     setHasSubmitted(false);
     setHasTrackedRenderComplete(false);
+    setSubmissionResult(null);
   }, [slug]);
+
+  const handleSubmissionComplete = (result: FlowSubmissionResponse) => {
+    setSubmissionResult(result);
+    setHasSubmitted(true);
+  };
 
   const { data: flow, isLoading, isError, error } = useQuery({
     queryKey: ["lead-portal-flow", slug, campaignCode ?? null],
@@ -124,15 +137,31 @@ export default function FlowPage() {
         };
   if (hasCustomTemplate && customTemplateHtml) {
     const templateVariables = customTemplateVariables ?? new Map<string, string>();
+    const successState = customTemplateFormSpec?.successState;
     return (
-      <CustomFlowTemplate
-        html={customTemplateHtml}
-        variables={templateVariables}
-        flowSlug={flow.slug}
-        formSpec={customTemplateFormSpec}
-        campaignCode={campaignCode}
-        onSubmitted={() => setHasSubmitted(true)}
-      />
+      <div className="flow-page flow-page--custom" style={styleVars}>
+        {hasSubmitted ? (
+          <div className="flow-custom-feedback">
+            <SubmissionSuccessCard
+              name={submissionResult?.name}
+              email={submissionResult?.email}
+              title={successState?.title}
+              message={successState?.message}
+            />
+          </div>
+        ) : (
+          <div className="flow-custom-template">
+            <CustomFlowTemplate
+              html={customTemplateHtml}
+              variables={templateVariables}
+              flowSlug={flow.slug}
+              formSpec={customTemplateFormSpec}
+              campaignCode={campaignCode}
+              onSubmitted={handleSubmissionComplete}
+            />
+          </div>
+        )}
+      </div>
     );
   }
 
@@ -240,7 +269,7 @@ export default function FlowPage() {
         <FlowForm
           flow={flowForForm}
           campaignCode={campaignCode}
-          onSubmitted={() => setHasSubmitted(true)}
+          onSubmitted={handleSubmissionComplete}
         />
       </div>
     </div>
@@ -253,7 +282,7 @@ interface CustomFlowTemplateProps {
   flowSlug: string;
   formSpec?: CustomTemplateFormSpec;
   campaignCode?: string | null;
-  onSubmitted?: () => void;
+  onSubmitted?: (result: FlowSubmissionResponse) => void;
 }
 
 const TOKEN_REGEX = /\{\{\s*([a-zA-Z0-9_-]+)\s*\}\}/g;
@@ -382,7 +411,7 @@ interface CustomTemplateBridgeOptions {
   flowSlug: string;
   formSpec?: CustomTemplateFormSpec;
   campaignCode?: string | null;
-  onSubmitted?: () => void;
+  onSubmitted?: (result: FlowSubmissionResponse) => void;
 }
 
 function attachCustomTemplateBridge(
@@ -440,7 +469,7 @@ function attachCustomTemplateBridge(
 
     try {
       const parsed = parseTemplateSubmissionPayload(target, options.campaignCode);
-      await submitFlowSubmission(options.flowSlug, parsed.payload, parsed.image);
+      const response = await submitFlowSubmission(options.flowSlug, parsed.payload, parsed.image);
       target.dataset.leadPortalSubmitted = "true";
       writeManagedTemplateFeedback(
         target,
@@ -460,7 +489,7 @@ function attachCustomTemplateBridge(
           },
         }),
       );
-      options.onSubmitted?.();
+      options.onSubmitted?.(response);
     } catch (error) {
       const message =
         error instanceof Error

--- a/lead-portal/frontend/src/styles.css
+++ b/lead-portal/frontend/src/styles.css
@@ -1090,6 +1090,25 @@ form.flow-form {
   }
 }
 
+.flow-page--custom {
+  min-height: 100vh;
+}
+
+.flow-custom-template,
+.flow-custom-feedback {
+  width: 100%;
+}
+
+.flow-custom-feedback {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
+
+.flow-custom-feedback .thank-you-card {
+  width: min(100%, 640px);
+}
+
 .flow-page--custom .flow-custom-template {
   width: 100%;
 }

--- a/lead-portal/frontend/tsconfig.node.json
+++ b/lead-portal/frontend/tsconfig.node.json
@@ -8,11 +8,19 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "target": "ESNext",
-    "lib": ["ESNext", "DOM"],
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true
+    "noEmit": true,
+    "ignoreDeprecations": "6.0"
   },
-  "include": ["vite.config.ts"],
-  "exclude": ["src"]
+  "include": [
+    "vite.config.ts"
+  ],
+  "exclude": [
+    "src"
+  ]
 }


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Precisamos fazer ajustes nas páginas geradas pelo pipeline de experimento (ID 10)  https://oportunidadebrasil.shop/flows/exp-10-landing

1- É preciso ter uma feedback claro na página para quando o usuário enviar o formulário. Como existe na pagina gerada manual : https://oportunidadebrasil.shop/flows/formpersonal

2- Nem todas as imagens estão corretas ainda existe uma errada: https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=1600&q=70

Sendo necessário use a ferramente web-search para ver os exemplos citados.

use a tool de banco de dados para pesquisar as informações necessárias
use a tool de web search para pesquisar documentação na internet se necessário
Teste a compilação dos módulos alterados
Faça os testes necessários para garantir que a solicitação está realmente atendida.
O modelo de dados do experimento e seus relacionamentos você encontra em: docs/modelo-dados-experimento.md
Se fizer alterações ajuste o modelo.
Sabendo que o dominio oportunidadebrasil.shop está apontando para 191.252.120.96
Consulte e se precisar atualize no esquema canônico de artefatos em : docs/modelo-canonico-artefatos-pipeline-experimento.md

**Resumo das alterações:**
**Resumo das alterações**
- Consultei os dados no banco (`lead_portal_flow` e `experiment`) para entender o estado atual do fluxo `exp-10-landing` e confirmar o HTML com placeholders.
- Criei o componente reutilizável `SubmissionSuccessCard` e o adotei no `FlowForm`, garantindo uma resposta visual consistente após o envio.
- Reestruturei o `FlowPage` para lidar com templates customizados dentro do layout padrão, armazenar o `FlowSubmissionResponse`, exibir o cartão de sucesso e ocultar o iframe após o envio; o `CustomFlowTemplate` agora entrega o resultado completo ao callback, e o CSS recebeu estilos dedicados para esse fluxo.
- Ajustei o `LandingPageImageInjector` para reconhecer os atributos `data-image-section-id/data-image-binding-key`, garantindo que imagens geradas substituam corretamente os placeholders; adicionei um teste unitário cobrindo o novo cenário e documentei esses atributos no modelo canônico.
- Incluí `ignoreDeprecations: "6.0"` no `tsconfig.node.json` para evitar o aviso de `moduleResolution=node10` nas builds atuais do TypeScript.

**Testes executados**
- `cd lead-portal/frontend && npm run build` (após instalar dependências com `npm install --include=dev` para contornar `NODE_ENV=production`): **sucesso**.
- `cd backend/ads-service && ../mvnw test`: **sucesso** (somente avisos padrão do Java agent).

> Observações: o `npm install` reporta vulnerabilidades já presentes nas dependências upstream; nenhuma nova dependência de produção foi introduzida.