### PR TITLE
feat(oprm): implement phase 3 routine inference pipeline

### DIFF
--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -88,3 +88,49 @@ Foi implementada a fase 2 do OPRM com pipeline inicial de enriquecimento web por
 **Próximo passo sugerido:**  
 - implementar fase 3 com inferência de rotina (`routineTaskPattern`, `routineConstraintSignal`, `routinePainSignal`, `routineWorkaroundSignal`)
 - definir contrato explícito de jobs/publicação com backend para persistir snapshots e lineage end-to-end
+
+## 2026-04-15 — fase 3: inferência de rotina
+
+**Status:** concluído
+
+**Resumo:**  
+Foi implementada a fase 3 do OPRM com inferência de rotina operacional a partir dos artefatos das fases 1 e 2, incluindo geração de padrões de tarefa, sinais de restrição/dor/workaround e publicação do artefato principal `occupationPersonaRoutineCard`.
+
+**O que foi implementado:**  
+- criação do serviço `RoutineInferenceService` para orquestrar as etapas de inferência com base em `occupationProfileSnapshot` e `occupationWebSourceSnapshot`
+- implementação dos artefatos de interpretação `routineTaskPattern`, `routineConstraintSignal`, `routinePainSignal` e `routineWorkaroundSignal` como estruturas de domínio explícitas
+- implementação do payload `OccupationPersonaRoutineCardPayload` para consolidar o card principal da rotina ocupacional inferida
+- criação do endpoint `POST /api/oprm/phase3/infer` para execução da fase 3 por ocupação
+- criação de testes unitários da fase 3 para validar geração do artefato `occupationPersonaRoutineCard`
+
+**Arquivos principais alterados:**  
+- `oprm/src/main/java/com/marketinghub/oprm/application/RoutineInferenceService.java`
+- `oprm/src/main/java/com/marketinghub/oprm/api/Phase3Controller.java`
+- `oprm/src/main/java/com/marketinghub/oprm/api/Phase3InferRequest.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/RoutineTaskPattern.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/RoutineConstraintSignal.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/RoutinePainSignal.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/RoutineWorkaroundSignal.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/OccupationPersonaRoutineCardPayload.java`
+- `oprm/src/test/java/com/marketinghub/oprm/application/RoutineInferenceServiceTest.java`
+- `oprm/README.md`
+
+**Contratos / artefatos afetados:**  
+- `routineTaskPattern`
+- `routineConstraintSignal`
+- `routinePainSignal`
+- `routineWorkaroundSignal`
+- `occupationPersonaRoutineCard`
+- endpoint interno do módulo: `POST /api/oprm/phase3/infer`
+
+**Testes executados:**  
+- `cd oprm && mvn test` — **passou**
+
+**Limitações ou pendências:**  
+- inferência inicial usa heurísticas determinísticas e ainda não aplica modelo de IA para síntese semântica avançada
+- artefatos de interpretação ainda não são publicados separadamente no backend principal; permanecem encapsulados no card de saída
+- ainda não há contrato de persistência end-to-end entre OPRM e backend para lineage completo
+
+**Próximo passo sugerido:**  
+- implementar fase 4 com `desiredOutcomeSignal`, `mechanismOpportunitySignal` e `dorResultadoOfertaMecanismoProvaInput`
+- definir contrato explícito de publicação de artefatos do OPRM no backend principal

--- a/oprm/README.md
+++ b/oprm/README.md
@@ -1,11 +1,12 @@
 # OPRM (Occupation Persona Routine Mapper)
 
-Módulo Spring Boot interno do Marketing Hub para as fases 1 e 2 do plano OPRM:
+Módulo Spring Boot interno do Marketing Hub para as fases 1, 2 e 3 do plano OPRM:
 
 - resolução ocupacional (`Occupation Resolver`)
 - intake estruturado baseado em fontes ocupacionais do MVP
 - enriquecimento web com política de allowlist
-- geração dos artefatos `occupationProfileSnapshot` e `occupationWebSourceSnapshot`
+- inferência de rotina operacional com geração de sinais de tarefa, restrição, dor e workaround
+- geração dos artefatos `occupationProfileSnapshot`, `occupationWebSourceSnapshot` e `occupationPersonaRoutineCard`
 - suporte inicial às 6 ocupações do MVP
 
 ## Executar localmente
@@ -24,6 +25,10 @@ mvn spring-boot:run
 ## Endpoint da fase 2
 
 - `POST /api/oprm/phase2/enrich`
+
+## Endpoint da fase 3
+
+- `POST /api/oprm/phase3/infer`
 
 Exemplo de payload:
 
@@ -44,5 +49,16 @@ Exemplo de payload da fase 2:
   "nicheName": "fitness",
   "locale": "pt-BR",
   "correlationId": "oprm-demo-002"
+}
+```
+
+Exemplo de payload da fase 3:
+
+```json
+{
+  "occupationLabel": "treinador pessoal",
+  "nicheName": "fitness",
+  "locale": "pt-BR",
+  "correlationId": "oprm-demo-003"
 }
 ```

--- a/oprm/src/main/java/com/marketinghub/oprm/api/Phase3Controller.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/api/Phase3Controller.java
@@ -1,0 +1,39 @@
+package com.marketinghub.oprm.api;
+
+import com.marketinghub.oprm.application.RoutineInferenceService;
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/oprm/phase3")
+public class Phase3Controller {
+
+    private final RoutineInferenceService routineInferenceService;
+
+    public Phase3Controller(RoutineInferenceService routineInferenceService) {
+        this.routineInferenceService = routineInferenceService;
+    }
+
+    @PostMapping("/infer")
+    public ResponseEntity<ArtifactEnvelope> infer(@Valid @RequestBody Phase3InferRequest request) {
+        ArtifactEnvelope result = routineInferenceService.inferRoutine(
+                request.occupationLabel(),
+                request.nicheName(),
+                request.locale(),
+                request.correlationId());
+        return ResponseEntity.ok(result);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException exception) {
+        return ResponseEntity.badRequest().body(Map.of("error", exception.getMessage()));
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/api/Phase3InferRequest.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/api/Phase3InferRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.api;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record Phase3InferRequest(
+        @NotBlank String occupationLabel,
+        @NotBlank String nicheName,
+        @NotBlank String locale,
+        String correlationId) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/application/RoutineInferenceService.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/application/RoutineInferenceService.java
@@ -1,0 +1,256 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.CapturedWebSource;
+import com.marketinghub.oprm.domain.OccupationPersonaRoutineCardPayload;
+import com.marketinghub.oprm.domain.OccupationProfileSnapshotPayload;
+import com.marketinghub.oprm.domain.OccupationWebSourceSnapshotPayload;
+import com.marketinghub.oprm.domain.RoutineConstraintSignal;
+import com.marketinghub.oprm.domain.RoutinePainSignal;
+import com.marketinghub.oprm.domain.RoutineTaskPattern;
+import com.marketinghub.oprm.domain.RoutineWorkaroundSignal;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class RoutineInferenceService {
+
+    private static final int MAX_TOP_TASKS = 4;
+
+    private final OccupationResolverService occupationResolverService;
+    private final WebEnrichmentService webEnrichmentService;
+
+    public RoutineInferenceService(OccupationResolverService occupationResolverService,
+                                   WebEnrichmentService webEnrichmentService) {
+        this.occupationResolverService = occupationResolverService;
+        this.webEnrichmentService = webEnrichmentService;
+    }
+
+    public ArtifactEnvelope inferRoutine(String rawOccupationLabel, String nicheName, String locale, String correlationId) {
+        ArtifactEnvelope profileSnapshot = occupationResolverService.resolveToProfileSnapshot(
+                rawOccupationLabel,
+                nicheName,
+                locale,
+                correlationId
+        );
+
+        ArtifactEnvelope webSnapshot = webEnrichmentService.enrichOccupation(
+                rawOccupationLabel,
+                nicheName,
+                locale,
+                correlationId
+        );
+
+        OccupationProfileSnapshotPayload profilePayload = (OccupationProfileSnapshotPayload) profileSnapshot.payload();
+        OccupationWebSourceSnapshotPayload webPayload = (OccupationWebSourceSnapshotPayload) webSnapshot.payload();
+
+        List<RoutineTaskPattern> taskPatterns = buildTaskPatterns(profilePayload, webPayload);
+        List<RoutineConstraintSignal> constraintSignals = buildConstraintSignals(profilePayload, taskPatterns);
+        List<RoutinePainSignal> painSignals = buildPainSignals(constraintSignals, taskPatterns);
+        List<RoutineWorkaroundSignal> workaroundSignals = buildWorkaroundSignals(taskPatterns, painSignals);
+
+        Map<String, Integer> sourceMix = Map.of(
+                "captured_web_sources", webPayload.capturedSources().size(),
+                "structured_records", profilePayload.sourceRecordIds().size()
+        );
+
+        OccupationPersonaRoutineCardPayload cardPayload = new OccupationPersonaRoutineCardPayload(
+                profilePayload.aliasResolution().rawLabel(),
+                profilePayload.occupationName(),
+                List.copyOf(profilePayload.aliasResolution().matchType().equals("ALIAS")
+                        ? List.of(profilePayload.aliasResolution().rawLabel())
+                        : List.of()),
+                profilePayload.nicheName(),
+                buildRoutineSummary(profilePayload, taskPatterns, painSignals),
+                taskPatterns,
+                profilePayload.toolsList().stream().limit(3).toList(),
+                constraintSignals,
+                profilePayload.workContextList().stream().limit(3).toList(),
+                "frequent direct interaction with end customers during service delivery",
+                "revenue depends on maintaining task consistency and client retention",
+                "high admin burden from fragmented communication, scheduling and follow-up",
+                workaroundSignals,
+                painSignals,
+                List.of(
+                        "reduzir retrabalho operacional",
+                        "ganhar previsibilidade diária",
+                        "diminuir tempo em tarefas administrativas"
+                ),
+                List.of(
+                        "padronização de rotina com checklist acionável",
+                        "automação de lembretes e acompanhamento",
+                        "centralização de tarefas e comunicação"
+                ),
+                webPayload.capturedSources().stream().map(CapturedWebSource::url).toList(),
+                sourceMix,
+                Instant.now()
+        );
+
+        double confidenceScore = calculateConfidence(taskPatterns, painSignals, webPayload.capturedSources());
+        String effectiveCorrelationId = correlationId == null || correlationId.isBlank()
+                ? UUID.randomUUID().toString()
+                : correlationId;
+
+        return new ArtifactEnvelope(
+                "occupationPersonaRoutineCard",
+                "1.0",
+                UUID.randomUUID().toString(),
+                "oprm",
+                "oprm.routine-inference",
+                Instant.now(),
+                effectiveCorrelationId,
+                UUID.randomUUID().toString(),
+                webPayload.capturedSources().stream().map(CapturedWebSource::url).toList(),
+                List.of(
+                        profileSnapshot.artifactId(),
+                        webSnapshot.artifactId(),
+                        "routineTaskPattern",
+                        "routineConstraintSignal",
+                        "routinePainSignal",
+                        "routineWorkaroundSignal"
+                ),
+                cardPayload,
+                "GENERATED",
+                confidenceScore,
+                Map.of(
+                        "phase", "phase-3",
+                        "task_patterns", taskPatterns.size(),
+                        "constraint_signals", constraintSignals.size(),
+                        "pain_signals", painSignals.size(),
+                        "workaround_signals", workaroundSignals.size()
+                )
+        );
+    }
+
+    private List<RoutineTaskPattern> buildTaskPatterns(OccupationProfileSnapshotPayload profilePayload,
+                                                       OccupationWebSourceSnapshotPayload webPayload) {
+        List<String> signals = webPayload.semanticRoutineSignals().stream()
+                .map(signal -> signal.toLowerCase(Locale.ROOT))
+                .toList();
+
+        return profilePayload.taskList().stream()
+                .limit(MAX_TOP_TASKS)
+                .map(task -> {
+                    String normalizedTask = task.toLowerCase(Locale.ROOT);
+                    boolean hasSignal = signals.stream().anyMatch(signal -> signal.contains(normalizedTask));
+                    String frequency = hasSignal ? "HIGH_RECURRENT" : "MEDIUM_RECURRENT";
+                    String trigger = hasSignal
+                            ? "triggered by recurring customer demand and daily execution"
+                            : "triggered by periodic operational needs";
+                    String timeCost = hasSignal ? "MEDIUM_HIGH" : "MEDIUM";
+                    return new RoutineTaskPattern(
+                            task,
+                            "core routine activity for " + profilePayload.occupationName(),
+                            trigger,
+                            frequency,
+                            timeCost,
+                            "uses tools such as " + String.join(", ", profilePayload.toolsList().stream().limit(2).toList()),
+                            webPayload.capturedSources().stream().map(CapturedWebSource::url).toList()
+                    );
+                })
+                .toList();
+    }
+
+    private List<RoutineConstraintSignal> buildConstraintSignals(OccupationProfileSnapshotPayload profilePayload,
+                                                                 List<RoutineTaskPattern> taskPatterns) {
+        List<String> evidenceRefs = taskPatterns.stream()
+                .flatMap(pattern -> pattern.evidenceRefs().stream())
+                .distinct()
+                .toList();
+
+        return List.of(
+                new RoutineConstraintSignal(
+                        "TIME_FRAGMENTATION",
+                        "high context switching between execution tasks and admin follow-up",
+                        0.82,
+                        String.join("; ", profilePayload.workContextList().stream().limit(2).toList()),
+                        evidenceRefs
+                ),
+                new RoutineConstraintSignal(
+                        "TOOL_FRAGMENTATION",
+                        "routine distributed across multiple communication and planning tools",
+                        0.75,
+                        "tool usage spread across " + String.join(", ", profilePayload.toolsList().stream().limit(3).toList()),
+                        evidenceRefs
+                )
+        );
+    }
+
+    private List<RoutinePainSignal> buildPainSignals(List<RoutineConstraintSignal> constraints,
+                                                     List<RoutineTaskPattern> taskPatterns) {
+        List<String> evidenceRefs = taskPatterns.stream()
+                .flatMap(pattern -> pattern.evidenceRefs().stream())
+                .distinct()
+                .toList();
+
+        return constraints.stream()
+                .sorted(Comparator.comparing(RoutineConstraintSignal::severityScore).reversed())
+                .map(constraint -> new RoutinePainSignal(
+                        "operational overload: " + constraint.constraintType().toLowerCase(Locale.ROOT),
+                        "constraint leads to recurrent friction and reduces daily predictability",
+                        "OPERATIONAL",
+                        Math.min(0.95, constraint.severityScore() + 0.08),
+                        0.84,
+                        "uses ad-hoc checklist and manual reminders to keep activities moving",
+                        evidenceRefs
+                ))
+                .toList();
+    }
+
+    private List<RoutineWorkaroundSignal> buildWorkaroundSignals(List<RoutineTaskPattern> taskPatterns,
+                                                                 List<RoutinePainSignal> painSignals) {
+        String relatedTask = taskPatterns.isEmpty() ? "general routine" : taskPatterns.getFirst().taskLabel();
+        String relatedPain = painSignals.isEmpty() ? "operational overload" : painSignals.getFirst().painLabel();
+        List<String> evidenceRefs = taskPatterns.stream()
+                .flatMap(pattern -> pattern.evidenceRefs().stream())
+                .distinct()
+                .toList();
+
+        return List.of(
+                new RoutineWorkaroundSignal(
+                        "manual-priority-list",
+                        "maintains temporary task ordering manually between customer demands",
+                        relatedTask,
+                        relatedPain,
+                        0.71,
+                        evidenceRefs
+                ),
+                new RoutineWorkaroundSignal(
+                        "chat-based-follow-up",
+                        "uses message threads as informal task tracker",
+                        relatedTask,
+                        relatedPain,
+                        0.76,
+                        evidenceRefs
+                )
+        );
+    }
+
+    private String buildRoutineSummary(OccupationProfileSnapshotPayload profilePayload,
+                                       List<RoutineTaskPattern> taskPatterns,
+                                       List<RoutinePainSignal> painSignals) {
+        return profilePayload.occupationName()
+                + " routine inferred with "
+                + taskPatterns.size()
+                + " recurring task patterns and "
+                + painSignals.size()
+                + " primary pain signals from structured and web evidence";
+    }
+
+    private double calculateConfidence(List<RoutineTaskPattern> taskPatterns,
+                                       List<RoutinePainSignal> painSignals,
+                                       List<CapturedWebSource> sources) {
+        long capturedSources = sources.stream().filter(source -> "CAPTURED".equals(source.captureStatus())).count();
+        double base = 0.62;
+        double taskContribution = Math.min(0.18, taskPatterns.size() * 0.04);
+        double painContribution = Math.min(0.12, painSignals.size() * 0.05);
+        double sourceContribution = Math.min(0.10, capturedSources * 0.03);
+        return Math.min(0.95, base + taskContribution + painContribution + sourceContribution);
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationPersonaRoutineCardPayload.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationPersonaRoutineCardPayload.java
@@ -1,0 +1,27 @@
+package com.marketinghub.oprm.domain;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record OccupationPersonaRoutineCardPayload(
+        String personaLabel,
+        String occupationName,
+        List<String> occupationAliases,
+        String nicheName,
+        String routineSummary,
+        List<RoutineTaskPattern> topTasks,
+        List<String> topTools,
+        List<RoutineConstraintSignal> topConstraints,
+        List<String> topWorkContexts,
+        String customerInteractionPattern,
+        String revenueDependencyPattern,
+        String adminBurdenPattern,
+        List<RoutineWorkaroundSignal> workaroundPatterns,
+        List<RoutinePainSignal> painSignals,
+        List<String> desiredOutcomeSignals,
+        List<String> mechanismOpportunitySignals,
+        List<String> evidenceRefs,
+        Map<String, Integer> sourceMix,
+        Instant generatedAt) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/RoutineConstraintSignal.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/RoutineConstraintSignal.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record RoutineConstraintSignal(
+        String constraintType,
+        String constraintSummary,
+        double severityScore,
+        String contextSummary,
+        List<String> evidenceRefs) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/RoutinePainSignal.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/RoutinePainSignal.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record RoutinePainSignal(
+        String painLabel,
+        String painSummary,
+        String painType,
+        double painIntensityScore,
+        double painRecurrenceScore,
+        String workaroundSummary,
+        List<String> evidenceRefs) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/RoutineTaskPattern.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/RoutineTaskPattern.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record RoutineTaskPattern(
+        String taskLabel,
+        String taskSummary,
+        String triggerSummary,
+        String frequencySignal,
+        String timeCostSignal,
+        String toolingSummary,
+        List<String> evidenceRefs) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/RoutineWorkaroundSignal.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/RoutineWorkaroundSignal.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record RoutineWorkaroundSignal(
+        String workaroundLabel,
+        String workaroundSummary,
+        String relatedTask,
+        String relatedPain,
+        double inefficiencyScore,
+        List<String> evidenceRefs) {
+}

--- a/oprm/src/test/java/com/marketinghub/oprm/application/RoutineInferenceServiceTest.java
+++ b/oprm/src/test/java/com/marketinghub/oprm/application/RoutineInferenceServiceTest.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.OccupationPersonaRoutineCardPayload;
+import com.marketinghub.oprm.infra.StructuredOccupationCatalog;
+import com.marketinghub.oprm.infra.enrichment.FetchedWebPage;
+import com.marketinghub.oprm.infra.enrichment.OccupationSourcePolicyRegistry;
+import com.marketinghub.oprm.infra.enrichment.OccupationWebSeedRegistry;
+import com.marketinghub.oprm.infra.enrichment.WebPageFetcher;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoutineInferenceServiceTest {
+
+    private final WebPageFetcher stubFetcher = url -> new FetchedWebPage(
+            url,
+            200,
+            "Personal Trainer Daily Routine",
+            "Montar fichas de treino, acompanhar alunos no WhatsApp e ajustar agenda.",
+            "pt-BR",
+            "captured-for-phase3-test",
+            true
+    );
+
+    private final RoutineInferenceService service = new RoutineInferenceService(
+            new OccupationResolverService(new StructuredOccupationCatalog()),
+            new WebEnrichmentService(
+                    new StructuredOccupationCatalog(),
+                    new OccupationSourcePolicyRegistry(),
+                    new OccupationWebSeedRegistry(),
+                    stubFetcher
+            )
+    );
+
+    @Test
+    void shouldGenerateOccupationPersonaRoutineCardForPhase3() {
+        ArtifactEnvelope result = service.inferRoutine("treinador pessoal", "fitness", "pt-BR", "corr-phase3-1");
+
+        assertEquals("occupationPersonaRoutineCard", result.artifactType());
+        assertEquals("GENERATED", result.status());
+
+        OccupationPersonaRoutineCardPayload payload = (OccupationPersonaRoutineCardPayload) result.payload();
+        assertEquals("personal trainer", payload.occupationName());
+        assertTrue(payload.topTasks().size() > 0);
+        assertTrue(payload.painSignals().size() > 0);
+        assertTrue(payload.workaroundPatterns().size() > 0);
+    }
+}


### PR DESCRIPTION
### Motivation
- Implementar a Fase 3 do OPRM para transformar sinais das fases 1 e 2 em uma rotina operacional inferida e um artefato consumível `occupationPersonaRoutineCard`.
- Fornecer artefatos interpretáveis e versionáveis que alimentem o framework dor→resultado→oferta→mecanismo→prova e reduzir drift documental entre módulos.
- Entregar uma baseline heurística de inferência antes de integrar modelos de IA e publicar artefatos no backend principal. 

### Description
- Adicionado o serviço `RoutineInferenceService` que combina `OccupationResolverService` e `WebEnrichmentService` para gerar o `occupationPersonaRoutineCard` embalado em `ArtifactEnvelope` com lineage e `confidence_score`. 
- Introduzidos os registros de domínio de fase 3: `RoutineTaskPattern`, `RoutineConstraintSignal`, `RoutinePainSignal`, `RoutineWorkaroundSignal` e o payload `OccupationPersonaRoutineCardPayload`. 
- Adicionados API e contrato para disparo da fase 3 com `POST /api/oprm/phase3/infer` via `Phase3Controller` e `Phase3InferRequest`, além de testes unitários `RoutineInferenceServiceTest` e atualização do `oprm/README.md` e do histórico em `docs/history/oprm-implementation-history.md`. 

### Testing
- Executei os testes com `cd oprm && mvn test` e o build de testes completou com sucesso; todos os testes do módulo passaram. 
- O novo teste unitário `RoutineInferenceServiceTest` foi incluído e passou ao validar geração do `occupationPersonaRoutineCard`. 
- Não foram executados testes de integração com o backend principal nesta entrega; publicação end-to-end e contratos com backend permanecem como próximo passo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdfcc48b88321ba09cf1fa93eaa94)