### PR TITLE
Corrige referência 'repository' para 'jobRepository' em OprmJobOrchestrationService

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java
@@ -122,7 +122,7 @@ public class OprmJobOrchestrationService {
     @Transactional(readOnly = true)
     public List<OprmWorkspaceOccupationSummaryDto> listWorkspaceOccupations() {
         Map<String, OprmJob> latestJobByOccupation = new LinkedHashMap<>();
-        for (OprmJob job : repository.findTop500ByOrderByCreatedAtDesc()) {
+        for (OprmJob job : jobRepository.findTop500ByOrderByCreatedAtDesc()) {
             latestJobByOccupation.putIfAbsent(job.getOccupationSeedRef(), job);
         }
 


### PR DESCRIPTION
### Motivation
- Corrigir erro de compilação causado por referência a variável inexistente `repository` no método `listWorkspaceOccupations`, que gerava `cannot find symbol: variable repository` durante o build.

### Description
- Substituída a chamada `repository.findTop500ByOrderByCreatedAtDesc()` por `jobRepository.findTop500ByOrderByCreatedAtDesc()` em `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java`.

### Testing
- Tentativa de execução de testes com `cd backend/ads-service && mvn -s ../settings.xml test -DskipITs` falhou por indisponibilidade de rede ao resolver dependências (download do parent POM do Spring Boot), então os testes unitários não puderam ser validados neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03ec4accc8321b301d02e104af8fe)