### PR TITLE
fix(frontend): adjust TypeScript ignoreDeprecations to supported version

### DIFF
--- a/lead-portal/frontend/tsconfig.node.json
+++ b/lead-portal/frontend/tsconfig.node.json
@@ -15,7 +15,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "5.0"
   },
   "include": [
     "vite.config.ts"


### PR DESCRIPTION
### Motivation
- Fix `TS5103: Invalid value for '--ignoreDeprecations'` emitted by `tsc -b` by using a supported value in the frontend TypeScript config.

### Description
- Change `compilerOptions.ignoreDeprecations` from `"6.0"` to `"5.0"` in `lead-portal/frontend/tsconfig.node.json`.

### Testing
- Ran `npm run build` in `lead-portal/frontend`; the `TS5103` error for `ignoreDeprecations` no longer appears, but the build still fails in this environment due to missing modules `vite` and `@vitejs/plugin-react`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5dbf2e50832196a638d58aeef05e)