### PR TITLE
Add MDS baseline: backend persistence, internal API and independent MDS module bootstrap

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mds/MdsArtifactLineageEdge.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/MdsArtifactLineageEdge.java
@@ -1,0 +1,36 @@
+package com.marketinghub.mds;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "artifact_lineage_edge")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MdsArtifactLineageEdge {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "parent_artifact_id", nullable = false)
+    private MdsArtifactRecord parentArtifact;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "child_artifact_id", nullable = false)
+    private MdsArtifactRecord childArtifact;
+
+    @Column(name = "relation_type", nullable = false, length = 64)
+    private String relationType;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/MdsArtifactRecord.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/MdsArtifactRecord.java
@@ -1,0 +1,54 @@
+package com.marketinghub.mds;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "artifact_record")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MdsArtifactRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "artifact_type", nullable = false, length = 128)
+    private String artifactType;
+
+    @Column(name = "schema_version", nullable = false, length = 32)
+    private String schemaVersion;
+
+    @Column(name = "version", nullable = false, length = 32)
+    private String version;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private MdsArtifactStatus status;
+
+    @Column(name = "producer_module", nullable = false, length = 64)
+    private String producerModule;
+
+    @Column(name = "owner_module", nullable = false, length = 64)
+    private String ownerModule;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "request_id", nullable = false)
+    private MdsRequest request;
+
+    @Column(name = "content_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String contentJson;
+
+    @Column(name = "hash", nullable = false, length = 64)
+    private String hash;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/MdsArtifactStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/MdsArtifactStatus.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mds;
+
+public enum MdsArtifactStatus {
+    DRAFT,
+    VALIDATED,
+    APPROVED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/MdsEventType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/MdsEventType.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mds;
+
+public enum MdsEventType {
+    INFO,
+    HEARTBEAT,
+    ERROR
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/MdsProcessingEvent.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/MdsProcessingEvent.java
@@ -1,0 +1,42 @@
+package com.marketinghub.mds;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "mds_processing_event")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MdsProcessingEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "request_id", nullable = false)
+    private MdsRequest request;
+
+    @Column(name = "stage_name", nullable = false, length = 128)
+    private String stageName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 32)
+    private MdsEventType eventType;
+
+    @Column(name = "message", nullable = false, columnDefinition = "LONGTEXT")
+    private String message;
+
+    @Column(name = "payload_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String payloadJson;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/MdsRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/MdsRequest.java
@@ -1,0 +1,64 @@
+package com.marketinghub.mds;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "mds_request")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MdsRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private MdsRequestStatus status;
+
+    @Column(name = "market", nullable = false, length = 191)
+    private String market;
+
+    @Column(name = "problem", nullable = false, columnDefinition = "LONGTEXT")
+    private String problem;
+
+    @Column(name = "desired_outcome", nullable = false, columnDefinition = "LONGTEXT")
+    private String desiredOutcome;
+
+    @Column(name = "context_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String contextJson;
+
+    @Column(name = "delivery_constraint", length = 191)
+    private String deliveryConstraint;
+
+    @Column(name = "evidence_preference", length = 64)
+    private String evidencePreference;
+
+    @Column(name = "started_at")
+    private Instant startedAt;
+
+    @Column(name = "finished_at")
+    private Instant finishedAt;
+
+    @Column(name = "failure_reason", columnDefinition = "LONGTEXT")
+    private String failureReason;
+
+    @Column(name = "correlation_id", nullable = false, length = 191)
+    private String correlationId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/MdsRequestStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/MdsRequestStatus.java
@@ -1,0 +1,8 @@
+package com.marketinghub.mds;
+
+public enum MdsRequestStatus {
+    PENDING,
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/MdsSourceAccessRecord.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/MdsSourceAccessRecord.java
@@ -1,0 +1,40 @@
+package com.marketinghub.mds;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "source_access_record")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MdsSourceAccessRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "source_document_id", nullable = false, length = 191)
+    private String sourceDocumentId;
+
+    @Column(name = "access_class", nullable = false, length = 64)
+    private String accessClass;
+
+    @Column(name = "permission_state", nullable = false, length = 64)
+    private String permissionState;
+
+    @Column(name = "license_text", columnDefinition = "LONGTEXT")
+    private String licenseText;
+
+    @Column(name = "access_url", length = 512)
+    private String accessUrl;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsArtifactPublishBatchRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsArtifactPublishBatchRequest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.mds.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record MdsArtifactPublishBatchRequest(
+        @NotNull Long requestId,
+        @NotEmpty List<@Valid MdsArtifactPayload> artifacts
+) {
+    public record MdsArtifactPayload(
+            @NotBlank String artifactType,
+            @NotBlank String schemaVersion,
+            @NotBlank String version,
+            @NotBlank String status,
+            @NotBlank String producerModule,
+            @NotBlank String ownerModule,
+            Object content,
+            String hash,
+            List<Long> parentArtifactIds
+    ) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsArtifactPublishBatchResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsArtifactPublishBatchResponse.java
@@ -1,0 +1,10 @@
+package com.marketinghub.mds.dto;
+
+import java.util.List;
+
+public record MdsArtifactPublishBatchResponse(
+        Long requestId,
+        int publishedCount,
+        List<Long> artifactIds
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsClaimRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsClaimRequest.java
@@ -1,0 +1,6 @@
+package com.marketinghub.mds.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MdsClaimRequest(@NotBlank String workerId) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsCompleteRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsCompleteRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.mds.dto;
+
+public record MdsCompleteRequest(String message) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsFailRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsFailRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.mds.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MdsFailRequest(
+        @NotBlank String reason,
+        String stageName,
+        String message
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsHeartbeatRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsHeartbeatRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.mds.dto;
+
+import java.util.Map;
+
+public record MdsHeartbeatRequest(
+        String stageName,
+        String message,
+        Map<String, Object> payload
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsLineageCreateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsLineageCreateRequest.java
@@ -1,0 +1,11 @@
+package com.marketinghub.mds.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record MdsLineageCreateRequest(
+        @NotNull Long parentArtifactId,
+        @NotNull Long childArtifactId,
+        @NotBlank String relationType
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsLineageResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsLineageResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.mds.dto;
+
+public record MdsLineageResponse(
+        Long id,
+        Long parentArtifactId,
+        Long childArtifactId,
+        String relationType
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRequestCreateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRequestCreateRequest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.mds.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Map;
+
+public record MdsRequestCreateRequest(
+        @NotBlank String market,
+        @NotBlank String problem,
+        @NotBlank String desiredOutcome,
+        @NotNull Map<String, Object> context,
+        String deliveryConstraint,
+        String evidencePreference,
+        @NotBlank String correlationId
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRequestStatusResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRequestStatusResponse.java
@@ -1,0 +1,20 @@
+package com.marketinghub.mds.dto;
+
+import com.marketinghub.mds.MdsRequestStatus;
+
+import java.time.Instant;
+
+public record MdsRequestStatusResponse(
+        Long id,
+        MdsRequestStatus status,
+        String market,
+        String problem,
+        String desiredOutcome,
+        String correlationId,
+        String failureReason,
+        Instant createdAt,
+        Instant startedAt,
+        Instant finishedAt,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactLineageEdgeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactLineageEdgeRepository.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mds.repository;
+
+import com.marketinghub.mds.MdsArtifactLineageEdge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MdsArtifactLineageEdgeRepository extends JpaRepository<MdsArtifactLineageEdge, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mds.repository;
+
+import com.marketinghub.mds.MdsArtifactRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MdsArtifactRecordRepository extends JpaRepository<MdsArtifactRecord, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsProcessingEventRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsProcessingEventRepository.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mds.repository;
+
+import com.marketinghub.mds.MdsProcessingEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MdsProcessingEventRepository extends JpaRepository<MdsProcessingEvent, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsRequestRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsRequestRepository.java
@@ -1,0 +1,11 @@
+package com.marketinghub.mds.repository;
+
+import com.marketinghub.mds.MdsRequest;
+import com.marketinghub.mds.MdsRequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MdsRequestRepository extends JpaRepository<MdsRequest, Long> {
+    List<MdsRequest> findTop50ByStatusOrderByCreatedAtAsc(MdsRequestStatus status);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsSourceAccessRecordRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsSourceAccessRecordRepository.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mds.repository;
+
+import com.marketinghub.mds.MdsSourceAccessRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MdsSourceAccessRecordRepository extends JpaRepository<MdsSourceAccessRecord, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
@@ -1,0 +1,132 @@
+package com.marketinghub.mds.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.mds.MdsArtifactLineageEdge;
+import com.marketinghub.mds.MdsArtifactRecord;
+import com.marketinghub.mds.MdsArtifactStatus;
+import com.marketinghub.mds.MdsRequest;
+import com.marketinghub.mds.dto.MdsArtifactPublishBatchRequest;
+import com.marketinghub.mds.dto.MdsArtifactPublishBatchResponse;
+import com.marketinghub.mds.dto.MdsLineageCreateRequest;
+import com.marketinghub.mds.dto.MdsLineageResponse;
+import com.marketinghub.mds.repository.MdsArtifactLineageEdgeRepository;
+import com.marketinghub.mds.repository.MdsArtifactRecordRepository;
+import com.marketinghub.mds.repository.MdsRequestRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+
+@Service
+public class MdsArtifactService {
+    private final MdsRequestRepository requestRepository;
+    private final MdsArtifactRecordRepository artifactRecordRepository;
+    private final MdsArtifactLineageEdgeRepository lineageEdgeRepository;
+    private final ObjectMapper objectMapper;
+
+    public MdsArtifactService(MdsRequestRepository requestRepository,
+                              MdsArtifactRecordRepository artifactRecordRepository,
+                              MdsArtifactLineageEdgeRepository lineageEdgeRepository,
+                              ObjectMapper objectMapper) {
+        this.requestRepository = requestRepository;
+        this.artifactRecordRepository = artifactRecordRepository;
+        this.lineageEdgeRepository = lineageEdgeRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public MdsArtifactPublishBatchResponse publishBatch(MdsArtifactPublishBatchRequest request) {
+        MdsRequest mdsRequest = requestRepository.findById(request.requestId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "mds request not found"));
+
+        List<Long> ids = new ArrayList<>();
+        for (MdsArtifactPublishBatchRequest.MdsArtifactPayload artifactPayload : request.artifacts()) {
+            String contentJson = toJson(artifactPayload.content());
+            MdsArtifactRecord record = MdsArtifactRecord.builder()
+                    .artifactType(artifactPayload.artifactType())
+                    .schemaVersion(artifactPayload.schemaVersion())
+                    .version(artifactPayload.version())
+                    .status(parseStatus(artifactPayload.status()))
+                    .producerModule(artifactPayload.producerModule())
+                    .ownerModule(artifactPayload.ownerModule())
+                    .request(mdsRequest)
+                    .contentJson(contentJson)
+                    .hash(resolveHash(artifactPayload.hash(), contentJson))
+                    .build();
+            MdsArtifactRecord saved = artifactRecordRepository.save(record);
+            ids.add(saved.getId());
+
+            if (artifactPayload.parentArtifactIds() != null) {
+                for (Long parentId : artifactPayload.parentArtifactIds()) {
+                    createLineage(parentId, saved.getId(), "DERIVED_FROM");
+                }
+            }
+        }
+
+        return new MdsArtifactPublishBatchResponse(request.requestId(), ids.size(), ids);
+    }
+
+    @Transactional
+    public MdsLineageResponse createLineage(MdsLineageCreateRequest request) {
+        return createLineage(request.parentArtifactId(), request.childArtifactId(), request.relationType());
+    }
+
+    private MdsLineageResponse createLineage(Long parentArtifactId, Long childArtifactId, String relationType) {
+        MdsArtifactRecord parent = artifactRecordRepository.findById(parentArtifactId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "parent artifact not found"));
+        MdsArtifactRecord child = artifactRecordRepository.findById(childArtifactId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "child artifact not found"));
+
+        MdsArtifactLineageEdge edge = MdsArtifactLineageEdge.builder()
+                .parentArtifact(parent)
+                .childArtifact(child)
+                .relationType(relationType)
+                .build();
+        MdsArtifactLineageEdge saved = lineageEdgeRepository.save(edge);
+
+        return new MdsLineageResponse(
+                saved.getId(),
+                saved.getParentArtifact().getId(),
+                saved.getChildArtifact().getId(),
+                saved.getRelationType()
+        );
+    }
+
+    private MdsArtifactStatus parseStatus(String status) {
+        try {
+            return MdsArtifactStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "artifact status must be one of DRAFT, VALIDATED, APPROVED");
+        }
+    }
+
+    private String toJson(Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload == null ? java.util.Map.of() : payload);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "invalid artifact content json");
+        }
+    }
+
+    private String resolveHash(String hash, String contentJson) {
+        if (hash != null && !hash.isBlank()) {
+            return hash;
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] raw = digest.digest(contentJson.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(raw);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm unavailable", e);
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsRequestService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsRequestService.java
@@ -1,0 +1,156 @@
+package com.marketinghub.mds.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.mds.*;
+import com.marketinghub.mds.dto.*;
+import com.marketinghub.mds.repository.MdsProcessingEventRepository;
+import com.marketinghub.mds.repository.MdsRequestRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+public class MdsRequestService {
+    private final MdsRequestRepository requestRepository;
+    private final MdsProcessingEventRepository processingEventRepository;
+    private final ObjectMapper objectMapper;
+
+    public MdsRequestService(MdsRequestRepository requestRepository,
+                             MdsProcessingEventRepository processingEventRepository,
+                             ObjectMapper objectMapper) {
+        this.requestRepository = requestRepository;
+        this.processingEventRepository = processingEventRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public MdsRequestStatusResponse createRequest(MdsRequestCreateRequest request) {
+        MdsRequest entity = MdsRequest.builder()
+                .status(MdsRequestStatus.PENDING)
+                .market(request.market())
+                .problem(request.problem())
+                .desiredOutcome(request.desiredOutcome())
+                .contextJson(toJson(request.context()))
+                .deliveryConstraint(request.deliveryConstraint())
+                .evidencePreference(request.evidencePreference())
+                .correlationId(request.correlationId())
+                .build();
+
+        return toResponse(requestRepository.save(entity));
+    }
+
+    @Transactional(readOnly = true)
+    public List<MdsRequestStatusResponse> pendingRequests() {
+        return requestRepository.findTop50ByStatusOrderByCreatedAtAsc(MdsRequestStatus.PENDING)
+                .stream().map(this::toResponse).toList();
+    }
+
+    @Transactional
+    public MdsRequestStatusResponse claim(Long id, MdsClaimRequest claimRequest) {
+        MdsRequest request = findRequest(id);
+        if (request.getStatus() != MdsRequestStatus.PENDING) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "request is not pending");
+        }
+        request.setStatus(MdsRequestStatus.IN_PROGRESS);
+        request.setStartedAt(Instant.now());
+        persistEvent(request, "orchestration", MdsEventType.INFO,
+                "request claimed by worker " + claimRequest.workerId(), claimRequest);
+        return toResponse(request);
+    }
+
+    @Transactional
+    public MdsRequestStatusResponse heartbeat(Long id, MdsHeartbeatRequest heartbeatRequest) {
+        MdsRequest request = findRequest(id);
+        persistEvent(
+                request,
+                defaultValue(heartbeatRequest.stageName(), "pipeline"),
+                MdsEventType.HEARTBEAT,
+                defaultValue(heartbeatRequest.message(), "heartbeat received"),
+                heartbeatRequest.payload()
+        );
+        return toResponse(request);
+    }
+
+    @Transactional
+    public MdsRequestStatusResponse complete(Long id, MdsCompleteRequest completeRequest) {
+        MdsRequest request = findRequest(id);
+        request.setStatus(MdsRequestStatus.COMPLETED);
+        request.setFinishedAt(Instant.now());
+        request.setFailureReason(null);
+        persistEvent(request, "orchestration", MdsEventType.INFO,
+                defaultValue(completeRequest.message(), "request completed"), completeRequest);
+        return toResponse(request);
+    }
+
+    @Transactional
+    public MdsRequestStatusResponse fail(Long id, MdsFailRequest failRequest) {
+        MdsRequest request = findRequest(id);
+        request.setStatus(MdsRequestStatus.FAILED);
+        request.setFinishedAt(Instant.now());
+        request.setFailureReason(failRequest.reason());
+        persistEvent(request,
+                defaultValue(failRequest.stageName(), "pipeline"),
+                MdsEventType.ERROR,
+                defaultValue(failRequest.message(), failRequest.reason()),
+                failRequest);
+        return toResponse(request);
+    }
+
+    @Transactional(readOnly = true)
+    public MdsRequestStatusResponse getById(Long id) {
+        return toResponse(findRequest(id));
+    }
+
+    private MdsRequest findRequest(Long id) {
+        return requestRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "mds request not found"));
+    }
+
+    private void persistEvent(MdsRequest request,
+                              String stageName,
+                              MdsEventType eventType,
+                              String message,
+                              Object payload) {
+        MdsProcessingEvent event = MdsProcessingEvent.builder()
+                .request(request)
+                .stageName(stageName)
+                .eventType(eventType)
+                .message(message)
+                .payloadJson(toJson(payload == null ? java.util.Map.of() : payload))
+                .build();
+        processingEventRepository.save(event);
+    }
+
+    private MdsRequestStatusResponse toResponse(MdsRequest request) {
+        return new MdsRequestStatusResponse(
+                request.getId(),
+                request.getStatus(),
+                request.getMarket(),
+                request.getProblem(),
+                request.getDesiredOutcome(),
+                request.getCorrelationId(),
+                request.getFailureReason(),
+                request.getCreatedAt(),
+                request.getStartedAt(),
+                request.getFinishedAt(),
+                request.getUpdatedAt()
+        );
+    }
+
+    private String toJson(Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "invalid json payload");
+        }
+    }
+
+    private String defaultValue(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
@@ -1,0 +1,83 @@
+package com.marketinghub.mds.web;
+
+import com.marketinghub.mds.dto.*;
+import com.marketinghub.mds.service.MdsArtifactService;
+import com.marketinghub.mds.service.MdsRequestService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/internal/mds")
+public class MdsInternalController {
+    private final MdsRequestService requestService;
+    private final MdsArtifactService artifactService;
+
+    public MdsInternalController(MdsRequestService requestService, MdsArtifactService artifactService) {
+        this.requestService = requestService;
+        this.artifactService = artifactService;
+    }
+
+    @PostMapping("/requests")
+    public MdsRequestStatusResponse createRequest(@Valid @RequestBody MdsRequestCreateRequest request) {
+        return requestService.createRequest(request);
+    }
+
+    @GetMapping("/requests/pending")
+    public List<MdsRequestStatusResponse> pending() {
+        return requestService.pendingRequests();
+    }
+
+    @PostMapping("/requests/{id}/claim")
+    public MdsRequestStatusResponse claim(@PathVariable Long id,
+                                          @Valid @RequestBody MdsClaimRequest request) {
+        return requestService.claim(id, request);
+    }
+
+    @PostMapping("/requests/{id}/heartbeat")
+    public MdsRequestStatusResponse heartbeat(@PathVariable Long id,
+                                              @RequestBody MdsHeartbeatRequest request) {
+        return requestService.heartbeat(id, request);
+    }
+
+    @PostMapping("/requests/{id}/complete")
+    public MdsRequestStatusResponse complete(@PathVariable Long id,
+                                             @RequestBody MdsCompleteRequest request) {
+        return requestService.complete(id, request);
+    }
+
+    @PostMapping("/requests/{id}/fail")
+    public MdsRequestStatusResponse fail(@PathVariable Long id,
+                                         @Valid @RequestBody MdsFailRequest request) {
+        return requestService.fail(id, request);
+    }
+
+    @GetMapping("/requests/{id}")
+    public MdsRequestStatusResponse getRequest(@PathVariable Long id) {
+        return requestService.getById(id);
+    }
+
+    @PostMapping("/artifacts/publish-batch")
+    public MdsArtifactPublishBatchResponse publishBatch(@Valid @RequestBody MdsArtifactPublishBatchRequest request) {
+        return artifactService.publishBatch(request);
+    }
+
+    @PostMapping("/artifacts/{id}/lineage")
+    public MdsLineageResponse createLineage(@PathVariable Long id,
+                                            @Valid @RequestBody MdsLineageCreateRequest request) {
+        if (!id.equals(request.childArtifactId())) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY,
+                    "path artifact id must match childArtifactId"
+            );
+        }
+        return artifactService.createLineage(request);
+    }
+
+    @GetMapping("/health")
+    public Map<String, String> health() {
+        return Map.of("status", "ok", "module", "mds-backend-orchestration");
+    }
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-17-mds-sprint1-base.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-17-mds-sprint1-base.yaml
@@ -1,0 +1,92 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-04-17-mds-sprint1-base
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: mds_request
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mds_request (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                status VARCHAR(32) NOT NULL,
+                market VARCHAR(191) NOT NULL,
+                problem LONGTEXT NOT NULL,
+                desired_outcome LONGTEXT NOT NULL,
+                context_json LONGTEXT NOT NULL,
+                delivery_constraint VARCHAR(191) NULL,
+                evidence_preference VARCHAR(64) NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                started_at TIMESTAMP NULL,
+                finished_at TIMESTAMP NULL,
+                failure_reason LONGTEXT NULL,
+                correlation_id VARCHAR(191) NOT NULL,
+                PRIMARY KEY (id),
+                KEY idx_mds_request_status_created_at (status, created_at),
+                KEY idx_mds_request_correlation_id (correlation_id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+              CREATE TABLE artifact_record (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                artifact_type VARCHAR(128) NOT NULL,
+                schema_version VARCHAR(32) NOT NULL,
+                version VARCHAR(32) NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                producer_module VARCHAR(64) NOT NULL,
+                owner_module VARCHAR(64) NOT NULL,
+                request_id BIGINT NOT NULL,
+                content_json LONGTEXT NOT NULL,
+                hash VARCHAR(64) NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                CONSTRAINT fk_artifact_record_request FOREIGN KEY (request_id) REFERENCES mds_request (id),
+                KEY idx_artifact_record_request_id (request_id),
+                KEY idx_artifact_record_type_status (artifact_type, status)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+              CREATE TABLE artifact_lineage_edge (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                parent_artifact_id BIGINT NOT NULL,
+                child_artifact_id BIGINT NOT NULL,
+                relation_type VARCHAR(64) NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                CONSTRAINT fk_artifact_lineage_parent FOREIGN KEY (parent_artifact_id) REFERENCES artifact_record (id),
+                CONSTRAINT fk_artifact_lineage_child FOREIGN KEY (child_artifact_id) REFERENCES artifact_record (id),
+                KEY idx_artifact_lineage_parent_id (parent_artifact_id),
+                KEY idx_artifact_lineage_child_id (child_artifact_id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+              CREATE TABLE source_access_record (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                source_document_id VARCHAR(191) NOT NULL,
+                access_class VARCHAR(64) NOT NULL,
+                permission_state VARCHAR(64) NOT NULL,
+                license_text LONGTEXT NULL,
+                access_url VARCHAR(512) NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY idx_source_access_source_document (source_document_id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+              CREATE TABLE mds_processing_event (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                request_id BIGINT NOT NULL,
+                stage_name VARCHAR(128) NOT NULL,
+                event_type VARCHAR(32) NOT NULL,
+                message LONGTEXT NOT NULL,
+                payload_json LONGTEXT NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                CONSTRAINT fk_mds_processing_event_request FOREIGN KEY (request_id) REFERENCES mds_request (id),
+                KEY idx_mds_processing_event_request_stage (request_id, stage_name)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -644,3 +644,6 @@ databaseChangeLog:
   - include:
       file: V2037_04_11__lead_portal_schema_first_flags_mysql5.sql
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-04-17-mds-sprint1-base.yaml
+      relativeToChangelogFile: true

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -50,6 +50,27 @@ Regras operacionais associadas:
 - resumo comercial (`performance-summary`) é projeção derivada dos fatos persistidos em `sales_video_conversion_event`;
 - comparação por variação técnica usa, no mínimo, o eixo `scriptId + providerName` para iniciar rotina de aprendizado.
 
+## Atualização incremental — MDS Sprint 1 (orquestração e persistência base)
+
+Entidades/tabelas adicionadas no backend (`ads-service`) para suportar o início do Mechanism Discovery Service:
+
+- `mds_request`
+  - request de descoberta com `status`, `market`, `problem`, `desired_outcome`, `context_json`, `correlation_id` e timestamps de ciclo de vida.
+- `artifact_record`
+  - catálogo de artefatos publicados com `artifact_type`, `schema_version`, `version`, `status`, `producer_module`, `owner_module`, `request_id`, `content_json` e `hash`.
+- `artifact_lineage_edge`
+  - edges explícitas de lineage entre artefatos (`parent_artifact_id`, `child_artifact_id`, `relation_type`).
+- `source_access_record`
+  - controle de classe de acesso/permissão de documento (`access_class`, `permission_state`, `license_text`, `access_url`).
+- `mds_processing_event`
+  - trilha operacional por request (`stage_name`, `event_type`, `message`, `payload_json`).
+
+Regras operacionais associadas:
+
+- persistência MDS permanece exclusiva do backend principal (MySQL 5.7);
+- ciclo mínimo de request no backend: `PENDING` → `IN_PROGRESS` → `COMPLETED`/`FAILED`;
+- publicação de artefatos aceita status canônico (`DRAFT`, `VALIDATED`, `APPROVED`) com lineage persistida.
+
 ## Diagrama ER (contexto do experimento)
 
 ```mermaid

--- a/docs/novos-modulos/MDS/contrato_backend_mds.md
+++ b/docs/novos-modulos/MDS/contrato_backend_mds.md
@@ -1,0 +1,37 @@
+# Contrato Backend ↔ MDS (Sprint 1)
+
+## Escopo
+Contrato interno implementado apenas para Sprint 1: persistência, orquestração básica de requests e publicação inicial de artefatos pelo backend principal.
+
+## Endpoints internos implementados
+Base path: `/api/internal/mds`
+
+### Requests
+- `POST /requests`
+- `GET /requests/pending`
+- `POST /requests/{id}/claim`
+- `POST /requests/{id}/heartbeat`
+- `POST /requests/{id}/complete`
+- `POST /requests/{id}/fail`
+- `GET /requests/{id}`
+
+### Artefatos e lineage
+- `POST /artifacts/publish-batch`
+- `POST /artifacts/{id}/lineage`
+
+### Operação
+- `GET /health`
+
+## Persistência (MySQL 5.7 via backend)
+Tabelas adicionadas nesta sprint:
+- `mds_request`
+- `artifact_record`
+- `artifact_lineage_edge`
+- `source_access_record`
+- `mds_processing_event`
+
+## Regras implementadas
+- Somente backend persiste em MySQL.
+- Claim só aceita request em `PENDING`.
+- Batch de artefatos valida status no envelope (`DRAFT`, `VALIDATED`, `APPROVED`).
+- Lineage pode ser criado no batch (via `parentArtifactIds`) ou endpoint dedicado.

--- a/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+++ b/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
@@ -367,19 +367,27 @@ Preparar o backend para ser o centro de persistência e orquestração do MDS.
 - ainda sem pipeline de análise.
 
 ### Registro do Codex ao final da sprint
-**Status:** `NAO_INICIADA`
+**Status:** `CONCLUIDO`
 
 **O que foi concluído:**
-- 
+- Namespace backend do MDS criado no `ads-service` com entidades, repositories, services e controller interno para requests, claim, heartbeat, complete, fail e publicação em lote de artefatos.
+- Migration Liquibase em YAML (MySQL 5.7) criada com as tabelas mínimas de Sprint 1 (`mds_request`, `artifact_record`, `artifact_lineage_edge`, `source_access_record`, `mds_processing_event`).
+- Contrato backend ↔ MDS documentado no arquivo `contrato_backend_mds.md`.
 
 **O que ficou pendente para a próxima sprint:**
-- 
+- Criar módulo `mds/` independente com loop de polling e integração ativa com os endpoints do backend.
+- Implementar processamento real de discovery (formulação de perguntas, busca, deduplicação e análise de evidência).
+- Implementar testes de contrato backend ↔ módulo MDS em execução ponta a ponta.
 
 **Riscos / observações:**
-- 
+- O contrato OpenAPI de stub em `openapi_mds_backend_stub.yaml` descreve rotas do serviço MDS, enquanto Sprint 1 focou rotas internas no backend para orquestração e persistência.
+- A tabela `source_access_record` foi criada para aderência ao artefato canônico, mas o preenchimento operacional ficará para as sprints com busca em fontes externas.
 
 **Arquivos alterados/criados:**
-- 
+- backend/ads-service/src/main/java/com/marketinghub/mds/*
+- backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-17-mds-sprint1-base.yaml
+- backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+- docs/novos-modulos/MDS/contrato_backend_mds.md
 
 ---
 
@@ -421,19 +429,29 @@ Criar o módulo `mds/` e conectá-lo ao backend para consumir requests reais.
 - ainda sem fontes externas operacionais.
 
 ### Registro do Codex ao final da sprint
-**Status:** `NAO_INICIADA`
+**Status:** `PARCIAL`
 
 **O que foi concluído:**
-- 
+- Criação do módulo independente `mds/` na raiz do repositório com projeto Maven Spring Boot completo (`pom.xml`, `Dockerfile`, `README.md`, `application.yml`, código e testes).
+- Bootstrap do serviço (`MdsApplication`), configuração (`MdsProperties`, `BackendClientConfig`) e health endpoint em `/internal/mechanism-discovery/actuator/health`.
+- Implementação de cliente HTTP para backend interno e loop básico de processamento com polling de pendências + claim + heartbeat + complete/fail.
 
 **O que ficou pendente para a próxima sprint:**
-- 
+- Discovery real (question builder, busca em fontes externas, deduplicação, screening e análise de evidências).
+- Implementação completa dos componentes de pipeline científico previstos no plano.
+- Hardening de observabilidade e retries avançados.
 
 **Riscos / observações:**
-- 
+- O loop atual publica artefatos stub para validar o acoplamento com o backend sem acesso direto ao banco.
+- Contratos HTTP dependem dos endpoints internos do backend para persistência e lifecycle.
 
 **Arquivos alterados/criados:**
-- 
+- mds/pom.xml
+- mds/Dockerfile
+- mds/README.md
+- mds/src/main/resources/application.yml
+- mds/src/main/java/com/marketinghub/mds/*
+- mds/src/test/java/com/marketinghub/mds/*
 
 ---
 

--- a/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+++ b/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
@@ -320,3 +320,177 @@ Ao fim de cada etapa relevante, o modelo deve:
 3. não reescrever entradas antigas, exceto para correção factual;
 4. registrar pendências reais;
 5. manter o documento utilizável como handoff entre chats e entre agentes.
+
+## [2026-04-17] — Etapa: sprint 1 - persistência e orquestração base no backend
+
+**Status:** `CONCLUIDO`
+
+**Resumo:**
+
+Foi implementada a base de Sprint 1 do MDS no backend principal, com persistência MySQL 5.7 via Liquibase, endpoints internos de orquestração de requests e publicação inicial de artefatos com lineage.
+
+**Objetivo da etapa:**
+
+Preparar o `backend/ads-service` como camada única de persistência e orquestração para o MDS, sem antecipar o módulo worker da Sprint 2.
+
+**O que foi implementado:**
+
+- Criação do namespace `com.marketinghub.mds` no backend com entidades e repositórios para as tabelas mínimas da sprint.
+- Implementação dos serviços de request lifecycle (`create`, `pending`, `claim`, `heartbeat`, `complete`, `fail`) e publicação em lote de artefatos.
+- Implementação de endpoints internos em `/api/internal/mds` para requests, artifact publish batch, lineage e health.
+- Criação de changelog Liquibase YAML da Sprint 1 com `preConditions` para MySQL e SQL com `splitStatements` / `stripComments`.
+- Documentação do contrato backend ↔ MDS da Sprint 1 em arquivo dedicado.
+
+**Arquivos alterados/criados:**
+
+- backend/ads-service/src/main/java/com/marketinghub/mds/MdsRequest.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/MdsArtifactRecord.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/MdsArtifactLineageEdge.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/MdsSourceAccessRecord.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/MdsProcessingEvent.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/MdsRequestStatus.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/MdsArtifactStatus.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/MdsEventType.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsRequestRepository.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactLineageEdgeRepository.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsSourceAccessRecordRepository.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsProcessingEventRepository.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRequestCreateRequest.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRequestStatusResponse.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsClaimRequest.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsHeartbeatRequest.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsCompleteRequest.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsFailRequest.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsArtifactPublishBatchRequest.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsArtifactPublishBatchResponse.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsLineageCreateRequest.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsLineageResponse.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsRequestService.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
+- backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-17-mds-sprint1-base.yaml
+- backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+- docs/novos-modulos/MDS/contrato_backend_mds.md
+- docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+
+**Tabelas / persistência afetadas:**
+
+- `mds_request`
+- `artifact_record`
+- `artifact_lineage_edge`
+- `source_access_record`
+- `mds_processing_event`
+
+**APIs / endpoints / contratos afetados:**
+
+- `POST /api/internal/mds/requests`
+- `GET /api/internal/mds/requests/pending`
+- `POST /api/internal/mds/requests/{id}/claim`
+- `POST /api/internal/mds/requests/{id}/heartbeat`
+- `POST /api/internal/mds/requests/{id}/complete`
+- `POST /api/internal/mds/requests/{id}/fail`
+- `GET /api/internal/mds/requests/{id}`
+- `POST /api/internal/mds/artifacts/publish-batch`
+- `POST /api/internal/mds/artifacts/{id}/lineage`
+- `GET /api/internal/mds/health`
+- `docs/novos-modulos/MDS/contrato_backend_mds.md`
+
+**Artefatos / schemas impactados:**
+
+- `mechanismDiscoveryRequest`
+- `artifact_record` envelope canônico para tipos MDS (status/version/schemaVersion/hash)
+- `artifact_lineage_edge`
+
+**Testes executados:**
+
+- `cd backend/ads-service && mvn -s ../settings.xml test`
+
+**Resultado observado:**
+
+O backend agora consegue registrar requests de discovery, controlar ciclo de execução básico e receber lote de artefatos com persistência de lineage no MySQL por meio de contratos internos.
+
+**Limitações / pendências:**
+
+- Não há módulo `mds/` executando loop de processamento ainda (escopo da Sprint 2).
+- Não há busca externa de evidências, deduplicação e análise científica nesta etapa.
+- Não há contract tests ponta a ponta com serviço MDS externo nesta sprint.
+
+**Próximo passo sugerido:**
+
+Iniciar Sprint 2 com criação do módulo `mds/` independente e integração ativa com endpoints internos do backend já implementados.
+
+## [2026-04-17] — Etapa: modulo mds independente (bootstrap Spring Boot)
+
+**Status:** `PARCIAL`
+
+**Resumo:**
+
+Foi criado o módulo `mds/` como serviço independente na raiz do repositório, com projeto Maven Spring Boot completo e loop básico de integração com endpoints internos do backend, sem acesso direto ao banco.
+
+**Objetivo da etapa:**
+
+Atender a diretriz de desacoplamento do MDS em container próprio, preservando a regra de persistência exclusiva do backend.
+
+**O que foi implementado:**
+
+- Novo projeto `mds/` com `pom.xml`, `Dockerfile`, `README.md`, `application.yml`, bootstrap Java e testes.
+- Cliente HTTP interno para consumo dos endpoints `/api/internal/mds/*` do backend.
+- Loop básico (`MdsLoopRunner`) com polling de pendências, claim, heartbeat, execução de pipeline stub e complete/fail.
+- Serviço de pipeline inicial (`MechanismDiscoveryPipelineService`) com publicação de artefatos stub no backend.
+- Endpoint de health do serviço em `/internal/mechanism-discovery/actuator/health`.
+
+**Arquivos alterados/criados:**
+
+- mds/pom.xml
+- mds/Dockerfile
+- mds/README.md
+- mds/src/main/resources/application.yml
+- mds/src/main/java/com/marketinghub/mds/MdsApplication.java
+- mds/src/main/java/com/marketinghub/mds/config/MdsProperties.java
+- mds/src/main/java/com/marketinghub/mds/config/BackendClientConfig.java
+- mds/src/main/java/com/marketinghub/mds/client/BackendMdsClient.java
+- mds/src/main/java/com/marketinghub/mds/controller/MdsHealthController.java
+- mds/src/main/java/com/marketinghub/mds/service/MdsLoopRunner.java
+- mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+- mds/src/main/java/com/marketinghub/mds/dto/*
+- mds/src/test/java/com/marketinghub/mds/MdsApplicationTests.java
+- mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+- docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+- docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+
+**Tabelas / persistência afetadas:**
+
+- `nenhuma` (o módulo `mds/` não acessa banco diretamente)
+
+**APIs / endpoints / contratos afetados:**
+
+- consumo de `GET /api/internal/mds/requests/pending`
+- consumo de `POST /api/internal/mds/requests/{id}/claim`
+- consumo de `POST /api/internal/mds/requests/{id}/heartbeat`
+- consumo de `POST /api/internal/mds/requests/{id}/complete`
+- consumo de `POST /api/internal/mds/requests/{id}/fail`
+- consumo de `POST /api/internal/mds/artifacts/publish-batch`
+- criação de `GET /internal/mechanism-discovery/actuator/health` no módulo independente
+
+**Artefatos / schemas impactados:**
+
+- `mechanismSpec` (stub inicial)
+- `practicalKnowledgePack` (stub inicial)
+
+**Testes executados:**
+
+- `cd mds && mvn test`
+
+**Resultado observado:**
+
+O MDS passa a existir como serviço executável independente em JAR/Container, integrado ao backend apenas por HTTP interno para persistência e ciclo de execução.
+
+**Limitações / pendências:**
+
+- Pipeline ainda é stub, sem busca científica real.
+- Sem implementação das etapas avançadas previstas nas sprints seguintes.
+
+**Próximo passo sugerido:**
+
+Implementar as etapas de discovery real (formulação de perguntas, busca em fontes externas, deduplicação e análise de evidência) mantendo persistência exclusivamente via backend.

--- a/mds/Dockerfile
+++ b/mds/Dockerfile
@@ -1,0 +1,15 @@
+FROM maven:3.9.8-eclipse-temurin-21 AS build
+WORKDIR /app
+
+COPY pom.xml .
+COPY src ./src
+
+RUN mvn -B -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /opt/mds
+
+COPY --from=build /app/target/mds-0.0.1-SNAPSHOT.jar app.jar
+
+EXPOSE 8091
+ENTRYPOINT ["java", "-jar", "/opt/mds/app.jar"]

--- a/mds/README.md
+++ b/mds/README.md
@@ -1,0 +1,48 @@
+# MDS (Mechanism Discovery Service)
+
+Serviço **independente** do Marketing Hub responsável por processar requests de mechanism discovery.
+
+## Princípios
+
+- Este módulo roda separado do `backend/ads-service`.
+- **Não acessa banco diretamente**.
+- Toda persistência acontece via endpoints internos do backend:
+  - `/api/internal/mds/requests/*`
+  - `/api/internal/mds/artifacts/*`
+
+## Estrutura
+
+- `src/main/java`: bootstrap, config, client HTTP, loop de processamento e serviços.
+- `src/main/resources/application.yml`: configuração do serviço.
+- `src/test/java`: testes de contexto e pipeline.
+
+## Executar local
+
+```bash
+cd mds
+mvn spring-boot:run
+```
+
+Variáveis úteis:
+
+- `MDS_BACKEND_BASE_URL` (default `http://localhost:8080`)
+- `MDS_WORKER_ID` (default `mds-worker-local`)
+
+## Build de artefato executável
+
+```bash
+cd mds
+mvn package
+```
+
+Gera JAR executável em `target/`.
+
+## Docker
+
+```bash
+cd mds
+docker build -t marketinghub-mds:local .
+docker run --rm -p 8091:8091 \
+  -e MDS_BACKEND_BASE_URL=http://host.docker.internal:8080 \
+  marketinghub-mds:local
+```

--- a/mds/pom.xml
+++ b/mds/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.marketinghub</groupId>
+    <artifactId>mds</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>Mechanism Discovery Service</name>
+    <description>Serviço independente para descoberta de mecanismos.</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mds/src/main/java/com/marketinghub/mds/MdsApplication.java
+++ b/mds/src/main/java/com/marketinghub/mds/MdsApplication.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mds;
+
+import com.marketinghub.mds.config.MdsProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+@EnableConfigurationProperties(MdsProperties.class)
+public class MdsApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MdsApplication.class, args);
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/client/BackendMdsClient.java
+++ b/mds/src/main/java/com/marketinghub/mds/client/BackendMdsClient.java
@@ -1,0 +1,65 @@
+package com.marketinghub.mds.client;
+
+import com.marketinghub.mds.dto.*;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+@Component
+public class BackendMdsClient {
+    private final RestClient restClient;
+
+    public BackendMdsClient(RestClient backendRestClient) {
+        this.restClient = backendRestClient;
+    }
+
+    public List<BackendMdsRequestDto> getPendingRequests() {
+        return restClient.get()
+                .uri("/api/internal/mds/requests/pending")
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {
+                });
+    }
+
+    public BackendMdsRequestDto claim(Long requestId, BackendClaimRequestDto claimRequestDto) {
+        return restClient.post()
+                .uri("/api/internal/mds/requests/{id}/claim", requestId)
+                .body(claimRequestDto)
+                .retrieve()
+                .body(BackendMdsRequestDto.class);
+    }
+
+    public void heartbeat(Long requestId, BackendHeartbeatRequestDto heartbeatRequestDto) {
+        restClient.post()
+                .uri("/api/internal/mds/requests/{id}/heartbeat", requestId)
+                .body(heartbeatRequestDto)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    public void complete(Long requestId, BackendCompleteRequestDto completeRequestDto) {
+        restClient.post()
+                .uri("/api/internal/mds/requests/{id}/complete", requestId)
+                .body(completeRequestDto)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    public void fail(Long requestId, BackendFailRequestDto failRequestDto) {
+        restClient.post()
+                .uri("/api/internal/mds/requests/{id}/fail", requestId)
+                .body(failRequestDto)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    public BackendArtifactPublishBatchResponseDto publishBatch(BackendArtifactPublishBatchRequestDto requestDto) {
+        return restClient.post()
+                .uri("/api/internal/mds/artifacts/publish-batch")
+                .body(requestDto)
+                .retrieve()
+                .body(BackendArtifactPublishBatchResponseDto.class);
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/config/BackendClientConfig.java
+++ b/mds/src/main/java/com/marketinghub/mds/config/BackendClientConfig.java
@@ -1,0 +1,15 @@
+package com.marketinghub.mds.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class BackendClientConfig {
+    @Bean
+    public RestClient backendRestClient(MdsProperties properties) {
+        return RestClient.builder()
+                .baseUrl(properties.getBackend().getBaseUrl())
+                .build();
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/config/MdsProperties.java
+++ b/mds/src/main/java/com/marketinghub/mds/config/MdsProperties.java
@@ -1,0 +1,55 @@
+package com.marketinghub.mds.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "mds")
+public class MdsProperties {
+    private boolean loopEnabled = true;
+    private int pollLimit = 5;
+    private Backend backend = new Backend();
+
+    public boolean isLoopEnabled() {
+        return loopEnabled;
+    }
+
+    public void setLoopEnabled(boolean loopEnabled) {
+        this.loopEnabled = loopEnabled;
+    }
+
+    public int getPollLimit() {
+        return pollLimit;
+    }
+
+    public void setPollLimit(int pollLimit) {
+        this.pollLimit = pollLimit;
+    }
+
+    public Backend getBackend() {
+        return backend;
+    }
+
+    public void setBackend(Backend backend) {
+        this.backend = backend;
+    }
+
+    public static class Backend {
+        private String baseUrl = "http://localhost:8080";
+        private String workerId = "mds-worker-local";
+
+        public String getBaseUrl() {
+            return baseUrl;
+        }
+
+        public void setBaseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+        }
+
+        public String getWorkerId() {
+            return workerId;
+        }
+
+        public void setWorkerId(String workerId) {
+            this.workerId = workerId;
+        }
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/controller/MdsHealthController.java
+++ b/mds/src/main/java/com/marketinghub/mds/controller/MdsHealthController.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mds.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/internal/mechanism-discovery")
+public class MdsHealthController {
+    @GetMapping("/actuator/health")
+    public Map<String, String> health() {
+        return Map.of("status", "ok", "service", "mds");
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/dto/BackendArtifactPublishBatchRequestDto.java
+++ b/mds/src/main/java/com/marketinghub/mds/dto/BackendArtifactPublishBatchRequestDto.java
@@ -1,0 +1,18 @@
+package com.marketinghub.mds.dto;
+
+import java.util.List;
+
+public record BackendArtifactPublishBatchRequestDto(Long requestId, List<ArtifactPayloadDto> artifacts) {
+    public record ArtifactPayloadDto(
+            String artifactType,
+            String schemaVersion,
+            String version,
+            String status,
+            String producerModule,
+            String ownerModule,
+            Object content,
+            String hash,
+            List<Long> parentArtifactIds
+    ) {
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/dto/BackendArtifactPublishBatchResponseDto.java
+++ b/mds/src/main/java/com/marketinghub/mds/dto/BackendArtifactPublishBatchResponseDto.java
@@ -1,0 +1,6 @@
+package com.marketinghub.mds.dto;
+
+import java.util.List;
+
+public record BackendArtifactPublishBatchResponseDto(Long requestId, int publishedCount, List<Long> artifactIds) {
+}

--- a/mds/src/main/java/com/marketinghub/mds/dto/BackendClaimRequestDto.java
+++ b/mds/src/main/java/com/marketinghub/mds/dto/BackendClaimRequestDto.java
@@ -1,0 +1,6 @@
+package com.marketinghub.mds.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record BackendClaimRequestDto(@NotBlank String workerId) {
+}

--- a/mds/src/main/java/com/marketinghub/mds/dto/BackendCompleteRequestDto.java
+++ b/mds/src/main/java/com/marketinghub/mds/dto/BackendCompleteRequestDto.java
@@ -1,0 +1,4 @@
+package com.marketinghub.mds.dto;
+
+public record BackendCompleteRequestDto(String message) {
+}

--- a/mds/src/main/java/com/marketinghub/mds/dto/BackendFailRequestDto.java
+++ b/mds/src/main/java/com/marketinghub/mds/dto/BackendFailRequestDto.java
@@ -1,0 +1,4 @@
+package com.marketinghub.mds.dto;
+
+public record BackendFailRequestDto(String reason, String stageName, String message) {
+}

--- a/mds/src/main/java/com/marketinghub/mds/dto/BackendHeartbeatRequestDto.java
+++ b/mds/src/main/java/com/marketinghub/mds/dto/BackendHeartbeatRequestDto.java
@@ -1,0 +1,6 @@
+package com.marketinghub.mds.dto;
+
+import java.util.Map;
+
+public record BackendHeartbeatRequestDto(String stageName, String message, Map<String, Object> payload) {
+}

--- a/mds/src/main/java/com/marketinghub/mds/dto/BackendMdsRequestDto.java
+++ b/mds/src/main/java/com/marketinghub/mds/dto/BackendMdsRequestDto.java
@@ -1,0 +1,11 @@
+package com.marketinghub.mds.dto;
+
+public record BackendMdsRequestDto(
+        Long id,
+        String status,
+        String market,
+        String problem,
+        String desiredOutcome,
+        String correlationId
+) {
+}

--- a/mds/src/main/java/com/marketinghub/mds/service/MdsLoopRunner.java
+++ b/mds/src/main/java/com/marketinghub/mds/service/MdsLoopRunner.java
@@ -1,0 +1,61 @@
+package com.marketinghub.mds.service;
+
+import com.marketinghub.mds.client.BackendMdsClient;
+import com.marketinghub.mds.config.MdsProperties;
+import com.marketinghub.mds.dto.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class MdsLoopRunner {
+    private static final Logger log = LoggerFactory.getLogger(MdsLoopRunner.class);
+
+    private final BackendMdsClient backendMdsClient;
+    private final MechanismDiscoveryPipelineService pipelineService;
+    private final MdsProperties properties;
+
+    public MdsLoopRunner(BackendMdsClient backendMdsClient,
+                         MechanismDiscoveryPipelineService pipelineService,
+                         MdsProperties properties) {
+        this.backendMdsClient = backendMdsClient;
+        this.pipelineService = pipelineService;
+        this.properties = properties;
+    }
+
+    @Scheduled(fixedDelayString = "${mds.loop-interval-ms:15000}")
+    public void poll() {
+        if (!properties.isLoopEnabled()) {
+            return;
+        }
+
+        List<BackendMdsRequestDto> pending = backendMdsClient.getPendingRequests();
+        pending.stream().limit(properties.getPollLimit()).forEach(this::processOne);
+    }
+
+    private void processOne(BackendMdsRequestDto request) {
+        try {
+            backendMdsClient.claim(request.id(), new BackendClaimRequestDto(properties.getBackend().getWorkerId()));
+            backendMdsClient.heartbeat(request.id(), new BackendHeartbeatRequestDto(
+                    "pipeline",
+                    "processing started",
+                    Map.of("requestId", request.id())
+            ));
+
+            pipelineService.execute(request);
+            backendMdsClient.complete(request.id(), new BackendCompleteRequestDto("mds pipeline finished"));
+            log.info("mds-request-complete requestId={} correlationId={}", request.id(), request.correlationId());
+        } catch (Exception ex) {
+            log.error("mds-request-failed requestId={} error={}", request.id(), ex.getMessage(), ex);
+            backendMdsClient.fail(request.id(), new BackendFailRequestDto(
+                    ex.getMessage(),
+                    "pipeline",
+                    "processing failed"
+            ));
+        }
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+++ b/mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
@@ -1,0 +1,59 @@
+package com.marketinghub.mds.service;
+
+import com.marketinghub.mds.client.BackendMdsClient;
+import com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto;
+import com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto;
+import com.marketinghub.mds.dto.BackendMdsRequestDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class MechanismDiscoveryPipelineService {
+    private final BackendMdsClient backendMdsClient;
+
+    public MechanismDiscoveryPipelineService(BackendMdsClient backendMdsClient) {
+        this.backendMdsClient = backendMdsClient;
+    }
+
+    public void execute(BackendMdsRequestDto request) {
+        ArtifactPayloadDto mechanismSpec = new ArtifactPayloadDto(
+                "mechanismSpec",
+                "v1",
+                "v1",
+                "DRAFT",
+                "mds",
+                "mds",
+                Map.of(
+                        "requestId", request.id(),
+                        "market", request.market(),
+                        "problem", request.problem(),
+                        "desiredOutcome", request.desiredOutcome(),
+                        "summary", "Stub inicial do mecanismo recomendado para Sprint inicial do modulo independente"
+                ),
+                null,
+                List.of()
+        );
+
+        ArtifactPayloadDto knowledgePack = new ArtifactPayloadDto(
+                "practicalKnowledgePack",
+                "v1",
+                "v1",
+                "DRAFT",
+                "mds",
+                "mds",
+                Map.of(
+                        "requestId", request.id(),
+                        "notes", List.of("Pipeline inicial sem acesso direto ao banco.", "Persistencia via backend interno.")
+                ),
+                null,
+                List.of()
+        );
+
+        backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(
+                request.id(),
+                List.of(mechanismSpec, knowledgePack)
+        ));
+    }
+}

--- a/mds/src/main/resources/application.yml
+++ b/mds/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+server:
+  port: 8091
+
+spring:
+  application:
+    name: mds
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+mds:
+  loop-enabled: true
+  loop-interval-ms: 15000
+  poll-limit: 5
+  backend:
+    base-url: ${MDS_BACKEND_BASE_URL:http://localhost:8080}
+    worker-id: ${MDS_WORKER_ID:mds-worker-local}

--- a/mds/src/test/java/com/marketinghub/mds/MdsApplicationTests.java
+++ b/mds/src/test/java/com/marketinghub/mds/MdsApplicationTests.java
@@ -1,0 +1,12 @@
+package com.marketinghub.mds;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = "mds.loop-enabled=false")
+class MdsApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+++ b/mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
@@ -1,0 +1,43 @@
+package com.marketinghub.mds.service;
+
+import com.marketinghub.mds.client.BackendMdsClient;
+import com.marketinghub.mds.dto.BackendMdsRequestDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MechanismDiscoveryPipelineServiceTest {
+    @Mock
+    private BackendMdsClient backendMdsClient;
+
+    @InjectMocks
+    private MechanismDiscoveryPipelineService service;
+
+    @Test
+    void shouldPublishAtLeastTwoArtifacts() {
+        BackendMdsRequestDto request = new BackendMdsRequestDto(
+                10L,
+                "IN_PROGRESS",
+                "weight-loss",
+                "plateau",
+                "consistent fat loss",
+                "corr-123"
+        );
+
+        service.execute(request);
+
+        ArgumentCaptor<com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto> captor =
+                ArgumentCaptor.forClass(com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.class);
+        verify(backendMdsClient).publishBatch(captor.capture());
+
+        assertThat(captor.getValue().requestId()).isEqualTo(10L);
+        assertThat(captor.getValue().artifacts()).hasSizeGreaterThanOrEqualTo(2);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal persistent orchestration layer for the Mechanism Discovery Service (MDS) in the main backend to record requests, artifacts, lineage and processing events. 
- Expose internal HTTP endpoints so an independent MDS worker can claim and progress discovery requests without writing to the DB directly.  
- Deliver a bootstrapped standalone `mds/` module (Spring Boot) that polls the backend, claims work, sends heartbeats and publishes artifact batches as a starting point for Sprint 2.

### Description

- Add new persistence model and repositories under `com.marketinghub.mds` for `MdsRequest`, `MdsArtifactRecord`, `MdsArtifactLineageEdge`, `MdsSourceAccessRecord`, `MdsProcessingEvent` and related enums and JPA repositories.  
- Implement request lifecycle and artifact handling services `MdsRequestService` and `MdsArtifactService`, and expose internal REST API controllers at `POST/GET /api/internal/mds/*` via `MdsInternalController`.  
- Add Liquibase changelog `changesets/2026-04-17-mds-sprint1-base.yaml` and include it in `db.changelog-master.yaml` to create the required MySQL 5.7 tables.  
- Create a new top-level `mds/` module with a Spring Boot app, HTTP client `BackendMdsClient`, scheduled `MdsLoopRunner`, `MechanismDiscoveryPipelineService` (publishes stub artifacts), configuration (`MdsProperties`), health endpoint, Dockerfile and unit tests, so the worker can run independently and operate via the backend API.  
- Add docs: internal contract `docs/novos-modulos/MDS/contrato_backend_mds.md`, sprint plan/history updates and README for the `mds` module.

### Testing

- Ran backend unit tests with `cd backend/ads-service && mvn -s ../settings.xml test`, which completed successfully.  
- Ran module tests with `cd mds && mvn test`, including `MdsApplicationTests` and `MechanismDiscoveryPipelineServiceTest`, which passed.  
- No end-to-end integration tests with a live database and worker were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e194fc7ee48321814e11bce9d4202c)