### PR TITLE
Implementa Sprint 2 do OPRM — orquestração de jobs no backend e worker consumidor

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJob.java
@@ -1,0 +1,77 @@
+package com.marketinghub.oprm;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OprmJob {
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "job_type", nullable = false, length = 64)
+    private OprmJobType jobType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "job_status", nullable = false, length = 32)
+    @Builder.Default
+    private OprmJobStatus jobStatus = OprmJobStatus.PENDING;
+
+    @Column(name = "occupation_seed_ref", nullable = false, length = 191)
+    private String occupationSeedRef;
+
+    @Column(name = "correlation_id", nullable = false, length = 191)
+    private String correlationId;
+
+    @Builder.Default
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount = 0;
+
+    @Column(name = "claimed_by", length = 191)
+    private String claimedBy;
+
+    @Column(name = "claimed_at")
+    private Instant claimedAt;
+
+    @Column(name = "lease_expires_at")
+    private Instant leaseExpiresAt;
+
+    @Column(name = "started_at")
+    private Instant startedAt;
+
+    @Column(name = "finished_at")
+    private Instant finishedAt;
+
+    @Column(name = "error_code", length = 64)
+    private String errorCode;
+
+    @Column(name = "error_message", columnDefinition = "LONGTEXT")
+    private String errorMessage;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJobEvent.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJobEvent.java
@@ -1,0 +1,52 @@
+package com.marketinghub.oprm;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OprmJobEvent {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "job_id", nullable = false)
+    private OprmJob job;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_status", nullable = false, length = 32)
+    private OprmJobStatus eventStatus;
+
+    @Column(name = "phase", length = 128)
+    private String phase;
+
+    @Column(name = "message", columnDefinition = "LONGTEXT")
+    private String message;
+
+    @Column(name = "worker_id", length = 191)
+    private String workerId;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJobInput.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJobInput.java
@@ -1,0 +1,40 @@
+package com.marketinghub.oprm;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OprmJobInput {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "job_id", nullable = false)
+    private OprmJob job;
+
+    @Column(name = "input_ref", nullable = false, length = 191)
+    private String inputRef;
+
+    @Column(name = "input_value", columnDefinition = "LONGTEXT")
+    private String inputValue;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJobStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJobStatus.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm;
+
+public enum OprmJobStatus {
+    PENDING,
+    CLAIMED,
+    RUNNING,
+    SUCCEEDED,
+    FAILED,
+    RETRY_WAIT,
+    CANCELLED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJobType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJobType.java
@@ -1,0 +1,6 @@
+package com.marketinghub.oprm;
+
+public enum OprmJobType {
+    OCCUPATION_MAPPING,
+    FEEDBACK_RECALIBRATION
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmCreateJobRequestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmCreateJobRequestDto.java
@@ -1,0 +1,14 @@
+package com.marketinghub.oprm.dto;
+
+import com.marketinghub.oprm.OprmJobType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record OprmCreateJobRequestDto(
+        @NotNull OprmJobType jobType,
+        @NotBlank String occupationSeedRef,
+        String correlationId,
+        List<String> inputRefs
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmJobClaimRequestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmJobClaimRequestDto.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record OprmJobClaimRequestDto(
+        @NotBlank String workerId,
+        @NotBlank String workerVersion,
+        @NotBlank String contractVersion,
+        @Min(1) int maxJobs,
+        @Min(30) int leaseSeconds
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmJobClaimResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmJobClaimResponseDto.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.dto;
+
+import com.marketinghub.oprm.OprmJobType;
+import java.util.Map;
+
+public record OprmJobClaimResponseDto(
+        String jobId,
+        OprmJobType jobType,
+        String occupationSeedRef,
+        String correlationId,
+        Map<String, Object> parameters,
+        String claimedAt,
+        String leaseExpiresAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmJobDetailResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmJobDetailResponseDto.java
@@ -1,0 +1,24 @@
+package com.marketinghub.oprm.dto;
+
+import com.marketinghub.oprm.OprmJobStatus;
+import com.marketinghub.oprm.OprmJobType;
+import java.util.List;
+import java.util.Map;
+
+public record OprmJobDetailResponseDto(
+        String jobId,
+        OprmJobType jobType,
+        OprmJobStatus jobStatus,
+        String occupationSeedRef,
+        String correlationId,
+        int attemptCount,
+        String createdAt,
+        String claimedAt,
+        String startedAt,
+        String finishedAt,
+        Map<String, Object> parameters,
+        List<String> inputRefs,
+        String errorCode,
+        String errorMessage
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmJobStatusUpdateRequestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmJobStatusUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.marketinghub.oprm.dto;
+
+import com.marketinghub.oprm.OprmJobStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public record OprmJobStatusUpdateRequestDto(
+        @NotBlank String workerId,
+        @NotNull OprmJobStatus status,
+        @NotBlank String occurredAt,
+        String phase,
+        String message,
+        String errorCode,
+        String errorMessage,
+        Map<String, Object> metrics
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmJobEventRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmJobEventRepository.java
@@ -1,0 +1,7 @@
+package com.marketinghub.oprm.repository;
+
+import com.marketinghub.oprm.OprmJobEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OprmJobEventRepository extends JpaRepository<OprmJobEvent, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmJobInputRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmJobInputRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.repository;
+
+import com.marketinghub.oprm.OprmJobInput;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OprmJobInputRepository extends JpaRepository<OprmJobInput, Long> {
+    List<OprmJobInput> findByJobIdOrderByCreatedAtAsc(UUID jobId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmJobRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmJobRepository.java
@@ -1,0 +1,40 @@
+package com.marketinghub.oprm.repository;
+
+import com.marketinghub.oprm.OprmJob;
+import com.marketinghub.oprm.OprmJobStatus;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OprmJobRepository extends JpaRepository<OprmJob, UUID> {
+
+    @Query("""
+            select j.id
+            from OprmJob j
+            where j.jobStatus = com.marketinghub.oprm.OprmJobStatus.PENDING
+            order by j.createdAt asc
+            """)
+    Optional<UUID> findNextPendingJobId();
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update OprmJob j
+            set j.jobStatus = :claimed,
+                j.claimedBy = :workerId,
+                j.claimedAt = :now,
+                j.leaseExpiresAt = :leaseExpiresAt,
+                j.attemptCount = j.attemptCount + 1
+            where j.id = :jobId
+              and j.jobStatus = :pending
+            """)
+    int claimPendingJob(@Param("jobId") UUID jobId,
+                        @Param("workerId") String workerId,
+                        @Param("now") Instant now,
+                        @Param("leaseExpiresAt") Instant leaseExpiresAt,
+                        @Param("pending") OprmJobStatus pending,
+                        @Param("claimed") OprmJobStatus claimed);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java
@@ -1,0 +1,226 @@
+package com.marketinghub.oprm.service;
+
+import com.marketinghub.oprm.OprmJob;
+import com.marketinghub.oprm.OprmJobEvent;
+import com.marketinghub.oprm.OprmJobInput;
+import com.marketinghub.oprm.OprmJobStatus;
+import com.marketinghub.oprm.dto.OprmCreateJobRequestDto;
+import com.marketinghub.oprm.dto.OprmJobClaimRequestDto;
+import com.marketinghub.oprm.dto.OprmJobClaimResponseDto;
+import com.marketinghub.oprm.dto.OprmJobDetailResponseDto;
+import com.marketinghub.oprm.dto.OprmJobStatusUpdateRequestDto;
+import com.marketinghub.oprm.repository.OprmJobEventRepository;
+import com.marketinghub.oprm.repository.OprmJobInputRepository;
+import com.marketinghub.oprm.repository.OprmJobRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class OprmJobOrchestrationService {
+    private final OprmJobRepository jobRepository;
+    private final OprmJobInputRepository jobInputRepository;
+    private final OprmJobEventRepository jobEventRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public OprmJobDetailResponseDto createJob(OprmCreateJobRequestDto request) {
+        OprmJob job = OprmJob.builder()
+                .jobType(request.jobType())
+                .jobStatus(OprmJobStatus.PENDING)
+                .occupationSeedRef(request.occupationSeedRef())
+                .correlationId(resolveCorrelationId(request.correlationId()))
+                .build();
+        OprmJob saved = jobRepository.save(job);
+
+        if (request.inputRefs() != null) {
+            request.inputRefs().stream()
+                    .filter(inputRef -> inputRef != null && !inputRef.isBlank())
+                    .map(inputRef -> OprmJobInput.builder()
+                            .job(saved)
+                            .inputRef(inputRef)
+                            .build())
+                    .forEach(jobInputRepository::save);
+        }
+
+        jobEventRepository.save(OprmJobEvent.builder()
+                .job(saved)
+                .eventStatus(OprmJobStatus.PENDING)
+                .phase("created")
+                .message("job created via backend orchestration")
+                .occurredAt(Instant.now())
+                .build());
+
+        return toJobDetail(saved, jobInputRepository.findByJobIdOrderByCreatedAtAsc(saved.getId()));
+    }
+
+    @Transactional
+    public Optional<OprmJobClaimResponseDto> claimNextJob(OprmJobClaimRequestDto request) {
+        Optional<UUID> nextJobId = jobRepository.findNextPendingJobId();
+        if (nextJobId.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Instant now = Instant.now();
+        Instant leaseExpiresAt = now.plusSeconds(request.leaseSeconds());
+        int updated = jobRepository.claimPendingJob(
+                nextJobId.get(),
+                request.workerId(),
+                now,
+                leaseExpiresAt,
+                OprmJobStatus.PENDING,
+                OprmJobStatus.CLAIMED
+        );
+
+        if (updated == 0) {
+            return Optional.empty();
+        }
+
+        OprmJob job = jobRepository.findById(nextJobId.get())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM job not found after claim"));
+
+        jobEventRepository.save(OprmJobEvent.builder()
+                .job(job)
+                .eventStatus(OprmJobStatus.CLAIMED)
+                .workerId(request.workerId())
+                .phase("claim")
+                .message("job claimed by worker")
+                .occurredAt(now)
+                .build());
+
+        return Optional.of(new OprmJobClaimResponseDto(
+                job.getId().toString(),
+                job.getJobType(),
+                job.getOccupationSeedRef(),
+                job.getCorrelationId(),
+                Map.of(),
+                toIso(job.getClaimedAt()),
+                toIso(job.getLeaseExpiresAt())
+        ));
+    }
+
+    @Transactional(readOnly = true)
+    public OprmJobDetailResponseDto getJobDetail(UUID jobId) {
+        OprmJob job = jobRepository.findById(jobId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM job not found"));
+        return toJobDetail(job, jobInputRepository.findByJobIdOrderByCreatedAtAsc(jobId));
+    }
+
+    @Transactional
+    public void updateJobStatus(UUID jobId, OprmJobStatusUpdateRequestDto request) {
+        OprmJob job = jobRepository.findById(jobId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM job not found"));
+
+        OprmJobStatus requestedStatus = request.status();
+        if (!isTransitionAllowed(job.getJobStatus(), requestedStatus)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "invalid OPRM job status transition: " + job.getJobStatus() + " -> " + requestedStatus);
+        }
+
+        job.setJobStatus(requestedStatus);
+        if (requestedStatus == OprmJobStatus.RUNNING && job.getStartedAt() == null) {
+            job.setStartedAt(parseOccurredAt(request.occurredAt()));
+        }
+
+        if (isTerminal(requestedStatus)) {
+            job.setFinishedAt(parseOccurredAt(request.occurredAt()));
+            job.setLeaseExpiresAt(null);
+        }
+
+        if (request.errorCode() != null && !request.errorCode().isBlank()) {
+            job.setErrorCode(request.errorCode());
+        }
+        if (request.errorMessage() != null && !request.errorMessage().isBlank()) {
+            job.setErrorMessage(request.errorMessage());
+        }
+
+        jobRepository.save(job);
+
+        jobEventRepository.save(OprmJobEvent.builder()
+                .job(job)
+                .eventStatus(requestedStatus)
+                .phase(request.phase())
+                .message(mergeMessageWithMetrics(request.message(), request.metrics()))
+                .workerId(request.workerId())
+                .occurredAt(parseOccurredAt(request.occurredAt()))
+                .build());
+    }
+
+    private OprmJobDetailResponseDto toJobDetail(OprmJob job, List<OprmJobInput> inputs) {
+        return new OprmJobDetailResponseDto(
+                job.getId().toString(),
+                job.getJobType(),
+                job.getJobStatus(),
+                job.getOccupationSeedRef(),
+                job.getCorrelationId(),
+                job.getAttemptCount(),
+                toIso(job.getCreatedAt()),
+                toIso(job.getClaimedAt()),
+                toIso(job.getStartedAt()),
+                toIso(job.getFinishedAt()),
+                Map.of(),
+                inputs.stream().map(OprmJobInput::getInputRef).toList(),
+                job.getErrorCode(),
+                job.getErrorMessage()
+        );
+    }
+
+    private boolean isTransitionAllowed(OprmJobStatus current, OprmJobStatus next) {
+        if (current == next) {
+            return true;
+        }
+        return switch (current) {
+            case PENDING -> next == OprmJobStatus.CLAIMED || next == OprmJobStatus.CANCELLED;
+            case CLAIMED -> next == OprmJobStatus.RUNNING || next == OprmJobStatus.RETRY_WAIT || next == OprmJobStatus.CANCELLED;
+            case RUNNING -> next == OprmJobStatus.SUCCEEDED || next == OprmJobStatus.FAILED || next == OprmJobStatus.RETRY_WAIT;
+            case RETRY_WAIT -> next == OprmJobStatus.PENDING || next == OprmJobStatus.CANCELLED;
+            case SUCCEEDED, FAILED, CANCELLED -> false;
+        };
+    }
+
+    private boolean isTerminal(OprmJobStatus status) {
+        return status == OprmJobStatus.SUCCEEDED || status == OprmJobStatus.FAILED || status == OprmJobStatus.CANCELLED;
+    }
+
+    private String resolveCorrelationId(String correlationId) {
+        if (correlationId == null || correlationId.isBlank()) {
+            return UUID.randomUUID().toString();
+        }
+        return correlationId;
+    }
+
+    private Instant parseOccurredAt(String occurredAt) {
+        try {
+            return Instant.parse(occurredAt);
+        } catch (DateTimeParseException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "occurredAt must use ISO-8601 format");
+        }
+    }
+
+    private String mergeMessageWithMetrics(String message, Map<String, Object> metrics) {
+        if (metrics == null || metrics.isEmpty()) {
+            return message;
+        }
+        try {
+            String metricsJson = objectMapper.writeValueAsString(metrics);
+            return (message == null || message.isBlank()) ? metricsJson : message + " | metrics=" + metricsJson;
+        } catch (JsonProcessingException e) {
+            return message;
+        }
+    }
+
+    private String toIso(Instant instant) {
+        return instant == null ? null : instant.toString();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmJobController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmJobController.java
@@ -1,0 +1,49 @@
+package com.marketinghub.oprm.web;
+
+import com.marketinghub.oprm.dto.OprmCreateJobRequestDto;
+import com.marketinghub.oprm.dto.OprmJobClaimRequestDto;
+import com.marketinghub.oprm.dto.OprmJobClaimResponseDto;
+import com.marketinghub.oprm.dto.OprmJobDetailResponseDto;
+import com.marketinghub.oprm.dto.OprmJobStatusUpdateRequestDto;
+import com.marketinghub.oprm.service.OprmJobOrchestrationService;
+import jakarta.validation.Valid;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/oprm/jobs")
+@RequiredArgsConstructor
+public class OprmJobController {
+    private final OprmJobOrchestrationService service;
+
+    @PostMapping
+    public OprmJobDetailResponseDto createJob(@Valid @RequestBody OprmCreateJobRequestDto request) {
+        return service.createJob(request);
+    }
+
+    @PostMapping("/claim")
+    public ResponseEntity<OprmJobClaimResponseDto> claim(@Valid @RequestBody OprmJobClaimRequestDto request) {
+        Optional<OprmJobClaimResponseDto> claimed = service.claimNextJob(request);
+        return claimed.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @GetMapping("/{jobId}")
+    public OprmJobDetailResponseDto detail(@PathVariable UUID jobId) {
+        return service.getJobDetail(jobId);
+    }
+
+    @PostMapping("/{jobId}/status")
+    public ResponseEntity<Void> updateStatus(@PathVariable UUID jobId,
+                                             @Valid @RequestBody OprmJobStatusUpdateRequestDto request) {
+        service.updateJobStatus(jobId, request);
+        return ResponseEntity.accepted().build();
+    }
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-job-orchestration.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-job-orchestration.yaml
@@ -1,0 +1,216 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-04-15-01-oprm-job-orchestration
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_job
+      changes:
+        - createTable:
+            tableName: oprm_job
+            columns:
+              - column:
+                  name: id
+                  type: CHAR(36)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: job_type
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: job_status
+                  type: VARCHAR(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: occupation_seed_ref
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: correlation_id
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: attempt_count
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: claimed_by
+                  type: VARCHAR(191)
+              - column:
+                  name: claimed_at
+                  type: DATETIME
+              - column:
+                  name: lease_expires_at
+                  type: DATETIME
+              - column:
+                  name: started_at
+                  type: DATETIME
+              - column:
+                  name: finished_at
+                  type: DATETIME
+              - column:
+                  name: error_code
+                  type: VARCHAR(64)
+              - column:
+                  name: error_message
+                  type: LONGTEXT
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: oprm_job
+            indexName: idx_oprm_job_status_created
+            columns:
+              - column:
+                  name: job_status
+              - column:
+                  name: created_at
+
+  - changeSet:
+      id: 2026-04-15-02-oprm-job-input
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_job_input
+      changes:
+        - createTable:
+            tableName: oprm_job_input
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: job_id
+                  type: CHAR(36)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: input_ref
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: input_value
+                  type: LONGTEXT
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: oprm_job_input
+            baseColumnNames: job_id
+            referencedTableName: oprm_job
+            referencedColumnNames: id
+            constraintName: fk_oprm_job_input_job
+            onDelete: CASCADE
+        - createIndex:
+            tableName: oprm_job_input
+            indexName: idx_oprm_job_input_job_id
+            columns:
+              - column:
+                  name: job_id
+
+  - changeSet:
+      id: 2026-04-15-03-oprm-job-event
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_job_event
+      changes:
+        - createTable:
+            tableName: oprm_job_event
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: job_id
+                  type: CHAR(36)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: event_status
+                  type: VARCHAR(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: phase
+                  type: VARCHAR(128)
+              - column:
+                  name: message
+                  type: LONGTEXT
+              - column:
+                  name: worker_id
+                  type: VARCHAR(191)
+              - column:
+                  name: occurred_at
+                  type: DATETIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: oprm_job_event
+            baseColumnNames: job_id
+            referencedTableName: oprm_job
+            referencedColumnNames: id
+            constraintName: fk_oprm_job_event_job
+            onDelete: CASCADE
+        - createIndex:
+            tableName: oprm_job_event
+            indexName: idx_oprm_job_event_job_id
+            columns:
+              - column:
+                  name: job_id
+        - createIndex:
+            tableName: oprm_job_event
+            indexName: idx_oprm_job_event_occurred
+            columns:
+              - column:
+                  name: occurred_at

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-04-15-oprm-job-orchestration.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2037-04-15-facebook-campaign-stop.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -308,3 +308,53 @@ Foi consolidado o contrato oficial de integração da Sprint 1 entre backend pri
 **Próximo passo sugerido:**  
 - implementar Sprint 2 com modelo de job no backend e endpoints reais de claim/detail/status
 - criar clients HTTP no OPRM usando os DTOs comuns da Sprint 1
+
+## 2026-04-15 — sprint 2: job orchestration no backend + consumo real no OPRM
+
+**Status:** concluído
+
+**Resumo:**  
+Foi implementada a base operacional da Sprint 2 para integrar OPRM e backend com modelo de jobs persistido no backend, endpoints reais de claim/detail/status e loop agendado no worker OPRM consumindo jobs reais e reportando transições de status.
+
+**O que foi implementado:**  
+- criação do modelo de orquestração no backend com `oprm_job`, `oprm_job_input` e `oprm_job_event`
+- implementação dos endpoints `POST /api/oprm/jobs`, `POST /api/oprm/jobs/claim`, `GET /api/oprm/jobs/{jobId}` e `POST /api/oprm/jobs/{jobId}/status`
+- implementação de lock lógico no claim via update condicional de status (`PENDING` → `CLAIMED`) para evitar duplicidade de claim
+- implementação no OPRM dos clients HTTP `BackendJobClient` e `BackendStatusClient`
+- implementação de loop agendado do worker (`OprmWorkerJobProcessor`) com claim, detail, execução de `OCCUPATION_MAPPING` e atualização de status `RUNNING`/`SUCCEEDED`/`FAILED`
+- atualização da documentação do OPRM e do checklist da Sprint 2 no plano de integração
+
+**Arquivos principais alterados:**  
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-job-orchestration.yaml`
+- `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJob.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJobInput.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/OprmJobEvent.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmJobRepository.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmJobController.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/client/BackendJobClient.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/client/BackendStatusClient.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/worker/OprmWorkerJobProcessor.java`
+- `oprm/src/main/java/com/marketinghub/oprm/OprmApplication.java`
+- `oprm/src/main/resources/application.properties`
+- `oprm/README.md`
+- `docs/novos-modulos/OPRM/oprm_plano_unico_desenvolvimento_integracao.md`
+
+**Contratos / artefatos afetados:**  
+- endpoints de orquestração de job: `POST /api/oprm/jobs/claim`, `GET /api/oprm/jobs/{jobId}`, `POST /api/oprm/jobs/{jobId}/status`
+- endpoint auxiliar de criação de job no backend para orquestração operacional: `POST /api/oprm/jobs`
+- estados de job canônicos da integração: `PENDING`, `CLAIMED`, `RUNNING`, `SUCCEEDED`, `FAILED`, `RETRY_WAIT`, `CANCELLED`
+
+**Testes executados:**  
+- `cd backend/ads-service && mvn -q -DskipTests compile` — **passou**
+- `cd oprm && mvn -q test` — **passou**
+
+**Limitações ou pendências:**  
+- execução do worker na Sprint 2 atual processa somente o tipo `OCCUPATION_MAPPING`; `FEEDBACK_RECALIBRATION` ainda não foi implementado no loop
+- o timeout de lease foi incluído no modelo, mas a rotina automática de requeue por lease expirado ainda não foi entregue
+- publicação remota de artefatos no backend permanece para Sprint 3
+
+**Próximo passo sugerido:**  
+- executar Sprint 3 com endpoint de publish artifact e persistência dos envelopes canônicos com lineage
+- adicionar consulta operacional de jobs/eventos para observabilidade de fila e diagnóstico de retry

--- a/docs/novos-modulos/OPRM/oprm_plano_unico_desenvolvimento_integracao.md
+++ b/docs/novos-modulos/OPRM/oprm_plano_unico_desenvolvimento_integracao.md
@@ -506,10 +506,10 @@ A fase de integração deve tratar explicitamente ao menos estes artefatos:
 - [ ] histórico atualizado
 
 ### Sprint 2
-- [ ] modelo de job criado no backend
-- [ ] endpoints de claim/detail/status implementados
-- [ ] clients HTTP criados no OPRM
-- [ ] loop real do worker funcionando
+- [x] modelo de job criado no backend
+- [x] endpoints de claim/detail/status implementados
+- [x] clients HTTP criados no OPRM
+- [x] loop real do worker funcionando
 
 ### Sprint 3
 - [ ] endpoint de publish artifact implementado

--- a/oprm/README.md
+++ b/oprm/README.md
@@ -120,6 +120,23 @@ Exemplo de payload da fase 5:
 - Versionamento: `docs/novos-modulos/OPRM/contracts/oprm-contrato-versionamento.md`
 - DTOs comuns (alinhamento de contrato): `oprm/src/main/java/com/marketinghub/oprm/integration/contract`
 
+## Integração Sprint 2 — worker consumindo jobs reais
+
+Configurações do worker:
+
+- `OPRM_BACKEND_BASE_URL` (default `http://localhost:8080`)
+- `OPRM_WORKER_ID`
+- `OPRM_WORKER_VERSION`
+- `OPRM_WORKER_CLAIM_LEASE_SECONDS`
+- `OPRM_WORKER_LOOP_DELAY_MS`
+
+Fluxo implementado:
+
+1. claim em `POST /api/oprm/jobs/claim`
+2. detalhamento em `GET /api/oprm/jobs/{jobId}`
+3. atualização de status em `POST /api/oprm/jobs/{jobId}/status`
+4. execução do job `OCCUPATION_MAPPING` no loop agendado do worker
+
 ## Deploy do container (host 177.153.62.107)
 
 Arquivos de deploy do módulo:

--- a/oprm/src/main/java/com/marketinghub/oprm/OprmApplication.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/OprmApplication.java
@@ -2,8 +2,10 @@ package com.marketinghub.oprm;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class OprmApplication {
 
     public static void main(String[] args) {

--- a/oprm/src/main/java/com/marketinghub/oprm/config/BackendIntegrationConfig.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/config/BackendIntegrationConfig.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class BackendIntegrationConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder.build();
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/client/BackendJobClient.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/client/BackendJobClient.java
@@ -1,0 +1,43 @@
+package com.marketinghub.oprm.integration.client;
+
+import com.marketinghub.oprm.integration.contract.OprmJobClaimRequest;
+import com.marketinghub.oprm.integration.contract.OprmJobClaimResponse;
+import com.marketinghub.oprm.integration.contract.OprmJobDetailResponse;
+import java.net.URI;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class BackendJobClient {
+    private final RestTemplate restTemplate;
+    private final String backendBaseUrl;
+
+    public BackendJobClient(RestTemplate restTemplate,
+                            @Value("${oprm.backend.base-url:http://localhost:8080}") String backendBaseUrl) {
+        this.restTemplate = restTemplate;
+        this.backendBaseUrl = backendBaseUrl;
+    }
+
+    public Optional<OprmJobClaimResponse> claimNextJob(OprmJobClaimRequest request) {
+        String endpoint = backendBaseUrl + "/api/oprm/jobs/claim";
+        ResponseEntity<OprmJobClaimResponse> response = restTemplate.postForEntity(
+                URI.create(endpoint),
+                request,
+                OprmJobClaimResponse.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(response.getBody());
+    }
+
+    public OprmJobDetailResponse getJobDetail(String jobId) {
+        String endpoint = backendBaseUrl + "/api/oprm/jobs/" + jobId;
+        return restTemplate.getForObject(URI.create(endpoint), OprmJobDetailResponse.class);
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/client/BackendStatusClient.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/client/BackendStatusClient.java
@@ -1,0 +1,26 @@
+package com.marketinghub.oprm.integration.client;
+
+import com.marketinghub.oprm.integration.contract.OprmJobStatusUpdateRequest;
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class BackendStatusClient {
+    private final RestTemplate restTemplate;
+    private final String backendBaseUrl;
+
+    public BackendStatusClient(RestTemplate restTemplate,
+                               @Value("${oprm.backend.base-url:http://localhost:8080}") String backendBaseUrl) {
+        this.restTemplate = restTemplate;
+        this.backendBaseUrl = backendBaseUrl;
+    }
+
+    public void updateStatus(String jobId, OprmJobStatusUpdateRequest request) {
+        String endpoint = backendBaseUrl + "/api/oprm/jobs/" + jobId + "/status";
+        restTemplate.exchange(URI.create(endpoint), HttpMethod.POST, new HttpEntity<>(request), Void.class);
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/worker/OprmWorkerJobProcessor.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/worker/OprmWorkerJobProcessor.java
@@ -1,0 +1,127 @@
+package com.marketinghub.oprm.integration.worker;
+
+import com.marketinghub.oprm.application.FrameworkIntegrationService;
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.integration.client.BackendJobClient;
+import com.marketinghub.oprm.integration.client.BackendStatusClient;
+import com.marketinghub.oprm.integration.contract.OprmContractVersion;
+import com.marketinghub.oprm.integration.contract.OprmJobClaimRequest;
+import com.marketinghub.oprm.integration.contract.OprmJobClaimResponse;
+import com.marketinghub.oprm.integration.contract.OprmJobDetailResponse;
+import com.marketinghub.oprm.integration.contract.OprmJobStatus;
+import com.marketinghub.oprm.integration.contract.OprmJobStatusUpdateRequest;
+import com.marketinghub.oprm.integration.contract.OprmJobType;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OprmWorkerJobProcessor {
+    private static final Logger log = LoggerFactory.getLogger(OprmWorkerJobProcessor.class);
+
+    private final BackendJobClient backendJobClient;
+    private final BackendStatusClient backendStatusClient;
+    private final FrameworkIntegrationService frameworkIntegrationService;
+    private final String workerId;
+    private final String workerVersion;
+    private final int claimLeaseSeconds;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    public OprmWorkerJobProcessor(BackendJobClient backendJobClient,
+                                  BackendStatusClient backendStatusClient,
+                                  FrameworkIntegrationService frameworkIntegrationService,
+                                  @Value("${oprm.worker.id:oprm-worker-local}") String workerId,
+                                  @Value("${oprm.worker.version:0.1.0}") String workerVersion,
+                                  @Value("${oprm.worker.claim-lease-seconds:120}") int claimLeaseSeconds) {
+        this.backendJobClient = backendJobClient;
+        this.backendStatusClient = backendStatusClient;
+        this.frameworkIntegrationService = frameworkIntegrationService;
+        this.workerId = workerId;
+        this.workerVersion = workerVersion;
+        this.claimLeaseSeconds = claimLeaseSeconds;
+    }
+
+    @Scheduled(fixedDelayString = "${oprm.worker.loop-delay-ms:15000}")
+    public void pollAndProcess() {
+        if (!running.compareAndSet(false, true)) {
+            return;
+        }
+
+        String activeJobId = null;
+        try {
+            OprmJobClaimRequest claimRequest = new OprmJobClaimRequest(
+                    workerId,
+                    workerVersion,
+                    OprmContractVersion.V1,
+                    1,
+                    claimLeaseSeconds
+            );
+
+            Optional<OprmJobClaimResponse> claimed = backendJobClient.claimNextJob(claimRequest);
+            if (claimed.isEmpty()) {
+                return;
+            }
+
+            OprmJobClaimResponse claimedJob = claimed.get();
+            activeJobId = claimedJob.jobId();
+
+            OprmJobDetailResponse detail = backendJobClient.getJobDetail(claimedJob.jobId());
+            updateStatus(claimedJob.jobId(), OprmJobStatus.RUNNING, "phase-run", "OPRM job started", null, null, Map.of());
+
+            if (detail.jobType() != OprmJobType.OCCUPATION_MAPPING) {
+                throw new IllegalStateException("unsupported OPRM job type for Sprint 2: " + detail.jobType());
+            }
+
+            ArtifactEnvelope artifact = frameworkIntegrationService.integrateRoutineSignals(
+                    detail.occupationSeedRef(),
+                    "default",
+                    "pt-BR",
+                    detail.correlationId()
+            );
+
+            updateStatus(claimedJob.jobId(), OprmJobStatus.SUCCEEDED, "phase-run",
+                    "OPRM job completed", null, null, Map.of("artifactType", artifact.artifactType()));
+            log.info("oprm-job-processed jobId={} correlationId={} artifactType={}",
+                    claimedJob.jobId(),
+                    detail.correlationId(),
+                    artifact.artifactType());
+        } catch (Exception ex) {
+            if (activeJobId != null) {
+                updateStatus(activeJobId, OprmJobStatus.FAILED, "phase-run",
+                        "OPRM job failed", "JOB_EXECUTION_ERROR", ex.getMessage(), Map.of());
+            }
+            log.error("oprm-worker-loop-failure", ex);
+        } finally {
+            running.set(false);
+        }
+    }
+
+    private void updateStatus(String jobId,
+                              OprmJobStatus status,
+                              String phase,
+                              String message,
+                              String errorCode,
+                              String errorMessage,
+                              Map<String, Object> metrics) {
+        try {
+            backendStatusClient.updateStatus(jobId, new OprmJobStatusUpdateRequest(
+                    workerId,
+                    status,
+                    Instant.now().toString(),
+                    phase,
+                    message,
+                    errorCode,
+                    errorMessage,
+                    metrics
+            ));
+        } catch (Exception statusException) {
+            log.warn("oprm-status-update-failed jobId={} status={}", jobId, status, statusException);
+        }
+    }
+}

--- a/oprm/src/main/resources/application.properties
+++ b/oprm/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 spring.application.name=oprm
 server.port=8093
+oprm.backend.base-url=${OPRM_BACKEND_BASE_URL:http://localhost:8080}
+oprm.worker.id=${OPRM_WORKER_ID:oprm-worker-local}
+oprm.worker.version=${OPRM_WORKER_VERSION:0.1.0}
+oprm.worker.claim-lease-seconds=${OPRM_WORKER_CLAIM_LEASE_SECONDS:120}
+oprm.worker.loop-delay-ms=${OPRM_WORKER_LOOP_DELAY_MS:15000}


### PR DESCRIPTION
### Motivation
- Fechar a Sprint 2 do plano OPRM integrando o worker ao backend principal por contrato e permitir que o OPRM consuma jobs reais e reporte status operacionais. 
- Evitar claims duplicados e garantir lineage/observabilidade básica via eventos de job no backend. 

### Description
- Backend: adicionadas entidades JPA `OprmJob`, `OprmJobInput`, `OprmJobEvent`, enums de `OprmJobStatus`/`OprmJobType`, repositórios com claim condicional, serviço de orquestração (`OprmJobOrchestrationService`) e controller REST em `/api/oprm/jobs` (`create`, `claim`, `detail`, `status`), e changelog Liquibase YAML (`2026-04-15-oprm-job-orchestration.yaml`) incluído em `db.changelog-master.yaml`.
- OPRM module: implementados `BackendJobClient` e `BackendStatusClient` usando `RestTemplate`, criado `OprmWorkerJobProcessor` com scheduler para poll/claim/process/update loop (processa `OCCUPATION_MAPPING`), adicionado `BackendIntegrationConfig` (bean `RestTemplate`), habilitado `@EnableScheduling` e propriedades configuráveis em `application.properties` para backend/worker.
- Documentação & histórico: atualizado `docs/novos-modulos/OPRM/oprm_plano_unico_desenvolvimento_integracao.md` (checklist Sprint 2), `oprm/README.md` (integração Sprint 2) e adicionada entrada seguindo o protocolo em `docs/history/oprm-implementation-history.md`.

### Testing
- Executado `cd backend/ads-service && mvn -q -DskipTests compile` — passou. 
- Executado `cd oprm && mvn -q test` — passou. 
- Observação: testes de integração runtime com banco/daemon externos e publish de artefatos end-to-end ficam para as próximas sprints (Sprint 3 e adiante).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00aea53c48321ad372a0fd8c8fa64)