### PR TITLE
feat(oprm): implementa fase 5 feedback loop com recalibração e histórico

### DIFF
--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -176,3 +176,48 @@ Foi implementada a fase 4 do OPRM para transformar a rotina inferida em insumo d
 **Próximo passo sugerido:**  
 - implementar fase 5 com feedback loop para recalibrar scores por ocupação
 - definir contrato de publicação/persistência com backend para lineage completo dos artefatos da fase 4
+
+## 2026-04-15 — fase 5: feedback loop
+
+**Status:** concluído
+
+**Resumo:**  
+Foi implementada a fase 5 do OPRM com feedback loop para recalibração dos sinais e scores a partir da performance de hipóteses, geração de histórico incremental por ocupação e publicação do artefato `occupationFeedbackLoopSnapshot`.
+
+**O que foi implementado:**  
+- criação do serviço `FeedbackLoopService` para orquestrar inferência de rotina, integração com framework e recalibração baseada em feedback downstream
+- implementação de comparação estruturada entre rotina inferida e performance de hipóteses (`HypothesisRoutineFit`)
+- implementação de reponderação de sinais (`RoutinePainSignal` e `MechanismOpportunitySignal`) e de confiança agregada do ciclo
+- implementação de histórico incremental em memória por ocupação para registrar recalibrações sucessivas da fase 5
+- criação do endpoint `POST /api/oprm/phase5/feedback` com payload para snapshots de performance de hipóteses
+- atualização do cânone de artefatos e do README do módulo para incluir o artefato e fluxo da fase 5
+- criação de testes unitários da fase 5 para validar geração do artefato e acumulação de histórico por ocupação
+
+**Arquivos principais alterados:**  
+- `oprm/src/main/java/com/marketinghub/oprm/application/FeedbackLoopService.java`
+- `oprm/src/main/java/com/marketinghub/oprm/api/Phase5Controller.java`
+- `oprm/src/main/java/com/marketinghub/oprm/api/Phase5FeedbackRequest.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/OccupationFeedbackLoopPayload.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/OccupationFeedbackHistoryEntry.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/HypothesisPerformanceSnapshot.java`
+- `oprm/src/main/java/com/marketinghub/oprm/domain/HypothesisRoutineFit.java`
+- `oprm/src/test/java/com/marketinghub/oprm/application/FeedbackLoopServiceTest.java`
+- `oprm/README.md`
+- `docs/oprm_canonico_artefatos.md`
+
+**Contratos / artefatos afetados:**  
+- `occupationFeedbackLoopSnapshot`
+- endpoint interno do módulo: `POST /api/oprm/phase5/feedback`
+- `HypothesisPerformanceSnapshot` (payload de entrada da fase 5)
+
+**Testes executados:**  
+- `cd oprm && mvn test` — **passou**
+
+**Limitações ou pendências:**  
+- histórico por ocupação está em memória local do processo e ainda não foi persistido no backend principal
+- cálculo de aderência entre hipótese e rotina usa heurística textual simples e precisa de evolução para comparação semântica mais robusta
+- ainda não existe contrato HTTP versionado com backend principal para ingestão automática de métricas de hipótese
+
+**Próximo passo sugerido:**  
+- implementar fase 6 de hardening operacional (persistência remota do feedback loop, observabilidade e integração contínua com backend)
+- versionar contrato HTTP entre backend principal e OPRM para ingestão/publicação completa dos artefatos da fase 5

--- a/docs/oprm_canonico_artefatos.md
+++ b/docs/oprm_canonico_artefatos.md
@@ -472,6 +472,29 @@ Payload sugerido:
 - `proof_angle_summary`
 - `evidence_refs`
 
+### 13.3 `occupationFeedbackLoopSnapshot`
+Representa o artefato de recalibração da fase 5 com feedback de hipóteses e performance do Marketing Hub.
+
+Uso:
+- reponderar scores de dor, mecanismo e confiança
+- manter histórico incremental por ocupação
+- comparar rotina inferida com resultado de hipóteses downstream
+
+Payload sugerido:
+- `persona_label`
+- `occupation_name`
+- `niche_name`
+- `baseline_routine_artifact_id`
+- `baseline_framework_artifact_id`
+- `recalibrated_pain_signals`
+- `recalibrated_mechanism_signals`
+- `hypothesis_comparison`
+- `occupation_history`
+- `recalibrated_routine_confidence`
+- `recalibrated_framework_confidence`
+- `score_reweighting`
+- `evidence_refs`
+
 ---
 
 ## 14. Regras de naming

--- a/oprm/README.md
+++ b/oprm/README.md
@@ -1,12 +1,13 @@
 # OPRM (Occupation Persona Routine Mapper)
 
-Módulo Spring Boot interno do Marketing Hub para as fases 1, 2, 3 e 4 do plano OPRM:
+Módulo Spring Boot interno do Marketing Hub para as fases 1, 2, 3, 4 e 5 do plano OPRM:
 
 - resolução ocupacional (`Occupation Resolver`)
 - intake estruturado baseado em fontes ocupacionais do MVP
 - enriquecimento web com política de allowlist
 - inferência de rotina operacional com geração de sinais de tarefa, restrição, dor e workaround
 - geração dos artefatos `occupationProfileSnapshot`, `occupationWebSourceSnapshot`, `occupationPersonaRoutineCard` e `dorResultadoOfertaMecanismoProvaInput`
+- feedback loop com reponderação de score, histórico por ocupação e comparação com performance de hipóteses
 - suporte inicial às 6 ocupações do MVP
 
 ## Executar localmente
@@ -33,6 +34,10 @@ mvn spring-boot:run
 ## Endpoint da fase 4
 
 - `POST /api/oprm/phase4/integrate`
+
+## Endpoint da fase 5
+
+- `POST /api/oprm/phase5/feedback`
 
 Exemplo de payload:
 
@@ -75,5 +80,34 @@ Exemplo de payload da fase 4:
   "nicheName": "fitness",
   "locale": "pt-BR",
   "correlationId": "oprm-demo-004"
+}
+```
+
+Exemplo de payload da fase 5:
+
+```json
+{
+  "occupationLabel": "treinador pessoal",
+  "nicheName": "fitness",
+  "locale": "pt-BR",
+  "correlationId": "oprm-demo-005",
+  "hypothesisPerformance": [
+    {
+      "hypothesisId": "hyp-001",
+      "hypothesisLabel": "Checklist semanal de alunos",
+      "ctr": 0.041,
+      "conversionRate": 0.087,
+      "cpa": 79.0,
+      "confidenceScore": 0.81
+    },
+    {
+      "hypothesisId": "hyp-002",
+      "hypothesisLabel": "Lembrete automático de treino",
+      "ctr": 0.037,
+      "conversionRate": 0.072,
+      "cpa": 88.0,
+      "confidenceScore": 0.76
+    }
+  ]
 }
 ```

--- a/oprm/src/main/java/com/marketinghub/oprm/api/Phase5Controller.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/api/Phase5Controller.java
@@ -1,0 +1,41 @@
+package com.marketinghub.oprm.api;
+
+import com.marketinghub.oprm.application.FeedbackLoopService;
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/oprm/phase5")
+public class Phase5Controller {
+
+    private final FeedbackLoopService feedbackLoopService;
+
+    public Phase5Controller(FeedbackLoopService feedbackLoopService) {
+        this.feedbackLoopService = feedbackLoopService;
+    }
+
+    @PostMapping("/feedback")
+    public ResponseEntity<ArtifactEnvelope> feedback(@Valid @RequestBody Phase5FeedbackRequest request) {
+        ArtifactEnvelope result = feedbackLoopService.recalibrateWithFeedback(
+                request.occupationLabel(),
+                request.nicheName(),
+                request.locale(),
+                request.correlationId(),
+                request.hypothesisPerformance()
+        );
+        return ResponseEntity.ok(result);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException exception) {
+        return ResponseEntity.badRequest().body(Map.of("error", exception.getMessage()));
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/api/Phase5FeedbackRequest.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/api/Phase5FeedbackRequest.java
@@ -1,0 +1,14 @@
+package com.marketinghub.oprm.api;
+
+import com.marketinghub.oprm.domain.HypothesisPerformanceSnapshot;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record Phase5FeedbackRequest(
+        @NotBlank String occupationLabel,
+        @NotBlank String nicheName,
+        @NotBlank String locale,
+        String correlationId,
+        List<HypothesisPerformanceSnapshot> hypothesisPerformance) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/application/FeedbackLoopService.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/application/FeedbackLoopService.java
@@ -1,0 +1,273 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.DorResultadoOfertaMecanismoProvaInputPayload;
+import com.marketinghub.oprm.domain.HypothesisPerformanceSnapshot;
+import com.marketinghub.oprm.domain.HypothesisRoutineFit;
+import com.marketinghub.oprm.domain.MechanismOpportunitySignal;
+import com.marketinghub.oprm.domain.OccupationFeedbackHistoryEntry;
+import com.marketinghub.oprm.domain.OccupationFeedbackLoopPayload;
+import com.marketinghub.oprm.domain.OccupationPersonaRoutineCardPayload;
+import com.marketinghub.oprm.domain.RoutinePainSignal;
+import com.marketinghub.oprm.domain.RoutineTaskPattern;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Service
+public class FeedbackLoopService {
+
+    private static final int MAX_HISTORY_SIZE = 12;
+
+    private final RoutineInferenceService routineInferenceService;
+    private final FrameworkIntegrationService frameworkIntegrationService;
+    private final Map<String, List<OccupationFeedbackHistoryEntry>> feedbackHistoryByOccupation = new ConcurrentHashMap<>();
+
+    public FeedbackLoopService(RoutineInferenceService routineInferenceService,
+                               FrameworkIntegrationService frameworkIntegrationService) {
+        this.routineInferenceService = routineInferenceService;
+        this.frameworkIntegrationService = frameworkIntegrationService;
+    }
+
+    public ArtifactEnvelope recalibrateWithFeedback(String rawOccupationLabel,
+                                                    String nicheName,
+                                                    String locale,
+                                                    String correlationId,
+                                                    List<HypothesisPerformanceSnapshot> performanceSnapshots) {
+        ArtifactEnvelope routineEnvelope = routineInferenceService.inferRoutine(rawOccupationLabel, nicheName, locale, correlationId);
+        ArtifactEnvelope frameworkEnvelope = frameworkIntegrationService.integrateRoutineSignals(rawOccupationLabel, nicheName, locale, correlationId);
+
+        OccupationPersonaRoutineCardPayload routinePayload = (OccupationPersonaRoutineCardPayload) routineEnvelope.payload();
+        DorResultadoOfertaMecanismoProvaInputPayload frameworkPayload = (DorResultadoOfertaMecanismoProvaInputPayload) frameworkEnvelope.payload();
+
+        List<HypothesisPerformanceSnapshot> sanitizedSnapshots = performanceSnapshots == null ? List.of() : performanceSnapshots;
+        List<HypothesisRoutineFit> comparison = buildRoutineComparison(sanitizedSnapshots, routinePayload, frameworkPayload);
+
+        double averageImpact = comparison.isEmpty()
+                ? 0.5
+                : comparison.stream().mapToDouble(HypothesisRoutineFit::weightedImpactScore).average().orElse(0.5);
+
+        List<RoutinePainSignal> recalibratedPainSignals = recalibratePainSignals(routinePayload.painSignals(), averageImpact);
+        List<MechanismOpportunitySignal> recalibratedMechanisms = recalibrateMechanismSignals(
+                frameworkPayload.mechanismOpportunitySignals(),
+                averageImpact
+        );
+
+        double recalibratedRoutineConfidence = recalibrateConfidence(routineEnvelope.confidenceScore(), averageImpact);
+        double recalibratedFrameworkConfidence = recalibrateConfidence(frameworkEnvelope.confidenceScore(), averageImpact);
+
+        OccupationFeedbackHistoryEntry historyEntry = new OccupationFeedbackHistoryEntry(
+                Instant.now(),
+                routineEnvelope.confidenceScore(),
+                recalibratedRoutineConfidence,
+                frameworkEnvelope.confidenceScore(),
+                recalibratedFrameworkConfidence,
+                averageImpact,
+                "phase-5 feedback recalibration using hypothesis performance snapshots"
+        );
+
+        List<OccupationFeedbackHistoryEntry> occupationHistory = registerHistory(
+                routinePayload.occupationName(),
+                historyEntry
+        );
+
+        Map<String, Double> scoreReweighting = Map.of(
+                "average_hypothesis_impact", averageImpact,
+                "routine_confidence_delta", recalibratedRoutineConfidence - routineEnvelope.confidenceScore(),
+                "framework_confidence_delta", recalibratedFrameworkConfidence - frameworkEnvelope.confidenceScore(),
+                "pain_intensity_multiplier", 0.90 + (averageImpact * 0.20),
+                "mechanism_fit_multiplier", 0.88 + (averageImpact * 0.24)
+        );
+
+        OccupationFeedbackLoopPayload payload = new OccupationFeedbackLoopPayload(
+                routinePayload.personaLabel(),
+                routinePayload.occupationName(),
+                routinePayload.nicheName(),
+                routineEnvelope.artifactId(),
+                frameworkEnvelope.artifactId(),
+                recalibratedPainSignals,
+                recalibratedMechanisms,
+                comparison,
+                occupationHistory,
+                recalibratedRoutineConfidence,
+                recalibratedFrameworkConfidence,
+                scoreReweighting,
+                routinePayload.evidenceRefs(),
+                Instant.now()
+        );
+
+        return new ArtifactEnvelope(
+                "occupationFeedbackLoopSnapshot",
+                "1.0",
+                UUID.randomUUID().toString(),
+                "oprm",
+                "oprm.feedback-loop",
+                Instant.now(),
+                effectiveCorrelationId(correlationId),
+                UUID.randomUUID().toString(),
+                routinePayload.evidenceRefs(),
+                List.of(
+                        routineEnvelope.artifactId(),
+                        frameworkEnvelope.artifactId(),
+                        "occupationPersonaRoutineCard",
+                        "dorResultadoOfertaMecanismoProvaInput"
+                ),
+                payload,
+                "GENERATED",
+                Math.min(0.96, (recalibratedRoutineConfidence + recalibratedFrameworkConfidence) / 2.0),
+                Map.of(
+                        "phase", "phase-5",
+                        "history_entries", occupationHistory.size(),
+                        "hypothesis_snapshots", sanitizedSnapshots.size(),
+                        "comparison_entries", comparison.size()
+                )
+        );
+    }
+
+    private List<HypothesisRoutineFit> buildRoutineComparison(List<HypothesisPerformanceSnapshot> snapshots,
+                                                              OccupationPersonaRoutineCardPayload routinePayload,
+                                                              DorResultadoOfertaMecanismoProvaInputPayload frameworkPayload) {
+        if (snapshots.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> routineSignals = new ArrayList<>();
+        routineSignals.addAll(routinePayload.topTasks().stream().map(RoutineTaskPattern::taskLabel).toList());
+        routineSignals.addAll(routinePayload.painSignals().stream().map(RoutinePainSignal::painLabel).toList());
+        routineSignals.addAll(frameworkPayload.mechanismOpportunitySignals().stream()
+                .map(MechanismOpportunitySignal::mechanismLabel)
+                .toList());
+
+        return snapshots.stream()
+                .map(snapshot -> {
+                    List<String> linkedSignals = routineSignals.stream()
+                            .filter(signal -> hasSemanticOverlap(snapshot.hypothesisLabel(), signal))
+                            .distinct()
+                            .limit(4)
+                            .toList();
+
+                    double fitScore = linkedSignals.isEmpty() ? 0.45 : Math.min(0.95, 0.50 + linkedSignals.size() * 0.10);
+                    double performanceScore = calculatePerformanceScore(snapshot);
+                    double weightedImpact = Math.min(0.98, (fitScore * 0.42) + (performanceScore * 0.58));
+
+                    return new HypothesisRoutineFit(
+                            snapshot.hypothesisId(),
+                            snapshot.hypothesisLabel(),
+                            performanceScore,
+                            fitScore,
+                            weightedImpact,
+                            linkedSignals,
+                            buildComparisonSummary(snapshot, linkedSignals, weightedImpact)
+                    );
+                })
+                .sorted(Comparator.comparing(HypothesisRoutineFit::weightedImpactScore).reversed())
+                .toList();
+    }
+
+    private String buildComparisonSummary(HypothesisPerformanceSnapshot snapshot,
+                                          List<String> linkedSignals,
+                                          double weightedImpact) {
+        String alignment = linkedSignals.isEmpty()
+                ? "baixa aderência aos sinais de rotina"
+                : "aderência parcial com sinais operacionais inferidos";
+        return snapshot.hypothesisLabel() + " apresenta " + alignment + " (impacto ponderado="
+                + String.format(Locale.US, "%.2f", weightedImpact) + ")";
+    }
+
+    private List<RoutinePainSignal> recalibratePainSignals(List<RoutinePainSignal> painSignals, double averageImpact) {
+        double intensityMultiplier = 0.90 + (averageImpact * 0.20);
+        double recurrenceMultiplier = 0.92 + (averageImpact * 0.16);
+
+        return painSignals.stream()
+                .map(pain -> new RoutinePainSignal(
+                        pain.painLabel(),
+                        pain.painSummary(),
+                        pain.painType(),
+                        capScore(pain.painIntensityScore() * intensityMultiplier),
+                        capScore(pain.painRecurrenceScore() * recurrenceMultiplier),
+                        pain.workaroundSummary(),
+                        pain.evidenceRefs()
+                ))
+                .toList();
+    }
+
+    private List<MechanismOpportunitySignal> recalibrateMechanismSignals(List<MechanismOpportunitySignal> mechanisms,
+                                                                          double averageImpact) {
+        double fitMultiplier = 0.88 + (averageImpact * 0.24);
+        double effortMultiplier = Math.max(0.65, 1.05 - (averageImpact * 0.15));
+
+        return mechanisms.stream()
+                .map(mechanism -> new MechanismOpportunitySignal(
+                        mechanism.mechanismLabel(),
+                        mechanism.mechanismSummary(),
+                        mechanism.linkedTaskRefs(),
+                        mechanism.linkedPainRefs(),
+                        capScore(mechanism.commercialFitScore() * fitMultiplier),
+                        capScore(mechanism.implementationEffortScore() * effortMultiplier),
+                        mechanism.evidenceRefs()
+                ))
+                .toList();
+    }
+
+    private double calculatePerformanceScore(HypothesisPerformanceSnapshot snapshot) {
+        double ctrScore = capScore(snapshot.ctr() / 0.06);
+        double conversionScore = capScore(snapshot.conversionRate() / 0.12);
+        double cpaScore = 1.0 - capScore(snapshot.cpa() / 140.0);
+        return capScore((ctrScore * 0.30) + (conversionScore * 0.45) + (cpaScore * 0.15) + (snapshot.confidenceScore() * 0.10));
+    }
+
+    private List<OccupationFeedbackHistoryEntry> registerHistory(String occupationName,
+                                                                 OccupationFeedbackHistoryEntry entry) {
+        String key = occupationName.toLowerCase(Locale.ROOT);
+        List<OccupationFeedbackHistoryEntry> updatedHistory = feedbackHistoryByOccupation.compute(key, (k, oldValue) -> {
+            List<OccupationFeedbackHistoryEntry> next = oldValue == null ? new ArrayList<>() : new ArrayList<>(oldValue);
+            next.add(entry);
+            if (next.size() > MAX_HISTORY_SIZE) {
+                return next.stream()
+                        .skip(next.size() - MAX_HISTORY_SIZE)
+                        .collect(Collectors.toCollection(ArrayList::new));
+            }
+            return next;
+        });
+
+        return List.copyOf(updatedHistory);
+    }
+
+    private double recalibrateConfidence(double previousConfidence, double averageImpact) {
+        double delta = (averageImpact - 0.50) * 0.22;
+        return capScore(previousConfidence + delta);
+    }
+
+    private String effectiveCorrelationId(String correlationId) {
+        if (correlationId == null || correlationId.isBlank()) {
+            return UUID.randomUUID().toString();
+        }
+        return correlationId;
+    }
+
+    private boolean hasSemanticOverlap(String hypothesisLabel, String routineSignal) {
+        String normalizedHypothesis = hypothesisLabel == null ? "" : hypothesisLabel.toLowerCase(Locale.ROOT);
+        String normalizedSignal = routineSignal == null ? "" : routineSignal.toLowerCase(Locale.ROOT);
+
+        if (normalizedHypothesis.isBlank() || normalizedSignal.isBlank()) {
+            return false;
+        }
+
+        List<String> hypothesisTokens = List.of(normalizedHypothesis.split("\\s+"));
+        return hypothesisTokens.stream()
+                .filter(token -> token.length() > 3)
+                .anyMatch(normalizedSignal::contains);
+    }
+
+    private double capScore(double value) {
+        return Math.max(0.0, Math.min(0.99, value));
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/HypothesisPerformanceSnapshot.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/HypothesisPerformanceSnapshot.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.domain;
+
+public record HypothesisPerformanceSnapshot(
+        String hypothesisId,
+        String hypothesisLabel,
+        double ctr,
+        double conversionRate,
+        double cpa,
+        double confidenceScore) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/HypothesisRoutineFit.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/HypothesisRoutineFit.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.domain;
+
+import java.util.List;
+
+public record HypothesisRoutineFit(
+        String hypothesisId,
+        String hypothesisLabel,
+        double performanceScore,
+        double routineFitScore,
+        double weightedImpactScore,
+        List<String> linkedRoutineSignals,
+        String comparisonSummary) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationFeedbackHistoryEntry.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationFeedbackHistoryEntry.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.domain;
+
+import java.time.Instant;
+
+public record OccupationFeedbackHistoryEntry(
+        Instant generatedAt,
+        double previousRoutineConfidence,
+        double recalibratedRoutineConfidence,
+        double previousFrameworkConfidence,
+        double recalibratedFrameworkConfidence,
+        double averageHypothesisImpact,
+        String notes) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationFeedbackLoopPayload.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/domain/OccupationFeedbackLoopPayload.java
@@ -1,0 +1,22 @@
+package com.marketinghub.oprm.domain;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record OccupationFeedbackLoopPayload(
+        String personaLabel,
+        String occupationName,
+        String nicheName,
+        String baselineRoutineArtifactId,
+        String baselineFrameworkArtifactId,
+        List<RoutinePainSignal> recalibratedPainSignals,
+        List<MechanismOpportunitySignal> recalibratedMechanismSignals,
+        List<HypothesisRoutineFit> hypothesisComparison,
+        List<OccupationFeedbackHistoryEntry> occupationHistory,
+        double recalibratedRoutineConfidence,
+        double recalibratedFrameworkConfidence,
+        Map<String, Double> scoreReweighting,
+        List<String> evidenceRefs,
+        Instant generatedAt) {
+}

--- a/oprm/src/test/java/com/marketinghub/oprm/application/FeedbackLoopServiceTest.java
+++ b/oprm/src/test/java/com/marketinghub/oprm/application/FeedbackLoopServiceTest.java
@@ -1,0 +1,102 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.HypothesisPerformanceSnapshot;
+import com.marketinghub.oprm.domain.OccupationFeedbackLoopPayload;
+import com.marketinghub.oprm.infra.StructuredOccupationCatalog;
+import com.marketinghub.oprm.infra.enrichment.FetchedWebPage;
+import com.marketinghub.oprm.infra.enrichment.OccupationSourcePolicyRegistry;
+import com.marketinghub.oprm.infra.enrichment.OccupationWebSeedRegistry;
+import com.marketinghub.oprm.infra.enrichment.WebPageFetcher;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FeedbackLoopServiceTest {
+
+    private final WebPageFetcher stubFetcher = url -> new FetchedWebPage(
+            url,
+            200,
+            "Routine Signals for Personal Trainer",
+            "Organizar agenda, mandar lembrete de treino e responder clientes no WhatsApp.",
+            "pt-BR",
+            "captured-for-phase5-test",
+            true
+    );
+
+    private final FeedbackLoopService service = new FeedbackLoopService(
+            new RoutineInferenceService(
+                    new OccupationResolverService(new StructuredOccupationCatalog()),
+                    new WebEnrichmentService(
+                            new StructuredOccupationCatalog(),
+                            new OccupationSourcePolicyRegistry(),
+                            new OccupationWebSeedRegistry(),
+                            stubFetcher
+                    )
+            ),
+            new FrameworkIntegrationService(
+                    new RoutineInferenceService(
+                            new OccupationResolverService(new StructuredOccupationCatalog()),
+                            new WebEnrichmentService(
+                                    new StructuredOccupationCatalog(),
+                                    new OccupationSourcePolicyRegistry(),
+                                    new OccupationWebSeedRegistry(),
+                                    stubFetcher
+                            )
+                    )
+            )
+    );
+
+    @Test
+    void shouldGenerateFeedbackLoopArtifactWithHistoryAndComparison() {
+        List<HypothesisPerformanceSnapshot> snapshots = List.of(
+                new HypothesisPerformanceSnapshot("hyp-1", "Checklist para rotina de personal trainer", 0.041, 0.087, 79.0, 0.81),
+                new HypothesisPerformanceSnapshot("hyp-2", "Automação de lembretes de agenda", 0.037, 0.072, 88.0, 0.76)
+        );
+
+        ArtifactEnvelope result = service.recalibrateWithFeedback(
+                "treinador pessoal",
+                "fitness",
+                "pt-BR",
+                "corr-phase5-1",
+                snapshots
+        );
+
+        assertEquals("occupationFeedbackLoopSnapshot", result.artifactType());
+        assertEquals("GENERATED", result.status());
+
+        OccupationFeedbackLoopPayload payload = (OccupationFeedbackLoopPayload) result.payload();
+        assertEquals("personal trainer", payload.occupationName());
+        assertEquals(2, payload.hypothesisComparison().size());
+        assertTrue(payload.occupationHistory().size() >= 1);
+        assertTrue(payload.recalibratedFrameworkConfidence() > 0.0);
+    }
+
+    @Test
+    void shouldAccumulateHistoryByOccupationAcrossExecutions() {
+        ArtifactEnvelope firstRun = service.recalibrateWithFeedback(
+                "treinador pessoal",
+                "fitness",
+                "pt-BR",
+                "corr-phase5-2",
+                List.of()
+        );
+
+        ArtifactEnvelope secondRun = service.recalibrateWithFeedback(
+                "personal trainer",
+                "fitness",
+                "pt-BR",
+                "corr-phase5-3",
+                List.of()
+        );
+
+        OccupationFeedbackLoopPayload firstPayload = (OccupationFeedbackLoopPayload) firstRun.payload();
+        OccupationFeedbackLoopPayload secondPayload = (OccupationFeedbackLoopPayload) secondRun.payload();
+
+        assertEquals(1, firstPayload.occupationHistory().size());
+        assertEquals(2, secondPayload.occupationHistory().size());
+    }
+}


### PR DESCRIPTION
### Motivation

- Implementar a Fase 5 do plano OPRM para fechar o ciclo de feedback usando resultados de hipóteses do Marketing Hub para recalibrar scores de dor, mecanismos e confiança. 
- Manter histórico incremental por ocupação para rastreabilidade e evolução das recalibrações. 
- Publicar um artefato canônico de saída que permita integrar ajustes do OPRM com o framework dor→resultado→oferta→mecanismo→prova. 

### Description

- Adicionado o serviço `FeedbackLoopService` que orquestra a inferência de rotina (`Phase 3`) e a integração de framework (`Phase 4`) e produz o artefato `occupationFeedbackLoopSnapshot` com lineage e metadados. 
- Criados novos contratos de domínio: `HypothesisPerformanceSnapshot`, `HypothesisRoutineFit`, `OccupationFeedbackHistoryEntry` e `OccupationFeedbackLoopPayload` para entrada de performance, comparação, histórico e payload de saída. 
- Nova API `POST /api/oprm/phase5/feedback` com request `Phase5FeedbackRequest` e testes unitários `FeedbackLoopServiceTest` cobrindo geração do artefato e acumulação de histórico por ocupação. 
- Atualizações de documentação e cânone: `oprm/README.md`, `docs/oprm_canonico_artefatos.md` (novo `occupationFeedbackLoopSnapshot`) e `docs/history/oprm-implementation-history.md` (registro da fase 5). 

### Testing

- Executed `cd oprm && mvn test` and all automated unit tests passed (summary: `Tests run: 8, Failures: 0, Errors: 0`) and build finished with `BUILD SUCCESS`. 
- The phase-5 unit tests exercise artifact generation and history accumulation and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe8331bb483218a3c3cf7622caa1f)