### PR TITLE
AI Hub: **Resumo**
- Consultei o banco de dados (`SELECT id, name, status, platform, creative_approved, facebook_pixel_id, facebook_pixel_created_at, facebook_release_requested_at, instagram_account_id, lead_portal_flow_id, daily_budget FROM experiment WH…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -724,12 +724,6 @@ public class ExperimentService {
         if (experiment.getPlatform() != ExperimentPlatform.FACEBOOK) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Experiment platform must be Facebook");
         }
-        if (!StringUtils.hasText(experiment.getFacebookPixelId())) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "Experiment must have a Facebook pixel registered before release"
-            );
-        }
         experiment.setStatus(ExperimentStatus.PLANNED);
         experiment.setFacebookReleaseRequestedAt(Instant.now());
         experimentFunnelEventRepository.deleteByExperimentId(id);

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -420,7 +420,6 @@ class ExperimentServiceTest {
         req1.setInstagramAccountId(createInstagramAccount().getId());
         var expApproved = service.create(req1);
         expApproved.setCreativeApproved(true);
-        expApproved.setFacebookPixelId("pixel-exp-approved");
         experimentRepository.save(expApproved);
         service.releaseForFacebook(expApproved.getId());
 
@@ -505,7 +504,6 @@ class ExperimentServiceTest {
         req.setLeadPortalFlowId(createLeadPortalFlow(niche));
         req.setInstagramAccountId(createInstagramAccount().getId());
         Experiment experiment = service.create(req);
-        experiment.setFacebookPixelId("pixel-status");
         experimentRepository.save(experiment);
 
         Experiment released = service.releaseForFacebook(experiment.getId());
@@ -552,7 +550,6 @@ class ExperimentServiceTest {
         req.setInstagramAccountId(createInstagramAccount().getId());
         Experiment experiment = service.create(req);
         experiment.setCreativeApproved(true);
-        experiment.setFacebookPixelId("pixel-release");
         experimentRepository.save(experiment);
 
         experimentFunnelEventRepository.save(ExperimentFunnelEvent.builder()
@@ -570,7 +567,7 @@ class ExperimentServiceTest {
     }
 
     @Test
-    void releaseForFacebookRequiresRegisteredPixel() {
+    void releaseForFacebookAllowsReleaseWithoutPixel() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche Pixel").build());
         var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("AP").build());
         var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
@@ -603,9 +600,11 @@ class ExperimentServiceTest {
         req.setInstagramAccountId(createInstagramAccount().getId());
         Experiment experiment = service.create(req);
 
-        assertThatThrownBy(() -> service.releaseForFacebook(experiment.getId()))
-                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
-                .hasMessageContaining("Facebook pixel registered");
+        Experiment released = service.releaseForFacebook(experiment.getId());
+
+        assertThat(released.getStatus()).isEqualTo(ExperimentStatus.PLANNED);
+        assertThat(released.getFacebookPixelId()).isNull();
+        assertThat(released.getFacebookReleaseRequestedAt()).isNotNull();
     }
 
     @Test

--- a/docs/regras/publicacao-campanha.md
+++ b/docs/regras/publicacao-campanha.md
@@ -54,7 +54,10 @@ há configuração faltante antes de liberar a campanha.
 - A segunda seção "Configurações do experimento" exibe os itens operacionais
   acima (conta, página, Instagram e orçamento).
 - Uma terceira seção "Fluxo operacional do Meta" relembra passos complementares
-  (instant form, plataforma e status Planejado).
+  (instant form, plataforma, status Planejado e o pixel automático do Facebook).
+- O item "Pixel do Facebook" aparece nesse bloco para deixar claro se o worker já criou
+  o identificador após a liberação. Enquanto isso não acontece, o checklist orienta o
+  operador a aguardar a criação automática.
 
 Quando todos os bloqueios estão prontos, o cartão sinaliza **Pronto** e o worker
 pode publicar as campanhas para o experimento.
@@ -66,6 +69,7 @@ pode publicar as campanhas para o experimento.
 3. O worker só consome `/api/facebook-campaigns/experiments-ready` para experimentos com status Planejado **e** liberação registrada; mudar o status manualmente não libera o job.
 4. Sempre que for necessário reiniciar a operação (por exemplo, depois de um reset de campanhas), basta clicar novamente no botão para gerar um novo carimbo de liberação e limpar o funil de testes.
 5. O campo `facebook_release_requested_at` agora permanece preenchido mesmo após o experimento mudar para RUNNING/PAUSED, garantindo que o funil continue filtrando os eventos coletados antes da última liberação. Ele só é atualizado quando o botão é acionado novamente.
+6. A liberação também coloca o experimento na fila do worker de pixels. O pixel é criado automaticamente assim que o status fica `PLANNED`, por isso o botão não exige mais um pixel prévio: ele é o gatilho para a criação e para o preenchimento dos campos `facebook_pixel_id` e `facebook_pixel_code`.
 
 ## Monitoramento do funil por experimento
 

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -328,21 +328,6 @@ export default function ExperimentDetailPage() {
       action: hasCompleteTargeting ? undefined : () => setTab("targeting"),
       actionLabel: hasCompleteTargeting ? undefined : "Ir para Segmentação",
     },
-    {
-      id: "facebook-pixel",
-      title: "Pixel registrado na Meta",
-      isMet: hasFacebookPixelRegistered,
-      hint: hasFacebookPixelRegistered
-        ? `Pixel ${data.facebookPixelId} já registrado para este experimento.`
-        : "Aguarde o worker registrar o pixel na Meta antes de liberar o experimento.",
-      action: hasFacebookPixelRegistered
-        ? undefined
-        : () => {
-            setShouldScrollToPixel(true);
-            setTab("overview");
-          },
-      actionLabel: hasFacebookPixelRegistered ? undefined : "Ver Pixel",
-    },
   ];
 
   const isReadyForFacebook = blockingChecklist.every((c) => c.isMet);
@@ -467,6 +452,23 @@ export default function ExperimentDetailPage() {
       actionDisabled:
         data.status === "PLANNED" ? undefined : releaseButtonDisabled,
       actionLoading: data.status === "PLANNED" ? undefined : releaseInProgress,
+    },
+    {
+      id: "facebook-pixel",
+      title: "Pixel do Facebook",
+      isMet: hasFacebookPixelRegistered,
+      hint: hasFacebookPixelRegistered
+        ? `Pixel ${data.facebookPixelId} já registrado para este experimento.`
+        : data.status === "PLANNED"
+          ? "O worker está criando o pixel automaticamente; isso pode levar alguns minutos."
+          : "O pixel será criado automaticamente assim que você liberar o experimento para o worker.",
+      action: hasFacebookPixelRegistered
+        ? undefined
+        : () => {
+            setShouldScrollToPixel(true);
+            setTab("overview");
+          },
+      actionLabel: hasFacebookPixelRegistered ? undefined : "Ver Pixel",
     },
   ];
   const checklistGroups = [


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Nessa página http://191.252.181.168:5173/experiments/10 
Temos um problema, não consigo liberar pq para liberar dependo do pixel e não consigo criar o pixel pq para liberar o pixel dependdo de ter a página liberada.
Veja que o experimento 10 só falta isso. Precisamos sair desse problema cíclico.

use a tool de banco de dados para pesquisar as informações necessárias
Teste a compilação dos módulos alterados
Faça os testes necessários para garantir que a solicitação está realmente atendida.
Sempre que alterar o frontend crie os métodos do backend para suportar. Tanto back quanto o front estão sendo executados no mesmo host.
Evite solicitações de um container diretamente para outro que não seja o backend principal da aplicação. E o backend acessando o banco de dados.
Voce pode usar a tool de web search para acessar o log do modulo Facebook Ads Worker na url : http://191.252.120.96:8082/public/runtime-logs/tail?lines=300
O modelo de dados do experimento e seus relacionamentos você encontra em: docs/modelo-dados-experimento.md
Se fizer alterações ajuste o modelo.
Use como base o documento de controle de publicação de campanhas no facebook em docs/regras/publicacao-campanha.md atualize ele se necessário

**Resumo das alterações:**
**Resumo**
- Consultei o banco de dados (`SELECT id, name, status, platform, creative_approved, facebook_pixel_id, facebook_pixel_created_at, facebook_release_requested_at, instagram_account_id, lead_portal_flow_id, daily_budget FROM experiment WHERE id = 10;`) e confirmei que o experimento 10 estava em `PLANNED`, com criativos aprovados, porém sem `facebook_pixel_id` e sem `facebook_release_requested_at`, reproduzindo o bloqueio circular relatado.
- Atualizei o backend (`ExperimentService.releaseForFacebook`) para não exigir mais um pixel prévio ao liberar o experimento. Ajustei o teste unitário correspondente para validar o novo fluxo (liberação gera status `PLANNED`, mantém o pixel nulo e registra o carimbo de liberação) e removi dependências artificiais de pixel em outros cenários de teste.
- No frontend, removi o pixel da lista de bloqueios e o reposicionei na seção “Fluxo operacional do Meta”, com novas mensagens orientando que a criação acontece automaticamente após a liberação; o botão de “Liberar para o Facebook Ads Worker” deixa de ficar desabilitado por conta do pixel.
- Documentei o novo fluxo em `docs/regras/publicacao-campanha.md`, explicitando que o pixel é criado após o status `PLANNED` e que o checklist mostra esse item apenas como acompanhamento operacional.

**Testes**
- `./mvnw -f ads-service/pom.xml test -Dtest=ExperimentServiceTest` ✅
- `npm run build` (após instalar as dependências de desenvolvimento com `npm install --include=dev`) ✅ — gera os avisos já conhecidos do bundle grande do Vite/CJS.

**Observações**
- Agora basta garantir os três bloqueios (criativos, fluxo do portal e público), clicar em “Liberar para o Facebook Ads Worker” e aguardar o worker criar o pixel automaticamente; o cartão do experimento mostrará o ID assim que o backend receber o retorno.