### PR TITLE
Render additional min-acceptable override lines for ENVIO_FORM in ExperimentFunnelTab

### DIFF
--- a/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
@@ -109,6 +109,9 @@ describe("ExperimentFunnelTab", () => {
     expect(screen.getByText("Diagnóstico estatístico do funil")).toBeInTheDocument();
     expect(screen.getByText(/Etapa reprovada estatisticamente/)).toBeInTheDocument();
     expect(screen.getByText(/Alerta contextual/)).toBeInTheDocument();
+    expect(screen.getByText("Mín. aceitável: 5,0%")).toBeInTheDocument();
+    expect(screen.getByText("Mín. aceitável: 3,0%")).toBeInTheDocument();
+    expect(screen.getByText("Mín. aceitável: 2,0%")).toBeInTheDocument();
   });
 
   it("shows the cost per conversion for each stage", () => {

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -300,6 +300,11 @@ export default function ExperimentFunnelTab({
                         {item.minAcceptableRate != null ? ` · Mín. aceitável: ${formatPercent(item.minAcceptableRate)}` : ""}
                         {item.upper95RateIfZero != null ? ` · Limite 95% (0 sucessos): ${formatPercent(item.upper95RateIfZero)}` : ""}
                       </div>
+                      {minAcceptableOverrideLines(item.stageKey).map((line) => (
+                        <div key={`${item.stageKey}-${line}`} className="small text-muted">
+                          {line}
+                        </div>
+                      ))}
                     </div>
                     <span className={`badge ${statusBadgeClass(item.status)}`} title="Diagnóstico calculado no backend">
                       {statusLabel(item.status)}
@@ -511,4 +516,12 @@ function statusBadgeClass(status: FunnelDiagnosticStatus) {
     default:
       return "text-bg-success";
   }
+}
+
+function minAcceptableOverrideLines(stageKey: string) {
+  if (stageKey !== "ENVIO_FORM") {
+    return [];
+  }
+
+  return ["Mín. aceitável: 5,0%", "Mín. aceitável: 3,0%", "Mín. aceitável: 2,0%"];
 }


### PR DESCRIPTION
### Motivation
- The funnel diagnostics UI needs to display extra, hardcoded minimum-acceptable rate lines for a specific stage to communicate legacy/override thresholds not provided by the backend.

### Description
- Added a helper `minAcceptableOverrideLines(stageKey: string)` that returns override lines when `stageKey === "ENVIO_FORM"`.
- Rendered the returned lines inside the diagnostics item block using a `map` so each override appears as its own `div` with `small text-muted` styling.
- Updated `ExperimentFunnelTab.test.tsx` to assert the presence of the three new lines (`"Mín. aceitável: 5,0%"`, `"Mín. aceitável: 3,0%"`, and `"Mín. aceitável: 2,0%"`).

### Testing
- Ran the Jest unit tests for `ExperimentFunnelTab` (`ExperimentFunnelTab.test.tsx`) and the updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deae558240832183035089fb645fc0)