### PR TITLE
Enable observability endpoints and default runtime log in facebook-ads-worker

### DIFF
--- a/facebook-ads-worker/src/main/resources/application.properties
+++ b/facebook-ads-worker/src/main/resources/application.properties
@@ -49,5 +49,11 @@ targeting.queue.batch-size=${TARGETING_QUEUE_BATCH_SIZE:5}
 targeting.queue.poll-interval=${TARGETING_QUEUE_POLL_INTERVAL:PT30S}
 targeting.queue.lock-ttl=${TARGETING_QUEUE_LOCK_TTL:PT2M}
 
-# Public runtime log endpoint (disabled by default)
-runtime.logs.public.enabled=${RUNTIME_LOGS_PUBLIC_ENABLED:false}
+# Observability / logs
+management.endpoints.web.base-path=${MANAGEMENT_BASE_PATH:/worker-observability}
+management.endpoints.web.exposure.include=${MANAGEMENT_EXPOSE_ENDPOINTS:health,info,loggers,logfile}
+management.endpoint.health.show-details=${MANAGEMENT_HEALTH_SHOW_DETAILS:never}
+logging.file.name=${FACEBOOK_ADS_WORKER_LOG_FILE:logs/facebook-ads-worker.log}
+
+# Public runtime log endpoint (enabled by default for diagnostics in this module)
+runtime.logs.public.enabled=${RUNTIME_LOGS_PUBLIC_ENABLED:true}


### PR DESCRIPTION
### Motivation
- Expose management/observability endpoints and enable runtime log exposure by default to improve diagnostics and centralized logging for the facebook-ads-worker module.

### Description
- Add management endpoint configuration keys `management.endpoints.web.base-path`, `management.endpoints.web.exposure.include`, and `management.endpoint.health.show-details` to control observability surface and health verbosity.
- Add `logging.file.name` to write logs to `logs/facebook-ads-worker.log` by default.
- Change `runtime.logs.public.enabled` default to `true` and update related comment to reflect the new default.

### Testing
- Executed unit tests via `./gradlew test` and confirmed the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3500c88483218b59f3180f104b81)