### PR TITLE
Align OPRM backend behavior with required Swagger endpoints contract

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmApiErrorResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmApiErrorResponseDto.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.dto;
+
+public record OprmApiErrorResponseDto(
+        String code,
+        String message,
+        String correlationId,
+        String details
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmArtifactRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmArtifactRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface OprmArtifactRepository extends JpaRepository<OprmArtifact, Long> {
     Optional<OprmArtifact> findByIdempotencyKey(String idempotencyKey);
 
+    List<OprmArtifact> findAllByOrderByCreatedAtDesc();
+
     List<OprmArtifact> findByCorrelationIdOrderByCreatedAtDesc(String correlationId);
 
     List<OprmArtifact> findByOccupationSeedRefAndArtifactStatusOrderByCreatedAtDesc(String occupationSeedRef,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java
@@ -52,11 +52,11 @@ public class OprmArtifactService {
         try {
             jobId = UUID.fromString(request.jobId());
         } catch (IllegalArgumentException exception) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jobId must be a valid UUID");
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "jobId must be a valid UUID");
         }
 
         OprmJob job = jobRepository.findById(jobId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM job not found"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "OPRM job not found"));
 
         OprmArtifactEnvelopeDto artifactEnvelope = request.artifact();
         if (!request.correlationId().equals(artifactEnvelope.correlationId())) {
@@ -118,8 +118,10 @@ public class OprmArtifactService {
             return artifacts.stream().map(this::toSummary).toList();
         }
 
-        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                "use correlationId or occupationSeedRef to filter OPRM artifacts");
+        return artifactRepository.findAllByOrderByCreatedAtDesc()
+                .stream()
+                .map(this::toSummary)
+                .toList();
     }
 
 
@@ -138,6 +140,10 @@ public class OprmArtifactService {
                         "dorResultadoOfertaMecanismoProvaInput"
                 )
                 .orElse(null);
+
+        if (routineCardArtifact == null && frameworkInputArtifact == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM workspace routine not found");
+        }
 
         Map<String, Object> routinePayload = readPayload(routineCardArtifact);
         Map<String, Object> frameworkPayload = readPayload(frameworkInputArtifact);
@@ -164,6 +170,9 @@ public class OprmArtifactService {
     @Transactional(readOnly = true)
     public OprmInsightsWorkspaceResponseDto getInsightsWorkspace(String occupationSeedRef) {
         List<OprmArtifact> artifacts = artifactRepository.findByOccupationSeedRefOrderByCreatedAtDesc(occupationSeedRef);
+        if (artifacts.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM workspace insights not found");
+        }
 
         OprmArtifact routineCardArtifact = findLatestArtifactByType(artifacts, "occupationPersonaRoutineCard");
         OprmArtifact feedbackArtifact = findLatestArtifactByType(artifacts, "occupationFeedbackLoopSnapshot");
@@ -279,7 +288,7 @@ public class OprmArtifactService {
         try {
             return Instant.parse(createdAt);
         } catch (DateTimeParseException exception) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "artifact.createdAt must use ISO-8601");
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "artifact.createdAt must use ISO-8601");
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmFeedbackService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmFeedbackService.java
@@ -35,11 +35,11 @@ public class OprmFeedbackService {
         try {
             jobId = UUID.fromString(request.jobId());
         } catch (IllegalArgumentException ex) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jobId must be a valid UUID");
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "jobId must be a valid UUID");
         }
 
         OprmJob job = jobRepository.findById(jobId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM job not found"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "OPRM job not found"));
 
         Instant generatedAt = parseGeneratedAt(request.generatedAt());
         OprmFeedbackSnapshot snapshot = OprmFeedbackSnapshot.builder()
@@ -93,7 +93,7 @@ public class OprmFeedbackService {
         try {
             return Instant.parse(generatedAt);
         } catch (DateTimeParseException ex) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "generatedAt must use ISO-8601 format");
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "generatedAt must use ISO-8601 format");
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java
@@ -86,7 +86,7 @@ public class OprmJobOrchestrationService {
         );
 
         if (updated == 0) {
-            return Optional.empty();
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "OPRM job claim conflict");
         }
 
         OprmJob job = jobRepository.findById(nextJobId.get())
@@ -224,7 +224,7 @@ public class OprmJobOrchestrationService {
         try {
             return Instant.parse(occurredAt);
         } catch (DateTimeParseException ex) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "occurredAt must use ISO-8601 format");
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "occurredAt must use ISO-8601 format");
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmApiExceptionHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmApiExceptionHandler.java
@@ -1,0 +1,94 @@
+package com.marketinghub.oprm.web;
+
+import com.marketinghub.oprm.dto.OprmApiErrorResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import java.util.stream.Collectors;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestControllerAdvice(basePackageClasses = {
+        OprmJobController.class,
+        OprmArtifactController.class,
+        OprmWorkspaceController.class,
+        OprmFeedbackController.class,
+        OprmHeartbeatController.class
+})
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class OprmApiExceptionHandler {
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<OprmApiErrorResponseDto> handleResponseStatus(
+            ResponseStatusException exception,
+            HttpServletRequest request
+    ) {
+        HttpStatus status = HttpStatus.resolve(exception.getStatusCode().value());
+        String errorCode = status == HttpStatus.CONFLICT ? "OPRM_CONFLICT" : "OPRM_REQUEST_ERROR";
+        return buildResponse(exception.getStatusCode().value(), errorCode, exception.getReason(), request, null);
+    }
+
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class,
+            HandlerMethodValidationException.class,
+            ConstraintViolationException.class,
+            MethodArgumentTypeMismatchException.class,
+            HttpMessageNotReadableException.class
+    })
+    public ResponseEntity<OprmApiErrorResponseDto> handleValidation(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        String details = switch (exception) {
+            case MethodArgumentNotValidException ex -> ex.getBindingResult()
+                    .getFieldErrors()
+                    .stream()
+                    .map(this::formatFieldError)
+                    .collect(Collectors.joining("; "));
+            case HandlerMethodValidationException ex -> ex.getAllValidationResults()
+                    .stream()
+                    .flatMap(result -> result.getResolvableErrors().stream())
+                    .map(error -> error.getDefaultMessage() == null ? "validation error" : error.getDefaultMessage())
+                    .collect(Collectors.joining("; "));
+            default -> exception.getMessage();
+        };
+        return buildResponse(
+                HttpStatus.UNPROCESSABLE_ENTITY.value(),
+                "OPRM_VALIDATION_ERROR",
+                "payload inválido para o endpoint OPRM",
+                request,
+                details
+        );
+    }
+
+    private ResponseEntity<OprmApiErrorResponseDto> buildResponse(
+            int statusCode,
+            String code,
+            String message,
+            HttpServletRequest request,
+            String details
+    ) {
+        String correlationId = request.getHeader("X-Correlation-Id");
+        OprmApiErrorResponseDto response = new OprmApiErrorResponseDto(
+                code,
+                message == null ? "erro na requisição OPRM" : message,
+                correlationId,
+                details
+        );
+        return ResponseEntity.status(statusCode).body(response);
+    }
+
+    private String formatFieldError(FieldError error) {
+        String defaultMessage = error.getDefaultMessage() == null ? "invalid value" : error.getDefaultMessage();
+        return error.getField() + ": " + defaultMessage;
+    }
+}

--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -259,6 +259,48 @@ Foi concluída a preparação de finalização operacional do OPRM para publica�
 - executar o fluxo de cópia e apply no host `177.153.62.107` com usuário de infraestrutura
 - versionar contrato HTTP backend↔OPRM para jobs e publicação de artefatos end-to-end
 
+## 2026-04-16 — alinhamento backend OPRM com contrato swagger required-endpoints v1.1.0
+
+**Status:** concluído
+
+**Resumo:**  
+Foi realizado o alinhamento dos endpoints OPRM do backend principal para aderir ao contrato de `docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml`, padronizando códigos HTTP de erro para payload inválido, resposta de conflito no claim de job e retorno `404` em workspaces sem artefatos.
+
+**O que foi implementado:**  
+- ajuste do fluxo de claim para retornar conflito explícito (`409`) quando houver disputa de lock no job pendente
+- ajuste dos serviços de artifacts e feedback para tratar payload inconsistente como `422` e aceitar listagem de artefatos sem filtro
+- ajuste dos endpoints de workspace para retornar `404` quando não houver dados para a ocupação solicitada
+- criação de `OprmApiExceptionHandler` para padronizar resposta de erro OPRM no formato `{code, message, correlationId, details}` e converter falhas de validação para `422`
+
+**Arquivos principais alterados:**  
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmFeedbackService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmApiExceptionHandler.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmApiErrorResponseDto.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmArtifactRepository.java`
+
+**Contratos / artefatos afetados:**  
+- endpoints do contrato `docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml`:
+  - `POST /api/oprm/jobs/claim`
+  - `GET /api/oprm/workspace/routine/{occupationSeedRef}`
+  - `GET /api/oprm/workspace/insights/{occupationSeedRef}`
+  - `POST /api/oprm/artifacts`
+  - `POST /api/oprm/feedback`
+  - `POST /api/oprm/heartbeat`
+- contrato de erro OPRM (`OprmApiErrorResponse`)
+
+**Testes executados:**  
+- `cd backend/ads-service && mvn -s ../settings.xml test` — **falhou** por indisponibilidade de rede no ambiente (`Network is unreachable` ao resolver `spring-boot-starter-parent:3.2.5`)
+
+**Limitações ou pendências:**  
+- não foram adicionados testes automatizados dedicados de controller/MockMvc para cada endpoint OPRM nesta etapa
+- `maxJobs` do claim permanece no contrato, mas o backend ainda realiza claim unitário de 1 job por requisição
+
+**Próximo passo sugerido:**  
+- adicionar suíte de testes HTTP para validar status code e payload de erro por endpoint OPRM
+- alinhar decisão de produto sobre claim em lote (`maxJobs > 1`) e evoluir contrato/implementação em conjunto
+
 ## 2026-04-16 — ajuste da tela inicial do workspace OPRM
 
 **Status:** concluído


### PR DESCRIPTION
### Motivation
- Align the backend OPRM endpoints to the consolidated OpenAPI contract in `docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml` for consistent HTTP status semantics and error payloads.
- Standardize OPRM error responses to a single envelope to make worker/frontend consumers handle errors uniformly and to follow the project's history/protocol rules.
- Record the implementation step in the OPRM deployment history following the Codex protocol for implantation history.

### Description
- Added a scoped exception handler `OprmApiExceptionHandler` and DTO `OprmApiErrorResponseDto` to return error payloads in the `{code, message, correlationId, details}` shape and to convert validation errors to `422` responses.
- Adjusted job claim flow in `OprmJobOrchestrationService` to return `409` on claim conflict and to return `422` for invalid `occurredAt` values.
- Updated `OprmArtifactService` to treat invalid `jobId`/missing job as `422`, allow artifact listing without filters (returns all ordered by createdAt), and return `404` for workspace routine/insights when no artifacts are found; added `findAllByOrderByCreatedAtDesc()` to `OprmArtifactRepository`.
- Updated `OprmFeedbackService` to return `422` for invalid `jobId`/missing job and invalid `generatedAt` formats.
- Documented the change using the required implantation history protocol in `docs/history/oprm-implementation-history.md` and listed the affected contract endpoints.

### Testing
- Attempted `cd backend/ads-service && mvn -s ../settings.xml test`, which failed in this environment due to network unavailability when resolving `spring-boot-starter-parent:3.2.5` (download error), so unit integration could not be completed here.
- Validated the OpenAPI YAML parse with `ruby -e "require 'yaml'; YAML.safe_load_file('docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml')"`, which passed during the rollout validation.
- Ran repository/lint checks (`git diff --check`) as part of the rollout, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10cd00bec8321adf51db76a1a9196)