### PR TITLE
feat(oprm): Sprint UI-2 — Rotina & Oferta UI + backend workspace aggregation endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmRoutineWorkspaceResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmRoutineWorkspaceResponseDto.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record OprmRoutineWorkspaceResponseDto(
+        String occupationSeedRef,
+        String lastCorrelationId,
+        Map<String, Object> routineCardPayload,
+        Map<String, Object> frameworkInputPayload,
+        List<Map<String, Object>> painSignals,
+        List<Map<String, Object>> desiredOutcomeSignals,
+        List<Map<String, Object>> mechanismOpportunitySignals
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmArtifactRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmArtifactRepository.java
@@ -15,4 +15,7 @@ public interface OprmArtifactRepository extends JpaRepository<OprmArtifact, Long
                                                                                      OprmArtifactStatus artifactStatus);
 
     List<OprmArtifact> findByOccupationSeedRefOrderByCreatedAtDesc(String occupationSeedRef);
+
+    java.util.Optional<OprmArtifact> findFirstByOccupationSeedRefAndArtifactTypeOrderByCreatedAtDesc(String occupationSeedRef,
+                                                                                                      String artifactType);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprm.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.oprm.OprmArtifact;
 import com.marketinghub.oprm.OprmArtifactStatus;
@@ -9,11 +10,13 @@ import com.marketinghub.oprm.dto.OprmArtifactEnvelopeDto;
 import com.marketinghub.oprm.dto.OprmArtifactPublishRequestDto;
 import com.marketinghub.oprm.dto.OprmArtifactPublishResponseDto;
 import com.marketinghub.oprm.dto.OprmArtifactSummaryDto;
+import com.marketinghub.oprm.dto.OprmRoutineWorkspaceResponseDto;
 import com.marketinghub.oprm.repository.OprmArtifactRepository;
 import com.marketinghub.oprm.repository.OprmJobRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -118,6 +121,44 @@ public class OprmArtifactService {
                 "use correlationId or occupationSeedRef to filter OPRM artifacts");
     }
 
+
+    @Transactional(readOnly = true)
+    public OprmRoutineWorkspaceResponseDto getRoutineWorkspace(String occupationSeedRef) {
+        OprmArtifact routineCardArtifact = artifactRepository
+                .findFirstByOccupationSeedRefAndArtifactTypeOrderByCreatedAtDesc(
+                        occupationSeedRef,
+                        "occupationPersonaRoutineCard"
+                )
+                .orElse(null);
+
+        OprmArtifact frameworkInputArtifact = artifactRepository
+                .findFirstByOccupationSeedRefAndArtifactTypeOrderByCreatedAtDesc(
+                        occupationSeedRef,
+                        "dorResultadoOfertaMecanismoProvaInput"
+                )
+                .orElse(null);
+
+        Map<String, Object> routinePayload = readPayload(routineCardArtifact);
+        Map<String, Object> frameworkPayload = readPayload(frameworkInputArtifact);
+
+        List<Map<String, Object>> painSignals = readSignalList(frameworkPayload.get("painSignals"));
+        if (painSignals.isEmpty()) {
+            painSignals = readSignalList(routinePayload.get("painSignals"));
+        }
+
+        return new OprmRoutineWorkspaceResponseDto(
+                occupationSeedRef,
+                frameworkInputArtifact != null
+                        ? frameworkInputArtifact.getCorrelationId()
+                        : routineCardArtifact != null ? routineCardArtifact.getCorrelationId() : null,
+                routinePayload.isEmpty() ? null : routinePayload,
+                frameworkPayload.isEmpty() ? null : frameworkPayload,
+                painSignals,
+                readSignalList(frameworkPayload.get("desiredOutcomeSignals")),
+                readSignalList(frameworkPayload.get("mechanismOpportunitySignals"))
+        );
+    }
+
     private OprmArtifactSummaryDto toSummary(OprmArtifact artifact) {
         return new OprmArtifactSummaryDto(
                 artifact.getArtifactId(),
@@ -128,6 +169,35 @@ public class OprmArtifactService {
                 artifact.getCorrelationId(),
                 artifact.getCreatedAt().toString()
         );
+    }
+
+
+    private Map<String, Object> readPayload(OprmArtifact artifact) {
+        if (artifact == null) {
+            return Collections.emptyMap();
+        }
+
+        try {
+            return objectMapper.readValue(artifact.getPayloadJson(), new TypeReference<>() {
+            });
+        } catch (JsonProcessingException exception) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "unable to parse persisted OPRM artifact payload"
+            );
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> readSignalList(Object rawValue) {
+        if (!(rawValue instanceof List<?> list)) {
+            return List.of();
+        }
+
+        return list.stream()
+                .filter(item -> item instanceof Map<?, ?>)
+                .map(item -> (Map<String, Object>) item)
+                .toList();
     }
 
     private Instant parseCreatedAt(String createdAt) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmWorkspaceController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmWorkspaceController.java
@@ -1,0 +1,21 @@
+package com.marketinghub.oprm.web;
+
+import com.marketinghub.oprm.dto.OprmRoutineWorkspaceResponseDto;
+import com.marketinghub.oprm.service.OprmArtifactService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/oprm/workspace")
+@RequiredArgsConstructor
+public class OprmWorkspaceController {
+    private final OprmArtifactService artifactService;
+
+    @GetMapping("/routine/{occupationSeedRef}")
+    public OprmRoutineWorkspaceResponseDto getRoutineWorkspace(@PathVariable String occupationSeedRef) {
+        return artifactService.getRoutineWorkspace(occupationSeedRef);
+    }
+}

--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -619,3 +619,49 @@ Foi entregue a Sprint UI-1 do OPRM no frontend do Marketing Hub com novo item de
 **Próximo passo sugerido:**  
 - implementar Sprint UI-2 com tela de rotina consumindo `occupationPersonaRoutineCard` e sinais derivados
 - evoluir endpoint de workspace para retornar agregados de confiança/dor/oportunidade a partir dos artefatos publicados
+
+## 2026-04-16 — sprint UI-2: rotina da persona + builder de oferta
+
+**Status:** concluído
+
+**Resumo:**  
+Foi entregue a Sprint UI-2 do OPRM no Marketing Hub com tela de Rotina e tela de Oferta conectadas a dados reais publicados no backend, incluindo navegação interna do módulo, seleção de dor/resultado/mecanismo e preview estruturado do framework dor → resultado → oferta → mecanismo → prova.
+
+**O que foi implementado:**  
+- criação do endpoint backend `GET /api/oprm/workspace/routine/{occupationSeedRef}` para consolidar os artefatos publicados (`occupationPersonaRoutineCard` e `dorResultadoOfertaMecanismoProvaInput`) e expor payloads/sinais para consumo da UI
+- implementação da tela `Rotina` com resumo executivo, tarefas, restrições, workarounds e blocos de sinais (dores, resultados e mecanismos)
+- implementação da tela `Oferta` com seleção guiada de dor/resultado/mecanismo, campos obrigatórios de prova e oferta e preview estruturado
+- adição da rota `/oprm/offer/:occupationSeedRef` e substituição do placeholder da rotina por página funcional
+- extração da navegação interna do OPRM para componente reutilizável nas telas do módulo
+- atualização da tela de `Ocupações` para incluir ação direta `Ir para oferta`
+
+**Arquivos principais alterados:**  
+- `frontend/src/App.tsx`
+- `frontend/src/pages/oprm/OprmWorkspacePage.tsx`
+- `frontend/src/pages/oprm/OprmModuleNavigation.tsx`
+- `frontend/src/pages/oprm/OprmRoutinePage.tsx`
+- `frontend/src/pages/oprm/OprmOfferPage.tsx`
+- `frontend/src/api/oprm/useOprmRoutineWorkspaceData.ts`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmWorkspaceController.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmArtifactRepository.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmRoutineWorkspaceResponseDto.java`
+- `docs/history/oprm-implementation-history.md`
+
+**Contratos / artefatos afetados:**  
+- endpoint novo: `GET /api/oprm/workspace/routine/{occupationSeedRef}`
+- artefatos consumidos na UI: `occupationPersonaRoutineCard` e `dorResultadoOfertaMecanismoProvaInput`
+- nenhum artefato canônico novo
+
+**Testes executados:**  
+- `cd frontend && npx vitest run src/__tests__/OprmNavigation.test.tsx` — **passou**
+- `cd frontend && npm run build` — **passou**
+- `cd backend/ads-service && mvn -s ../settings.xml -DskipTests compile` — **falhou** por indisponibilidade de rede no ambiente para resolver dependências Maven
+
+**Limitações ou pendências:**  
+- ações de exportação na tela de oferta redirecionam para os módulos de destino e não persistem payload de exportação dedicado nesta sprint
+- não foi possível validar compilação do backend localmente por bloqueio de rede para download de dependências Maven
+
+**Próximo passo sugerido:**  
+- implementar endpoints de exportação explícitos do builder de oferta para hipótese/landing/experimento com persistência do payload selecionado
+- iniciar Sprint UI-3 com telas de `Evidências` e `Feedback` usando lineage e histórico persistido

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,7 +109,8 @@ import NewPromptDomainPage from "./pages/promptDomain/NewPromptDomainPage";
 import EditPromptDomainPage from "./pages/promptDomain/EditPromptDomainPage";
 import TargetingRecentQueriesPage from "./pages/targeting/TargetingRecentQueriesPage";
 import OprmWorkspacePage from "./pages/oprm/OprmWorkspacePage";
-import OprmRoutinePlaceholderPage from "./pages/oprm/OprmRoutinePlaceholderPage";
+import OprmRoutinePage from "./pages/oprm/OprmRoutinePage";
+import OprmOfferPage from "./pages/oprm/OprmOfferPage";
 
 export default function App() {
   return (
@@ -257,7 +258,11 @@ export default function App() {
               <Route path="/oprm" element={<OprmWorkspacePage />} />
               <Route
                 path="/oprm/routine/:occupationSeedRef"
-                element={<OprmRoutinePlaceholderPage />}
+                element={<OprmRoutinePage />}
+              />
+              <Route
+                path="/oprm/offer/:occupationSeedRef"
+                element={<OprmOfferPage />}
               />
               <Route path="/angles" element={<AnglesPage />} />
               <Route path="/visual-proofs" element={<VisualProofsPage />} />

--- a/frontend/src/api/oprm/useOprmRoutineWorkspaceData.ts
+++ b/frontend/src/api/oprm/useOprmRoutineWorkspaceData.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface OprmRoutineWorkspaceData {
+  occupationSeedRef: string;
+  lastCorrelationId: string | null;
+  routineCardPayload: Record<string, unknown> | null;
+  frameworkInputPayload: Record<string, unknown> | null;
+  painSignals: Record<string, unknown>[];
+  desiredOutcomeSignals: Record<string, unknown>[];
+  mechanismOpportunitySignals: Record<string, unknown>[];
+}
+
+export function useOprmRoutineWorkspaceData(occupationSeedRef?: string) {
+  return useQuery({
+    queryKey: ["oprm", "routine", occupationSeedRef],
+    enabled: Boolean(occupationSeedRef),
+    queryFn: async () => {
+      const { data } = await axios.get<OprmRoutineWorkspaceData>(
+        `/api/oprm/workspace/routine/${encodeURIComponent(occupationSeedRef ?? "")}`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/oprm/OprmModuleNavigation.tsx
+++ b/frontend/src/pages/oprm/OprmModuleNavigation.tsx
@@ -1,0 +1,59 @@
+import { NavLink } from "react-router-dom";
+
+interface OprmModuleNavigationProps {
+  occupationSeedRef?: string;
+}
+
+interface OprmNavItem {
+  label: string;
+  to?: string;
+}
+
+const baseItems: OprmNavItem[] = [
+  { label: "Ocupações", to: "/oprm" },
+  { label: "Evidências" },
+  { label: "Feedback" },
+  { label: "Operações" },
+];
+
+export default function OprmModuleNavigation({
+  occupationSeedRef,
+}: OprmModuleNavigationProps) {
+  const scopedItems: OprmNavItem[] = occupationSeedRef
+    ? [
+        {
+          label: "Rotina",
+          to: `/oprm/routine/${encodeURIComponent(occupationSeedRef)}`,
+        },
+        {
+          label: "Oferta",
+          to: `/oprm/offer/${encodeURIComponent(occupationSeedRef)}`,
+        },
+      ]
+    : [{ label: "Rotina" }, { label: "Oferta" }];
+
+  const items: OprmNavItem[] = [baseItems[0], ...scopedItems, ...baseItems.slice(1)];
+
+  return (
+    <nav aria-label="Navegação interna do OPRM">
+      <ul className="nav nav-pills gap-2">
+        {items.map((item) => (
+          <li className="nav-item" key={item.label}>
+            {item.to ? (
+              <NavLink
+                to={item.to}
+                className={({ isActive }) =>
+                  isActive ? "nav-link active" : "nav-link"
+                }
+              >
+                {item.label}
+              </NavLink>
+            ) : (
+              <span className="nav-link disabled">{item.label}</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/src/pages/oprm/OprmOfferPage.tsx
+++ b/frontend/src/pages/oprm/OprmOfferPage.tsx
@@ -1,0 +1,249 @@
+import { useMemo, useState } from "react";
+import { AlertCircle } from "lucide-react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+import { useOprmRoutineWorkspaceData } from "../../api/oprm/useOprmRoutineWorkspaceData";
+
+function readSignalList(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (item): item is Record<string, unknown> =>
+      typeof item === "object" && item !== null,
+  );
+}
+
+function readSignalLabel(signal: Record<string, unknown>, primary: string, fallback: string) {
+  return typeof signal[primary] === "string"
+    ? String(signal[primary])
+    : typeof signal[fallback] === "string"
+      ? String(signal[fallback])
+      : "Sinal sem descrição";
+}
+
+export default function OprmOfferPage() {
+  const { occupationSeedRef } = useParams();
+  const navigate = useNavigate();
+  const routineQuery = useOprmRoutineWorkspaceData(occupationSeedRef);
+
+  const [selectedPain, setSelectedPain] = useState("");
+  const [selectedOutcome, setSelectedOutcome] = useState("");
+  const [selectedMechanism, setSelectedMechanism] = useState("");
+  const [proofText, setProofText] = useState("");
+  const [offerText, setOfferText] = useState("");
+
+  const pains = useMemo(
+    () => routineQuery.data?.painSignals ?? [],
+    [routineQuery.data?.painSignals],
+  );
+
+  const outcomes = useMemo(
+    () => routineQuery.data?.desiredOutcomeSignals ?? [],
+    [routineQuery.data?.desiredOutcomeSignals],
+  );
+
+  const mechanisms = useMemo(
+    () => routineQuery.data?.mechanismOpportunitySignals ?? [],
+    [routineQuery.data?.mechanismOpportunitySignals],
+  );
+
+  const canBuild = selectedPain && selectedOutcome && selectedMechanism;
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>OPRM · Oferta</PageTitle>
+        <p className="text-secondary mb-0">
+          Construa a proposta comercial baseada nos sinais reais da rotina da ocupação.
+        </p>
+      </header>
+
+      <OprmModuleNavigation occupationSeedRef={occupationSeedRef} />
+
+      {routineQuery.isLoading ? (
+        <div className="d-flex justify-content-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Carregando dados para oferta...</span>
+          </div>
+        </div>
+      ) : null}
+
+      {routineQuery.isError ? (
+        <div className="alert alert-danger d-flex gap-2 mb-0" role="alert">
+          <AlertCircle size={18} className="mt-1" aria-hidden="true" />
+          <div>
+            <strong>Não foi possível carregar os sinais para o builder.</strong>
+            <p className="mb-0">Garanta que a rotina já foi publicada para esta ocupação.</p>
+          </div>
+        </div>
+      ) : null}
+
+      {!routineQuery.isLoading && !routineQuery.isError && !routineQuery.data?.frameworkInputPayload ? (
+        <div className="alert alert-secondary mb-0" role="status">
+          Nenhum artifact `dorResultadoOfertaMecanismoProvaInput` disponível para esta ocupação.
+          <div className="mt-2">
+            <Link to={`/oprm/routine/${encodeURIComponent(occupationSeedRef ?? "")}`}>Voltar para rotina</Link>
+          </div>
+        </div>
+      ) : null}
+
+      {!routineQuery.isLoading && !routineQuery.isError && routineQuery.data?.frameworkInputPayload ? (
+        <>
+          <section className="row g-3">
+            <div className="col-12 col-xl-4">
+              <div className="card border-0 shadow-sm h-100">
+                <div className="card-body d-flex flex-column gap-2">
+                  <label className="form-label fw-semibold mb-0">Dor principal *</label>
+                  {pains.length > 0 ? pains.map((pain, index) => {
+                    const label = readSignalLabel(pain, "painLabel", "painSummary");
+                    return (
+                      <div className="form-check" key={`pain-${index}`}>
+                        <input
+                          className="form-check-input"
+                          type="radio"
+                          name="oprm-pain"
+                          id={`oprm-pain-${index}`}
+                          checked={selectedPain === label}
+                          onChange={() => setSelectedPain(label)}
+                        />
+                        <label className="form-check-label" htmlFor={`oprm-pain-${index}`}>
+                          {label}
+                        </label>
+                      </div>
+                    );
+                  }) : <p className="mb-0 text-secondary">Sem dores disponíveis.</p>}
+                </div>
+              </div>
+            </div>
+
+            <div className="col-12 col-xl-4">
+              <div className="card border-0 shadow-sm h-100">
+                <div className="card-body d-flex flex-column gap-2">
+                  <label className="form-label fw-semibold mb-0">Resultado desejado *</label>
+                  {outcomes.length > 0 ? outcomes.map((outcome, index) => {
+                    const label = readSignalLabel(outcome, "outcomeLabel", "outcomeSummary");
+                    return (
+                      <div className="form-check" key={`outcome-${index}`}>
+                        <input
+                          className="form-check-input"
+                          type="radio"
+                          name="oprm-outcome"
+                          id={`oprm-outcome-${index}`}
+                          checked={selectedOutcome === label}
+                          onChange={() => setSelectedOutcome(label)}
+                        />
+                        <label className="form-check-label" htmlFor={`oprm-outcome-${index}`}>
+                          {label}
+                        </label>
+                      </div>
+                    );
+                  }) : <p className="mb-0 text-secondary">Sem resultados disponíveis.</p>}
+                </div>
+              </div>
+            </div>
+
+            <div className="col-12 col-xl-4">
+              <div className="card border-0 shadow-sm h-100">
+                <div className="card-body d-flex flex-column gap-2">
+                  <label className="form-label fw-semibold mb-0">Mecanismo sugerido *</label>
+                  {mechanisms.length > 0 ? mechanisms.map((mechanism, index) => {
+                    const label = readSignalLabel(mechanism, "mechanismLabel", "mechanismSummary");
+                    return (
+                      <div className="form-check" key={`mechanism-${index}`}>
+                        <input
+                          className="form-check-input"
+                          type="radio"
+                          name="oprm-mechanism"
+                          id={`oprm-mechanism-${index}`}
+                          checked={selectedMechanism === label}
+                          onChange={() => setSelectedMechanism(label)}
+                        />
+                        <label className="form-check-label" htmlFor={`oprm-mechanism-${index}`}>
+                          {label}
+                        </label>
+                      </div>
+                    );
+                  }) : <p className="mb-0 text-secondary">Sem mecanismos disponíveis.</p>}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body d-flex flex-column gap-3">
+              <div>
+                <label className="form-label" htmlFor="oprm-proof">Prova inicial *</label>
+                <textarea
+                  id="oprm-proof"
+                  className="form-control"
+                  rows={3}
+                  value={proofText}
+                  onChange={(event) => setProofText(event.target.value)}
+                  placeholder="Ex.: Evidência operacional ou social proof relacionada"
+                />
+              </div>
+              <div>
+                <label className="form-label" htmlFor="oprm-offer">Oferta proposta *</label>
+                <textarea
+                  id="oprm-offer"
+                  className="form-control"
+                  rows={5}
+                  value={offerText}
+                  onChange={(event) => setOfferText(event.target.value)}
+                  placeholder="Descreva a proposta no formato comercial"
+                />
+              </div>
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body d-flex flex-column gap-2">
+              <h2 className="h5 mb-0">Preview estruturado</h2>
+              <dl className="row mb-0">
+                <dt className="col-sm-3">Dor</dt>
+                <dd className="col-sm-9">{selectedPain || "—"}</dd>
+                <dt className="col-sm-3">Resultado</dt>
+                <dd className="col-sm-9">{selectedOutcome || "—"}</dd>
+                <dt className="col-sm-3">Oferta</dt>
+                <dd className="col-sm-9">{offerText || "—"}</dd>
+                <dt className="col-sm-3">Mecanismo</dt>
+                <dd className="col-sm-9">{selectedMechanism || "—"}</dd>
+                <dt className="col-sm-3">Prova</dt>
+                <dd className="col-sm-9">{proofText || "—"}</dd>
+              </dl>
+            </div>
+          </section>
+
+          <div className="d-flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={!canBuild}
+              onClick={() => navigate("/hypotheses")}
+            >
+              Enviar para hipótese
+            </button>
+            <button
+              type="button"
+              className="btn btn-outline-primary"
+              disabled={!canBuild}
+              onClick={() => navigate("/landings")}
+            >
+              Enviar para landing
+            </button>
+            <button
+              type="button"
+              className="btn btn-outline-secondary"
+              disabled={!canBuild}
+              onClick={() => navigate("/experiments/new")}
+            >
+              Enviar para experimento
+            </button>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/oprm/OprmRoutinePage.tsx
+++ b/frontend/src/pages/oprm/OprmRoutinePage.tsx
@@ -1,0 +1,175 @@
+import { AlertCircle } from "lucide-react";
+import { Link, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+import { useOprmRoutineWorkspaceData } from "../../api/oprm/useOprmRoutineWorkspaceData";
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function readSignalList(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (item): item is Record<string, unknown> =>
+      typeof item === "object" && item !== null,
+  );
+}
+
+function signalLabel(signal: Record<string, unknown>): string {
+  const keys = ["painLabel", "outcomeLabel", "mechanismLabel", "painSummary", "outcomeSummary", "mechanismSummary"];
+  const found = keys.find((key) => typeof signal[key] === "string");
+  return found ? String(signal[found]) : "Sinal sem rótulo";
+}
+
+export default function OprmRoutinePage() {
+  const { occupationSeedRef } = useParams();
+  const routineQuery = useOprmRoutineWorkspaceData(occupationSeedRef);
+
+  const routineCard =
+    routineQuery.data?.routineCardPayload &&
+    typeof routineQuery.data.routineCardPayload === "object"
+      ? routineQuery.data.routineCardPayload
+      : null;
+
+  const topTasks = readSignalList(routineCard?.topTasks);
+  const topConstraints = readSignalList(routineCard?.topConstraints);
+  const topWorkarounds = readSignalList(routineCard?.workaroundPatterns);
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>OPRM · Rotina</PageTitle>
+        <p className="text-secondary mb-0">
+          Visualize a rotina operacional da ocupação e selecione os sinais para montar a oferta.
+        </p>
+      </header>
+
+      <OprmModuleNavigation occupationSeedRef={occupationSeedRef} />
+
+      {routineQuery.isLoading ? (
+        <div className="d-flex justify-content-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Carregando rotina OPRM...</span>
+          </div>
+        </div>
+      ) : null}
+
+      {routineQuery.isError ? (
+        <div className="alert alert-danger d-flex gap-2 mb-0" role="alert">
+          <AlertCircle size={18} className="mt-1" aria-hidden="true" />
+          <div>
+            <strong>Não foi possível carregar os sinais da rotina.</strong>
+            <p className="mb-0">Valide se existem artefatos publicados para a ocupação selecionada.</p>
+          </div>
+        </div>
+      ) : null}
+
+      {!routineQuery.isLoading && !routineQuery.isError && !routineCard ? (
+        <div className="alert alert-secondary mb-0" role="status">
+          Nenhum artifact `occupationPersonaRoutineCard` foi encontrado para a ocupação.
+        </div>
+      ) : null}
+
+      {!routineQuery.isLoading && !routineQuery.isError && routineCard ? (
+        <>
+          <section className="card border-0 shadow-sm">
+            <div className="card-body d-flex flex-column gap-3">
+              <h2 className="h5 mb-0">Resumo da rotina</h2>
+              <p className="mb-0 text-secondary">{String(routineCard.routineSummary ?? "Resumo indisponível")}</p>
+            </div>
+          </section>
+
+          <section className="row g-3">
+            <div className="col-12 col-xl-4">
+              <div className="card h-100 border-0 shadow-sm">
+                <div className="card-body d-flex flex-column gap-2">
+                  <h3 className="h6 mb-0">Top tarefas</h3>
+                  <ul className="mb-0 ps-3">
+                    {topTasks.length > 0 ? topTasks.map((task, index) => (
+                      <li key={`task-${index}`}>{String(task.taskLabel ?? task.taskSummary ?? "Tarefa")}</li>
+                    )) : <li>Sem tarefas mapeadas.</li>}
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <div className="col-12 col-xl-4">
+              <div className="card h-100 border-0 shadow-sm">
+                <div className="card-body d-flex flex-column gap-2">
+                  <h3 className="h6 mb-0">Top restrições</h3>
+                  <ul className="mb-0 ps-3">
+                    {topConstraints.length > 0 ? topConstraints.map((constraint, index) => (
+                      <li key={`constraint-${index}`}>{String(constraint.constraintSummary ?? constraint.constraintType ?? "Restrição")}</li>
+                    )) : <li>Sem restrições mapeadas.</li>}
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <div className="col-12 col-xl-4">
+              <div className="card h-100 border-0 shadow-sm">
+                <div className="card-body d-flex flex-column gap-2">
+                  <h3 className="h6 mb-0">Workarounds observados</h3>
+                  <ul className="mb-0 ps-3">
+                    {topWorkarounds.length > 0 ? topWorkarounds.map((workaround, index) => (
+                      <li key={`workaround-${index}`}>{String(workaround.workaroundSummary ?? workaround.workaroundLabel ?? "Workaround")}</li>
+                    )) : <li>Sem workarounds mapeados.</li>}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body d-flex flex-column gap-3">
+              <h2 className="h5 mb-0">Seleções para oferta</h2>
+              <div className="row g-3">
+                <div className="col-12 col-lg-4">
+                  <h3 className="h6">Dores</h3>
+                  <ul className="list-group">
+                    {routineQuery.data?.painSignals.length ? routineQuery.data.painSignals.map((signal, index) => (
+                      <li className="list-group-item" key={`pain-${index}`}>{signalLabel(signal)}</li>
+                    )) : <li className="list-group-item">Sem dores derivadas.</li>}
+                  </ul>
+                </div>
+                <div className="col-12 col-lg-4">
+                  <h3 className="h6">Resultados desejados</h3>
+                  <ul className="list-group">
+                    {routineQuery.data?.desiredOutcomeSignals.length ? routineQuery.data.desiredOutcomeSignals.map((signal, index) => (
+                      <li className="list-group-item" key={`outcome-${index}`}>{signalLabel(signal)}</li>
+                    )) : readStringArray(routineCard.desiredOutcomeSignals).map((item, index) => (
+                      <li className="list-group-item" key={`outcome-fallback-${index}`}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="col-12 col-lg-4">
+                  <h3 className="h6">Mecanismos candidatos</h3>
+                  <ul className="list-group">
+                    {routineQuery.data?.mechanismOpportunitySignals.length ? routineQuery.data.mechanismOpportunitySignals.map((signal, index) => (
+                      <li className="list-group-item" key={`mechanism-${index}`}>{signalLabel(signal)}</li>
+                    )) : readStringArray(routineCard.mechanismOpportunitySignals).map((item, index) => (
+                      <li className="list-group-item" key={`mechanism-fallback-${index}`}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <div>
+            <Link
+              to={`/oprm/offer/${encodeURIComponent(occupationSeedRef ?? "")}`}
+              className="btn btn-primary"
+            >
+              Ir para oferta
+            </Link>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/oprm/OprmWorkspacePage.tsx
+++ b/frontend/src/pages/oprm/OprmWorkspacePage.tsx
@@ -9,6 +9,7 @@ import {
   useOprmWorkspaceOccupations,
 } from "../../api/oprm/useOprmWorkspaceOccupations";
 import { useCreateOprmJob } from "../../api/oprm/useCreateOprmJob";
+import OprmModuleNavigation from "./OprmModuleNavigation";
 
 const STATUS_LABEL: Record<OprmJobStatus, string> = {
   PENDING: "Pendente",
@@ -87,26 +88,7 @@ export default function OprmWorkspacePage() {
         </p>
       </header>
 
-      <nav aria-label="Navegação interna do OPRM">
-        <ul className="nav nav-pills gap-2">
-          <li className="nav-item">
-            <span className="nav-link active" aria-current="page">
-              Ocupações
-            </span>
-          </li>
-          {[
-            "Rotina",
-            "Oferta",
-            "Evidências",
-            "Feedback",
-            "Operações",
-          ].map((item) => (
-            <li className="nav-item" key={item}>
-              <span className="nav-link disabled">{item}</span>
-            </li>
-          ))}
-        </ul>
-      </nav>
+      <OprmModuleNavigation />
 
       <section className="card border-0 shadow-sm">
         <div className="card-body d-flex flex-column gap-3">
@@ -218,6 +200,12 @@ export default function OprmWorkspacePage() {
                               className="btn btn-outline-primary btn-sm"
                             >
                               Ver rotina
+                            </Link>
+                            <Link
+                              to={`/oprm/offer/${encodeURIComponent(occupation.occupationSeedRef)}`}
+                              className="btn btn-outline-success btn-sm"
+                            >
+                              Ir para oferta
                             </Link>
                             <button
                               type="button"


### PR DESCRIPTION
### Motivation
- Entregar a Sprint UI-2 do OPRM conforme a especificação, movendo a rota de rotina do placeholder para página funcional e adicionando o builder de oferta. 
- Permitir que a UI consuma artefatos reais do backend (`occupationPersonaRoutineCard` e `dorResultadoOfertaMecanismoProvaInput`) para suportar seleção e composição comercial. 
- Centralizar no backend a agregação dos artefatos publicados para simplificar consumo pela UI e evitar lógica de parsing espalhada pela camada cliente.

### Description
- Backend: adicionado DTO `OprmRoutineWorkspaceResponseDto`, controller `OprmWorkspaceController` e método `getRoutineWorkspace` em `OprmArtifactService` que agrega os últimos artefatos `occupationPersonaRoutineCard` e `dorResultadoOfertaMecanismoProvaInput` e expõe sinais úteis para a UI; estendida a `OprmArtifactRepository` com `findFirstByOccupationSeedRefAndArtifactTypeOrderByCreatedAtDesc` e incluídas funções auxiliares de parsing (`readPayload`, `readSignalList`).
- Frontend: criada navegação interna do módulo `OprmModuleNavigation`, pages `OprmRoutinePage` e `OprmOfferPage`, hook `useOprmRoutineWorkspaceData`, e adicionadas rotas `/oprm/routine/:occupationSeedRef` e `/oprm/offer/:occupationSeedRef`; `OprmWorkspacePage` atualizado para usar a navegação interna e incluir ação `Ir para oferta`.
- Docs/history: atualizei `docs/history/oprm-implementation-history.md` com a entrada da Sprint UI-2 seguindo o protocolo de histórico do projeto.

### Testing
- `cd frontend && npm install` — passou (dependências instaladas).
- `cd frontend && npx vitest run src/__tests__/OprmNavigation.test.tsx` — passou (frontend unit tests for navigation).
- `cd frontend && npm run build` — passou (production build via `vite build`).
- `cd backend/ads-service && mvn -s ../settings.xml -DskipTests compile` — falhou na execução local devido à indisponibilidade de rede no ambiente para resolver dependências Maven (compilação em CI/pipeline recomendada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0397c8a688321be371fc40cdb0888)