### PR TITLE
feat(oprm): Sprint 3 — publish OPRM artifacts and persist envelopes end-to-end

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmArtifact.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmArtifact.java
@@ -1,0 +1,95 @@
+package com.marketinghub.oprm;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OprmArtifact {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "job_id", nullable = false)
+    private OprmJob job;
+
+    @Column(name = "artifact_id", nullable = false, length = 191)
+    private String artifactId;
+
+    @Column(name = "artifact_type", nullable = false, length = 128)
+    private String artifactType;
+
+    @Column(name = "artifact_version", nullable = false, length = 32)
+    private String artifactVersion;
+
+    @Column(name = "module_name", nullable = false, length = 64)
+    private String moduleName;
+
+    @Column(name = "producer", nullable = false, length = 191)
+    private String producer;
+
+    @Column(name = "artifact_created_at", nullable = false)
+    private Instant artifactCreatedAt;
+
+    @Column(name = "correlation_id", nullable = false, length = 191)
+    private String correlationId;
+
+    @Column(name = "occupation_seed_ref", nullable = false, length = 191)
+    private String occupationSeedRef;
+
+    @Column(name = "trace_id", nullable = false, length = 191)
+    private String traceId;
+
+    @Column(name = "source_refs_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String sourceRefsJson;
+
+    @Column(name = "input_refs_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String inputRefsJson;
+
+    @Column(name = "payload_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String payloadJson;
+
+    @Column(name = "lineage_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String lineageJson;
+
+    @Column(name = "metadata_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String metadataJson;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "artifact_status", nullable = false, length = 32)
+    private OprmArtifactStatus artifactStatus;
+
+    @Column(name = "confidence_score", precision = 5, scale = 4)
+    private BigDecimal confidenceScore;
+
+    @Column(name = "idempotency_key", nullable = false, length = 191)
+    private String idempotencyKey;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmArtifactStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmArtifactStatus.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm;
+
+public enum OprmArtifactStatus {
+    DRAFT,
+    GENERATED,
+    VALIDATED,
+    REJECTED,
+    PUBLISHED,
+    SUPERSEDED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactEnvelopeDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactEnvelopeDto.java
@@ -1,0 +1,25 @@
+package com.marketinghub.oprm.dto;
+
+import com.marketinghub.oprm.OprmArtifactStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+public record OprmArtifactEnvelopeDto(
+        @NotBlank String artifactType,
+        @NotBlank String artifactVersion,
+        @NotBlank String artifactId,
+        @NotBlank String moduleName,
+        @NotBlank String producer,
+        @NotBlank String createdAt,
+        @NotBlank String correlationId,
+        @NotBlank String traceId,
+        @NotNull List<String> sourceRefs,
+        @NotNull List<String> inputRefs,
+        @NotNull Map<String, Object> payload,
+        @NotNull OprmArtifactStatus status,
+        Double confidenceScore,
+        @NotNull Map<String, Object> metadata
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactPublishRequestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactPublishRequestDto.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public record OprmArtifactPublishRequestDto(
+        @NotBlank String jobId,
+        @NotBlank String correlationId,
+        @NotNull @Valid OprmArtifactEnvelopeDto artifact,
+        @NotNull Map<String, Object> lineage,
+        @NotBlank String idempotencyKey
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactPublishResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactPublishResponseDto.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.dto;
+
+public record OprmArtifactPublishResponseDto(
+        String artifactId,
+        String artifactType,
+        String artifactVersion,
+        String persistedAt,
+        String status,
+        boolean duplicated
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactSummaryDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactSummaryDto.java
@@ -1,0 +1,14 @@
+package com.marketinghub.oprm.dto;
+
+import com.marketinghub.oprm.OprmArtifactStatus;
+
+public record OprmArtifactSummaryDto(
+        String artifactId,
+        String artifactType,
+        String artifactVersion,
+        OprmArtifactStatus artifactStatus,
+        String occupationSeedRef,
+        String correlationId,
+        String createdAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmArtifactRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmArtifactRepository.java
@@ -1,0 +1,18 @@
+package com.marketinghub.oprm.repository;
+
+import com.marketinghub.oprm.OprmArtifact;
+import com.marketinghub.oprm.OprmArtifactStatus;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OprmArtifactRepository extends JpaRepository<OprmArtifact, Long> {
+    Optional<OprmArtifact> findByIdempotencyKey(String idempotencyKey);
+
+    List<OprmArtifact> findByCorrelationIdOrderByCreatedAtDesc(String correlationId);
+
+    List<OprmArtifact> findByOccupationSeedRefAndArtifactStatusOrderByCreatedAtDesc(String occupationSeedRef,
+                                                                                     OprmArtifactStatus artifactStatus);
+
+    List<OprmArtifact> findByOccupationSeedRefOrderByCreatedAtDesc(String occupationSeedRef);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java
@@ -1,0 +1,153 @@
+package com.marketinghub.oprm.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.oprm.OprmArtifact;
+import com.marketinghub.oprm.OprmArtifactStatus;
+import com.marketinghub.oprm.OprmJob;
+import com.marketinghub.oprm.dto.OprmArtifactEnvelopeDto;
+import com.marketinghub.oprm.dto.OprmArtifactPublishRequestDto;
+import com.marketinghub.oprm.dto.OprmArtifactPublishResponseDto;
+import com.marketinghub.oprm.dto.OprmArtifactSummaryDto;
+import com.marketinghub.oprm.repository.OprmArtifactRepository;
+import com.marketinghub.oprm.repository.OprmJobRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class OprmArtifactService {
+    private final OprmArtifactRepository artifactRepository;
+    private final OprmJobRepository jobRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public OprmArtifactPublishResponseDto publishArtifact(OprmArtifactPublishRequestDto request) {
+        OprmArtifact duplicatedArtifact = artifactRepository.findByIdempotencyKey(request.idempotencyKey()).orElse(null);
+        if (duplicatedArtifact != null) {
+            return new OprmArtifactPublishResponseDto(
+                    duplicatedArtifact.getArtifactId(),
+                    duplicatedArtifact.getArtifactType(),
+                    duplicatedArtifact.getArtifactVersion(),
+                    duplicatedArtifact.getCreatedAt().toString(),
+                    duplicatedArtifact.getArtifactStatus().name(),
+                    true
+            );
+        }
+
+        UUID jobId;
+        try {
+            jobId = UUID.fromString(request.jobId());
+        } catch (IllegalArgumentException exception) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jobId must be a valid UUID");
+        }
+
+        OprmJob job = jobRepository.findById(jobId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM job not found"));
+
+        OprmArtifactEnvelopeDto artifactEnvelope = request.artifact();
+        if (!request.correlationId().equals(artifactEnvelope.correlationId())) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "correlationId from request must match artifact envelope");
+        }
+
+        if (artifactEnvelope.sourceRefs().isEmpty() && artifactEnvelope.inputRefs().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "artifact lineage requires sourceRefs or inputRefs");
+        }
+
+        OprmArtifact saved = artifactRepository.save(OprmArtifact.builder()
+                .job(job)
+                .artifactId(artifactEnvelope.artifactId())
+                .artifactType(artifactEnvelope.artifactType())
+                .artifactVersion(artifactEnvelope.artifactVersion())
+                .moduleName(artifactEnvelope.moduleName())
+                .producer(artifactEnvelope.producer())
+                .artifactCreatedAt(parseCreatedAt(artifactEnvelope.createdAt()))
+                .correlationId(artifactEnvelope.correlationId())
+                .occupationSeedRef(job.getOccupationSeedRef())
+                .traceId(artifactEnvelope.traceId())
+                .sourceRefsJson(toJson(artifactEnvelope.sourceRefs()))
+                .inputRefsJson(toJson(artifactEnvelope.inputRefs()))
+                .payloadJson(toJson(artifactEnvelope.payload()))
+                .lineageJson(toJson(request.lineage()))
+                .metadataJson(toJson(artifactEnvelope.metadata()))
+                .artifactStatus(artifactEnvelope.status())
+                .confidenceScore(toBigDecimal(artifactEnvelope.confidenceScore()))
+                .idempotencyKey(request.idempotencyKey())
+                .build());
+
+        return new OprmArtifactPublishResponseDto(
+                saved.getArtifactId(),
+                saved.getArtifactType(),
+                saved.getArtifactVersion(),
+                saved.getCreatedAt().toString(),
+                saved.getArtifactStatus().name(),
+                false
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<OprmArtifactSummaryDto> listArtifacts(String correlationId,
+                                                      String occupationSeedRef,
+                                                      OprmArtifactStatus status) {
+        if (correlationId != null && !correlationId.isBlank()) {
+            return artifactRepository.findByCorrelationIdOrderByCreatedAtDesc(correlationId)
+                    .stream()
+                    .map(this::toSummary)
+                    .toList();
+        }
+
+        if (occupationSeedRef != null && !occupationSeedRef.isBlank()) {
+            List<OprmArtifact> artifacts = status == null
+                    ? artifactRepository.findByOccupationSeedRefOrderByCreatedAtDesc(occupationSeedRef)
+                    : artifactRepository.findByOccupationSeedRefAndArtifactStatusOrderByCreatedAtDesc(occupationSeedRef, status);
+            return artifacts.stream().map(this::toSummary).toList();
+        }
+
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                "use correlationId or occupationSeedRef to filter OPRM artifacts");
+    }
+
+    private OprmArtifactSummaryDto toSummary(OprmArtifact artifact) {
+        return new OprmArtifactSummaryDto(
+                artifact.getArtifactId(),
+                artifact.getArtifactType(),
+                artifact.getArtifactVersion(),
+                artifact.getArtifactStatus(),
+                artifact.getOccupationSeedRef(),
+                artifact.getCorrelationId(),
+                artifact.getCreatedAt().toString()
+        );
+    }
+
+    private Instant parseCreatedAt(String createdAt) {
+        try {
+            return Instant.parse(createdAt);
+        } catch (DateTimeParseException exception) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "artifact.createdAt must use ISO-8601");
+        }
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException exception) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "unable to serialize artifact payload for persistence");
+        }
+    }
+
+    private BigDecimal toBigDecimal(Double value) {
+        return value == null ? null : BigDecimal.valueOf(value);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmArtifactController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmArtifactController.java
@@ -1,0 +1,36 @@
+package com.marketinghub.oprm.web;
+
+import com.marketinghub.oprm.OprmArtifactStatus;
+import com.marketinghub.oprm.dto.OprmArtifactPublishRequestDto;
+import com.marketinghub.oprm.dto.OprmArtifactPublishResponseDto;
+import com.marketinghub.oprm.dto.OprmArtifactSummaryDto;
+import com.marketinghub.oprm.service.OprmArtifactService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/oprm/artifacts")
+@RequiredArgsConstructor
+public class OprmArtifactController {
+    private final OprmArtifactService service;
+
+    @PostMapping
+    public ResponseEntity<OprmArtifactPublishResponseDto> publish(@Valid @RequestBody OprmArtifactPublishRequestDto request) {
+        return ResponseEntity.accepted().body(service.publishArtifact(request));
+    }
+
+    @GetMapping
+    public List<OprmArtifactSummaryDto> list(@RequestParam(required = false) String correlationId,
+                                             @RequestParam(required = false) String occupationSeedRef,
+                                             @RequestParam(required = false) OprmArtifactStatus status) {
+        return service.listArtifacts(correlationId, occupationSeedRef, status);
+    }
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-artifact-publication.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-artifact-publication.yaml
@@ -1,0 +1,158 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-04-15-04-oprm-artifact
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_artifact
+      changes:
+        - createTable:
+            tableName: oprm_artifact
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: job_id
+                  type: CHAR(36)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: artifact_id
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: artifact_type
+                  type: VARCHAR(128)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: artifact_version
+                  type: VARCHAR(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: module_name
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: producer
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: artifact_created_at
+                  type: DATETIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: correlation_id
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: occupation_seed_ref
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: trace_id
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: source_refs_json
+                  type: LONGTEXT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: input_refs_json
+                  type: LONGTEXT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: payload_json
+                  type: LONGTEXT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: lineage_json
+                  type: LONGTEXT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: metadata_json
+                  type: LONGTEXT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: artifact_status
+                  type: VARCHAR(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: confidence_score
+                  type: DECIMAL(5,4)
+              - column:
+                  name: idempotency_key
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: oprm_artifact
+            baseColumnNames: job_id
+            referencedTableName: oprm_job
+            referencedColumnNames: id
+            constraintName: fk_oprm_artifact_job
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: oprm_artifact
+            columnNames: artifact_id
+            constraintName: uk_oprm_artifact_artifact_id
+        - addUniqueConstraint:
+            tableName: oprm_artifact
+            columnNames: idempotency_key
+            constraintName: uk_oprm_artifact_idempotency
+        - createIndex:
+            tableName: oprm_artifact
+            indexName: idx_oprm_artifact_correlation
+            columns:
+              - column:
+                  name: correlation_id
+        - createIndex:
+            tableName: oprm_artifact
+            indexName: idx_oprm_artifact_occupation_status
+            columns:
+              - column:
+                  name: occupation_seed_ref
+              - column:
+                  name: artifact_status
+        - createIndex:
+            tableName: oprm_artifact
+            indexName: idx_oprm_artifact_job_id
+            columns:
+              - column:
+                  name: job_id

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,6 +3,9 @@ databaseChangeLog:
       file: changesets/2026-04-15-oprm-job-orchestration.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-04-15-oprm-artifact-publication.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2037-04-15-facebook-campaign-stop.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -358,3 +358,53 @@ Foi implementada a base operacional da Sprint 2 para integrar OPRM e backend com
 **Próximo passo sugerido:**  
 - executar Sprint 3 com endpoint de publish artifact e persistência dos envelopes canônicos com lineage
 - adicionar consulta operacional de jobs/eventos para observabilidade de fila e diagnóstico de retry
+
+## 2026-04-15 — sprint 3: publicação remota de artefatos + persistência end-to-end
+
+**Status:** concluído
+
+**Resumo:**  
+Foi concluída a Sprint 3 da integração OPRM com publicação remota de artefatos para o backend principal, persistência de envelope canônico com lineage e vínculo operacional entre job e artefatos gerados no ciclo do worker.
+
+**O que foi implementado:**  
+- criação do endpoint backend `POST /api/oprm/artifacts` com persistência de envelope, lineage e controle de idempotência
+- criação da consulta de artefatos no backend com filtros por `correlationId`, `occupationSeedRef` e `status`
+- criação do modelo persistente `oprm_artifact` com vínculo ao `oprm_job` e índices para consulta operacional
+- implementação no worker OPRM de publicação remota de artefatos após processamento do job
+- implementação do pipeline de artefatos da Sprint 3 no worker publicando: `occupationProfileSnapshot`, `occupationWebSourceSnapshot`, `occupationPersonaRoutineCard`, `desiredOutcomeSignal`, `mechanismOpportunitySignal` e `dorResultadoOfertaMecanismoProvaInput`
+- atualização do checklist da Sprint 3 no plano único de integração
+
+**Arquivos principais alterados:**  
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-artifact-publication.yaml`
+- `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/OprmArtifact.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/OprmArtifactStatus.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmArtifactRepository.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmArtifactController.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactEnvelopeDto.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactPublishRequestDto.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactPublishResponseDto.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmArtifactSummaryDto.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/client/BackendArtifactPublishClient.java`
+- `oprm/src/main/java/com/marketinghub/oprm/application/OprmArtifactPipelineService.java`
+- `oprm/src/main/java/com/marketinghub/oprm/integration/worker/OprmWorkerJobProcessor.java`
+- `docs/novos-modulos/OPRM/oprm_plano_unico_desenvolvimento_integracao.md`
+
+**Contratos / artefatos afetados:**  
+- endpoint `POST /api/oprm/artifacts` implementado no backend com persistência de envelope canônico
+- endpoint `GET /api/oprm/artifacts` implementado para consulta operacional por correlação/ocupação/status
+- artefatos publicados no fluxo do worker: `occupationProfileSnapshot`, `occupationWebSourceSnapshot`, `occupationPersonaRoutineCard`, `desiredOutcomeSignal`, `mechanismOpportunitySignal`, `dorResultadoOfertaMecanismoProvaInput`
+
+**Testes executados:**  
+- `cd backend/ads-service && mvn -q -DskipTests compile` — **passou**
+- `cd oprm && mvn -q test` — **passou**
+
+**Limitações ou pendências:**  
+- o endpoint de consulta retorna resumo operacional do artefato; leitura completa do payload persistido ainda não foi exposta
+- validação de contrato automatizada em CI (Spring Cloud Contract) permanece como item da Sprint 5
+- o loop de job ainda mantém suporte funcional principal para `OCCUPATION_MAPPING`
+
+**Próximo passo sugerido:**  
+- executar Sprint 4 para persistir `occupationFeedbackLoopSnapshot` e histórico de recalibração por ocupação no backend
+- adicionar ingestão de snapshots downstream no fluxo do backend para retroalimentar o OPRM com estado persistido

--- a/docs/novos-modulos/OPRM/oprm_plano_unico_desenvolvimento_integracao.md
+++ b/docs/novos-modulos/OPRM/oprm_plano_unico_desenvolvimento_integracao.md
@@ -512,10 +512,10 @@ A fase de integração deve tratar explicitamente ao menos estes artefatos:
 - [x] loop real do worker funcionando
 
 ### Sprint 3
-- [ ] endpoint de publish artifact implementado
-- [ ] envelopes persistidos
-- [ ] lineage persistido
-- [ ] vínculo job → artifact funcionando
+- [x] endpoint de publish artifact implementado
+- [x] envelopes persistidos
+- [x] lineage persistido
+- [x] vínculo job → artifact funcionando
 
 ### Sprint 4
 - [ ] feedback loop persistido

--- a/oprm/src/main/java/com/marketinghub/oprm/application/OprmArtifactPipelineService.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/application/OprmArtifactPipelineService.java
@@ -1,0 +1,121 @@
+package com.marketinghub.oprm.application;
+
+import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.domain.DesiredOutcomeSignal;
+import com.marketinghub.oprm.domain.DorResultadoOfertaMecanismoProvaInputPayload;
+import com.marketinghub.oprm.domain.MechanismOpportunitySignal;
+import com.marketinghub.oprm.domain.OccupationPersonaRoutineCardPayload;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OprmArtifactPipelineService {
+    private final OccupationResolverService occupationResolverService;
+    private final WebEnrichmentService webEnrichmentService;
+    private final RoutineInferenceService routineInferenceService;
+    private final FrameworkIntegrationService frameworkIntegrationService;
+
+    public OprmArtifactPipelineService(OccupationResolverService occupationResolverService,
+                                       WebEnrichmentService webEnrichmentService,
+                                       RoutineInferenceService routineInferenceService,
+                                       FrameworkIntegrationService frameworkIntegrationService) {
+        this.occupationResolverService = occupationResolverService;
+        this.webEnrichmentService = webEnrichmentService;
+        this.routineInferenceService = routineInferenceService;
+        this.frameworkIntegrationService = frameworkIntegrationService;
+    }
+
+    public List<ArtifactEnvelope> runPipeline(String occupationSeedRef,
+                                              String nicheName,
+                                              String locale,
+                                              String correlationId) {
+        ArtifactEnvelope profileSnapshot = occupationResolverService.resolveToProfileSnapshot(
+                occupationSeedRef,
+                nicheName,
+                locale,
+                correlationId
+        );
+
+        ArtifactEnvelope webSnapshot = webEnrichmentService.enrichOccupation(
+                occupationSeedRef,
+                nicheName,
+                locale,
+                correlationId
+        );
+
+        ArtifactEnvelope routineCard = routineInferenceService.inferRoutine(
+                occupationSeedRef,
+                nicheName,
+                locale,
+                correlationId
+        );
+
+        ArtifactEnvelope frameworkInput = frameworkIntegrationService.integrateRoutineSignals(
+                occupationSeedRef,
+                nicheName,
+                locale,
+                correlationId
+        );
+
+        List<ArtifactEnvelope> result = new ArrayList<>();
+        result.add(profileSnapshot);
+        result.add(webSnapshot);
+        result.add(routineCard);
+
+        OccupationPersonaRoutineCardPayload routinePayload = (OccupationPersonaRoutineCardPayload) routineCard.payload();
+        DorResultadoOfertaMecanismoProvaInputPayload frameworkPayload =
+                (DorResultadoOfertaMecanismoProvaInputPayload) frameworkInput.payload();
+
+        result.add(buildDesiredOutcomeArtifact(frameworkPayload.desiredOutcomeSignals(), routineCard, routinePayload));
+        result.add(buildMechanismOpportunityArtifact(frameworkPayload.mechanismOpportunitySignals(), routineCard, routinePayload));
+        result.add(frameworkInput);
+
+        return result;
+    }
+
+    private ArtifactEnvelope buildDesiredOutcomeArtifact(List<DesiredOutcomeSignal> desiredOutcomeSignals,
+                                                         ArtifactEnvelope routineCard,
+                                                         OccupationPersonaRoutineCardPayload routinePayload) {
+        return new ArtifactEnvelope(
+                "desiredOutcomeSignal",
+                "1.0",
+                UUID.randomUUID().toString(),
+                "oprm",
+                "oprm.framework-integration",
+                Instant.now(),
+                routineCard.correlationId(),
+                UUID.randomUUID().toString(),
+                routinePayload.evidenceRefs(),
+                List.of(routineCard.artifactId()),
+                Map.of("signals", desiredOutcomeSignals),
+                "GENERATED",
+                0.84,
+                Map.of("phase", "phase-4", "signal_count", desiredOutcomeSignals.size())
+        );
+    }
+
+    private ArtifactEnvelope buildMechanismOpportunityArtifact(List<MechanismOpportunitySignal> mechanismSignals,
+                                                               ArtifactEnvelope routineCard,
+                                                               OccupationPersonaRoutineCardPayload routinePayload) {
+        return new ArtifactEnvelope(
+                "mechanismOpportunitySignal",
+                "1.0",
+                UUID.randomUUID().toString(),
+                "oprm",
+                "oprm.framework-integration",
+                Instant.now(),
+                routineCard.correlationId(),
+                UUID.randomUUID().toString(),
+                routinePayload.evidenceRefs(),
+                List.of(routineCard.artifactId(), "desiredOutcomeSignal"),
+                Map.of("signals", mechanismSignals),
+                "GENERATED",
+                0.82,
+                Map.of("phase", "phase-4", "signal_count", mechanismSignals.size())
+        );
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/client/BackendArtifactPublishClient.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/client/BackendArtifactPublishClient.java
@@ -1,0 +1,31 @@
+package com.marketinghub.oprm.integration.client;
+
+import com.marketinghub.oprm.integration.contract.OprmArtifactPublishRequest;
+import com.marketinghub.oprm.integration.contract.OprmArtifactPublishResponse;
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class BackendArtifactPublishClient {
+    private final RestTemplate restTemplate;
+    private final String backendBaseUrl;
+
+    public BackendArtifactPublishClient(RestTemplate restTemplate,
+                                        @Value("${oprm.backend.base-url:http://localhost:8080}") String backendBaseUrl) {
+        this.restTemplate = restTemplate;
+        this.backendBaseUrl = backendBaseUrl;
+    }
+
+    public OprmArtifactPublishResponse publish(OprmArtifactPublishRequest request) {
+        String endpoint = backendBaseUrl + "/api/oprm/artifacts";
+        ResponseEntity<OprmArtifactPublishResponse> response = restTemplate.postForEntity(
+                URI.create(endpoint),
+                request,
+                OprmArtifactPublishResponse.class
+        );
+        return response.getBody();
+    }
+}

--- a/oprm/src/main/java/com/marketinghub/oprm/integration/worker/OprmWorkerJobProcessor.java
+++ b/oprm/src/main/java/com/marketinghub/oprm/integration/worker/OprmWorkerJobProcessor.java
@@ -1,9 +1,14 @@
 package com.marketinghub.oprm.integration.worker;
 
-import com.marketinghub.oprm.application.FrameworkIntegrationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.oprm.application.OprmArtifactPipelineService;
 import com.marketinghub.oprm.domain.ArtifactEnvelope;
+import com.marketinghub.oprm.integration.client.BackendArtifactPublishClient;
 import com.marketinghub.oprm.integration.client.BackendJobClient;
 import com.marketinghub.oprm.integration.client.BackendStatusClient;
+import com.marketinghub.oprm.integration.contract.OprmArtifactEnvelopeDto;
+import com.marketinghub.oprm.integration.contract.OprmArtifactPublishRequest;
+import com.marketinghub.oprm.integration.contract.OprmArtifactStatus;
 import com.marketinghub.oprm.integration.contract.OprmContractVersion;
 import com.marketinghub.oprm.integration.contract.OprmJobClaimRequest;
 import com.marketinghub.oprm.integration.contract.OprmJobClaimResponse;
@@ -12,6 +17,7 @@ import com.marketinghub.oprm.integration.contract.OprmJobStatus;
 import com.marketinghub.oprm.integration.contract.OprmJobStatusUpdateRequest;
 import com.marketinghub.oprm.integration.contract.OprmJobType;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -27,7 +33,9 @@ public class OprmWorkerJobProcessor {
 
     private final BackendJobClient backendJobClient;
     private final BackendStatusClient backendStatusClient;
-    private final FrameworkIntegrationService frameworkIntegrationService;
+    private final BackendArtifactPublishClient backendArtifactPublishClient;
+    private final OprmArtifactPipelineService artifactPipelineService;
+    private final ObjectMapper objectMapper;
     private final String workerId;
     private final String workerVersion;
     private final int claimLeaseSeconds;
@@ -35,13 +43,17 @@ public class OprmWorkerJobProcessor {
 
     public OprmWorkerJobProcessor(BackendJobClient backendJobClient,
                                   BackendStatusClient backendStatusClient,
-                                  FrameworkIntegrationService frameworkIntegrationService,
+                                  BackendArtifactPublishClient backendArtifactPublishClient,
+                                  OprmArtifactPipelineService artifactPipelineService,
+                                  ObjectMapper objectMapper,
                                   @Value("${oprm.worker.id:oprm-worker-local}") String workerId,
                                   @Value("${oprm.worker.version:0.1.0}") String workerVersion,
                                   @Value("${oprm.worker.claim-lease-seconds:120}") int claimLeaseSeconds) {
         this.backendJobClient = backendJobClient;
         this.backendStatusClient = backendStatusClient;
-        this.frameworkIntegrationService = frameworkIntegrationService;
+        this.backendArtifactPublishClient = backendArtifactPublishClient;
+        this.artifactPipelineService = artifactPipelineService;
+        this.objectMapper = objectMapper;
         this.workerId = workerId;
         this.workerVersion = workerVersion;
         this.claimLeaseSeconds = claimLeaseSeconds;
@@ -78,19 +90,21 @@ public class OprmWorkerJobProcessor {
                 throw new IllegalStateException("unsupported OPRM job type for Sprint 2: " + detail.jobType());
             }
 
-            ArtifactEnvelope artifact = frameworkIntegrationService.integrateRoutineSignals(
+            List<ArtifactEnvelope> artifacts = artifactPipelineService.runPipeline(
                     detail.occupationSeedRef(),
                     "default",
                     "pt-BR",
                     detail.correlationId()
             );
 
+            artifacts.forEach(artifact -> publishArtifact(claimedJob.jobId(), detail.correlationId(), artifact));
+
             updateStatus(claimedJob.jobId(), OprmJobStatus.SUCCEEDED, "phase-run",
-                    "OPRM job completed", null, null, Map.of("artifactType", artifact.artifactType()));
-            log.info("oprm-job-processed jobId={} correlationId={} artifactType={}",
+                    "OPRM job completed", null, null, Map.of("artifactsPublished", artifacts.size()));
+            log.info("oprm-job-processed jobId={} correlationId={} artifactsPublished={}",
                     claimedJob.jobId(),
                     detail.correlationId(),
-                    artifact.artifactType());
+                    artifacts.size());
         } catch (Exception ex) {
             if (activeJobId != null) {
                 updateStatus(activeJobId, OprmJobStatus.FAILED, "phase-run",
@@ -100,6 +114,39 @@ public class OprmWorkerJobProcessor {
         } finally {
             running.set(false);
         }
+    }
+
+    private void publishArtifact(String jobId, String correlationId, ArtifactEnvelope artifact) {
+        OprmArtifactEnvelopeDto envelopeDto = new OprmArtifactEnvelopeDto(
+                artifact.artifactType(),
+                artifact.artifactVersion(),
+                artifact.artifactId(),
+                artifact.moduleName(),
+                artifact.producer(),
+                artifact.createdAt().toString(),
+                artifact.correlationId(),
+                artifact.traceId(),
+                artifact.sourceRefs(),
+                artifact.inputRefs(),
+                objectMapper.convertValue(artifact.payload(), Map.class),
+                OprmArtifactStatus.valueOf(artifact.status()),
+                artifact.confidenceScore(),
+                artifact.metadata()
+        );
+
+        OprmArtifactPublishRequest publishRequest = new OprmArtifactPublishRequest(
+                jobId,
+                correlationId,
+                envelopeDto,
+                Map.of(
+                        "sourceRefs", artifact.sourceRefs(),
+                        "inputRefs", artifact.inputRefs(),
+                        "producer", artifact.producer()
+                ),
+                jobId + ":" + artifact.artifactId()
+        );
+
+        backendArtifactPublishClient.publish(publishRequest);
     }
 
     private void updateStatus(String jobId,


### PR DESCRIPTION
### Motivation
- Close the integration gap so OPRM-produced artefacts are persisted and queryable in the backend with lineage and idempotency.
- Ensure jobs processed by the OPRM worker publish canonical envelopes to the backend and link artefacts to the originating job for end-to-end traceability.
- Provide operational filters (by `correlationId` / occupation / status) to support downstream consumption and debugging.

### Description
- Backend: added Liquibase changeset `2026-04-15-oprm-artifact-publication.yaml` and included it in `db.changelog-master.yaml` to create the `oprm_artifact` table with FK to `oprm_job`, uniques and indexes for operational queries.
- Backend: new persistence model `OprmArtifact` and enum `OprmArtifactStatus`, repository `OprmArtifactRepository`, service `OprmArtifactService`, controller `OprmArtifactController` and DTOs for publish/list requests and responses to implement `POST /api/oprm/artifacts` and `GET /api/oprm/artifacts`.
- Worker (OPRM): added `OprmArtifactPipelineService` to produce the Sprint 3 artefact set and `BackendArtifactPublishClient` to call the backend; updated `OprmWorkerJobProcessor` to run the pipeline after claim and publish each artifact to the backend, reporting published count in job status updates.
- Integration: created request/response shapes and mapping between `ArtifactEnvelope` and the backend envelope DTO, enforcing lineage and idempotency on publish; updated docs and the OPRM implementation history and checklist to mark Sprint 3 completed.

### Testing
- `cd backend/ads-service && mvn -q -DskipTests compile` — passed (backend compiles with new changelog and service).
- `cd oprm && mvn -q test` — passed (OPRM unit tests ran successfully after changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00db55ad883219617739fffaac8fe)