### PR TITLE
AI Hub: Resumo:
- Criei `docs/canonical/system-governance-canon.v1.md`, estruturando o cânone-mãe com propósito, escopo, princípios globais, critérios de drift, lista de domínios futuros, regras de evolução e árvore-alvo de documentos. O conteúdo referenc…

### DIFF
--- a/docs/canonical/system-governance-canon.v1.md
+++ b/docs/canonical/system-governance-canon.v1.md
@@ -1,0 +1,68 @@
+# Marketing Hub — System Governance Canon v1
+
+## 1. Propósito
+
+- Estabelecer um documento-mãe curto que orienta como o Marketing Hub deve preservar a unidade de regras entre backend (`backend/ads-service`), frontend, workers (por exemplo `ai-worker`, `facebook-ads-worker`, `video-management-service`) e serviços satélites (`lead-portal`, `email-service`, `image-watermark-service`, `image-zipper-service`, `lead-portal-payments-service`).
+- Criar uma "constituição" de governança para reduzir o drift observado nas evoluções independentes de módulos (vide alertas em `docs/inconsistencias-modelo-canonico-artefatos-pipeline-experimento.md`).
+- Definir o roteiro para cânones específicos por domínio (experimentos, mídia, captura de leads, prompts/IA etc.), mantendo este arquivo como referência global mínima.
+
+## 2. Escopo
+
+| Cobre agora | Ainda não cobre |
+| --- | --- |
+| Princípios que determinam onde mora a fonte da verdade (por exemplo, modelos em `docs/data-model.md` e `docs/modelo-dados-experimento.md`, contratos REST do backend, schemas canônicos). | Regras detalhadas de cada fluxo (ex.: todas as etapas de publicação de anúncios, validações campo a campo do formulário de experimento, sequências completas do Lead Portal). |
+| Critérios para detectar divergências entre frontend (`docs/frontend-screens-entities.md`), backend e serviços auxiliares. | Diagramas de arquitetura completos, design de infraestrutura, listas de endpoints ou tabelas completas (essa granularidade ficará nos cânones de domínio). |
+| Estrutura futura da família de cânones e como evoluir versões. | Decisões irrevogáveis sobre topologias (monólito x microserviço), ferramentas como OPA/workflow engine ou refactors abrangentes (podem ser considerados em documentos futuros). |
+
+## 3. Princípios Canônicos Globais
+
+1. **Fonte de verdade explícita.** Cada regra operacional deve apontar para seu contrato oficial: modelos de dados (`docs/data-model.md` e derivados) vivem no backend, payloads canônicos vivem em `docs/modelo-canonico-artefatos-pipeline-experimento.md`, e qualquer worker deve apenas consumir/produzir registros seguindo esses contratos.
+2. **Frontend não reimplementa domínio.** A UI (vide `docs/frontend-screens-entities.md`) só exibe ou coleta dados; cálculo de elegibilidade, aprovação de experimento, gating de packages etc. acontece no backend. Qualquer lógica temporária em `frontend/src` deve ser acompanhada por validação equivalente no backend até ser removida.
+3. **Workers e integrações emitem fatos.** `ai-worker`, `facebook-ads-worker`, `market-research-service`, `video-management-service`, `image-watermark-service` e `image-zipper-service` processam filas, mas não decidem regras de negócio finais. Eles devem persistir fatos (artefatos gerados, métricas coletadas) junto com `model` e `prompt` (regra do `AGENTS.md`), deixando a decisão para o backend.
+4. **Flags derivadas não são verdade primária.** Campos como `novo` em `success_product`, `status` em `lead_portal_package` ou rótulos de UI são projeções de estados declarados no backend. Workers e frontend só podem lê-los; atualizações acontecem via caso de uso oficial.
+5. **Contratos entre módulos são explícitos e versionados.** Integrações (`/api/internal/targeting/elements/...`, `/internal/video/...`, `lead-portal` callbacks, payloads do `lead-portal-payments-service`) devem ter schema documentado sob `docs/canonical` ou no OpenAPI, com versionamento claro. Nenhum módulo pode depender de campos "ocultos" sem registro.
+6. **Mudanças relevantes exigem testes + documentação.** Quando uma regra mudar (por exemplo, validação de targeting no backend e no `facebook-ads-worker`), a alteração deve incluir testes automatizados no repositório responsável e atualização do cânone aplicável.
+
+## 4. Critérios para identificar risco de drift
+
+- **Mesma regra repetida em múltiplos módulos.** Ex.: targeting e score de anchors presentes no backend e no `facebook-ads-worker` (`docs/facebook-targeting-integracao.md`). Se a regra não tiver uma descrição canônica única, há risco imediato.
+- **Bloqueios condicionais diferentes entre frontend e backend.** `docs/frontend-screens-entities.md` mostra que a UI manipula `Experiment`, `Hypothesis`, `LeadPortalSimpleFormStyle`, enquanto o backend reforça estados via `docs/modelo-dados-experimento.md`. Divergências em validação de status ou orçamento são sinais de drift.
+- **Workers inferindo elegibilidade.** Quando `ai-worker`, `image-watermark-service` ou `image-zipper-service` passam a aprovar/reprovar itens com base em heurísticas locais (em vez de estados como `WATERMARK_PENDING`), a regra precisa voltar ao backend.
+- **Ausência de contrato único para estados encadeados.** O pipeline `Lead Portal → watermark → zipper → email → payments` depende de mesmo `packageId`/`status`. Qualquer campo transitório não registrado (por exemplo, `optimizedAsset` usado como miniatura sem contrato formal) deve ser promovido a schema.
+- **Flags múltiplas para o mesmo conceito.** O documento de inconsistências evidencia `landingCodeBundle` vs `landingPageHtml`. Sempre que nomes ou flags duplicadas aparecerem, normalize antes que módulos diferentes adotem versões distintas.
+- **Cópias locais de modelo.** Toda vez que um serviço tenta manter entidades próprias (por exemplo, redefinir tabelas do backend em outro módulo), valide se há justificativa ou se deve reutilizar o artefato já publicado (regra explícita no backend `AGENTS.md`).
+
+## 5. Áreas candidatas a futuros cânones específicos
+
+| Domínio sugerido | Justificativa breve |
+| --- | --- |
+| **Experiments & Activation** | Abrange nicho → hipótese → targeting → ad sets → creatives → métricas (`backend/ads-service`, `docs/modelo-dados-experimento.md`, `facebook-ads-worker`). Precisa de um cânone que descreva estados, SLAs e contratos Meta. |
+| **Lead Capture & Portal / Payments** | `lead-portal` (frontend+backend) e `lead-portal-payments-service` compartilham eventos (`LEAD_PORTAL_FUNNEL_TRACKING_URL`, webhooks Mercado Pago). Um cânone deve fixar contratos de `flow`, `submission`, `package`, `purchase` e reenvios. |
+| **Media Asset Lifecycle** | Pacotes processados por `image-watermark-service`, `image-zipper-service` e distribuídos pelo `email-service`. Requer regras claras de status, nomes de arquivos e limites (por exemplo, geração da miniatura 364x364). |
+| **Ads Delivery & Channel Integrations** | `facebook-ads-worker` hoje cobre Meta; documentos como `docs/facebook-targeting-integracao.md` e `pipeline-3-publicos-meta-ads.md` mostram complexidade suficiente para um cânone dedicado a contratos externos. |
+| **AI Prompt & Worker Governance** | `ai-worker`, `market-research-service`, `video-management-service` e fluxos descritos em `docs/experiment-image-generation-worker-flow.md` compartilham obrigações de registrar `model`/`prompt`, budget de tokens e versionamento de prompt. |
+| **Vitrines & Content Entitlements** | O produto `vitrines` (frontend + backend) introduz governance própria de roles, planos e conteúdos (`vitrines/README.md`). Um cânone específico manterá alinhados autenticação, magic links e políticas de acesso. |
+
+## 6. Regras de evolução
+
+- Este documento deve continuar enxuto; qualquer detalhe operacional deve migrar para um cânone de domínio assim que existir.
+- Atualizações que mudam princípios, escopo ou estrutura exigem nova versão (`system-governance-canon.v2.md`) e changelog curto no topo do arquivo.
+- Cada cânone de domínio deve referenciar explicitamente o contrato (OpenAPI, schema, diagrama) que rege aquela regra e apontar testes automatizados correspondentes.
+- Conflitos entre cânones devem ser registrados como tal (seção "Conflitos conhecidos") até que a revisão os elimine; nunca esconda divergências.
+- Toda alteração que muda comportamento em produção precisa alinhar: (1) código/SQL, (2) testes, (3) cânone relevante, (4) comunicação para módulos dependentes (ex.: workers via version bump do contrato).
+
+## 7. Estrutura-alvo da família de cânones
+
+```
+docs/canonical/
+├─ system-governance-canon.v1.md              # documento-mãe
+├─ experiments-canon.v1.md                    # estados e contratos do pipeline de experimentos
+├─ experiments-decision-schema.v1.json        # schema machine-readable para validações automáticas
+├─ lead-capture-canon.v1.md                   # fluxos do Lead Portal, packages e payments
+├─ media-packages-canon.v1.md                 # lifecycle watermark → zip → email → entrega
+├─ ads-integrations-canon.v1.md               # contratos Meta / canais pagos
+├─ ai-workers-canon.v1.md                     # prompts, modelos e auditoria cross serviços
+└─ <domínio>-decision-schema.v1.json          # schemas específicos quando necessário
+```
+
+> Cada novo documento deve declarar propósito, limites, contratos oficiais e tabela de estados, referenciando explicitamente os módulos (código, serviços ou docs) que implementam as regras descritas.


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Quero que você gere o documento canônico inicial de mais alto nível para o Marketing Hub.

Objetivo:
Criar um documento-mãe curto, claro e prático que estabeleça a governança canônica de regras operacionais do sistema. Este documento NÃO deve tentar detalhar todos os fluxos e regras de todos os módulos. Ele deve ser apenas a base inicial para futuros documentos canônicos por domínio.

Contexto importante:
- Este repositório é grande e possui múltiplos módulos e serviços.
- Já existe um AGENTS.md na raiz do repositório. Leia e respeite esse arquivo antes de qualquer análise.
- O sistema foi evoluindo por partes, inclusive com módulos gerados/alterados por IA, então há risco de drift de regra de negócio entre backend, frontend, workers e serviços auxiliares.
- O objetivo deste documento é reduzir esse drift, criando uma “constituição” inicial do sistema.
- Este documento deve ser de ALTO NÍVEL.
- Este documento deve ser CURTO. Não quero um material extenso, nem um inventário profundo de todas as regras existentes.
- Este documento é o início de uma família de documentos canônicos futuros por domínio.

Sua tarefa:
1. Pesquise o repositório inteiro para entender:
   - principais módulos
   - principais responsabilidades
   - pontos de integração entre módulos
   - onde existem maiores chances de drift de regra de negócio
   - quais áreas parecem merecer cânones próprios no futuro
2. Com base nessa análise, gere um documento inicial de governança canônica de alto nível.
3. O documento deve propor uma estrutura sustentável para evolução futura, sem tentar resolver tudo agora.
4. Depois de gerar o documento, salve-o no repositório.

Nome e local do arquivo:
- Criar em: `docs/canonical/system-governance-canon.v1.md`

Título do documento:
- `Marketing Hub — System Governance Canon v1`

Restrições importantes:
- Não criar um documento longo.
- Não detalhar regras específicas de cada fluxo em profundidade.
- Não transformar o documento em documentação de arquitetura completa.
- Não repetir conteúdo irrelevante do README ou do AGENTS.md.
- Não inventar detalhes que não estejam sustentados pelo código, estrutura do repositório ou documentos existentes.
- Não propor OPA, workflow engine, microserviços ou refactors grandes como decisão já tomada.
- Pode citar esses caminhos como possibilidades futuras, mas o documento inicial deve permanecer neutro, simples e estável.

O que o documento DEVE conter:
1. Propósito
   - explicar por que este documento existe
   - explicar que ele é um documento-mãe de governança
   - explicar que documentos canônicos específicos por domínio virão depois

2. Escopo
   - dizer o que este documento cobre
   - dizer o que ele ainda não cobre
   - deixar explícito que regras detalhadas por domínio ficarão em cânones próprios

3. Princípios canônicos globais
   Incluir princípios como:
   - regras operacionais relevantes devem ter fonte de verdade explícita
   - frontend não deve reinventar regra de negócio já decidida em backend/domínio
   - workers e integrações externas devem emitir fatos/resultados, não virar donos da regra
   - flags derivadas não devem ser tratadas como verdade primária
   - contratos entre módulos devem ser explícitos
   - mudanças de regra relevante precisam de teste e documentação correspondente

4. Critérios para identificar risco de drift
   O documento deve listar sinais de alerta, por exemplo:
   - mesma regra espalhada em mais de um módulo
   - bloqueios condicionais calculados em frontend e backend de formas diferentes
   - workers inferindo elegibilidade de ações
   - ausência de contrato único para estados e decisões
   - múltiplas flags representando mal o mesmo conceito

5. Áreas candidatas a futuros cânones específicos
   Com base no repositório, sugerir uma lista inicial de domínios que merecem documentos próprios no futuro.
   Não detalhar profundamente. Só identificar e justificar brevemente.
   Exemplo do tipo de saída esperada:
   - publication / activation flows
   - artifact workflow / AI generation flows
   - lead capture / portal flows
   - ads delivery / channel integration flows
   - prompt / worker governance
   - media asset lifecycle
   Ajuste essa lista ao que realmente aparecer no repositório.

6. Regras de evolução
   Definir como este documento deve evoluir:
   - documento global deve permanecer curto e estável
   - detalhes entram em documentos por domínio
   - mudanças estruturais relevantes devem ser registradas por versão
   - conflitos entre documentos devem ser explicitados, não escondidos

7. Estrutura-alvo da família de cânones
   Propor, em nível alto, a árvore futura de documentos, por exemplo:
   - `docs/canonical/system-governance-canon.v1.md`
   - `docs/canonical/<domain>-canon.v1.md`
   - `docs/canonical/<domain>-decision-schema.v1.json`
   Isso é só estrutura proposta, sem criar todos os arquivos agora.

Formato esperado do documento:
- Markdown
- Direto ao ponto
- Pouco texto
- Títulos curtos
- Tabelas curtas quando ajudarem
- Sem floreio
- Sem jargão excessivo
- Máximo desejado: algo como 2 a 4 páginas equivalentes em markdown

Também quero que você siga este processo:
1. Ler AGENTS.md da raiz
2. Inspecionar a estrutura do repositório e identificar módulos
3. Ler apenas os documentos e arquivos necessários para entender o sistema em nível alto
4. Produzir o documento
5. Salvar o arquivo no caminho solicitado

Critérios de qualidade:
- O documento precisa ser útil como base real para o projeto
- Precisa ser curto o suficiente para ser lido sempre
- Precisa deixar claro que não é o lugar para detalhar tudo
- Precisa orientar futuras decisões de Codex e humanas
- Precisa refletir a realidade do repositório atual, sem ficar genérico demais

Entregável final:
- Criar o arquivo `docs/canonical/system-governance-canon.v1.md`
- Mostrar no final um resumo curto com:
  - o que foi criado
  - quais domínios foram identificados como candidatos a cânones específicos
  - quais dúvidas ou lacunas ficaram abertas

use a tool de banco de dados para pesquisar as informações necessárias
use a tool de web search para pesquisar documentação na internet se necessário
O modelo de dados do experimento e seus relacionamentos você encontra em: docs/modelo-dados-experimento.md
Se fizer alterações ajuste o modelo.
Temos vários módulos com objetivos bem específicos:
Objetivo de alguns dos principais módulos do sistema:

Facebook Ads Worker -> integração com a API da Meta
Worker AI -> Integração com modelos OpenAi
MarketingHub FrontEnd e BackEnd --> Onde o administrador do MArketing Hub interage com todo o sistema
lead-portal-payments-service  --> A parte de pagamentos, atualmente integrado com Mercado Pago
lead-portal-backend-1 / front-end --> onde os leads são direcionados após o anuncio.
email-service --> tratamento de envio de e-mails integrado ao amazona SES
image-watermark-service -> geração de marca dagua nas imagens para virar amostras
image-zipper-service --> montar zip dos produtos e amostrar para deixar disponível para o cliente ou lead

**Resumo das alterações:**
Resumo:
- Criei `docs/canonical/system-governance-canon.v1.md`, estruturando o cânone-mãe com propósito, escopo, princípios globais, critérios de drift, lista de domínios futuros, regras de evolução e árvore-alvo de documentos. O conteúdo referencia módulos reais (backend/ads-service, frontend, ai-worker, facebook-ads-worker, lead-portal, serviços de mídia, etc.) e documentos existentes (`docs/data-model.md`, `docs/modelo-dados-experimento.md`, `docs/frontend-screens-entities.md`, `docs/inconsistencias-modelo-canonico-artefatos-pipeline-experimento.md`), mantendo o texto curto e prático conforme solicitado.
- Mantive o documento neutro quanto a decisões arquiteturais irreversíveis e destaquei onde futuros cânones devem detalhar regras específicas.

Domínios candidatos a cânones específicos identificados:
1. Experiments & Activation (pipeline de nichos, hipóteses, targeting, ad sets e métricas).
2. Lead Capture & Portal / Payments (lead-portal, callbacks e integrações com Mercado Pago).
3. Media Asset Lifecycle (watermark → zip → email → entrega de pacotes).
4. Ads Delivery & Channel Integrations (facebook-ads-worker e contratos com a Meta).
5. AI Prompt & Worker Governance (ai-worker, market-research-service, video-management-service e demais produtores de artefatos IA).
6. Vitrines & Content Entitlements (novo produto de vitrines com magic link e planos).

Dúvidas/Lacunas:
- Ainda não há contratos formalizados para estados compartilhados do pipeline de pacotes (Lead Portal → watermark → zip → email) nem schema único para os payloads Mercado Pago ↔ backend; esses itens devem ser priorizados nos futuros cânones de domínio.

Testes:
- Não executei testes automatizados, pois a entrega é exclusivamente documental e não altera código executável.