### PR TITLE
fix(lead-portal): corrigir erros de lint no FlowPage

### DIFF
--- a/lead-portal/frontend/src/pages/FlowPage.tsx
+++ b/lead-portal/frontend/src/pages/FlowPage.tsx
@@ -104,6 +104,13 @@ export default function FlowPage() {
     };
   }, [resolvedFlowSlug, isLoading, isError, hasTrackedRenderComplete, campaignCode]);
 
+  useEffect(() => {
+    if (!flow?.facebookPixelId) {
+      return;
+    }
+    initializeMetaPixel(flow.facebookPixelId);
+  }, [flow?.facebookPixelId]);
+
   if (!slug) {
     return <p className="flow-message">Fluxo não informado.</p>;
   }
@@ -138,12 +145,6 @@ export default function FlowPage() {
           questions: formQuestions,
         };
 
-  useEffect(() => {
-    if (!flow?.facebookPixelId) {
-      return;
-    }
-    initializeMetaPixel(flow.facebookPixelId);
-  }, [flow?.facebookPixelId]);
   if (hasCustomTemplate && customTemplateHtml) {
     const templateVariables = customTemplateVariables ?? new Map<string, string>();
     if (shouldRenderStandaloneTemplate) {
@@ -1232,8 +1233,10 @@ function extractSimpleFormMetadata(questions: FlowQuestion[]): SimpleFormMetadat
   };
 }
 
-type FbqFunction = ((...args: any[]) => void) & {
-  callMethod?: (...args: any[]) => void;
+type FbqArgument = string | number | boolean | null | undefined | Record<string, unknown>;
+
+type FbqFunction = ((...args: FbqArgument[]) => void) & {
+  callMethod?: (...args: FbqArgument[]) => void;
   queue: unknown[];
   push?: FbqFunction;
   loaded?: boolean;
@@ -1276,9 +1279,9 @@ function ensureMetaPixelBase(): FbqFunction {
   if (w.fbq) {
     return w.fbq;
   }
-  const fbq: FbqFunction = function (...args: any[]) {
+  const fbq: FbqFunction = function (...args: FbqArgument[]) {
     if (fbq.callMethod) {
-      fbq.callMethod.apply(fbq, args);
+      fbq.callMethod(...args);
     } else {
       fbq.queue.push(args);
     }


### PR DESCRIPTION
### Motivation
- Corrigir falhas de lint e regras do React Hooks reportadas em `lead-portal/frontend/src/pages/FlowPage.tsx`, incluindo chamada condicional de `useEffect` e usos de `any`.
- Garantir conformidade com `@typescript-eslint` e regras `react-hooks/rules-of-hooks` para evitar comportamentos inconsistentes em runtime.

### Description
- Move o `useEffect` de inicialização do Meta Pixel para antes dos retornos condicionais do componente para evitar chamada condicional de hook (`useEffect` relocado em `FlowPage.tsx`).
- Introduz o tipo `FbqArgument` e aplica-o ao wrapper do `fbq` para remover usos de `any` e satisfazer `@typescript-eslint/no-explicit-any`.
- Substitui `fbq.callMethod.apply(fbq, args)` por `fbq.callMethod(...args)` para atender a regra `prefer-spread`.
- Mudanças limitadas ao arquivo `lead-portal/frontend/src/pages/FlowPage.tsx` sem alterar contratos de API.

### Testing
- Executado `cd lead-portal/frontend && npm install` e a instalação das dependências concluiu com sucesso.
- Executado `cd lead-portal/frontend && npm run lint` e o lint completou sem erros (anteriormente o lint falhava com erros de hooks/typing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18c9fec3c832180725c0e20082c66)