### PR TITLE
docs(avatar): Sprint V1 closure + OpenAPI integration contract for video module

### DIFF
--- a/docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md
+++ b/docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md
@@ -1,0 +1,77 @@
+# Avatar Sales Video — Histórico de Implantação
+
+## Como ler este histórico
+
+Este arquivo registra, de forma cumulativa, as entregas e pendências relevantes do módulo Avatar Sales Video, seguindo o protocolo em `avatar-sales-video-implementation-history-protocol.md`.
+
+Cada entrada descreve:
+- o que foi implementado;
+- o que foi alterado;
+- validações executadas;
+- limitações e continuidade.
+
+---
+
+## Índice rápido
+- 2026-04-16 — Sprint V1 (contrato de integração e atualização de planejamento)
+
+---
+
+## Entradas
+
+## 2026-04-16 — Sprint V1 (contrato de integração e atualização de planejamento)
+
+**Status:** concluída com pendências
+
+### Resumo
+- Sprint V1 foi consolidada no plano de reinício com foco em contrato operacional e rastreabilidade.
+- Foi criado um documento OpenAPI dedicado à troca de dados backend ↔ módulo de vídeo.
+- As pendências críticas de robustez foram explicitamente carregadas para a Sprint V2.
+
+### O que foi implementado
+- Atualização do fechamento da Sprint V1 no plano de reinício.
+- Preenchimento do bloco obrigatório de handoff para a próxima sprint.
+- Formalização do contrato de endpoints e payloads com OpenAPI 3.0.3.
+
+### O que foi alterado
+- Arquivos:
+  - `docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md`
+  - `docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml`
+  - `docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md`
+- Módulos:
+  - Documentação canônica do módulo Avatar Sales Video.
+- Endpoints/contratos:
+  - `/internal/video/jobs`
+  - `/internal/video/jobs/{jobId}`
+  - `/internal/video/jobs/{jobId}/claim`
+  - `/internal/video/jobs/{jobId}/heartbeat`
+  - `/internal/video/jobs/{jobId}/progress`
+  - `/internal/video/jobs/{jobId}/complete`
+  - `/internal/video/jobs/{jobId}/fail`
+  - `/internal/video/jobs/{jobId}/expired`
+  - `/api/sales-videos/profiles/{profileId}`
+
+### Contratos e artefatos afetados
+- DTOs de job e perfil (`SalesVideoJobDto`, `SalesVideoProfileDto`).
+- Payloads de atualização assíncrona (`JobClaimRequest`, `JobProgressRequest`, `JobCompletionRequest`, `JobFailureRequest`, `JobHeartbeatRequest`, `JobExpirationRequest`).
+- Enumerações canônicas de status, tipo de job, família de provider e retry reason.
+
+### Testes e validações executados
+- Revisão de aderência entre o Swagger novo e os controladores/DTOs existentes no backend.
+- Revisão de consistência do planejamento da Sprint V1 com o protocolo de histórico.
+- Verificação local de mudanças via `git diff` e inspeção dos arquivos alterados.
+
+### Limitações e pendências
+- Integração com provider real ainda não está validada em staging nesta entrega documental.
+- Políticas de timeout/retry/claim duplicado permanecem para Sprint V2.
+- Observabilidade e alertas seguem como pendência para Sprint V3.
+
+### Próximo passo sugerido
+- Implementar Sprint V2 com foco em robustez do ciclo assíncrono e recuperação automática segura.
+
+### Handoff para a próxima etapa
+- Prioridade imediata: endurecer regras de claim/heartbeat/timeout/retry no fluxo de render.
+- O que não deve ser refeito: contrato de integração backend ↔ módulo de vídeo já consolidado neste ciclo.
+- Riscos abertos: drift de estado entre provider externo e backend; backlog por falhas intermitentes sem auto-recuperação.
+- Dependências externas: credenciais/provider real e ambiente de staging com conectividade validada.
+- Onde continuar: `docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md` e `docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml`.

--- a/docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml
+++ b/docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml
@@ -1,0 +1,399 @@
+openapi: 3.0.3
+info:
+  title: Avatar Sales Video - Backend x Video Module Integration API
+  version: 1.0.0
+  description: |
+    Contrato de integração entre o `backend/ads-service` (fonte canônica de estado/persistência)
+    e o módulo assíncrono de vídeo (`video-management-service`) para o pipeline Avatar Sales Video.
+
+    Escopo: endpoints usados na troca de dados operacional do ciclo de render.
+servers:
+  - url: http://backend:8000
+    description: Ambiente local/staging
+
+tags:
+  - name: InternalVideoJobs
+    description: Endpoints internos consumidos pelo módulo de vídeo para orquestrar jobs.
+  - name: PublicVideoProfiles
+    description: Endpoints de leitura de perfil usados pelo módulo de vídeo.
+
+paths:
+  /internal/video/jobs:
+    get:
+      tags: [InternalVideoJobs]
+      summary: Lista jobs de vídeo para processamento assíncrono
+      parameters:
+        - in: query
+          name: status
+          schema:
+            $ref: '#/components/schemas/SalesVideoStatus'
+        - in: query
+          name: type
+          schema:
+            $ref: '#/components/schemas/SalesVideoJobType'
+        - in: query
+          name: providerFamily
+          schema:
+            $ref: '#/components/schemas/SalesVideoProviderFamily'
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            default: 25
+      responses:
+        '200':
+          description: Lista de jobs encontrada
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SalesVideoJobDto'
+
+  /internal/video/jobs/{jobId}:
+    get:
+      tags: [InternalVideoJobs]
+      summary: Busca um job específico
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Job encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesVideoJobDto'
+        '404':
+          description: Job não encontrado
+
+  /internal/video/jobs/{jobId}/claim:
+    post:
+      tags: [InternalVideoJobs]
+      summary: Faz claim de job para o worker atual
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobClaimRequest'
+      responses:
+        '200':
+          description: Claim aplicado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesVideoJobDto'
+
+  /internal/video/jobs/{jobId}/heartbeat:
+    post:
+      tags: [InternalVideoJobs]
+      summary: Atualiza heartbeat do job em execução
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobHeartbeatRequest'
+      responses:
+        '200':
+          description: Heartbeat registrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesVideoJobDto'
+
+  /internal/video/jobs/{jobId}/progress:
+    post:
+      tags: [InternalVideoJobs]
+      summary: Reporta progresso intermediário do job
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobProgressRequest'
+      responses:
+        '200':
+          description: Progresso atualizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesVideoJobDto'
+
+  /internal/video/jobs/{jobId}/complete:
+    post:
+      tags: [InternalVideoJobs]
+      summary: Marca job como concluído
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobCompletionRequest'
+      responses:
+        '200':
+          description: Job concluído
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesVideoJobDto'
+
+  /internal/video/jobs/{jobId}/fail:
+    post:
+      tags: [InternalVideoJobs]
+      summary: Marca job como falho
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobFailureRequest'
+      responses:
+        '200':
+          description: Falha registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesVideoJobDto'
+
+  /internal/video/jobs/{jobId}/expired:
+    post:
+      tags: [InternalVideoJobs]
+      summary: Marca job como expirado pelo provider
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobExpirationRequest'
+      responses:
+        '200':
+          description: Expiração registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesVideoJobDto'
+
+  /api/sales-videos/profiles/{profileId}:
+    get:
+      tags: [PublicVideoProfiles]
+      summary: Carrega perfil para execução do render
+      parameters:
+        - in: path
+          name: profileId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Perfil encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesVideoProfileDto'
+        '404':
+          description: Perfil não encontrado
+
+components:
+  parameters:
+    JobId:
+      in: path
+      name: jobId
+      required: true
+      schema:
+        type: integer
+        format: int64
+
+  schemas:
+    SalesVideoStatus:
+      type: string
+      enum:
+        - DRAFT
+        - SCRIPT_PENDING
+        - SCRIPT_READY
+        - STORYBOARD_PENDING
+        - STORYBOARD_READY
+        - VIDEO_REQUESTED
+        - VIDEO_PROCESSING
+        - VIDEO_READY
+        - VIDEO_FAILED
+        - PUBLISHED
+        - ARCHIVED
+
+    SalesVideoJobType:
+      type: string
+      enum: [SCRIPT, STORYBOARD, RENDER, PUBLISH, RETRY]
+
+    SalesVideoProviderFamily:
+      type: string
+      enum: [OPENAI, EXTERNAL_VIDEO_MODULE]
+
+    SalesVideoRetryReason:
+      type: string
+      enum:
+        - MANUAL_INTERVENTION
+        - PROVIDER_FAILURE
+        - ASSET_EXPIRED
+        - QUALITY_ASSURANCE
+        - AUTO_RECOVERY
+        - OTHER
+
+    SalesVideoKind:
+      type: string
+      enum: [HERO, OBJECTION, PROOF]
+
+    SalesVideoScriptSource:
+      type: string
+      enum: [MANUAL, OPENAI]
+
+    SalesVideoScriptStatus:
+      type: string
+      enum: [DRAFT, READY_FOR_REVIEW, APPROVED, ARCHIVED]
+
+    SalesVideoJobDto:
+      type: object
+      properties:
+        id: { type: integer, format: int64 }
+        profileId: { type: integer, format: int64 }
+        scriptId: { type: integer, format: int64 }
+        tenantId: { type: string }
+        providerFamily: { $ref: '#/components/schemas/SalesVideoProviderFamily' }
+        providerName: { type: string }
+        providerJobId: { type: string }
+        jobType: { $ref: '#/components/schemas/SalesVideoJobType' }
+        status: { $ref: '#/components/schemas/SalesVideoStatus' }
+        retryAttempt: { type: integer }
+        retryReason: { $ref: '#/components/schemas/SalesVideoRetryReason' }
+        retryOfJobId: { type: integer, format: int64 }
+        retryNotes: { type: string }
+        progressPercent: { type: integer }
+        failureCode: { type: string }
+        failureDetail: { type: string }
+        requestedBy: { type: string }
+        requestedAt: { type: string, format: date-time }
+        startedAt: { type: string, format: date-time }
+        finishedAt: { type: string, format: date-time }
+        expiresAt: { type: string, format: date-time }
+        assetId: { type: integer, format: int64 }
+        posterAssetId: { type: integer, format: int64 }
+        vttAssetId: { type: integer, format: int64 }
+        metadataJson: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    SalesVideoScriptDto:
+      type: object
+      properties:
+        id: { type: integer, format: int64 }
+        version: { type: integer }
+        createdBy: { type: string }
+        scriptText: { type: string }
+        hookText: { type: string }
+        ctaText: { type: string }
+        captionText: { type: string }
+        storyboardJson: { type: string }
+        source: { $ref: '#/components/schemas/SalesVideoScriptSource' }
+        model: { type: string }
+        prompt: { type: string }
+        status: { $ref: '#/components/schemas/SalesVideoScriptStatus' }
+        approvedBy: { type: string }
+        approvedAt: { type: string, format: date-time }
+        createdAt: { type: string, format: date-time }
+
+    SalesVideoProfileDto:
+      type: object
+      properties:
+        id: { type: integer, format: int64 }
+        productId: { type: integer, format: int64 }
+        landingPageId: { type: integer, format: int64 }
+        tenantId: { type: string }
+        createdBy: { type: string }
+        videoKind: { $ref: '#/components/schemas/SalesVideoKind' }
+        title: { type: string }
+        personaName: { type: string }
+        personaStyle: { type: string }
+        voiceStyle: { type: string }
+        language: { type: string }
+        targetDurationSeconds: { type: integer }
+        status: { $ref: '#/components/schemas/SalesVideoStatus' }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        latestScript: { $ref: '#/components/schemas/SalesVideoScriptDto' }
+        lastJob: { $ref: '#/components/schemas/SalesVideoJobDto' }
+
+    JobClaimRequest:
+      type: object
+      required: [workerId]
+      properties:
+        workerId:
+          type: string
+          minLength: 1
+        message:
+          type: string
+
+    JobHeartbeatRequest:
+      type: object
+      properties:
+        message: { type: string }
+        detailsJson: { type: string }
+
+    JobProgressRequest:
+      type: object
+      properties:
+        progressPercent: { type: integer, minimum: 0, maximum: 100 }
+        status: { $ref: '#/components/schemas/SalesVideoStatus' }
+        message: { type: string }
+        detailsJson: { type: string }
+
+    GeneratedScriptResultPayload:
+      type: object
+      properties:
+        scriptText: { type: string }
+        hookText: { type: string }
+        ctaText: { type: string }
+        captionText: { type: string }
+        storyboardJson: { type: string }
+        prompt: { type: string }
+        model: { type: string }
+
+    JobCompletionRequest:
+      type: object
+      properties:
+        status: { $ref: '#/components/schemas/SalesVideoStatus' }
+        assetId: { type: integer, format: int64 }
+        posterAssetId: { type: integer, format: int64 }
+        vttAssetId: { type: integer, format: int64 }
+        providerJobId: { type: string }
+        metadataJson: { type: string }
+        message: { type: string }
+        detailsJson: { type: string }
+        scriptResult:
+          $ref: '#/components/schemas/GeneratedScriptResultPayload'
+
+    JobFailureRequest:
+      type: object
+      properties:
+        failureCode: { type: string }
+        failureDetail: { type: string }
+        status: { $ref: '#/components/schemas/SalesVideoStatus' }
+        message: { type: string }
+
+    JobExpirationRequest:
+      type: object
+      properties:
+        message: { type: string }
+        detailsJson: { type: string }

--- a/docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md
+++ b/docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md
@@ -94,28 +94,47 @@ Substituir a dependência exclusiva do provider `stub` por um **adapter real de 
 ## Fechamento da sprint — preencher pelo Codex
 
 ### Status
-- 
+- concluída com pendências (escopo documental + contrato de integração backend ↔ módulo de vídeo)
 
 ### O que foi implementado
-- 
+- consolidação do contrato operacional da Sprint V1 para o fluxo `VIDEO_REQUESTED -> VIDEO_PROCESSING -> VIDEO_READY/VIDEO_FAILED`.
+- definição formal (OpenAPI) dos endpoints que o `video-management-service` consome para buscar jobs, claim, progresso, conclusão, falha e expiração.
+- alinhamento explícito da fronteira arquitetural: backend como persistência canônica e módulo de vídeo como executor assíncrono.
 
 ### Arquivos alterados
-- 
+- `docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md`
+- `docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml`
+- `docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md`
 
 ### Endpoints/contratos afetados
-- 
+- `GET /internal/video/jobs`
+- `GET /internal/video/jobs/{jobId}`
+- `POST /internal/video/jobs/{jobId}/claim`
+- `POST /internal/video/jobs/{jobId}/heartbeat`
+- `POST /internal/video/jobs/{jobId}/progress`
+- `POST /internal/video/jobs/{jobId}/complete`
+- `POST /internal/video/jobs/{jobId}/fail`
+- `POST /internal/video/jobs/{jobId}/expired`
+- `GET /api/sales-videos/profiles/{profileId}`
 
 ### Providers suportados
-- 
+- `stub` (homologação/desenvolvimento)
+- `real` (alvo da integração da Sprint V1; habilitação condicionada por configuração por ambiente)
 
 ### Limitações restantes
-- 
+- adapter de provider real ainda depende de credenciais, mapeamento de erros e validação E2E em staging.
+- sem política endurecida de timeout/heartbeat/retry para recuperação automática.
+- sem baseline operacional de métricas e alertas.
 
 ### Pendências carregadas para a Sprint V2
-- 
+- definir política canônica de claim duplicado, heartbeat e timeout com regras de recuperação.
+- especificar retry técnico com deduplicação e classificação de `retryReason`.
+- documentar fallback operacional por ambiente (staging vs produção).
+- incluir cenários de asset expirado e job órfão como casos obrigatórios de validação.
 
 ### Evidências/testes executados
-- 
+- validação documental do contrato comparando o plano de reinício com os controladores e DTOs existentes no backend.
+- revisão de consistência semântica com os cânones (`system-governance` e artefatos do módulo).
 
 ---
 
@@ -468,36 +487,36 @@ Iniciar a transição do módulo de “pipeline técnico funcional” para “pi
 ## Handoff para a próxima sprint
 
 ### 1. Resumo factual do estado atual
-- O que está concluído:
-- O que está parcialmente concluído:
-- O que ainda não começou:
+- O que está concluído: contrato de integração backend ↔ módulo de vídeo formalizado e backlog da Sprint V1 consolidado.
+- O que está parcialmente concluído: validação do fluxo com provider real (dependente de credenciais, adapter final e testes em staging).
+- O que ainda não começou: robustez avançada de retry/timeout, observabilidade operacional e rollout controlado.
 
 ### 2. Pendências carregadas
-- Pendência 1:
-- Pendência 2:
-- Pendência 3:
+- Pendência 1: implementar política de timeout + heartbeat + detecção de job órfão no worker de vídeo.
+- Pendência 2: endurecer retry técnico sem duplicação silenciosa de processamento.
+- Pendência 3: validar cenários de expiração de asset com transição de estado previsível no backend.
 
 ### 3. Riscos abertos
-- Risco 1:
-- Risco 2:
-- Risco 3:
+- Risco 1: divergência entre estado externo do provider e estado canônico interno (`SalesVideoStatus`).
+- Risco 2: falhas intermitentes do provider causarem backlog sem reprocessamento automático seguro.
+- Risco 3: aumento de latência sem métricas mínimas em tempo real dificultar operação.
 
 ### 4. Decisões tomadas nesta sprint
-- Decisão 1:
-- Decisão 2:
-- Decisão 3:
+- Decisão 1: manter backend como única fonte de verdade para estado e persistência do módulo.
+- Decisão 2: formalizar o contrato de integração em OpenAPI dentro do diretório canônico do módulo.
+- Decisão 3: carregar para a Sprint V2 toda regra de robustez operacional (claim/timeout/retry/expiração).
 
 ### 5. Contratos/artefatos afetados
-- Endpoint:
-- DTO/schema:
-- Eventos:
-- Métricas:
-- Flags:
+- Endpoint: `/internal/video/jobs/*` e `/api/sales-videos/profiles/{profileId}`.
+- DTO/schema: `SalesVideoJobDto`, `SalesVideoProfileDto`, `JobClaimRequest`, `JobProgressRequest`, `JobCompletionRequest`, `JobFailureRequest`, `JobHeartbeatRequest`, `JobExpirationRequest`.
+- Eventos: atualizações de progresso/conclusão/falha/expiração reportadas pelo módulo assíncrono ao backend.
+- Métricas: pendente para Sprint V3 (ainda não implementadas).
+- Flags: pendente para Sprint V6 (rollout por tenant/feature flag).
 
 ### 6. Instruções para o próximo ciclo do Codex
-- Prioridade imediata:
-- O que não deve ser refeito:
-- Onde continuar:
+- Prioridade imediata: Sprint V2 com foco em robustez do ciclo assíncrono e prevenção de jobs órfãos.
+- O que não deve ser refeito: contrato de endpoints já mapeado/documentado para integração backend ↔ módulo de vídeo.
+- Onde continuar: `docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md` e `docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml`.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Formalizar o fechamento da Sprint V1 do módulo Avatar Sales Video e registrar pendências operacionais para o próximo ciclo.
- Fornecer um contrato explícito e legível por máquina entre `backend/ads-service` e o módulo assíncrono `video-management-service` para evitar drift entre implementações.
- Garantir rastreabilidade e histórico cumulativo das mudanças do módulo seguindo o protocolo canônico do projeto.

### Description
- Atualizei `docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md` com o fechamento da Sprint V1, itens implementados, limitações e o bloco de handoff com pendências carregadas para a Sprint V2.
- Adicionei `docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml` (OpenAPI 3.0.3) documentando os endpoints operacionais usados pelo módulo de vídeo: `GET /internal/video/jobs`, `GET /internal/video/jobs/{jobId}`, `POST /internal/video/jobs/{jobId}/claim|heartbeat|progress|complete|fail|expired` e `GET /api/sales-videos/profiles/{profileId}`, além dos schemas principais alinhados aos DTOs do backend.
- Criei `docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md` com a entrada de `2026-04-16` descrevendo status, alterações, validações e handoff para continuidade.
- Mantive explícita a regra arquitetural do projeto: o backend continua sendo a fonte canônica de persistência e estado do módulo.

### Testing
- Executei `git diff --check` para verificar problemas de whitespace e formatação, e não foram encontrados erros.
- Validei automaticamente a presença e estrutura dos arquivos criados e comparei os contratos descritos no Swagger com os controladores/DTOs existentes no backend por inspeção de código (estrutura/nomes de campos e endpoints).
- Tentei validar o YAML com `python -c "import yaml"`, mas a validação automática não foi possível devido à ausência do pacote `PyYAML` no ambiente, portanto a análise sintática completa do YAML não foi executada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e165034464832198af2a9b35f59a4d)