### PR TITLE
MDS Sprint 2: bootstrap module, enforce lifecycle and add contract/loop tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsRequestService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsRequestService.java
@@ -66,6 +66,7 @@ public class MdsRequestService {
     @Transactional
     public MdsRequestStatusResponse heartbeat(Long id, MdsHeartbeatRequest heartbeatRequest) {
         MdsRequest request = findRequest(id);
+        assertInProgress(request, "heartbeat can only be sent for in-progress requests");
         persistEvent(
                 request,
                 defaultValue(heartbeatRequest.stageName(), "pipeline"),
@@ -79,6 +80,7 @@ public class MdsRequestService {
     @Transactional
     public MdsRequestStatusResponse complete(Long id, MdsCompleteRequest completeRequest) {
         MdsRequest request = findRequest(id);
+        assertInProgress(request, "request can only be completed from in-progress status");
         request.setStatus(MdsRequestStatus.COMPLETED);
         request.setFinishedAt(Instant.now());
         request.setFailureReason(null);
@@ -90,6 +92,7 @@ public class MdsRequestService {
     @Transactional
     public MdsRequestStatusResponse fail(Long id, MdsFailRequest failRequest) {
         MdsRequest request = findRequest(id);
+        assertInProgress(request, "request can only fail from in-progress status");
         request.setStatus(MdsRequestStatus.FAILED);
         request.setFinishedAt(Instant.now());
         request.setFailureReason(failRequest.reason());
@@ -152,5 +155,11 @@ public class MdsRequestService {
 
     private String defaultValue(String value, String fallback) {
         return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private void assertInProgress(MdsRequest request, String message) {
+        if (request.getStatus() != MdsRequestStatus.IN_PROGRESS) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, message);
+        }
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/mds/service/MdsRequestServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mds/service/MdsRequestServiceTest.java
@@ -1,0 +1,88 @@
+package com.marketinghub.mds.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.mds.MdsRequest;
+import com.marketinghub.mds.MdsRequestStatus;
+import com.marketinghub.mds.dto.MdsCompleteRequest;
+import com.marketinghub.mds.dto.MdsFailRequest;
+import com.marketinghub.mds.dto.MdsHeartbeatRequest;
+import com.marketinghub.mds.repository.MdsProcessingEventRepository;
+import com.marketinghub.mds.repository.MdsRequestRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MdsRequestServiceTest {
+
+    @Mock
+    private MdsRequestRepository requestRepository;
+
+    @Mock
+    private MdsProcessingEventRepository processingEventRepository;
+
+    private MdsRequestService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MdsRequestService(requestRepository, processingEventRepository, new ObjectMapper());
+    }
+
+    @Test
+    void shouldRejectHeartbeatWhenRequestIsNotInProgress() {
+        when(requestRepository.findById(11L)).thenReturn(Optional.of(requestWithStatus(MdsRequestStatus.PENDING)));
+
+        assertThatThrownBy(() -> service.heartbeat(11L, new MdsHeartbeatRequest("pipeline", "tick", Map.of())))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("statusCode.value")
+                .isEqualTo(409);
+    }
+
+    @Test
+    void shouldCompleteInProgressRequest() {
+        MdsRequest request = requestWithStatus(MdsRequestStatus.IN_PROGRESS);
+        when(requestRepository.findById(11L)).thenReturn(Optional.of(request));
+
+        var response = service.complete(11L, new MdsCompleteRequest("done"));
+
+        assertThat(response.status()).isEqualTo(MdsRequestStatus.COMPLETED);
+        assertThat(request.getFinishedAt()).isNotNull();
+        verify(processingEventRepository).save(any());
+    }
+
+    @Test
+    void shouldFailInProgressRequest() {
+        MdsRequest request = requestWithStatus(MdsRequestStatus.IN_PROGRESS);
+        when(requestRepository.findById(11L)).thenReturn(Optional.of(request));
+
+        var response = service.fail(11L, new MdsFailRequest("network timeout", "pipeline", "error"));
+
+        assertThat(response.status()).isEqualTo(MdsRequestStatus.FAILED);
+        assertThat(response.failureReason()).isEqualTo("network timeout");
+        verify(processingEventRepository).save(any());
+    }
+
+    private MdsRequest requestWithStatus(MdsRequestStatus status) {
+        return MdsRequest.builder()
+                .id(11L)
+                .status(status)
+                .market("weight-loss")
+                .problem("plateau")
+                .desiredOutcome("consistent fat loss")
+                .contextJson("{}")
+                .correlationId("corr-11")
+                .build();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
@@ -1,0 +1,134 @@
+package com.marketinghub.mds.web;
+
+import com.marketinghub.mds.MdsRequestStatus;
+import com.marketinghub.mds.dto.MdsArtifactPublishBatchResponse;
+import com.marketinghub.mds.dto.MdsLineageCreateRequest;
+import com.marketinghub.mds.dto.MdsLineageResponse;
+import com.marketinghub.mds.dto.MdsRequestStatusResponse;
+import com.marketinghub.mds.service.MdsArtifactService;
+import com.marketinghub.mds.service.MdsRequestService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MdsInternalController.class)
+class MdsInternalControllerContractTest {
+
+    @SpringBootApplication
+    static class TestConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MdsRequestService requestService;
+
+    @MockBean
+    private MdsArtifactService artifactService;
+
+    @Test
+    void shouldClaimRequestWithExpectedContract() throws Exception {
+        when(requestService.claim(eq(7L), any())).thenReturn(response(MdsRequestStatus.IN_PROGRESS));
+
+        mockMvc.perform(post("/api/internal/mds/requests/7/claim")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"workerId":"mds-worker-contract"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(7))
+                .andExpect(jsonPath("$.status").value("IN_PROGRESS"));
+    }
+
+    @Test
+    void shouldRejectLineageWhenPathIdDoesNotMatchBody() throws Exception {
+        mockMvc.perform(post("/api/internal/mds/artifacts/31/lineage")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "parentArtifactId": 10,
+                                  "childArtifactId": 30,
+                                  "relationType": "derived_from"
+                                }
+                                """))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void shouldCreateLineageWhenPathIdMatchesBody() throws Exception {
+        when(artifactService.createLineage(any(MdsLineageCreateRequest.class)))
+                .thenReturn(new MdsLineageResponse(99L, 10L, 30L, "derived_from"));
+
+        mockMvc.perform(post("/api/internal/mds/artifacts/30/lineage")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "parentArtifactId": 10,
+                                  "childArtifactId": 30,
+                                  "relationType": "derived_from"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(99))
+                .andExpect(jsonPath("$.parentArtifactId").value(10))
+                .andExpect(jsonPath("$.childArtifactId").value(30));
+    }
+
+    @Test
+    void shouldPublishArtifactsWithExpectedContract() throws Exception {
+        when(artifactService.publishBatch(any()))
+                .thenReturn(new MdsArtifactPublishBatchResponse(12L, 1, java.util.List.of(101L)));
+
+        mockMvc.perform(post("/api/internal/mds/artifacts/publish-batch")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "requestId": 12,
+                                  "artifacts": [
+                                    {
+                                      "artifactType": "mechanismSpec",
+                                      "schemaVersion": "v1",
+                                      "version": "1",
+                                      "status": "DRAFT",
+                                      "producerModule": "mds",
+                                      "ownerModule": "mds",
+                                      "content": {"title": "stub"}
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value(12))
+                .andExpect(jsonPath("$.publishedCount").value(1));
+    }
+
+    private MdsRequestStatusResponse response(MdsRequestStatus status) {
+        return new MdsRequestStatusResponse(
+                7L,
+                status,
+                "weight-loss",
+                "plateau",
+                "consistent fat loss",
+                "corr-7",
+                null,
+                Instant.parse("2026-04-17T00:00:00Z"),
+                Instant.parse("2026-04-17T00:01:00Z"),
+                null,
+                Instant.parse("2026-04-17T00:01:00Z")
+        );
+    }
+}

--- a/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+++ b/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
@@ -429,29 +429,30 @@ Criar o módulo `mds/` e conectá-lo ao backend para consumir requests reais.
 - ainda sem fontes externas operacionais.
 
 ### Registro do Codex ao final da sprint
-**Status:** `PARCIAL`
+**Status:** `CONCLUIDO`
 
-**O que foi concluído:**
-- Criação do módulo independente `mds/` na raiz do repositório com projeto Maven Spring Boot completo (`pom.xml`, `Dockerfile`, `README.md`, `application.yml`, código e testes).
-- Bootstrap do serviço (`MdsApplication`), configuração (`MdsProperties`, `BackendClientConfig`) e health endpoint em `/internal/mechanism-discovery/actuator/health`.
-- Implementação de cliente HTTP para backend interno e loop básico de processamento com polling de pendências + claim + heartbeat + complete/fail.
+**Concluído:**
+- Módulo `mds/` bootstrapado como serviço Spring Boot independente com `pom.xml`, `Dockerfile`, `README.md`, `application.yml`, health endpoint e cliente HTTP para o backend interno.
+- Loop básico de processamento ativo com polling de pendências, `claim`, `heartbeat`, execução de pipeline mínimo e finalização com `complete` ou `fail` controlado.
+- Ajuste fino no backend para lifecycle de requests: `heartbeat`, `complete` e `fail` agora exigem status `IN_PROGRESS` para evitar transições inválidas.
+- Contract tests iniciais adicionados para endpoints internos do backend (`claim`, `lineage`, `publish-batch`) e testes de loop no módulo MDS para o fluxo claim/heartbeat/complete/fail.
 
-**O que ficou pendente para a próxima sprint:**
-- Discovery real (question builder, busca em fontes externas, deduplicação, screening e análise de evidências).
-- Implementação completa dos componentes de pipeline científico previstos no plano.
-- Hardening de observabilidade e retries avançados.
+**Pendências para a próxima sprint:**
+- Discovery real (formulação de pergunta, busca estruturada, normalização de `sourceDocument`, classificação de acesso e permissões).
+- Persistência operacional de `mechanismEvidenceSearch` e `sourceDocument` em fluxo real.
+- Hardening de observabilidade, retries avançados e métricas de pipeline científico.
 
 **Riscos / observações:**
-- O loop atual publica artefatos stub para validar o acoplamento com o backend sem acesso direto ao banco.
-- Contratos HTTP dependem dos endpoints internos do backend para persistência e lifecycle.
+- O pipeline do Sprint 2 continua stubado para artefatos (sem busca científica real), intencionalmente limitado ao contrato de orquestração.
+- A estabilidade do loop depende da disponibilidade dos endpoints internos do backend para lifecycle e publicação.
 
-**Arquivos alterados/criados:**
-- mds/pom.xml
-- mds/Dockerfile
-- mds/README.md
-- mds/src/main/resources/application.yml
-- mds/src/main/java/com/marketinghub/mds/*
-- mds/src/test/java/com/marketinghub/mds/*
+**Arquivos alterados:**
+- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsRequestService.java
+- backend/ads-service/src/test/java/com/marketinghub/mds/service/MdsRequestServiceTest.java
+- backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
+- mds/src/test/java/com/marketinghub/mds/service/MdsLoopRunnerTest.java
+- docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+- docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
 
 ---
 

--- a/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+++ b/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
@@ -494,3 +494,67 @@ O MDS passa a existir como serviço executável independente em JAR/Container, i
 **Próximo passo sugerido:**
 
 Implementar as etapas de discovery real (formulação de perguntas, busca em fontes externas, deduplicação e análise de evidência) mantendo persistência exclusivamente via backend.
+
+## [2026-04-17] — Etapa: sprint 2 concluída com bootstrap do módulo MDS e loop básico
+
+**Status:** `CONCLUIDO`
+
+**Resumo:**
+
+A Sprint 2 foi finalizada com o módulo `mds/` operacional no fluxo mínimo de orquestração com backend, incluindo ajustes de lifecycle e testes iniciais de contrato.
+
+**Objetivo da etapa:**
+
+Concluir a integração básica MDS ↔ backend para consumo de requests pendentes com claim/heartbeat/complete/fail, sem antecipar o pipeline científico da Sprint 3.
+
+**O que foi implementado:**
+
+- Endurecimento do lifecycle no backend: `heartbeat`, `complete` e `fail` restritos a requests em `IN_PROGRESS`.
+- Testes de serviço no backend cobrindo transições de estado válidas e rejeição de transição inválida.
+- Contract tests iniciais no controller interno do backend cobrindo contratos de `claim`, `lineage` e `publish-batch`.
+- Testes de loop no módulo MDS validando fluxo de sucesso (claim + heartbeat + execute + complete) e fluxo de falha controlada (claim + heartbeat + fail).
+
+**Arquivos alterados/criados:**
+
+- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsRequestService.java
+- backend/ads-service/src/test/java/com/marketinghub/mds/service/MdsRequestServiceTest.java
+- backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
+- mds/src/test/java/com/marketinghub/mds/service/MdsLoopRunnerTest.java
+- docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+- docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+
+**Tabelas / persistência afetadas:**
+
+- `nenhuma`
+
+**APIs / endpoints / contratos afetados:**
+
+- `POST /api/internal/mds/requests/{id}/claim`
+- `POST /api/internal/mds/requests/{id}/heartbeat`
+- `POST /api/internal/mds/requests/{id}/complete`
+- `POST /api/internal/mds/requests/{id}/fail`
+- `POST /api/internal/mds/artifacts/publish-batch`
+- `POST /api/internal/mds/artifacts/{id}/lineage`
+
+**Artefatos / schemas impactados:**
+
+- `nenhum`
+
+**Testes executados:**
+
+- `cd backend/ads-service && mvn -Dtest=MdsRequestServiceTest,MdsInternalControllerContractTest test`
+- `cd mds && mvn test`
+
+**Resultado observado:**
+
+O módulo MDS processa requests pendentes no ciclo mínimo de orquestração e o backend aplica transições de estado mais seguras para o lifecycle do request.
+
+**Limitações / pendências:**
+
+- Sem implementação de discovery real (question builder, busca externa, deduplicação, triagem e análise de evidências).
+- Sem persistência operacional de `mechanismEvidenceSearch` e `sourceDocument`.
+- Sem hardening de observabilidade/retries avançados.
+
+**Próximo passo sugerido:**
+
+Iniciar Sprint 3 com formulação de perguntas de mecanismo e busca estruturada em fontes externas permitidas, mantendo persistência exclusivamente via backend.

--- a/mds/src/test/java/com/marketinghub/mds/service/MdsLoopRunnerTest.java
+++ b/mds/src/test/java/com/marketinghub/mds/service/MdsLoopRunnerTest.java
@@ -1,0 +1,79 @@
+package com.marketinghub.mds.service;
+
+import com.marketinghub.mds.client.BackendMdsClient;
+import com.marketinghub.mds.config.MdsProperties;
+import com.marketinghub.mds.dto.BackendMdsRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MdsLoopRunnerTest {
+
+    @Mock
+    private BackendMdsClient backendMdsClient;
+
+    @Mock
+    private MechanismDiscoveryPipelineService pipelineService;
+
+    @InjectMocks
+    private MdsLoopRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        MdsProperties properties = new MdsProperties();
+        properties.setLoopEnabled(true);
+        properties.setPollLimit(1);
+        properties.getBackend().setWorkerId("mds-worker-test");
+        runner = new MdsLoopRunner(backendMdsClient, pipelineService, properties);
+    }
+
+    @Test
+    void shouldClaimHeartbeatExecuteAndCompleteForPendingRequest() {
+        BackendMdsRequestDto request = new BackendMdsRequestDto(
+                42L,
+                "PENDING",
+                "weight-loss",
+                "plateau",
+                "consistent fat loss",
+                "corr-42"
+        );
+        when(backendMdsClient.getPendingRequests()).thenReturn(List.of(request));
+
+        runner.poll();
+
+        verify(backendMdsClient).claim(eq(42L), any());
+        verify(backendMdsClient).heartbeat(eq(42L), any());
+        verify(pipelineService).execute(request);
+        verify(backendMdsClient).complete(eq(42L), any());
+        verify(backendMdsClient, never()).fail(eq(42L), any());
+    }
+
+    @Test
+    void shouldFailRequestWhenPipelineThrows() {
+        BackendMdsRequestDto request = new BackendMdsRequestDto(
+                43L,
+                "PENDING",
+                "metabolic-health",
+                "energy crash",
+                "stable energy",
+                "corr-43"
+        );
+        when(backendMdsClient.getPendingRequests()).thenReturn(List.of(request));
+        doThrow(new RuntimeException("boom")).when(pipelineService).execute(request);
+
+        runner.poll();
+
+        verify(backendMdsClient).claim(eq(43L), any());
+        verify(backendMdsClient).heartbeat(eq(43L), any());
+        verify(backendMdsClient).fail(eq(43L), any());
+        verify(backendMdsClient, never()).complete(eq(43L), any());
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement strictly the Sprint 2 scope for the Mechanism Discovery Service (MDS): bootstrap an independent `mds/` module and validate the basic orchestration loop against the backend without moving into Sprint 3 features.
- Ensure safe lifecycle transitions for MDS requests in the backend to avoid invalid state changes during the worker loop.

### Description
- Enforce lifecycle checks in the backend by requiring requests to be `IN_PROGRESS` for `heartbeat`, `complete` and `fail` operations in `MdsRequestService` (added `assertInProgress`).
- Add contract tests for the backend internal controller covering `claim`, `artifacts/publish-batch` and `artifacts/{id}/lineage` contracts (`MdsInternalControllerContractTest`).
- Add service tests for backend request lifecycle transitions (`MdsRequestServiceTest`) and loop tests for the independent `mds/` module validating claim → heartbeat → execute → complete and failure flows (`MdsLoopRunnerTest`).
- Update Sprint 2 documentation and the MDS deployment history: mark Sprint 2 `CONCLUIDO` and append a factual entry to `protocolo_historico_implantacao_mds.md` and the sprint plan (`plano_implementacao_mds_baseado_na_especificacao.md`) listing files changed and explicit Sprint 3 pendencies.

### Testing
- `cd backend/ads-service && mvn -Dtest=MdsRequestServiceTest,MdsInternalControllerContractTest test` — tests passed (unit/controller contract tests executed successfully).
- `cd mds && mvn test` — tests passed (mds loop and pipeline unit tests executed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2289e3d248321ae53ac709e582288)