### PR TITLE
fix(liquibase): corrige preConditions do changelog OPRM

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-feedback-loop.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-feedback-loop.yaml
@@ -3,8 +3,8 @@ databaseChangeLog:
       id: 2026-04-15-05-oprm-feedback-snapshot
       author: codex
       preConditions:
-        onFail: MARK_RAN
-        onError: HALT
+        - onFail: MARK_RAN
+        - onError: HALT
         - dbms:
             type: mysql
         - not:
@@ -104,8 +104,8 @@ databaseChangeLog:
       id: 2026-04-15-06-oprm-feedback-history
       author: codex
       preConditions:
-        onFail: MARK_RAN
-        onError: HALT
+        - onFail: MARK_RAN
+        - onError: HALT
         - dbms:
             type: mysql
         - not:

--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -508,3 +508,35 @@ Foi concluída a Sprint 5 com contract tests de integração backend↔OPRM, ins
 **Próximo passo sugerido:**  
 - adicionar exportação de tracing distribuído (OpenTelemetry) com propagação de `traceparent` backend↔worker
 - evoluir heartbeat para persistência agregada por worker/janela de tempo para dashboards operacionais
+
+## 2026-04-15 — hardening de migração: correção de preConditions Liquibase (MySQL 5.7)
+
+**Status:** concluído
+
+**Resumo:**  
+Foi corrigido o changelog incremental da fase 5 do OPRM para resolver falha de parsing no Liquibase durante o `validate` do GitHub Actions, ajustando a estrutura YAML de `preConditions` para o formato aceito no parser usado com MySQL 5.7.
+
+**O que foi implementado:**  
+- correção da sintaxe YAML de `preConditions` no changeset de criação de `oprm_feedback_snapshot`
+- correção da sintaxe YAML de `preConditions` no changeset de criação de `oprm_feedback_history`
+- manutenção das condições canônicas para MySQL (`dbms: mysql` + `not tableExists`) sem alterar a intenção funcional da migração
+
+**Arquivos principais alterados:**  
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-feedback-loop.yaml`
+- `docs/history/oprm-implementation-history.md`
+
+**Contratos / artefatos afetados:**  
+- nenhum contrato novo
+- artefato técnico afetado: changelog Liquibase incremental da fase 5 do OPRM
+
+**Testes executados:**  
+- `ruby -e "require 'yaml'; YAML.load_file('backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-feedback-loop.yaml'); puts 'YAML OK'"` — **passou**
+- `cd backend/ads-service && mvn -s ../settings.xml -DskipTests liquibase:validate` — **falhou** por indisponibilidade de rede para resolver dependências Maven no ambiente local
+
+**Limitações ou pendências:**  
+- validação completa do Liquibase no Maven ficou pendente localmente por indisponibilidade de rede para baixar dependências
+- recomendada revalidação no pipeline GitHub Actions após merge
+
+**Próximo passo sugerido:**  
+- reexecutar a action de backend para confirmar `liquibase:validate` sem erro de parsing
+- manter o padrão de `preConditions` em lista nos próximos changesets YAML para evitar regressão de parser


### PR DESCRIPTION
### Motivation
- O step de validação do Liquibase no CI estava falhando com erro de parsing YAML na seção `preConditions` do changeset do feedback do OPRM, gerando `expected <block end>, but found '-'` para MySQL 5.7. 
- É necessário garantir que os changelogs YAML sigam o formato aceito pelo parser usado em MySQL 5.7 sem alterar a intenção funcional da migração.

### Description
- Ajustei a estrutura de `preConditions` nos dois changesets do arquivo `backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-feedback-loop.yaml` para usar itens de lista (`- onFail: MARK_RAN`, `- onError: HALT`, etc.), preservando `dbms: mysql` e a verificação `not tableExists`.
- Mantive a semântica original das condições (`onFail`, `onError`, `dbms`, `not tableExists`) sem alterar os `changes` do schema.
- Adicionei uma entrada de histórico operacional em `docs/history/oprm-implementation-history.md` seguindo o protocolo de implantação do Codex para registrar a correção e os próximos passos.

### Testing
- Validação sintática do YAML executada localmente com `ruby -e "require 'yaml'; YAML.load_file('backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-feedback-loop.yaml'); puts 'YAML OK'"` — passou.
- Tentativa de validação do Liquibase via Maven com `cd backend/ads-service && mvn -s ../settings.xml -DskipTests liquibase:validate` — não concluiu por indisponibilidade de rede / resolução de dependências no ambiente (recomenda-se reexecutar no pipeline CI do GitHub Actions).
- Registro no histórico atualizado para documentar os testes, a limitação local e a recomendação de revalidação em CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e017ba1af4832189078c847e4194a1)