### PR TITLE
Melhora observabilidade OPRM com logs estruturados

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmArtifactService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +30,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OprmArtifactService {
     private final OprmArtifactRepository artifactRepository;
     private final OprmJobRepository jobRepository;
@@ -38,6 +40,8 @@ public class OprmArtifactService {
     public OprmArtifactPublishResponseDto publishArtifact(OprmArtifactPublishRequestDto request) {
         OprmArtifact duplicatedArtifact = artifactRepository.findByIdempotencyKey(request.idempotencyKey()).orElse(null);
         if (duplicatedArtifact != null) {
+            log.info("oprm-artifact-duplicate idempotencyKey={} artifactId={} correlationId={}",
+                    request.idempotencyKey(), duplicatedArtifact.getArtifactId(), duplicatedArtifact.getCorrelationId());
             return new OprmArtifactPublishResponseDto(
                     duplicatedArtifact.getArtifactId(),
                     duplicatedArtifact.getArtifactType(),
@@ -89,6 +93,9 @@ public class OprmArtifactService {
                 .confidenceScore(toBigDecimal(artifactEnvelope.confidenceScore()))
                 .idempotencyKey(request.idempotencyKey())
                 .build());
+        log.info("oprm-artifact-published jobId={} artifactId={} artifactType={} artifactVersion={} correlationId={} status={}",
+                jobId, saved.getArtifactId(), saved.getArtifactType(), saved.getArtifactVersion(),
+                saved.getCorrelationId(), saved.getArtifactStatus());
 
         return new OprmArtifactPublishResponseDto(
                 saved.getArtifactId(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmFeedbackService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmFeedbackService.java
@@ -16,6 +16,7 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OprmFeedbackService {
     private final OprmJobRepository jobRepository;
     private final OprmFeedbackSnapshotRepository feedbackSnapshotRepository;
@@ -70,6 +72,8 @@ public class OprmFeedbackService {
                 .notes("feedback snapshot persisted from OPRM worker")
                 .build();
         feedbackHistoryRepository.save(history);
+        log.info("oprm-feedback-published jobId={} correlationId={} occupationName={} personaLabel={} generatedAt={}",
+                job.getId(), request.correlationId(), request.occupationName(), request.personaLabel(), generatedAt);
     }
 
     @Transactional(readOnly = true)

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +31,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OprmJobOrchestrationService {
     private final OprmJobRepository jobRepository;
     private final OprmJobInputRepository jobInputRepository;
@@ -63,6 +65,8 @@ public class OprmJobOrchestrationService {
                 .message("job created via backend orchestration")
                 .occurredAt(Instant.now())
                 .build());
+        log.info("oprm-job-created jobId={} jobType={} occupationSeedRef={} correlationId={}",
+                saved.getId(), saved.getJobType(), saved.getOccupationSeedRef(), saved.getCorrelationId());
 
         return toJobDetail(saved, jobInputRepository.findByJobIdOrderByCreatedAtAsc(saved.getId()));
     }
@@ -71,6 +75,7 @@ public class OprmJobOrchestrationService {
     public Optional<OprmJobClaimResponseDto> claimNextJob(OprmJobClaimRequestDto request) {
         Optional<UUID> nextJobId = jobRepository.findNextPendingJobId();
         if (nextJobId.isEmpty()) {
+            log.debug("oprm-job-claim-empty workerId={} leaseSeconds={}", request.workerId(), request.leaseSeconds());
             return Optional.empty();
         }
 
@@ -100,6 +105,8 @@ public class OprmJobOrchestrationService {
                 .message("job claimed by worker")
                 .occurredAt(now)
                 .build());
+        log.info("oprm-job-claimed jobId={} workerId={} leaseExpiresAt={}",
+                job.getId(), request.workerId(), job.getLeaseExpiresAt());
 
         return Optional.of(new OprmJobClaimResponseDto(
                 job.getId().toString(),
@@ -141,6 +148,7 @@ public class OprmJobOrchestrationService {
     public void updateJobStatus(UUID jobId, OprmJobStatusUpdateRequestDto request) {
         OprmJob job = jobRepository.findById(jobId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM job not found"));
+        OprmJobStatus previousStatus = job.getJobStatus();
 
         OprmJobStatus requestedStatus = request.status();
         if (!isTransitionAllowed(job.getJobStatus(), requestedStatus)) {
@@ -175,6 +183,8 @@ public class OprmJobOrchestrationService {
                 .workerId(request.workerId())
                 .occurredAt(parseOccurredAt(request.occurredAt()))
                 .build());
+        log.info("oprm-job-status-updated jobId={} previousStatus={} newStatus={} workerId={} phase={} errorCode={}",
+                job.getId(), previousStatus, requestedStatus, request.workerId(), request.phase(), job.getErrorCode());
     }
 
     private OprmJobDetailResponseDto toJobDetail(OprmJob job, List<OprmJobInput> inputs) {


### PR DESCRIPTION
### Motivation
- O módulo OPRM tinha pouca telemetria além do `oprm-heartbeat`, dificultando distinguir inatividade de falta de logs. 
- Inserir logs explícitos em pontos-chave facilita diagnóstico operacional e rastreio de jobs, artefatos e feedbacks. 

### Description
- Adiciona `@Slf4j` e logs estruturados em `OprmJobOrchestrationService` para registro de criação de job (`oprm-job-created`), ausência de job para claim em nível `DEBUG` (`oprm-job-claim-empty`), claim bem-sucedido (`oprm-job-claimed`) e atualização de status (`oprm-job-status-updated`). 
- Adiciona `@Slf4j` e log de deduplicação (`oprm-artifact-duplicate`) e publicação de artefato (`oprm-artifact-published`) em `OprmArtifactService`. 
- Adiciona `@Slf4j` e log de publicação de feedback (`oprm-feedback-published`) em `OprmFeedbackService`. 
- Arquivos modificados: `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java`, `OprmArtifactService.java`, `OprmFeedbackService.java`.

### Testing
- Executados comandos de inspeção de código e busca: `rg`, `cat` e leituras dos arquivos relevantes, todos concluídos com sucesso. 
- Tentei compilar com `cd backend/ads-service && mvn -s ../settings.xml -DskipTests compile`, mas a tentativa falhou por limitação ambiental: dependências não puderam ser baixadas (`Network is unreachable` para o Maven Central). 
- Nenhum teste automatizado foi executado dentro deste ambiente por causa da falha de resolução de dependências.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1498182548321a26d09c03c5de03b)