### PR TITLE
feat(mds): implementar Sprint 4 — deduplicação, triagem e publicação de evidenceItem

### DIFF
--- a/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+++ b/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
@@ -582,40 +582,30 @@ Transformar resultados brutos de busca em evidência utilizável para construç�
 **Status:** `CONCLUIDO`
 
 **O que foi concluído:**
-- Implementada formulação de pergunta de mecanismo (`MechanismQuestionBuilder`) e planejamento de queries por fonte (`SearchQueryPlanBuilder`) no módulo `mds/`.
-- Implementados clientes reais de busca estruturada para PubMed/NCBI E-utilities e Crossref, com execução via `SearchExecutionService`.
-- Pipeline do MDS passou a publicar `mechanismEvidenceSearch` e `sourceDocument` com query rastreável, metadados normalizados e classificação inicial de acesso/permissão.
-- Backend recebeu suporte explícito para persistência de `source_access_record` por lote via endpoint interno dedicado (`/api/internal/mds/source-access/publish-batch`).
-- Contratos de teste foram atualizados no backend e no módulo `mds/` para cobrir o fluxo novo de Sprint 3.
+- Implementado `SourceDedupService` no módulo `mds/` com deduplicação por DOI, PMID, PMCID, título normalizado e URL canônica, priorizando o registro mais completo.
+- Implementado `EvidenceScreeningService` para triagem mínima por relevância e aplicabilidade ao nicho, com priorização de evidências para publicação.
+- Implementado `EvidenceConfidenceService` com classificação de confiança em quatro níveis (`alta`, `moderada`, `baixa`, `muito_baixa`).
+- Implementado `EvidenceItemBuilder` e publicação de artefatos `evidenceItem` no backend com lineage explícito para o `sourceDocument` de origem.
+- Pipeline do MDS atualizado para registrar eventos por etapa via heartbeat (`dedup-normalize`, `screening`, `evidence-analysis`) e publicar `mechanismEvidenceSearch` com contadores de deduplicação/triagem.
+- Testes do pipeline atualizados e novo teste unitário de deduplicação adicionado no módulo `mds/`.
 
 **O que ficou pendente para a próxima sprint:**
-- Deduplicação avançada de `sourceDocument` por DOI/PMID/PMCID/título/URL canônica.
-- Triagem científica estruturada com critérios de elegibilidade e priorização.
-- Construção e persistência de `evidenceItem` com classificação de confiança.
+- Extração robusta de componentes ativos para construção de `mechanismCandidate`.
+- Agrupamento semântico de componentes recorrentes e regra de seleção final de mecanismo recomendado.
 
 **Riscos / observações:**
-- Os clientes externos de busca dependem de disponibilidade e limites das APIs públicas (NCBI e Crossref), podendo reduzir volume em execuções reais sem fallback adicional.
-- A classificação `accessClass` / `permissionState` nesta sprint é inicial e heurística, devendo ser refinada na Sprint 4 junto com triagem.
+- Triagem e confiança ainda são heurísticas iniciais baseadas em metadados e texto (sem avaliação científica profunda por desenho de estudo).
+- A deduplicação cobre os identificadores principais, mas pode exigir refinamentos para fontes heterogêneas adicionais nas próximas sprints.
 
 **Arquivos alterados/criados:**
 - mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
-- mds/src/main/java/com/marketinghub/mds/client/BackendMdsClient.java
-- mds/src/main/java/com/marketinghub/mds/dto/BackendSourceAccessPublishBatchRequestDto.java
-- mds/src/main/java/com/marketinghub/mds/dto/BackendSourceAccessPublishBatchResponseDto.java
-- mds/src/main/java/com/marketinghub/mds/search/MechanismQuestion.java
-- mds/src/main/java/com/marketinghub/mds/search/MechanismQuestionBuilder.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchQueryPlan.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchQueryPlanBuilder.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchExecutionService.java
-- mds/src/main/java/com/marketinghub/mds/search/EvidenceSearchClient.java
-- mds/src/main/java/com/marketinghub/mds/search/PubmedSearchClient.java
-- mds/src/main/java/com/marketinghub/mds/search/CrossrefSearchClient.java
+- mds/src/main/java/com/marketinghub/mds/search/SourceDedupService.java
+- mds/src/main/java/com/marketinghub/mds/search/EvidenceScreeningService.java
+- mds/src/main/java/com/marketinghub/mds/search/EvidenceConfidenceService.java
+- mds/src/main/java/com/marketinghub/mds/search/EvidenceItemBuilder.java
+- mds/src/main/java/com/marketinghub/mds/search/ScreenedEvidence.java
 - mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsSourceAccessService.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsSourceAccessPublishBatchRequest.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsSourceAccessPublishBatchResponse.java
-- backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
+- mds/src/test/java/com/marketinghub/mds/search/SourceDedupServiceTest.java
 - docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
 - docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
 

--- a/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+++ b/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
@@ -636,3 +636,71 @@ O MDS agora executa busca estruturada em fontes científicas, registra a estrat�
 **Próximo passo sugerido:**
 
 Implementar a Sprint 4 com deduplicação, triagem estruturada, `EvidenceConfidenceService` e persistência de `evidenceItem`.
+
+## [2026-04-17] — Etapa: sprint 4 - normalização, deduplicação, triagem e evidenceItem
+
+**Status:** `CONCLUIDO`
+
+**Resumo:**
+
+A Sprint 4 foi implementada no módulo `mds/` com deduplicação de documentos, triagem por relevância/aplicabilidade, classificação de confiança e publicação de `evidenceItem` com lineage para os `sourceDocument` de origem.
+
+**Objetivo da etapa:**
+
+Transformar os resultados brutos da busca da Sprint 3 em evidências priorizadas e persistíveis no backend, mantendo rastreabilidade e eventos por etapa.
+
+**O que foi implementado:**
+
+- criação de `SourceDedupService` com regras por DOI, PMID, PMCID, título normalizado e URL canônica;
+- criação de `EvidenceScreeningService` para triagem mínima e priorização de evidências;
+- criação de `EvidenceConfidenceService` com níveis `alta`, `moderada`, `baixa` e `muito_baixa`;
+- criação de `EvidenceItemBuilder` para montar `evidenceItem` com limitação, proximidade com problema, aplicabilidade ao nicho e sinais de força da evidência;
+- atualização do `MechanismDiscoveryPipelineService` para publicar `evidenceItem` e ligar lineage ao `sourceDocument` via `parentArtifactIds`;
+- heartbeat por etapa (`dedup-normalize`, `screening`, `evidence-analysis`) para registrar eventos operacionais no backend.
+
+**Arquivos alterados/criados:**
+
+- mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+- mds/src/main/java/com/marketinghub/mds/search/SourceDedupService.java
+- mds/src/main/java/com/marketinghub/mds/search/EvidenceScreeningService.java
+- mds/src/main/java/com/marketinghub/mds/search/EvidenceConfidenceService.java
+- mds/src/main/java/com/marketinghub/mds/search/EvidenceItemBuilder.java
+- mds/src/main/java/com/marketinghub/mds/search/ScreenedEvidence.java
+- mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+- mds/src/test/java/com/marketinghub/mds/search/SourceDedupServiceTest.java
+- docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+- docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+
+**Tabelas / persistência afetadas:**
+
+- `artifact_record` (novo tipo persistido: `evidenceItem`)
+- `artifact_lineage_edge` (lineage `evidenceItem` -> `sourceDocument`)
+- `mds_processing_event` (eventos adicionais por etapa do pipeline)
+
+**APIs / endpoints / contratos afetados:**
+
+- `POST /api/internal/mds/artifacts/publish-batch` (uso expandido para `evidenceItem`)
+- `POST /api/internal/mds/requests/{id}/heartbeat` (uso expandido para eventos de etapa da Sprint 4)
+
+**Artefatos / schemas impactados:**
+
+- `mds.evidenceItem.v1`
+- `mds.sourceDocument.v1` (lineage consumido como origem)
+- `mds.mechanismEvidenceSearch.v1` (metadados de deduplicação/triagem)
+
+**Testes executados:**
+
+- `cd mds && mvn test`
+
+**Resultado observado:**
+
+O MDS agora reduz duplicatas de fontes, aplica triagem mínima, classifica confiança e publica `evidenceItem` com rastreabilidade para o documento fonte, preparando o terreno para construção de mecanismos candidatos na sprint seguinte.
+
+**Limitações / pendências:**
+
+- heurísticas de triagem e confiança ainda não avaliam profundidade metodológica completa dos estudos;
+- extração de componentes ativos e recomendação de mecanismo não fazem parte desta sprint.
+
+**Próximo passo sugerido:**
+
+Implementar a Sprint 5 com extração de componentes ativos, montagem de `mechanismCandidate` e seleção do mecanismo recomendado.

--- a/mds/src/main/java/com/marketinghub/mds/search/EvidenceConfidenceService.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/EvidenceConfidenceService.java
@@ -1,0 +1,23 @@
+package com.marketinghub.mds.search;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class EvidenceConfidenceService {
+
+    public String classify(ScreenedEvidence evidence) {
+        boolean hasStrongSignals = !evidence.evidenceStrengthSignals().isEmpty();
+        boolean hasManyLimitations = evidence.limitations().size() >= 2;
+
+        if (evidence.priorityScore() >= 0.65 && hasStrongSignals && !hasManyLimitations) {
+            return "alta";
+        }
+        if (evidence.priorityScore() >= 0.45 && !hasManyLimitations) {
+            return "moderada";
+        }
+        if (evidence.priorityScore() >= 0.25) {
+            return "baixa";
+        }
+        return "muito_baixa";
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/search/EvidenceItemBuilder.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/EvidenceItemBuilder.java
@@ -1,0 +1,51 @@
+package com.marketinghub.mds.search;
+
+import com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class EvidenceItemBuilder {
+
+    public ArtifactPayloadDto build(Long requestId,
+                                    ScreenedEvidence screenedEvidence,
+                                    String confidenceLevel,
+                                    List<Long> parentArtifactIds) {
+        Map<String, Object> content = new LinkedHashMap<>();
+        content.put("requestId", requestId);
+        content.put("source", screenedEvidence.source());
+        content.put("sourceDocumentId", screenedEvidence.sourceDocumentId());
+        content.put("title", empty(screenedEvidence.title()));
+        content.put("abstract", empty(screenedEvidence.abstractText()));
+        content.put("doi", empty(screenedEvidence.doi()));
+        content.put("url", empty(screenedEvidence.url()));
+        content.put("publicationYear", empty(screenedEvidence.publicationYear()));
+        content.put("limitation", screenedEvidence.limitations());
+        content.put("proximidadeComProblema", screenedEvidence.proximityWithProblem());
+        content.put("aplicabilidadeAoNicho", screenedEvidence.applicabilityToNiche());
+        content.put("sinaisForcaEvidencia", screenedEvidence.evidenceStrengthSignals());
+        content.put("relevanceScore", screenedEvidence.relevanceScore());
+        content.put("applicabilityScore", screenedEvidence.applicabilityScore());
+        content.put("priorityScore", screenedEvidence.priorityScore());
+        content.put("confidenceLevel", confidenceLevel);
+
+        return new ArtifactPayloadDto(
+                "evidenceItem",
+                "v1",
+                "v1",
+                "DRAFT",
+                "mds",
+                "mds",
+                content,
+                null,
+                parentArtifactIds == null ? List.of() : parentArtifactIds
+        );
+    }
+
+    private String empty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/search/EvidenceScreeningService.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/EvidenceScreeningService.java
@@ -1,0 +1,93 @@
+package com.marketinghub.mds.search;
+
+import com.marketinghub.mds.dto.BackendMdsRequestDto;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class EvidenceScreeningService {
+    private static final List<String> LIMITATION_HINTS = List.of(
+            "mouse", "mice", "rat", "animal model", "in vitro", "pilot", "case report", "small sample"
+    );
+    private static final List<String> STRENGTH_HINTS = List.of(
+            "randomized", "meta-analysis", "systematic review", "double blind", "placebo", "cohort"
+    );
+
+    public List<ScreenedEvidence> screen(BackendMdsRequestDto request, List<SourceSearchHit> hits) {
+        String problemAndOutcome = safe(request.problem()) + " " + safe(request.desiredOutcome());
+        Set<String> problemTokens = tokenize(problemAndOutcome);
+        Set<String> nicheTokens = tokenize(request.market());
+
+        List<ScreenedEvidence> screened = new ArrayList<>();
+        for (SourceSearchHit hit : hits) {
+            String content = (safe(hit.title()) + " " + safe(hit.abstractText())).toLowerCase(Locale.ROOT);
+            double relevance = overlap(problemTokens, tokenize(content));
+            double applicability = overlap(nicheTokens, tokenize(content));
+            List<String> limitations = hintsFound(content, LIMITATION_HINTS);
+            List<String> strengthSignals = hintsFound(content, STRENGTH_HINTS);
+
+            String proximity = relevance >= 0.45 ? "alta" : relevance >= 0.2 ? "moderada" : "baixa";
+            String nicheApplicability = applicability >= 0.3 ? "alta" : applicability >= 0.1 ? "moderada" : "baixa";
+            double priority = (relevance * 0.6) + (applicability * 0.3) + (strengthSignals.isEmpty() ? 0.0 : 0.1);
+
+            if (relevance < 0.1) {
+                continue;
+            }
+
+            screened.add(new ScreenedEvidence(
+                    hit.source(),
+                    hit.sourceDocumentId(),
+                    hit.title(),
+                    hit.abstractText(),
+                    hit.doi(),
+                    hit.url(),
+                    hit.publicationYear(),
+                    limitations,
+                    proximity,
+                    nicheApplicability,
+                    strengthSignals,
+                    relevance,
+                    applicability,
+                    priority
+            ));
+        }
+
+        return screened;
+    }
+
+    public List<ScreenedEvidence> prioritize(List<ScreenedEvidence> screened, int maxItems) {
+        return screened.stream()
+                .sorted(Comparator.comparingDouble(ScreenedEvidence::priorityScore).reversed())
+                .limit(maxItems)
+                .toList();
+    }
+
+    private Set<String> tokenize(String text) {
+        return List.of(text.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9 ]", " ").split("\\s+"))
+                .stream()
+                .filter(token -> token.length() >= 3)
+                .collect(Collectors.toSet());
+    }
+
+    private double overlap(Set<String> expected, Set<String> actual) {
+        if (expected.isEmpty() || actual.isEmpty()) {
+            return 0;
+        }
+        long matches = expected.stream().filter(actual::contains).count();
+        return (double) matches / expected.size();
+    }
+
+    private List<String> hintsFound(String content, List<String> hints) {
+        return hints.stream().filter(content::contains).toList();
+    }
+
+    private String safe(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/search/ScreenedEvidence.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/ScreenedEvidence.java
@@ -1,0 +1,21 @@
+package com.marketinghub.mds.search;
+
+import java.util.List;
+
+public record ScreenedEvidence(
+        String source,
+        String sourceDocumentId,
+        String title,
+        String abstractText,
+        String doi,
+        String url,
+        String publicationYear,
+        List<String> limitations,
+        String proximityWithProblem,
+        String applicabilityToNiche,
+        List<String> evidenceStrengthSignals,
+        double relevanceScore,
+        double applicabilityScore,
+        double priorityScore
+) {
+}

--- a/mds/src/main/java/com/marketinghub/mds/search/SourceDedupService.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/SourceDedupService.java
@@ -1,0 +1,137 @@
+package com.marketinghub.mds.search;
+
+import org.springframework.stereotype.Service;
+
+import java.text.Normalizer;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+public class SourceDedupService {
+
+    public List<SourceSearchHit> deduplicate(List<SourceSearchHit> hits) {
+        Map<String, SourceSearchHit> byKey = new LinkedHashMap<>();
+        for (SourceSearchHit hit : hits) {
+            String key = dedupKey(hit);
+            SourceSearchHit existing = byKey.get(key);
+            if (existing == null) {
+                byKey.put(key, hit);
+            } else {
+                byKey.put(key, chooseBest(existing, hit));
+            }
+        }
+        return List.copyOf(byKey.values());
+    }
+
+    private SourceSearchHit chooseBest(SourceSearchHit left, SourceSearchHit right) {
+        return score(right) > score(left) ? right : left;
+    }
+
+    private int score(SourceSearchHit hit) {
+        int score = 0;
+        if (notBlank(hit.doi())) score += 4;
+        if (notBlank(hit.abstractText())) score += 3;
+        if (notBlank(hit.url())) score += 2;
+        if (notBlank(hit.title())) score += 2;
+        if (hit.openAccess()) score += 1;
+        return score;
+    }
+
+    private String dedupKey(SourceSearchHit hit) {
+        String doi = normalizeDoi(hit.doi());
+        if (notBlank(doi)) return "doi:" + doi;
+
+        String pmid = extractPmid(hit);
+        if (notBlank(pmid)) return "pmid:" + pmid;
+
+        String pmcid = extractPmcid(hit);
+        if (notBlank(pmcid)) return "pmcid:" + pmcid;
+
+        String normalizedTitle = normalizeTitle(hit.title());
+        if (notBlank(normalizedTitle)) {
+            return "title:" + normalizedTitle + ":" + normalizeBasic(hit.publicationYear());
+        }
+
+        String url = canonicalizeUrl(hit.url());
+        if (notBlank(url)) return "url:" + url;
+
+        return "fallback:" + normalizeBasic(hit.source()) + ":" + normalizeBasic(hit.sourceDocumentId());
+    }
+
+    private String extractPmid(SourceSearchHit hit) {
+        String id = normalizeBasic(hit.sourceDocumentId());
+        if (id.startsWith("pubmed:")) {
+            return id.substring("pubmed:".length());
+        }
+        String url = normalizeBasic(hit.url());
+        if (url.contains("pubmed.ncbi.nlm.nih.gov/")) {
+            String tail = url.substring(url.indexOf("pubmed.ncbi.nlm.nih.gov/") + "pubmed.ncbi.nlm.nih.gov/".length());
+            StringBuilder pmid = new StringBuilder();
+            for (char c : tail.toCharArray()) {
+                if (Character.isDigit(c)) pmid.append(c);
+                else break;
+            }
+            return pmid.toString();
+        }
+        return "";
+    }
+
+    private String extractPmcid(SourceSearchHit hit) {
+        String id = normalizeBasic(hit.sourceDocumentId());
+        if (id.contains("pmc")) {
+            int idx = id.indexOf("pmc");
+            return id.substring(idx).replaceAll("[^a-z0-9]", "");
+        }
+        String url = normalizeBasic(hit.url());
+        if (url.contains("/pmc/articles/")) {
+            String tail = url.substring(url.indexOf("/pmc/articles/") + "/pmc/articles/".length());
+            int stop = tail.indexOf('/');
+            return (stop >= 0 ? tail.substring(0, stop) : tail).replaceAll("[^a-z0-9]", "");
+        }
+        return "";
+    }
+
+    private String normalizeDoi(String doi) {
+        String value = normalizeBasic(doi);
+        if (value.startsWith("https://doi.org/")) {
+            value = value.substring("https://doi.org/".length());
+        }
+        if (value.startsWith("http://doi.org/")) {
+            value = value.substring("http://doi.org/".length());
+        }
+        if (value.startsWith("doi:")) {
+            value = value.substring("doi:".length());
+        }
+        return value;
+    }
+
+    private String normalizeTitle(String title) {
+        String value = normalizeBasic(title);
+        value = Normalizer.normalize(value, Normalizer.Form.NFD).replaceAll("\\p{M}", "");
+        value = value.replaceAll("[^a-z0-9]+", " ").trim().replaceAll("\\s+", " ");
+        return value;
+    }
+
+    private String canonicalizeUrl(String url) {
+        String value = normalizeBasic(url);
+        if (value.startsWith("https://")) value = value.substring(8);
+        if (value.startsWith("http://")) value = value.substring(7);
+        if (value.startsWith("www.")) value = value.substring(4);
+        int query = value.indexOf('?');
+        if (query >= 0) value = value.substring(0, query);
+        int fragment = value.indexOf('#');
+        if (fragment >= 0) value = value.substring(0, fragment);
+        while (value.endsWith("/")) value = value.substring(0, value.length() - 1);
+        return value;
+    }
+
+    private String normalizeBasic(String value) {
+        return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private boolean notBlank(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+++ b/mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
@@ -5,15 +5,21 @@ import com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto;
 import com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto;
 import com.marketinghub.mds.dto.BackendMdsRequestDto;
 import com.marketinghub.mds.dto.BackendSourceAccessPublishBatchRequestDto;
+import com.marketinghub.mds.search.EvidenceConfidenceService;
+import com.marketinghub.mds.search.EvidenceItemBuilder;
+import com.marketinghub.mds.search.EvidenceScreeningService;
 import com.marketinghub.mds.search.MechanismQuestion;
 import com.marketinghub.mds.search.MechanismQuestionBuilder;
+import com.marketinghub.mds.search.ScreenedEvidence;
 import com.marketinghub.mds.search.SearchExecutionService;
 import com.marketinghub.mds.search.SearchQueryPlan;
 import com.marketinghub.mds.search.SearchQueryPlanBuilder;
+import com.marketinghub.mds.search.SourceDedupService;
 import com.marketinghub.mds.search.SourceSearchHit;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -23,21 +29,48 @@ public class MechanismDiscoveryPipelineService {
     private final MechanismQuestionBuilder mechanismQuestionBuilder;
     private final SearchQueryPlanBuilder searchQueryPlanBuilder;
     private final SearchExecutionService searchExecutionService;
+    private final SourceDedupService sourceDedupService;
+    private final EvidenceScreeningService evidenceScreeningService;
+    private final EvidenceConfidenceService evidenceConfidenceService;
+    private final EvidenceItemBuilder evidenceItemBuilder;
 
     public MechanismDiscoveryPipelineService(BackendMdsClient backendMdsClient,
                                              MechanismQuestionBuilder mechanismQuestionBuilder,
                                              SearchQueryPlanBuilder searchQueryPlanBuilder,
-                                             SearchExecutionService searchExecutionService) {
+                                             SearchExecutionService searchExecutionService,
+                                             SourceDedupService sourceDedupService,
+                                             EvidenceScreeningService evidenceScreeningService,
+                                             EvidenceConfidenceService evidenceConfidenceService,
+                                             EvidenceItemBuilder evidenceItemBuilder) {
         this.backendMdsClient = backendMdsClient;
         this.mechanismQuestionBuilder = mechanismQuestionBuilder;
         this.searchQueryPlanBuilder = searchQueryPlanBuilder;
         this.searchExecutionService = searchExecutionService;
+        this.sourceDedupService = sourceDedupService;
+        this.evidenceScreeningService = evidenceScreeningService;
+        this.evidenceConfidenceService = evidenceConfidenceService;
+        this.evidenceItemBuilder = evidenceItemBuilder;
     }
 
     public void execute(BackendMdsRequestDto request) {
         MechanismQuestion question = mechanismQuestionBuilder.build(request);
         List<SearchQueryPlan> plans = searchQueryPlanBuilder.buildPlans(question);
-        List<SourceSearchHit> hits = searchExecutionService.execute(plans);
+        List<SourceSearchHit> rawHits = searchExecutionService.execute(plans);
+
+        List<SourceSearchHit> dedupedHits = sourceDedupService.deduplicate(rawHits);
+        backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
+                "dedup-normalize",
+                "deduplication finished",
+                Map.of("rawCount", rawHits.size(), "dedupedCount", dedupedHits.size())
+        ));
+
+        List<ScreenedEvidence> screened = evidenceScreeningService.screen(request, dedupedHits);
+        List<ScreenedEvidence> prioritized = evidenceScreeningService.prioritize(screened, 12);
+        backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
+                "screening",
+                "screening finished",
+                Map.of("eligibleCount", screened.size(), "prioritizedCount", prioritized.size())
+        ));
 
         ArtifactPayloadDto evidenceSearch = new ArtifactPayloadDto(
                 "mechanismEvidenceSearch",
@@ -50,7 +83,9 @@ public class MechanismDiscoveryPipelineService {
                         "requestId", request.id(),
                         "question", question.text(),
                         "queries", plans.stream().map(p -> Map.of("source", p.source(), "query", p.query(), "limit", p.limit())).toList(),
-                        "resultCount", hits.size()
+                        "rawResultCount", rawHits.size(),
+                        "dedupedResultCount", dedupedHits.size(),
+                        "screenedResultCount", prioritized.size()
                 ),
                 null,
                 List.of()
@@ -59,7 +94,7 @@ public class MechanismDiscoveryPipelineService {
         List<ArtifactPayloadDto> sourceDocumentArtifacts = new ArrayList<>();
         List<BackendSourceAccessPublishBatchRequestDto.SourceAccessPayloadDto> sourceAccessRecords = new ArrayList<>();
 
-        for (SourceSearchHit hit : hits) {
+        for (SourceSearchHit hit : dedupedHits) {
             String accessClass = resolveAccessClass(hit);
             String permissionState = resolvePermissionState(hit);
 
@@ -97,15 +132,38 @@ public class MechanismDiscoveryPipelineService {
             ));
         }
 
-        List<ArtifactPayloadDto> allArtifacts = new ArrayList<>();
-        allArtifacts.add(evidenceSearch);
-        allArtifacts.addAll(sourceDocumentArtifacts);
-
-        backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), allArtifacts));
+        List<ArtifactPayloadDto> sourceBatch = new ArrayList<>();
+        sourceBatch.add(evidenceSearch);
+        sourceBatch.addAll(sourceDocumentArtifacts);
+        var sourcePublishResponse = backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), sourceBatch));
 
         if (!sourceAccessRecords.isEmpty()) {
             backendMdsClient.publishSourceAccessBatch(new BackendSourceAccessPublishBatchRequestDto(sourceAccessRecords));
         }
+
+        Map<String, Long> sourceArtifactIdsBySourceDocumentId = new LinkedHashMap<>();
+        List<Long> sourceArtifactIds = sourcePublishResponse.artifactIds().stream().skip(1).toList();
+        for (int i = 0; i < dedupedHits.size() && i < sourceArtifactIds.size(); i++) {
+            sourceArtifactIdsBySourceDocumentId.put(dedupedHits.get(i).sourceDocumentId(), sourceArtifactIds.get(i));
+        }
+
+        List<ArtifactPayloadDto> evidenceItems = new ArrayList<>();
+        for (ScreenedEvidence screenedEvidence : prioritized) {
+            String confidenceLevel = evidenceConfidenceService.classify(screenedEvidence);
+            Long parentArtifactId = sourceArtifactIdsBySourceDocumentId.get(screenedEvidence.sourceDocumentId());
+            evidenceItems.add(evidenceItemBuilder.build(request.id(), screenedEvidence, confidenceLevel,
+                    parentArtifactId == null ? List.of() : List.of(parentArtifactId)));
+        }
+
+        if (!evidenceItems.isEmpty()) {
+            backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), evidenceItems));
+        }
+
+        backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
+                "evidence-analysis",
+                "evidence items published",
+                Map.of("evidenceItemCount", evidenceItems.size())
+        ));
     }
 
     private String resolveAccessClass(SourceSearchHit hit) {

--- a/mds/src/test/java/com/marketinghub/mds/search/SourceDedupServiceTest.java
+++ b/mds/src/test/java/com/marketinghub/mds/search/SourceDedupServiceTest.java
@@ -1,0 +1,49 @@
+package com.marketinghub.mds.search;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SourceDedupServiceTest {
+    private final SourceDedupService service = new SourceDedupService();
+
+    @Test
+    void shouldDeduplicateUsingDoiAndKeepMostCompleteDocument() {
+        SourceSearchHit first = new SourceSearchHit(
+                "pubmed",
+                "pubmed:1",
+                "10.1000/xyz",
+                "Title",
+                "",
+                "",
+                "2024",
+                "",
+                false,
+                false,
+                false,
+                List.of()
+        );
+        SourceSearchHit second = new SourceSearchHit(
+                "crossref",
+                "crossref:9",
+                "https://doi.org/10.1000/xyz",
+                "Title",
+                "Detailed abstract",
+                "https://example.org/paper",
+                "2024",
+                "CC-BY",
+                true,
+                true,
+                true,
+                List.of("Author")
+        );
+
+        List<SourceSearchHit> deduped = service.deduplicate(List.of(first, second));
+
+        assertThat(deduped).hasSize(1);
+        assertThat(deduped.get(0).source()).isEqualTo("crossref");
+        assertThat(deduped.get(0).abstractText()).isEqualTo("Detailed abstract");
+    }
+}

--- a/mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+++ b/mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.mds.service;
 
 import com.marketinghub.mds.client.BackendMdsClient;
+import com.marketinghub.mds.dto.BackendArtifactPublishBatchResponseDto;
 import com.marketinghub.mds.dto.BackendMdsRequestDto;
 import com.marketinghub.mds.search.*;
 import org.junit.jupiter.api.Test;
@@ -13,28 +14,33 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MechanismDiscoveryPipelineServiceTest {
     @Mock
     private BackendMdsClient backendMdsClient;
-
     @Mock
     private MechanismQuestionBuilder mechanismQuestionBuilder;
-
     @Mock
     private SearchQueryPlanBuilder searchQueryPlanBuilder;
-
     @Mock
     private SearchExecutionService searchExecutionService;
+    @Mock
+    private SourceDedupService sourceDedupService;
+    @Mock
+    private EvidenceScreeningService evidenceScreeningService;
+    @Mock
+    private EvidenceConfidenceService evidenceConfidenceService;
+    @Mock
+    private EvidenceItemBuilder evidenceItemBuilder;
 
     @InjectMocks
     private MechanismDiscoveryPipelineService service;
 
     @Test
-    void shouldPublishEvidenceSearchAndSourceDocuments() {
+    void shouldPublishSourceDocumentsAndEvidenceItemsWithLineage() {
         BackendMdsRequestDto request = new BackendMdsRequestDto(
                 10L,
                 "IN_PROGRESS",
@@ -43,39 +49,71 @@ class MechanismDiscoveryPipelineServiceTest {
                 "consistent fat loss",
                 "corr-123"
         );
+        SearchQueryPlan plan = new SearchQueryPlan("pubmed", "q1", 10);
+        SourceSearchHit hit = new SourceSearchHit(
+                "pubmed",
+                "pubmed:1",
+                "10.1000/xyz",
+                "title",
+                "abstract",
+                "https://pubmed.ncbi.nlm.nih.gov/1/",
+                "2024",
+                "CC-BY",
+                true,
+                true,
+                false,
+                List.of("A Author")
+        );
+        ScreenedEvidence screenedEvidence = new ScreenedEvidence(
+                "pubmed",
+                "pubmed:1",
+                "title",
+                "abstract",
+                "10.1000/xyz",
+                "https://pubmed.ncbi.nlm.nih.gov/1/",
+                "2024",
+                List.of("pilot"),
+                "alta",
+                "moderada",
+                List.of("randomized"),
+                0.7,
+                0.3,
+                0.62
+        );
+
         when(mechanismQuestionBuilder.build(request)).thenReturn(new MechanismQuestion("q1"));
-        when(searchQueryPlanBuilder.buildPlans(new MechanismQuestion("q1")))
-                .thenReturn(List.of(new SearchQueryPlan("pubmed", "q1", 10)));
-        when(searchExecutionService.execute(List.of(new SearchQueryPlan("pubmed", "q1", 10))))
-                .thenReturn(List.of(new SourceSearchHit(
-                        "pubmed",
-                        "pubmed:1",
-                        null,
-                        "title",
-                        "abstract",
-                        "https://pubmed.ncbi.nlm.nih.gov/1/",
-                        "2024",
-                        "CC-BY",
-                        true,
-                        true,
-                        false,
-                        List.of("A Author")
-                )));
+        when(searchQueryPlanBuilder.buildPlans(new MechanismQuestion("q1"))).thenReturn(List.of(plan));
+        when(searchExecutionService.execute(List.of(plan))).thenReturn(List.of(hit));
+        when(sourceDedupService.deduplicate(List.of(hit))).thenReturn(List.of(hit));
+        when(evidenceScreeningService.screen(request, List.of(hit))).thenReturn(List.of(screenedEvidence));
+        when(evidenceScreeningService.prioritize(List.of(screenedEvidence), 12)).thenReturn(List.of(screenedEvidence));
+        when(evidenceConfidenceService.classify(screenedEvidence)).thenReturn("moderada");
+        when(evidenceItemBuilder.build(eq(10L), eq(screenedEvidence), eq("moderada"), eq(List.of(101L))))
+                .thenReturn(new com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto(
+                        "evidenceItem", "v1", "v1", "DRAFT", "mds", "mds", java.util.Map.of("id", "ev-1"), null, List.of(101L)
+                ));
+
+        when(backendMdsClient.publishBatch(any()))
+                .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 2, List.of(100L, 101L)))
+                .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(102L)));
 
         service.execute(request);
 
-        ArgumentCaptor<com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto> artifactCaptor =
+        ArgumentCaptor<com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto> batchCaptor =
                 ArgumentCaptor.forClass(com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.class);
-        verify(backendMdsClient).publishBatch(artifactCaptor.capture());
+        verify(backendMdsClient, times(2)).publishBatch(batchCaptor.capture());
 
-        assertThat(artifactCaptor.getValue().requestId()).isEqualTo(10L);
-        assertThat(artifactCaptor.getValue().artifacts()).hasSize(2);
-        assertThat(artifactCaptor.getValue().artifacts().get(0).artifactType()).isEqualTo("mechanismEvidenceSearch");
-        assertThat(artifactCaptor.getValue().artifacts().get(1).artifactType()).isEqualTo("sourceDocument");
+        List<com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto> batches = batchCaptor.getAllValues();
+        assertThat(batches.get(0).artifacts()).extracting(a -> a.artifactType())
+                .containsExactly("mechanismEvidenceSearch", "sourceDocument");
+        assertThat(batches.get(1).artifacts()).extracting(a -> a.artifactType())
+                .containsExactly("evidenceItem");
 
         ArgumentCaptor<com.marketinghub.mds.dto.BackendSourceAccessPublishBatchRequestDto> sourceAccessCaptor =
                 ArgumentCaptor.forClass(com.marketinghub.mds.dto.BackendSourceAccessPublishBatchRequestDto.class);
         verify(backendMdsClient).publishSourceAccessBatch(sourceAccessCaptor.capture());
         assertThat(sourceAccessCaptor.getValue().records()).hasSize(1);
+
+        verify(backendMdsClient, times(3)).heartbeat(eq(10L), any());
     }
 }


### PR DESCRIPTION
### Motivation
- Entregar estritamente a Sprint 4 do Mechanism Discovery Service (MDS) para transformar resultados de busca em evidência priorizada e persistível sem antecipar itens da Sprint 5. 
- Garantir que o MDS permaneça sem acesso direto ao MySQL e que a persistência de artefatos ocorra via backend conforme o contrato canônico.

### Description
- Implementados serviços de Sprint 4 no módulo `mds/`: `SourceDedupService`, `EvidenceScreeningService`, `EvidenceConfidenceService`, `EvidenceItemBuilder` e o record `ScreenedEvidence` para representar evidências triadas.
- Atualizado o pipeline `MechanismDiscoveryPipelineService` para deduplicar resultados, executar triagem/priorização, classificar confiança e publicar `evidenceItem` no backend com `parentArtifactIds` para lineage e heartbeat por etapas (`dedup-normalize`, `screening`, `evidence-analysis`).
- Adicionados testes unitários e de integração do fluxo: `SourceDedupServiceTest` e atualização de `MechanismDiscoveryPipelineServiceTest` para cobrir publicação de `sourceDocument` e `evidenceItem` com lineage; também atualizados artefatos de documentação (`plano_implementacao_mds_baseado_na_especificacao.md` e `protocolo_historico_implantacao_mds.md`) com o registro da Sprint 4.
- Escopo estrito mantido: nenhuma funcionalidade de Sprint 5 (`mechanismCandidate`, extração de componentes e seleção do mecanismo) foi introduzida.

### Testing
- Executado `cd mds && mvn test`; primeira tentativa falhou por erro transitório no download de dependência (HTTP 502 ao Maven Central), reexecutado com sucesso e todos os testes do módulo `mds` passaram. 
- Testes de pipeline cobrem publicação em lote ao backend e chamadas de `heartbeat`, e o novo teste unitário de deduplicação passou localmente com `mvn test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22f004c5883218cb76acebde9da59)