### PR TITLE
fix(lead-portal): update tsconfig ignoreDeprecations for build compatibility

### DIFF
--- a/lead-portal/frontend/tsconfig.node.json
+++ b/lead-portal/frontend/tsconfig.node.json
@@ -15,7 +15,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "5.0"
   },
   "include": [
     "vite.config.ts"


### PR DESCRIPTION
### Motivation
- Fix the `TS5103: Invalid value for '--ignoreDeprecations'` error that caused `npm run build` to fail for the lead-portal frontend.

### Description
- Change `compilerOptions.ignoreDeprecations` from `"6.0"` to `"5.0"` in `lead-portal/frontend/tsconfig.node.json` to use a valid TypeScript value.

### Testing
- Ran `cd lead-portal/frontend && npm install` and `cd lead-portal/frontend && npm run build`, both completed successfully (TypeScript build and `vite build` produced the `dist` output).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fa6be5a483218cb760b79f2a1f0b)