### PR TITLE
ci(oprm): reuse video SSH credential secret for deploy

### DIFF
--- a/.github/workflows/oprm-ci.yml
+++ b/.github/workflows/oprm-ci.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Configure SSH
         env:
-          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_CHAVE != '' && secrets.VPS_SSH_CHAVE || secrets.VPS_SSH_KEY }}
         run: |
           install -m 700 -d ~/.ssh
           printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519


### PR DESCRIPTION
### Motivation
- The OPRM deploy workflow was failing with `Permission denied (publickey,password)` when connecting to the same host used by the Video module, indicating the SSH secret in use differed from the working video pipeline.

### Description
- Updated `.github/workflows/oprm-ci.yml` to set `VPS_SSH_KEY` as `secrets.VPS_SSH_CHAVE != '' && secrets.VPS_SSH_CHAVE || secrets.VPS_SSH_KEY` so the workflow will prefer the Video module SSH secret with a fallback to the original key.

### Testing
- Ran `git diff --check` after the change and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f022fb68832197af701740735b54)