### PR TITLE
Revert "AI Hub: Resumo:- Reescrevi `frontend/agents.md` de forma mais minimalista e alinhada ao `System Governance Canon v2`, destacando mandato, fontes de verdade e checklist objetivo.- Documentei a relação do frontend com os principais módulos (MarketingHub, …"

### DIFF
--- a/frontend/agents.md
+++ b/frontend/agents.md
@@ -1,43 +1,29 @@
 # AGENTS.md — Frontend
 
-## 1. Mandato canônico
-- O frontend do Marketing Hub implementa as superfícies administrativas do ecossistema e segue a precedência descrita no _System Governance Canon v2_ (`docs/canonical/system-governance-canon.v2.md`): os contratos de domínio e schemas publicados são a fonte primária, este arquivo apenas deriva diretrizes de execução.
-- Interfaces não redefinem regra de negócio. Todo comportamento deve ser rastreado ao backend responsável ou ao cânone de domínio correspondente.
-- Mudanças relevantes exigem alinhamento com o backend, teste automatizado sempre que possível e atualização dos contratos citados na seção "Fontes de verdade".
+## Consistência visual global
+- Trate a aba de criativos como referência canônica de acabamento visual. Sempre que criar ou revisar telas, reutilize (ou extraia para um utilitário compartilhado) padrões como a grade responsiva (`display: grid` com `gap: 1.5rem` e `minmax(260px, 1fr)`), cartões com cantos de 1rem, sombras brandas e tokens `var(--bs-*)` que garantem contraste e acessibilidade.
+- Listagens e dashboards não devem voltar a exibir blocos de conteúdo em tabelas cruas sem ícones ou hierarquia visual. Prefira cards responsivos com badges de status (`text-bg-*`), metadados resumidos e ações em botões icônicos. Quando precisar de uma tabela por densidade, mantenha uma barra de ações com o mesmo nível de hierarquia, ícones Lucide e estados de carregamento/vazio equivalentes.
+- Barras superiores (toolbars, filtros, cabeçalhos de página) devem seguir a composição do `creative-toolbar`: layout flexível com espaçamentos consistentes, fundos suaves (`var(--bs-tertiary-bg)`), borda de 1px e cantos arredondados. Se uma tela ainda não possuir essa estrutura, crie-a antes de adicionar novos botões ou contadores.
+- Toda interação assíncrona deve contemplar três estados: `spinner-border` centralizado durante carregamento, blocos de esqueleto ou placeholders quando aplicável e um estado vazio com contorno tracejado, ícone decorativo e instruções objetivas (equivalente ao `creative-empty-state`).
+- Botões principais e ações contextuais precisam combinar rótulos e ícones Lucide de 16–18px, alinhados como na aba de criativos. Mantenha ícones como `Sparkles` para automações da IA e `Plus` para criação de itens, evitando trocar por variantes genéricas.
+- Consolidar novos estilos globais em utilitários reutilizáveis (`src/components` ou CSS dedicado) é obrigatório para evitar divergências. Não espalhe regras inline ou duplicadas; derive tokens diretamente dos que já existem em `src/pages/experiment/CriativosTab.css`.
 
-## 2. Fontes de verdade
-| Tipo | Documento/artefato |
-| --- | --- |
-| Governança global | `docs/canonical/system-governance-canon.v2.md` |
-| Modelo de dados do experimento | `docs/modelo-dados-experimento.md` |
-| Backend MarketingHub | `apps/backend` (contratos REST/gRPC publicados) |
-| Workers e integrações | `docs/facebook-ads-worker`, `docs/ai-worker`, `docs/email-service`, `docs/image-watermark-service`, `docs/image-zipper-service`, `docs/lead-portal-*` |
+## Formulários
+- Toda tela de edição/inserção de dados por formulário deve manter o log de erros de validação usando o padrão:
+  ```tsx
+  onClick={handleSubmit(onSubmit, (errors) => {
+    console.log("Validation errors", errors);
+  })}
+  ```
+- Todo campo que aciona serviços do Worker IA deve possuir um tooltip explicando seu funcionamento.
 
-## 3. Módulos atendidos
-| Módulo | Propósito observado pelo frontend |
-| --- | --- |
-| MarketingHub Frontend/Backend | Painéis do administrador e orquestração de regras. O frontend consome APIs oficiais e nunca aplica lógica exclusiva sem validação de domínio. |
-| Worker AI | Solicitações para geração/apoio de conteúdo via OpenAI. Formular fluxos sempre com estados assíncronos e mensagens orientadas por contrato. |
-| Facebook Ads Worker | Disparo de automações Meta Ads. O frontend apenas inicia fluxos e exibe estados retornados. |
-| Lead Portal (backend/frontend) | Superfícies para leads; quando houver dependências cruzadas, priorizar contratos versionados. |
-| lead-portal-payments-service | Status e callbacks de pagamento (Mercado Pago). Exibir projeções confirmadas pelo backend. |
-| email-service | Feedback de envios via Amazon SES; tratar como fatos emitidos por worker. |
-| image-watermark-service & image-zipper-service | Disponibilização de assets tratados; o frontend baixa/exibe apenas URLs e estados emitidos pelos serviços. |
-
-## 4. Padrões mínimos de UI
-- A aba de Criativos (`src/pages/experiment/CriativosTab.tsx` + `.css`) é o kit canônico de layout responsivo (grade `creative-grid`, cards `creative-card`, toolbar `creative-toolbar`). Reutilize os componentes antes de criar novos estilos.
-- Todo fluxo assíncrono mantém os três estados obrigatórios: carregando (`spinner-border` ou skeleton), sucesso/erro com `creative-feedback` e estado vazio equivalente a `creative-empty-state`.
-- Toolbars/filtros repetem o padrão de fundo `var(--bs-tertiary-bg)`, borda de 1px e cantos de 1rem. Centralize ações principais com ícones Lucide 16–18px e tokens `var(--bs-*)`.
-- Formulários que acionam IA ou integrações externas precisam de tooltip explicativo e do bloco de log de validação `handleSubmit(..., (errors) => console.log(...))` para rastreabilidade.
-
-## 5. Operações e integrações
-- Chame workers (AI, Facebook Ads, e-mail, imagens) apenas via backend principal. O frontend não deve abrir canais diretos entre containers.
-- Cada chamada ao backend explicita o contrato usado e registra o requestId no log/debugger para rastrear fatos emitidos pelos workers.
-- Estados exibidos ao usuário sempre destacam a origem (ex.: "Status confirmado pelo Worker AI"), reforçando que flags derivadas não substituem a verdade primária.
-
-## 6. Checklist rápido antes de abrir PR
-1. **Fonte** — apontou para o contrato ou cânone que suporta a regra?
-2. **UI kit** — reutilizou `creative-grid`, `creative-card`, `creative-toolbar` ou extraiu utilitário compartilhado equivalente?
-3. **Estados** — forneceu carregando/vazio/feedback e tratou erros do backend com mensagens claras?
-4. **Integração** — evitou chamar serviços externos diretamente e validou o request com o domínio responsável?
-5. **Documentação** — atualizou o contrato relevante (ou abriu issue/ADR) quando a mudança afetar regras de negócio?
+## Experimentos › Aba de Criativos (`src/pages/experiment/CriativosTab.tsx`)
+- Preserve o layout de galeria responsiva implementado com a grade `creative-grid` e os cards `creative-card`. Nunca volte a apresentar os criativos em listagens tabulares simples.
+- Cada card precisa exibir as badges de status (`statusVariant`) e de formato, headline, `primaryText` e os metadados de CTA/URL (`creative-card-meta`). Quando não houver imagem, mantenha o placeholder `creative-card-placeholder`.
+- A barra superior `creative-toolbar` deve continuar mostrando os totais com badges e os botões de ação. O botão "Gerar criativos" precisa alternar entre ícone `Sparkles` e spinner durante `requestCreatives.isPending`, e o botão "Novo Criativo" deve permanecer com o ícone `Plus`.
+- Garanta sempre os estados visuais de carregamento com spinner centralizado e o estado vazio `creative-empty-state` com ícone decorativo e instruções curtas.
+- As ações dos cards (Editar, Duplicar, Excluir, Aprovar, Preview) precisam permanecer como botões com ícones Lucide (`Edit3`, `Copy`, `Trash2`, `CheckCircle2`, `Eye`) e layout responsivo definido por `creative-card-actions`.
+- Ao ajustar estilos em `CriativosTab.css`, mantenha os mesmos espaçamentos, sombras, breakpoints e tokens de cor para assegurar hierarquia visual, responsividade e acessibilidade do grid de criativos.
+- É proibido retornar aos `alert()` do navegador para feedbacks. Reutilize o banner `creative-feedback` com variantes `creative-feedback-success|warning|error`, ícones `CheckCircle2`/`AlertTriangle`/`XCircle`, botão `creative-feedback-close` e autoexpiração de 8s (via `setTimeout`). Toda ação de upload, solicitação ou operação relevante deve acionar esse padrão com título e descrição consistentes.
+- O fluxo "Gerar criativos" deve permanecer encapsulado no modal `creative-request-modal`: valide `requestQuantity` antes de chamar `requestCreatives`, surface erros com `creative-request-error`, mantenha estados de carregamento usando `requestCreatives.isPending` (inclusive nos botões da toolbar) e feche o modal ao concluir com sucesso.
+- Estilos relacionados a feedbacks e ao modal de solicitação precisam viver em `CriativosTab.css` (ou em utilitário compartilhado dedicado) respeitando bordas arredondadas de 1rem, sombras suaves e a paleta/gradientes já definidos. Não introduza regras inline ou classes avulsas fora desse padrão.


### PR DESCRIPTION
Reverts paulofor/marketing-hub#1974