### PR TITLE
feat(oprm): implementar fase 2 de enriquecimento web

### DIFF
--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -43,3 +43,48 @@ Foi criada a implementação inicial da fase 1 do módulo OPRM com estrutura Spr
 **Próximo passo sugerido:**  
 - implementar fase 2 com captura web por allowlist e `occupationWebSourceSnapshot`
 - definir contrato explícito de troca entre OPRM e backend para jobs e publicação de artefatos
+
+## 2026-04-15 — fase 2: enriquecimento web
+
+**Status:** concluído
+
+**Resumo:**  
+Foi implementada a fase 2 do OPRM com pipeline inicial de enriquecimento web por allowlist, captura de páginas públicas por ocupação do MVP e publicação do artefato canônico `occupationWebSourceSnapshot` com lineage e sinais semânticos para apoiar as próximas fases.
+
+**O que foi implementado:**  
+- criação do serviço `WebEnrichmentService` para resolver ocupação, aplicar política de fontes e capturar sementes públicas
+- implementação de `OccupationSourcePolicyProfile` com allowlist, blocklist e metadados de risco para governar coleta
+- implementação de fetch HTTP inicial (`HttpWebPageFetcher`) com extração de título/conteúdo, hash e classificação de tipo de fonte
+- criação do endpoint `POST /api/oprm/phase2/enrich` para disparar enriquecimento web por ocupação
+- criação do artefato `occupationWebSourceSnapshot` com fontes capturadas, sinais semânticos e resumo de enriquecimento
+- adição de testes unitários da fase 2 para geração do artefato e validação de ocupação não suportada
+
+**Arquivos principais alterados:**  
+- `oprm/src/main/java/com/marketinghub/oprm/application/WebEnrichmentService.java`
+- `oprm/src/main/java/com/marketinghub/oprm/api/Phase2Controller.java`
+- `oprm/src/main/java/com/marketinghub/oprm/api/Phase2EnrichRequest.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/OccupationWebSourceSnapshotPayload.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/OccupationSourcePolicyProfile.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/CapturedWebSource.java`
+- `oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/HttpWebPageFetcher.java`
+- `oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/OccupationSourcePolicyRegistry.java`
+- `oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/OccupationWebSeedRegistry.java`
+- `oprm/src/test/java/com/marketinghub/oprm/application/WebEnrichmentServiceTest.java`
+- `oprm/README.md`
+
+**Contratos / artefatos afetados:**  
+- `occupationSourcePolicyProfile`
+- `occupationWebSourceSnapshot`
+- endpoint interno do módulo: `POST /api/oprm/phase2/enrich`
+
+**Testes executados:**  
+- `cd oprm && mvn test` — **passou**
+
+**Limitações ou pendências:**  
+- pipeline de enriquecimento ainda não publica artefatos no backend principal do Marketing Hub
+- seeds de URL estão em registro local estático e ainda não possuem gestão dinâmica por backend
+- crawler atual não implementa persistência de cache transitório nem retry/backoff avançado
+
+**Próximo passo sugerido:**  
+- implementar fase 3 com inferência de rotina (`routineTaskPattern`, `routineConstraintSignal`, `routinePainSignal`, `routineWorkaroundSignal`)
+- definir contrato explícito de jobs/publicação com backend para persistir snapshots e lineage end-to-end

--- a/oprm/README.md
+++ b/oprm/README.md
@@ -1,10 +1,11 @@
 # OPRM (Occupation Persona Routine Mapper)
 
-Módulo Spring Boot interno do Marketing Hub para a fase 1 do plano OPRM:
+Módulo Spring Boot interno do Marketing Hub para as fases 1 e 2 do plano OPRM:
 
 - resolução ocupacional (`Occupation Resolver`)
 - intake estruturado baseado em fontes ocupacionais do MVP
-- geração de artefato `occupationProfileSnapshot`
+- enriquecimento web com política de allowlist
+- geração dos artefatos `occupationProfileSnapshot` e `occupationWebSourceSnapshot`
 - suporte inicial às 6 ocupações do MVP
 
 ## Executar localmente
@@ -20,6 +21,10 @@ mvn spring-boot:run
 - `GET /api/oprm/phase1/supported-occupations`
 - `POST /api/oprm/phase1/resolve`
 
+## Endpoint da fase 2
+
+- `POST /api/oprm/phase2/enrich`
+
 Exemplo de payload:
 
 ```json
@@ -28,5 +33,16 @@ Exemplo de payload:
   "nicheName": "fitness",
   "locale": "pt-BR",
   "correlationId": "oprm-demo-001"
+}
+```
+
+Exemplo de payload da fase 2:
+
+```json
+{
+  "occupationLabel": "treinador pessoal",
+  "nicheName": "fitness",
+  "locale": "pt-BR",
+  "correlationId": "oprm-demo-002"
 }
 ```

--- a/oprm/src/main/java/com/marketinghub/oprm/api/Phase2Controller.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/api/Phase2Controller.java
@@ -1,0 +1,39 @@
+package com.marketinghub.oprm.api;
+
+import com.marketinghub.oprm.application.WebEnrichmentService;
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/oprm/phase2")
+public class Phase2Controller {
+
+    private final WebEnrichmentService webEnrichmentService;
+
+    public Phase2Controller(WebEnrichmentService webEnrichmentService) {
+        this.webEnrichmentService = webEnrichmentService;
+    }
+
+    @PostMapping("/enrich")
+    public ResponseEntity<ArtifactEnvelope> enrich(@Valid @RequestBody Phase2EnrichRequest request) {
+        ArtifactEnvelope result = webEnrichmentService.enrichOccupation(
+                request.occupationLabel(),
+                request.nicheName(),
+                request.locale(),
+                request.correlationId());
+        return ResponseEntity.ok(result);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException exception) {
+        return ResponseEntity.badRequest().body(Map.of("error", exception.getMessage()));
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/api/Phase2EnrichRequest.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/api/Phase2EnrichRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.api;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record Phase2EnrichRequest(
+        @NotBlank String occupationLabel,
+        @NotBlank String nicheName,
+        @NotBlank String locale,
+        String correlationId) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/application/OccupationLabelNormalizer.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/application/OccupationLabelNormalizer.java
@@ -1,0 +1,21 @@
+package com.marketinghub.oprm.application;
+
+import java.text.Normalizer;
+import java.util.Locale;
+
+public final class OccupationLabelNormalizer {
+
+    private OccupationLabelNormalizer() {
+    }
+
+    public static String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+        String cleaned = Normalizer.normalize(value, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}+", "")
+                .toLowerCase(Locale.ROOT)
+                .trim();
+        return cleaned.replaceAll("\\s+", " ");
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/application/OccupationResolverService.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/application/OccupationResolverService.java
@@ -7,10 +7,8 @@ import com.marketinghub.oprm.domain.OccupationProfileSnapshotPayload;
 import com.marketinghub.oprm.infra.StructuredOccupationCatalog;
 import org.springframework.stereotype.Service;
 
-import java.text.Normalizer;
 import java.time.Instant;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -34,11 +32,11 @@ public class OccupationResolverService {
     }
 
     public ArtifactEnvelope resolveToProfileSnapshot(String rawOccupationLabel, String nicheName, String locale, String correlationId) {
-        String normalized = normalize(rawOccupationLabel);
+        String normalized = OccupationLabelNormalizer.normalize(rawOccupationLabel);
         OccupationCatalogItem item = resolveItem(normalized)
                 .orElseThrow(() -> new IllegalArgumentException("occupation_not_supported_for_phase_1: " + rawOccupationLabel));
 
-        boolean exactName = normalize(item.occupationName()).equals(normalized);
+        boolean exactName = OccupationLabelNormalizer.normalize(item.occupationName()).equals(normalized);
         double confidence = exactName ? 0.98 : 0.92;
 
         OccupationAliasResolution aliasResolution = new OccupationAliasResolution(
@@ -88,19 +86,9 @@ public class OccupationResolverService {
 
     private Optional<OccupationCatalogItem> resolveItem(String normalizedLabel) {
         return catalog.listAll().stream()
-                .filter(item -> normalize(item.occupationName()).equals(normalizedLabel)
-                        || item.aliases().stream().map(this::normalize).anyMatch(normalizedLabel::equals))
+                .filter(item -> OccupationLabelNormalizer.normalize(item.occupationName()).equals(normalizedLabel)
+                        || item.aliases().stream().map(OccupationLabelNormalizer::normalize).anyMatch(normalizedLabel::equals))
                 .findFirst();
     }
 
-    private String normalize(String value) {
-        if (value == null) {
-            return "";
-        }
-        String cleaned = Normalizer.normalize(value, Normalizer.Form.NFD)
-                .replaceAll("\\p{M}+", "")
-                .toLowerCase(Locale.ROOT)
-                .trim();
-        return cleaned.replaceAll("\\s+", " ");
-    }
 }

--- a/oprm/src/main/java/com/marketinghub/oprm/application/WebEnrichmentService.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/application/WebEnrichmentService.java
@@ -1,0 +1,201 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.CapturedWebSource;
+import com.marketinghub.oprm.domain.OccupationCatalogItem;
+import com.marketinghub.oprm.domain.OccupationSourcePolicyProfile;
+import com.marketinghub.oprm.domain.OccupationWebSourceSnapshotPayload;
+import com.marketinghub.oprm.infra.StructuredOccupationCatalog;
+import com.marketinghub.oprm.infra.enrichment.FetchedWebPage;
+import com.marketinghub.oprm.infra.enrichment.OccupationSourcePolicyRegistry;
+import com.marketinghub.oprm.infra.enrichment.OccupationWebSeedRegistry;
+import com.marketinghub.oprm.infra.enrichment.WebPageFetcher;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class WebEnrichmentService {
+
+    private static final int MAX_CAPTURED_SOURCES = 3;
+
+    private final StructuredOccupationCatalog catalog;
+    private final OccupationSourcePolicyRegistry policyRegistry;
+    private final OccupationWebSeedRegistry seedRegistry;
+    private final WebPageFetcher webPageFetcher;
+
+    public WebEnrichmentService(StructuredOccupationCatalog catalog,
+                                OccupationSourcePolicyRegistry policyRegistry,
+                                OccupationWebSeedRegistry seedRegistry,
+                                WebPageFetcher webPageFetcher) {
+        this.catalog = catalog;
+        this.policyRegistry = policyRegistry;
+        this.seedRegistry = seedRegistry;
+        this.webPageFetcher = webPageFetcher;
+    }
+
+    public ArtifactEnvelope enrichOccupation(String rawOccupationLabel, String nicheName, String locale, String correlationId) {
+        String normalized = OccupationLabelNormalizer.normalize(rawOccupationLabel);
+        OccupationCatalogItem item = resolveItem(normalized)
+                .orElseThrow(() -> new IllegalArgumentException("occupation_not_supported_for_phase_2: " + rawOccupationLabel));
+
+        OccupationSourcePolicyProfile policyProfile = policyRegistry.policyFor(item.occupationName());
+        List<String> seededUrls = seedRegistry.seedsFor(item.occupationName());
+
+        if (seededUrls.isEmpty()) {
+            throw new IllegalArgumentException("no_web_seeds_for_occupation: " + item.occupationName());
+        }
+
+        List<CapturedWebSource> capturedSources = seededUrls.stream()
+                .filter(url -> isAllowed(url, policyProfile.allowedDomains(), policyProfile.blockedDomains()))
+                .limit(MAX_CAPTURED_SOURCES)
+                .map(this::captureSource)
+                .toList();
+
+        List<String> semanticSignals = buildSemanticSignals(item, capturedSources);
+
+        OccupationWebSourceSnapshotPayload payload = new OccupationWebSourceSnapshotPayload(
+                item.occupationName(),
+                nicheName,
+                locale,
+                policyProfile,
+                capturedSources,
+                semanticSignals,
+                buildSummary(item.occupationName(), capturedSources)
+        );
+
+        double confidenceScore = capturedSources.stream().anyMatch(source -> "CAPTURED".equals(source.captureStatus())) ? 0.87 : 0.45;
+
+        return new ArtifactEnvelope(
+                "occupationWebSourceSnapshot",
+                "1.0",
+                UUID.randomUUID().toString(),
+                "oprm",
+                "oprm.web-enrichment",
+                Instant.now(),
+                correlationId == null || correlationId.isBlank() ? UUID.randomUUID().toString() : correlationId,
+                UUID.randomUUID().toString(),
+                capturedSources.stream().map(CapturedWebSource::url).toList(),
+                List.of("occupationSeed", "occupationProfileSnapshot"),
+                payload,
+                "GENERATED",
+                confidenceScore,
+                Map.of(
+                        "phase", "phase-2",
+                        "allowlist_domains", policyProfile.allowedDomains().size(),
+                        "captured_sources", capturedSources.size()
+                )
+        );
+    }
+
+    private Optional<OccupationCatalogItem> resolveItem(String normalizedLabel) {
+        return catalog.listAll().stream()
+                .filter(item -> OccupationLabelNormalizer.normalize(item.occupationName()).equals(normalizedLabel)
+                        || item.aliases().stream().map(OccupationLabelNormalizer::normalize).anyMatch(normalizedLabel::equals))
+                .findFirst();
+    }
+
+    private boolean isAllowed(String url, List<String> allowedDomains, List<String> blockedDomains) {
+        String normalizedUrl = url.toLowerCase(Locale.ROOT);
+        boolean explicitlyBlocked = blockedDomains.stream().anyMatch(normalizedUrl::contains);
+        boolean explicitlyAllowed = allowedDomains.stream().anyMatch(normalizedUrl::contains);
+        return !explicitlyBlocked && explicitlyAllowed;
+    }
+
+    private CapturedWebSource captureSource(String url) {
+        FetchedWebPage page = webPageFetcher.fetch(url);
+        String excerpt = excerpt(page.content());
+        String captureStatus = page.success() ? "CAPTURED" : "FAILED";
+
+        return new CapturedWebSource(
+                page.url(),
+                classifySourceType(page.url()),
+                page.title(),
+                Instant.now(),
+                page.language(),
+                sha256(page.title() + "\n" + excerpt),
+                excerpt.isBlank() ? List.of() : List.of(excerpt),
+                page.captureNotes(),
+                captureStatus
+        );
+    }
+
+    private List<String> buildSemanticSignals(OccupationCatalogItem item, List<CapturedWebSource> sources) {
+        Set<String> signals = new LinkedHashSet<>();
+        signals.add("daily-operations");
+
+        sources.stream()
+                .map(source -> String.join(" ", source.extractedBlocks()).toLowerCase(Locale.ROOT))
+                .forEach(content -> {
+                    for (String task : item.taskList()) {
+                        if (content.contains(task.toLowerCase(Locale.ROOT))) {
+                            signals.add("task:" + task);
+                        }
+                    }
+                    for (String tool : item.toolsList()) {
+                        if (content.contains(tool.toLowerCase(Locale.ROOT))) {
+                            signals.add("tool:" + tool);
+                        }
+                    }
+                });
+
+        if (signals.size() <= 1) {
+            signals.add("insufficient-domain-terms-detected");
+        }
+
+        return new ArrayList<>(signals);
+    }
+
+    private String buildSummary(String occupationName, List<CapturedWebSource> capturedSources) {
+        long capturedCount = capturedSources.stream().filter(source -> "CAPTURED".equals(source.captureStatus())).count();
+        return "phase-2 web enrichment completed for " + occupationName
+                + " with " + capturedCount + "/" + capturedSources.size() + " successful captures";
+    }
+
+    private String classifySourceType(String url) {
+        String normalizedUrl = url.toLowerCase(Locale.ROOT);
+        if (normalizedUrl.contains("wikipedia.org")) {
+            return "ENCYCLOPEDIA";
+        }
+        if (normalizedUrl.contains("bls.gov")) {
+            return "LABOR_STATISTICS";
+        }
+        if (normalizedUrl.contains("coursera.org") || normalizedUrl.contains("senac")) {
+            return "TRAINING_CONTENT";
+        }
+        if (normalizedUrl.contains("sebrae") || normalizedUrl.contains("indeed")) {
+            return "PRACTICAL_GUIDE";
+        }
+        return "PUBLIC_WEB";
+    }
+
+    private String excerpt(String content) {
+        if (content == null || content.isBlank()) {
+            return "";
+        }
+        int limit = Math.min(content.length(), 280);
+        return content.substring(0, limit).trim();
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("sha-256-unavailable", exception);
+        }
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/ArtifactEnvelope.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/ArtifactEnvelope.java
@@ -15,7 +15,7 @@ public record ArtifactEnvelope(
         String traceId,
         List<String> sourceRefs,
         List<String> inputRefs,
-        OccupationProfileSnapshotPayload payload,
+        Object payload,
         String status,
         double confidenceScore,
         Map<String, Object> metadata) {

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/CapturedWebSource.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/CapturedWebSource.java
@@ -1,0 +1,16 @@
+package com.marketinghub.oprm.domain;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CapturedWebSource(
+        String url,
+        String sourceType,
+        String title,
+        Instant capturedAt,
+        String language,
+        String contentHash,
+        List<String> extractedBlocks,
+        String captureNotes,
+        String captureStatus) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationSourcePolicyProfile.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationSourcePolicyProfile.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record OccupationSourcePolicyProfile(
+        List<String> allowedDomains,
+        List<String> blockedDomains,
+        String rateLimitPolicy,
+        String sourceRiskLevel,
+        boolean manualReviewRequired,
+        String notes) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationWebSourceSnapshotPayload.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationWebSourceSnapshotPayload.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record OccupationWebSourceSnapshotPayload(
+        String occupationName,
+        String nicheName,
+        String locale,
+        OccupationSourcePolicyProfile sourcePolicyProfile,
+        List<CapturedWebSource> capturedSources,
+        List<String> semanticRoutineSignals,
+        String enrichmentSummary) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/FetchedWebPage.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/FetchedWebPage.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.infra.enrichment;
+
+public record FetchedWebPage(
+        String url,
+        int statusCode,
+        String title,
+        String content,
+        String language,
+        String captureNotes,
+        boolean success) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/HttpWebPageFetcher.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/HttpWebPageFetcher.java
@@ -1,0 +1,69 @@
+package com.marketinghub.oprm.infra.enrichment;
+
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class HttpWebPageFetcher implements WebPageFetcher {
+
+    private static final Pattern TITLE_PATTERN = Pattern.compile("<title>(.*?)</title>", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(8))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+    @Override
+    public FetchedWebPage fetch(String url) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(12))
+                .header("User-Agent", "marketing-hub-oprm/0.1")
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            String body = response.body() == null ? "" : response.body();
+            String title = extractTitle(body);
+            String stripped = body.replaceAll("<script[^>]*>.*?</script>", " ")
+                    .replaceAll("<style[^>]*>.*?</style>", " ")
+                    .replaceAll("<[^>]+>", " ")
+                    .replaceAll("\\s+", " ")
+                    .trim();
+            String language = guessLanguage(url);
+            boolean success = response.statusCode() >= 200 && response.statusCode() < 300;
+            return new FetchedWebPage(url, response.statusCode(), title, stripped, language,
+                    success ? "captured-from-web" : "http-status-" + response.statusCode(), success);
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+            return new FetchedWebPage(url, 499, "", "", "unknown", "interrupted", false);
+        } catch (IOException | IllegalArgumentException exception) {
+            return new FetchedWebPage(url, 598, "", "", "unknown", "fetch-error: " + exception.getClass().getSimpleName(), false);
+        }
+    }
+
+    private String extractTitle(String html) {
+        Matcher matcher = TITLE_PATTERN.matcher(html);
+        if (!matcher.find()) {
+            return "";
+        }
+        return matcher.group(1).replaceAll("\\s+", " ").trim();
+    }
+
+    private String guessLanguage(String url) {
+        if (url.contains("/pt") || url.contains("pt.")) {
+            return "pt-BR";
+        }
+        return "en";
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/OccupationSourcePolicyRegistry.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/OccupationSourcePolicyRegistry.java
@@ -1,0 +1,37 @@
+package com.marketinghub.oprm.infra.enrichment;
+
+import com.marketinghub.oprm.domain.OccupationSourcePolicyProfile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class OccupationSourcePolicyRegistry {
+
+    private static final List<String> DEFAULT_ALLOWLIST = List.of(
+            "wikipedia.org",
+            "bls.gov",
+            "coursera.org",
+            "senac.br",
+            "sebrae.com.br",
+            "indeed.com"
+    );
+
+    private static final List<String> DEFAULT_BLOCKLIST = List.of(
+            "facebook.com",
+            "instagram.com",
+            "tiktok.com",
+            "linkedin.com"
+    );
+
+    public OccupationSourcePolicyProfile policyFor(String occupationName) {
+        return new OccupationSourcePolicyProfile(
+                DEFAULT_ALLOWLIST,
+                DEFAULT_BLOCKLIST,
+                "max-5-requests-per-minute",
+                "MEDIUM",
+                false,
+                "phase-2 allowlist policy for public occupation enrichment: " + occupationName
+        );
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/OccupationWebSeedRegistry.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/OccupationWebSeedRegistry.java
@@ -1,0 +1,41 @@
+package com.marketinghub.oprm.infra.enrichment;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class OccupationWebSeedRegistry {
+
+    private static final Map<String, List<String>> SEEDS = Map.of(
+            "personal trainer", List.of(
+                    "https://en.wikipedia.org/wiki/Personal_trainer",
+                    "https://www.bls.gov/ooh/personal-care-and-service/fitness-trainers-and-instructors.htm"
+            ),
+            "pastor", List.of(
+                    "https://en.wikipedia.org/wiki/Pastor",
+                    "https://www.indeed.com/career-advice/finding-a-job/how-to-become-a-pastor"
+            ),
+            "agricultor", List.of(
+                    "https://en.wikipedia.org/wiki/Farmer",
+                    "https://www.bls.gov/ooh/farming-fishing-and-forestry/farmers-ranchers-and-other-agricultural-managers.htm"
+            ),
+            "manicure", List.of(
+                    "https://en.wikipedia.org/wiki/Manicure",
+                    "https://www.coursera.org/articles/nail-technician"
+            ),
+            "cabeleireiro", List.of(
+                    "https://en.wikipedia.org/wiki/Hairdresser",
+                    "https://www.coursera.org/articles/hairdresser"
+            ),
+            "dono de loja de celulares", List.of(
+                    "https://en.wikipedia.org/wiki/Mobile_phone_retailer",
+                    "https://www.sebrae.com.br/sites/PortalSebrae/artigos/como-montar-uma-loja-de-celular"
+            )
+    );
+
+    public List<String> seedsFor(String occupationName) {
+        return SEEDS.getOrDefault(occupationName, List.of());
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/WebPageFetcher.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/WebPageFetcher.java
@@ -1,0 +1,5 @@
+package com.marketinghub.oprm.infra.enrichment;
+
+public interface WebPageFetcher {
+    FetchedWebPage fetch(String url);
+}

--- a/oprm/src/test/java/com/marketinghub/oprm/application/OccupationResolverServiceTest.java
+++ b/oprm/src/test/java/com/marketinghub/oprm/application/OccupationResolverServiceTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprm.application;
 
 import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.OccupationProfileSnapshotPayload;
 import com.marketinghub.oprm.infra.StructuredOccupationCatalog;
 import org.junit.jupiter.api.Test;
 
@@ -16,8 +17,9 @@ class OccupationResolverServiceTest {
         ArtifactEnvelope result = service.resolveToProfileSnapshot("treinador pessoal", "fitness", "pt-BR", "corr-1");
 
         assertEquals("occupationProfileSnapshot", result.artifactType());
-        assertEquals("personal trainer", result.payload().occupationName());
-        assertEquals("ALIAS", result.payload().aliasResolution().matchType());
+        OccupationProfileSnapshotPayload payload = (OccupationProfileSnapshotPayload) result.payload();
+        assertEquals("personal trainer", payload.occupationName());
+        assertEquals("ALIAS", payload.aliasResolution().matchType());
         assertEquals("GENERATED", result.status());
     }
 

--- a/oprm/src/test/java/com/marketinghub/oprm/application/WebEnrichmentServiceTest.java
+++ b/oprm/src/test/java/com/marketinghub/oprm/application/WebEnrichmentServiceTest.java
@@ -1,0 +1,53 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.OccupationWebSourceSnapshotPayload;
+import com.marketinghub.oprm.infra.StructuredOccupationCatalog;
+import com.marketinghub.oprm.infra.enrichment.FetchedWebPage;
+import com.marketinghub.oprm.infra.enrichment.OccupationSourcePolicyRegistry;
+import com.marketinghub.oprm.infra.enrichment.OccupationWebSeedRegistry;
+import com.marketinghub.oprm.infra.enrichment.WebPageFetcher;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebEnrichmentServiceTest {
+
+    private final WebPageFetcher stubFetcher = url -> new FetchedWebPage(
+            url,
+            200,
+            "Personal Trainer Daily Routine",
+            "Montar fichas de treino e acompanhar alunos usando WhatsApp e apps de treino.",
+            "pt-BR",
+            "captured-for-test",
+            true
+    );
+
+    private final WebEnrichmentService service = new WebEnrichmentService(
+            new StructuredOccupationCatalog(),
+            new OccupationSourcePolicyRegistry(),
+            new OccupationWebSeedRegistry(),
+            stubFetcher
+    );
+
+    @Test
+    void shouldGeneratePhase2WebSourceSnapshot() {
+        ArtifactEnvelope result = service.enrichOccupation("treinador pessoal", "fitness", "pt-BR", "corr-phase2-1");
+
+        assertEquals("occupationWebSourceSnapshot", result.artifactType());
+        assertEquals("GENERATED", result.status());
+
+        OccupationWebSourceSnapshotPayload payload = (OccupationWebSourceSnapshotPayload) result.payload();
+        assertEquals("personal trainer", payload.occupationName());
+        assertEquals(2, payload.capturedSources().size());
+        assertTrue(payload.semanticRoutineSignals().stream().anyMatch(signal -> signal.startsWith("task:")));
+    }
+
+    @Test
+    void shouldRejectUnsupportedOccupationInPhase2() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.enrichOccupation("astronauta", "espacial", "pt-BR", null));
+    }
+}


### PR DESCRIPTION
### Motivation
- Implementar a Fase 2 do OPRM para aproximar perfis ocupacionais da prática real por meio de enriquecimento web controlado por política de fontes. 
- Fornecer artefatos canônicos consumíveis pelo ecossistema (`occupationWebSourceSnapshot`) e preparar o módulo para as próximas fases do roadmap.

### Description
- Adiciona o serviço `WebEnrichmentService` que resolve ocupação, aplica allowlist/blocklist, captura seeds e produz o artefato `occupationWebSourceSnapshot` (arquivo principal: `oprm/src/main/java/com/marketinghub/oprm/application/WebEnrichmentService.java`).
- Cria a infraestrutura de captura e política: `HttpWebPageFetcher`, `OccupationSourcePolicyRegistry`, `OccupationWebSeedRegistry` e a interface `WebPageFetcher` sob `oprm/src/main/java/com/marketinghub/oprm/infra/enrichment/`.
- Introduz os novos tipos de domínio `CapturedWebSource`, `OccupationSourcePolicyProfile` e `OccupationWebSourceSnapshotPayload` em `oprm/src/main/java/com/marketinghub/oprm/domain/` e generaliza o campo `payload` de `ArtifactEnvelope` para `Object` para suportar múltiplos artefatos.
- Expõe o endpoint HTTP interno `POST /api/oprm/phase2/enrich` com request `Phase2EnrichRequest`, atualiza `oprm/README.md` e registra a entrada da fase 2 em `docs/history/oprm-implementation-history.md`.

### Testing
- Executado `cd oprm && mvn test` e todos os testes unitários passaram (fases 1 e 2).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdbf8cf7c8321a1db6589213ec179)