### PR TITLE
chore(oprm): finalizar deploy em container do módulo OPRM

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -51,3 +51,31 @@ Quando for necessário atualizar **somente** o serviço `video-management` no ho
    ```
 
 Esse fluxo atualiza só o container `marketinghub-video-management`, preservando `backend` e `frontend` em execução.
+
+## Deploy apenas do módulo OPRM
+
+Quando for necessário atualizar **somente** o serviço `oprm-worker` no host `177.153.62.107`, use o fluxo abaixo.
+
+> Neste cenário, o OPRM deve apontar para o backend remoto em `191.252.181.168` (porta `8000`).
+
+1. Gere a imagem do módulo OPRM e exporte para tar:
+   ```bash
+   docker build -f oprm/Dockerfile -t marketinghub-oprm:latest oprm
+   docker save marketinghub-oprm:latest -o /tmp/oprm-image.tar
+   ```
+2. Copie o tar e os arquivos de deploy para o servidor:
+   ```bash
+   scp /tmp/oprm-image.tar deploy/bin/apply-oprm-only.sh deploy/docker-compose.yml <usuario>@177.153.62.107:/tmp/
+   ```
+3. No servidor, mova os arquivos para o diretório de deploy e rode o apply específico:
+   ```bash
+   ssh <usuario>@177.153.62.107
+   sudo mkdir -p /opt/marketinghub/containers
+   sudo mv /tmp/docker-compose.yml /opt/marketinghub/containers/docker-compose.yml
+   sudo mv /tmp/apply-oprm-only.sh /opt/marketinghub/containers/apply-oprm-only.sh
+   sudo chmod +x /opt/marketinghub/containers/apply-oprm-only.sh
+   OPRM_BACKEND_BASE_URL=http://191.252.181.168:8000 sudo /opt/marketinghub/containers/apply-oprm-only.sh
+   ```
+
+Esse fluxo atualiza só o container `marketinghub-oprm`, preservando os demais serviços já em execução.
+

--- a/deploy/bin/apply-oprm-only.sh
+++ b/deploy/bin/apply-oprm-only.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEPLOY_DIR=${DEPLOY_DIR:-/opt/marketinghub/containers}
+OPRM_TAR=${OPRM_TAR:-/tmp/oprm-image.tar}
+OPRM_IMAGE=${OPRM_IMAGE:-marketinghub-oprm}
+IMAGE_TAG=${IMAGE_TAG:-latest}
+OPRM_BACKEND_BASE_URL=${OPRM_BACKEND_BASE_URL:-http://191.252.181.168:8000}
+OPRM_SPRING_PROFILE=${OPRM_SPRING_PROFILE:-default}
+OPRM_JOBS_POLLING_ENABLED=${OPRM_JOBS_POLLING_ENABLED:-false}
+OPRM_JOBS_POLL_INTERVAL=${OPRM_JOBS_POLL_INTERVAL:-PT5M}
+
+mkdir -p "${DEPLOY_DIR}"
+cd "${DEPLOY_DIR}"
+
+if [[ -f "${OPRM_TAR}" ]]; then
+  docker load -i "${OPRM_TAR}"
+fi
+
+if [[ "${IMAGE_TAG}" != "latest" ]]; then
+  if docker image inspect "${OPRM_IMAGE}:${IMAGE_TAG}" >/dev/null 2>&1; then
+    docker tag "${OPRM_IMAGE}:${IMAGE_TAG}" "${OPRM_IMAGE}:latest"
+  else
+    echo "[apply-oprm-only.sh] Aviso: imagem ${OPRM_IMAGE}:${IMAGE_TAG} não encontrada; mantendo latest atual." >&2
+  fi
+fi
+
+cleanup_previous_tags() {
+  local repository="$1"
+  local keep_tag="$2"
+
+  docker image ls "${repository}" --format '{{.Repository}}:{{.Tag}}' \
+    | awk -F':' -v keep_tag="${keep_tag}" '$2 != "<none>" && $2 != keep_tag {print $0}' \
+    | xargs -r docker image rm >/dev/null 2>&1 || true
+}
+
+# Atualiza somente o OPRM sem reiniciar backend/frontend.
+OPRM_BACKEND_BASE_URL="${OPRM_BACKEND_BASE_URL}" \
+OPRM_SPRING_PROFILE="${OPRM_SPRING_PROFILE}" \
+OPRM_JOBS_POLLING_ENABLED="${OPRM_JOBS_POLLING_ENABLED}" \
+OPRM_JOBS_POLL_INTERVAL="${OPRM_JOBS_POLL_INTERVAL}" \
+  docker compose up -d --no-deps oprm-worker
+
+cleanup_previous_tags "${OPRM_IMAGE}" "latest"
+
+docker image prune -f >/dev/null 2>&1 || true
+rm -f "${OPRM_TAR}" >/dev/null 2>&1 || true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -38,6 +38,19 @@ services:
     ports:
       - "${VIDEO_MANAGEMENT_PORT:-8095}:8095"
 
+  oprm-worker:
+    image: ${OPRM_IMAGE:-marketinghub-oprm}:latest
+    container_name: marketinghub-oprm
+    restart: unless-stopped
+    environment:
+      SPRING_PROFILES_ACTIVE: ${OPRM_SPRING_PROFILE:-default}
+      OPRM_BACKEND_BASE_URL: ${OPRM_BACKEND_BASE_URL:-http://191.252.181.168:8000}
+      OPRM_JOBS_POLLING_ENABLED: ${OPRM_JOBS_POLLING_ENABLED:-false}
+      OPRM_JOBS_POLL_INTERVAL: ${OPRM_JOBS_POLL_INTERVAL:-PT5M}
+      TZ: America/Sao_Paulo
+    ports:
+      - "${OPRM_PORT:-8093}:8093"
+
   mcp-server:
     image: ${MCP_SERVER_IMAGE:-marketinghub-mcp-server}:latest
     container_name: marketinghub-mcp-server

--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -221,3 +221,40 @@ Foi implementada a fase 5 do OPRM com feedback loop para recalibração dos sina
 **Próximo passo sugerido:**  
 - implementar fase 6 de hardening operacional (persistência remota do feedback loop, observabilidade e integração contínua com backend)
 - versionar contrato HTTP entre backend principal e OPRM para ingestão/publicação completa dos artefatos da fase 5
+
+## 2026-04-15 — fase de finalização: containerização e publicação operacional
+
+**Status:** parcial
+
+**Resumo:**  
+Foi concluída a preparação de finalização operacional do OPRM para publicação em container no host `177.153.62.107`, incluindo artefatos YML e script de apply dedicado para atualização isolada do módulo sem reiniciar os demais serviços.
+
+**O que foi implementado:**  
+- criação do arquivo `oprm/docker-compose.deploy.yml` para execução do módulo por imagem publicada
+- adição do serviço `oprm-worker` no `deploy/docker-compose.yml` com variáveis de ambiente e porta dedicadas
+- criação do script `deploy/bin/apply-oprm-only.sh` para carregar imagem tar, atualizar tag `latest` e aplicar somente o serviço OPRM
+- atualização da documentação de deploy com passo a passo específico do host `177.153.62.107`
+- atualização do README do módulo com os arquivos de deploy e fluxo resumido de publicação
+
+**Arquivos principais alterados:**  
+- `oprm/docker-compose.deploy.yml`
+- `deploy/docker-compose.yml`
+- `deploy/bin/apply-oprm-only.sh`
+- `deploy/README.md`
+- `oprm/README.md`
+
+**Contratos / artefatos afetados:**  
+- nenhum contrato de API novo
+- artefatos operacionais de deploy do container OPRM (`docker-compose` e script de apply)
+
+**Testes executados:**  
+- `cd oprm && mvn test` — **passou**
+- `docker compose -f deploy/docker-compose.yml config` — **bloqueado por ambiente** (`docker` indisponível neste runner)
+
+**Limitações ou pendências:**  
+- publicação remota no host `177.153.62.107` depende de credenciais de SSH e execução no ambiente de infraestrutura
+- integração ativa com backend principal segue como próxima etapa funcional (o módulo ainda não consome endpoint remoto real)
+
+**Próximo passo sugerido:**  
+- executar o fluxo de cópia e apply no host `177.153.62.107` com usuário de infraestrutura
+- versionar contrato HTTP backend↔OPRM para jobs e publicação de artefatos end-to-end

--- a/oprm/README.md
+++ b/oprm/README.md
@@ -1,6 +1,6 @@
 # OPRM (Occupation Persona Routine Mapper)
 
-Módulo Spring Boot interno do Marketing Hub para as fases 1, 2, 3, 4 e 5 do plano OPRM:
+Módulo Spring Boot interno do Marketing Hub para as fases 1, 2, 3, 4, 5 e finalização operacional do plano OPRM:
 
 - resolução ocupacional (`Occupation Resolver`)
 - intake estruturado baseado em fontes ocupacionais do MVP
@@ -110,4 +110,23 @@ Exemplo de payload da fase 5:
     }
   ]
 }
+```
+
+
+## Deploy do container (host 177.153.62.107)
+
+Arquivos de deploy do módulo:
+
+- `oprm/docker-compose.deploy.yml` (override para uso com imagem publicada)
+- `deploy/docker-compose.yml` (stack consolidada com serviço `oprm-worker`)
+- `deploy/bin/apply-oprm-only.sh` (atualização sem reiniciar outros serviços)
+
+Fluxo resumido:
+
+```bash
+docker build -f oprm/Dockerfile -t marketinghub-oprm:latest oprm
+docker save marketinghub-oprm:latest -o /tmp/oprm-image.tar
+scp /tmp/oprm-image.tar deploy/bin/apply-oprm-only.sh deploy/docker-compose.yml <usuario>@177.153.62.107:/tmp/
+ssh <usuario>@177.153.62.107
+OPRM_BACKEND_BASE_URL=http://191.252.181.168:8000 sudo /opt/marketinghub/containers/apply-oprm-only.sh
 ```

--- a/oprm/docker-compose.deploy.yml
+++ b/oprm/docker-compose.deploy.yml
@@ -1,0 +1,4 @@
+services:
+  oprm-worker:
+    image: ${OPRM_IMAGE}
+    build: null


### PR DESCRIPTION
### Motivation
- Finalizar a etapa operacional do OPRM para permitir publicação do container no host dedicado (`177.153.62.107`) e habilitar um fluxo de atualização isolada do serviço sem reiniciar a stack principal. 
- Fornecer artefatos YML e scripts de deploy reutilizáveis que sigam o padrão existente de deploy do projeto e documentar o procedimento operacional. 

### Description
- Adiciona `oprm/docker-compose.deploy.yml` como override para execução do OPRM via imagem publicada. 
- Inclui o serviço `oprm-worker` em `deploy/docker-compose.yml` com variáveis de ambiente, porta dedicada (`8093`) e configuração de polling/back-end. 
- Cria `deploy/bin/apply-oprm-only.sh` para carregar um `*.tar` de imagem, retaggar (quando aplicável) e rodar `docker compose up -d --no-deps oprm-worker` sem tocar outros serviços. 
- Atualiza documentação operacional em `deploy/README.md` e `oprm/README.md` e registra a entrada de finalização em `docs/history/oprm-implementation-history.md`.

### Testing
- Executado `cd oprm && mvn test` — passou. 
- Tentativa de validar `docker compose -f deploy/docker-compose.yml config` — bloqueado por ambiente (`docker` indisponível no runner). 
- Tentativa de conexão SSH ao host `177.153.62.107` (`ssh -o BatchMode=yes -o ConnectTimeout=8 177.153.62.107 'echo connected'`) — falhou com `Network is unreachable` (conectividade/credenciais requeridas no ambiente de infra).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfea5348f48321a0bb388da261bb09)