### PR TITLE
ci: update DEPLOY_HOST IP in oprm-ci.yml

### DIFF
--- a/.github/workflows/oprm-ci.yml
+++ b/.github/workflows/oprm-ci.yml
@@ -83,7 +83,7 @@ jobs:
       contents: read
       packages: read
     env:
-      DEPLOY_HOST: 191.252.120.96
+      DEPLOY_HOST: 177.153.62.107
       DEPLOY_USER: root
       REMOTE_PATH: ${{ secrets.OPRM_REMOTE_PATH || '/root/oprm' }}
       IMAGE_REGISTRY: ghcr.io


### PR DESCRIPTION
### Motivation
- Update deployment target host IP for the `deploy` job to point to the new VPS.

### Description
- Change `DEPLOY_HOST` value in `.github/workflows/oprm-ci.yml` from `191.252.120.96` to `177.153.62.107`.

### Testing
- No automated tests were modified or executed as part of this change; CI jobs remain unchanged and should be validated by running the workflow after merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0514419ec8321a3f0f6924d04029f)