### PR TITLE
Fix video-only deployment image tag resolution

### DIFF
--- a/deploy/bin/apply-video-only.sh
+++ b/deploy/bin/apply-video-only.sh
@@ -33,7 +33,10 @@ cleanup_previous_tags() {
 
 # Atualiza somente o módulo de vídeo sem reiniciar backend/frontend
 # (backend/frontend permanecem no host 191.252.181.168)
-VIDEO_BACKEND_BASE_URL="${VIDEO_BACKEND_BASE_URL}" docker compose up -d --no-deps video-management
+VIDEO_MGMT_IMAGE="${VIDEO_IMAGE}" \
+VIDEO_MGMT_IMAGE_TAG=latest \
+VIDEO_BACKEND_BASE_URL="${VIDEO_BACKEND_BASE_URL}" \
+docker compose up -d --no-deps video-management
 
 cleanup_previous_tags "${VIDEO_IMAGE}" "latest"
 


### PR DESCRIPTION
### Motivation
- Avoid `docker compose` pulling the default image tag from `deploy/docker-compose.yml` when the SHA-tagged video image is loaded and retagged to `latest` during the video-only deploy.

### Description
- Export `VIDEO_MGMT_IMAGE` and force `VIDEO_MGMT_IMAGE_TAG=latest` when invoking `docker compose up` in `deploy/bin/apply-video-only.sh` so the compose service `video-management` uses the already-loaded `:latest` image instead of attempting to pull the default tag.

### Testing
- Ran a syntax check with `bash -n deploy/bin/apply-video-only.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e02366c6ec83219ff161db09e476f8)