### PR TITLE
AI Hub: Resumo:
- Normalizei os blocos `preConditions` dos changeSets `2026-04-15-oprm-job-orchestration.yaml`, `2026-04-15-oprm-artifact-publication.yaml` e `2026-04-15-oprm-feedback-loop.yaml`, eliminando a mistura inválida entre mapas e listas que fazi…

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-artifact-publication.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-artifact-publication.yaml
@@ -5,11 +5,11 @@ databaseChangeLog:
       preConditions:
         onFail: MARK_RAN
         onError: HALT
-        - dbms:
-            type: mysql
-        - not:
-            tableExists:
-              tableName: oprm_artifact
+        dbms:
+          type: mysql
+        not:
+          tableExists:
+            tableName: oprm_artifact
       changes:
         - createTable:
             tableName: oprm_artifact

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-feedback-loop.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-feedback-loop.yaml
@@ -3,13 +3,13 @@ databaseChangeLog:
       id: 2026-04-15-05-oprm-feedback-snapshot
       author: codex
       preConditions:
-        - onFail: MARK_RAN
-        - onError: HALT
-        - dbms:
-            type: mysql
-        - not:
-            tableExists:
-              tableName: oprm_feedback_snapshot
+        onFail: MARK_RAN
+        onError: HALT
+        dbms:
+          type: mysql
+        not:
+          tableExists:
+            tableName: oprm_feedback_snapshot
       changes:
         - createTable:
             tableName: oprm_feedback_snapshot
@@ -104,13 +104,13 @@ databaseChangeLog:
       id: 2026-04-15-06-oprm-feedback-history
       author: codex
       preConditions:
-        - onFail: MARK_RAN
-        - onError: HALT
-        - dbms:
-            type: mysql
-        - not:
-            tableExists:
-              tableName: oprm_feedback_history
+        onFail: MARK_RAN
+        onError: HALT
+        dbms:
+          type: mysql
+        not:
+          tableExists:
+            tableName: oprm_feedback_history
       changes:
         - createTable:
             tableName: oprm_feedback_history

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-job-orchestration.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-job-orchestration.yaml
@@ -5,11 +5,11 @@ databaseChangeLog:
       preConditions:
         onFail: MARK_RAN
         onError: HALT
-        - dbms:
-            type: mysql
-        - not:
-            tableExists:
-              tableName: oprm_job
+        dbms:
+          type: mysql
+        not:
+          tableExists:
+            tableName: oprm_job
       changes:
         - createTable:
             tableName: oprm_job
@@ -94,11 +94,11 @@ databaseChangeLog:
       preConditions:
         onFail: MARK_RAN
         onError: HALT
-        - dbms:
-            type: mysql
-        - not:
-            tableExists:
-              tableName: oprm_job_input
+        dbms:
+          type: mysql
+        not:
+          tableExists:
+            tableName: oprm_job_input
       changes:
         - createTable:
             tableName: oprm_job_input
@@ -149,11 +149,11 @@ databaseChangeLog:
       preConditions:
         onFail: MARK_RAN
         onError: HALT
-        - dbms:
-            type: mysql
-        - not:
-            tableExists:
-              tableName: oprm_job_event
+        dbms:
+          type: mysql
+        not:
+          tableExists:
+            tableName: oprm_job_event
       changes:
         - createTable:
             tableName: oprm_job_event

--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -540,3 +540,35 @@ Foi corrigido o changelog incremental da fase 5 do OPRM para resolver falha de p
 **Próximo passo sugerido:**  
 - reexecutar a action de backend para confirmar `liquibase:validate` sem erro de parsing
 - manter o padrão de `preConditions` em lista nos próximos changesets YAML para evitar regressão de parser
+
+## 2026-04-15 — hardening de migração: alinhamento preConditions do cluster de jobs do OPRM
+
+**Status:** concluído
+
+**Resumo:**  
+Foram alinhados os changeSets YAML do cluster de orquestração de jobs e publicação de artefatos do OPRM para remover a mistura inválida de mapas e listas em `preConditions`, eliminando o erro de parsing visto no `liquibase:validate` do GitHub Actions.
+
+**O que foi implementado:**  
+- normalização dos blocos `preConditions` para `oprm_job`, `oprm_job_input` e `oprm_job_event` no arquivo `2026-04-15-oprm-job-orchestration.yaml`
+- ajuste do changeSet `2026-04-15-oprm-artifact-publication.yaml` para o mesmo formato aceito pelo parser do Liquibase 4.26.0
+- harmonização do `2026-04-15-oprm-feedback-loop.yaml` para compartilhar o padrão e evitar regressões futuras
+
+**Arquivos principais alterados:**  
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-job-orchestration.yaml`
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-artifact-publication.yaml`
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-15-oprm-feedback-loop.yaml`
+
+**Contratos / artefatos afetados:**  
+- tabelas: `oprm_job`, `oprm_job_input`, `oprm_job_event`, `oprm_artifact`, `oprm_feedback_snapshot`, `oprm_feedback_history`
+- nenhum contrato HTTP novo
+
+**Testes executados:**  
+- `cd backend/ads-service && mvn -DskipTests org.liquibase:liquibase-maven-plugin:4.26.0:validate -Dliquibase.url=offline:mysql -Dliquibase.username=dummy -Dliquibase.password=dummy -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml` — **passou** (modo offline, validação sintática do changelog)
+
+**Limitações ou pendências:**  
+- validação ocorreu em URL offline; ainda é necessário confirmar a execução conectada ao MySQL 5.7 real no pipeline
+- não foi executado `liquibase update` contra banco físico, então as tabelas ainda não existem fora do changelog
+
+**Próximo passo sugerido:**  
+- reexecutar o workflow de backend no GitHub Actions para confirmar `liquibase:validate` com o banco real
+- planejar o `liquibase updateSQL`/`update` direcionado para staging antes da sincronização com o worker OPRM


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Vamos trabalhar na melhoria do novo modulo para o Marketing Hub - OPRM

Temos um erro no action do GitHub, precisamos ajustar.

Mantenha registros conforme : docs/novos-modulos/OPRM/protocolo-historico-implantacao-codex.md

Leia para seguir e manter os canônicos de regras: docs/canonical/system-governance-canon.v2.md 

Leia para seguir e manter os canônicos de artefatos: docs/oprm_canonico_artefatos.md

Veja o erro, lembre que estamos usando Mysql 5.7

[INFO] ####################################################
##   _     _             _ _                      ##
##  | |   (_)           (_) |                     ##
##  | |    _  __ _ _   _ _| |__   __ _ ___  ___   ##
##  | |   | |/ _` | | | | | '_ \ / _` / __|/ _ \  ##
##  | |___| | (_| | |_| | | |_) | (_| \__ \  __/  ##
##  \_____/_|\__, |\__,_|_|_.__/ \__,_|___/\___|  ##
##              | |                               ##
##              |_|                               ##
##                                                ## 
##  Get documentation at docs.liquibase.com       ##
##  Get certified courses at learn.liquibase.com  ## 
##                                                ##
####################################################
Starting Liquibase at 23:02:53 (version 4.26.0 #1141 built at 2024-02-06 21:31+0000)
Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.
[INFO] Executing on Database: jdbc:mysql://localhost:3306/ads
[INFO] Logging exception.
[INFO] ERROR: Exception Details
[INFO] ERROR: Exception Primary Class:  ParserException
[INFO] ERROR: Exception Primary Reason: while parsing a block mapping
 in 'reader', line 6, column 9:
            onFail: MARK_RAN
            ^
expected <block end>, but found '-'
 in 'reader', line 8, column 9:
            - dbms:
            ^

[INFO] ERROR: Exception Primary Source: MySQL 5.7.44
[INFO] Command execution complete
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.347 s
[INFO] Finished at: 2026-04-15T23:02:54Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.liquibase:liquibase-maven-plugin:4.26.0:validate (default-cli) on project ads-service: 
Error:  Error setting up or running Liquibase:
Error:  liquibase.exception.ChangeLogParseException: Error parsing src/main/resources/db/changelog/db.changelog-master.yaml : Syntax error in file src/main/resources/db/changelog/changesets/2026-04-15-oprm-job-orchestration.yaml: while parsing a block mapping
Error:   in 'reader', line 6, column 9:
Error:              onFail: MARK_RAN
Error:              ^
Error:  expected <block end>, but found '-'
Error:   in 'reader', line 8, column 9:
Error:              - dbms:
Error:              ^
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: Process completed with exit code 1.

**Resumo das alterações:**
Resumo:
- Normalizei os blocos `preConditions` dos changeSets `2026-04-15-oprm-job-orchestration.yaml`, `2026-04-15-oprm-artifact-publication.yaml` e `2026-04-15-oprm-feedback-loop.yaml`, eliminando a mistura inválida entre mapas e listas que fazia o parser do Liquibase falhar no `validate` do GitHub Actions (mantendo `dbms: mysql` + `not tableExists` para MySQL 5.7).
- Removi o artefato temporário `databasechangelog.csv` gerado pela execução local do Liquibase.
- Registrei a intervenção no histórico do módulo seguindo o protocolo em `docs/history/oprm-implementation-history.md`.

Testes:
- `cd backend/ads-service && mvn -DskipTests org.liquibase:liquibase-maven-plugin:4.26.0:validate -Dliquibase.url=offline:mysql -Dliquibase.username=dummy -Dliquibase.password=dummy -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml` — **passou** (validação sintática em modo offline).

Pendências:
- A validação ainda não foi executada contra um MySQL 5.7 real; é recomendada a reexecução do workflow do GitHub Actions (ou `liquibase updateSQL/update`) usando as credenciais verdadeiras para garantir que o banco aceite o changelog ajustado.