### PR TITLE
Configure Spring Boot Maven plugin mainClass and repackage execution

### DIFF
--- a/oprm/pom.xml
+++ b/oprm/pom.xml
@@ -14,6 +14,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <spring.boot.version>3.4.5</spring.boot.version>
         <spring-cloud.version>2024.0.1</spring-cloud.version>
+        <start-class>com.marketinghub.oprm.OprmApplication</start-class>
     </properties>
 
     <dependencyManagement>
@@ -70,6 +71,16 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot.version}</version>
+                <configuration>
+                    <mainClass>${start-class}</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Motivation
- Explicitly set the application entry point and ensure the Spring Boot Maven plugin repackages the artifact so the module can be built as an executable jar by CI and local builds.

### Description
- Add a `start-class` property and configure the `spring-boot-maven-plugin` with `<mainClass>${start-class}</mainClass>` and an `execution` that runs the `repackage` goal.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f4042d2c8321897a6a670784985d)