### PR TITLE
feat(oprm): implementar fase 1 do módulo OPRM (Occupation Resolver & intake)

### DIFF
--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -1,0 +1,45 @@
+# OPRM — Implementation History
+
+## 2026-04-15 — fase 1: resolução ocupacional e intake estruturado
+
+**Status:** concluído
+
+**Resumo:**  
+Foi criada a implementação inicial da fase 1 do módulo OPRM com estrutura Spring Boot dedicada, resolução ocupacional para o conjunto MVP e geração do artefato canônico `occupationProfileSnapshot` com envelope padrão e lineage mínimo.
+
+**O que foi implementado:**  
+- criação do módulo `oprm` com estrutura Java 21 + Spring Boot
+- implementação de catálogo estruturado com suporte às 6 ocupações do MVP
+- implementação do `Occupation Resolver` com normalização de aliases e validação de ocupações suportadas
+- implementação da geração do artefato `occupationProfileSnapshot` com campos de envelope (`artifact_type`, `artifact_version`, `source_refs`, `input_refs`, `status`, `confidence_score`)
+- disponibilização de endpoints da fase 1 para ocupações suportadas e resolução de intake
+- criação de testes unitários da resolução e tratamento de ocupação não suportada
+
+**Arquivos principais alterados:**  
+- `oprm/pom.xml`
+- `oprm/src/main/java/com/marketinghub/oprm/OprmApplication.java`
+- `oprm/src/main/java/com/marketinghub/oprm/application/OccupationResolverService.java`
+- `oprm/src/main/java/com/marketinghub/oprm/api/Phase1Controller.java`
+- `oprm/src/main/java/com/marketinghub/oprm/infra/StructuredOccupationCatalog.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/ArtifactEnvelope.java`
+- `oprm/src/test/java/com/marketinghub/oprm/application/OccupationResolverServiceTest.java`
+- `oprm/README.md`
+- `oprm/Dockerfile`
+- `oprm/docker-compose.yml`
+
+**Contratos / artefatos afetados:**  
+- `occupationAliasResolution`
+- `occupationProfileSnapshot`
+- nenhum contrato HTTP externo ao módulo foi versionado nesta etapa
+
+**Testes executados:**  
+- `cd oprm && mvn test` — **passou**
+
+**Limitações ou pendências:**  
+- intake estruturado ainda está em fonte local em memória, sem integração com backend principal
+- não há persistência remota dos artefatos no backend nesta fase
+- não há enriquecimento web nesta etapa
+
+**Próximo passo sugerido:**  
+- implementar fase 2 com captura web por allowlist e `occupationWebSourceSnapshot`
+- definir contrato explícito de troca entre OPRM e backend para jobs e publicação de artefatos

--- a/oprm/Dockerfile
+++ b/oprm/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/target/oprm-0.1.0-SNAPSHOT.jar app.jar
+EXPOSE 8093
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/oprm/README.md
+++ b/oprm/README.md
@@ -1,0 +1,32 @@
+# OPRM (Occupation Persona Routine Mapper)
+
+Módulo Spring Boot interno do Marketing Hub para a fase 1 do plano OPRM:
+
+- resolução ocupacional (`Occupation Resolver`)
+- intake estruturado baseado em fontes ocupacionais do MVP
+- geração de artefato `occupationProfileSnapshot`
+- suporte inicial às 6 ocupações do MVP
+
+## Executar localmente
+
+```bash
+cd oprm
+mvn test
+mvn spring-boot:run
+```
+
+## Endpoints da fase 1
+
+- `GET /api/oprm/phase1/supported-occupations`
+- `POST /api/oprm/phase1/resolve`
+
+Exemplo de payload:
+
+```json
+{
+  "occupationLabel": "treinador pessoal",
+  "nicheName": "fitness",
+  "locale": "pt-BR",
+  "correlationId": "oprm-demo-001"
+}
+```

--- a/oprm/docker-compose.yml
+++ b/oprm/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  oprm-worker:
+    build: .
+    container_name: oprm-worker
+    ports:
+      - "8093:8093"
+    environment:
+      - SPRING_PROFILES_ACTIVE=default

--- a/oprm/pom.xml
+++ b/oprm/pom.xml
@@ -1,0 +1,63 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.marketinghub</groupId>
+    <artifactId>oprm</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>oprm</name>
+    <description>Occupation Persona Routine Mapper module</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <spring.boot.version>3.4.5</spring.boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/oprm/src/main/java/com/marketinghub/oprm/OprmApplication.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/OprmApplication.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OprmApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OprmApplication.class, args);
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/api/Phase1Controller.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/api/Phase1Controller.java
@@ -1,0 +1,46 @@
+package com.marketinghub.oprm.api;
+
+import com.marketinghub.oprm.application.OccupationResolverService;
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/oprm/phase1")
+public class Phase1Controller {
+
+    private final OccupationResolverService occupationResolverService;
+
+    public Phase1Controller(OccupationResolverService occupationResolverService) {
+        this.occupationResolverService = occupationResolverService;
+    }
+
+    @GetMapping("/supported-occupations")
+    public ResponseEntity<List<String>> supportedOccupations() {
+        return ResponseEntity.ok(occupationResolverService.supportedOccupations());
+    }
+
+    @PostMapping("/resolve")
+    public ResponseEntity<ArtifactEnvelope> resolve(@Valid @RequestBody Phase1ResolveRequest request) {
+        ArtifactEnvelope result = occupationResolverService.resolveToProfileSnapshot(
+                request.occupationLabel(),
+                request.nicheName(),
+                request.locale(),
+                request.correlationId()
+        );
+        return ResponseEntity.ok(result);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException exception) {
+        return ResponseEntity.badRequest().body(Map.of("error", exception.getMessage()));
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/api/Phase1ResolveRequest.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/api/Phase1ResolveRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.api;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record Phase1ResolveRequest(
+        @NotBlank String occupationLabel,
+        @NotBlank String nicheName,
+        @NotBlank String locale,
+        String correlationId) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/application/OccupationResolverService.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/application/OccupationResolverService.java
@@ -1,0 +1,106 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.OccupationAliasResolution;
+import com.marketinghub.oprm.domain.OccupationCatalogItem;
+import com.marketinghub.oprm.domain.OccupationProfileSnapshotPayload;
+import com.marketinghub.oprm.infra.StructuredOccupationCatalog;
+import org.springframework.stereotype.Service;
+
+import java.text.Normalizer;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class OccupationResolverService {
+
+    private static final List<String> MVP_OCCUPATIONS = List.of(
+            "personal trainer",
+            "pastor",
+            "agricultor",
+            "manicure",
+            "cabeleireiro",
+            "dono de loja de celulares"
+    );
+
+    private final StructuredOccupationCatalog catalog;
+
+    public OccupationResolverService(StructuredOccupationCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    public ArtifactEnvelope resolveToProfileSnapshot(String rawOccupationLabel, String nicheName, String locale, String correlationId) {
+        String normalized = normalize(rawOccupationLabel);
+        OccupationCatalogItem item = resolveItem(normalized)
+                .orElseThrow(() -> new IllegalArgumentException("occupation_not_supported_for_phase_1: " + rawOccupationLabel));
+
+        boolean exactName = normalize(item.occupationName()).equals(normalized);
+        double confidence = exactName ? 0.98 : 0.92;
+
+        OccupationAliasResolution aliasResolution = new OccupationAliasResolution(
+                rawOccupationLabel,
+                normalized,
+                item.occupationName(),
+                exactName ? "EXACT" : "ALIAS",
+                confidence,
+                "phase-1 occupation resolver"
+        );
+
+        OccupationProfileSnapshotPayload payload = new OccupationProfileSnapshotPayload(
+                item.occupationName(),
+                item.occupationSummary(),
+                item.taskList(),
+                item.skillsList(),
+                item.toolsList(),
+                item.workContextList(),
+                item.sourceSystem(),
+                item.sourceRecordIds(),
+                aliasResolution,
+                nicheName,
+                locale
+        );
+
+        return new ArtifactEnvelope(
+                "occupationProfileSnapshot",
+                "1.0",
+                UUID.randomUUID().toString(),
+                "oprm",
+                "oprm.occupation-resolver",
+                Instant.now(),
+                correlationId == null || correlationId.isBlank() ? UUID.randomUUID().toString() : correlationId,
+                UUID.randomUUID().toString(),
+                item.sourceRecordIds(),
+                List.of("occupationSeed"),
+                payload,
+                "GENERATED",
+                confidence,
+                Map.of("phase", "phase-1", "supported_mvp_occupations", MVP_OCCUPATIONS.size())
+        );
+    }
+
+    public List<String> supportedOccupations() {
+        return MVP_OCCUPATIONS;
+    }
+
+    private Optional<OccupationCatalogItem> resolveItem(String normalizedLabel) {
+        return catalog.listAll().stream()
+                .filter(item -> normalize(item.occupationName()).equals(normalizedLabel)
+                        || item.aliases().stream().map(this::normalize).anyMatch(normalizedLabel::equals))
+                .findFirst();
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+        String cleaned = Normalizer.normalize(value, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}+", "")
+                .toLowerCase(Locale.ROOT)
+                .trim();
+        return cleaned.replaceAll("\\s+", " ");
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/ArtifactEnvelope.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/ArtifactEnvelope.java
@@ -1,0 +1,22 @@
+package com.marketinghub.oprm.domain;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record ArtifactEnvelope(
+        String artifactType,
+        String artifactVersion,
+        String artifactId,
+        String moduleName,
+        String producer,
+        Instant createdAt,
+        String correlationId,
+        String traceId,
+        List<String> sourceRefs,
+        List<String> inputRefs,
+        OccupationProfileSnapshotPayload payload,
+        String status,
+        double confidenceScore,
+        Map<String, Object> metadata) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationAliasResolution.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationAliasResolution.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.domain;
+
+public record OccupationAliasResolution(
+        String rawLabel,
+        String normalizedLabel,
+        String matchedOccupationName,
+        String matchType,
+        double matchConfidence,
+        String resolverNotes) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationCatalogItem.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationCatalogItem.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record OccupationCatalogItem(
+        String occupationName,
+        List<String> aliases,
+        String occupationSummary,
+        List<String> taskList,
+        List<String> skillsList,
+        List<String> toolsList,
+        List<String> workContextList,
+        String sourceSystem,
+        List<String> sourceRecordIds) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationProfileSnapshotPayload.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationProfileSnapshotPayload.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record OccupationProfileSnapshotPayload(
+        String occupationName,
+        String occupationSummary,
+        List<String> taskList,
+        List<String> skillsList,
+        List<String> toolsList,
+        List<String> workContextList,
+        String sourceSystem,
+        List<String> sourceRecordIds,
+        OccupationAliasResolution aliasResolution,
+        String nicheName,
+        String locale) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/infra/StructuredOccupationCatalog.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/infra/StructuredOccupationCatalog.java
@@ -1,0 +1,77 @@
+package com.marketinghub.oprm.infra;
+
+import com.marketinghub.oprm.domain.OccupationCatalogItem;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class StructuredOccupationCatalog {
+
+    private final List<OccupationCatalogItem> items = List.of(
+            new OccupationCatalogItem(
+                    "personal trainer",
+                    List.of("personal trainer", "treinador pessoal", "pt"),
+                    "Profissional que orienta treinos, corrige execução e acompanha evolução física.",
+                    List.of("Montar fichas de treino", "Acompanhar alunos", "Registrar evolução", "Captar novos clientes"),
+                    List.of("Avaliação física", "Comunicação", "Didática", "Gestão de agenda"),
+                    List.of("WhatsApp", "Planilhas", "Apps de treino", "Instagram"),
+                    List.of("Academias", "Atendimento domiciliar", "Consultoria online"),
+                    "oprm-mvp-structured-sources",
+                    List.of("mvp-pt-001")),
+            new OccupationCatalogItem(
+                    "pastor",
+                    List.of("pastor", "líder religioso evangélico", "ministro pastoral"),
+                    "Lidera comunidade religiosa, organiza cultos e atende demandas pastorais da congregação.",
+                    List.of("Preparar sermões", "Conduzir cultos", "Aconselhamento", "Visitas pastorais"),
+                    List.of("Oratória", "Gestão comunitária", "Escuta ativa", "Planejamento"),
+                    List.of("Bíblia", "Ferramentas de apresentação", "WhatsApp", "Planilhas"),
+                    List.of("Igreja local", "Eventos comunitários", "Atendimento individual"),
+                    "oprm-mvp-structured-sources",
+                    List.of("mvp-pastor-001")),
+            new OccupationCatalogItem(
+                    "agricultor",
+                    List.of("agricultor", "produtor rural", "lavrador"),
+                    "Produz culturas agrícolas e administra atividades operacionais da propriedade rural.",
+                    List.of("Planejar plantio", "Monitorar clima", "Gerir insumos", "Organizar colheita"),
+                    List.of("Manejo de solo", "Gestão operacional", "Negociação", "Controle de custos"),
+                    List.of("Maquinário agrícola", "Aplicativos meteorológicos", "Planilhas", "WhatsApp"),
+                    List.of("Propriedade rural", "Cooperativas", "Feiras e distribuidores"),
+                    "oprm-mvp-structured-sources",
+                    List.of("mvp-agri-001")),
+            new OccupationCatalogItem(
+                    "manicure",
+                    List.of("manicure", "nail designer", "profissional de unhas"),
+                    "Atende clientes para cuidados estéticos das unhas, com forte dependência de agenda e fidelização.",
+                    List.of("Atender clientes", "Gerenciar agenda", "Esterilizar materiais", "Divulgar serviços"),
+                    List.of("Técnicas de esmaltação", "Atendimento", "Higienização", "Venda consultiva"),
+                    List.of("Agenda digital", "WhatsApp", "Instagram", "Máquina de cartão"),
+                    List.of("Salão", "Atendimento em domicílio", "Studio próprio"),
+                    "oprm-mvp-structured-sources",
+                    List.of("mvp-mani-001")),
+            new OccupationCatalogItem(
+                    "cabeleireiro",
+                    List.of("cabeleireiro", "hair stylist", "profissional de salão"),
+                    "Profissional de beleza que realiza cortes, tratamentos e organiza fluxo de clientes no salão.",
+                    List.of("Realizar cortes", "Fazer procedimentos", "Organizar agenda", "Vender produtos"),
+                    List.of("Técnicas capilares", "Atendimento", "Gestão de tempo", "Upsell"),
+                    List.of("Tesouras e secadores", "Agenda digital", "Instagram", "Sistema de caixa"),
+                    List.of("Salões de beleza", "Studio próprio", "Atendimento em eventos"),
+                    "oprm-mvp-structured-sources",
+                    List.of("mvp-cabel-001")),
+            new OccupationCatalogItem(
+                    "dono de loja de celulares",
+                    List.of("dono de loja de celulares", "lojista de celulares", "comerciante de smartphones"),
+                    "Empreendedor que comercializa celulares e acessórios, gerindo estoque, vendas e pós-venda.",
+                    List.of("Atender clientes", "Negociar preços", "Controlar estoque", "Pós-venda e garantia"),
+                    List.of("Vendas", "Negociação", "Gestão de estoque", "Relacionamento com fornecedores"),
+                    List.of("Sistema de PDV", "Marketplace", "WhatsApp", "Planilhas"),
+                    List.of("Loja física", "Comércio local", "Canais digitais"),
+                    "oprm-mvp-structured-sources",
+                    List.of("mvp-cel-001"))
+    );
+
+    public List<OccupationCatalogItem> listAll() {
+        return items;
+    }
+}

--- a/oprm/src/main/resources/application.properties
+++ b/oprm/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.application.name=oprm
+server.port=8093

--- a/oprm/src/test/java/com/marketinghub/oprm/application/OccupationResolverServiceTest.java
+++ b/oprm/src/test/java/com/marketinghub/oprm/application/OccupationResolverServiceTest.java
@@ -1,0 +1,29 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.infra.StructuredOccupationCatalog;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OccupationResolverServiceTest {
+
+    private final OccupationResolverService service = new OccupationResolverService(new StructuredOccupationCatalog());
+
+    @Test
+    void shouldResolveAliasAndGenerateOccupationProfileSnapshot() {
+        ArtifactEnvelope result = service.resolveToProfileSnapshot("treinador pessoal", "fitness", "pt-BR", "corr-1");
+
+        assertEquals("occupationProfileSnapshot", result.artifactType());
+        assertEquals("personal trainer", result.payload().occupationName());
+        assertEquals("ALIAS", result.payload().aliasResolution().matchType());
+        assertEquals("GENERATED", result.status());
+    }
+
+    @Test
+    void shouldRejectUnsupportedOccupation() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.resolveToProfileSnapshot("astronauta", "espacial", "pt-BR", null));
+    }
+}


### PR DESCRIPTION
### Motivation
- Implementar a Fase 1 do plano OPRM para criar a infraestrutura mínima do módulo dentro do repo e permitir intake estruturado de ocupações do MVP. 
- Produzir artefatos canônicos iniciais (`occupationProfileSnapshot`, `occupationAliasResolution`) e registrar a etapa conforme o protocolo de histórico do Codex. 

### Description
- Adiciona o módulo `oprm` em Java 21 + Spring Boot com estrutura própria, `pom.xml`, `Dockerfile`, `docker-compose.yml` e `README.md` explicando execução e endpoints. 
- Implementa `OccupationResolverService` que normaliza labels/aliases, resolve ocupações do catálogo MVP e gera o envelope canônico `occupationProfileSnapshot` com lineage e `confidence_score`. 
- Inclui catálogo estruturado `StructuredOccupationCatalog` com as 6 ocupações do MVP e os DTOs/records de domínio (`OccupationCatalogItem`, `OccupationProfileSnapshotPayload`, `OccupationAliasResolution`, `ArtifactEnvelope`). 
- Expõe endpoints REST da Fase 1 em `Phase1Controller`: `GET /api/oprm/phase1/supported-occupations` e `POST /api/oprm/phase1/resolve`, e adiciona testes unitários para resolver alias e rejeitar ocupações não suportadas. 
- Registra a etapa no histórico incremental em `docs/history/oprm-implementation-history.md` seguindo o `protocolo-historico-implantacao-codex.md`. 

### Testing
- Executed `cd oprm && mvn test` and the unit test suite completed successfully (tests passed). 
- Executed `cd oprm && mvn test -q` for a quiet verification and it also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfca18998883219751de36a9bf5e9a)