### PR TITLE
feat(video-management): add RealVideoProvider, heartbeat/expired flows and staging config

### DIFF
--- a/docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md
+++ b/docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md
@@ -14,6 +14,7 @@ Cada entrada descreve:
 
 ## Índice rápido
 - 2026-04-16 — Sprint V1 (contrato de integração e atualização de planejamento)
+- 2026-04-16 — Sprint V1 (implementação do adapter real e integração backend)
 
 ---
 
@@ -75,3 +76,75 @@ Cada entrada descreve:
 - Riscos abertos: drift de estado entre provider externo e backend; backlog por falhas intermitentes sem auto-recuperação.
 - Dependências externas: credenciais/provider real e ambiente de staging com conectividade validada.
 - Onde continuar: `docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md` e `docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml`.
+
+## 2026-04-16 — Sprint V1 (implementação do adapter real e integração backend)
+
+**Status:** parcialmente concluída
+
+### Resumo
+- Foi implementado um adapter `real` no `video-management-service`, preservando o `stub` como fallback de desenvolvimento.
+- O fluxo real passou a suportar `submit`, polling, download de artefatos e devolução de metadata mínima para o backend.
+- Falhas do provider e expiração foram normalizadas para os endpoints internos canônicos do backend.
+
+### O que foi implementado
+- Novo provider `RealVideoProvider` com:
+  - seleção por `providerName`;
+  - criação de job no provider externo;
+  - polling de status com timeout configurável;
+  - download de vídeo/poster/legenda por URL;
+  - metadata com `provider`, `provider_job_id` e status externo final.
+- Ampliação do `BackendVideoClient` para:
+  - `heartbeat` (`POST /internal/video/jobs/{jobId}/heartbeat`);
+  - `expired` (`POST /internal/video/jobs/{jobId}/expired`).
+- Atualização do `VideoJobProcessor` para:
+  - mapear `PROVIDER_ASSET_EXPIRED` para endpoint de expiração;
+  - manter tradução de falhas técnicas em `failureCode`.
+- Configuração de staging com backend `http://191.252.181.168:8000`.
+
+### O que foi alterado
+- Arquivos:
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/service/provider/RealVideoProvider.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/service/provider/VideoProviderException.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProcessor.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProgressReporter.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/client/BackendVideoClient.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobHeartbeatPayload.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobExpirationPayload.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/config/VideoManagementProperties.java`
+  - `video-management-service/src/main/resources/application.yml`
+  - `video-management-service/README.md`
+  - `docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml`
+  - `docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md`
+- Módulos:
+  - `video-management-service`
+  - documentação canônica do módulo Avatar Sales Video
+- Endpoints/contratos:
+  - `/internal/video/jobs/{jobId}/heartbeat`
+  - `/internal/video/jobs/{jobId}/expired`
+  - `/internal/video/jobs/{jobId}/progress`
+  - `/internal/video/jobs/{jobId}/complete`
+  - `/internal/video/jobs/{jobId}/fail`
+
+### Contratos e artefatos afetados
+- `avatar.salesVideoRenderJob.v1` (campos `providerName`, `providerJobId`, estados do ciclo assíncrono).
+- `avatar.salesVideoProviderExecution.v1` (metadata técnica de provider devolvida ao backend).
+- Payloads de job interno para heartbeat e expiração.
+
+### Testes e validações executados
+- Build e suíte de testes do `video-management-service`.
+- Revisão de compatibilidade do client com os endpoints OpenAPI da integração backend ↔ módulo de vídeo.
+
+### Limitações e pendências
+- Sem credenciais reais no repositório para validar provider externo contra ambiente staging.
+- Contrato JSON do provider real pode exigir ajuste fino por vendor (nomes de campos de status/URL).
+- Sem observabilidade consolidada de métricas/alertas (escopo Sprint V3).
+
+### Próximo passo sugerido
+- Executar validação E2E em staging com credenciais reais, cobrindo sucesso/falha/expiração e aferindo tempos de polling.
+
+### Handoff para a próxima etapa
+- Prioridade imediata: Sprint V2 (robustez de timeout/retry/deduplicação) + validação E2E do provider real.
+- O que não deve ser refeito: contrato de endpoints internos `/internal/video/jobs/*` e fluxo canônico backend como fonte de verdade.
+- Riscos abertos: campos de status divergentes entre providers reais e parser atual; timeout insuficiente para renders longos.
+- Dependências externas: credenciais e documentação final do provider real por ambiente.
+- Onde continuar: `video-management-service/src/main/java/com/marketinghub/videomanagement/service/provider/RealVideoProvider.java`.

--- a/docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml
+++ b/docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml
@@ -10,6 +10,8 @@ info:
 servers:
   - url: http://backend:8000
     description: Ambiente local/staging
+  - url: http://191.252.181.168:8000
+    description: Backend staging compartilhado (Sprint V1)
 
 tags:
   - name: InternalVideoJobs

--- a/docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md
+++ b/docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md
@@ -94,17 +94,24 @@ Substituir a dependência exclusiva do provider `stub` por um **adapter real de 
 ## Fechamento da sprint — preencher pelo Codex
 
 ### Status
-- concluída com pendências (escopo documental + contrato de integração backend ↔ módulo de vídeo)
+- concluída com pendências (adapter real inicial implementado no `video-management-service`, aguardando validação E2E em staging)
 
 ### O que foi implementado
 - consolidação do contrato operacional da Sprint V1 para o fluxo `VIDEO_REQUESTED -> VIDEO_PROCESSING -> VIDEO_READY/VIDEO_FAILED`.
 - definição formal (OpenAPI) dos endpoints que o `video-management-service` consome para buscar jobs, claim, progresso, conclusão, falha e expiração.
 - alinhamento explícito da fronteira arquitetural: backend como persistência canônica e módulo de vídeo como executor assíncrono.
+- implementação do adapter `real` com fluxo `submit -> polling -> download`, mantendo `stub` para desenvolvimento.
+- normalização de falhas técnicas (`PROVIDER_TIMEOUT`, `PROVIDER_RENDER_FAILED`) e expiração (`PROVIDER_ASSET_EXPIRED`) para atualização do backend via endpoints internos.
+- envio de heartbeat durante progress updates para reforçar rastreabilidade operacional.
 
 ### Arquivos alterados
 - `docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md`
 - `docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml`
 - `docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md`
+- `video-management-service/src/main/java/com/marketinghub/videomanagement/service/provider/RealVideoProvider.java`
+- `video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProcessor.java`
+- `video-management-service/src/main/java/com/marketinghub/videomanagement/client/BackendVideoClient.java`
+- `video-management-service/src/main/resources/application.yml`
 
 ### Endpoints/contratos afetados
 - `GET /internal/video/jobs`
@@ -122,7 +129,7 @@ Substituir a dependência exclusiva do provider `stub` por um **adapter real de 
 - `real` (alvo da integração da Sprint V1; habilitação condicionada por configuração por ambiente)
 
 ### Limitações restantes
-- adapter de provider real ainda depende de credenciais, mapeamento de erros e validação E2E em staging.
+- adapter de provider real ainda depende de credenciais válidas e endpoints definitivos do provider por ambiente.
 - sem política endurecida de timeout/heartbeat/retry para recuperação automática.
 - sem baseline operacional de métricas e alertas.
 
@@ -131,6 +138,7 @@ Substituir a dependência exclusiva do provider `stub` por um **adapter real de 
 - especificar retry técnico com deduplicação e classificação de `retryReason`.
 - documentar fallback operacional por ambiente (staging vs produção).
 - incluir cenários de asset expirado e job órfão como casos obrigatórios de validação.
+- validar E2E em staging do provider real (job completo + falha + asset expirado) contra backend `191.252.181.168`.
 
 ### Evidências/testes executados
 - validação documental do contrato comparando o plano de reinício com os controladores e DTOs existentes no backend.

--- a/video-management-service/README.md
+++ b/video-management-service/README.md
@@ -9,6 +9,7 @@ Módulo dedicado ao gerenciamento técnico do ciclo de vida de vídeos que não 
 - Cliente REST para todos os endpoints internos de jobs (`claim`, `progress`, `complete`, `fail`).
 - Upload automático de vídeo, poster e legendas através do novo endpoint interno `/internal/video/assets` do backend.
 - Provider `stub` que lê o script aprovado do perfil, gera artefatos fictícios (MP4, PNG e VTT) e reporta progresso durante o pipeline.
+- Provider `real` com integração HTTP configurável (request render + polling + download), com normalização de falhas/expiração para o backend.
 - Dispatcher multi-thread com controle contra concorrência duplicada.
 - Poller interno (desativado por padrão) que consome jobs `RENDER` com `provider_family=EXTERNAL_VIDEO_MODULE` e envia para o dispatcher.
 
@@ -30,6 +31,18 @@ Para acompanhar os logs dos jobs, mantenha `video.jobs.polling-enabled=true` e v
 | `video.jobs.polling-enabled` | Liga/desliga o poller automático. | `false` |
 | `video.jobs.poll-interval` | Intervalo em ISO-8601 (ex.: `PT30S`). | `PT30S` |
 | `video.jobs.batch-size` | Número máximo de jobs por ciclo. | `10` |
+| `video.providers.real.enabled` | Habilita adapter do provider real. | `false` |
+| `video.providers.real.accepted-names` | Valores de `providerName` que ativam o provider real. | `REAL,HEYGEN,SYNTHESIA` |
+| `video.providers.real.base-url` | Base URL da API do provider real. | `http://real-video-provider:8080` |
+| `video.providers.real.create-path` | Path para criar render no provider. | `/v1/renders` |
+| `video.providers.real.status-path-template` | Path para consultar status do render por `providerJobId`. | `/v1/renders/{providerJobId}` |
+| `video.providers.real.poll-interval` | Intervalo de polling do status no provider. | `PT5S` |
+| `video.providers.real.max-poll-attempts` | Máximo de tentativas de polling antes de timeout técnico. | `120` |
+
+### Staging atual
+
+- Backend de staging configurado para `http://191.252.181.168:8000`.
+- O provider real só deve ser habilitado após configurar credenciais (`video.providers.real.auth-token`) e conectividade da API externa.
 
 ## Construção do container
 

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/client/BackendVideoClient.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/client/BackendVideoClient.java
@@ -5,7 +5,9 @@ import com.marketinghub.videomanagement.client.dto.SalesVideoProfile;
 import com.marketinghub.videomanagement.client.dto.SalesVideoStatus;
 import com.marketinghub.videomanagement.client.payload.JobClaimPayload;
 import com.marketinghub.videomanagement.client.payload.JobCompletionPayload;
+import com.marketinghub.videomanagement.client.payload.JobExpirationPayload;
 import com.marketinghub.videomanagement.client.payload.JobFailurePayload;
+import com.marketinghub.videomanagement.client.payload.JobHeartbeatPayload;
 import com.marketinghub.videomanagement.client.payload.JobProgressPayload;
 import com.marketinghub.videomanagement.config.VideoManagementProperties;
 import com.marketinghub.videomanagement.exception.BackendIntegrationException;
@@ -90,12 +92,20 @@ public class BackendVideoClient {
         postIgnoringBody("/internal/video/jobs/{jobId}/progress", jobId, payload);
     }
 
+    public void reportHeartbeat(Long jobId, JobHeartbeatPayload payload) {
+        postIgnoringBody("/internal/video/jobs/{jobId}/heartbeat", jobId, payload);
+    }
+
     public void completeJob(Long jobId, JobCompletionPayload payload) {
         postIgnoringBody("/internal/video/jobs/{jobId}/complete", jobId, payload);
     }
 
     public void failJob(Long jobId, JobFailurePayload payload) {
         postIgnoringBody("/internal/video/jobs/{jobId}/fail", jobId, payload);
+    }
+
+    public void expireJob(Long jobId, JobExpirationPayload payload) {
+        postIgnoringBody("/internal/video/jobs/{jobId}/expired", jobId, payload);
     }
 
     private SalesVideoJob postForJob(String path,

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobExpirationPayload.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobExpirationPayload.java
@@ -1,0 +1,6 @@
+package com.marketinghub.videomanagement.client.payload;
+
+public record JobExpirationPayload(
+        String message,
+        String detailsJson) {
+}

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobHeartbeatPayload.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobHeartbeatPayload.java
@@ -1,0 +1,6 @@
+package com.marketinghub.videomanagement.client.payload;
+
+public record JobHeartbeatPayload(
+        String message,
+        String detailsJson) {
+}

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/config/VideoManagementProperties.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/config/VideoManagementProperties.java
@@ -10,6 +10,8 @@ import org.springframework.validation.annotation.Validated;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -31,6 +33,9 @@ public class VideoManagementProperties {
     @NotNull
     private Jobs jobs = new Jobs();
 
+    @NotNull
+    private Providers providers = new Providers();
+
     @Getter
     @Setter
     public static class Jobs {
@@ -41,5 +46,43 @@ public class VideoManagementProperties {
 
         @Min(1)
         private int batchSize = 10;
+    }
+
+    @Getter
+    @Setter
+    public static class Providers {
+        @NotNull
+        private Real real = new Real();
+    }
+
+    @Getter
+    @Setter
+    public static class Real {
+        private boolean enabled = false;
+
+        /**
+         * Nomes que identificam o provider real dentro de providerName do job.
+         */
+        @NotNull
+        private List<String> acceptedNames = new ArrayList<>(List.of("REAL", "HEYGEN", "SYNTHESIA"));
+
+        /**
+         * Base URL da API do provider real.
+         */
+        private URI baseUrl;
+
+        /**
+         * Token opcional para autenticação bearer na API do provider.
+         */
+        private String authToken;
+
+        private String createPath = "/v1/renders";
+        private String statusPathTemplate = "/v1/renders/{providerJobId}";
+
+        @NotNull
+        private Duration pollInterval = Duration.ofSeconds(5);
+
+        @Min(1)
+        private int maxPollAttempts = 120;
     }
 }

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProcessor.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProcessor.java
@@ -8,6 +8,7 @@ import com.marketinghub.videomanagement.client.dto.SalesVideoProfile;
 import com.marketinghub.videomanagement.client.dto.SalesVideoStatus;
 import com.marketinghub.videomanagement.client.payload.JobClaimPayload;
 import com.marketinghub.videomanagement.client.payload.JobCompletionPayload;
+import com.marketinghub.videomanagement.client.payload.JobExpirationPayload;
 import com.marketinghub.videomanagement.client.payload.JobFailurePayload;
 import com.marketinghub.videomanagement.config.VideoManagementProperties;
 import com.marketinghub.videomanagement.exception.BackendIntegrationException;
@@ -70,11 +71,20 @@ public class VideoJobProcessor {
             log.info("Job {} concluído com vídeo {}", job.id(), uploadedAssets.videoAssetId());
         } catch (VideoProviderException | BackendIntegrationException ex) {
             log.warn("Falha ao processar job {}: {}", job.id(), ex.getMessage());
-            backendClient.failJob(job.id(), new JobFailurePayload(
-                    "VIDEO_PROVIDER_ERROR",
-                    ex.getMessage(),
-                    SalesVideoStatus.VIDEO_FAILED,
-                    ex.getMessage()));
+            if (isExpiredFailure(ex)) {
+                backendClient.expireJob(job.id(), new JobExpirationPayload(
+                        "Provider informou asset expirado",
+                        ex.getMessage()));
+            } else {
+                String failureCode = ex instanceof VideoProviderException providerException
+                        ? providerException.getCode()
+                        : "VIDEO_PROVIDER_ERROR";
+                backendClient.failJob(job.id(), new JobFailurePayload(
+                        failureCode,
+                        ex.getMessage(),
+                        SalesVideoStatus.VIDEO_FAILED,
+                        ex.getMessage()));
+            }
         } catch (Exception ex) {
             log.error("Erro inesperado ao processar job {}", job.id(), ex);
             backendClient.failJob(job.id(), new JobFailurePayload(
@@ -83,6 +93,13 @@ public class VideoJobProcessor {
                     SalesVideoStatus.VIDEO_FAILED,
                     "Falha inesperada ao processar job"));
         }
+    }
+
+    private boolean isExpiredFailure(Exception ex) {
+        if (ex instanceof VideoProviderException providerException) {
+            return "PROVIDER_ASSET_EXPIRED".equalsIgnoreCase(providerException.getCode());
+        }
+        return false;
     }
 
     private SalesVideoProfile loadProfile(SalesVideoJob job) {

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProgressReporter.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProgressReporter.java
@@ -2,6 +2,7 @@ package com.marketinghub.videomanagement.service;
 
 import com.marketinghub.videomanagement.client.BackendVideoClient;
 import com.marketinghub.videomanagement.client.dto.SalesVideoStatus;
+import com.marketinghub.videomanagement.client.payload.JobHeartbeatPayload;
 import com.marketinghub.videomanagement.client.payload.JobProgressPayload;
 import com.marketinghub.videomanagement.service.provider.ProgressCallback;
 
@@ -21,5 +22,6 @@ public class VideoJobProgressReporter implements ProgressCallback {
     @Override
     public void onProgress(Integer percent, SalesVideoStatus status, String message) {
         backendClient.reportProgress(jobId, new JobProgressPayload(percent, status, message, null));
+        backendClient.reportHeartbeat(jobId, new JobHeartbeatPayload(message, null));
     }
 }

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/service/provider/RealVideoProvider.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/service/provider/RealVideoProvider.java
@@ -1,0 +1,255 @@
+package com.marketinghub.videomanagement.service.provider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.videomanagement.client.dto.AssetType;
+import com.marketinghub.videomanagement.client.dto.SalesVideoJob;
+import com.marketinghub.videomanagement.client.dto.SalesVideoJobType;
+import com.marketinghub.videomanagement.client.dto.SalesVideoProfile;
+import com.marketinghub.videomanagement.client.dto.SalesVideoScript;
+import com.marketinghub.videomanagement.client.dto.SalesVideoStatus;
+import com.marketinghub.videomanagement.config.VideoManagementProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Adapter de provider real com fluxo request -> polling -> download.
+ */
+@Component
+@ConditionalOnProperty(prefix = "video.providers.real", name = "enabled", havingValue = "true")
+public class RealVideoProvider implements VideoProvider {
+    private static final MediaType VIDEO_MP4 = MediaType.valueOf("video/mp4");
+    private static final MediaType IMAGE_PNG = MediaType.IMAGE_PNG;
+    private static final MediaType TEXT_VTT = MediaType.valueOf("text/vtt");
+
+    private final VideoManagementProperties properties;
+    private final ObjectMapper objectMapper;
+    private final WebClient webClient;
+
+    public RealVideoProvider(VideoManagementProperties properties,
+                             ObjectMapper objectMapper,
+                             WebClient.Builder webClientBuilder) {
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+        this.webClient = webClientBuilder.baseUrl(resolveBaseUrl(properties)).build();
+    }
+
+    @Override
+    public boolean supports(SalesVideoJob job) {
+        if (job.jobType() != SalesVideoJobType.RENDER) {
+            return false;
+        }
+        String providerName = normalize(job.providerName());
+        if (!StringUtils.hasText(providerName)) {
+            return false;
+        }
+        return properties.getProviders().getReal().getAcceptedNames().stream()
+                .map(this::normalize)
+                .anyMatch(providerName::equals);
+    }
+
+    @Override
+    public ProviderArtifacts render(SalesVideoJob job,
+                                    SalesVideoProfile profile,
+                                    ProgressCallback progressCallback) {
+        SalesVideoScript script = ensureScript(profile);
+        progressCallback.onProgress(10, SalesVideoStatus.VIDEO_PROCESSING, "Enviando render para provider real");
+
+        String providerJobId = submitRender(job, profile, script);
+        progressCallback.onProgress(35, SalesVideoStatus.VIDEO_PROCESSING,
+                "Render aceito pelo provider: " + providerJobId);
+
+        JsonNode finalStatus = waitUntilFinished(providerJobId, progressCallback);
+        String status = readText(finalStatus, "status");
+        if ("FAILED".equals(status)) {
+            throw new VideoProviderException(resolveFailureCode(finalStatus), readText(finalStatus, "error_message"));
+        }
+        if ("EXPIRED".equals(status)) {
+            throw new VideoProviderException("PROVIDER_ASSET_EXPIRED", "Provider marcou o output como expirado");
+        }
+
+        progressCallback.onProgress(80, SalesVideoStatus.VIDEO_PROCESSING, "Baixando assets finais do provider");
+        ProviderFile video = downloadRequiredFile(finalStatus, "video_url", VIDEO_MP4,
+                AssetType.VIDEO, ProviderAssetRole.VIDEO, "sales-video-" + job.id() + ".mp4");
+        ProviderFile poster = downloadOptionalFile(finalStatus, "poster_url", IMAGE_PNG,
+                AssetType.IMAGE, ProviderAssetRole.POSTER, "sales-video-" + job.id() + "-poster.png");
+        ProviderFile caption = downloadOptionalFile(finalStatus, "captions_url", TEXT_VTT,
+                AssetType.CAPTION, ProviderAssetRole.CAPTION, "sales-video-" + job.id() + ".vtt");
+
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("provider", normalize(job.providerName()));
+        metadata.put("provider_job_id", providerJobId);
+        metadata.put("provider_status", status);
+        metadata.put("polled_at", Instant.now().toString());
+        JsonNode providerMetadata = finalStatus.path("metadata");
+        if (!providerMetadata.isMissingNode() && !providerMetadata.isNull()) {
+            metadata.put("provider_metadata", objectMapper.convertValue(providerMetadata, Map.class));
+        }
+
+        progressCallback.onProgress(95, SalesVideoStatus.VIDEO_PROCESSING, "Assets reais finalizados");
+        return new ProviderArtifacts(providerJobId, video, poster, caption, metadata);
+    }
+
+    private String submitRender(SalesVideoJob job,
+                                SalesVideoProfile profile,
+                                SalesVideoScript script) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("job_id", job.id());
+        payload.put("profile_id", profile.id());
+        payload.put("title", profile.title());
+        payload.put("language", profile.language());
+        payload.put("persona_name", profile.personaName());
+        payload.put("voice_style", profile.voiceStyle());
+        payload.put("target_duration_seconds", profile.targetDurationSeconds());
+        payload.put("script_text", script.scriptText());
+        payload.put("hook_text", script.hookText());
+        payload.put("cta_text", script.ctaText());
+        payload.put("provider", normalize(job.providerName()));
+
+        JsonNode response = authorized(webClient.post()
+                        .uri(properties.getProviders().getReal().getCreatePath())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bodyValue(payload))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+        String providerJobId = readText(response, "provider_job_id");
+        if (!StringUtils.hasText(providerJobId)) {
+            providerJobId = readText(response, "id");
+        }
+        if (!StringUtils.hasText(providerJobId)) {
+            throw new VideoProviderException("Resposta do provider sem provider_job_id");
+        }
+        return providerJobId;
+    }
+
+    private JsonNode waitUntilFinished(String providerJobId,
+                                       ProgressCallback progressCallback) {
+        VideoManagementProperties.Real config = properties.getProviders().getReal();
+        for (int attempt = 1; attempt <= config.getMaxPollAttempts(); attempt++) {
+            JsonNode statusResponse = fetchStatus(providerJobId);
+            String status = normalize(readText(statusResponse, "status"));
+            Integer percent = readInt(statusResponse, "progress_percent");
+            if ("COMPLETED".equals(status)) {
+                return statusResponse;
+            }
+            if ("FAILED".equals(status) || "EXPIRED".equals(status)) {
+                return statusResponse;
+            }
+            int normalizedProgress = Math.max(40, Math.min(percent == null ? 0 : percent, 90));
+            progressCallback.onProgress(normalizedProgress, SalesVideoStatus.VIDEO_PROCESSING,
+                    "Provider em processamento (tentativa %d/%d)".formatted(attempt, config.getMaxPollAttempts()));
+            sleep(config.getPollInterval().toMillis());
+        }
+        throw new VideoProviderException("PROVIDER_TIMEOUT", "Timeout aguardando conclusão do provider real");
+    }
+
+    private JsonNode fetchStatus(String providerJobId) {
+        String pathTemplate = properties.getProviders().getReal().getStatusPathTemplate();
+        return authorized(webClient.get().uri(pathTemplate, providerJobId))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+    }
+
+    private ProviderFile downloadRequiredFile(JsonNode payload,
+                                              String field,
+                                              MediaType mediaType,
+                                              AssetType assetType,
+                                              ProviderAssetRole role,
+                                              String filename) {
+        ProviderFile file = downloadOptionalFile(payload, field, mediaType, assetType, role, filename);
+        if (file == null) {
+            throw new VideoProviderException("Provider não retornou URL obrigatória: " + field);
+        }
+        return file;
+    }
+
+    private ProviderFile downloadOptionalFile(JsonNode payload,
+                                              String field,
+                                              MediaType mediaType,
+                                              AssetType assetType,
+                                              ProviderAssetRole role,
+                                              String filename) {
+        String url = readText(payload, field);
+        if (!StringUtils.hasText(url)) {
+            return null;
+        }
+        byte[] content = webClient.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .block();
+        if (content == null || content.length == 0) {
+            throw new VideoProviderException("Download vazio para campo " + field);
+        }
+        return new ProviderFile(filename, mediaType, assetType, role, content);
+    }
+
+    private SalesVideoScript ensureScript(SalesVideoProfile profile) {
+        SalesVideoScript script = profile.latestScript();
+        if (script == null || !StringUtils.hasText(script.scriptText())) {
+            throw new VideoProviderException("Perfil não possui script aprovado para renderização");
+        }
+        return script;
+    }
+
+    private String resolveFailureCode(JsonNode finalStatus) {
+        String code = readText(finalStatus, "error_code");
+        return StringUtils.hasText(code) ? code : "PROVIDER_RENDER_FAILED";
+    }
+
+    private WebClient.RequestHeadersSpec<?> authorized(WebClient.RequestHeadersSpec<?> request) {
+        String authToken = properties.getProviders().getReal().getAuthToken();
+        if (StringUtils.hasText(authToken)) {
+            request.header(HttpHeaders.AUTHORIZATION, "Bearer " + authToken);
+        }
+        return request;
+    }
+
+    private String resolveBaseUrl(VideoManagementProperties properties) {
+        if (properties.getProviders().getReal().getBaseUrl() == null) {
+            throw new IllegalStateException("video.providers.real.base-url precisa ser configurado quando provider real estiver habilitado");
+        }
+        return properties.getProviders().getReal().getBaseUrl().toString();
+    }
+
+    private String readText(JsonNode node,
+                            String field) {
+        if (node == null || node.get(field) == null || node.get(field).isNull()) {
+            return null;
+        }
+        return node.get(field).asText(null);
+    }
+
+    private Integer readInt(JsonNode node,
+                            String field) {
+        if (node == null || node.get(field) == null || node.get(field).isNull()) {
+            return null;
+        }
+        return node.get(field).asInt();
+    }
+
+    private String normalize(String value) {
+        return StringUtils.hasText(value) ? value.trim().toUpperCase(Locale.ROOT) : "";
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new VideoProviderException("Thread interrompida durante polling do provider", ex);
+        }
+    }
+}

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/service/provider/VideoProviderException.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/service/provider/VideoProviderException.java
@@ -4,11 +4,32 @@ package com.marketinghub.videomanagement.service.provider;
  * Exceção lançada pelos providers em caso de falha de renderização.
  */
 public class VideoProviderException extends RuntimeException {
+    private final String code;
+
     public VideoProviderException(String message) {
         super(message);
+        this.code = "VIDEO_PROVIDER_ERROR";
+    }
+
+    public VideoProviderException(String code,
+                                  String message) {
+        super(message);
+        this.code = code;
     }
 
     public VideoProviderException(String message, Throwable cause) {
         super(message, cause);
+        this.code = "VIDEO_PROVIDER_ERROR";
+    }
+
+    public VideoProviderException(String code,
+                                  String message,
+                                  Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
     }
 }

--- a/video-management-service/src/main/resources/application.yml
+++ b/video-management-service/src/main/resources/application.yml
@@ -2,13 +2,26 @@ server:
   port: 8095
 
 video:
-  backend-base-url: http://backend:8000
+  backend-base-url: http://191.252.181.168:8000
   worker-id: vm-service-local
   auth-token: ""
   jobs:
     polling-enabled: false
     poll-interval: PT30S
     batch-size: 10
+  providers:
+    real:
+      enabled: false
+      accepted-names:
+        - REAL
+        - HEYGEN
+        - SYNTHESIA
+      base-url: http://real-video-provider:8080
+      auth-token: ""
+      create-path: /v1/renders
+      status-path-template: /v1/renders/{providerJobId}
+      poll-interval: PT5S
+      max-poll-attempts: 120
 
 management:
   endpoints:


### PR DESCRIPTION
### Motivation
- Enable Sprint V1 goal to replace the dev `stub` with a real provider adapter so jobs can complete end-to-end in staging. 
- Keep the backend (`backend/ads-service`) as the single source of truth while improving worker↔backend operational signals (heartbeat, expiration). 
- Prepare the video worker for staging validation against the shared backend at `191.252.181.168` and capture provider metadata/errors for normalization.

### Description
- Added a real provider adapter `RealVideoProvider` implementing request → polling → download and returning `ProviderArtifacts` with `provider_job_id` and normalized metadata. 
- Added provider configuration under `VideoManagementProperties` (`video.providers.real.*`) including `acceptedNames`, `baseUrl`, paths, `pollInterval` and `maxPollAttempts`. 
- Introduced payload records `JobHeartbeatPayload` and `JobExpirationPayload` and extended `BackendVideoClient` with `reportHeartbeat` and `expireJob` methods to call `/internal/video/jobs/{jobId}/heartbeat` and `/internal/video/jobs/{jobId}/expired`. 
- Updated `VideoJobProgressReporter` to send heartbeat messages along with progress updates and updated `VideoJobProcessor` to: map provider failure codes to backend `failureCode`, route provider asset expiration (`PROVIDER_ASSET_EXPIRED`) to the `/expired` endpoint, and preserve failure-code semantics returned by providers. 
- Added `VideoProviderException` code support for richer failure mapping. 
- Updated configuration and docs: set backend staging URL in `application.yml` to `http://191.252.181.168:8000`, added provider real settings, updated `README.md`, OpenAPI servers list, restart plan closure and the implementation history entry describing the Sprint V1 changes and next steps. 

### Testing
- Ran the module test suite with `cd video-management-service && mvn test -q`, which completed successfully. 
- Performed local code inspection and API contract verification against `docs/novos-modulos/avatar/avatar-sales-video-integration-swagger.yaml` to ensure client endpoints match backend internal endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e169342bfc832190e4b40a991af574)