### PR TITLE
feat(oprm): implement fase 4 de integração com framework dor-resultado-oferta-mecanismo-prova

### DIFF
--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -134,3 +134,45 @@ Foi implementada a fase 3 do OPRM com inferência de rotina operacional a partir
 **Próximo passo sugerido:**  
 - implementar fase 4 com `desiredOutcomeSignal`, `mechanismOpportunitySignal` e `dorResultadoOfertaMecanismoProvaInput`
 - definir contrato explícito de publicação de artefatos do OPRM no backend principal
+
+## 2026-04-15 — fase 4: integração com o framework
+
+**Status:** concluído
+
+**Resumo:**  
+Foi implementada a fase 4 do OPRM para transformar a rotina inferida em insumo direto do framework dor→resultado→oferta→mecanismo→prova, incluindo geração estruturada de `desiredOutcomeSignal`, `mechanismOpportunitySignal` e publicação do artefato `dorResultadoOfertaMecanismoProvaInput`.
+
+**O que foi implementado:**  
+- criação do serviço `FrameworkIntegrationService` para orquestrar a integração a partir do `occupationPersonaRoutineCard` da fase 3
+- implementação dos artefatos de domínio `DesiredOutcomeSignal`, `MechanismOpportunitySignal` e `DorResultadoOfertaMecanismoProvaInputPayload`
+- criação do endpoint `POST /api/oprm/phase4/integrate` para execução da integração do framework por ocupação
+- atualização da documentação do módulo com endpoint e exemplo de payload da fase 4
+- adição de teste unitário dedicado da fase 4 para validar geração do artefato de integração
+
+**Arquivos principais alterados:**  
+- `oprm/src/main/java/com/marketinghub/oprm/application/FrameworkIntegrationService.java`
+- `oprm/src/main/java/com/marketinghub/oprm/api/Phase4Controller.java`
+- `oprm/src/main/java/com/marketinghub/oprm/api/Phase4IntegrateRequest.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/DesiredOutcomeSignal.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/MechanismOpportunitySignal.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/DorResultadoOfertaMecanismoProvaInputPayload.java`
+- `oprm/src/test/java/com/marketinghub/oprm/application/FrameworkIntegrationServiceTest.java`
+- `oprm/README.md`
+
+**Contratos / artefatos afetados:**  
+- `desiredOutcomeSignal`
+- `mechanismOpportunitySignal`
+- `dorResultadoOfertaMecanismoProvaInput`
+- endpoint interno do módulo: `POST /api/oprm/phase4/integrate`
+
+**Testes executados:**  
+- `cd oprm && mvn test` — **passou**
+
+**Limitações ou pendências:**  
+- os sinais da fase 4 ainda são derivados por heurísticas determinísticas e não usam calibração com feedback downstream
+- publicação dos artefatos continua local ao módulo, sem persistência end-to-end no backend principal
+- faltam contratos HTTP versionados entre backend principal e OPRM para ingestão/persistência dos novos artefatos
+
+**Próximo passo sugerido:**  
+- implementar fase 5 com feedback loop para recalibrar scores por ocupação
+- definir contrato de publicação/persistência com backend para lineage completo dos artefatos da fase 4

--- a/oprm/README.md
+++ b/oprm/README.md
@@ -1,12 +1,12 @@
 # OPRM (Occupation Persona Routine Mapper)
 
-Módulo Spring Boot interno do Marketing Hub para as fases 1, 2 e 3 do plano OPRM:
+Módulo Spring Boot interno do Marketing Hub para as fases 1, 2, 3 e 4 do plano OPRM:
 
 - resolução ocupacional (`Occupation Resolver`)
 - intake estruturado baseado em fontes ocupacionais do MVP
 - enriquecimento web com política de allowlist
 - inferência de rotina operacional com geração de sinais de tarefa, restrição, dor e workaround
-- geração dos artefatos `occupationProfileSnapshot`, `occupationWebSourceSnapshot` e `occupationPersonaRoutineCard`
+- geração dos artefatos `occupationProfileSnapshot`, `occupationWebSourceSnapshot`, `occupationPersonaRoutineCard` e `dorResultadoOfertaMecanismoProvaInput`
 - suporte inicial às 6 ocupações do MVP
 
 ## Executar localmente
@@ -29,6 +29,10 @@ mvn spring-boot:run
 ## Endpoint da fase 3
 
 - `POST /api/oprm/phase3/infer`
+
+## Endpoint da fase 4
+
+- `POST /api/oprm/phase4/integrate`
 
 Exemplo de payload:
 
@@ -60,5 +64,16 @@ Exemplo de payload da fase 3:
   "nicheName": "fitness",
   "locale": "pt-BR",
   "correlationId": "oprm-demo-003"
+}
+```
+
+Exemplo de payload da fase 4:
+
+```json
+{
+  "occupationLabel": "treinador pessoal",
+  "nicheName": "fitness",
+  "locale": "pt-BR",
+  "correlationId": "oprm-demo-004"
 }
 ```

--- a/oprm/src/main/java/com/marketinghub/oprm/api/Phase4Controller.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/api/Phase4Controller.java
@@ -1,0 +1,40 @@
+package com.marketinghub.oprm.api;
+
+import com.marketinghub.oprm.application.FrameworkIntegrationService;
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/oprm/phase4")
+public class Phase4Controller {
+
+    private final FrameworkIntegrationService frameworkIntegrationService;
+
+    public Phase4Controller(FrameworkIntegrationService frameworkIntegrationService) {
+        this.frameworkIntegrationService = frameworkIntegrationService;
+    }
+
+    @PostMapping("/integrate")
+    public ResponseEntity<ArtifactEnvelope> integrate(@Valid @RequestBody Phase4IntegrateRequest request) {
+        ArtifactEnvelope result = frameworkIntegrationService.integrateRoutineSignals(
+                request.occupationLabel(),
+                request.nicheName(),
+                request.locale(),
+                request.correlationId()
+        );
+        return ResponseEntity.ok(result);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException exception) {
+        return ResponseEntity.badRequest().body(Map.of("error", exception.getMessage()));
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/api/Phase4IntegrateRequest.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/api/Phase4IntegrateRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.api;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record Phase4IntegrateRequest(
+        @NotBlank String occupationLabel,
+        @NotBlank String nicheName,
+        @NotBlank String locale,
+        String correlationId) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/application/FrameworkIntegrationService.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/application/FrameworkIntegrationService.java
@@ -1,0 +1,142 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.DesiredOutcomeSignal;
+import com.marketinghub.oprm.domain.DorResultadoOfertaMecanismoProvaInputPayload;
+import com.marketinghub.oprm.domain.MechanismOpportunitySignal;
+import com.marketinghub.oprm.domain.OccupationPersonaRoutineCardPayload;
+import com.marketinghub.oprm.domain.RoutinePainSignal;
+import com.marketinghub.oprm.domain.RoutineTaskPattern;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+@Service
+public class FrameworkIntegrationService {
+
+    private final RoutineInferenceService routineInferenceService;
+
+    public FrameworkIntegrationService(RoutineInferenceService routineInferenceService) {
+        this.routineInferenceService = routineInferenceService;
+    }
+
+    public ArtifactEnvelope integrateRoutineSignals(String rawOccupationLabel,
+                                                    String nicheName,
+                                                    String locale,
+                                                    String correlationId) {
+        ArtifactEnvelope routineCard = routineInferenceService.inferRoutine(rawOccupationLabel, nicheName, locale, correlationId);
+        OccupationPersonaRoutineCardPayload routinePayload = (OccupationPersonaRoutineCardPayload) routineCard.payload();
+
+        List<DesiredOutcomeSignal> desiredOutcomeSignals = buildDesiredOutcomeSignals(routinePayload.painSignals());
+        List<MechanismOpportunitySignal> mechanismSignals = buildMechanismSignals(
+                routinePayload.topTasks(),
+                routinePayload.painSignals(),
+                desiredOutcomeSignals,
+                routinePayload.evidenceRefs()
+        );
+
+        DorResultadoOfertaMecanismoProvaInputPayload integrationPayload = new DorResultadoOfertaMecanismoProvaInputPayload(
+                routinePayload.personaLabel(),
+                routinePayload.occupationName(),
+                routinePayload.nicheName(),
+                routinePayload.painSignals(),
+                desiredOutcomeSignals,
+                mechanismSignals,
+                routinePayload.evidenceRefs(),
+                List.of(
+                        routineCard.artifactId(),
+                        "desiredOutcomeSignal",
+                        "mechanismOpportunitySignal",
+                        "occupationPersonaRoutineCard"
+                ),
+                "OPRM phase 4 integration package for dor→resultado→oferta→mecanismo→prova framework",
+                Instant.now()
+        );
+
+        String effectiveCorrelationId = correlationId == null || correlationId.isBlank()
+                ? UUID.randomUUID().toString()
+                : correlationId;
+
+        return new ArtifactEnvelope(
+                "dorResultadoOfertaMecanismoProvaInput",
+                "1.0",
+                UUID.randomUUID().toString(),
+                "oprm",
+                "oprm.framework-integration",
+                Instant.now(),
+                effectiveCorrelationId,
+                UUID.randomUUID().toString(),
+                routinePayload.evidenceRefs(),
+                List.of(
+                        routineCard.artifactId(),
+                        "desiredOutcomeSignal",
+                        "mechanismOpportunitySignal"
+                ),
+                integrationPayload,
+                "GENERATED",
+                calculateIntegrationConfidence(routinePayload.painSignals(), desiredOutcomeSignals, mechanismSignals),
+                java.util.Map.of(
+                        "phase", "phase-4",
+                        "pain_signals", routinePayload.painSignals().size(),
+                        "desired_outcome_signals", desiredOutcomeSignals.size(),
+                        "mechanism_opportunity_signals", mechanismSignals.size()
+                )
+        );
+    }
+
+    private List<DesiredOutcomeSignal> buildDesiredOutcomeSignals(List<RoutinePainSignal> painSignals) {
+        if (painSignals.isEmpty()) {
+            return List.of();
+        }
+
+        return painSignals.stream()
+                .limit(3)
+                .map(pain -> new DesiredOutcomeSignal(
+                        "outcome for " + pain.painType().toLowerCase(Locale.ROOT),
+                        "reduce recurring friction caused by " + pain.painLabel().toLowerCase(Locale.ROOT),
+                        List.of(pain.painLabel()),
+                        Math.min(0.95, (pain.painIntensityScore() + pain.painRecurrenceScore()) / 2.0 + 0.08),
+                        pain.evidenceRefs()
+                ))
+                .toList();
+    }
+
+    private List<MechanismOpportunitySignal> buildMechanismSignals(List<RoutineTaskPattern> taskPatterns,
+                                                                    List<RoutinePainSignal> painSignals,
+                                                                    List<DesiredOutcomeSignal> desiredOutcomeSignals,
+                                                                    List<String> evidenceRefs) {
+        if (painSignals.isEmpty() || taskPatterns.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> linkedTasks = taskPatterns.stream().limit(3).map(RoutineTaskPattern::taskLabel).toList();
+        List<String> linkedPains = painSignals.stream().limit(3).map(RoutinePainSignal::painLabel).toList();
+
+        return desiredOutcomeSignals.stream()
+                .limit(3)
+                .map(outcome -> new MechanismOpportunitySignal(
+                        "mechanism for " + outcome.outcomeLabel().toLowerCase(Locale.ROOT),
+                        "introduce workflow guardrails and automation to sustain "
+                                + outcome.outcomeLabel().toLowerCase(Locale.ROOT),
+                        linkedTasks,
+                        linkedPains,
+                        0.84,
+                        0.46,
+                        evidenceRefs
+                ))
+                .toList();
+    }
+
+    private double calculateIntegrationConfidence(List<RoutinePainSignal> painSignals,
+                                                  List<DesiredOutcomeSignal> desiredSignals,
+                                                  List<MechanismOpportunitySignal> mechanismSignals) {
+        double base = 0.66;
+        double painContribution = Math.min(0.10, painSignals.size() * 0.03);
+        double desiredContribution = Math.min(0.10, desiredSignals.size() * 0.03);
+        double mechanismContribution = Math.min(0.10, mechanismSignals.size() * 0.03);
+        return Math.min(0.95, base + painContribution + desiredContribution + mechanismContribution);
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/DesiredOutcomeSignal.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/DesiredOutcomeSignal.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record DesiredOutcomeSignal(
+        String outcomeLabel,
+        String outcomeSummary,
+        List<String> linkedPainRefs,
+        double impactScore,
+        List<String> evidenceRefs) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/DorResultadoOfertaMecanismoProvaInputPayload.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/DorResultadoOfertaMecanismoProvaInputPayload.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.domain;
+
+import java.time.Instant;
+import java.util.List;
+
+public record DorResultadoOfertaMecanismoProvaInputPayload(
+        String personaLabel,
+        String occupationName,
+        String nicheName,
+        List<RoutinePainSignal> painSignals,
+        List<DesiredOutcomeSignal> desiredOutcomeSignals,
+        List<MechanismOpportunitySignal> mechanismOpportunitySignals,
+        List<String> evidenceRefs,
+        List<String> originArtifactRefs,
+        String integrationNotes,
+        Instant generatedAt) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/MechanismOpportunitySignal.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/MechanismOpportunitySignal.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record MechanismOpportunitySignal(
+        String mechanismLabel,
+        String mechanismSummary,
+        List<String> linkedTaskRefs,
+        List<String> linkedPainRefs,
+        double commercialFitScore,
+        double implementationEffortScore,
+        List<String> evidenceRefs) {
+}

--- a/oprm/src/test/java/com/marketinghub/oprm/application/FrameworkIntegrationServiceTest.java
+++ b/oprm/src/test/java/com/marketinghub/oprm/application/FrameworkIntegrationServiceTest.java
@@ -1,0 +1,52 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.DorResultadoOfertaMecanismoProvaInputPayload;
+import com.marketinghub.oprm.infra.StructuredOccupationCatalog;
+import com.marketinghub.oprm.infra.enrichment.FetchedWebPage;
+import com.marketinghub.oprm.infra.enrichment.OccupationSourcePolicyRegistry;
+import com.marketinghub.oprm.infra.enrichment.OccupationWebSeedRegistry;
+import com.marketinghub.oprm.infra.enrichment.WebPageFetcher;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FrameworkIntegrationServiceTest {
+
+    private final WebPageFetcher stubFetcher = url -> new FetchedWebPage(
+            url,
+            200,
+            "Personal Trainer Daily Routine",
+            "Montar fichas de treino, acompanhar alunos no WhatsApp e ajustar agenda.",
+            "pt-BR",
+            "captured-for-phase4-test",
+            true
+    );
+
+    private final FrameworkIntegrationService service = new FrameworkIntegrationService(
+            new RoutineInferenceService(
+                    new OccupationResolverService(new StructuredOccupationCatalog()),
+                    new WebEnrichmentService(
+                            new StructuredOccupationCatalog(),
+                            new OccupationSourcePolicyRegistry(),
+                            new OccupationWebSeedRegistry(),
+                            stubFetcher
+                    )
+            )
+    );
+
+    @Test
+    void shouldGenerateFrameworkIntegrationArtifactForPhase4() {
+        ArtifactEnvelope result = service.integrateRoutineSignals("treinador pessoal", "fitness", "pt-BR", "corr-phase4-1");
+
+        assertEquals("dorResultadoOfertaMecanismoProvaInput", result.artifactType());
+        assertEquals("GENERATED", result.status());
+
+        DorResultadoOfertaMecanismoProvaInputPayload payload = (DorResultadoOfertaMecanismoProvaInputPayload) result.payload();
+        assertEquals("personal trainer", payload.occupationName());
+        assertTrue(payload.painSignals().size() > 0);
+        assertTrue(payload.desiredOutcomeSignals().size() > 0);
+        assertTrue(payload.mechanismOpportunitySignals().size() > 0);
+    }
+}


### PR DESCRIPTION
### Motivation
- Entregar a Fase 4 do plano OPRM para transformar a rotina inferida em insumo direto ao framework dor→resultado→oferta→mecanismo→prova. 
- Produzir sinais estruturados de resultado e oportunidade que possam ser consumidos por pipelines downstream com lineage e confidence score. 

### Description
- Adicionado o serviço `FrameworkIntegrationService` que consome o `occupationPersonaRoutineCard`, gera `DesiredOutcomeSignal` e `MechanismOpportunitySignal` e monta o artefato de integração `dorResultadoOfertaMecanismoProvaInput` com metadata e cálculo de confiança.  
- Criados os novos tipos de domínio `DesiredOutcomeSignal`, `MechanismOpportunitySignal` e `DorResultadoOfertaMecanismoProvaInputPayload`.  
- Exposto endpoint HTTP `POST /api/oprm/phase4/integrate` com o request DTO `Phase4IntegrateRequest` e mantida a consistência do envelope `ArtifactEnvelope`.  
- Atualizados `oprm/README.md` e `docs/history/oprm-implementation-history.md` e incluído o teste unitário `FrameworkIntegrationServiceTest` para validar a geração do artefato de integração. 

### Testing
- Executado o conjunto de testes do módulo com `cd oprm && mvn test` e todos os testes unitários passaram.  
- O teste específico `FrameworkIntegrationServiceTest` foi executado e validou a criação do `dorResultadoOfertaMecanismoProvaInput` com sinais `desiredOutcomeSignal` e `mechanismOpportunitySignal` (passou).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe64241b08321840bff3bc992998e)