### PR TITLE
Adicionar checagem por limiar (10%, 5%, 3%, 2%) com cálculo de tentativas e reprovação no diagnóstico do funil

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticConfig.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticConfig.java
@@ -14,7 +14,12 @@ public class ExperimentFunnelDiagnosticConfig {
     private static final int MIN_OPTIMIZATION_EVENT_VOLUME_FOR_CONTEXT = 50;
 
     private static final List<ConversionRuleSpec> PRIORITIZED_RULES = List.of(
-            new ConversionRuleSpec(ExperimentFunnelStage.VISUALIZACAO_FORM, ExperimentFunnelStage.ENVIO_FORM, 0.10),
+            new ConversionRuleSpec(
+                    ExperimentFunnelStage.VISUALIZACAO_FORM,
+                    ExperimentFunnelStage.ENVIO_FORM,
+                    0.10,
+                    List.of(0.05, 0.03, 0.02)
+            ),
             new ConversionRuleSpec(ExperimentFunnelStage.ENVIO_FORM, ExperimentFunnelStage.ABERTURA_EMAIL_AMOSTRA, 0.05),
             new ConversionRuleSpec(ExperimentFunnelStage.ACESSO_CHECKOUT, ExperimentFunnelStage.COMPRA, 0.03)
     );
@@ -30,7 +35,23 @@ public class ExperimentFunnelDiagnosticConfig {
     public record ConversionRuleSpec(
             ExperimentFunnelStage from,
             ExperimentFunnelStage to,
-            double minAcceptableRate
+            double minAcceptableRate,
+            List<Double> additionalThresholdRates
     ) {
+        public ConversionRuleSpec(ExperimentFunnelStage from,
+                                  ExperimentFunnelStage to,
+                                  double minAcceptableRate) {
+            this(from, to, minAcceptableRate, List.of());
+        }
+
+        public List<Double> allThresholdRates() {
+            return java.util.stream.Stream.concat(
+                            java.util.stream.Stream.of(minAcceptableRate),
+                            additionalThresholdRates.stream()
+                    )
+                    .distinct()
+                    .sorted(java.util.Comparator.reverseOrder())
+                    .toList();
+        }
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticService.java
@@ -5,6 +5,7 @@ import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDiagnosticDto
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
 import com.marketinghub.experiment.funnel.dto.FunnelDiagnosticReasonCode;
 import com.marketinghub.experiment.funnel.dto.FunnelDiagnosticStatus;
+import com.marketinghub.experiment.funnel.dto.FunnelThresholdCheckDto;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
@@ -53,6 +54,7 @@ public class ExperimentFunnelDiagnosticService {
         long successes = Optional.ofNullable(byStage.get(rule.to()))
                 .map(ExperimentFunnelStageDto::getTotalCount)
                 .orElse(0L);
+        List<FunnelThresholdCheckDto> thresholdChecks = buildThresholdChecks(rule, attempts, successes);
 
         if (attempts == 0 && successes == 0) {
             return new ExperimentFunnelStageDiagnosticDto(
@@ -63,6 +65,7 @@ public class ExperimentFunnelDiagnosticService {
                     null,
                     rule.minAcceptableRate(),
                     null,
+                    thresholdChecks,
                     FunnelDiagnosticStatus.NO_DATA,
                     FunnelDiagnosticReasonCode.NO_ATTEMPTS,
                     "Ainda não há dados dessa etapa para concluir.",
@@ -79,6 +82,7 @@ public class ExperimentFunnelDiagnosticService {
                     attempts > 0 ? (double) successes / attempts : null,
                     rule.minAcceptableRate(),
                     null,
+                    thresholdChecks,
                     FunnelDiagnosticStatus.TECHNICAL_ISSUE_SUSPECTED,
                     FunnelDiagnosticReasonCode.SEQUENTIAL_INCONSISTENCY,
                     "Possível problema técnico nesta etapa. Os números entre etapas sequenciais estão inconsistentes.",
@@ -100,13 +104,14 @@ public class ExperimentFunnelDiagnosticService {
                         observedRate,
                         rule.minAcceptableRate(),
                         upper95,
+                        thresholdChecks,
                         FunnelDiagnosticStatus.INSUFFICIENT_DATA,
                         FunnelDiagnosticReasonCode.LOW_SAMPLE_SIZE,
                         "Ainda cedo para concluir nesta etapa.",
                         false
                 );
             }
-            if (upper95 < rule.minAcceptableRate()) {
+            if (upper95 <= rule.minAcceptableRate()) {
                 return new ExperimentFunnelStageDiagnosticDto(
                         rule.to(),
                         rule.to().getLabel(),
@@ -115,6 +120,7 @@ public class ExperimentFunnelDiagnosticService {
                         observedRate,
                         rule.minAcceptableRate(),
                         upper95,
+                        thresholdChecks,
                         FunnelDiagnosticStatus.STATISTICALLY_FAILED,
                         FunnelDiagnosticReasonCode.RULE_OF_THREE_FAILED,
                         "Etapa reprovada estatisticamente no limite definido.",
@@ -129,6 +135,7 @@ public class ExperimentFunnelDiagnosticService {
                     observedRate,
                     rule.minAcceptableRate(),
                     upper95,
+                    thresholdChecks,
                     FunnelDiagnosticStatus.WEAK_SIGNAL,
                     FunnelDiagnosticReasonCode.RULE_OF_THREE_STILL_INCONCLUSIVE,
                     "Sinal fraco nesta etapa. Continue coletando eventos.",
@@ -145,6 +152,7 @@ public class ExperimentFunnelDiagnosticService {
                     observedRate,
                     rule.minAcceptableRate(),
                     null,
+                    thresholdChecks,
                     FunnelDiagnosticStatus.WEAK_SIGNAL,
                     FunnelDiagnosticReasonCode.BELOW_MIN_RATE,
                     "Sinal fraco nesta etapa. Continue monitorando.",
@@ -160,11 +168,35 @@ public class ExperimentFunnelDiagnosticService {
                 observedRate,
                 rule.minAcceptableRate(),
                 null,
+                thresholdChecks,
                 FunnelDiagnosticStatus.HEALTHY_OR_INCONCLUSIVE,
                 FunnelDiagnosticReasonCode.HEALTHY_OR_INCONCLUSIVE,
                 "Sem indício forte de reprovação estatística nesta etapa.",
                 false
         );
+    }
+
+    private List<FunnelThresholdCheckDto> buildThresholdChecks(ExperimentFunnelDiagnosticConfig.ConversionRuleSpec rule,
+                                                               long attempts,
+                                                               long successes) {
+        return rule.allThresholdRates().stream()
+                .map(thresholdRate -> {
+                    int attemptsFor95Confidence = (int) Math.ceil(3.0 / thresholdRate);
+                    Double upper95 = attempts > 0 ? 3.0 / attempts : null;
+                    boolean attemptsTargetReached = attempts >= attemptsFor95Confidence;
+                    boolean statisticallyFailed = successes == 0
+                            && attemptsTargetReached
+                            && upper95 != null
+                            && upper95 <= thresholdRate;
+                    return new FunnelThresholdCheckDto(
+                            thresholdRate,
+                            attemptsFor95Confidence,
+                            upper95,
+                            statisticallyFailed,
+                            attemptsTargetReached
+                    );
+                })
+                .toList();
     }
 
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/ExperimentFunnelStageDiagnosticDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/ExperimentFunnelStageDiagnosticDto.java
@@ -10,6 +10,7 @@ public record ExperimentFunnelStageDiagnosticDto(
         Double observedRate,
         Double minAcceptableRate,
         Double upper95RateIfZero,
+        java.util.List<FunnelThresholdCheckDto> thresholdChecks,
         FunnelDiagnosticStatus status,
         FunnelDiagnosticReasonCode reasonCode,
         String message,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/FunnelThresholdCheckDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/dto/FunnelThresholdCheckDto.java
@@ -1,0 +1,10 @@
+package com.marketinghub.experiment.funnel.dto;
+
+public record FunnelThresholdCheckDto(
+        Double minAcceptableRate,
+        int attemptsFor95Confidence,
+        Double upper95RateIfZero,
+        boolean statisticallyFailed,
+        boolean attemptsTargetReached
+) {
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticServiceTest.java
@@ -42,7 +42,10 @@ class ExperimentFunnelDiagnosticServiceTest {
                 .anySatisfy(item -> {
                     if (item.stageKey() == ExperimentFunnelStage.ENVIO_FORM) {
                         assertThat(item.status()).isEqualTo(FunnelDiagnosticStatus.STATISTICALLY_FAILED);
-                        assertThat(item.upper95RateIfZero()).isLessThan(item.minAcceptableRate());
+                        assertThat(item.upper95RateIfZero()).isLessThanOrEqualTo(item.minAcceptableRate());
+                        assertThat(item.thresholdChecks())
+                                .extracting(check -> check.minAcceptableRate())
+                                .containsExactly(0.10, 0.05, 0.03, 0.02);
                     }
                 });
     }

--- a/frontend/src/api/experiment/useExperimentFunnelDiagnostics.ts
+++ b/frontend/src/api/experiment/useExperimentFunnelDiagnostics.ts
@@ -18,6 +18,13 @@ export interface ExperimentFunnelStageDiagnostic {
   observedRate?: number | null;
   minAcceptableRate?: number | null;
   upper95RateIfZero?: number | null;
+  thresholdChecks?: {
+    minAcceptableRate?: number | null;
+    attemptsFor95Confidence: number;
+    upper95RateIfZero?: number | null;
+    statisticallyFailed: boolean;
+    attemptsTargetReached: boolean;
+  }[];
   status: FunnelDiagnosticStatus;
   reasonCode: string;
   message: string;

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
@@ -75,6 +75,22 @@ describe("ExperimentFunnelTab", () => {
             observedRate: 0,
             minAcceptableRate: 0.1,
             upper95RateIfZero: 0.0769,
+            thresholdChecks: [
+              {
+                minAcceptableRate: 0.1,
+                attemptsFor95Confidence: 30,
+                upper95RateIfZero: 0.0769,
+                statisticallyFailed: true,
+                attemptsTargetReached: true,
+              },
+              {
+                minAcceptableRate: 0.05,
+                attemptsFor95Confidence: 60,
+                upper95RateIfZero: 0.0769,
+                statisticallyFailed: false,
+                attemptsTargetReached: false,
+              },
+            ],
             status: "STATISTICALLY_FAILED",
             reasonCode: "RULE_OF_THREE_FAILED",
             message: "Etapa reprovada estatisticamente no limite definido.",
@@ -109,9 +125,8 @@ describe("ExperimentFunnelTab", () => {
     expect(screen.getByText("Diagnóstico estatístico do funil")).toBeInTheDocument();
     expect(screen.getByText(/Etapa reprovada estatisticamente/)).toBeInTheDocument();
     expect(screen.getByText(/Alerta contextual/)).toBeInTheDocument();
-    expect(screen.getByText("Mín. aceitável: 5,0%")).toBeInTheDocument();
-    expect(screen.getByText("Mín. aceitável: 3,0%")).toBeInTheDocument();
-    expect(screen.getByText("Mín. aceitável: 2,0%")).toBeInTheDocument();
+    expect(screen.getByText(/Limite 10,0% · Tentativas mín\. .*: 30/)).toBeInTheDocument();
+    expect(screen.getByText(/Limite 5,0% · Tentativas mín\. .*: 60/)).toBeInTheDocument();
   });
 
   it("shows the cost per conversion for each stage", () => {

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -300,9 +300,18 @@ export default function ExperimentFunnelTab({
                         {item.minAcceptableRate != null ? ` · Mín. aceitável: ${formatPercent(item.minAcceptableRate)}` : ""}
                         {item.upper95RateIfZero != null ? ` · Limite 95% (0 sucessos): ${formatPercent(item.upper95RateIfZero)}` : ""}
                       </div>
-                      {minAcceptableOverrideLines(item.stageKey).map((line) => (
-                        <div key={`${item.stageKey}-${line}`} className="small text-muted">
-                          {line}
+                      {item.thresholdChecks?.map((thresholdCheck) => (
+                        <div
+                          key={`${item.stageKey}-${thresholdCheck.minAcceptableRate}`}
+                          className={`small ${thresholdCheck.statisticallyFailed ? "text-danger" : "text-muted"}`}
+                        >
+                          Limite {formatPercent(thresholdCheck.minAcceptableRate)} · Tentativas mín. (95%, 0 sucessos): {thresholdCheck.attemptsFor95Confidence}
+                          {thresholdCheck.upper95RateIfZero != null ? ` · Limite 95% atual: ${formatPercent(thresholdCheck.upper95RateIfZero)}` : ""}
+                          {thresholdCheck.statisticallyFailed
+                            ? " · Reprovada"
+                            : thresholdCheck.attemptsTargetReached
+                              ? " · Alvo de tentativas atingido"
+                              : " · Ainda coletando"}
                         </div>
                       ))}
                     </div>
@@ -516,12 +525,4 @@ function statusBadgeClass(status: FunnelDiagnosticStatus) {
     default:
       return "text-bg-success";
   }
-}
-
-function minAcceptableOverrideLines(stageKey: string) {
-  if (stageKey !== "ENVIO_FORM") {
-    return [];
-  }
-
-  return ["Mín. aceitável: 5,0%", "Mín. aceitável: 3,0%", "Mín. aceitável: 2,0%"];
 }


### PR DESCRIPTION
### Motivation
- Implementar cálculo de tentativas mínimas e marcar como reprovado quando o limite estatístico for atingido para os limites já existentes e adicionais (fazer o mesmo procedimento para 10% e adicionar 5%, 3% e 2%).
- Manter o backend como fonte da verdade para a lógica estatística e expor apenas o resultado estruturado para a UI, evitando drift entre camadas.

### Description
- Adiciona thresholds adicionais para a regra `VISUALIZACAO_FORM -> ENVIO_FORM` e torna a lista de limiares extensível em `ExperimentFunnelDiagnosticConfig` (inclui 0.05, 0.03, 0.02 além do 0.10). (`backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticConfig.java`).
- Introduz `FunnelThresholdCheckDto` e passa a retornar `thresholdChecks` em `ExperimentFunnelStageDiagnosticDto`, contendo `minAcceptableRate`, `attemptsFor95Confidence`, `upper95RateIfZero`, `statisticallyFailed` e `attemptsTargetReached` (novo DTO em `backend/.../dto/FunnelThresholdCheckDto.java`).
- Implementa `buildThresholdChecks(...)` em `ExperimentFunnelDiagnosticService` que calcula `ceil(3 / rate)` (tentativas mínimas para 95% com 0 sucessos), determina se o alvo de tentativas foi atingido e marca reprovação quando `upper95 <= thresholdRate`, aplicando assim também o caso de 10%. (`backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelDiagnosticService.java`).
- Atualiza a API TypeScript para aceitar `thresholdChecks` e altera a UI em `ExperimentFunnelTab.tsx` para renderizar, por limiar, o limite, tentativas mínimas, limite 95% atual e rótulo de status (`Reprovada` / `Alvo de tentativas atingido` / `Ainda coletando`), removendo as linhas estáticas antigas de mínimos aceitáveis. (arquivos modificados em `frontend/src/api/experiment/useExperimentFunnelDiagnostics.ts` e `frontend/src/pages/experiment/ExperimentFunnelTab.tsx`).
- Ajusta testes de backend e frontend para cobrir o novo payload e comportamento (`backend/.../ExperimentFunnelDiagnosticServiceTest.java`, `frontend/.../ExperimentFunnelTab.test.tsx`).

### Testing
- Executado: `cd backend/ads-service && mvn -s ../settings.xml -Dtest=ExperimentFunnelDiagnosticServiceTest test`; resultado: falhou devido a limitação do ambiente (rede indisponível para baixar dependências Maven).
- Executado: `cd frontend && npm run test -- ExperimentFunnelTab.test.tsx`; resultado: falhou no ambiente atual porque `vitest` não está disponível (ferramentas de test não instaladas aqui).
- Observação: testes unitários foram atualizados para refletir as novas `thresholdChecks` e a condição `upper95 <= minAcceptableRate` (os testes esperam agora os múltiplos limiares no DTO).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb6952e78832193d8cba1b295f170)