### PR TITLE
Add CI workflow for OPRM module

### DIFF
--- a/.github/workflows/oprm-ci.yml
+++ b/.github/workflows/oprm-ci.yml
@@ -1,0 +1,126 @@
+name: CI – OPRM
+
+on:
+  push:
+    branches: ["main", "master"]
+    paths:
+      - 'oprm/**'
+      - '.github/workflows/oprm-ci.yml'
+  pull_request:
+    paths:
+      - 'oprm/**'
+      - '.github/workflows/oprm-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: oprm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Run tests
+        run: mvn -B test
+
+  docker:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
+      IMAGE_TAG: latest
+      IMAGE_SHA_TAG: ${{ github.sha }}
+    outputs:
+      image-tag: ${{ steps.image_tag.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAMESPACE }}/oprm
+          tags: |
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=${{ env.IMAGE_SHA_TAG }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: oprm
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/oprm:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/oprm:buildcache,mode=max
+      - name: Expose image tag
+        id: image_tag
+        run: echo "value=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - test
+      - docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      DEPLOY_HOST: 191.252.120.96
+      DEPLOY_USER: root
+      REMOTE_PATH: ${{ secrets.OPRM_REMOTE_PATH || '/root/oprm' }}
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
+      IMAGE_TAG: ${{ needs.docker.outputs['image-tag'] }}
+      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME != '' && secrets.GHCR_USERNAME || github.repository_owner }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure SSH
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "SSH_COMMON_ARGS=-i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -o ConnectTimeout=60" >> "$GITHUB_ENV"
+      - name: Prepare remote directory
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p ${REMOTE_PATH}"
+      - name: Sync service to VPS
+        run: |
+          rsync -az --delete \
+            -e "ssh ${SSH_COMMON_ARGS}" \
+            --exclude '.git/' \
+            --exclude 'target/' \
+            oprm/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_PATH}"
+      - name: Publish service
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "set -euo pipefail \
+            && cd ${REMOTE_PATH} \
+            && if [ -n '${GHCR_TOKEN}' ]; then echo '${GHCR_TOKEN}' | docker login ${IMAGE_REGISTRY} -u '${GHCR_USERNAME}' --password-stdin; fi \
+            && export OPRM_IMAGE='${IMAGE_NAMESPACE}/oprm:${IMAGE_TAG}' \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml pull \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml up -d --remove-orphans \
+            && docker image prune -af"
+      - name: Clean build artifacts from repository
+        if: always()
+        run: |
+          git clean -ffdx -- oprm/target


### PR DESCRIPTION
### Motivation
- Provide CI/CD coverage for the internal `oprm` module so changes under `oprm/**` run tests, produce a Docker image and can be deployed automatically to the existing VPS pipeline.

### Description
- Add `.github/workflows/oprm-ci.yml` which triggers on `push`/`pull_request` for `oprm/**` and implements three jobs: `test` (runs `mvn -B test` using Java 21), `docker` (builds and pushes `ghcr.io/${{ github.repository_owner }}/oprm` with `latest` and SHA tags) and `deploy` (on `main` it SSHs/rsyncs the `oprm/` folder to the VPS and runs `docker compose` using the exported `OPRM_IMAGE`, with `REMOTE_PATH` configurable via `secrets.OPRM_REMOTE_PATH`).

### Testing
- Executed `cd oprm && mvn -B test` locally and observed `BUILD SUCCESS` with all unit tests passing (8 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfecff6a8483218bc98fe43e545513)