### PR TITLE
Add funnel diagnostics backend + endpoint and surface results in UI with tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticConfig.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticConfig.java
@@ -1,0 +1,36 @@
+package com.marketinghub.experiment.funnel;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Configuração inicial dos diagnósticos estatísticos do funil.
+ * Mantém thresholds em um ponto único para facilitar evolução sem espalhar regra na UI.
+ */
+@Component
+public class ExperimentFunnelDiagnosticConfig {
+
+    private static final int MIN_OPTIMIZATION_EVENT_VOLUME_FOR_CONTEXT = 50;
+
+    private static final List<ConversionRuleSpec> PRIORITIZED_RULES = List.of(
+            new ConversionRuleSpec(ExperimentFunnelStage.VISUALIZACAO_FORM, ExperimentFunnelStage.ENVIO_FORM, 0.10),
+            new ConversionRuleSpec(ExperimentFunnelStage.ENVIO_FORM, ExperimentFunnelStage.ABERTURA_EMAIL_AMOSTRA, 0.05),
+            new ConversionRuleSpec(ExperimentFunnelStage.ACESSO_CHECKOUT, ExperimentFunnelStage.COMPRA, 0.03)
+    );
+
+    public List<ConversionRuleSpec> prioritizedRules() {
+        return PRIORITIZED_RULES;
+    }
+
+    public int minOptimizationEventVolumeForContext() {
+        return MIN_OPTIMIZATION_EVENT_VOLUME_FOR_CONTEXT;
+    }
+
+    public record ConversionRuleSpec(
+            ExperimentFunnelStage from,
+            ExperimentFunnelStage to,
+            double minAcceptableRate
+    ) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticService.java
@@ -1,0 +1,170 @@
+package com.marketinghub.experiment.funnel;
+
+import com.marketinghub.experiment.funnel.dto.ExperimentFunnelDiagnosticsResponseDto;
+import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDiagnosticDto;
+import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
+import com.marketinghub.experiment.funnel.dto.FunnelDiagnosticReasonCode;
+import com.marketinghub.experiment.funnel.dto.FunnelDiagnosticStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class ExperimentFunnelDiagnosticService {
+
+    private final ExperimentFunnelService funnelService;
+    private final ExperimentFunnelDiagnosticConfig config;
+
+    public ExperimentFunnelDiagnosticService(ExperimentFunnelService funnelService,
+                                             ExperimentFunnelDiagnosticConfig config) {
+        this.funnelService = funnelService;
+        this.config = config;
+    }
+
+    public ExperimentFunnelDiagnosticsResponseDto diagnose(Long experimentId) {
+        List<ExperimentFunnelStageDto> stages = funnelService.summarize(experimentId);
+        Map<ExperimentFunnelStage, ExperimentFunnelStageDto> byStage = stages.stream()
+                .collect(Collectors.toMap(ExperimentFunnelStageDto::getStage, stage -> stage));
+
+        List<ExperimentFunnelStageDiagnosticDto> diagnostics = config.prioritizedRules().stream()
+                .map(rule -> diagnoseRule(byStage, rule))
+                .sorted(Comparator.comparing(dto -> dto.stageKey().getOrder()))
+                .toList();
+
+        long optimizationEvents = Optional.ofNullable(byStage.get(ExperimentFunnelStage.COMPRA))
+                .map(ExperimentFunnelStageDto::getTotalCount)
+                .orElse(0L);
+        String contextualAlert = optimizationEvents < config.minOptimizationEventVolumeForContext()
+                ? "Alerta contextual: o evento principal de otimização ainda está com volume baixo para aprendizado da mídia."
+                : null;
+
+        return new ExperimentFunnelDiagnosticsResponseDto(diagnostics, contextualAlert);
+    }
+
+    private ExperimentFunnelStageDiagnosticDto diagnoseRule(Map<ExperimentFunnelStage, ExperimentFunnelStageDto> byStage,
+                                                            ExperimentFunnelDiagnosticConfig.ConversionRuleSpec rule) {
+        long attempts = Optional.ofNullable(byStage.get(rule.from()))
+                .map(ExperimentFunnelStageDto::getTotalCount)
+                .orElse(0L);
+        long successes = Optional.ofNullable(byStage.get(rule.to()))
+                .map(ExperimentFunnelStageDto::getTotalCount)
+                .orElse(0L);
+
+        if (attempts == 0 && successes == 0) {
+            return new ExperimentFunnelStageDiagnosticDto(
+                    rule.to(),
+                    rule.to().getLabel(),
+                    attempts,
+                    successes,
+                    null,
+                    rule.minAcceptableRate(),
+                    null,
+                    FunnelDiagnosticStatus.NO_DATA,
+                    FunnelDiagnosticReasonCode.NO_ATTEMPTS,
+                    "Ainda não há dados dessa etapa para concluir.",
+                    false
+            );
+        }
+
+        if (successes > attempts || (attempts == 0 && successes > 0)) {
+            return new ExperimentFunnelStageDiagnosticDto(
+                    rule.to(),
+                    rule.to().getLabel(),
+                    attempts,
+                    successes,
+                    attempts > 0 ? (double) successes / attempts : null,
+                    rule.minAcceptableRate(),
+                    null,
+                    FunnelDiagnosticStatus.TECHNICAL_ISSUE_SUSPECTED,
+                    FunnelDiagnosticReasonCode.SEQUENTIAL_INCONSISTENCY,
+                    "Possível problema técnico nesta etapa. Os números entre etapas sequenciais estão inconsistentes.",
+                    true
+            );
+        }
+
+        int attemptsFor95Confidence = (int) Math.ceil(3.0 / rule.minAcceptableRate());
+        double observedRate = attempts > 0 ? (double) successes / attempts : 0.0;
+
+        if (successes == 0) {
+            double upper95 = attempts > 0 ? 3.0 / attempts : 1.0;
+            if (attempts < attemptsFor95Confidence) {
+                return new ExperimentFunnelStageDiagnosticDto(
+                        rule.to(),
+                        rule.to().getLabel(),
+                        attempts,
+                        successes,
+                        observedRate,
+                        rule.minAcceptableRate(),
+                        upper95,
+                        FunnelDiagnosticStatus.INSUFFICIENT_DATA,
+                        FunnelDiagnosticReasonCode.LOW_SAMPLE_SIZE,
+                        "Ainda cedo para concluir nesta etapa.",
+                        false
+                );
+            }
+            if (upper95 < rule.minAcceptableRate()) {
+                return new ExperimentFunnelStageDiagnosticDto(
+                        rule.to(),
+                        rule.to().getLabel(),
+                        attempts,
+                        successes,
+                        observedRate,
+                        rule.minAcceptableRate(),
+                        upper95,
+                        FunnelDiagnosticStatus.STATISTICALLY_FAILED,
+                        FunnelDiagnosticReasonCode.RULE_OF_THREE_FAILED,
+                        "Etapa reprovada estatisticamente no limite definido.",
+                        false
+                );
+            }
+            return new ExperimentFunnelStageDiagnosticDto(
+                    rule.to(),
+                    rule.to().getLabel(),
+                    attempts,
+                    successes,
+                    observedRate,
+                    rule.minAcceptableRate(),
+                    upper95,
+                    FunnelDiagnosticStatus.WEAK_SIGNAL,
+                    FunnelDiagnosticReasonCode.RULE_OF_THREE_STILL_INCONCLUSIVE,
+                    "Sinal fraco nesta etapa. Continue coletando eventos.",
+                    false
+            );
+        }
+
+        if (observedRate < rule.minAcceptableRate()) {
+            return new ExperimentFunnelStageDiagnosticDto(
+                    rule.to(),
+                    rule.to().getLabel(),
+                    attempts,
+                    successes,
+                    observedRate,
+                    rule.minAcceptableRate(),
+                    null,
+                    FunnelDiagnosticStatus.WEAK_SIGNAL,
+                    FunnelDiagnosticReasonCode.BELOW_MIN_RATE,
+                    "Sinal fraco nesta etapa. Continue monitorando.",
+                    false
+            );
+        }
+
+        return new ExperimentFunnelStageDiagnosticDto(
+                rule.to(),
+                rule.to().getLabel(),
+                attempts,
+                successes,
+                observedRate,
+                rule.minAcceptableRate(),
+                null,
+                FunnelDiagnosticStatus.HEALTHY_OR_INCONCLUSIVE,
+                FunnelDiagnosticReasonCode.HEALTHY_OR_INCONCLUSIVE,
+                "Sem indício forte de reprovação estatística nesta etapa.",
+                false
+        );
+    }
+
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/ExperimentFunnelDiagnosticsResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/ExperimentFunnelDiagnosticsResponseDto.java
@@ -1,0 +1,9 @@
+package com.marketinghub.experiment.funnel.dto;
+
+import java.util.List;
+
+public record ExperimentFunnelDiagnosticsResponseDto(
+        List<ExperimentFunnelStageDiagnosticDto> diagnostics,
+        String contextualAlert
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/ExperimentFunnelStageDiagnosticDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/ExperimentFunnelStageDiagnosticDto.java
@@ -1,0 +1,18 @@
+package com.marketinghub.experiment.funnel.dto;
+
+import com.marketinghub.experiment.funnel.ExperimentFunnelStage;
+
+public record ExperimentFunnelStageDiagnosticDto(
+        ExperimentFunnelStage stageKey,
+        String stageLabel,
+        long attempts,
+        long successes,
+        Double observedRate,
+        Double minAcceptableRate,
+        Double upper95RateIfZero,
+        FunnelDiagnosticStatus status,
+        FunnelDiagnosticReasonCode reasonCode,
+        String message,
+        boolean technicalIssueSuspected
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/FunnelDiagnosticReasonCode.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/FunnelDiagnosticReasonCode.java
@@ -1,0 +1,11 @@
+package com.marketinghub.experiment.funnel.dto;
+
+public enum FunnelDiagnosticReasonCode {
+    NO_ATTEMPTS,
+    LOW_SAMPLE_SIZE,
+    SEQUENTIAL_INCONSISTENCY,
+    RULE_OF_THREE_FAILED,
+    RULE_OF_THREE_STILL_INCONCLUSIVE,
+    BELOW_MIN_RATE,
+    HEALTHY_OR_INCONCLUSIVE
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/FunnelDiagnosticStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/FunnelDiagnosticStatus.java
@@ -1,0 +1,10 @@
+package com.marketinghub.experiment.funnel.dto;
+
+public enum FunnelDiagnosticStatus {
+    NO_DATA,
+    INSUFFICIENT_DATA,
+    TECHNICAL_ISSUE_SUSPECTED,
+    WEAK_SIGNAL,
+    STATISTICALLY_FAILED,
+    HEALTHY_OR_INCONCLUSIVE
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentFunnelController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentFunnelController.java
@@ -1,6 +1,8 @@
 package com.marketinghub.experiment.web;
 
+import com.marketinghub.experiment.funnel.ExperimentFunnelDiagnosticService;
 import com.marketinghub.experiment.funnel.ExperimentFunnelService;
+import com.marketinghub.experiment.funnel.dto.ExperimentFunnelDiagnosticsResponseDto;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelResetResponse;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
 import com.marketinghub.experiment.funnel.dto.RegisterExperimentFunnelEventRequest;
@@ -18,10 +20,17 @@ import java.util.List;
 public class ExperimentFunnelController {
 
     private final ExperimentFunnelService experimentFunnelService;
+    private final ExperimentFunnelDiagnosticService experimentFunnelDiagnosticService;
 
     @GetMapping
     public List<ExperimentFunnelStageDto> summarize(@PathVariable Long experimentId) {
         return experimentFunnelService.summarize(experimentId);
+    }
+
+
+    @GetMapping("/diagnostics")
+    public ExperimentFunnelDiagnosticsResponseDto diagnostics(@PathVariable Long experimentId) {
+        return experimentFunnelDiagnosticService.diagnose(experimentId);
     }
 
     @PostMapping("/events")

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticServiceTest.java
@@ -1,0 +1,100 @@
+package com.marketinghub.experiment.funnel;
+
+import com.marketinghub.experiment.funnel.dto.ExperimentFunnelDiagnosticsResponseDto;
+import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
+import com.marketinghub.experiment.funnel.dto.FunnelDiagnosticStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExperimentFunnelDiagnosticServiceTest {
+
+    @Mock
+    private ExperimentFunnelService funnelService;
+
+    private ExperimentFunnelDiagnosticService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ExperimentFunnelDiagnosticService(funnelService, new ExperimentFunnelDiagnosticConfig());
+    }
+
+    @Test
+    void marksStageAsStatisticallyFailedWhenRuleOfThreeDropsBelowMinimumRate() {
+        when(funnelService.summarize(10L)).thenReturn(stageList(
+                stage(ExperimentFunnelStage.VISUALIZACAO_FORM, 40),
+                stage(ExperimentFunnelStage.ENVIO_FORM, 0),
+                stage(ExperimentFunnelStage.COMPRA, 0)
+        ));
+
+        ExperimentFunnelDiagnosticsResponseDto response = service.diagnose(10L);
+
+        assertThat(response.diagnostics())
+                .anySatisfy(item -> {
+                    if (item.stageKey() == ExperimentFunnelStage.ENVIO_FORM) {
+                        assertThat(item.status()).isEqualTo(FunnelDiagnosticStatus.STATISTICALLY_FAILED);
+                        assertThat(item.upper95RateIfZero()).isLessThan(item.minAcceptableRate());
+                    }
+                });
+    }
+
+    @Test
+    void marksTechnicalIssueWhenSuccessesAreHigherThanAttempts() {
+        when(funnelService.summarize(20L)).thenReturn(stageList(
+                stage(ExperimentFunnelStage.ENVIO_FORM, 5),
+                stage(ExperimentFunnelStage.ABERTURA_EMAIL_AMOSTRA, 8),
+                stage(ExperimentFunnelStage.COMPRA, 0)
+        ));
+
+        ExperimentFunnelDiagnosticsResponseDto response = service.diagnose(20L);
+
+        assertThat(response.diagnostics())
+                .anySatisfy(item -> {
+                    if (item.stageKey() == ExperimentFunnelStage.ABERTURA_EMAIL_AMOSTRA) {
+                        assertThat(item.status()).isEqualTo(FunnelDiagnosticStatus.TECHNICAL_ISSUE_SUSPECTED);
+                        assertThat(item.technicalIssueSuspected()).isTrue();
+                    }
+                });
+    }
+
+    @Test
+    void marksInsufficientDataWhenStillBelowMinimumAttemptsForRuleOfThree() {
+        when(funnelService.summarize(30L)).thenReturn(stageList(
+                stage(ExperimentFunnelStage.VISUALIZACAO_FORM, 12),
+                stage(ExperimentFunnelStage.ENVIO_FORM, 0),
+                stage(ExperimentFunnelStage.COMPRA, 0)
+        ));
+
+        ExperimentFunnelDiagnosticsResponseDto response = service.diagnose(30L);
+
+        assertThat(response.diagnostics())
+                .anySatisfy(item -> {
+                    if (item.stageKey() == ExperimentFunnelStage.ENVIO_FORM) {
+                        assertThat(item.status()).isEqualTo(FunnelDiagnosticStatus.INSUFFICIENT_DATA);
+                    }
+                });
+        assertThat(response.contextualAlert()).contains("Alerta contextual");
+    }
+
+    private List<ExperimentFunnelStageDto> stageList(ExperimentFunnelStageDto... stages) {
+        return Arrays.asList(stages);
+    }
+
+    private ExperimentFunnelStageDto stage(ExperimentFunnelStage stage, long total) {
+        ExperimentFunnelStageDto dto = new ExperimentFunnelStageDto();
+        dto.setStage(stage);
+        dto.setLabel(stage.getLabel());
+        dto.setOrder(stage.getOrder());
+        dto.setTotalCount(total);
+        return dto;
+    }
+}

--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -76,6 +76,7 @@ O cartão também lista itens operacionais que não travam o worker, mas devem s
 2. **Custo por etapa** – o cartão mostra o gasto total sincronizado pela Marketing API do Meta Ads e divide o valor por conversão em cada etapa, permitindo encontrar gargalos sem sair do experimento. (Fonte externa: [Meta Marketing API](https://developers.facebook.com/docs/marketing-api/)).
 3. **Zerar contagens** – o botão atualiza `experiment.funnel_reset_at`, e somente eventos com `occurred_at >= funnel_reset_at` permanecem visíveis. Use quando testes internos poluírem o funil sem necessidade de liberar novamente o worker.
 4. **Execução registrada por anúncio** – cada criativo listado traz sua referência de rastreio e a tabela de conversões para as etapas 3 a 9, permitindo diagnosticar rapidamente qual anúncio sustentou o restante do funil.
+5. **Diagnóstico estatístico por etapa** – o backend expõe `GET /api/experiments/{experimentId}/funnel/diagnostics` com status por transição prioritária, separando explicitamente risco estatístico (`INSUFFICIENT_DATA`, `WEAK_SIGNAL`, `STATISTICALLY_FAILED`) de suspeita técnica (`TECHNICAL_ISSUE_SUSPECTED`). A UI consome o diagnóstico e não replica regras críticas.
 
 ## 9. Dependências externas e domínio publicado
 
@@ -86,5 +87,5 @@ O cartão também lista itens operacionais que não travam o worker, mas devem s
 
 - `system-governance-canon.v2.md` – precedência canônica e critérios de criação de novos cânones.
 - `ExperimentReadinessService` (backend) – cálculo dos bloqueios.
-- Endpoints: `/api/facebook-campaigns/experiments-ready`, `/api/facebook-pixels`.
+- Endpoints: `/api/facebook-campaigns/experiments-ready`, `/api/facebook-pixels`, `/api/experiments/{experimentId}/funnel/diagnostics`.
 - Tabelas do schema `marketinghubdb`: `experiment`, `creative`, `lead_portal_flow`, `targeting_element`, `experiment_campaign_metric`.

--- a/frontend/src/api/experiment/useExperimentFunnelDiagnostics.ts
+++ b/frontend/src/api/experiment/useExperimentFunnelDiagnostics.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { ExperimentFunnelStage } from "./useExperimentFunnel";
+
+export type FunnelDiagnosticStatus =
+  | "NO_DATA"
+  | "INSUFFICIENT_DATA"
+  | "TECHNICAL_ISSUE_SUSPECTED"
+  | "WEAK_SIGNAL"
+  | "STATISTICALLY_FAILED"
+  | "HEALTHY_OR_INCONCLUSIVE";
+
+export interface ExperimentFunnelStageDiagnostic {
+  stageKey: ExperimentFunnelStage;
+  stageLabel: string;
+  attempts: number;
+  successes: number;
+  observedRate?: number | null;
+  minAcceptableRate?: number | null;
+  upper95RateIfZero?: number | null;
+  status: FunnelDiagnosticStatus;
+  reasonCode: string;
+  message: string;
+  technicalIssueSuspected: boolean;
+}
+
+export interface ExperimentFunnelDiagnosticsResponse {
+  diagnostics: ExperimentFunnelStageDiagnostic[];
+  contextualAlert?: string | null;
+}
+
+export function useExperimentFunnelDiagnostics(experimentId?: string) {
+  return useQuery<ExperimentFunnelDiagnosticsResponse>({
+    queryKey: ["experiment", experimentId, "funnel", "diagnostics"],
+    queryFn: async () => {
+      const { data } = await axios.get<ExperimentFunnelDiagnosticsResponse>(
+        `/api/experiments/${experimentId}/funnel/diagnostics`,
+      );
+      return data;
+    },
+    enabled: Boolean(experimentId),
+  });
+}

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
@@ -6,11 +6,13 @@ import ExperimentFunnelTab from "./ExperimentFunnelTab";
 import { useExperimentFunnel } from "../../api/experiment/useExperimentFunnel";
 import { useRegisterExperimentFunnelEvent } from "../../api/experiment/useRegisterExperimentFunnelEvent";
 import { useResetExperimentFunnel } from "../../api/experiment/useResetExperimentFunnel";
+import { useExperimentFunnelDiagnostics } from "../../api/experiment/useExperimentFunnelDiagnostics";
 import "@testing-library/jest-dom/vitest";
 
 vi.mock("../../api/experiment/useExperimentFunnel");
 vi.mock("../../api/experiment/useRegisterExperimentFunnelEvent");
 vi.mock("../../api/experiment/useResetExperimentFunnel");
+vi.mock("../../api/experiment/useExperimentFunnelDiagnostics");
 
 const renderWithClient = (ui: ReactElement) => {
   const client = new QueryClient();
@@ -61,6 +63,30 @@ describe("ExperimentFunnelTab", () => {
       mutateAsync: vi.fn(),
       isPending: false,
     });
+
+    (useExperimentFunnelDiagnostics as unknown as Mock).mockReturnValue({
+      data: {
+        diagnostics: [
+          {
+            stageKey: "ENVIO_FORM",
+            stageLabel: "Envio do formulário",
+            attempts: 39,
+            successes: 0,
+            observedRate: 0,
+            minAcceptableRate: 0.1,
+            upper95RateIfZero: 0.0769,
+            status: "STATISTICALLY_FAILED",
+            reasonCode: "RULE_OF_THREE_FAILED",
+            message: "Etapa reprovada estatisticamente no limite definido.",
+            technicalIssueSuspected: false,
+          },
+        ],
+        contextualAlert:
+          "Alerta contextual: o evento principal de otimização ainda está com volume baixo para aprendizado da mídia.",
+      },
+      isLoading: false,
+      isError: false,
+    });
   });
 
   it("highlights the total spend", () => {
@@ -77,6 +103,14 @@ describe("ExperimentFunnelTab", () => {
     expect(screen.getByText(/Última sincronização/)).toBeInTheDocument();
   });
 
+  it("renders the diagnostic block with backend messages", () => {
+    renderWithClient(<ExperimentFunnelTab experimentId="42" totalSpend={100} />);
+
+    expect(screen.getByText("Diagnóstico estatístico do funil")).toBeInTheDocument();
+    expect(screen.getByText(/Etapa reprovada estatisticamente/)).toBeInTheDocument();
+    expect(screen.getByText(/Alerta contextual/)).toBeInTheDocument();
+  });
+
   it("shows the cost per conversion for each stage", () => {
     renderWithClient(
       <ExperimentFunnelTab experimentId="42" totalSpend={100} />,
@@ -85,10 +119,10 @@ describe("ExperimentFunnelTab", () => {
     const rows = screen.getAllByRole("row");
     const firstStageRow = rows[1];
     const firstStageCells = within(firstStageRow).getAllByRole("cell");
-    expect(firstStageCells[4]).toHaveTextContent(/R\$\s*1,00/);
+    expect(firstStageCells[3]).toHaveTextContent(/R\$\s*1,00/);
 
     const secondStageRow = rows[2];
     const secondStageCells = within(secondStageRow).getAllByRole("cell");
-    expect(secondStageCells[4]).toHaveTextContent("—");
+    expect(secondStageCells[3]).toHaveTextContent("—");
   });
 });

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -4,6 +4,7 @@ import { toast } from "react-toastify";
 import { useExperimentFunnel, type ExperimentFunnelStageSummary } from "../../api/experiment/useExperimentFunnel";
 import { useRegisterExperimentFunnelEvent } from "../../api/experiment/useRegisterExperimentFunnelEvent";
 import { useResetExperimentFunnel } from "../../api/experiment/useResetExperimentFunnel";
+import { useExperimentFunnelDiagnostics, type FunnelDiagnosticStatus } from "../../api/experiment/useExperimentFunnelDiagnostics";
 
 const currencyFormatter = new Intl.NumberFormat("pt-BR", {
   style: "currency",
@@ -33,6 +34,7 @@ export default function ExperimentFunnelTab({
   spendLastSyncedAt,
 }: ExperimentFunnelTabProps) {
   const { data, isLoading, isError } = useExperimentFunnel(experimentId);
+  const diagnosticsQuery = useExperimentFunnelDiagnostics(experimentId);
   const stages = (data ?? []).slice().sort((a, b) => a.order - b.order);
   const normalizedTotalSpend = normalizeSpend(totalSpend);
   const fallbackStages: ExperimentFunnelStageSummary[] = [
@@ -272,6 +274,43 @@ export default function ExperimentFunnelTab({
           </div>
         )}
 
+        {diagnosticsQuery.isError ? (
+          <div className="alert alert-warning py-2 mt-4" role="alert">
+            Não foi possível carregar o diagnóstico estatístico agora.
+          </div>
+        ) : null}
+
+        {diagnosticsQuery.data?.diagnostics?.length ? (
+          <div className="mt-4">
+            <h6 className="mb-2">Diagnóstico estatístico do funil</h6>
+            {diagnosticsQuery.data.contextualAlert ? (
+              <div className="alert alert-warning py-2" role="alert">
+                {diagnosticsQuery.data.contextualAlert}
+              </div>
+            ) : null}
+            <div className="list-group mb-3">
+              {diagnosticsQuery.data.diagnostics.map((item) => (
+                <div key={item.stageKey} className="list-group-item">
+                  <div className="d-flex flex-wrap justify-content-between gap-2 align-items-start">
+                    <div>
+                      <div className="fw-semibold">{item.stageLabel}</div>
+                      <div className="small text-muted">{item.message}</div>
+                      <div className="small text-muted">
+                        Tentativas: {item.attempts} · Sucessos: {item.successes}
+                        {item.minAcceptableRate != null ? ` · Mín. aceitável: ${formatPercent(item.minAcceptableRate)}` : ""}
+                        {item.upper95RateIfZero != null ? ` · Limite 95% (0 sucessos): ${formatPercent(item.upper95RateIfZero)}` : ""}
+                      </div>
+                    </div>
+                    <span className={`badge ${statusBadgeClass(item.status)}`} title="Diagnóstico calculado no backend">
+                      {statusLabel(item.status)}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
         <hr className="my-4" />
         <form className="row g-3 align-items-end" onSubmit={onSubmit}>
           <div className="col-12 col-lg-3">
@@ -432,4 +471,44 @@ function formatRateComparedToPreviousStage(
   }
   const conversionRate = (currentCount / previousCount) * 100;
   return `${conversionRate.toFixed(1).replace(".", ",")}%`;
+}
+
+function formatPercent(value?: number | null) {
+  if (value == null || Number.isNaN(value)) {
+    return "—";
+  }
+  return `${(value * 100).toFixed(1).replace(".", ",")}%`;
+}
+
+function statusLabel(status: FunnelDiagnosticStatus) {
+  switch (status) {
+    case "NO_DATA":
+      return "Sem dados";
+    case "INSUFFICIENT_DATA":
+      return "Ainda cedo";
+    case "TECHNICAL_ISSUE_SUSPECTED":
+      return "Suspeita técnica";
+    case "WEAK_SIGNAL":
+      return "Sinal fraco";
+    case "STATISTICALLY_FAILED":
+      return "Reprovada";
+    default:
+      return "Saudável/Inconclusiva";
+  }
+}
+
+function statusBadgeClass(status: FunnelDiagnosticStatus) {
+  switch (status) {
+    case "NO_DATA":
+    case "INSUFFICIENT_DATA":
+      return "text-bg-secondary";
+    case "TECHNICAL_ISSUE_SUSPECTED":
+      return "text-bg-warning";
+    case "WEAK_SIGNAL":
+      return "text-bg-info";
+    case "STATISTICALLY_FAILED":
+      return "text-bg-danger";
+    default:
+      return "text-bg-success";
+  }
 }


### PR DESCRIPTION
### Motivation

- Centralize statistical diagnostic rules and thresholds for experiment funnels to avoid duplicating logic in the UI.
- Provide a backend endpoint to evaluate prioritized funnel transitions and surface both statistical risk and technical inconsistency signals.
- Expose diagnostics to the frontend so the UI can display backend-calculated guidance and contextual alerts instead of re-implementing rules.

### Description

- Added `ExperimentFunnelDiagnosticConfig` to hold prioritized conversion rules and the minimum optimization event volume in a single place.
- Implemented `ExperimentFunnelDiagnosticService` plus DTOs and enums (`ExperimentFunnelDiagnosticsResponseDto`, `ExperimentFunnelStageDiagnosticDto`, `FunnelDiagnosticStatus`, `FunnelDiagnosticReasonCode`) to compute per-transition diagnostics using rule-of-three heuristics and consistency checks.
- Exposed `GET /api/experiments/{experimentId}/funnel/diagnostics` in `ExperimentFunnelController` and added a frontend hook `useExperimentFunnelDiagnostics` plus UI support in `ExperimentFunnelTab` to render diagnostics, badges and contextual alerts; updated docs to reference the new endpoint.
- Added unit tests: `ExperimentFunnelDiagnosticServiceTest` for backend logic and updated `ExperimentFunnelTab.test.tsx` (Vitest) to include diagnostic rendering assertions and minor test adjustments to table column indices.

### Testing

- Added `ExperimentFunnelDiagnosticServiceTest` (JUnit) which exercises rule-of-three failure, technical inconsistency and insufficient-data branches in `ExperimentFunnelDiagnosticService` and updated `ExperimentFunnelTab.test.tsx` (Vitest) to assert UI rendering of backend diagnostics.
- The new and updated tests are present in the diff (`backend/.../ExperimentFunnelDiagnosticServiceTest.java` and `frontend/.../ExperimentFunnelTab.test.tsx`).
- No automated test run results are included in this rollout transcript, so CI/pass/fail status is not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de974db084832194de6ea7ac5caf4a)