### PR TITLE
OPRM: add occupation catalog (CRUD) with frontend UI and job validation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmOccupation.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/OprmOccupation.java
@@ -1,0 +1,52 @@
+package com.marketinghub.oprm;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OprmOccupation {
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    @JdbcTypeCode(SqlTypes.CHAR)
+    @Column(name = "id", nullable = false, length = 36)
+    private UUID id;
+
+    @Column(name = "occupation_seed_ref", nullable = false, length = 191, unique = true)
+    private String occupationSeedRef;
+
+    @Column(name = "display_name", nullable = false, length = 191)
+    private String displayName;
+
+    @Column(name = "aliases_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String aliasesJson;
+
+    @Builder.Default
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmOccupationResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmOccupationResponseDto.java
@@ -1,0 +1,14 @@
+package com.marketinghub.oprm.dto;
+
+import java.util.List;
+
+public record OprmOccupationResponseDto(
+        String id,
+        String occupationSeedRef,
+        String displayName,
+        List<String> aliases,
+        boolean active,
+        String createdAt,
+        String updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmOccupationUpsertRequestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/dto/OprmOccupationUpsertRequestDto.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record OprmOccupationUpsertRequestDto(
+        @NotBlank String occupationSeedRef,
+        @NotBlank String displayName,
+        List<String> aliases,
+        boolean active
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmOccupationRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmOccupationRepository.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.repository;
+
+import com.marketinghub.oprm.OprmOccupation;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OprmOccupationRepository extends JpaRepository<OprmOccupation, UUID> {
+    List<OprmOccupation> findAllByOrderByDisplayNameAsc();
+
+    Optional<OprmOccupation> findByOccupationSeedRefIgnoreCase(String occupationSeedRef);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java
@@ -11,6 +11,7 @@ import com.marketinghub.oprm.dto.OprmJobDetailResponseDto;
 import com.marketinghub.oprm.dto.OprmJobStatusUpdateRequestDto;
 import com.marketinghub.oprm.dto.OprmWorkspaceOccupationSummaryDto;
 import com.marketinghub.oprm.repository.OprmJobEventRepository;
+import com.marketinghub.oprm.repository.OprmOccupationRepository;
 import com.marketinghub.oprm.repository.OprmJobInputRepository;
 import com.marketinghub.oprm.repository.OprmJobRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -36,14 +37,21 @@ public class OprmJobOrchestrationService {
     private final OprmJobRepository jobRepository;
     private final OprmJobInputRepository jobInputRepository;
     private final OprmJobEventRepository jobEventRepository;
+    private final OprmOccupationRepository occupationRepository;
     private final ObjectMapper objectMapper;
 
     @Transactional
     public OprmJobDetailResponseDto createJob(OprmCreateJobRequestDto request) {
+        String normalizedOccupationSeedRef = request.occupationSeedRef().trim().toLowerCase();
+        occupationRepository.findByOccupationSeedRefIgnoreCase(normalizedOccupationSeedRef)
+                .filter(com.marketinghub.oprm.OprmOccupation::isActive)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "occupationSeedRef is not active in OPRM catalog"));
+
         OprmJob job = OprmJob.builder()
                 .jobType(request.jobType())
                 .jobStatus(OprmJobStatus.PENDING)
-                .occupationSeedRef(request.occupationSeedRef())
+                .occupationSeedRef(normalizedOccupationSeedRef)
                 .correlationId(resolveCorrelationId(request.correlationId()))
                 .build();
         OprmJob saved = jobRepository.save(job);

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmOccupationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmOccupationService.java
@@ -1,0 +1,133 @@
+package com.marketinghub.oprm.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.oprm.OprmOccupation;
+import com.marketinghub.oprm.dto.OprmOccupationResponseDto;
+import com.marketinghub.oprm.dto.OprmOccupationUpsertRequestDto;
+import com.marketinghub.oprm.repository.OprmOccupationRepository;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class OprmOccupationService {
+    private static final TypeReference<List<String>> STRING_LIST = new TypeReference<>() {
+    };
+
+    private final OprmOccupationRepository repository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(readOnly = true)
+    public List<OprmOccupationResponseDto> listOccupations() {
+        return repository.findAllByOrderByDisplayNameAsc().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public OprmOccupationResponseDto createOccupation(OprmOccupationUpsertRequestDto request) {
+        String normalizedSeedRef = normalizeSeedRef(request.occupationSeedRef());
+        repository.findByOccupationSeedRefIgnoreCase(normalizedSeedRef).ifPresent(existing -> {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "occupationSeedRef already exists");
+        });
+
+        OprmOccupation saved = repository.save(OprmOccupation.builder()
+                .occupationSeedRef(normalizedSeedRef)
+                .displayName(request.displayName().trim())
+                .aliasesJson(writeAliasesJson(request.aliases()))
+                .active(request.active())
+                .build());
+
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public OprmOccupationResponseDto updateOccupation(UUID id, OprmOccupationUpsertRequestDto request) {
+        OprmOccupation occupation = repository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM occupation not found"));
+
+        String normalizedSeedRef = normalizeSeedRef(request.occupationSeedRef());
+        repository.findByOccupationSeedRefIgnoreCase(normalizedSeedRef)
+                .filter(existing -> !existing.getId().equals(id))
+                .ifPresent(existing -> {
+                    throw new ResponseStatusException(HttpStatus.CONFLICT, "occupationSeedRef already exists");
+                });
+
+        occupation.setOccupationSeedRef(normalizedSeedRef);
+        occupation.setDisplayName(request.displayName().trim());
+        occupation.setAliasesJson(writeAliasesJson(request.aliases()));
+        occupation.setActive(request.active());
+
+        return toResponse(repository.save(occupation));
+    }
+
+    @Transactional
+    public void deleteOccupation(UUID id) {
+        if (!repository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "OPRM occupation not found");
+        }
+        repository.deleteById(id);
+    }
+
+    private OprmOccupationResponseDto toResponse(OprmOccupation occupation) {
+        return new OprmOccupationResponseDto(
+                occupation.getId().toString(),
+                occupation.getOccupationSeedRef(),
+                occupation.getDisplayName(),
+                readAliases(occupation.getAliasesJson()),
+                occupation.isActive(),
+                toIso(occupation.getCreatedAt()),
+                toIso(occupation.getUpdatedAt())
+        );
+    }
+
+    private String toIso(Instant value) {
+        return value == null ? null : value.toString();
+    }
+
+    private String normalizeSeedRef(String value) {
+        String normalized = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+        if (normalized.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "occupationSeedRef is required");
+        }
+        return normalized;
+    }
+
+    private String writeAliasesJson(List<String> aliases) {
+        List<String> normalizedAliases = aliases == null
+                ? List.of()
+                : aliases.stream()
+                        .map(alias -> alias == null ? "" : alias.trim())
+                        .filter(alias -> !alias.isBlank())
+                        .collect(java.util.stream.Collectors.collectingAndThen(
+                                java.util.stream.Collectors.toCollection(LinkedHashSet::new),
+                                List::copyOf
+                        ));
+        try {
+            return objectMapper.writeValueAsString(normalizedAliases);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "aliases payload is invalid");
+        }
+    }
+
+    private List<String> readAliases(String aliasesJson) {
+        if (aliasesJson == null || aliasesJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(aliasesJson, STRING_LIST);
+        } catch (JsonProcessingException e) {
+            return List.of();
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmOccupationController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmOccupationController.java
@@ -1,0 +1,49 @@
+package com.marketinghub.oprm.web;
+
+import com.marketinghub.oprm.dto.OprmOccupationResponseDto;
+import com.marketinghub.oprm.dto.OprmOccupationUpsertRequestDto;
+import com.marketinghub.oprm.service.OprmOccupationService;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/oprm/occupations")
+@RequiredArgsConstructor
+public class OprmOccupationController {
+    private final OprmOccupationService service;
+
+    @GetMapping
+    public List<OprmOccupationResponseDto> list() {
+        return service.listOccupations();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public OprmOccupationResponseDto create(@Valid @RequestBody OprmOccupationUpsertRequestDto request) {
+        return service.createOccupation(request);
+    }
+
+    @PutMapping("/{occupationId}")
+    public OprmOccupationResponseDto update(@PathVariable UUID occupationId,
+                                            @Valid @RequestBody OprmOccupationUpsertRequestDto request) {
+        return service.updateOccupation(occupationId, request);
+    }
+
+    @DeleteMapping("/{occupationId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID occupationId) {
+        service.deleteOccupation(occupationId);
+    }
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-16-oprm-occupation-catalog.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-16-oprm-occupation-catalog.yaml
@@ -1,0 +1,115 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-04-16-01-oprm-occupation-catalog
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        dbms:
+          type: mysql
+        not:
+          tableExists:
+            tableName: oprm_occupation
+      changes:
+        - createTable:
+            tableName: oprm_occupation
+            columns:
+              - column:
+                  name: id
+                  type: CHAR(36)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: occupation_seed_ref
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: display_name
+                  type: VARCHAR(191)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: aliases_json
+                  type: LONGTEXT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: active
+                  type: BIT(1)
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  defaultValueComputed: CURRENT_TIMESTAMP(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  defaultValueComputed: CURRENT_TIMESTAMP(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: oprm_occupation
+            columnNames: occupation_seed_ref
+            constraintName: uk_oprm_occupation_seed_ref
+        - createIndex:
+            tableName: oprm_occupation
+            indexName: idx_oprm_occupation_active_display
+            columns:
+              - column:
+                  name: active
+              - column:
+                  name: display_name
+        - insert:
+            tableName: oprm_occupation
+            columns:
+              - column: { name: id, value: "3a1bda9f-1023-4df3-b151-9af69a10c101" }
+              - column: { name: occupation_seed_ref, value: "personal trainer" }
+              - column: { name: display_name, value: "Personal Trainer" }
+              - column: { name: aliases_json, value: '["treinador pessoal","pt"]' }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: oprm_occupation
+            columns:
+              - column: { name: id, value: "3a1bda9f-1023-4df3-b151-9af69a10c102" }
+              - column: { name: occupation_seed_ref, value: "pastor" }
+              - column: { name: display_name, value: "Pastor" }
+              - column: { name: aliases_json, value: '["líder religioso evangélico","ministro pastoral"]' }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: oprm_occupation
+            columns:
+              - column: { name: id, value: "3a1bda9f-1023-4df3-b151-9af69a10c103" }
+              - column: { name: occupation_seed_ref, value: "agricultor" }
+              - column: { name: display_name, value: "Agricultor" }
+              - column: { name: aliases_json, value: '["produtor rural","lavrador"]' }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: oprm_occupation
+            columns:
+              - column: { name: id, value: "3a1bda9f-1023-4df3-b151-9af69a10c104" }
+              - column: { name: occupation_seed_ref, value: "manicure" }
+              - column: { name: display_name, value: "Manicure" }
+              - column: { name: aliases_json, value: '["nail designer","profissional de unhas"]' }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: oprm_occupation
+            columns:
+              - column: { name: id, value: "3a1bda9f-1023-4df3-b151-9af69a10c105" }
+              - column: { name: occupation_seed_ref, value: "cabeleireiro" }
+              - column: { name: display_name, value: "Cabeleireiro" }
+              - column: { name: aliases_json, value: '["hair stylist","profissional de salão"]' }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: oprm_occupation
+            columns:
+              - column: { name: id, value: "3a1bda9f-1023-4df3-b151-9af69a10c106" }
+              - column: { name: occupation_seed_ref, value: "dono de loja de celulares" }
+              - column: { name: display_name, value: "Dono de Loja de Celulares" }
+              - column: { name: aliases_json, value: '["lojista de celulares","comerciante de smartphones"]' }
+              - column: { name: active, valueBoolean: true }

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-04-16-oprm-occupation-catalog.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-04-15-oprm-feedback-loop.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/history/oprm-implementation-history.md
+++ b/docs/history/oprm-implementation-history.md
@@ -953,3 +953,53 @@ Foi atualizada a documentação OpenAPI de endpoints obrigatórios do backend OP
 **Próximo passo sugerido:**
 - revisar com o time de produto se devem ser traduzidos também nomes de tags e exemplos de payload exibidos na UI de documentação
 - alinhar eventual dicionário oficial de termos OPRM pt-BR para manter consistência entre backend, frontend e worker
+
+## 2026-04-16 — sprint catálogo de ocupações: CRUD backend + tela administrativa
+
+**Status:** concluído
+
+**Resumo:**
+Foi implementado o gerenciamento completo de ocupações do OPRM com CRUD no backend principal e nova tela administrativa no frontend, permitindo cadastrar, alterar e excluir ocupações com persistência em tabela dedicada e validação de ocupações ativas na criação de jobs.
+
+**O que foi implementado:**
+- criação da tabela `oprm_occupation` via Liquibase com índices, restrição de unicidade e seed inicial das ocupações MVP
+- criação de entidade, repositório, DTOs, serviço e controller para o contrato `GET/POST/PUT/DELETE /api/oprm/occupations`
+- validação no fluxo de criação de job OPRM para aceitar apenas `occupationSeedRef` ativa no catálogo
+- criação da tela `OPRM · Catálogo de Ocupações` no frontend com formulário e ações de editar/excluir
+- inclusão da rota `/oprm/occupations` e novo item `Catálogo` na navegação interna do módulo OPRM
+- atualização da documentação de modelo de dados e do contrato OpenAPI consolidado do backend OPRM
+
+**Arquivos principais alterados:**
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/OprmOccupation.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/repository/OprmOccupationRepository.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmOccupationService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmOccupationController.java`
+- `backend/ads-service/src/main/java/com/marketinghub/oprm/service/OprmJobOrchestrationService.java`
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-16-oprm-occupation-catalog.yaml`
+- `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`
+- `frontend/src/pages/oprm/OprmOccupationCatalogPage.tsx`
+- `frontend/src/api/oprm/useOprmOccupationCatalog.ts`
+- `frontend/src/pages/oprm/OprmModuleNavigation.tsx`
+- `frontend/src/pages/oprm/OprmWorkspacePage.tsx`
+- `frontend/src/App.tsx`
+- `frontend/src/__tests__/OprmNavigation.test.tsx`
+- `docs/modelo-dados-experimento.md`
+- `docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml`
+
+**Contratos / artefatos afetados:**
+- endpoints novos: `GET /api/oprm/occupations`, `POST /api/oprm/occupations`, `PUT /api/oprm/occupations/{occupationId}`, `DELETE /api/oprm/occupations/{occupationId}`
+- endpoint ajustado: `POST /api/oprm/jobs` (validação de `occupationSeedRef` ativa no catálogo)
+- nenhum artefato canônico novo
+
+**Testes executados:**
+- `cd frontend && npm run test -- --run src/__tests__/OprmNavigation.test.tsx` — **passou**
+- `cd frontend && npm run build` — **passou**
+- `cd backend/ads-service && mvn -s ../settings.xml -DskipTests compile` — **passou**
+
+**Limitações ou pendências:**
+- o worker OPRM ainda mantém catálogo local estruturado para geração de payload detalhado (sumário, tarefas, skills), portanto o CRUD atual governa seed e ativação no backend, mas não substitui automaticamente o catálogo interno do worker
+- não foi adicionada tela de confirmação modal para exclusão; a ação é imediata no clique do botão
+
+**Próximo passo sugerido:**
+- integrar o worker OPRM para consumir o catálogo gerenciado do backend como fonte única de ocupações e aliases
+- evoluir o catálogo para incluir campos estruturados completos do perfil ocupacional (sumário, tarefas, skills e contexto de trabalho)

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -425,3 +425,24 @@ Para sustentar a Fase 3 do framework, foram criadas duas novas tabelas vinculada
   - `insights_json` e `suggestions_json` armazenam, em JSON, listas tipadas de insights (Dor/Resultado/Mecanismo/Prova/Oferta) e recomendações de backlog.
 
 Essas tabelas alimentam a nova API de "Banco de aprendizados" e o recomendador de backlog por nicho. Cada novo aprendizado nasce de uma `EXPERIMENT_LEARNING_REQUEST` consumida pelo AI Worker, garantindo rastreabilidade e versionamento dos insights.
+
+## Catálogo de ocupações do OPRM
+
+Para suportar o gerenciamento administrativo de ocupações no módulo OPRM (cadastro, alteração e exclusão), foi adicionada a entidade de catálogo abaixo no backend principal:
+
+### OPRM_OCCUPATION
+
+| Campo | Tipo | Descrição |
+| --- | --- | --- |
+| id | CHAR(36) PK | Identificador UUID textual da ocupação |
+| occupation_seed_ref | VARCHAR(191) UNIQUE | Referência estável usada nos jobs e no workspace OPRM |
+| display_name | VARCHAR(191) | Nome amigável exibido na UI |
+| aliases_json | LONGTEXT | Lista JSON de aliases da ocupação |
+| active | BIT(1) | Flag operacional para liberar uso da ocupação no fluxo de jobs |
+| created_at / updated_at | DATETIME(6) | Auditoria padrão |
+
+**Relacionamentos e uso operacional**
+
+- `OPRM_OCCUPATION` não substitui `OPRM_JOB`; ela governa o catálogo permitido para criação de novos jobs OPRM.
+- A criação de job (`POST /api/oprm/jobs`) valida se `occupation_seed_ref` está ativa no catálogo.
+- A UI do OPRM passa a consumir endpoints dedicados de catálogo (`/api/oprm/occupations`) para CRUD administrativo.

--- a/docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml
+++ b/docs/novos-modulos/OPRM/oprm-backend-required-endpoints.swagger.yaml
@@ -18,6 +18,8 @@ tags:
     description: Publicação e consulta de artefatos canônicos OPRM
   - name: workspace
     description: Endpoints de leitura para telas do módulo OPRM
+  - name: occupation-catalog
+    description: Gestão administrativa do catálogo de ocupações do OPRM
   - name: feedback
     description: Feedback loop e histórico de recalibração
   - name: operations
@@ -96,6 +98,96 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/OprmWorkspaceOccupationSummary'
+
+  /api/oprm/occupations:
+    get:
+      tags: [occupation-catalog]
+      summary: Lista ocupações cadastradas no catálogo do OPRM
+      operationId: listOprmOccupations
+      responses:
+        '200':
+          description: Lista de ocupações do catálogo.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OprmOccupationCatalogItem'
+    post:
+      tags: [occupation-catalog]
+      summary: Cadastra uma ocupação no catálogo do OPRM
+      operationId: createOprmOccupation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OprmOccupationCatalogUpsertRequest'
+      responses:
+        '201':
+          description: Ocupação cadastrada com sucesso.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmOccupationCatalogItem'
+        '409':
+          description: occupationSeedRef já cadastrado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+
+  /api/oprm/occupations/{occupationId}:
+    put:
+      tags: [occupation-catalog]
+      summary: Atualiza uma ocupação do catálogo do OPRM
+      operationId: updateOprmOccupation
+      parameters:
+        - in: path
+          name: occupationId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OprmOccupationCatalogUpsertRequest'
+      responses:
+        '200':
+          description: Ocupação atualizada com sucesso.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmOccupationCatalogItem'
+        '404':
+          description: Ocupação não encontrada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
+    delete:
+      tags: [occupation-catalog]
+      summary: Exclui uma ocupação do catálogo do OPRM
+      operationId: deleteOprmOccupation
+      parameters:
+        - in: path
+          name: occupationId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Ocupação excluída com sucesso.
+        '404':
+          description: Ocupação não encontrada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OprmApiErrorResponse'
 
   /api/oprm/jobs/{jobId}:
     get:
@@ -389,6 +481,48 @@ components:
           type: string
           format: date-time
         leaseExpiresAt:
+          type: string
+          format: date-time
+
+    OprmOccupationCatalogUpsertRequest:
+      type: object
+      required: [occupationSeedRef, displayName]
+      properties:
+        occupationSeedRef:
+          type: string
+          example: dentista
+        displayName:
+          type: string
+          example: Dentista
+        aliases:
+          type: array
+          items:
+            type: string
+          example: [odontologista, odonto]
+        active:
+          type: boolean
+          example: true
+
+    OprmOccupationCatalogItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        occupationSeedRef:
+          type: string
+        displayName:
+          type: string
+        aliases:
+          type: array
+          items:
+            type: string
+        active:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
           type: string
           format: date-time
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -114,6 +114,7 @@ import OprmOfferPage from "./pages/oprm/OprmOfferPage";
 import OprmEvidencePage from "./pages/oprm/OprmEvidencePage";
 import OprmFeedbackPage from "./pages/oprm/OprmFeedbackPage";
 import OprmOperationsPage from "./pages/oprm/OprmOperationsPage";
+import OprmOccupationCatalogPage from "./pages/oprm/OprmOccupationCatalogPage";
 
 export default function App() {
   return (
@@ -278,6 +279,10 @@ export default function App() {
               <Route
                 path="/oprm/operations"
                 element={<OprmOperationsPage />}
+              />
+              <Route
+                path="/oprm/occupations"
+                element={<OprmOccupationCatalogPage />}
               />
               <Route path="/angles" element={<AnglesPage />} />
               <Route path="/visual-proofs" element={<VisualProofsPage />} />

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -37,4 +37,9 @@ describe("OPRM navigation", () => {
     setup(<App />, ["/oprm/operations"]);
     expect(await screen.findByText(/carregando jobs do oprm/i)).toBeTruthy();
   });
+
+  it("renders loading state on /oprm/occupations route", async () => {
+    setup(<App />, ["/oprm/occupations"]);
+    expect(await screen.findByText(/carregando catálogo de ocupações/i)).toBeTruthy();
+  });
 });

--- a/frontend/src/api/oprm/useOprmOccupationCatalog.ts
+++ b/frontend/src/api/oprm/useOprmOccupationCatalog.ts
@@ -1,0 +1,69 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface OprmOccupationCatalogItem {
+  id: string;
+  occupationSeedRef: string;
+  displayName: string;
+  aliases: string[];
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OprmOccupationCatalogUpsertRequest {
+  occupationSeedRef: string;
+  displayName: string;
+  aliases: string[];
+  active: boolean;
+}
+
+export function useOprmOccupationCatalog() {
+  return useQuery({
+    queryKey: ["oprm", "occupation-catalog"],
+    queryFn: async () => {
+      const { data } = await axios.get<OprmOccupationCatalogItem[]>(
+        "/api/oprm/occupations",
+      );
+      return data;
+    },
+  });
+}
+
+export function useCreateOprmOccupation() {
+  return useMutation({
+    mutationFn: async (request: OprmOccupationCatalogUpsertRequest) => {
+      const { data } = await axios.post<OprmOccupationCatalogItem>(
+        "/api/oprm/occupations",
+        request,
+      );
+      return data;
+    },
+  });
+}
+
+export function useUpdateOprmOccupation() {
+  return useMutation({
+    mutationFn: async ({
+      occupationId,
+      request,
+    }: {
+      occupationId: string;
+      request: OprmOccupationCatalogUpsertRequest;
+    }) => {
+      const { data } = await axios.put<OprmOccupationCatalogItem>(
+        `/api/oprm/occupations/${occupationId}`,
+        request,
+      );
+      return data;
+    },
+  });
+}
+
+export function useDeleteOprmOccupation() {
+  return useMutation({
+    mutationFn: async (occupationId: string) => {
+      await axios.delete(`/api/oprm/occupations/${occupationId}`);
+    },
+  });
+}

--- a/frontend/src/pages/oprm/OprmModuleNavigation.tsx
+++ b/frontend/src/pages/oprm/OprmModuleNavigation.tsx
@@ -10,7 +10,8 @@ interface OprmNavItem {
 }
 
 const baseItems: OprmNavItem[] = [
-  { label: "Ocupações", to: "/oprm" },
+  { label: "Workspace", to: "/oprm" },
+  { label: "Catálogo", to: "/oprm/occupations" },
   { label: "Operações", to: "/oprm/operations" },
 ];
 

--- a/frontend/src/pages/oprm/OprmOccupationCatalogPage.tsx
+++ b/frontend/src/pages/oprm/OprmOccupationCatalogPage.tsx
@@ -1,0 +1,285 @@
+import { FormEvent, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { AlertCircle, Pencil, Plus, Trash2 } from "lucide-react";
+import PageTitle from "../../components/PageTitle";
+import {
+  type OprmOccupationCatalogItem,
+  useCreateOprmOccupation,
+  useDeleteOprmOccupation,
+  useOprmOccupationCatalog,
+  useUpdateOprmOccupation,
+} from "../../api/oprm/useOprmOccupationCatalog";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+
+interface CatalogFormState {
+  occupationSeedRef: string;
+  displayName: string;
+  aliasesText: string;
+  active: boolean;
+}
+
+const INITIAL_FORM: CatalogFormState = {
+  occupationSeedRef: "",
+  displayName: "",
+  aliasesText: "",
+  active: true,
+};
+
+function toRequestPayload(form: CatalogFormState) {
+  return {
+    occupationSeedRef: form.occupationSeedRef.trim(),
+    displayName: form.displayName.trim(),
+    aliases: form.aliasesText
+      .split(",")
+      .map((alias) => alias.trim())
+      .filter((alias) => alias.length > 0),
+    active: form.active,
+  };
+}
+
+export default function OprmOccupationCatalogPage() {
+  const queryClient = useQueryClient();
+  const occupationCatalogQuery = useOprmOccupationCatalog();
+  const createMutation = useCreateOprmOccupation();
+  const updateMutation = useUpdateOprmOccupation();
+  const deleteMutation = useDeleteOprmOccupation();
+
+  const [formState, setFormState] = useState<CatalogFormState>(INITIAL_FORM);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const occupationCatalog = occupationCatalogQuery.data ?? [];
+  const sortedCatalog = useMemo(
+    () => [...occupationCatalog].sort((a, b) => a.displayName.localeCompare(b.displayName, "pt-BR")),
+    [occupationCatalog],
+  );
+
+  function startEdit(item: OprmOccupationCatalogItem) {
+    setEditingId(item.id);
+    setFormState({
+      occupationSeedRef: item.occupationSeedRef,
+      displayName: item.displayName,
+      aliasesText: item.aliases.join(", "),
+      active: item.active,
+    });
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (editingId) {
+      await updateMutation.mutateAsync({
+        occupationId: editingId,
+        request: toRequestPayload(formState),
+      });
+    } else {
+      await createMutation.mutateAsync(toRequestPayload(formState));
+    }
+
+    await queryClient.invalidateQueries({ queryKey: ["oprm", "occupation-catalog"] });
+    setEditingId(null);
+    setFormState(INITIAL_FORM);
+  }
+
+  async function handleDelete(occupationId: string) {
+    setDeletingId(occupationId);
+    try {
+      await deleteMutation.mutateAsync(occupationId);
+      await queryClient.invalidateQueries({ queryKey: ["oprm", "occupation-catalog"] });
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  const saving = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>OPRM · Catálogo de Ocupações</PageTitle>
+        <p className="text-secondary mb-0">
+          Cadastre, altere e exclua ocupações que podem ser usadas no fluxo do OPRM.
+        </p>
+      </header>
+
+      <OprmModuleNavigation />
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <form className="row g-3" onSubmit={handleSubmit}>
+            <div className="col-12 col-lg-4">
+              <label className="form-label" htmlFor="oprm-occupation-seed-ref">
+                Referência da ocupação *
+              </label>
+              <input
+                id="oprm-occupation-seed-ref"
+                className="form-control"
+                value={formState.occupationSeedRef}
+                onChange={(event) =>
+                  setFormState((current) => ({ ...current, occupationSeedRef: event.target.value }))
+                }
+                placeholder="Ex.: dentista"
+                required
+              />
+            </div>
+            <div className="col-12 col-lg-4">
+              <label className="form-label" htmlFor="oprm-occupation-display-name">
+                Nome de exibição *
+              </label>
+              <input
+                id="oprm-occupation-display-name"
+                className="form-control"
+                value={formState.displayName}
+                onChange={(event) =>
+                  setFormState((current) => ({ ...current, displayName: event.target.value }))
+                }
+                placeholder="Ex.: Dentista"
+                required
+              />
+            </div>
+            <div className="col-12 col-lg-4">
+              <label className="form-label" htmlFor="oprm-occupation-aliases">
+                Aliases
+              </label>
+              <input
+                id="oprm-occupation-aliases"
+                className="form-control"
+                value={formState.aliasesText}
+                onChange={(event) =>
+                  setFormState((current) => ({ ...current, aliasesText: event.target.value }))
+                }
+                placeholder="Ex.: odontologista, odonto"
+              />
+            </div>
+            <div className="col-12 col-lg-3">
+              <div className="form-check mt-2">
+                <input
+                  id="oprm-occupation-active"
+                  className="form-check-input"
+                  type="checkbox"
+                  checked={formState.active}
+                  onChange={(event) =>
+                    setFormState((current) => ({ ...current, active: event.target.checked }))
+                  }
+                />
+                <label className="form-check-label" htmlFor="oprm-occupation-active">
+                  Ocupação ativa
+                </label>
+              </div>
+            </div>
+            <div className="col-12 col-lg-9 d-flex gap-2 justify-content-end">
+              {editingId ? (
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  onClick={() => {
+                    setEditingId(null);
+                    setFormState(INITIAL_FORM);
+                  }}
+                  disabled={saving}
+                >
+                  Cancelar edição
+                </button>
+              ) : null}
+              <button
+                type="submit"
+                className="btn btn-primary d-inline-flex align-items-center gap-2"
+                disabled={saving || formState.occupationSeedRef.trim().length === 0 || formState.displayName.trim().length === 0}
+              >
+                {saving ? <span className="spinner-border spinner-border-sm" aria-hidden="true" /> : <Plus size={14} aria-hidden="true" />}
+                {editingId ? "Salvar alterações" : "Cadastrar ocupação"}
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      {occupationCatalogQuery.isLoading ? (
+        <div className="d-flex justify-content-center py-5">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Carregando catálogo de ocupações...</span>
+          </div>
+        </div>
+      ) : null}
+
+      {occupationCatalogQuery.isError ? (
+        <div className="alert alert-danger d-flex align-items-start gap-2 mb-0" role="alert">
+          <AlertCircle size={18} className="mt-1" aria-hidden="true" />
+          <div>
+            <strong>Não foi possível carregar o catálogo de ocupações.</strong>
+            <p className="mb-0">Valide a disponibilidade do backend e tente novamente.</p>
+          </div>
+        </div>
+      ) : null}
+
+      {!occupationCatalogQuery.isLoading && !occupationCatalogQuery.isError ? (
+        <section className="card border-0 shadow-sm">
+          <div className="table-responsive">
+            <table className="table table-hover align-middle mb-0">
+              <thead>
+                <tr>
+                  <th scope="col">Referência</th>
+                  <th scope="col">Nome</th>
+                  <th scope="col">Aliases</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedCatalog.length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="text-center py-4 text-secondary">
+                      Nenhuma ocupação cadastrada.
+                    </td>
+                  </tr>
+                ) : (
+                  sortedCatalog.map((item) => {
+                    const isDeleting = deletingId === item.id;
+                    return (
+                      <tr key={item.id}>
+                        <td className="fw-semibold">{item.occupationSeedRef}</td>
+                        <td>{item.displayName}</td>
+                        <td>{item.aliases.length ? item.aliases.join(", ") : "—"}</td>
+                        <td>
+                          <span className={`badge ${item.active ? "text-bg-success" : "text-bg-secondary"}`}>
+                            {item.active ? "Ativa" : "Inativa"}
+                          </span>
+                        </td>
+                        <td>
+                          <div className="d-flex flex-wrap gap-2">
+                            <button
+                              type="button"
+                              className="btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2"
+                              onClick={() => startEdit(item)}
+                              disabled={saving || isDeleting}
+                            >
+                              <Pencil size={14} aria-hidden="true" />
+                              Editar
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-danger btn-sm d-inline-flex align-items-center gap-2"
+                              onClick={() => handleDelete(item.id)}
+                              disabled={saving || isDeleting}
+                            >
+                              {isDeleting ? (
+                                <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+                              ) : (
+                                <Trash2 size={14} aria-hidden="true" />
+                              )}
+                              Excluir
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/oprm/OprmWorkspacePage.tsx
+++ b/frontend/src/pages/oprm/OprmWorkspacePage.tsx
@@ -117,7 +117,7 @@ export default function OprmWorkspacePage() {
           <div>
             <h2 className="h5 mb-1">Rodar OPRM</h2>
             <p className="text-secondary mb-0">
-              Inicie um novo processamento informando a referência da ocupação/persona.
+              Inicie um novo processamento informando a referência da ocupação/persona já cadastrada no catálogo.
             </p>
           </div>
           <form
@@ -129,7 +129,7 @@ export default function OprmWorkspacePage() {
           >
             <div className="col-12 col-lg-8">
               <label className="form-label" htmlFor="oprm-seed-ref">
-                Ocupação/persona
+                Ocupação/persona *
               </label>
               <input
                 id="oprm-seed-ref"
@@ -154,6 +154,9 @@ export default function OprmWorkspacePage() {
               </button>
             </div>
           </form>
+          <p className="text-secondary mb-0">
+            Precisa cadastrar uma nova ocupação? Acesse a aba <Link to="/oprm/occupations">Catálogo</Link>.
+          </p>
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Introduce a managed catalog of occupations for OPRM to allow administrative CRUD and to gate job creation to known/active occupations.
- Provide a UI for administrators to create, update and remove occupation seeds and aliases so the workspace and workers can rely on a single source of truth.

### Description
- Adds a new JPA entity `OprmOccupation`, repository `OprmOccupationRepository`, DTOs, service `OprmOccupationService` and REST controller `OprmOccupationController` to expose `GET/POST/PUT/DELETE /api/oprm/occupations` endpoints.
- Adds Liquibase changelog `2026-04-16-oprm-occupation-catalog.yaml` and updates the master changelog to create `oprm_occupation` table, indexes, unique constraint and seed rows.
- Integrates catalog validation into job creation by normalizing `occupationSeedRef` and rejecting job creation when the seed is not present or not active in the catalog inside `OprmJobOrchestrationService`.
- Implements frontend pieces: hook API `useOprmOccupationCatalog`, new page `OprmOccupationCatalogPage`, navigation `OprmModuleNavigation` and route registration in `App.tsx`, plus a small UI copy update in `OprmWorkspacePage` and a navigation test update.

### Testing
- Frontend unit test `cd frontend && npm run test -- --run src/__tests__/OprmNavigation.test.tsx` was executed and **passed**.
- Frontend build `cd frontend && npm run build` was executed and **passed**.
- Backend build `cd backend/ads-service && mvn -s ../settings.xml -DskipTests compile` was executed and **passed**.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14df7a6448321831defe59a41125d)