### PR TITLE
AI Hub: **Resumo das alterações**
- Adicionei a coluna `system_user_access_token` à tabela `fb_account` via novo changeset Liquibase (`V2026_11_30__add_fb_account_system_user_token.sql`) e atualizei o `db.changelog-master`.
- Ampliei o domínio do backend …

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccount.java
@@ -119,6 +119,14 @@ public class FacebookAccount {
     @Column(columnDefinition = "LONGTEXT")
     private String appSecret;
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Column(name = "system_user_access_token", columnDefinition = "LONGTEXT")
+    private String systemUserAccessToken;
+    @Transient
+    @JsonIgnore
+    @Setter(AccessLevel.NONE)
+    private boolean systemUserAccessTokenProvided;
+
     @Column(name = "worker_enabled")
     private boolean workerEnabled;
 
@@ -179,6 +187,22 @@ public class FacebookAccount {
     @JsonIgnore
     public boolean isAccessTokenProvided() {
         return accessTokenProvided;
+    }
+
+    public void setSystemUserAccessToken(String systemUserAccessToken) {
+        this.systemUserAccessToken = systemUserAccessToken;
+    }
+
+    @JsonSetter("systemUserAccessToken")
+    public void jsonSystemUserAccessTokenSetter(String systemUserAccessToken) {
+        this.systemUserAccessTokenProvided = true;
+        this.systemUserAccessToken = systemUserAccessToken;
+    }
+
+    @Transient
+    @JsonIgnore
+    public boolean isSystemUserAccessTokenProvided() {
+        return systemUserAccessTokenProvided;
     }
 
     public void setDefaultPageId(String defaultPageId) {

--- a/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/ads/FacebookAccountController.java
@@ -109,6 +109,10 @@ public class FacebookAccountController {
             }
         }
 
+        if (account.isSystemUserAccessTokenProvided()) {
+            persisted.setSystemUserAccessToken(account.getSystemUserAccessToken());
+        }
+
         if (account.isAppSecretProvided()) {
             persisted.overwriteAppSecret(account.getAppSecret());
         }
@@ -207,6 +211,7 @@ public class FacebookAccountController {
         account.setName(trim(account.getName()));
         account.setCurrency(trim(account.getCurrency()));
         account.setAccessToken(trimToNull(account.getAccessToken()));
+        account.setSystemUserAccessToken(trimToNull(account.getSystemUserAccessToken()));
         account.setAuthorizedUserId(trimToNull(account.getAuthorizedUserId()));
         account.setAuthorizedUserName(trimToNull(account.getAuthorizedUserName()));
         account.setAuthorizedUserEmail(trimToNull(account.getAuthorizedUserEmail()));
@@ -265,6 +270,7 @@ public class FacebookAccountController {
             account.getId(),
             account.getAdAccountId(),
             account.getAccessToken(),
+            account.getSystemUserAccessToken(),
             account.getAppId(),
             account.getAppSecret(),
             account.getDefaultPageId(),
@@ -425,6 +431,7 @@ public class FacebookAccountController {
         Long accountId,
         String adAccountId,
         String accessToken,
+        String systemUserAccessToken,
         String appId,
         String appSecret,
         String defaultPageId,

--- a/backend/ads-service/src/main/resources/db/changelog/V2026_11_30__add_fb_account_system_user_token.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2026_11_30__add_fb_account_system_user_token.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--changeset repo:2026-11-30-add-fb-account-system-user-token dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'fb_account' AND column_name = 'system_user_access_token';
+ALTER TABLE fb_account
+    ADD COLUMN system_user_access_token LONGTEXT AFTER app_secret;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -258,6 +258,9 @@ databaseChangeLog:
       file: V2026_05_10__support_lead_forms.sql
       relativeToChangelogFile: true
   - include:
+      file: V2026_11_30__add_fb_account_system_user_token.sql
+      relativeToChangelogFile: true
+  - include:
       file: V2026_05_20__link_experiment_to_fb_page.sql
       relativeToChangelogFile: true
   - include:

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -846,6 +846,7 @@ allow variants to be created before an experiment is defined.
 - `authorized_user_email` VARCHAR(320)
 - `app_id` VARCHAR(255)
 - `app_secret` LONGTEXT
+- `system_user_access_token` LONGTEXT
 - `token_renewal_enabled` TINYINT(1) DEFAULT 0
 - `token_renewal_status` VARCHAR(40)
 - `token_renewal_last_attempt_at` DATETIME
@@ -875,6 +876,8 @@ em `token_renewal_last_error` quando a renovação falha. A conta marcada como
 `worker_enabled = 1` é exposta pelo endpoint `GET /api/accounts/facebook/worker-config`
 e fornece os parâmetros padrão utilizados pelo `facebook-ads-worker` (ID da conta
 de anúncios, token, App ID/Secret, página fallback, orçamento diário etc.).
+O campo `system_user_access_token` armazena o token privilegiado do usuário de sistema
+necessário para criar pixels e, futuramente, gerenciar públicos diretamente pela API.
 
 ### ig_account
 

--- a/docs/modelo-dados.md
+++ b/docs/modelo-dados.md
@@ -430,6 +430,7 @@ fb_account|authorized_user_name|varchar(255)|YES|NULL||
 fb_account|authorized_user_email|varchar(320)|YES|NULL||
 fb_account|app_id|varchar(255)|YES|NULL||
 fb_account|app_secret|longtext|YES|NULL||
+fb_account|system_user_access_token|longtext|YES|NULL||
 fb_account|token_renewal_enabled|tinyint(1)|NO|0||
 fb_account|token_renewal_status|varchar(40)|YES|NULL||
 fb_account|token_renewal_last_attempt_at|datetime|YES|NULL||
@@ -1445,7 +1446,7 @@ visual_proof|proof_type|varchar(255)|YES|NULL||
 
 ### `fb_account`
 - **Finalidade da tabela:** Armazena dados relacionados a **fb_account** no contexto do Marketing Hub.
-- **Campos (34):**
+- **Campos (35):**
   - `id`: Identificador único do registro. (tipo `bigint(20)`; obrigatório; chave `PRI`).
   - `currency`: Campo usado para armazenar informações de **currency**. (tipo `varchar(255)`; opcional).
   - `name`: Nome de exibição do registro. (tipo `varchar(255)`; opcional).
@@ -1457,6 +1458,7 @@ visual_proof|proof_type|varchar(255)|YES|NULL||
   - `authorized_user_email`: Campo usado para armazenar informações de **authorized user email**. (tipo `varchar(320)`; opcional).
   - `app_id`: Chave de referência para o registro relacionado de **app**. (tipo `varchar(255)`; opcional).
   - `app_secret`: Campo usado para armazenar informações de **app secret**. (tipo `longtext`; opcional).
+  - `system_user_access_token`: Campo usado para armazenar o **token de usuário do sistema** utilizado pelo worker do Facebook Ads. (tipo `longtext`; opcional).
   - `token_renewal_enabled`: Campo usado para armazenar informações de **token renewal enabled**. (tipo `tinyint(1)`; obrigatório; default `0`).
   - `token_renewal_status`: Campo usado para armazenar informações de **token renewal status**. (tipo `varchar(40)`; opcional).
   - `token_renewal_last_attempt_at`: Campo usado para armazenar informações de **token renewal last attempt at**. (tipo `datetime`; opcional).

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -131,6 +131,13 @@ public class FacebookAdsService {
         return token;
     }
 
+    private String resolveAccessToken(String overrideToken) {
+        if (hasText(overrideToken)) {
+            return overrideToken.trim();
+        }
+        return requireAccessToken();
+    }
+
     public void updateAccessToken(String newToken) {
         if (!hasText(newToken)) {
             throw new IllegalArgumentException("newToken must not be blank");
@@ -174,24 +181,32 @@ public class FacebookAdsService {
     }
 
     public String createPixel(String adAccountId, String name) {
+        return createPixel(adAccountId, name, null);
+    }
+
+    public String createPixel(String adAccountId, String name, String accessTokenOverride) {
         if (!hasText(adAccountId)) {
             throw new IllegalArgumentException("adAccountId must not be blank");
         }
         Map<String, Object> body = new HashMap<>();
         body.put("name", name);
-        body.put("access_token", requireAccessToken());
+        body.put("access_token", resolveAccessToken(accessTokenOverride));
         String path = buildVersionedPath("/act_" + adAccountId + "/adspixels");
         JsonNode response = executePost(path, body);
         return response.path("id").asText();
     }
 
     public String fetchPixelCode(String pixelId) {
+        return fetchPixelCode(pixelId, null);
+    }
+
+    public String fetchPixelCode(String pixelId, String accessTokenOverride) {
         if (!hasText(pixelId)) {
             return null;
         }
         String path = UriComponentsBuilder.fromPath(buildVersionedPath("/" + pixelId))
             .queryParam("fields", "code")
-            .queryParam("access_token", requireAccessToken())
+            .queryParam("access_token", resolveAccessToken(accessTokenOverride))
             .build()
             .toString();
         FacebookApiResponse response = executeGet(path);

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/configuration/FacebookWorkerConfigurationClient.java
@@ -101,6 +101,7 @@ public class FacebookWorkerConfigurationClient {
         Long accountId,
         String adAccountId,
         String accessToken,
+        String systemUserAccessToken,
         String appId,
         String appSecret,
         String defaultPageId,

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookpixel/FacebookPixelService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookpixel/FacebookPixelService.java
@@ -82,6 +82,11 @@ public class FacebookPixelService {
             LOGGER.warn("Facebook ad account id is not configured; skipping pixel creation");
             return;
         }
+        if (!StringUtils.hasText(config.systemUserAccessToken())) {
+            LOGGER.warn("Facebook system user access token is not configured; skipping pixel creation");
+            return;
+        }
+        String systemUserToken = config.systemUserAccessToken().trim();
         List<ExperimentPixel> experiments = fetchExperimentsReadyForPixel();
         if (experiments.isEmpty()) {
             return;
@@ -89,8 +94,8 @@ public class FacebookPixelService {
         for (ExperimentPixel exp : experiments) {
             try {
                 String pixelName = buildPixelName(exp);
-                String pixelId = facebookAdsService.createPixel(config.adAccountId(), pixelName);
-                String pixelCode = facebookAdsService.fetchPixelCode(pixelId);
+                String pixelId = facebookAdsService.createPixel(config.adAccountId(), pixelName, systemUserToken);
+                String pixelCode = facebookAdsService.fetchPixelCode(pixelId, systemUserToken);
                 registerPixel(exp.experimentId(), pixelId, pixelCode);
             } catch (Exception ex) {
                 LOGGER.error(

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -654,6 +654,7 @@ class FacebookCampaignServiceTest {
             1L,
             "1",
             "token",
+            "system-token",
             "app",
             "secret",
             "42",
@@ -1172,6 +1173,7 @@ class FacebookCampaignServiceTest {
             1L,
             "1",
             accessToken,
+            accessToken,
             "app",
             "secret",
             "42",
@@ -1194,6 +1196,7 @@ class FacebookCampaignServiceTest {
         return new FacebookWorkerConfiguration(
             1L,
             "1",
+            accessToken,
             accessToken,
             "app",
             "secret",


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Vamos criar mais um campo na tabela fb_count. Vai ser o token de sistema do facebook ads. Vou inserir lá manualmente.
Esse token deve ser usado no Facebook Ads Worker para a criação de pixel e manipulação de publicos ( que será desenvolvido no futuro )
Altere a criação do pixel para usar esse campo novo.

use a tool de banco de dados para pesquisar as informações necessárias
Teste a compilação dos módulos alterados
use a tool de web search para pesquisar documentação na internet se necessário
Faça os testes necessários para garantir que a solicitação está realmente atendida.
Evite solicitações de um container diretamente para outro que não seja o backend principal da aplicação. E o backend acessando o banco de dados.
use a tool de web search para acessar a documentação da api de Meta Ad
Voce pode usar a tool de web search para acessar o log do modulo Facebook Ads Worker na url : http://191.252.120.96:8082/public/runtime-logs/tail?lines=300
O modelo de dados do experimento e seus relacionamentos você encontra em: docs/modelo-dados-experimento.md
Se fizer alterações ajuste o modelo.
Temos vários módulos com objetivos bem específicos:
Objetivo de alguns dos principais módulos do sistema:

Facebook Ads Worker -> integração com a API da Meta
Worker AI -> Integração com modelos OpenAi
MarketingHub FrontEnd e BackEnd --> Onde o administrador do MArketing Hub interage com todo o sistema
lead-portal-payments-service  --> A parte de pagamentos, atualmente integrado com Mercado Pago
lead-portal-backend-1 / front-end --> onde os leads são direcionados após o anuncio.
email-service --> tratamento de envio de e-mails integrado ao amazona SES
image-watermark-service -> geração de marca dagua nas imagens para virar amostras
image-zipper-service --> montar zip dos produtos e amostrar para deixar disponível para o cliente ou lead
Use como base de regras canonicas: docs/canonical/system-governance-canon.v2.md
Lembrando que o nosso banco de dados principal de produção é o MySql 5.7

**Resumo das alterações:**
**Resumo das alterações**
- Adicionei a coluna `system_user_access_token` à tabela `fb_account` via novo changeset Liquibase (`V2026_11_30__add_fb_account_system_user_token.sql`) e atualizei o `db.changelog-master`.
- Ampliei o domínio do backend (entidade `FacebookAccount`, controller e DTO `FacebookWorkerConfiguration`) para aceitar o novo token, preservando atualizações condicionais e normalização de dados. O campo é tratado como `WRITE_ONLY` na API para reduzir exposição.
- O Facebook Ads Worker agora recebe o novo campo pelo `FacebookWorkerConfigurationClient`, valida se ele existe antes de criar pixels e passa o token de usuário do sistema aos novos métodos sobrecarregados `createPixel(..., accessTokenOverride)` e `fetchPixelCode(..., accessTokenOverride)` em `FacebookAdsService`.
- Ajustei os testes unitários que instanciam `FacebookWorkerConfiguration` para o novo parâmetro.
- Atualizei a documentação (`docs/modelo-dados.md` e `docs/data-model.md`) para refletir o novo atributo e seu propósito operacional.

**Banco de dados**
- Consumi a ferramenta `db_query` para inspecionar o esquema atual do `fb_account` antes da mudança.
- Novo arquivo: `backend/ads-service/src/main/resources/db/changelog/V2026_11_30__add_fb_account_system_user_token.sql`.
- `db.changelog-master.yaml` atualizado para incluir o changeset.
- Após publicar, será necessário preencher manualmente `fb_account.system_user_access_token` para a conta usada pelo worker, conforme solicitado.

**Documentação e referências**
- Consultei a documentação oficial “Graph API Reference v25.0: Ad Account Adspixels” (https://developers.facebook.com/docs/marketing-api/reference/ad-account/adspixels/) via WebSearch para confirmar o fluxo de criação de pixels com tokens privilegiados.
- Atualizei a visão do modelo de dados nos arquivos mencionados, descrevendo o novo campo.
- Usei a URL de log fornecida (http://191.252.120.96:8082/public/runtime-logs/tail?lines=300) para verificar o worker: o log atual apresenta erros 403 “Permissions error” durante `createPixel`, coerentes com a ausência de um token de usuário do sistema. Com o novo campo preenchido, essa criação passa a usar o token correto.

**Testes executados**
1. `cd backend/ads-service && mvn test` – sucesso (apenas warnings de Lombok já conhecidos).
2. `cd facebook-ads-worker && mvn test` – sucesso (warnings padrão de testes que simulam falhas intencionais).

**Observações**
- Caso o token de sistema não esteja configurado, o worker agora registra um aviso e simplesmente pula a criação de pixels, evitando novas falhas 403.
- O arquivo `docs/estrategia-token/modo-eco2.md` citado nas instruções não existe neste repositório; portanto segui o padrão vigente do projeto para migrations/formatação.

Tudo pronto.