### PR TITLE
Atualiza URL padrão do backend OPRM para endereço remoto

### DIFF
--- a/oprm/README.md
+++ b/oprm/README.md
@@ -124,7 +124,7 @@ Exemplo de payload da fase 5:
 
 Configurações do worker:
 
-- `OPRM_BACKEND_BASE_URL` (default `http://localhost:8080`)
+- `OPRM_BACKEND_BASE_URL` (default `http://191.252.181.168:8000`)
 - `OPRM_WORKER_ID`
 - `OPRM_WORKER_VERSION`
 - `OPRM_WORKER_CLAIM_LEASE_SECONDS`

--- a/oprm/src/main/resources/application.properties
+++ b/oprm/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=oprm
 server.port=8093
-oprm.backend.base-url=${OPRM_BACKEND_BASE_URL:http://localhost:8080}
+oprm.backend.base-url=${OPRM_BACKEND_BASE_URL:http://191.252.181.168:8000}
 oprm.worker.id=${OPRM_WORKER_ID:oprm-worker-local}
 oprm.worker.version=${OPRM_WORKER_VERSION:0.1.0}
 oprm.worker.claim-lease-seconds=${OPRM_WORKER_CLAIM_LEASE_SECONDS:120}


### PR DESCRIPTION
### Motivation
- Ajustar o valor padrão de conexão do worker OPRM para apontar a URL de backend fornecida pela infraestrutura em vez de `localhost` para permitir integração com o backend remoto por padrão.

### Description
- Alterado o valor padrão de `OPRM_BACKEND_BASE_URL` em `oprm/src/main/resources/application.properties` de `http://localhost:8080` para `http://191.252.181.168:8000`.
- Atualizada a documentação em `oprm/README.md` para refletir a nova URL padrão do backend.

### Testing
- Nenhum teste automatizado foi executado como parte desta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fae805b48321a625a8487ed07177)