### PR TITLE
Adicionar coluna de % vs. etapa anterior no funil do experimento

### DIFF
--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -242,13 +242,14 @@ export default function ExperimentFunnelTab({
                 <tr>
                   <th style={{ minWidth: 220 }}>Etapa</th>
                   <th>Total</th>
+                  <th>% vs. etapa anterior</th>
                   <th>Custo por conv.</th>
                   <th>Únicos</th>
                   <th>Último evento</th>
                 </tr>
               </thead>
               <tbody>
-                {selectableStages.map((stage) => (
+                {selectableStages.map((stage, index) => (
                   <tr key={stage.stage}>
                     <td>
                       <div className="fw-semibold">
@@ -258,6 +259,7 @@ export default function ExperimentFunnelTab({
                     <td>
                       <strong>{stage.totalCount}</strong>
                     </td>
+                    <td>{formatRateComparedToPreviousStage(stage.totalCount, selectableStages[index - 1]?.totalCount)}</td>
                     <td>
                       {formatCostPerConversion(normalizedTotalSpend, stage.totalCount)}
                     </td>
@@ -416,4 +418,18 @@ function calculateCostPerConversion(totalSpend: number | null, totalConversions?
 function formatCostPerConversion(totalSpend: number | null, totalConversions?: number | null) {
   const cost = calculateCostPerConversion(totalSpend, totalConversions);
   return cost === null ? "—" : formatCurrency(cost);
+}
+
+function formatRateComparedToPreviousStage(
+  currentCount?: number | null,
+  previousCount?: number | null,
+) {
+  if (!currentCount || currentCount < 0) {
+    return "0%";
+  }
+  if (!previousCount || previousCount <= 0) {
+    return "—";
+  }
+  const conversionRate = (currentCount / previousCount) * 100;
+  return `${conversionRate.toFixed(1).replace(".", ",")}%`;
 }


### PR DESCRIPTION
### Motivation
- Usuário requisitou exibir, nesta tela do funil, um percentual de cada etapa em relação à etapa anterior para facilitar acompanhamento de conversões.
- Melhorar visibilidade das quedas/retornos entre etapas do funil sem alterar contratos backend.

### Description
- Adiciona a coluna de tabela `% vs. etapa anterior` em `frontend/src/pages/experiment/ExperimentFunnelTab.tsx` e passa o índice ao map para comparar com a etapa anterior. 
- Implementa `formatRateComparedToPreviousStage(currentCount, previousCount)` com regras de fallback (`—` quando não há etapa anterior válida, `0%` quando atual é zero) e formatação `pt-BR` com vírgula decimal.
- Mantém as demais colunas (total, custo por conversão, únicos, último evento) inalteradas; mudança é somente de UI/formatção no frontend.

### Testing
- Executado `cd frontend && npm run build` inicialmente (falhou por `vite: not found`) como passo automático de verificação da build.
- Executado `cd frontend && npm install` para instalar dependências e em seguida `cd frontend && npm run build`, e o build completou com sucesso.
- Não foram executados testes unitários automáticos (`npm run test`) nesta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de76f8b6f08321bd41e1c2599bb3a5)