### PR TITLE
feat(video-module): Sprint V3 — observability, logging correlation and failure contract alignment

### DIFF
--- a/docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md
+++ b/docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md
@@ -13,6 +13,7 @@ Cada entrada descreve:
 ---
 
 ## Índice rápido
+- 2026-04-16 — Sprint V3 (observabilidade e confiabilidade operacional)
 - 2026-04-16 — Sprint V2 (robustez do ciclo assíncrono e recuperação de órfãos)
 - 2026-04-16 — Sprint V1 (contrato de integração e atualização de planejamento)
 - 2026-04-16 — Sprint V1 (implementação do adapter real e integração backend)
@@ -20,6 +21,67 @@ Cada entrada descreve:
 ---
 
 ## Entradas
+
+## 2026-04-16 — Sprint V3 (observabilidade e confiabilidade operacional)
+
+**Status:** concluída com pendências
+
+### Resumo
+- A Sprint V3 instrumentou observabilidade mínima no `video-management-service` com métricas, correlação de logs e exposição Prometheus.
+- O contrato de falha backend ↔ módulo de vídeo foi alinhado ao Swagger canônico com `retryable` e `retryReason`.
+- Dashboards e alertas foram definidos como baseline documental, permanecendo a implantação na stack compartilhada como pendência operacional.
+
+### O que foi implementado
+- Instrumentação de métricas operacionais para dispatch, conclusão, falha, expiração, conflito de claim, retry backend, recuperação de órfãos, backlog e latência total de render.
+- Inclusão de contexto de correlação (`jobId`, `profileId`, `provider`, `providerJobId`, `tenant`) no MDC do processamento de jobs.
+- Padronização do `logging.pattern.level` para emitir os campos de correlação em todos os logs do módulo durante execução do job.
+- Exposição de métricas em `/actuator/prometheus` via Micrometer Prometheus Registry.
+- Alinhamento do payload de falha para incluir `retryable` e `retryReason` em conformidade com `JobFailureRequest` do OpenAPI canônico.
+
+### O que foi alterado
+- Arquivos:
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobObservabilityService.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProcessor.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobPoller.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/client/BackendVideoClient.java`
+  - `video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobFailurePayload.java`
+  - `video-management-service/src/main/resources/application.yml`
+  - `video-management-service/pom.xml`
+  - `video-management-service/README.md`
+  - `video-management-service/src/test/java/com/marketinghub/videomanagement/service/VideoJobProcessorTest.java`
+  - `docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md`
+  - `docs/novos-modulos/avatar/avatar-sales-video-implementation-history.md`
+- Módulos:
+  - `video-management-service`
+  - documentação canônica do módulo Avatar Sales Video
+- Endpoints/contratos:
+  - `/internal/video/jobs/{jobId}/fail` (payload alinhado com `retryable` + `retryReason`)
+  - `/actuator/prometheus` (telemetria operacional)
+
+### Contratos e artefatos afetados
+- `avatar.salesVideoRenderJob.v1` (rastreabilidade operacional de retries, falhas e latência do ciclo).
+- `avatar.salesVideoJobEvent.v1` (correlação de logs e eventos por chaves de contexto).
+- `JobFailureRequest`/`JobFailurePayload` com `retryable` e `retryReason` como campos explícitos no fluxo de falha.
+
+### Testes e validações executados
+- `mvn test` no `video-management-service` com ajuste dos testes de `VideoJobProcessor`.
+- `mvn package -DskipTests` no `video-management-service` para validar build com novo registry Prometheus.
+- Revisão de consistência entre documentação de sprint, histórico e contrato OpenAPI do módulo.
+
+### Limitações e pendências
+- Dashboards e alertas ainda não foram provisionados no ambiente compartilhado de observabilidade (Grafana/Alertmanager).
+- Limiar de alertas ainda depende de baseline real em staging com carga concorrente.
+- Validação E2E dos alarmes em cenários de degradação permanece para próximos ciclos.
+
+### Próximo passo sugerido
+- Iniciar Sprint V4 (compliance/consentimento), mantendo em paralelo a materialização dos dashboards e alertas definidos na Sprint V3.
+
+### Handoff para a próxima etapa
+- Prioridade imediata: implementar bloqueios de workflow para compliance e trilha auditável de consentimento/publicação.
+- O que não deve ser refeito: métricas base, MDC de correlação, alinhamento de payload de falha e retry técnico do backend.
+- Riscos abertos: alertas sem calibração em produção podem ter ruído; compliance ainda não bloqueia render produtivo.
+- Dependências externas: stack de observabilidade compartilhada para dashboards/alertas e staging com provider real.
+- Onde continuar: `backend/ads-service` (regras de compliance), `video-management-service` (calibração de métricas) e documentação canônica de Sprint V4.
 
 ## 2026-04-16 — Sprint V2 (robustez do ciclo assíncrono e recuperação de órfãos)
 

--- a/docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md
+++ b/docs/novos-modulos/avatar/avatar-sales-video-restart-plan.md
@@ -262,28 +262,49 @@ Dar visibilidade operacional real ao módulo para permitir monitoramento e respo
 ## Fechamento da sprint — preencher pelo Codex
 
 ### Status
-- 
+- concluída com pendências (instrumentação e padrão operacional implementados; configuração de dashboards/alertas em stack de observabilidade externa ainda pendente)
 
 ### Métricas adicionadas
-- 
+- `video_jobs_dispatched_total` por provider.
+- `video_jobs_completed_total` por provider.
+- `video_jobs_failed_total` por provider e `failure_code`.
+- `video_render_latency_seconds` (latência total do render).
+- `video_jobs_backlog{status=VIDEO_REQUESTED|VIDEO_PROCESSING}` via gauge no poller.
+- `video_backend_retry_total` por operação e status HTTP.
+- `video_jobs_claim_conflict_total`, `video_jobs_orphan_recovery_total`, `video_jobs_asset_expired_total`.
 
 ### Logs/correlation fields adicionados
-- 
+- inclusão de MDC no `VideoJobProcessor` com os campos:
+  - `jobId`
+  - `profileId`
+  - `provider`
+  - `providerJobId`
+  - `tenant`
+- padronização do padrão de log em `application.yml` para emissão explícita desses campos.
 
 ### Dashboards configurados
-- 
+- documentação de baseline no `README` do `video-management-service` para painéis de backlog, confiabilidade e latência.
+- endpoints e métricas expostos para integração com Prometheus/Grafana (`/actuator/prometheus`).
 
 ### Alertas configurados
-- 
+- definição documentada de alertas mínimos:
+  - backlog `VIDEO_REQUESTED` acima de limiar operacional;
+  - aumento anormal de falhas por provider;
+  - crescimento de retries técnicos (`429/5xx`) no backend.
 
 ### Limitações restantes
-- 
+- dashboards e regras de alertas ainda precisam ser materializados na stack de observabilidade do ambiente staging/produção.
+- sem validação E2E em staging dos alertas disparando em cenário de degradação real.
 
 ### Pendências carregadas para a Sprint V4
-- 
+- integrar as métricas do módulo ao dashboard oficial do time em staging.
+- calibrar limiares de alerta por tenant/provider após baseline de operação contínua.
+- validar alarmística com carga concorrente e cenários de falha real do provider.
 
 ### Evidências/testes executados
-- 
+- suíte de testes do `video-management-service` (incluindo ajustes de contrato de falha com `retryable/retryReason`).
+- build local do módulo com instrumentação de métricas e endpoint Prometheus habilitado.
+- revisão de consistência entre código, Swagger de integração e documentação de observabilidade.
 
 ---
 
@@ -510,38 +531,37 @@ Iniciar a transição do módulo de “pipeline técnico funcional” para “pi
 ## Handoff para a próxima sprint
 
 ### 1. Resumo factual do estado atual
-- O que está concluído: Sprint V1 (adapter real inicial) + Sprint V2 (deduplicação de claim, retry técnico de backend e recuperação de órfãos).
-- O que está parcialmente concluído: validação E2E em staging do provider real com cenários de falha/expiração sob carga concorrente.
-- O que ainda não começou: observabilidade operacional estruturada (métricas, dashboards, alertas) e rollout controlado.
+- O que está concluído: Sprint V1 (adapter real inicial), Sprint V2 (robustez assíncrona) e Sprint V3 (instrumentação de observabilidade no `video-management-service`).
+- O que está parcialmente concluído: materialização de dashboards/alertas na stack oficial de monitoramento de staging.
+- O que ainda não começou: bloqueios de compliance e governança operacional da Sprint V4.
 
 ### 2. Pendências carregadas
-- Pendência 1: instrumentar métricas de `retry`, `claim_conflict` e `orphan_recovery`.
-- Pendência 2: configurar dashboards/alertas para latência total e acúmulo de backlog.
-- Pendência 3: executar bateria E2E em staging com cenários de sucesso/falha/expiração/concorrência.
+- Pendência 1: publicar dashboards no ambiente de observabilidade compartilhado (Prometheus/Grafana).
+- Pendência 2: calibrar limiares de alerta com baseline real por provider/tenant.
+- Pendência 3: executar bateria E2E em staging com cenários de alerta e degradação para validar alarmística.
 
 ### 3. Riscos abertos
-- Risco 1: divergência entre estado externo do provider e estado canônico interno (`SalesVideoStatus`).
-- Risco 2: falhas intermitentes do provider causarem backlog sem reprocessamento automático seguro.
-- Risco 3: aumento de latência sem métricas mínimas em tempo real dificultar operação.
+- Risco 1: divergência entre status externo do provider e estado canônico interno (`SalesVideoStatus`) ainda depende de validação E2E contínua.
+- Risco 2: sem calibração de limiar, alertas podem gerar ruído (falso positivo) ou atraso de detecção (falso negativo).
+- Risco 3: compliance de consentimento ainda não bloqueia workflow produtivo (escopo Sprint V4).
 
 ### 4. Decisões tomadas nesta sprint
 - Decisão 1: manter backend como única fonte de verdade para estado e persistência do módulo.
-- Decisão 2: formalizar o contrato de integração em OpenAPI dentro do diretório canônico do módulo.
-- Decisão 3: tratar `claim` concorrente como condição esperada (skip seguro), sem marcar falha funcional no job.
-- Decisão 4: adotar retry técnico com backoff apenas para falhas transitórias (`429/5xx`).
-- Decisão 5: ativar recuperação automática de jobs órfãos por idade de `updatedAt` em `VIDEO_PROCESSING`.
+- Decisão 2: expor métricas via Actuator/Prometheus no próprio `video-management-service`.
+- Decisão 3: padronizar logs correlacionáveis por MDC com chaves de rastreio de job/provider/tenant.
+- Decisão 4: manter contrato de falha com `retryable` e `retryReason` alinhado ao Swagger canônico.
 
 ### 5. Contratos/artefatos afetados
-- Endpoint: `/internal/video/jobs/*` e `/api/sales-videos/profiles/{profileId}`.
-- DTO/schema: `SalesVideoJobDto`, `SalesVideoProfileDto`, `JobClaimRequest`, `JobProgressRequest`, `JobCompletionRequest`, `JobFailureRequest`, `JobHeartbeatRequest`, `JobExpirationRequest`.
+- Endpoint: `/internal/video/jobs/*` e `/api/sales-videos/profiles/{profileId}` (sem mudança de rota, com alinhamento de payload de falha).
+- DTO/schema: `JobFailureRequest`/`JobFailurePayload` com `retryable` e `retryReason`.
 - Eventos: atualizações de progresso/conclusão/falha/expiração reportadas pelo módulo assíncrono ao backend.
-- Métricas: pendente para Sprint V3 (ainda não implementadas).
+- Métricas: `video_jobs_*`, `video_render_latency_seconds`, `video_backend_retry_total`, `video_jobs_backlog`.
 - Flags: pendente para Sprint V6 (rollout por tenant/feature flag).
 
 ### 6. Instruções para o próximo ciclo do Codex
-- Prioridade imediata: Sprint V3 com foco em observabilidade (métricas, logs correlacionáveis, dashboards e alertas).
-- O que não deve ser refeito: regras de claim deduplicado, retry técnico transitório e recuperação de órfãos implementadas na Sprint V2.
-- Onde continuar: `video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobPoller.java`, `.../BackendVideoClient.java` e documentação canônica de observabilidade do módulo.
+- Prioridade imediata: Sprint V4 com foco em compliance/consentimento e trilha auditável de publicação.
+- O que não deve ser refeito: instrumentação de métricas, MDC de correlação e políticas de retry/claim/orphan já implementadas até V3.
+- Onde continuar: backend (`ads-service`) para regras de bloqueio de workflow e documentação canônica de compliance do módulo.
 
 ---
 

--- a/video-management-service/README.md
+++ b/video-management-service/README.md
@@ -39,6 +39,38 @@ Para acompanhar os logs dos jobs, mantenha `video.jobs.polling-enabled=true` e v
 | `video.providers.real.poll-interval` | Intervalo de polling do status no provider. | `PT5S` |
 | `video.providers.real.max-poll-attempts` | Máximo de tentativas de polling antes de timeout técnico. | `120` |
 
+## Observabilidade (Sprint V3)
+
+O módulo expõe métricas em `/actuator/prometheus` com os principais indicadores operacionais:
+
+- `video_jobs_dispatched_total`
+- `video_jobs_completed_total`
+- `video_jobs_failed_total` (tag `failure_code`)
+- `video_render_latency_seconds`
+- `video_jobs_backlog` (tag `status=VIDEO_REQUESTED|VIDEO_PROCESSING`)
+- `video_backend_retry_total` (tags `operation` e `status`)
+- `video_jobs_claim_conflict_total`
+- `video_jobs_orphan_recovery_total`
+- `video_jobs_asset_expired_total`
+
+Os logs também passam a incluir correlação por MDC com:
+
+- `jobId`
+- `profileId`
+- `provider`
+- `providerJobId`
+- `tenant`
+
+### Dashboards/alertas mínimos recomendados
+
+- **Backlog**: painel com `video_jobs_backlog` por status.
+- **Confiabilidade**: taxa de falhas e retries por provider.
+- **Latência**: p95/p99 de `video_render_latency_seconds`.
+- **Alertas**:
+  - backlog `VIDEO_REQUESTED` acima do limiar operacional;
+  - aumento de `video_jobs_failed_total`;
+  - elevação de `video_backend_retry_total` por 5xx/429.
+
 ### Staging atual
 
 - Backend de staging configurado para `http://191.252.181.168:8000`.

--- a/video-management-service/pom.xml
+++ b/video-management-service/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/client/BackendVideoClient.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/client/BackendVideoClient.java
@@ -11,6 +11,7 @@ import com.marketinghub.videomanagement.client.payload.JobHeartbeatPayload;
 import com.marketinghub.videomanagement.client.payload.JobProgressPayload;
 import com.marketinghub.videomanagement.config.VideoManagementProperties;
 import com.marketinghub.videomanagement.exception.BackendIntegrationException;
+import com.marketinghub.videomanagement.service.VideoJobObservabilityService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -35,13 +36,16 @@ public class BackendVideoClient {
     private final Logger log = LoggerFactory.getLogger(BackendVideoClient.class);
     private final WebClient webClient;
     private final VideoManagementProperties properties;
+    private final VideoJobObservabilityService observabilityService;
 
     public BackendVideoClient(WebClient.Builder builder,
-                              VideoManagementProperties properties) {
+                              VideoManagementProperties properties,
+                              VideoJobObservabilityService observabilityService) {
         this.webClient = builder
                 .baseUrl(properties.getBackendBaseUrl().toString())
                 .build();
         this.properties = properties;
+        this.observabilityService = observabilityService;
     }
 
     public List<SalesVideoJob> fetchPendingJobs(int limit) {
@@ -205,6 +209,7 @@ public class BackendVideoClient {
                 if (!shouldRetry(ex.getStatusCode()) || attempt == maxAttempts) {
                     throw ex;
                 }
+                observabilityService.incrementBackendRetry(operation, ex.getStatusCode());
                 log.warn("Tentativa {}/{} falhou em {} (status={}): {}",
                         attempt, maxAttempts, operation, ex.getStatusCode(), ex.getMessage());
                 sleep(backoffMs);
@@ -215,6 +220,7 @@ public class BackendVideoClient {
                 if (!shouldRetry(ex.getStatusCode().value()) || attempt == maxAttempts) {
                     throw lastError;
                 }
+                observabilityService.incrementBackendRetry(operation, ex.getStatusCode().value());
                 log.warn("Tentativa {}/{} falhou em {} (status={}): {}",
                         attempt, maxAttempts, operation, ex.getStatusCode().value(), ex.getMessage());
                 sleep(backoffMs);
@@ -223,6 +229,7 @@ public class BackendVideoClient {
                 if (attempt == maxAttempts) {
                     throw lastError;
                 }
+                observabilityService.incrementBackendRetry(operation, null);
                 log.warn("Tentativa {}/{} falhou em {}: {}", attempt, maxAttempts, operation, ex.getMessage());
                 sleep(backoffMs);
             }

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobFailurePayload.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/client/payload/JobFailurePayload.java
@@ -8,5 +8,7 @@ import com.marketinghub.videomanagement.client.dto.SalesVideoStatus;
 public record JobFailurePayload(String failureCode,
                                 String failureDetail,
                                 SalesVideoStatus status,
-                                String message) {
+                                String message,
+                                Boolean retryable,
+                                String retryReason) {
 }

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobObservabilityService.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobObservabilityService.java
@@ -1,0 +1,101 @@
+package com.marketinghub.videomanagement.service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+public class VideoJobObservabilityService {
+
+    private final MeterRegistry meterRegistry;
+    private final AtomicInteger backlogRequested = new AtomicInteger(0);
+    private final AtomicInteger backlogProcessing = new AtomicInteger(0);
+
+    public VideoJobObservabilityService(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+        Gauge.builder("video_jobs_backlog", backlogRequested, AtomicInteger::get)
+                .tag("status", "VIDEO_REQUESTED")
+                .description("Quantidade de jobs em backlog no backend")
+                .register(meterRegistry);
+        Gauge.builder("video_jobs_backlog", backlogProcessing, AtomicInteger::get)
+                .tag("status", "VIDEO_PROCESSING")
+                .description("Quantidade de jobs em backlog no backend")
+                .register(meterRegistry);
+    }
+
+    public void setBacklogRequested(int value) {
+        backlogRequested.set(Math.max(value, 0));
+    }
+
+    public void setBacklogProcessing(int value) {
+        backlogProcessing.set(Math.max(value, 0));
+    }
+
+    public void incrementJobsDispatched(String provider) {
+        incrementCounter("video_jobs_dispatched_total", provider, null);
+    }
+
+    public void incrementJobsCompleted(String provider) {
+        incrementCounter("video_jobs_completed_total", provider, null);
+    }
+
+    public void incrementJobsFailed(String provider, String failureCode) {
+        incrementCounter("video_jobs_failed_total", provider, failureCode);
+    }
+
+    public void incrementAssetExpired(String provider) {
+        incrementCounter("video_jobs_asset_expired_total", provider, null);
+    }
+
+    public void incrementClaimConflict(String provider) {
+        incrementCounter("video_jobs_claim_conflict_total", provider, null);
+    }
+
+    public void incrementOrphanRecovered(String provider) {
+        incrementCounter("video_jobs_orphan_recovery_total", provider, null);
+    }
+
+    public void incrementBackendRetry(String operation, Integer statusCode) {
+        Counter.builder("video_backend_retry_total")
+                .description("Retentativas técnicas de integração com backend")
+                .tag("operation", normalize(operation))
+                .tag("status", statusCode == null ? "unknown" : String.valueOf(statusCode))
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void recordRenderLatency(String provider, Duration latency) {
+        if (latency == null || latency.isNegative()) {
+            return;
+        }
+        Timer.builder("video_render_latency_seconds")
+                .description("Latência total do render por job")
+                .tag("provider", normalize(provider))
+                .register(meterRegistry)
+                .record(latency);
+    }
+
+    private void incrementCounter(String metric,
+                                  String provider,
+                                  String failureCode) {
+        Counter.Builder builder = Counter.builder(metric)
+                .description("Métrica operacional do módulo Avatar Sales Video")
+                .tag("provider", normalize(provider));
+        if (failureCode != null) {
+            builder.tag("failure_code", normalize(failureCode));
+        }
+        builder.register(meterRegistry).increment();
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return "unknown";
+        }
+        return value;
+    }
+}

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobPoller.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobPoller.java
@@ -18,13 +18,16 @@ public class VideoJobPoller {
     private final VideoManagementProperties properties;
     private final BackendVideoClient backendClient;
     private final VideoJobDispatcher dispatcher;
+    private final VideoJobObservabilityService observabilityService;
 
     public VideoJobPoller(VideoManagementProperties properties,
                           BackendVideoClient backendClient,
-                          VideoJobDispatcher dispatcher) {
+                          VideoJobDispatcher dispatcher,
+                          VideoJobObservabilityService observabilityService) {
         this.properties = properties;
         this.backendClient = backendClient;
         this.dispatcher = dispatcher;
+        this.observabilityService = observabilityService;
     }
 
     @Scheduled(initialDelay = 5000,
@@ -35,6 +38,7 @@ public class VideoJobPoller {
         }
         try {
             List<SalesVideoJob> jobs = backendClient.fetchPendingJobs(properties.getJobs().getBatchSize());
+            observabilityService.setBacklogRequested(jobs.size());
             if (!jobs.isEmpty()) {
                 log.info("Encontrados {} jobs pendentes", jobs.size());
                 jobs.forEach(dispatcher::dispatch);
@@ -50,6 +54,7 @@ public class VideoJobPoller {
     private void recoverOrphanJobs() {
         List<SalesVideoJob> processingJobs = backendClient.fetchJobsByStatus(
                 SalesVideoStatus.VIDEO_PROCESSING, properties.getJobs().getBatchSize());
+        observabilityService.setBacklogProcessing(processingJobs.size());
         if (processingJobs.isEmpty()) {
             return;
         }
@@ -63,6 +68,9 @@ public class VideoJobPoller {
         }
         log.warn("Recuperação automática encontrou {} jobs órfãos/candidatos (threshold={}s)",
                 orphanCandidates.size(), properties.getJobs().getOrphanThreshold().toSeconds());
-        orphanCandidates.forEach(dispatcher::dispatch);
+        orphanCandidates.forEach(job -> {
+            observabilityService.incrementOrphanRecovered(job.providerName());
+            dispatcher.dispatch(job);
+        });
     }
 }

--- a/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProcessor.java
+++ b/video-management-service/src/main/java/com/marketinghub/videomanagement/service/VideoJobProcessor.java
@@ -19,8 +19,11 @@ import com.marketinghub.videomanagement.service.provider.VideoProvider;
 import com.marketinghub.videomanagement.service.provider.VideoProviderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 
 @Service
@@ -29,27 +32,31 @@ public class VideoJobProcessor {
     private final BackendVideoClient backendClient;
     private final ProviderRegistry providerRegistry;
     private final VideoAssetUploader assetUploader;
+    private final VideoJobObservabilityService observabilityService;
     private final VideoManagementProperties properties;
     private final ObjectMapper objectMapper;
 
     public VideoJobProcessor(BackendVideoClient backendClient,
                              ProviderRegistry providerRegistry,
                              VideoAssetUploader assetUploader,
+                             VideoJobObservabilityService observabilityService,
                              VideoManagementProperties properties,
                              ObjectMapper objectMapper) {
         this.backendClient = backendClient;
         this.providerRegistry = providerRegistry;
         this.assetUploader = assetUploader;
+        this.observabilityService = observabilityService;
         this.properties = properties;
         this.objectMapper = objectMapper;
     }
 
     public void process(SalesVideoJob job) {
-        log.info("Processando job {} para profile {}", job.id(), job.profileId());
-        try {
+        try (AutoCloseable ignored = putMdc(job)) {
+            log.info("Processando job {} para profile {}", job.id(), job.profileId());
             if (!claimJob(job)) {
                 return;
             }
+            observabilityService.incrementJobsDispatched(job.providerName());
             backendClient.reportHeartbeat(job.id(), new JobHeartbeatPayload(
                     "Job em execução pelo worker " + properties.getWorkerId(), null));
             SalesVideoProfile profile = loadProfile(job);
@@ -71,10 +78,14 @@ public class VideoJobProcessor {
                     metadataJson,
                     "Vídeo processado com sucesso",
                     metadataJson));
+            observabilityService.incrementJobsCompleted(job.providerName());
+            observabilityService.recordRenderLatency(job.providerName(), computeLatency(job));
             log.info("Job {} concluído com vídeo {}", job.id(), uploadedAssets.videoAssetId());
         } catch (VideoProviderException ex) {
             log.warn("Falha ao processar job {}: {}", job.id(), ex.getMessage());
+            observabilityService.incrementJobsFailed(job.providerName(), ex.getCode());
             if (isExpiredFailure(ex)) {
+                observabilityService.incrementAssetExpired(job.providerName());
                 backendClient.expireJob(job.id(), new JobExpirationPayload(
                         "Provider informou asset expirado",
                         ex.getMessage()));
@@ -84,12 +95,15 @@ public class VideoJobProcessor {
                         failureCode,
                         buildFailureDetail(ex),
                         SalesVideoStatus.VIDEO_FAILED,
-                        ex.getMessage()));
+                        ex.getMessage(),
+                        isRetryableFailure(failureCode),
+                        toRetryReason(failureCode)));
             }
         } catch (BackendIntegrationException ex) {
             if (isDuplicateClaim(ex) || isNotFound(ex)) {
                 log.info("Job {} não será processado neste worker (status={}): {}",
                         job.id(), ex.getStatusCode(), ex.getMessage());
+                observabilityService.incrementClaimConflict(job.providerName());
                 return;
             }
             log.error("Falha de integração com backend ao processar job {}: {}", job.id(), ex.getMessage());
@@ -133,7 +147,13 @@ public class VideoJobProcessor {
                              String detail,
                              String message) {
         try {
-            backendClient.failJob(jobId, new JobFailurePayload(code, detail, SalesVideoStatus.VIDEO_FAILED, message));
+            backendClient.failJob(jobId, new JobFailurePayload(
+                    code,
+                    detail,
+                    SalesVideoStatus.VIDEO_FAILED,
+                    message,
+                    false,
+                    "OTHER"));
         } catch (Exception failEx) {
             log.error("Falha ao registrar erro do job {} no backend: {}", jobId, failEx.getMessage());
         }
@@ -149,8 +169,47 @@ public class VideoJobProcessor {
 
     private String buildFailureDetail(VideoProviderException ex) {
         String reason = ex.getCode();
-        boolean retryable = "PROVIDER_TIMEOUT".equalsIgnoreCase(reason) || "PROVIDER_RATE_LIMIT".equalsIgnoreCase(reason);
+        boolean retryable = isRetryableFailure(reason);
         return "retryable=%s;code=%s;message=%s".formatted(retryable, reason, ex.getMessage());
+    }
+
+    private boolean isRetryableFailure(String reason) {
+        return "PROVIDER_TIMEOUT".equalsIgnoreCase(reason) || "PROVIDER_RATE_LIMIT".equalsIgnoreCase(reason);
+    }
+
+    private String toRetryReason(String failureCode) {
+        if ("PROVIDER_ASSET_EXPIRED".equalsIgnoreCase(failureCode)) {
+            return "ASSET_EXPIRED";
+        }
+        if (isRetryableFailure(failureCode)) {
+            return "PROVIDER_FAILURE";
+        }
+        return "OTHER";
+    }
+
+    private AutoCloseable putMdc(SalesVideoJob job) {
+        MDC.put("jobId", asString(job.id()));
+        MDC.put("profileId", asString(job.profileId()));
+        MDC.put("provider", valueOrUnknown(job.providerName()));
+        MDC.put("providerJobId", valueOrUnknown(job.providerJobId()));
+        MDC.put("tenant", valueOrUnknown(job.tenantId()));
+        return MDC::clear;
+    }
+
+    private String asString(Long value) {
+        return value == null ? "null" : String.valueOf(value);
+    }
+
+    private String valueOrUnknown(String value) {
+        return value == null || value.isBlank() ? "unknown" : value;
+    }
+
+    private Duration computeLatency(SalesVideoJob job) {
+        Instant requestedAt = job.requestedAt();
+        if (requestedAt == null) {
+            return null;
+        }
+        return Duration.between(requestedAt, Instant.now());
     }
 
     private String serializeMetadata(Map<String, Object> metadata) {

--- a/video-management-service/src/main/resources/application.yml
+++ b/video-management-service/src/main/resources/application.yml
@@ -31,8 +31,12 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,prometheus
   endpoint:
     health:
       probes:
         enabled: true
+
+logging:
+  pattern:
+    level: "%5p [jobId:%X{jobId:-na} profileId:%X{profileId:-na} provider:%X{provider:-na} providerJobId:%X{providerJobId:-na} tenant:%X{tenant:-na}]"

--- a/video-management-service/src/test/java/com/marketinghub/videomanagement/service/VideoJobProcessorTest.java
+++ b/video-management-service/src/test/java/com/marketinghub/videomanagement/service/VideoJobProcessorTest.java
@@ -54,6 +54,9 @@ class VideoJobProcessorTest {
     @Mock
     private VideoProvider videoProvider;
 
+    @Mock
+    private VideoJobObservabilityService observabilityService;
+
     @Captor
     private ArgumentCaptor<JobCompletionPayload> completionCaptor;
 
@@ -66,7 +69,13 @@ class VideoJobProcessorTest {
     void setUp() {
         VideoManagementProperties properties = new VideoManagementProperties();
         properties.setWorkerId("worker-test");
-        processor = new VideoJobProcessor(backendClient, providerRegistry, assetUploader, properties, new ObjectMapper());
+        processor = new VideoJobProcessor(
+                backendClient,
+                providerRegistry,
+                assetUploader,
+                observabilityService,
+                properties,
+                new ObjectMapper());
     }
 
     @Test
@@ -102,6 +111,8 @@ class VideoJobProcessorTest {
 
         verify(backendClient).failJob(any(), failureCaptor.capture());
         assertThat(failureCaptor.getValue().failureCode()).isEqualTo("VIDEO_PROVIDER_ERROR");
+        assertThat(failureCaptor.getValue().retryable()).isFalse();
+        assertThat(failureCaptor.getValue().retryReason()).isEqualTo("OTHER");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Deliver Sprint V3 to close pending work from prior sprints by adding operational observability and readiness for staging rollouts. 
- Allow operators to detect backlog, retries and provider issues quickly and preserve traceability across backend ↔ `video-management-service`. 

### Description
- Added a dedicated observability service `VideoJobObservabilityService` that registers Prometheus metrics/gauges/counters/timers (dispatch/completion/failures/asset-expiry/backlog/retries/orphan-recovery and render latency) and is wired into the module. 
- Instrumented the processing flow: `VideoJobProcessor` now emits metrics (`incrementJobsDispatched`, `incrementJobsCompleted`, `incrementJobsFailed`, `recordRenderLatency`), sets MDC correlation fields (`jobId`, `profileId`, `provider`, `providerJobId`, `tenant`) and maps provider failures to the backend `JobFailurePayload` with `retryable` and `retryReason`. 
- Poller and client enhancements: `VideoJobPoller` publishes backlog gauges and reports orphan recoveries to metrics, and `BackendVideoClient` increments `video_backend_retry_total` on backend-call retries. 
- Contract/ops changes: extended `JobFailurePayload` with `retryable` and `retryReason`, added Micrometer Prometheus dependency, exposed `/actuator/prometheus`, added logging pattern for MDC, and updated README + canonical docs (`avatar-sales-video-restart-plan.md`, `avatar-sales-video-implementation-history.md`) to record Sprint V3. 

### Testing
- Ran unit and integration tests: `cd video-management-service && mvn test`; all tests passed (7 tests total — local unit suite). 
- Verified build: `cd video-management-service && mvn -q -DskipTests package` completed successfully. 
- Updated `VideoJobProcessorTest` to assert new failure payload fields and added observability mocks; tests validated the new behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e175d5106c8321beeadb299ecbafeb)