### PR TITLE
docs(oprm): traduzir contrato OpenAPI para português-BR

### DIFF
--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -920,3 +920,36 @@ Foi corrigido o mapeamento JPA da entidade `OprmJob` para alinhar o tipo de UUID
 **Próximo passo sugerido:**
 - executar subida da aplicação em ambiente integrado com MySQL para confirmar ausência dos `alter table ... binary(16)` no startup
 - padronizar mapeamentos UUID legados (CHAR vs BINARY) em guideline interno para evitar regressões futuras
+
+## 2026-04-16 — tradução do contrato OpenAPI do OPRM para português-BR
+
+**Status:** concluído
+
+**Resumo:**
+Foi atualizada a documentação OpenAPI de endpoints obrigatórios do backend OPRM para reduzir trechos em inglês e padronizar a linguagem para português do Brasil, mantendo o contrato técnico e a estrutura de schemas existentes.
+
+**O que foi implementado:**
+- tradução de título e descrições operacionais do contrato para português-BR
+- ajuste de resumos de endpoints para termos mais claros ao time local (ex.: reserva de job, linha do tempo, sinal de vida)
+- inclusão de descrições em schemas de resposta/erro para melhorar entendimento operacional no contexto Brasil
+- atualização de exemplos de versão de contrato (`1.1.0`) e campo de persona com exemplo em português
+
+**Arquivos principais alterados:**
+- `docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml`
+- `docs/history/oprm-implementation-history.md`
+
+**Contratos / artefatos afetados:**
+- contrato OpenAPI: `docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml`
+- nenhum endpoint novo; apenas adaptação textual e de documentação
+
+**Testes executados:**
+- `python - <<'PY' ... yaml.safe_load(...)` — **falhou** por ausência do módulo `yaml` no ambiente
+- `ruby -e "require 'yaml'; YAML.load_file(...)"` — **passou**
+
+**Limitações ou pendências:**
+- ainda existem termos técnicos em inglês preservados por compatibilidade de nomenclatura de domínio (ex.: `job`, `worker`, `lineage`)
+- não foi executada validação externa via editor Swagger remoto; validação local ficou restrita ao parser YAML do ambiente
+
+**Próximo passo sugerido:**
+- revisar com o time de produto se devem ser traduzidos também nomes de tags e exemplos de payload exibidos na UI de documentação
+- alinhar eventual dicionário oficial de termos OPRM pt-BR para manter consistência entre backend, frontend e worker

--- a/docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml
+++ b/docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: OPRM — Backend Required Endpoints
+  title: OPRM — Endpoints obrigatórios do backend
   version: 1.1.0
   description: |
     Contrato consolidado dos endpoints que o backend principal deve oferecer para o OPRM operar
@@ -52,7 +52,7 @@ paths:
   /api/oprm/jobs/claim:
     post:
       tags: [jobs]
-      summary: Claim de job disponível para processamento do OPRM
+      summary: Reserva (claim) de job disponível para processamento do OPRM
       operationId: claimOprmJob
       requestBody:
         required: true
@@ -70,13 +70,13 @@ paths:
         '204':
           description: Nenhum job disponível no momento.
         '409':
-          description: Conflito de lock/claim.
+          description: Conflito de bloqueio (lock) ou reserva (claim).
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OprmApiErrorResponse'
         '422':
-          description: Contrato inválido (versão incompatível ou payload inconsistente).
+          description: Contrato inválido (versão incompatível ou corpo da requisição inconsistente).
           content:
             application/json:
               schema:
@@ -242,7 +242,7 @@ paths:
   /api/oprm/workspace/insights/{occupationSeedRef}:
     get:
       tags: [workspace]
-      summary: Retorna evidências e timeline para a tela de insights
+      summary: Retorna evidências e linha do tempo para a tela de insights
       operationId: getOprmInsightsWorkspace
       parameters:
         - in: path
@@ -252,7 +252,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Dados agregados de evidência, lineage e feedback.
+          description: Dados agregados de evidência, rastreabilidade (lineage) e feedback.
           content:
             application/json:
               schema:
@@ -288,7 +288,7 @@ paths:
   /api/oprm/feedback/history:
     get:
       tags: [feedback]
-      summary: Lista histórico de feedback por ocupação/persona
+      summary: Lista o histórico de feedback por ocupação e persona
       operationId: listOprmFeedbackHistory
       parameters:
         - in: query
@@ -314,7 +314,7 @@ paths:
   /api/oprm/heartbeat:
     post:
       tags: [operations]
-      summary: Heartbeat operacional do worker OPRM
+      summary: Sinal de vida (heartbeat) operacional do worker OPRM
       operationId: publishOprmHeartbeat
       requestBody:
         required: true
@@ -324,9 +324,9 @@ paths:
               $ref: '#/components/schemas/OprmHeartbeatRequest'
       responses:
         '202':
-          description: Heartbeat recebido.
+          description: Sinal de vida recebido.
         '422':
-          description: Heartbeat inválido.
+          description: Sinal de vida inválido.
           content:
             application/json:
               schema:
@@ -361,7 +361,7 @@ components:
           type: string
         contractVersion:
           type: string
-          example: '1.0'
+          example: '1.1.0'
         maxJobs:
           type: integer
           minimum: 1
@@ -407,7 +407,7 @@ components:
         lastUpdatedAt:
           type: string
           nullable: true
-          description: Timestamp serializado pelo backend.
+          description: Data/hora serializada pelo backend em padrão ISO-8601.
 
     OprmJobDetailResponse:
       type: object
@@ -618,6 +618,9 @@ components:
           items:
             type: object
             additionalProperties: true
+      description: |
+        Resposta agregada para a tela Rotina no contexto brasileiro, consolidando
+        sinais de dores, resultados e oportunidades de mecanismo da ocupação mapeada.
 
     OprmInsightsWorkspaceResponse:
       type: object
@@ -655,6 +658,9 @@ components:
           type: object
           additionalProperties: true
           nullable: true
+      description: |
+        Resposta para a tela de Evidências, com linha do tempo dos artefatos,
+        fontes observadas e snapshots de feedback para auditoria operacional.
 
     OprmFeedbackPublishRequest:
       type: object
@@ -679,6 +685,7 @@ components:
           type: string
         personaLabel:
           type: string
+          example: personal trainer autônomo
         baselineRoutineArtifactId:
           type: string
         baselineFrameworkArtifactId:
@@ -697,6 +704,7 @@ components:
           additionalProperties: true
         generatedAt:
           type: string
+          description: Data/hora de geração do snapshot de feedback em ISO-8601.
 
     OprmFeedbackHistoryEntry:
       type: object
@@ -728,6 +736,7 @@ components:
         notes:
           type: string
           nullable: true
+          description: Observações opcionais da equipe sobre a recalibração.
 
     OprmHeartbeatRequest:
       type: object
@@ -739,7 +748,7 @@ components:
           type: string
         contractVersion:
           type: string
-          example: '1.0'
+          example: '1.1.0'
         sentAt:
           type: string
         health:
@@ -763,6 +772,7 @@ components:
         details:
           type: string
           nullable: true
+          description: Detalhes adicionais úteis para diagnóstico operacional.
 
     OprmJobType:
       type: string


### PR DESCRIPTION
### Motivation
- Padronizar e localizar a documentação do contrato OpenAPI do OPRM para português do Brasil, facilitando leitura e alinhamento com times locais sem alterar a estrutura técnica do contrato.

### Description
- Traduzi e adaptei textos visíveis do Swagger (`docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml`) incluindo título, summaries e descrições operacionais (ex.: reserva/claim de job, linha do tempo/insights, sinal de vida/heartbeat).
- Adicionei descrições contextuais em schemas de resposta/erro e campos (ex.: `lastUpdatedAt` ISO-8601, `generatedAt` do feedback, `details` em `OprmApiErrorResponse`) e incluí um exemplo de `personaLabel` em português.
- Atualizei o exemplo de `contractVersion` para `1.1.0` em schemas relevantes e preservei nomenclaturas técnicas em inglês (`job`, `worker`, `lineage`) para evitar drift entre consumidores.
- Registrei a etapa no histórico incremental (`docs/history/oprm-implementation-history.md`) com resumo da mudança, arquivos afetados e próximos passos sugeridos.

### Testing
- `ruby -e "require 'yaml'; YAML.load_file('docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml')"` — passou (parsing YAML localmente com Ruby).
- `ruby -e "require 'yaml'; YAML.safe_load_file('docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml')"` — passou (validação adicional de parse local).
- `git diff --check` — passou (checagem de whitespace/diff).
- `python - <<'PY' ... yaml.safe_load(...)` — falhou por ausência do módulo `yaml` no ambiente (limitação do runner).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1407bb4c0832194f5e97a26ae91a3)