### PR TITLE
Fix deploy apply script to use loaded :latest image tags with docker compose

### DIFF
--- a/deploy/bin/apply.sh
+++ b/deploy/bin/apply.sh
@@ -58,6 +58,9 @@ fi
 docker compose down --remove-orphans || true
 
 # Start only backend/frontend stack on app host
+BACKEND_IMAGE_TAG=latest \
+FRONTEND_IMAGE_TAG=latest \
+VIDEO_MGMT_IMAGE_TAG=latest \
 docker compose up -d backend frontend
 
 cleanup_previous_tags "${BACKEND_IMAGE}" "latest"


### PR DESCRIPTION
### Motivation
- Deployment was failing because `docker compose` attempted to pull date-based tags (e.g. `2026.04.15`) that are not present in the registry after images are loaded from tar files. 
- The deploy script already retags loaded images to `:latest`, but `docker compose` still defaulted to the date tags declared in the compose file. 
- The intent is to ensure compose uses the locally-loaded `:latest` images instead of trying to pull remote tags.

### Description
- Updated `deploy/bin/apply.sh` to export `BACKEND_IMAGE_TAG=latest`, `FRONTEND_IMAGE_TAG=latest`, and `VIDEO_MGMT_IMAGE_TAG=latest` inline when running `docker compose up -d backend frontend` so compose will use the retagged local images. 
- Kept the existing behavior that retags loaded images to `:latest` via `tag_image_if_exists` and the subsequent image cleanup logic. 
- Change is minimal and scoped to the compose invocation to avoid unnecessary pulls.

### Testing
- Ran `bash -n deploy/bin/apply.sh` with no syntax errors and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0206665cc8321984af4db960d2724)