### PR TITLE
feat(oprm): definir contrato oficial de integração Sprint 1

### DIFF
--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -258,3 +258,53 @@ Foi concluída a preparação de finalização operacional do OPRM para publica�
 **Próximo passo sugerido:**  
 - executar o fluxo de cópia e apply no host `177.153.62.107` com usuário de infraestrutura
 - versionar contrato HTTP backend↔OPRM para jobs e publicação de artefatos end-to-end
+
+## 2026-04-15 — sprint 1: contrato oficial backend ↔ OPRM
+
+**Status:** concluído
+
+**Resumo:**  
+Foi consolidado o contrato oficial de integração da Sprint 1 entre backend principal e OPRM com OpenAPI v1, DTOs comuns de troca e política inicial de versionamento/erros HTTP para remover ambiguidades de comunicação entre os módulos.
+
+**O que foi implementado:**  
+- criação do documento OpenAPI v1 para endpoints de claim, detail, status, artifacts, feedback e heartbeat
+- criação de DTOs comuns do contrato em `oprm` para job, artifact, status, feedback, heartbeat e erro de API
+- criação de enums canônicos de `jobStatus`, `jobType` e `artifactStatus` para alinhamento semântico
+- criação da documentação de versionamento do contrato com regras de compatibilidade e política de erro HTTP
+- atualização do README do módulo com links oficiais de contrato da Sprint 1
+
+**Arquivos principais alterados:**  
+- `docs/novos-modulos/OPRM/contracts/oprm-backend-integration-openapi.v1.yaml`
+- `docs/novos-modulos/OPRM/contracts/oprm-contrato-versionamento.md`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmContractVersion.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobClaimRequest.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobClaimResponse.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobDetailResponse.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactEnvelopeDto.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactPublishRequest.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactPublishResponse.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobStatusUpdateRequest.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmFeedbackPublishRequest.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmHeartbeatRequest.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmApiErrorResponse.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobType.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobStatus.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactStatus.java`
+- `oprm/README.md`
+
+**Contratos / artefatos afetados:**  
+- contrato HTTP versionado v1: `/api/oprm/jobs/claim`, `/api/oprm/jobs/{jobId}`, `/api/oprm/jobs/{jobId}/status`, `/api/oprm/artifacts`, `/api/oprm/feedback`, `/api/oprm/heartbeat`
+- DTOs comuns: `OprmJobClaimRequest`, `OprmJobDetailResponse`, `OprmArtifactPublishRequest`, `OprmJobStatusUpdateRequest`, `OprmFeedbackPublishRequest`, `OprmHeartbeatRequest`
+- política de versionamento: `contractVersion` série `1.x`
+
+**Testes executados:**  
+- `cd oprm && mvn test` — **passou**
+
+**Limitações ou pendências:**  
+- contrato está publicado e documentado, mas endpoints backend ainda não foram implementados
+- ainda não existe contract testing automatizado em CI para validar compatibilidade backend ↔ OPRM
+- integração runtime com claim real de jobs será tratada na Sprint 2
+
+**Próximo passo sugerido:**  
+- implementar Sprint 2 com modelo de job no backend e endpoints reais de claim/detail/status
+- criar clients HTTP no OPRM usando os DTOs comuns da Sprint 1

--- a/docs/novos-modulos/OPRM/contracts/oprm-backend-integration-openapi.v1.yaml
+++ b/docs/novos-modulos/OPRM/contracts/oprm-backend-integration-openapi.v1.yaml
@@ -1,0 +1,470 @@
+openapi: 3.0.3
+info:
+  title: OPRM ↔ Backend Integration API
+  version: 1.0.0
+  description: |
+    Contrato oficial da Sprint 1 para integração backend principal do Marketing Hub e worker OPRM.
+servers:
+  - url: https://backend.marketinghub.local
+    description: Backend principal
+  - url: http://localhost:8080
+    description: Ambiente local
+paths:
+  /api/oprm/jobs/claim:
+    post:
+      tags: [jobs]
+      summary: Claim de job disponível para processamento do OPRM
+      operationId: claimOprmJob
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OprmJobClaimRequest'
+      responses:
+        '200':
+          description: Job disponível e reservado para o worker.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmJobClaimResponse'
+        '204':
+          description: Nenhum job disponível no momento.
+        '409':
+          description: Conflito de lock/claim.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+        '422':
+          description: Contrato inválido (versão incompatível ou payload inconsistente).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+  /api/oprm/jobs/{jobId}:
+    get:
+      tags: [jobs]
+      summary: Consulta os detalhes do job
+      operationId: getOprmJobDetails
+      parameters:
+        - in: path
+          name: jobId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Detalhes completos do job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmJobDetailResponse'
+        '404':
+          description: Job não encontrado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+  /api/oprm/jobs/{jobId}/status:
+    post:
+      tags: [jobs]
+      summary: Atualiza o status de processamento do job
+      operationId: updateOprmJobStatus
+      parameters:
+        - in: path
+          name: jobId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OprmJobStatusUpdateRequest'
+      responses:
+        '202':
+          description: Status aceito para processamento assíncrono.
+        '404':
+          description: Job não encontrado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+        '409':
+          description: Transição de estado inválida para o job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+  /api/oprm/artifacts:
+    post:
+      tags: [artifacts]
+      summary: Publica artefato gerado pelo OPRM
+      operationId: publishOprmArtifact
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OprmArtifactPublishRequest'
+      responses:
+        '202':
+          description: Artefato aceito para persistência.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmArtifactPublishResponse'
+        '409':
+          description: Duplicidade de idempotency key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+        '422':
+          description: Envelope inválido ou lineage insuficiente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+  /api/oprm/feedback:
+    post:
+      tags: [feedback]
+      summary: Publica snapshot de feedback loop
+      operationId: publishOprmFeedback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OprmFeedbackPublishRequest'
+      responses:
+        '202':
+          description: Feedback aceito para persistência.
+        '422':
+          description: Snapshot inválido.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+  /api/oprm/heartbeat:
+    post:
+      tags: [operations]
+      summary: Heartbeat operacional do worker OPRM
+      operationId: publishOprmHeartbeat
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OprmHeartbeatRequest'
+      responses:
+        '202':
+          description: Heartbeat recebido.
+        '422':
+          description: Heartbeat inválido.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+components:
+  schemas:
+    OprmJobClaimRequest:
+      type: object
+      required: [workerId, workerVersion, contractVersion, maxJobs, leaseSeconds]
+      properties:
+        workerId:
+          type: string
+        workerVersion:
+          type: string
+        contractVersion:
+          type: string
+          example: '1.0'
+        maxJobs:
+          type: integer
+          minimum: 1
+          maximum: 20
+        leaseSeconds:
+          type: integer
+          minimum: 30
+    OprmJobClaimResponse:
+      type: object
+      required: [jobId, jobType, occupationSeedRef, correlationId, parameters, claimedAt, leaseExpiresAt]
+      properties:
+        jobId:
+          type: string
+        jobType:
+          $ref: '#/components/schemas/OprmJobType'
+        occupationSeedRef:
+          type: string
+        correlationId:
+          type: string
+        parameters:
+          type: object
+          additionalProperties: true
+        claimedAt:
+          type: string
+          format: date-time
+        leaseExpiresAt:
+          type: string
+          format: date-time
+    OprmJobDetailResponse:
+      type: object
+      required: [jobId, jobType, jobStatus, occupationSeedRef, correlationId, attemptCount, createdAt, parameters, inputRefs]
+      properties:
+        jobId:
+          type: string
+        jobType:
+          $ref: '#/components/schemas/OprmJobType'
+        jobStatus:
+          $ref: '#/components/schemas/OprmJobStatus'
+        occupationSeedRef:
+          type: string
+        correlationId:
+          type: string
+        attemptCount:
+          type: integer
+          minimum: 0
+        createdAt:
+          type: string
+          format: date-time
+        claimedAt:
+          type: string
+          format: date-time
+          nullable: true
+        startedAt:
+          type: string
+          format: date-time
+          nullable: true
+        finishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        parameters:
+          type: object
+          additionalProperties: true
+        inputRefs:
+          type: array
+          items:
+            type: string
+        errorCode:
+          type: string
+          nullable: true
+        errorMessage:
+          type: string
+          nullable: true
+    OprmArtifactPublishRequest:
+      type: object
+      required: [jobId, correlationId, artifact, lineage, idempotencyKey]
+      properties:
+        jobId:
+          type: string
+        correlationId:
+          type: string
+        artifact:
+          $ref: '#/components/schemas/OprmArtifactEnvelopeDto'
+        lineage:
+          type: object
+          additionalProperties: true
+        idempotencyKey:
+          type: string
+    OprmArtifactPublishResponse:
+      type: object
+      required: [artifactId, artifactType, artifactVersion, persistedAt, status, duplicated]
+      properties:
+        artifactId:
+          type: string
+        artifactType:
+          type: string
+        artifactVersion:
+          type: string
+        persistedAt:
+          type: string
+          format: date-time
+        status:
+          type: string
+        duplicated:
+          type: boolean
+    OprmArtifactEnvelopeDto:
+      type: object
+      required:
+        - artifactType
+        - artifactVersion
+        - artifactId
+        - moduleName
+        - producer
+        - createdAt
+        - correlationId
+        - traceId
+        - sourceRefs
+        - inputRefs
+        - payload
+        - status
+        - metadata
+      properties:
+        artifactType:
+          type: string
+        artifactVersion:
+          type: string
+        artifactId:
+          type: string
+        moduleName:
+          type: string
+          example: oprm
+        producer:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        correlationId:
+          type: string
+        traceId:
+          type: string
+        sourceRefs:
+          type: array
+          items:
+            type: string
+        inputRefs:
+          type: array
+          items:
+            type: string
+        payload:
+          type: object
+          additionalProperties: true
+        status:
+          $ref: '#/components/schemas/OprmArtifactStatus'
+        confidenceScore:
+          type: number
+          format: double
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+    OprmJobStatusUpdateRequest:
+      type: object
+      required: [workerId, status, occurredAt]
+      properties:
+        workerId:
+          type: string
+        status:
+          $ref: '#/components/schemas/OprmJobStatus'
+        occurredAt:
+          type: string
+          format: date-time
+        phase:
+          type: string
+          nullable: true
+        message:
+          type: string
+          nullable: true
+        errorCode:
+          type: string
+          nullable: true
+        errorMessage:
+          type: string
+          nullable: true
+        metrics:
+          type: object
+          additionalProperties: true
+          nullable: true
+    OprmFeedbackPublishRequest:
+      type: object
+      required:
+        - jobId
+        - correlationId
+        - occupationName
+        - personaLabel
+        - baselineRoutineArtifactId
+        - baselineFrameworkArtifactId
+        - recalibratedPainSignals
+        - recalibratedMechanismSignals
+        - hypothesisComparison
+        - scoreReweighting
+        - generatedAt
+      properties:
+        jobId:
+          type: string
+        correlationId:
+          type: string
+        occupationName:
+          type: string
+        personaLabel:
+          type: string
+        baselineRoutineArtifactId:
+          type: string
+        baselineFrameworkArtifactId:
+          type: string
+        recalibratedPainSignals:
+          type: object
+          additionalProperties: true
+        recalibratedMechanismSignals:
+          type: object
+          additionalProperties: true
+        hypothesisComparison:
+          type: object
+          additionalProperties: true
+        scoreReweighting:
+          type: object
+          additionalProperties: true
+        generatedAt:
+          type: string
+          format: date-time
+    OprmHeartbeatRequest:
+      type: object
+      required: [workerId, workerVersion, contractVersion, sentAt, health, counters]
+      properties:
+        workerId:
+          type: string
+        workerVersion:
+          type: string
+        contractVersion:
+          type: string
+          example: '1.0'
+        sentAt:
+          type: string
+          format: date-time
+        health:
+          type: object
+          additionalProperties: true
+        counters:
+          type: object
+          additionalProperties: true
+    OprmApiErrorResponse:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        correlationId:
+          type: string
+          nullable: true
+        details:
+          type: string
+          nullable: true
+    OprmJobType:
+      type: string
+      enum:
+        - OCCUPATION_MAPPING
+        - FEEDBACK_RECALIBRATION
+    OprmJobStatus:
+      type: string
+      enum:
+        - PENDING
+        - CLAIMED
+        - RUNNING
+        - SUCCEEDED
+        - FAILED
+        - RETRY_WAIT
+        - CANCELLED
+    OprmArtifactStatus:
+      type: string
+      enum:
+        - DRAFT
+        - GENERATED
+        - VALIDATED
+        - REJECTED
+        - PUBLISHED
+        - SUPERSEDED

--- a/docs/novos-modulos/OPRM/contracts/oprm-contrato-versionamento.md
+++ b/docs/novos-modulos/OPRM/contracts/oprm-contrato-versionamento.md
@@ -1,0 +1,59 @@
+# OPRM — Versionamento de Contrato Backend ↔ Worker
+
+## 1. Objetivo
+
+Definir a estratégia mínima de versionamento do contrato HTTP entre backend principal e worker OPRM, iniciada na Sprint 1.
+
+## 2. Convenção de versão
+
+- Série inicial: **v1**
+- Valor de contrato no payload: `contractVersion: "1.0"`
+- Documento canônico OpenAPI da série: `docs/novos-modulos/OPRM/contracts/oprm-backend-integration-openapi.v1.yaml`
+
+## 3. Regras de compatibilidade
+
+### 3.1 Mudança compatível
+Exemplos:
+- adição de campo opcional
+- adição de enum sem quebrar consumidores existentes
+- ampliação de metadados opcionais
+
+Ação:
+- mantém caminho da API (`/api/oprm/*`)
+- incrementa versão menor (`1.0` → `1.1`)
+- atualiza OpenAPI v1 e histórico de implementação
+
+### 3.2 Mudança incompatível
+Exemplos:
+- remoção de campo obrigatório
+- troca de semântica em campo existente
+- mudança de tipo incompatível
+- alteração de transição de estados de job
+
+Ação:
+- cria nova série principal (v2)
+- publica novo arquivo OpenAPI (`...openapi.v2.yaml`)
+- mantém janela de convivência entre v1 e v2
+- registra ADR quando houver impacto cross-domain
+
+## 4. Regra de validação runtime
+
+- Backend deve validar `contractVersion` em endpoints de entrada do worker (`claim`, `status`, `heartbeat`).
+- Worker deve registrar erro operacional quando receber `422` por incompatibilidade de versão.
+- Chamadas com contrato incompatível não devem ser processadas parcialmente.
+
+## 5. Política de erro HTTP da Sprint 1
+
+- `200`: resposta síncrona de leitura ou claim bem-sucedido
+- `202`: operação assíncrona aceita (status/artifact/feedback/heartbeat)
+- `204`: claim sem job disponível
+- `404`: job inexistente
+- `409`: conflito de lock/transição/idempotência
+- `422`: payload inválido ou versão incompatível
+- `5xx`: falha interna do backend
+
+## 6. Governança
+
+- O contrato OpenAPI é a referência primária para integração backend ↔ OPRM.
+- DTOs comuns em `oprm/src/main/java/com/marketinghub/oprm/integration/contract` devem permanecer alinhados ao OpenAPI.
+- Nenhum endpoint novo deve ser adicionado sem atualização simultânea de OpenAPI, histórico e documentação de versão.

--- a/oprm/README.md
+++ b/oprm/README.md
@@ -113,6 +113,13 @@ Exemplo de payload da fase 5:
 ```
 
 
+
+## Contrato oficial backend ↔ OPRM (Sprint 1)
+
+- OpenAPI v1: `docs/novos-modulos/OPRM/contracts/oprm-backend-integration-openapi.v1.yaml`
+- Versionamento: `docs/novos-modulos/OPRM/contracts/oprm-contrato-versionamento.md`
+- DTOs comuns (alinhamento de contrato): `oprm/src/main/java/com/marketinghub/oprm/integration/contract`
+
 ## Deploy do container (host 177.153.62.107)
 
 Arquivos de deploy do módulo:

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmApiErrorResponse.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmApiErrorResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.integration.contract;
+
+public record OprmApiErrorResponse(
+        String code,
+        String message,
+        String correlationId,
+        String details
+) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactEnvelopeDto.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactEnvelopeDto.java
@@ -1,0 +1,24 @@
+package com.marketinghub.oprm.integration.contract;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+public record OprmArtifactEnvelopeDto(
+        @NotBlank String artifactType,
+        @NotBlank String artifactVersion,
+        @NotBlank String artifactId,
+        @NotBlank String moduleName,
+        @NotBlank String producer,
+        @NotBlank String createdAt,
+        @NotBlank String correlationId,
+        @NotBlank String traceId,
+        @NotNull List<String> sourceRefs,
+        @NotNull List<String> inputRefs,
+        @NotNull Map<String, Object> payload,
+        @NotNull OprmArtifactStatus status,
+        Double confidenceScore,
+        @NotNull Map<String, Object> metadata
+) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactPublishRequest.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactPublishRequest.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.integration.contract;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public record OprmArtifactPublishRequest(
+        @NotBlank String jobId,
+        @NotBlank String correlationId,
+        @NotNull @Valid OprmArtifactEnvelopeDto artifact,
+        @NotNull Map<String, Object> lineage,
+        @NotBlank String idempotencyKey
+) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactPublishResponse.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactPublishResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.integration.contract;
+
+public record OprmArtifactPublishResponse(
+        String artifactId,
+        String artifactType,
+        String artifactVersion,
+        String persistedAt,
+        String status,
+        boolean duplicated
+) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactStatus.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmArtifactStatus.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.integration.contract;
+
+public enum OprmArtifactStatus {
+    DRAFT,
+    GENERATED,
+    VALIDATED,
+    REJECTED,
+    PUBLISHED,
+    SUPERSEDED
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmContractVersion.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmContractVersion.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.integration.contract;
+
+public final class OprmContractVersion {
+
+    public static final String V1 = "1.0";
+
+    private OprmContractVersion() {
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmFeedbackPublishRequest.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmFeedbackPublishRequest.java
@@ -1,0 +1,20 @@
+package com.marketinghub.oprm.integration.contract;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public record OprmFeedbackPublishRequest(
+        @NotBlank String jobId,
+        @NotBlank String correlationId,
+        @NotBlank String occupationName,
+        @NotBlank String personaLabel,
+        @NotBlank String baselineRoutineArtifactId,
+        @NotBlank String baselineFrameworkArtifactId,
+        @NotNull Map<String, Object> recalibratedPainSignals,
+        @NotNull Map<String, Object> recalibratedMechanismSignals,
+        @NotNull Map<String, Object> hypothesisComparison,
+        @NotNull Map<String, Object> scoreReweighting,
+        @NotBlank String generatedAt
+) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmHeartbeatRequest.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmHeartbeatRequest.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.integration.contract;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public record OprmHeartbeatRequest(
+        @NotBlank String workerId,
+        @NotBlank String workerVersion,
+        @NotBlank String contractVersion,
+        @NotBlank String sentAt,
+        @NotNull Map<String, Object> health,
+        @NotNull Map<String, Object> counters
+) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobClaimRequest.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobClaimRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.integration.contract;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record OprmJobClaimRequest(
+        @NotBlank String workerId,
+        @NotBlank String workerVersion,
+        @NotBlank String contractVersion,
+        @Min(1) int maxJobs,
+        @Min(30) int leaseSeconds
+) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobClaimResponse.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobClaimResponse.java
@@ -1,0 +1,14 @@
+package com.marketinghub.oprm.integration.contract;
+
+import java.util.Map;
+
+public record OprmJobClaimResponse(
+        String jobId,
+        OprmJobType jobType,
+        String occupationSeedRef,
+        String correlationId,
+        Map<String, Object> parameters,
+        String claimedAt,
+        String leaseExpiresAt
+) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobDetailResponse.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobDetailResponse.java
@@ -1,0 +1,22 @@
+package com.marketinghub.oprm.integration.contract;
+
+import java.util.List;
+import java.util.Map;
+
+public record OprmJobDetailResponse(
+        String jobId,
+        OprmJobType jobType,
+        OprmJobStatus jobStatus,
+        String occupationSeedRef,
+        String correlationId,
+        int attemptCount,
+        String createdAt,
+        String claimedAt,
+        String startedAt,
+        String finishedAt,
+        Map<String, Object> parameters,
+        List<String> inputRefs,
+        String errorCode,
+        String errorMessage
+) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobStatus.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobStatus.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.integration.contract;
+
+public enum OprmJobStatus {
+    PENDING,
+    CLAIMED,
+    RUNNING,
+    SUCCEEDED,
+    FAILED,
+    RETRY_WAIT,
+    CANCELLED
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobStatusUpdateRequest.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobStatusUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.integration.contract;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public record OprmJobStatusUpdateRequest(
+        @NotBlank String workerId,
+        @NotNull OprmJobStatus status,
+        @NotBlank String occurredAt,
+        String phase,
+        String message,
+        String errorCode,
+        String errorMessage,
+        Map<String, Object> metrics
+) {
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobType.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/contract/OprmJobType.java
@@ -1,0 +1,6 @@
+package com.marketinghub.oprm.integration.contract;
+
+public enum OprmJobType {
+    OCCUPATION_MAPPING,
+    FEEDBACK_RECALIBRATION
+}


### PR DESCRIPTION
### Motivation
- Eliminar ambiguidades de comunicação entre o backend principal e o worker OPRM através de um contrato HTTP versionado e DTOs comuns. 
- Preparar a base para que o OPRM deixe de operar apenas localmente e passe a consumir/persistir artefatos via backend conforme o plano de integração. 

### Description
- Publica o documento OpenAPI v1 do contrato backend ↔ OPRM com endpoints de `claim`, `job detail`, `status`, `artifacts`, `feedback` e `heartbeat` (`docs/novos-modulos/OPRM/contracts/oprm-backend-integration-openapi.v1.yaml`).
- Adiciona a política de versionamento e regras de compatibilidade para a série `1.x` (`docs/novos-modulos/OPRM/contracts/oprm-contrato-versionamento.md`).
- Cria DTOs/records e enums compartilhados no módulo `oprm` para alinhar o código ao contrato (`oprm/src/main/java/com/marketinghub/oprm/integration/contract/*`).
- Atualiza o `oprm/README.md` com referências ao contrato e registra a Sprint 1 no histórico incremental do módulo (`docs/history/oprm-implementation-history.md`).

### Testing
- `cd oprm && mvn test` — execução automática inicial falhou por erro transitório no download de dependência (HTTP 502) durante resolução Maven. 
- `cd oprm && mvn test` — segunda execução automática completou com sucesso e os testes unitários do módulo passaram (`Tests run: 8, Failures: 0, Errors: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff14b9a108321bb96b6fc55393f7a)