### PR TITLE
OPRM: adicionar bloco 'Rodar OPRM' e estado vazio guiado no workspace

### DIFF
--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -259,6 +259,38 @@ Foi concluída a preparação de finalização operacional do OPRM para publica�
 - executar o fluxo de cópia e apply no host `177.153.62.107` com usuário de infraestrutura
 - versionar contrato HTTP backend↔OPRM para jobs e publicação de artefatos end-to-end
 
+## 2026-04-16 — ajuste da tela inicial do workspace OPRM
+
+**Status:** concluído
+
+**Resumo:**  
+Foi ajustada a tela inicial do módulo OPRM no frontend para reduzir a sensação de incompletude no primeiro acesso, adicionando entrada explícita para disparar processamento e um estado vazio guiado para o fluxo de negócio.
+
+**O que foi implementado:**  
+- inclusão de bloco dedicado `Rodar OPRM` com campo para ocupação/persona e ação de submit
+- implementação de disparo de job OPRM diretamente pela tela inicial usando a mutação já existente
+- inclusão de indicador de carregamento e bloqueio do botão durante a requisição assíncrona
+- substituição do alerta simples de vazio por estado guiado com próximos passos (rodar processamento, aguardar status e navegar para rotina/oferta)
+
+**Arquivos principais alterados:**  
+- `frontend/src/pages/oprm/OprmWorkspacePage.tsx`
+- `docs/history/oprm-implementation-history.md`
+
+**Contratos / artefatos afetados:**  
+- nenhum contrato novo
+
+**Testes executados:**  
+- `cd frontend && npm run test -- OprmNavigation.test.tsx` — **passou**
+- `cd frontend && npm run build` — **passou**
+
+**Limitações ou pendências:**  
+- campos adicionais da tabela de ocupações previstos na especificação (nicho, confiança/dor/oportunidade reais e origem) continuam dependentes de expansão do payload do backend
+- filtro de confiança permanece como placeholder de sprint futura
+
+**Próximo passo sugerido:**  
+- evoluir endpoint `/api/oprm/jobs/workspace/occupations` para retornar metadados completos da ocupação previstos na especificação
+- implementar filtro de confiança real no workspace usando dados persistidos do card de rotina e artefatos correlatos
+
 ## 2026-04-15 — sprint 1: contrato oficial backend ↔ OPRM
 
 **Status:** concluído
@@ -745,3 +777,35 @@ Foi concluída a Sprint UI-4 do módulo OPRM no frontend com a nova tela de Oper
 **Próximo passo sugerido:**  
 - expor endpoint de observabilidade dedicado para heartbeat e métricas do worker no backend
 - adicionar endpoint de listagem operacional de jobs com paginação para detalhamento técnico completo
+
+## 2026-04-16 — ajuste da tela inicial do workspace OPRM
+
+**Status:** concluído
+
+**Resumo:**  
+Foi ajustada a tela inicial do módulo OPRM no frontend para reduzir a sensação de incompletude no primeiro acesso, adicionando entrada explícita para disparar processamento e um estado vazio guiado para o fluxo de negócio.
+
+**O que foi implementado:**  
+- inclusão de bloco dedicado `Rodar OPRM` com campo para ocupação/persona e ação de submit
+- implementação de disparo de job OPRM diretamente pela tela inicial usando a mutação já existente
+- inclusão de indicador de carregamento e bloqueio do botão durante a requisição assíncrona
+- substituição do alerta simples de vazio por estado guiado com próximos passos (rodar processamento, aguardar status e navegar para rotina/oferta)
+
+**Arquivos principais alterados:**  
+- `frontend/src/pages/oprm/OprmWorkspacePage.tsx`
+- `docs/history/oprm-implementation-history.md`
+
+**Contratos / artefatos afetados:**  
+- nenhum contrato novo
+
+**Testes executados:**  
+- `cd frontend && npm run test -- --run OprmNavigation.test.tsx` — **passou**
+- `cd frontend && npm run build` — **passou**
+
+**Limitações ou pendências:**  
+- campos adicionais da tabela de ocupações previstos na especificação (nicho, confiança/dor/oportunidade reais e origem) continuam dependentes de expansão do payload do backend
+- filtro de confiança permanece como placeholder de sprint futura
+
+**Próximo passo sugerido:**  
+- evoluir endpoint `/api/oprm/jobs/workspace/occupations` para retornar metadados completos da ocupação previstos na especificação
+- implementar filtro de confiança real no workspace usando dados persistidos do card de rotina e artefatos correlatos

--- a/frontend/src/pages/oprm/OprmWorkspacePage.tsx
+++ b/frontend/src/pages/oprm/OprmWorkspacePage.tsx
@@ -41,6 +41,7 @@ function formatDate(value: string): string {
 export default function OprmWorkspacePage() {
   const [statusFilter, setStatusFilter] = useState<"ALL" | OprmJobStatus>("ALL");
   const [search, setSearch] = useState("");
+  const [newOccupationSeedRef, setNewOccupationSeedRef] = useState("");
   const [processingOccupation, setProcessingOccupation] = useState<string | null>(null);
 
   const queryClient = useQueryClient();
@@ -79,6 +80,27 @@ export default function OprmWorkspacePage() {
     }
   }
 
+  async function handleCreateJob() {
+    const occupationSeedRef = newOccupationSeedRef.trim();
+    if (!occupationSeedRef) {
+      return;
+    }
+
+    setProcessingOccupation(occupationSeedRef);
+    try {
+      await reprocessMutation.mutateAsync({
+        jobType: "OCCUPATION_MAPPING",
+        occupationSeedRef,
+      });
+      setNewOccupationSeedRef("");
+      await queryClient.invalidateQueries({
+        queryKey: ["oprm", "workspace", "occupations"],
+      });
+    } finally {
+      setProcessingOccupation(null);
+    }
+  }
+
   return (
     <div className="d-flex flex-column gap-4">
       <header className="d-flex flex-column gap-2">
@@ -89,6 +111,51 @@ export default function OprmWorkspacePage() {
       </header>
 
       <OprmModuleNavigation />
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <div>
+            <h2 className="h5 mb-1">Rodar OPRM</h2>
+            <p className="text-secondary mb-0">
+              Inicie um novo processamento informando a referência da ocupação/persona.
+            </p>
+          </div>
+          <form
+            className="row g-2"
+            onSubmit={async (event) => {
+              event.preventDefault();
+              await handleCreateJob();
+            }}
+          >
+            <div className="col-12 col-lg-8">
+              <label className="form-label" htmlFor="oprm-seed-ref">
+                Ocupação/persona
+              </label>
+              <input
+                id="oprm-seed-ref"
+                className="form-control"
+                placeholder="Ex.: dentista"
+                value={newOccupationSeedRef}
+                onChange={(event) => setNewOccupationSeedRef(event.target.value)}
+              />
+            </div>
+            <div className="col-12 col-lg-4 d-grid align-content-end">
+              <button
+                type="submit"
+                className="btn btn-primary d-inline-flex align-items-center justify-content-center gap-2"
+                disabled={reprocessMutation.isPending || newOccupationSeedRef.trim().length === 0}
+              >
+                {reprocessMutation.isPending && processingOccupation === newOccupationSeedRef.trim() ? (
+                  <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+                ) : (
+                  <RefreshCw size={14} aria-hidden="true" />
+                )}
+                Rodar OPRM
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
 
       <section className="card border-0 shadow-sm">
         <div className="card-body d-flex flex-column gap-3">
@@ -157,9 +224,19 @@ export default function OprmWorkspacePage() {
 
       {!occupationsQuery.isLoading && !occupationsQuery.isError ? (
         filteredOccupations.length === 0 ? (
-          <div className="alert alert-secondary mb-0" role="status">
-            Nenhuma ocupação encontrada com os filtros atuais.
-          </div>
+          <section className="card border-0 shadow-sm">
+            <div className="card-body d-flex flex-column gap-3">
+              <h2 className="h5 mb-0">Workspace de Ocupações vazio</h2>
+              <p className="text-secondary mb-0">
+                Nenhuma ocupação foi encontrada para os filtros atuais. Para iniciar o fluxo guiado do OPRM:
+              </p>
+              <ol className="mb-0">
+                <li>Informe a ocupação/persona no bloco <strong>Rodar OPRM</strong>.</li>
+                <li>Dispare o processamento e aguarde o status mudar para concluído.</li>
+                <li>Use as ações da tabela para abrir <strong>Rotina</strong> e <strong>Oferta</strong>.</li>
+              </ol>
+            </div>
+          </section>
         ) : (
           <section className="card border-0 shadow-sm">
             <div className="table-responsive">


### PR DESCRIPTION
### Motivation
- A tela inicial do workspace OPRM estava incompleta como porta de entrada operacional e precisava de um ponto explícito para iniciar o fluxo de negócio (especificação OPRM). 
- Usuários devem conseguir disparar processamento diretamente da tela inicial e receber feedback assíncrono seguro (botão desabilitado + spinner). 
- A alteração deve ser registrada no protocolo de histórico de implantação do OPRM. 

### Description
- Adiciona bloco `Rodar OPRM` com campo de `ocupação/persona` e ação de submit que cria um job usando a mutação existente `useCreateOprmJob`, incluindo spinner e bloqueio do botão durante a requisição. 
- Implementa `handleCreateJob` e estado local `newOccupationSeedRef`, e invalida a query `['oprm','workspace','occupations']` após criação do job. 
- Substitui o alerta simples de workspace vazio por um empty-state guiado com passos (informar ocupação → rodar processamento → abrir Rotina/Oferta), mantendo placeholders existentes (filtro de confiança). 
- Atualiza o histórico incremental `docs/history/oprm-implementation-history.md` com a entrada da alteração conforme o protocolo. 

Arquivos alterados: `frontend/src/pages/oprm/OprmWorkspacePage.tsx`, `docs/history/oprm-implementation-history.md`.

### Testing
- Executado `cd frontend && npm install` — concluído com sucesso. 
- Executado `cd frontend && npm run test -- --run OprmNavigation.test.tsx` — suite de testes relevante passou (`3 tests passed`). 
- Executado `cd frontend && npm run build` — build concluído com sucesso. 
- Observação: os testes exibiram logs de `AggregateError` do jsdom/axios no stderr, porém os testes automatizados passaram conforme resultado do runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04c21213883219cd0850981563b03)