### PR TITLE
feat(oprm): add Evidence & Feedback UI and workspace insights endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmInsightsWorkspaceResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmInsightsWorkspaceResponseDto.java
@@ -1,0 +1,16 @@
+package com.marketinghub.oprm.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record OprmInsightsWorkspaceResponseDto(
+        String occupationSeedRef,
+        String lastCorrelationId,
+        List<OprmArtifactSummaryDto> timeline,
+        List<Map<String, Object>> sources,
+        List<Map<String, Object>> excerpts,
+        Map<String, Object> lineage,
+        List<Map<String, Object>> feedbackSnapshots,
+        Map<String, Object> feedbackComparison
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java
@@ -10,6 +10,7 @@ import com.marketinghub.oprm.dto.OprmArtifactEnvelopeDto;
 import com.marketinghub.oprm.dto.OprmArtifactPublishRequestDto;
 import com.marketinghub.oprm.dto.OprmArtifactPublishResponseDto;
 import com.marketinghub.oprm.dto.OprmArtifactSummaryDto;
+import com.marketinghub.oprm.dto.OprmInsightsWorkspaceResponseDto;
 import com.marketinghub.oprm.dto.OprmRoutineWorkspaceResponseDto;
 import com.marketinghub.oprm.repository.OprmArtifactRepository;
 import com.marketinghub.oprm.repository.OprmJobRepository;
@@ -159,6 +160,63 @@ public class OprmArtifactService {
         );
     }
 
+
+    @Transactional(readOnly = true)
+    public OprmInsightsWorkspaceResponseDto getInsightsWorkspace(String occupationSeedRef) {
+        List<OprmArtifact> artifacts = artifactRepository.findByOccupationSeedRefOrderByCreatedAtDesc(occupationSeedRef);
+
+        OprmArtifact routineCardArtifact = findLatestArtifactByType(artifacts, "occupationPersonaRoutineCard");
+        OprmArtifact feedbackArtifact = findLatestArtifactByType(artifacts, "occupationFeedbackLoopSnapshot");
+
+        Map<String, Object> routinePayload = readPayload(routineCardArtifact);
+        Map<String, Object> routineLineage = readJsonMap(routineCardArtifact == null ? null : routineCardArtifact.getLineageJson());
+        List<Map<String, Object>> feedbackSnapshots = artifacts.stream()
+                .filter(artifact -> "occupationFeedbackLoopSnapshot".equals(artifact.getArtifactType()))
+                .map(this::readPayload)
+                .toList();
+
+        Map<String, Object> latestFeedback = readPayload(feedbackArtifact);
+        Map<String, Object> previousFeedback = feedbackSnapshots.size() > 1 ? feedbackSnapshots.get(1) : Map.of();
+
+        List<Map<String, Object>> sources = readSignalList(routinePayload.get("sourceRefs"));
+        if (sources.isEmpty()) {
+            sources = readSignalList(routineLineage.get("sourceRefs"));
+        }
+
+        List<Map<String, Object>> excerpts = readSignalList(routinePayload.get("evidenceExcerpts"));
+
+        List<OprmArtifactSummaryDto> timeline = artifacts.stream()
+                .limit(20)
+                .map(this::toSummary)
+                .toList();
+
+        Map<String, Object> feedbackComparison = new java.util.LinkedHashMap<>();
+        feedbackComparison.put("latestConfidence", latestFeedback.get("recalibratedConfidenceScore"));
+        feedbackComparison.put("previousConfidence", previousFeedback.get("recalibratedConfidenceScore"));
+        feedbackComparison.put("latestGeneratedAt", latestFeedback.get("generatedAt"));
+        feedbackComparison.put("previousGeneratedAt", previousFeedback.get("generatedAt"));
+
+        return new OprmInsightsWorkspaceResponseDto(
+                occupationSeedRef,
+                feedbackArtifact != null
+                        ? feedbackArtifact.getCorrelationId()
+                        : routineCardArtifact != null ? routineCardArtifact.getCorrelationId() : null,
+                timeline,
+                sources,
+                excerpts,
+                routineLineage,
+                feedbackSnapshots,
+                feedbackComparison
+        );
+    }
+
+    private OprmArtifact findLatestArtifactByType(List<OprmArtifact> artifacts, String artifactType) {
+        return artifacts.stream()
+                .filter(artifact -> artifactType.equals(artifact.getArtifactType()))
+                .findFirst()
+                .orElse(null);
+    }
+
     private OprmArtifactSummaryDto toSummary(OprmArtifact artifact) {
         return new OprmArtifactSummaryDto(
                 artifact.getArtifactId(),
@@ -184,6 +242,23 @@ public class OprmArtifactService {
             throw new ResponseStatusException(
                     HttpStatus.INTERNAL_SERVER_ERROR,
                     "unable to parse persisted OPRM artifact payload"
+            );
+        }
+    }
+
+
+    private Map<String, Object> readJsonMap(String rawJson) {
+        if (rawJson == null || rawJson.isBlank()) {
+            return Map.of();
+        }
+
+        try {
+            return objectMapper.readValue(rawJson, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException exception) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "unable to parse persisted OPRM artifact lineage"
             );
         }
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmWorkspaceController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmWorkspaceController.java
@@ -1,5 +1,6 @@
 package com.marketinghub.oprm.web;
 
+import com.marketinghub.oprm.dto.OprmInsightsWorkspaceResponseDto;
 import com.marketinghub.oprm.dto.OprmRoutineWorkspaceResponseDto;
 import com.marketinghub.oprm.service.OprmArtifactService;
 import lombok.RequiredArgsConstructor;
@@ -17,5 +18,10 @@ public class OprmWorkspaceController {
     @GetMapping("/routine/{occupationSeedRef}")
     public OprmRoutineWorkspaceResponseDto getRoutineWorkspace(@PathVariable String occupationSeedRef) {
         return artifactService.getRoutineWorkspace(occupationSeedRef);
+    }
+
+    @GetMapping("/insights/{occupationSeedRef}")
+    public OprmInsightsWorkspaceResponseDto getInsightsWorkspace(@PathVariable String occupationSeedRef) {
+        return artifactService.getInsightsWorkspace(occupationSeedRef);
     }
 }

--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -608,7 +608,7 @@ Foi entregue a Sprint UI-1 do OPRM no frontend do Marketing Hub com novo item de
 - nenhum artefato canônico novo
 
 **Testes executados:**  
-- `cd frontend && npm run test -- src/__tests__/OprmNavigation.test.tsx` — **passou**
+- `cd frontend && npm run test -- --run src/__tests__/OprmNavigation.test.tsx` — **passou**
 - `cd frontend && npm run build` — **passou**
 - `cd backend/ads-service && mvn -s ../settings.xml -DskipTests compile` — **passou**
 
@@ -665,3 +665,45 @@ Foi entregue a Sprint UI-2 do OPRM no Marketing Hub com tela de Rotina e tela de
 **Próximo passo sugerido:**  
 - implementar endpoints de exportação explícitos do builder de oferta para hipótese/landing/experimento com persistência do payload selecionado
 - iniciar Sprint UI-3 com telas de `Evidências` e `Feedback` usando lineage e histórico persistido
+
+## 2026-04-16 — sprint UI-3: evidências e feedback
+
+**Status:** concluído
+
+**Resumo:**  
+Foi implementada a Sprint UI-3 do módulo OPRM no Marketing Hub, adicionando as telas de Evidências e Feedback com leitura de dados reais via backend, timeline de artefatos por ocupação e comparativo de recalibração de confiança.
+
+**O que foi implementado:**  
+- criação do endpoint backend `GET /api/oprm/workspace/insights/{occupationSeedRef}` para consolidar timeline, lineage, fontes, excerpts e snapshots de feedback
+- implementação da tela `OPRM · Evidências` com timeline de geração, lista de fontes e painel de excerpts
+- implementação da tela `OPRM · Feedback` com histórico por ocupação e comparativo antes/depois de confiança
+- atualização da navegação interna do OPRM para incluir links ativos de `Evidências` e `Feedback` quando uma ocupação está selecionada
+- inclusão das novas rotas do frontend para as telas de sprint UI-3
+
+**Arquivos principais alterados:**  
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmWorkspaceController.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmInsightsWorkspaceResponseDto.java`
+- `frontend/src/api/oprm/useOprmInsightsWorkspaceData.ts`
+- `frontend/src/pages/oprm/OprmEvidencePage.tsx`
+- `frontend/src/pages/oprm/OprmFeedbackPage.tsx`
+- `frontend/src/pages/oprm/OprmModuleNavigation.tsx`
+- `frontend/src/App.tsx`
+
+**Contratos / artefatos afetados:**  
+- endpoint backend: `GET /api/oprm/workspace/insights/{occupationSeedRef}`
+- leitura dos artefatos `occupationPersonaRoutineCard` e `occupationFeedbackLoopSnapshot` na composição de workspace
+- nenhum artefato canônico novo
+
+**Testes executados:**  
+- `cd frontend && npm run test -- --run src/__tests__/OprmNavigation.test.tsx` — **passou**
+- `cd frontend && npm run build` — **passou**
+- `cd backend/ads-service && mvn -DskipTests compile` — **passou**
+
+**Limitações ou pendências:**  
+- o painel de excerpts depende da presença de `evidenceExcerpts` no payload persistido de rotina
+- a comparação de feedback usa os dois snapshots mais recentes da ocupação; não há configuração de janela temporal customizada nesta sprint
+
+**Próximo passo sugerido:**  
+- implementar Sprint UI-4 com tela de Operações completa (jobs, heartbeat, métricas e falhas)
+- padronizar payload de evidências no pipeline para enriquecer a profundidade de auditoria na UI

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -111,6 +111,8 @@ import TargetingRecentQueriesPage from "./pages/targeting/TargetingRecentQueries
 import OprmWorkspacePage from "./pages/oprm/OprmWorkspacePage";
 import OprmRoutinePage from "./pages/oprm/OprmRoutinePage";
 import OprmOfferPage from "./pages/oprm/OprmOfferPage";
+import OprmEvidencePage from "./pages/oprm/OprmEvidencePage";
+import OprmFeedbackPage from "./pages/oprm/OprmFeedbackPage";
 
 export default function App() {
   return (
@@ -263,6 +265,14 @@ export default function App() {
               <Route
                 path="/oprm/offer/:occupationSeedRef"
                 element={<OprmOfferPage />}
+              />
+              <Route
+                path="/oprm/evidence/:occupationSeedRef"
+                element={<OprmEvidencePage />}
+              />
+              <Route
+                path="/oprm/feedback/:occupationSeedRef"
+                element={<OprmFeedbackPage />}
               />
               <Route path="/angles" element={<AnglesPage />} />
               <Route path="/visual-proofs" element={<VisualProofsPage />} />

--- a/frontend/src/api/oprm/useOprmInsightsWorkspaceData.ts
+++ b/frontend/src/api/oprm/useOprmInsightsWorkspaceData.ts
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface OprmArtifactSummary {
+  artifactId: string;
+  artifactType: string;
+  artifactVersion: string;
+  artifactStatus: string;
+  occupationSeedRef: string;
+  correlationId: string;
+  createdAt: string;
+}
+
+export interface OprmInsightsWorkspaceData {
+  occupationSeedRef: string;
+  lastCorrelationId: string | null;
+  timeline: OprmArtifactSummary[];
+  sources: Record<string, unknown>[];
+  excerpts: Record<string, unknown>[];
+  lineage: Record<string, unknown>;
+  feedbackSnapshots: Record<string, unknown>[];
+  feedbackComparison: Record<string, unknown>;
+}
+
+export function useOprmInsightsWorkspaceData(occupationSeedRef?: string) {
+  return useQuery({
+    queryKey: ["oprm", "insights", occupationSeedRef],
+    enabled: Boolean(occupationSeedRef),
+    queryFn: async () => {
+      const { data } = await axios.get<OprmInsightsWorkspaceData>(
+        `/api/oprm/workspace/insights/${encodeURIComponent(occupationSeedRef ?? "")}`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/oprm/OprmEvidencePage.tsx
+++ b/frontend/src/pages/oprm/OprmEvidencePage.tsx
@@ -1,0 +1,129 @@
+import { AlertCircle } from "lucide-react";
+import { useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useOprmInsightsWorkspaceData } from "../../api/oprm/useOprmInsightsWorkspaceData";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+
+function formatDate(value: unknown): string {
+  if (typeof value !== "string") {
+    return "-";
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime())
+    ? value
+    : parsed.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
+}
+
+export default function OprmEvidencePage() {
+  const { occupationSeedRef } = useParams();
+  const insightsQuery = useOprmInsightsWorkspaceData(occupationSeedRef);
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>OPRM · Evidências</PageTitle>
+        <p className="text-secondary mb-0">
+          Audite a linha de geração dos artefatos e as fontes que sustentam a rotina inferida.
+        </p>
+      </header>
+
+      <OprmModuleNavigation occupationSeedRef={occupationSeedRef} />
+
+      {insightsQuery.isLoading ? (
+        <div className="d-flex justify-content-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Carregando evidências do OPRM...</span>
+          </div>
+        </div>
+      ) : null}
+
+      {insightsQuery.isError ? (
+        <div className="alert alert-danger d-flex gap-2 mb-0" role="alert">
+          <AlertCircle size={18} className="mt-1" aria-hidden="true" />
+          <div>
+            <strong>Não foi possível carregar as evidências.</strong>
+            <p className="mb-0">Verifique a disponibilidade do backend e tente novamente.</p>
+          </div>
+        </div>
+      ) : null}
+
+      {!insightsQuery.isLoading && !insightsQuery.isError ? (
+        <>
+          <section className="card border-0 shadow-sm">
+            <div className="card-body d-flex flex-column gap-3">
+              <h2 className="h5 mb-0">Timeline de geração</h2>
+              {insightsQuery.data?.timeline?.length ? (
+                <div className="table-responsive">
+                  <table className="table table-sm align-middle mb-0">
+                    <thead>
+                      <tr>
+                        <th>Artefato</th>
+                        <th>Status</th>
+                        <th>Correlation ID</th>
+                        <th>Gerado em</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {insightsQuery.data.timeline.map((artifact) => (
+                        <tr key={artifact.artifactId}>
+                          <td>{artifact.artifactType}</td>
+                          <td><span className="badge text-bg-secondary">{artifact.artifactStatus}</span></td>
+                          <td className="font-monospace small">{artifact.correlationId}</td>
+                          <td>{formatDate(artifact.createdAt)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div className="alert alert-secondary mb-0" role="status">Nenhuma evidência publicada para esta ocupação.</div>
+              )}
+            </div>
+          </section>
+
+          <section className="row g-3">
+            <div className="col-12 col-xl-6">
+              <div className="card border-0 shadow-sm h-100">
+                <div className="card-body d-flex flex-column gap-2">
+                  <h3 className="h6 mb-0">Fontes estruturadas</h3>
+                  {insightsQuery.data?.sources?.length ? (
+                    <ul className="list-group list-group-flush">
+                      {insightsQuery.data.sources.map((source, index) => (
+                        <li className="list-group-item px-0" key={`source-${index}`}>
+                          <span className="fw-semibold">{String(source.title ?? source.url ?? `Fonte ${index + 1}`)}</span>
+                          <div className="small text-secondary">{String(source.url ?? source.domain ?? "Origem não informada")}</div>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-secondary mb-0">Sem fontes explícitas no payload atual.</p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="col-12 col-xl-6">
+              <div className="card border-0 shadow-sm h-100">
+                <div className="card-body d-flex flex-column gap-2">
+                  <h3 className="h6 mb-0">Excerpts relevantes</h3>
+                  {insightsQuery.data?.excerpts?.length ? (
+                    <ul className="list-group list-group-flush">
+                      {insightsQuery.data.excerpts.map((excerpt, index) => (
+                        <li className="list-group-item px-0" key={`excerpt-${index}`}>
+                          {String(excerpt.excerpt ?? excerpt.summary ?? excerpt.text ?? `Excerpt ${index + 1}`)}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-secondary mb-0">Sem excerpts publicados para a rotina atual.</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/oprm/OprmFeedbackPage.tsx
+++ b/frontend/src/pages/oprm/OprmFeedbackPage.tsx
@@ -1,0 +1,122 @@
+import { AlertCircle } from "lucide-react";
+import { Link, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useOprmInsightsWorkspaceData } from "../../api/oprm/useOprmInsightsWorkspaceData";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+
+function toPercent(value: unknown): string {
+  if (typeof value !== "number") {
+    return "—";
+  }
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function scoreLabel(snapshot: Record<string, unknown>) {
+  return toPercent(snapshot.recalibratedConfidenceScore ?? snapshot.confidenceScore);
+}
+
+export default function OprmFeedbackPage() {
+  const { occupationSeedRef } = useParams();
+  const insightsQuery = useOprmInsightsWorkspaceData(occupationSeedRef);
+
+  const latest = insightsQuery.data?.feedbackComparison?.latestConfidence;
+  const previous = insightsQuery.data?.feedbackComparison?.previousConfidence;
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>OPRM · Feedback</PageTitle>
+        <p className="text-secondary mb-0">
+          Acompanhe snapshots de recalibração e compare a evolução de confiança por ocupação.
+        </p>
+      </header>
+
+      <OprmModuleNavigation occupationSeedRef={occupationSeedRef} />
+
+      {insightsQuery.isLoading ? (
+        <div className="d-flex justify-content-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Carregando feedback do OPRM...</span>
+          </div>
+        </div>
+      ) : null}
+
+      {insightsQuery.isError ? (
+        <div className="alert alert-danger d-flex gap-2 mb-0" role="alert">
+          <AlertCircle size={18} className="mt-1" aria-hidden="true" />
+          <div>
+            <strong>Não foi possível carregar o histórico de feedback.</strong>
+            <p className="mb-0">Valide o endpoint de workspace de insights no backend.</p>
+          </div>
+        </div>
+      ) : null}
+
+      {!insightsQuery.isLoading && !insightsQuery.isError ? (
+        <>
+          <section className="row g-3">
+            <div className="col-12 col-lg-6">
+              <div className="card border-0 shadow-sm h-100">
+                <div className="card-body">
+                  <h2 className="h6">Comparativo antes/depois</h2>
+                  <dl className="row mb-0">
+                    <dt className="col-6">Confiança anterior</dt>
+                    <dd className="col-6 text-end">{toPercent(previous)}</dd>
+                    <dt className="col-6">Confiança atual</dt>
+                    <dd className="col-6 text-end">{toPercent(latest)}</dd>
+                  </dl>
+                </div>
+              </div>
+            </div>
+            <div className="col-12 col-lg-6">
+              <div className="card border-0 shadow-sm h-100">
+                <div className="card-body d-flex flex-column gap-2">
+                  <h2 className="h6">Próxima ação recomendada</h2>
+                  <p className="text-secondary mb-0">
+                    Use o comparativo para validar se a recalibração está melhorando a aderência comercial da oferta.
+                  </p>
+                  <div>
+                    <Link className="btn btn-outline-primary btn-sm" to={`/oprm/offer/${encodeURIComponent(occupationSeedRef ?? "")}`}>
+                      Revisar oferta atual
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body d-flex flex-column gap-3">
+              <h2 className="h5 mb-0">Histórico por ocupação</h2>
+              {insightsQuery.data?.feedbackSnapshots?.length ? (
+                <div className="table-responsive">
+                  <table className="table table-hover align-middle mb-0">
+                    <thead>
+                      <tr>
+                        <th>Snapshot</th>
+                        <th>Confiança</th>
+                        <th>Aderência de hipóteses</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {insightsQuery.data.feedbackSnapshots.map((snapshot, index) => (
+                        <tr key={`feedback-${index}`}>
+                          <td>{String(snapshot.generatedAt ?? `Execução ${index + 1}`)}</td>
+                          <td>{scoreLabel(snapshot)}</td>
+                          <td>{Array.isArray(snapshot.hypothesisRoutineFit) ? snapshot.hypothesisRoutineFit.length : 0}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div className="alert alert-secondary mb-0" role="status">
+                  Nenhum `occupationFeedbackLoopSnapshot` encontrado para esta ocupação.
+                </div>
+              )}
+            </div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/oprm/OprmModuleNavigation.tsx
+++ b/frontend/src/pages/oprm/OprmModuleNavigation.tsx
@@ -11,8 +11,6 @@ interface OprmNavItem {
 
 const baseItems: OprmNavItem[] = [
   { label: "Ocupações", to: "/oprm" },
-  { label: "Evidências" },
-  { label: "Feedback" },
   { label: "Operações" },
 ];
 
@@ -29,8 +27,16 @@ export default function OprmModuleNavigation({
           label: "Oferta",
           to: `/oprm/offer/${encodeURIComponent(occupationSeedRef)}`,
         },
+        {
+          label: "Evidências",
+          to: `/oprm/evidence/${encodeURIComponent(occupationSeedRef)}`,
+        },
+        {
+          label: "Feedback",
+          to: `/oprm/feedback/${encodeURIComponent(occupationSeedRef)}`,
+        },
       ]
-    : [{ label: "Rotina" }, { label: "Oferta" }];
+    : [{ label: "Rotina" }, { label: "Oferta" }, { label: "Evidências" }, { label: "Feedback" }];
 
   const items: OprmNavItem[] = [baseItems[0], ...scopedItems, ...baseItems.slice(1)];
 


### PR DESCRIPTION
### Motivation
- Deliver Sprint UI-3 for the OPRM to provide auditability (evidence) and feedback telemetry inside the Marketing Hub UI. 
- Expose a backend workspace endpoint to consolidate timeline, lineage, sources, excerpts and feedback snapshots so the UI reads real artifacts instead of mocks. 
- Record the implementation step in the OPRM incremental history following the project's protocol. 

### Description
- Backend: add `OprmInsightsWorkspaceResponseDto` and `OprmArtifactService.getInsightsWorkspace(...)` to aggregate artifacts, lineage, `evidenceExcerpts` and `occupationFeedbackLoopSnapshot` snapshots, with helper `readJsonMap(...)` and `findLatestArtifactByType(...)`, and expose `GET /api/oprm/workspace/insights/{occupationSeedRef}` in `OprmWorkspaceController`. 
- Frontend: add hook `useOprmInsightsWorkspaceData` and two new pages `OprmEvidencePage.tsx` and `OprmFeedbackPage.tsx` that render timeline, sources, excerpts and feedback comparison; update `OprmModuleNavigation` to include active links for `Evidências` and `Feedback` and register new routes in `App.tsx`. 
- Documentation: append a Sprint UI-3 entry to `docs/history/oprm-implementation-history.md` describing the change and artifacts affected. 

### Testing
- `cd frontend && npm run test -- --run src/__tests__/OprmNavigation.test.tsx` — passed. 
- `cd frontend && npm run build` — passed. 
- `cd backend/ads-service && mvn -DskipTests compile` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03f5ea084832190dcd0ae6bca3a3f)