### PR TITLE
feat(oprm-ui): implementar Sprint UI-4 com tela de Operações

### DIFF
--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -707,3 +707,41 @@ Foi implementada a Sprint UI-3 do módulo OPRM no Marketing Hub, adicionando as 
 **Próximo passo sugerido:**  
 - implementar Sprint UI-4 com tela de Operações completa (jobs, heartbeat, métricas e falhas)
 - padronizar payload de evidências no pipeline para enriquecer a profundidade de auditoria na UI
+
+## 2026-04-16 — sprint ui-4: operações e hardening da UI
+
+**Status:** concluído
+
+**Resumo:**  
+Foi concluída a Sprint UI-4 do módulo OPRM no frontend com a nova tela de Operações, busca por `correlationId`, visão de falhas recentes e refinamento da navegação interna para manter consistência entre as telas do módulo.
+
+**O que foi implementado:**  
+- criação da tela `OPRM · Operações` com cards operacionais, tabela de jobs por ocupação e painel de falhas recentes
+- adição de busca por `correlationId` com listagem de artefatos correlacionados
+- adição da rota `/oprm/operations` e ativação do item `Operações` na navegação interna do OPRM
+- inclusão de reexecução de job com estado assíncrono (botão desabilitado + spinner)
+- adição de hook de dados para operações consumindo `/api/oprm/artifacts` com filtros de status e correlação
+
+**Arquivos principais alterados:**  
+- `frontend/src/pages/oprm/OprmOperationsPage.tsx`
+- `frontend/src/api/oprm/useOprmOperationsWorkspaceData.ts`
+- `frontend/src/pages/oprm/OprmModuleNavigation.tsx`
+- `frontend/src/App.tsx`
+- `frontend/src/__tests__/OprmNavigation.test.tsx`
+
+**Contratos / artefatos afetados:**  
+- consumo de contrato existente `GET /api/oprm/artifacts` com filtros `status` e `correlationId`
+- consumo de contrato existente `GET /api/oprm/jobs/workspace/occupations`
+- nenhum contrato novo
+
+**Testes executados:**  
+- `cd frontend && npm run test -- OprmNavigation.test.tsx` — **passou**
+- `cd frontend && npm run build` — **passou**
+
+**Limitações ou pendências:**  
+- heartbeat exibido via proxy do último `lastUpdatedAt` dos jobs; não há endpoint de leitura dedicado de heartbeat no backend atual
+- tabela operacional de jobs usa resumo por ocupação, pois não existe endpoint de listagem completa de jobs no workspace
+
+**Próximo passo sugerido:**  
+- expor endpoint de observabilidade dedicado para heartbeat e métricas do worker no backend
+- adicionar endpoint de listagem operacional de jobs com paginação para detalhamento técnico completo

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -113,6 +113,7 @@ import OprmRoutinePage from "./pages/oprm/OprmRoutinePage";
 import OprmOfferPage from "./pages/oprm/OprmOfferPage";
 import OprmEvidencePage from "./pages/oprm/OprmEvidencePage";
 import OprmFeedbackPage from "./pages/oprm/OprmFeedbackPage";
+import OprmOperationsPage from "./pages/oprm/OprmOperationsPage";
 
 export default function App() {
   return (
@@ -273,6 +274,10 @@ export default function App() {
               <Route
                 path="/oprm/feedback/:occupationSeedRef"
                 element={<OprmFeedbackPage />}
+              />
+              <Route
+                path="/oprm/operations"
+                element={<OprmOperationsPage />}
               />
               <Route path="/angles" element={<AnglesPage />} />
               <Route path="/visual-proofs" element={<VisualProofsPage />} />

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -32,4 +32,9 @@ describe("OPRM navigation", () => {
     expect(link).toBeTruthy();
     expect(link.getAttribute("href")).toBe("/oprm");
   });
+
+  it("renders loading state on /oprm/operations route", async () => {
+    setup(<App />, ["/oprm/operations"]);
+    expect(await screen.findByText(/carregando jobs do oprm/i)).toBeTruthy();
+  });
 });

--- a/frontend/src/api/oprm/useOprmOperationsWorkspaceData.ts
+++ b/frontend/src/api/oprm/useOprmOperationsWorkspaceData.ts
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { OprmArtifactSummary } from "./useOprmInsightsWorkspaceData";
+
+export type OprmArtifactStatus =
+  | "DRAFT"
+  | "GENERATED"
+  | "VALIDATED"
+  | "REJECTED"
+  | "PUBLISHED"
+  | "SUPERSEDED";
+
+export function useOprmFailedArtifacts() {
+  return useQuery({
+    queryKey: ["oprm", "operations", "failed-artifacts"],
+    queryFn: async () => {
+      const { data } = await axios.get<OprmArtifactSummary[]>("/api/oprm/artifacts", {
+        params: { status: "REJECTED" satisfies OprmArtifactStatus },
+      });
+      return data;
+    },
+  });
+}
+
+export function useOprmArtifactsByCorrelationId(correlationId?: string) {
+  return useQuery({
+    queryKey: ["oprm", "operations", "correlation", correlationId],
+    enabled: Boolean(correlationId),
+    queryFn: async () => {
+      const { data } = await axios.get<OprmArtifactSummary[]>("/api/oprm/artifacts", {
+        params: { correlationId },
+      });
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/oprm/OprmModuleNavigation.tsx
+++ b/frontend/src/pages/oprm/OprmModuleNavigation.tsx
@@ -11,7 +11,7 @@ interface OprmNavItem {
 
 const baseItems: OprmNavItem[] = [
   { label: "Ocupações", to: "/oprm" },
-  { label: "Operações" },
+  { label: "Operações", to: "/oprm/operations" },
 ];
 
 export default function OprmModuleNavigation({

--- a/frontend/src/pages/oprm/OprmOperationsPage.tsx
+++ b/frontend/src/pages/oprm/OprmOperationsPage.tsx
@@ -1,0 +1,346 @@
+import { useMemo, useState } from "react";
+import { AlertCircle, Copy } from "lucide-react";
+import { Link } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import PageTitle from "../../components/PageTitle";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+import {
+  type OprmJobStatus,
+  useOprmWorkspaceOccupations,
+} from "../../api/oprm/useOprmWorkspaceOccupations";
+import {
+  useOprmArtifactsByCorrelationId,
+  useOprmFailedArtifacts,
+} from "../../api/oprm/useOprmOperationsWorkspaceData";
+import { useCreateOprmJob } from "../../api/oprm/useCreateOprmJob";
+
+const JOB_STATUS_LABEL: Record<OprmJobStatus, string> = {
+  PENDING: "Pendente",
+  CLAIMED: "Claimed",
+  RUNNING: "Em execução",
+  SUCCEEDED: "Concluído",
+  FAILED: "Falhou",
+  RETRY_WAIT: "Aguardando retry",
+  CANCELLED: "Cancelado",
+};
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "-"
+    : date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
+}
+
+function toStatusSummary(statusList: OprmJobStatus[]) {
+  return {
+    pending: statusList.filter((status) => status === "PENDING" || status === "CLAIMED" || status === "RUNNING")
+      .length,
+    failed: statusList.filter((status) => status === "FAILED" || status === "RETRY_WAIT").length,
+    succeeded: statusList.filter((status) => status === "SUCCEEDED").length,
+  };
+}
+
+export default function OprmOperationsPage() {
+  const [correlationSearch, setCorrelationSearch] = useState("");
+  const [submittedCorrelationId, setSubmittedCorrelationId] = useState<string | undefined>(undefined);
+  const [processingOccupation, setProcessingOccupation] = useState<string | null>(null);
+  const [copiedCorrelationId, setCopiedCorrelationId] = useState<string | null>(null);
+
+  const queryClient = useQueryClient();
+  const occupationsQuery = useOprmWorkspaceOccupations();
+  const failedArtifactsQuery = useOprmFailedArtifacts();
+  const correlationQuery = useOprmArtifactsByCorrelationId(submittedCorrelationId);
+  const reprocessMutation = useCreateOprmJob();
+
+  const occupations = occupationsQuery.data ?? [];
+  const statusSummary = useMemo(
+    () => toStatusSummary(occupations.map((occupation) => occupation.lastJobStatus)),
+    [occupations],
+  );
+
+  const latestUpdate = useMemo(() => {
+    if (occupations.length === 0) {
+      return null;
+    }
+
+    return occupations.reduce((latest, current) =>
+      new Date(current.lastUpdatedAt) > new Date(latest.lastUpdatedAt) ? current : latest,
+    );
+  }, [occupations]);
+
+  async function handleReprocess(occupationSeedRef: string) {
+    setProcessingOccupation(occupationSeedRef);
+    try {
+      await reprocessMutation.mutateAsync({
+        jobType: "OCCUPATION_MAPPING",
+        occupationSeedRef,
+      });
+      await queryClient.invalidateQueries({ queryKey: ["oprm", "workspace", "occupations"] });
+    } finally {
+      setProcessingOccupation(null);
+    }
+  }
+
+  async function handleCopyCorrelation(correlationId: string) {
+    try {
+      await navigator.clipboard.writeText(correlationId);
+      setCopiedCorrelationId(correlationId);
+      setTimeout(() => {
+        setCopiedCorrelationId((current) => (current === correlationId ? null : current));
+      }, 1500);
+    } catch {
+      setCopiedCorrelationId(null);
+    }
+  }
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>OPRM · Operações</PageTitle>
+        <p className="text-secondary mb-0">
+          Monitore jobs, artefatos e correlação operacional do OPRM sem sair do Marketing Hub.
+        </p>
+      </header>
+
+      <OprmModuleNavigation />
+
+      <section className="row g-3">
+        <div className="col-12 col-md-6 col-xl-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <h2 className="h6 text-secondary">Jobs ativos</h2>
+              <p className="display-6 mb-0">{statusSummary.pending}</p>
+            </div>
+          </div>
+        </div>
+        <div className="col-12 col-md-6 col-xl-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <h2 className="h6 text-secondary">Jobs concluídos</h2>
+              <p className="display-6 mb-0">{statusSummary.succeeded}</p>
+            </div>
+          </div>
+        </div>
+        <div className="col-12 col-md-6 col-xl-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <h2 className="h6 text-secondary">Falhas recentes</h2>
+              <p className="display-6 mb-0">{statusSummary.failed}</p>
+            </div>
+          </div>
+        </div>
+        <div className="col-12 col-md-6 col-xl-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <h2 className="h6 text-secondary">Heartbeat (último sinal)</h2>
+              <p className="mb-0 fw-semibold">
+                {latestUpdate ? formatDate(latestUpdate.lastUpdatedAt) : "Sem sinal recebido"}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <h2 className="h5 mb-0">Buscar por correlationId</h2>
+          <form
+            className="row g-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              setSubmittedCorrelationId(correlationSearch.trim() || undefined);
+            }}
+          >
+            <div className="col-12 col-lg-9">
+              <input
+                className="form-control"
+                value={correlationSearch}
+                onChange={(event) => setCorrelationSearch(event.target.value)}
+                placeholder="Informe o correlationId"
+              />
+            </div>
+            <div className="col-12 col-lg-3 d-grid">
+              <button type="submit" className="btn btn-primary">
+                Buscar correlationId
+              </button>
+            </div>
+          </form>
+
+          {correlationQuery.isLoading ? (
+            <div className="d-flex align-items-center gap-2 text-secondary">
+              <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+              Carregando artefatos por correlationId...
+            </div>
+          ) : null}
+
+          {correlationQuery.isError ? (
+            <div className="alert alert-danger d-flex gap-2 mb-0" role="alert">
+              <AlertCircle size={18} className="mt-1" aria-hidden="true" />
+              <div>Não foi possível buscar artefatos por correlationId.</div>
+            </div>
+          ) : null}
+
+          {!correlationQuery.isLoading && !correlationQuery.isError && submittedCorrelationId ? (
+            correlationQuery.data?.length ? (
+              <div className="table-responsive">
+                <table className="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th>Artefato</th>
+                      <th>Status</th>
+                      <th>Ocupação</th>
+                      <th>Gerado em</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {correlationQuery.data.map((artifact) => (
+                      <tr key={artifact.artifactId}>
+                        <td>{artifact.artifactType}</td>
+                        <td>{artifact.artifactStatus}</td>
+                        <td>{artifact.occupationSeedRef}</td>
+                        <td>{formatDate(artifact.createdAt)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="alert alert-secondary mb-0" role="status">
+                Nenhum artefato encontrado para o correlationId informado.
+              </div>
+            )
+          ) : null}
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <h2 className="h5 mb-0">Tabela de jobs por ocupação</h2>
+
+          {occupationsQuery.isLoading ? (
+            <div className="d-flex justify-content-center py-4">
+              <div className="spinner-border text-primary" role="status">
+                <span className="visually-hidden">Carregando jobs do OPRM...</span>
+              </div>
+            </div>
+          ) : null}
+
+          {occupationsQuery.isError ? (
+            <div className="alert alert-danger d-flex gap-2 mb-0" role="alert">
+              <AlertCircle size={18} className="mt-1" aria-hidden="true" />
+              <div>Não foi possível carregar a tabela de jobs.</div>
+            </div>
+          ) : null}
+
+          {!occupationsQuery.isLoading && !occupationsQuery.isError ? (
+            occupations.length ? (
+              <div className="table-responsive">
+                <table className="table table-hover align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th>Ocupação</th>
+                      <th>Status</th>
+                      <th>CorrelationId</th>
+                      <th>Última atualização</th>
+                      <th>Ações</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {occupations.map((occupation) => {
+                      const isProcessing = processingOccupation === occupation.occupationSeedRef;
+
+                      return (
+                        <tr key={occupation.occupationSeedRef}>
+                          <td className="fw-semibold">{occupation.occupationSeedRef}</td>
+                          <td>{JOB_STATUS_LABEL[occupation.lastJobStatus]}</td>
+                          <td className="font-monospace small">{occupation.lastCorrelationId}</td>
+                          <td>{formatDate(occupation.lastUpdatedAt)}</td>
+                          <td>
+                            <div className="d-flex flex-wrap gap-2 align-items-center">
+                              <button
+                                type="button"
+                                className="btn btn-outline-secondary btn-sm"
+                                onClick={() => handleCopyCorrelation(occupation.lastCorrelationId)}
+                              >
+                                <Copy size={14} className="me-1" aria-hidden="true" />
+                                {copiedCorrelationId === occupation.lastCorrelationId ? "Copiado" : "Copiar ID"}
+                              </button>
+                              <button
+                                type="button"
+                                className="btn btn-outline-primary btn-sm"
+                                onClick={() => handleReprocess(occupation.occupationSeedRef)}
+                                disabled={isProcessing || reprocessMutation.isPending}
+                              >
+                                {isProcessing ? (
+                                  <>
+                                    <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />
+                                    Reprocessando...
+                                  </>
+                                ) : (
+                                  "Reexecutar"
+                                )}
+                              </button>
+                              <Link
+                                className="btn btn-outline-success btn-sm"
+                                to={`/oprm/evidence/${encodeURIComponent(occupation.occupationSeedRef)}`}
+                              >
+                                Ver falhas
+                              </Link>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="alert alert-secondary mb-0" role="status">
+                Nenhum job encontrado para o workspace operacional.
+              </div>
+            )
+          ) : null}
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <h2 className="h5 mb-0">Falhas recentes de publicação</h2>
+
+          {failedArtifactsQuery.isLoading ? (
+            <div className="d-flex align-items-center gap-2 text-secondary">
+              <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+              Carregando falhas recentes...
+            </div>
+          ) : null}
+
+          {failedArtifactsQuery.isError ? (
+            <div className="alert alert-danger mb-0" role="alert">
+              Não foi possível carregar falhas de artefatos.
+            </div>
+          ) : null}
+
+          {!failedArtifactsQuery.isLoading && !failedArtifactsQuery.isError ? (
+            failedArtifactsQuery.data?.length ? (
+              <ul className="list-group list-group-flush">
+                {failedArtifactsQuery.data.slice(0, 10).map((artifact) => (
+                  <li className="list-group-item px-0" key={artifact.artifactId}>
+                    <div className="fw-semibold">{artifact.artifactType}</div>
+                    <div className="small text-secondary">
+                      correlationId: <span className="font-monospace">{artifact.correlationId}</span>
+                    </div>
+                    <div className="small text-secondary">{formatDate(artifact.createdAt)}</div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="alert alert-secondary mb-0" role="status">
+                Nenhuma falha recente de publicação encontrada.
+              </div>
+            )
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Entregar a Sprint UI-4 do OPRM adicionando uma visão operacional para monitorar jobs, artefatos e falhas sem sair do Marketing Hub.
- Fornecer capacidades de investigação (buscar por `correlationId`, listar falhas) e ações operacionais básicas (reexecutar job) para reduzir o tempo de resposta a problemas do worker.
- Manter o histórico incremental do módulo conforme o protocolo de implantação do Codex.

### Description
- Adiciona a nova página de operações `frontend/src/pages/oprm/OprmOperationsPage.tsx` com cards de status, busca por `correlationId`, tabela de jobs por ocupação, lista de falhas recentes e ação de reexecução com spinner/estado desabilitado. 
- Cria o hook `frontend/src/api/oprm/useOprmOperationsWorkspaceData.ts` que consome o contrato existente `GET /api/oprm/artifacts` para filtrar por `status=REJECTED` e por `correlationId`.
- Ativa o item `Operações` na navegação interna do OPRM (`frontend/src/pages/oprm/OprmModuleNavigation.tsx`) e registra a rota `/oprm/operations` em `frontend/src/App.tsx`.
- Atualiza o teste de navegação `frontend/src/__tests__/OprmNavigation.test.tsx` para cobrir a nova rota de operações e registra a Sprint UI-4 em `docs/history/oprm-implementation-history.md`.
- Não foram introduzidos novos contratos backend; a UI consome apenas endpoints existentes (`GET /api/oprm/artifacts` e `GET /api/oprm/jobs/workspace/occupations`) e usa o hook de criação de job já presente para reprocessamento.

### Testing
- Executado `cd frontend && npm install` — **passou**.
- Executado `cd frontend && npm run test -- --run OprmNavigation.test.tsx` (Vitest) — **passou** (tests referentes a navegação OPRM: 3 tests passed).
- Executado `cd frontend && npm run build` — **passou** (build concluído com avisos de chunk size, sem impedir o artefato).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04212897883218569d17d335a5132)