### PR TITLE
MDS Sprint 5: mechanismCandidate/mechanismSpec publication and recommended-mechanism read API

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRecommendedMechanismResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRecommendedMechanismResponse.java
@@ -1,0 +1,14 @@
+package com.marketinghub.mds.dto;
+
+import java.util.Map;
+
+public record MdsRecommendedMechanismResponse(
+        Long requestId,
+        Long artifactId,
+        String artifactType,
+        String schemaVersion,
+        String version,
+        String status,
+        Map<String, Object> content
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
@@ -4,4 +4,8 @@ import com.marketinghub.mds.MdsArtifactRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MdsArtifactRecordRepository extends JpaRepository<MdsArtifactRecord, Long> {
+    java.util.Optional<MdsArtifactRecord> findFirstByRequestIdAndArtifactTypeOrderByCreatedAtDescIdDesc(
+            Long requestId,
+            String artifactType
+    );
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
@@ -10,6 +10,7 @@ import com.marketinghub.mds.dto.MdsArtifactPublishBatchRequest;
 import com.marketinghub.mds.dto.MdsArtifactPublishBatchResponse;
 import com.marketinghub.mds.dto.MdsLineageCreateRequest;
 import com.marketinghub.mds.dto.MdsLineageResponse;
+import com.marketinghub.mds.dto.MdsRecommendedMechanismResponse;
 import com.marketinghub.mds.repository.MdsArtifactLineageEdgeRepository;
 import com.marketinghub.mds.repository.MdsArtifactRecordRepository;
 import com.marketinghub.mds.repository.MdsRequestRepository;
@@ -24,6 +25,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class MdsArtifactService {
@@ -79,6 +81,23 @@ public class MdsArtifactService {
         return createLineage(request.parentArtifactId(), request.childArtifactId(), request.relationType());
     }
 
+    @Transactional(readOnly = true)
+    public MdsRecommendedMechanismResponse getRecommendedMechanismByRequest(Long requestId) {
+        MdsArtifactRecord record = artifactRecordRepository
+                .findFirstByRequestIdAndArtifactTypeOrderByCreatedAtDescIdDesc(requestId, "mechanismSpec")
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "recommended mechanism not found"));
+
+        return new MdsRecommendedMechanismResponse(
+                requestId,
+                record.getId(),
+                record.getArtifactType(),
+                record.getSchemaVersion(),
+                record.getVersion(),
+                record.getStatus().name(),
+                readContent(record.getContentJson())
+        );
+    }
+
     private MdsLineageResponse createLineage(Long parentArtifactId, Long childArtifactId, String relationType) {
         MdsArtifactRecord parent = artifactRecordRepository.findById(parentArtifactId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "parent artifact not found"));
@@ -127,6 +146,15 @@ public class MdsArtifactService {
             return HexFormat.of().formatHex(raw);
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 algorithm unavailable", e);
+        }
+    }
+
+    private Map<String, Object> readContent(String contentJson) {
+        try {
+            return objectMapper.readValue(contentJson, new com.fasterxml.jackson.core.type.TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "invalid artifact content json");
         }
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
@@ -88,6 +88,11 @@ public class MdsInternalController {
         return artifactService.createLineage(request);
     }
 
+    @GetMapping("/requests/{id}/recommended-mechanism")
+    public MdsRecommendedMechanismResponse getRecommendedMechanism(@PathVariable Long id) {
+        return artifactService.getRecommendedMechanismByRequest(id);
+    }
+
     @GetMapping("/health")
     public Map<String, String> health() {
         return Map.of("status", "ok", "module", "mds-backend-orchestration");

--- a/backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -143,6 +144,30 @@ class MdsInternalControllerContractTest {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.savedCount").value(1));
+    }
+
+    @Test
+    void shouldGetRecommendedMechanismByRequest() throws Exception {
+        when(artifactService.getRecommendedMechanismByRequest(12L))
+                .thenReturn(new com.marketinghub.mds.dto.MdsRecommendedMechanismResponse(
+                        12L,
+                        401L,
+                        "mechanismSpec",
+                        "v1",
+                        "v1",
+                        "DRAFT",
+                        java.util.Map.of(
+                                "recommendedMechanismCandidateKey", "mc-1",
+                                "confidenceLevel", "moderada"
+                        )
+                ));
+
+        mockMvc.perform(get("/api/internal/mds/requests/12/recommended-mechanism"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value(12))
+                .andExpect(jsonPath("$.artifactId").value(401))
+                .andExpect(jsonPath("$.artifactType").value("mechanismSpec"))
+                .andExpect(jsonPath("$.content.recommendedMechanismCandidateKey").value("mc-1"));
     }
 
     private MdsRequestStatusResponse response(MdsRequestStatus status) {

--- a/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+++ b/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
@@ -502,39 +502,33 @@ Fazer o MDS sair de “orquestração vazia” para um pipeline que formula perg
 **Status:** `CONCLUIDO`
 
 **O que foi concluído:**
-- Implementada formulação de pergunta de mecanismo (`MechanismQuestionBuilder`) e planejamento de queries por fonte (`SearchQueryPlanBuilder`) no módulo `mds/`.
-- Implementados clientes reais de busca estruturada para PubMed/NCBI E-utilities e Crossref, com execução via `SearchExecutionService`.
-- Pipeline do MDS passou a publicar `mechanismEvidenceSearch` e `sourceDocument` com query rastreável, metadados normalizados e classificação inicial de acesso/permissão.
-- Backend recebeu suporte explícito para persistência de `source_access_record` por lote via endpoint interno dedicado (`/api/internal/mds/source-access/publish-batch`).
-- Contratos de teste foram atualizados no backend e no módulo `mds/` para cobrir o fluxo novo de Sprint 3.
+- Implementados `ActiveComponentExtractor` e `MechanismCandidateBuilder` no módulo `mds/`, cobrindo extração de componentes ativos, agrupamento recorrente e separação de componentes essenciais/opcionais.
+- O pipeline do MDS passou a gerar e publicar `mechanismCandidate` com justificativa explícita, riscos/limitações e nível de confiança consolidado a partir de `evidenceItem`.
+- O pipeline passou a gerar e publicar `mechanismSpec` com seleção de mecanismo recomendado e lineage para o `mechanismCandidate` escolhido e evidências de suporte.
+- Backend recebeu endpoint interno para leitura do mecanismo recomendado por request (`GET /api/internal/mds/requests/{id}/recommended-mechanism`), baseado no artefato `mechanismSpec`.
+- Testes unitários e de contrato foram atualizados para cobrir publicação de `mechanismCandidate`, publicação de `mechanismSpec` e leitura de mecanismo final no backend.
 
 **O que ficou pendente para a próxima sprint:**
-- Deduplicação avançada de `sourceDocument` por DOI/PMID/PMCID/título/URL canônica.
-- Triagem científica estruturada com critérios de elegibilidade e priorização.
-- Construção e persistência de `evidenceItem` com classificação de confiança.
+- Geração de `practicalKnowledgePack` para consumo downstream ainda não foi implementada nesta sprint.
+- Publicação de `mechanismDiscoveryReport` final ainda não foi implementada nesta sprint.
+- Consolidação de relatório operacional fim-a-fim (com pacote prático + spec + métricas finais) permanece para a Sprint 6.
 
 **Riscos / observações:**
-- Os clientes externos de busca dependem de disponibilidade e limites das APIs públicas (NCBI e Crossref), podendo reduzir volume em execuções reais sem fallback adicional.
-- A classificação `accessClass` / `permissionState` nesta sprint é inicial e heurística, devendo ser refinada na Sprint 4 junto com triagem.
+- A extração de componentes ativos nesta sprint é heurística e lexical; agrupamento semântico mais robusto pode melhorar precisão em corpora heterogêneos.
+- Em requests com baixa densidade textual nos abstracts, a cobertura de componentes pode ficar limitada e reduzir qualidade da justificativa.
+- A leitura de mecanismo recomendado no backend depende da publicação prévia de `mechanismSpec`; requests sem artefato retornam `404`.
 
 **Arquivos alterados/criados:**
 - mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
-- mds/src/main/java/com/marketinghub/mds/client/BackendMdsClient.java
-- mds/src/main/java/com/marketinghub/mds/dto/BackendSourceAccessPublishBatchRequestDto.java
-- mds/src/main/java/com/marketinghub/mds/dto/BackendSourceAccessPublishBatchResponseDto.java
-- mds/src/main/java/com/marketinghub/mds/search/MechanismQuestion.java
-- mds/src/main/java/com/marketinghub/mds/search/MechanismQuestionBuilder.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchQueryPlan.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchQueryPlanBuilder.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchExecutionService.java
-- mds/src/main/java/com/marketinghub/mds/search/EvidenceSearchClient.java
-- mds/src/main/java/com/marketinghub/mds/search/PubmedSearchClient.java
-- mds/src/main/java/com/marketinghub/mds/search/CrossrefSearchClient.java
+- mds/src/main/java/com/marketinghub/mds/search/ActiveComponentExtractor.java
+- mds/src/main/java/com/marketinghub/mds/search/MechanismCandidateBuilder.java
 - mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+- mds/src/test/java/com/marketinghub/mds/search/ActiveComponentExtractorTest.java
+- mds/src/test/java/com/marketinghub/mds/search/MechanismCandidateBuilderTest.java
 - backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsSourceAccessService.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsSourceAccessPublishBatchRequest.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsSourceAccessPublishBatchResponse.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRecommendedMechanismResponse.java
 - backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
 - docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
 - docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
@@ -650,39 +644,33 @@ Implementar o coração do MDS: extrair componentes ativos e montar mecanismos c
 **Status:** `CONCLUIDO`
 
 **O que foi concluído:**
-- Implementada formulação de pergunta de mecanismo (`MechanismQuestionBuilder`) e planejamento de queries por fonte (`SearchQueryPlanBuilder`) no módulo `mds/`.
-- Implementados clientes reais de busca estruturada para PubMed/NCBI E-utilities e Crossref, com execução via `SearchExecutionService`.
-- Pipeline do MDS passou a publicar `mechanismEvidenceSearch` e `sourceDocument` com query rastreável, metadados normalizados e classificação inicial de acesso/permissão.
-- Backend recebeu suporte explícito para persistência de `source_access_record` por lote via endpoint interno dedicado (`/api/internal/mds/source-access/publish-batch`).
-- Contratos de teste foram atualizados no backend e no módulo `mds/` para cobrir o fluxo novo de Sprint 3.
+- Implementados `ActiveComponentExtractor` e `MechanismCandidateBuilder` no módulo `mds/`, cobrindo extração de componentes ativos, agrupamento recorrente e separação de componentes essenciais/opcionais.
+- O pipeline do MDS passou a gerar e publicar `mechanismCandidate` com justificativa explícita, riscos/limitações e nível de confiança consolidado a partir de `evidenceItem`.
+- O pipeline passou a gerar e publicar `mechanismSpec` com seleção de mecanismo recomendado e lineage para o `mechanismCandidate` escolhido e evidências de suporte.
+- Backend recebeu endpoint interno para leitura do mecanismo recomendado por request (`GET /api/internal/mds/requests/{id}/recommended-mechanism`), baseado no artefato `mechanismSpec`.
+- Testes unitários e de contrato foram atualizados para cobrir publicação de `mechanismCandidate`, publicação de `mechanismSpec` e leitura de mecanismo final no backend.
 
 **O que ficou pendente para a próxima sprint:**
-- Deduplicação avançada de `sourceDocument` por DOI/PMID/PMCID/título/URL canônica.
-- Triagem científica estruturada com critérios de elegibilidade e priorização.
-- Construção e persistência de `evidenceItem` com classificação de confiança.
+- Geração de `practicalKnowledgePack` para consumo downstream ainda não foi implementada nesta sprint.
+- Publicação de `mechanismDiscoveryReport` final ainda não foi implementada nesta sprint.
+- Consolidação de relatório operacional fim-a-fim (com pacote prático + spec + métricas finais) permanece para a Sprint 6.
 
 **Riscos / observações:**
-- Os clientes externos de busca dependem de disponibilidade e limites das APIs públicas (NCBI e Crossref), podendo reduzir volume em execuções reais sem fallback adicional.
-- A classificação `accessClass` / `permissionState` nesta sprint é inicial e heurística, devendo ser refinada na Sprint 4 junto com triagem.
+- A extração de componentes ativos nesta sprint é heurística e lexical; agrupamento semântico mais robusto pode melhorar precisão em corpora heterogêneos.
+- Em requests com baixa densidade textual nos abstracts, a cobertura de componentes pode ficar limitada e reduzir qualidade da justificativa.
+- A leitura de mecanismo recomendado no backend depende da publicação prévia de `mechanismSpec`; requests sem artefato retornam `404`.
 
 **Arquivos alterados/criados:**
 - mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
-- mds/src/main/java/com/marketinghub/mds/client/BackendMdsClient.java
-- mds/src/main/java/com/marketinghub/mds/dto/BackendSourceAccessPublishBatchRequestDto.java
-- mds/src/main/java/com/marketinghub/mds/dto/BackendSourceAccessPublishBatchResponseDto.java
-- mds/src/main/java/com/marketinghub/mds/search/MechanismQuestion.java
-- mds/src/main/java/com/marketinghub/mds/search/MechanismQuestionBuilder.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchQueryPlan.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchQueryPlanBuilder.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchExecutionService.java
-- mds/src/main/java/com/marketinghub/mds/search/EvidenceSearchClient.java
-- mds/src/main/java/com/marketinghub/mds/search/PubmedSearchClient.java
-- mds/src/main/java/com/marketinghub/mds/search/CrossrefSearchClient.java
+- mds/src/main/java/com/marketinghub/mds/search/ActiveComponentExtractor.java
+- mds/src/main/java/com/marketinghub/mds/search/MechanismCandidateBuilder.java
 - mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+- mds/src/test/java/com/marketinghub/mds/search/ActiveComponentExtractorTest.java
+- mds/src/test/java/com/marketinghub/mds/search/MechanismCandidateBuilderTest.java
 - backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsSourceAccessService.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsSourceAccessPublishBatchRequest.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsSourceAccessPublishBatchResponse.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRecommendedMechanismResponse.java
 - backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
 - docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
 - docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md

--- a/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+++ b/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
@@ -704,3 +704,73 @@ O MDS agora reduz duplicatas de fontes, aplica triagem mínima, classifica confi
 **Próximo passo sugerido:**
 
 Implementar a Sprint 5 com extração de componentes ativos, montagem de `mechanismCandidate` e seleção do mecanismo recomendado.
+
+## [2026-04-17] — Etapa: mechanismCandidate e mechanismSpec com recomendação final
+
+**Status:** `CONCLUIDO`
+
+**Resumo:**
+
+Foi implementada a etapa de construção de `mechanismCandidate` e seleção do mecanismo recomendado com publicação de `mechanismSpec`, incluindo leitura do mecanismo final por request no backend.
+
+**Objetivo da etapa:**
+
+Concluir o núcleo da Sprint 5 para transformar evidências priorizadas em mecanismo candidato rastreável, selecionar recomendação com justificativa explícita e persistir `mechanismSpec` com lineage.
+
+**O que foi implementado:**
+
+- criação do `ActiveComponentExtractor` para extração heurística de componentes ativos a partir de título e resumo das evidências;
+- criação do `MechanismCandidateBuilder` para agrupamento de componentes recorrentes, separação essencial/opcional, agregação de limitações e cálculo de confiança consolidada;
+- atualização do pipeline (`MechanismDiscoveryPipelineService`) para publicar `mechanismCandidate` e `mechanismSpec` após publicação de `evidenceItem`, com lineage até artefatos de evidência;
+- criação do endpoint backend `GET /api/internal/mds/requests/{id}/recommended-mechanism` para leitura do mecanismo recomendado por request com base no último `mechanismSpec`;
+- ampliação de testes de unidade e contrato para cobrir a nova etapa de construção e leitura do mecanismo final.
+
+**Arquivos alterados/criados:**
+
+- mds/src/main/java/com/marketinghub/mds/search/ActiveComponentExtractor.java
+- mds/src/main/java/com/marketinghub/mds/search/MechanismCandidateBuilder.java
+- mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+- mds/src/test/java/com/marketinghub/mds/search/ActiveComponentExtractorTest.java
+- mds/src/test/java/com/marketinghub/mds/search/MechanismCandidateBuilderTest.java
+- mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsRecommendedMechanismResponse.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
+- backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
+- docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+- docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+
+**Tabelas / persistência afetadas:**
+
+- artifact_record
+- artifact_lineage_edge
+
+**APIs / endpoints / contratos afetados:**
+
+- `POST /api/internal/mds/artifacts/publish-batch` (uso ampliado para `mechanismCandidate` e `mechanismSpec`)
+- `GET /api/internal/mds/requests/{id}/recommended-mechanism` (novo endpoint)
+
+**Artefatos / schemas impactados:**
+
+- mds.mechanismCandidate.v1
+- mds.mechanismSpec.v1
+
+**Testes executados:**
+
+- `cd mds && mvn test -Dtest=MechanismDiscoveryPipelineServiceTest,ActiveComponentExtractorTest,MechanismCandidateBuilderTest`
+- `cd backend/ads-service && mvn test -Dtest=MdsInternalControllerContractTest`
+
+**Resultado observado:**
+
+Requests com evidência priorizada agora geram `mechanismCandidate`, escolhem um mecanismo recomendado com justificativa explícita e publicam `mechanismSpec` com lineage para suporte rastreável no backend.
+
+**Limitações / pendências:**
+
+- `practicalKnowledgePack` não foi implementado nesta etapa;
+- relatório final (`mechanismDiscoveryReport`) permanece pendente;
+- extração de componentes ainda é heurística lexical (sem clusterização semântica avançada).
+
+**Próximo passo sugerido:**
+
+Implementar a Sprint 6 para publicação de `practicalKnowledgePack`, relatório final e fechamento completo do pacote de saída do MDS.

--- a/mds/src/main/java/com/marketinghub/mds/search/ActiveComponentExtractor.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/ActiveComponentExtractor.java
@@ -1,0 +1,63 @@
+package com.marketinghub.mds.search;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+@Service
+public class ActiveComponentExtractor {
+    private static final List<String> COMPONENT_HINTS = List.of(
+            "calorie deficit",
+            "protein intake",
+            "resistance training",
+            "strength training",
+            "aerobic exercise",
+            "sleep quality",
+            "stress management",
+            "fiber intake",
+            "hydration",
+            "behavioral adherence",
+            "meal timing"
+    );
+
+    private static final Set<String> STOPWORDS = Set.of(
+            "with", "from", "that", "this", "were", "have", "into", "between", "through",
+            "loss", "weight", "result", "results", "problem", "desired", "outcome", "market",
+            "study", "studies", "effect", "effects", "group", "groups", "patient", "patients"
+    );
+
+    public List<String> extract(ScreenedEvidence evidence) {
+        String content = ((safe(evidence.title()) + " " + safe(evidence.abstractText()))).toLowerCase(Locale.ROOT);
+        Set<String> components = new LinkedHashSet<>();
+
+        for (String hint : COMPONENT_HINTS) {
+            if (content.contains(hint)) {
+                components.add(hint);
+            }
+        }
+
+        if (!components.isEmpty()) {
+            return new ArrayList<>(components);
+        }
+
+        for (String token : content.replaceAll("[^a-z0-9 ]", " ").split("\\s+")) {
+            if (token.length() < 6 || STOPWORDS.contains(token)) {
+                continue;
+            }
+            components.add(token);
+            if (components.size() >= 3) {
+                break;
+            }
+        }
+
+        return new ArrayList<>(components);
+    }
+
+    private String safe(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/search/MechanismCandidateBuilder.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/MechanismCandidateBuilder.java
@@ -1,0 +1,197 @@
+package com.marketinghub.mds.search;
+
+import com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class MechanismCandidateBuilder {
+    private final ActiveComponentExtractor activeComponentExtractor;
+
+    public MechanismCandidateBuilder(ActiveComponentExtractor activeComponentExtractor) {
+        this.activeComponentExtractor = activeComponentExtractor;
+    }
+
+    public MechanismBuildResult build(Long requestId,
+                                      List<ScreenedEvidence> prioritizedEvidence,
+                                      Map<String, String> confidenceBySourceDocumentId,
+                                      Map<String, Long> evidenceArtifactIdsBySourceDocumentId) {
+        if (prioritizedEvidence == null || prioritizedEvidence.isEmpty()) {
+            return new MechanismBuildResult(List.of(), null, List.of());
+        }
+
+        Map<String, Integer> componentFrequency = new LinkedHashMap<>();
+        Set<String> limitations = new LinkedHashSet<>();
+        double avgPriority = prioritizedEvidence.stream().mapToDouble(ScreenedEvidence::priorityScore).average().orElse(0.0);
+        List<Long> supportingEvidenceIds = new ArrayList<>();
+        List<String> evidenceConfidence = new ArrayList<>();
+
+        for (ScreenedEvidence evidence : prioritizedEvidence) {
+            List<String> components = activeComponentExtractor.extract(evidence);
+            for (String component : components) {
+                componentFrequency.merge(component, 1, Integer::sum);
+            }
+            limitations.addAll(evidence.limitations());
+            evidenceConfidence.add(confidenceBySourceDocumentId.getOrDefault(evidence.sourceDocumentId(), "muito_baixa"));
+            Long evidenceArtifactId = evidenceArtifactIdsBySourceDocumentId.get(evidence.sourceDocumentId());
+            if (evidenceArtifactId != null) {
+                supportingEvidenceIds.add(evidenceArtifactId);
+            }
+        }
+
+        if (componentFrequency.isEmpty()) {
+            return new MechanismBuildResult(List.of(), null, supportingEvidenceIds);
+        }
+
+        int threshold = Math.max(2, (int) Math.ceil(prioritizedEvidence.size() * 0.4));
+        List<String> initialEssentialComponents = componentFrequency.entrySet().stream()
+                .filter(entry -> entry.getValue() >= threshold)
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .map(Map.Entry::getKey)
+                .toList();
+
+        List<String> optionalComponents = componentFrequency.entrySet().stream()
+                .filter(entry -> !initialEssentialComponents.contains(entry.getKey()))
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .map(Map.Entry::getKey)
+                .limit(4)
+                .toList();
+
+        List<String> essentialComponents = initialEssentialComponents;
+        if (initialEssentialComponents.isEmpty()) {
+            essentialComponents = componentFrequency.entrySet().stream()
+                    .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                    .map(Map.Entry::getKey)
+                    .limit(2)
+                    .toList();
+        }
+
+        String confidenceLevel = aggregateConfidence(avgPriority, evidenceConfidence);
+        String justification = buildJustification(essentialComponents, optionalComponents, prioritizedEvidence.size(), confidenceLevel);
+
+        Map<String, Object> candidateContent = new LinkedHashMap<>();
+        String candidateKey = "mc-1";
+        candidateContent.put("requestId", requestId);
+        candidateContent.put("candidateKey", candidateKey);
+        candidateContent.put("candidateLabel", "Mecanismo recorrente principal");
+        candidateContent.put("essentialComponents", essentialComponents);
+        candidateContent.put("optionalComponents", optionalComponents);
+        candidateContent.put("riskOrLimitations", new ArrayList<>(limitations));
+        candidateContent.put("supportingEvidenceCount", prioritizedEvidence.size());
+        candidateContent.put("confidenceLevel", confidenceLevel);
+        candidateContent.put("selectionJustification", justification);
+        candidateContent.put("recommended", true);
+
+        ArtifactPayloadDto candidateArtifact = new ArtifactPayloadDto(
+                "mechanismCandidate",
+                "v1",
+                "v1",
+                "DRAFT",
+                "mds",
+                "mds",
+                candidateContent,
+                null,
+                supportingEvidenceIds
+        );
+
+        MechanismSpecDraft mechanismSpecDraft = new MechanismSpecDraft(
+                requestId,
+                candidateKey,
+                essentialComponents,
+                optionalComponents,
+                new ArrayList<>(limitations),
+                confidenceLevel,
+                justification
+        );
+
+        return new MechanismBuildResult(List.of(candidateArtifact), mechanismSpecDraft, supportingEvidenceIds);
+    }
+
+    public ArtifactPayloadDto buildMechanismSpec(MechanismSpecDraft draft,
+                                                 Long selectedCandidateArtifactId,
+                                                 List<Long> supportingEvidenceIds) {
+        if (draft == null || selectedCandidateArtifactId == null) {
+            return null;
+        }
+
+        List<Long> parentArtifactIds = new ArrayList<>();
+        parentArtifactIds.add(selectedCandidateArtifactId);
+        parentArtifactIds.addAll(supportingEvidenceIds.stream().filter(id -> !id.equals(selectedCandidateArtifactId)).toList());
+
+        Map<String, Object> content = new LinkedHashMap<>();
+        content.put("requestId", draft.requestId());
+        content.put("recommendedMechanismCandidateKey", draft.recommendedCandidateKey());
+        content.put("essentialComponents", draft.essentialComponents());
+        content.put("optionalComponents", draft.optionalComponents());
+        content.put("riskOrLimitations", draft.riskOrLimitations());
+        content.put("confidenceLevel", draft.confidenceLevel());
+        content.put("selectionJustification", draft.selectionJustification());
+
+        return new ArtifactPayloadDto(
+                "mechanismSpec",
+                "v1",
+                "v1",
+                "DRAFT",
+                "mds",
+                "mds",
+                content,
+                null,
+                parentArtifactIds
+        );
+    }
+
+    private String buildJustification(List<String> essential,
+                                      List<String> optional,
+                                      int evidenceCount,
+                                      String confidenceLevel) {
+        return "Seleção baseada em recorrência de componentes (essenciais: "
+                + String.join(", ", essential)
+                + "), suporte em "
+                + evidenceCount
+                + " evidências e confiança "
+                + confidenceLevel
+                + ". Componentes opcionais considerados: "
+                + String.join(", ", optional)
+                + ".";
+    }
+
+    private String aggregateConfidence(double avgPriority, List<String> evidenceConfidence) {
+        int high = (int) evidenceConfidence.stream().filter(c -> c.equals("alta")).count();
+        int medium = (int) evidenceConfidence.stream().filter(c -> c.equals("moderada")).count();
+
+        if (avgPriority >= 0.65 && high >= 1) {
+            return "alta";
+        }
+        if (avgPriority >= 0.45 && (high + medium) >= 1) {
+            return "moderada";
+        }
+        if (avgPriority >= 0.25) {
+            return "baixa";
+        }
+        return "muito_baixa";
+    }
+
+    public record MechanismBuildResult(
+            List<ArtifactPayloadDto> candidateArtifacts,
+            MechanismSpecDraft mechanismSpecDraft,
+            List<Long> supportingEvidenceArtifactIds
+    ) {
+    }
+
+    public record MechanismSpecDraft(
+            Long requestId,
+            String recommendedCandidateKey,
+            List<String> essentialComponents,
+            List<String> optionalComponents,
+            List<String> riskOrLimitations,
+            String confidenceLevel,
+            String selectionJustification
+    ) {
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+++ b/mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
@@ -10,6 +10,7 @@ import com.marketinghub.mds.search.EvidenceItemBuilder;
 import com.marketinghub.mds.search.EvidenceScreeningService;
 import com.marketinghub.mds.search.MechanismQuestion;
 import com.marketinghub.mds.search.MechanismQuestionBuilder;
+import com.marketinghub.mds.search.MechanismCandidateBuilder;
 import com.marketinghub.mds.search.ScreenedEvidence;
 import com.marketinghub.mds.search.SearchExecutionService;
 import com.marketinghub.mds.search.SearchQueryPlan;
@@ -33,6 +34,7 @@ public class MechanismDiscoveryPipelineService {
     private final EvidenceScreeningService evidenceScreeningService;
     private final EvidenceConfidenceService evidenceConfidenceService;
     private final EvidenceItemBuilder evidenceItemBuilder;
+    private final MechanismCandidateBuilder mechanismCandidateBuilder;
 
     public MechanismDiscoveryPipelineService(BackendMdsClient backendMdsClient,
                                              MechanismQuestionBuilder mechanismQuestionBuilder,
@@ -41,7 +43,8 @@ public class MechanismDiscoveryPipelineService {
                                              SourceDedupService sourceDedupService,
                                              EvidenceScreeningService evidenceScreeningService,
                                              EvidenceConfidenceService evidenceConfidenceService,
-                                             EvidenceItemBuilder evidenceItemBuilder) {
+                                             EvidenceItemBuilder evidenceItemBuilder,
+                                             MechanismCandidateBuilder mechanismCandidateBuilder) {
         this.backendMdsClient = backendMdsClient;
         this.mechanismQuestionBuilder = mechanismQuestionBuilder;
         this.searchQueryPlanBuilder = searchQueryPlanBuilder;
@@ -50,6 +53,7 @@ public class MechanismDiscoveryPipelineService {
         this.evidenceScreeningService = evidenceScreeningService;
         this.evidenceConfidenceService = evidenceConfidenceService;
         this.evidenceItemBuilder = evidenceItemBuilder;
+        this.mechanismCandidateBuilder = mechanismCandidateBuilder;
     }
 
     public void execute(BackendMdsRequestDto request) {
@@ -148,21 +152,59 @@ public class MechanismDiscoveryPipelineService {
         }
 
         List<ArtifactPayloadDto> evidenceItems = new ArrayList<>();
+        Map<String, String> confidenceBySourceDocumentId = new LinkedHashMap<>();
         for (ScreenedEvidence screenedEvidence : prioritized) {
             String confidenceLevel = evidenceConfidenceService.classify(screenedEvidence);
+            confidenceBySourceDocumentId.put(screenedEvidence.sourceDocumentId(), confidenceLevel);
             Long parentArtifactId = sourceArtifactIdsBySourceDocumentId.get(screenedEvidence.sourceDocumentId());
             evidenceItems.add(evidenceItemBuilder.build(request.id(), screenedEvidence, confidenceLevel,
                     parentArtifactId == null ? List.of() : List.of(parentArtifactId)));
         }
 
+        Map<String, Long> evidenceArtifactIdsBySourceDocumentId = new LinkedHashMap<>();
         if (!evidenceItems.isEmpty()) {
-            backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), evidenceItems));
+            var evidencePublishResponse =
+                    backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), evidenceItems));
+            List<Long> evidenceArtifactIds = evidencePublishResponse.artifactIds();
+            for (int i = 0; i < prioritized.size() && i < evidenceArtifactIds.size(); i++) {
+                evidenceArtifactIdsBySourceDocumentId.put(prioritized.get(i).sourceDocumentId(), evidenceArtifactIds.get(i));
+            }
         }
 
         backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
                 "evidence-analysis",
                 "evidence items published",
                 Map.of("evidenceItemCount", evidenceItems.size())
+        ));
+
+        var mechanismBuild = mechanismCandidateBuilder.build(
+                request.id(),
+                prioritized,
+                confidenceBySourceDocumentId,
+                evidenceArtifactIdsBySourceDocumentId
+        );
+        if (!mechanismBuild.candidateArtifacts().isEmpty()) {
+            var candidatePublishResponse = backendMdsClient.publishBatch(
+                    new BackendArtifactPublishBatchRequestDto(request.id(), mechanismBuild.candidateArtifacts())
+            );
+            Long selectedCandidateArtifactId = candidatePublishResponse.artifactIds().isEmpty()
+                    ? null
+                    : candidatePublishResponse.artifactIds().get(0);
+
+            ArtifactPayloadDto mechanismSpec = mechanismCandidateBuilder.buildMechanismSpec(
+                    mechanismBuild.mechanismSpecDraft(),
+                    selectedCandidateArtifactId,
+                    mechanismBuild.supportingEvidenceArtifactIds()
+            );
+            if (mechanismSpec != null) {
+                backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), List.of(mechanismSpec)));
+            }
+        }
+
+        backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
+                "mechanism-building",
+                "mechanism candidates and mechanism spec published",
+                Map.of("mechanismCandidateCount", mechanismBuild.candidateArtifacts().size())
         ));
     }
 

--- a/mds/src/test/java/com/marketinghub/mds/search/ActiveComponentExtractorTest.java
+++ b/mds/src/test/java/com/marketinghub/mds/search/ActiveComponentExtractorTest.java
@@ -1,0 +1,37 @@
+package com.marketinghub.mds.search;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActiveComponentExtractorTest {
+
+    private final ActiveComponentExtractor extractor = new ActiveComponentExtractor();
+
+    @Test
+    void shouldExtractKnownComponentsWhenHintsArePresent() {
+        ScreenedEvidence evidence = new ScreenedEvidence(
+                "pubmed",
+                "doc-1",
+                "Calorie deficit and resistance training improves outcomes",
+                "Protocol combines protein intake with sleep quality support.",
+                "",
+                "",
+                "2024",
+                List.of(),
+                "alta",
+                "alta",
+                List.of("randomized"),
+                0.7,
+                0.6,
+                0.72
+        );
+
+        List<String> components = extractor.extract(evidence);
+
+        assertThat(components)
+                .contains("calorie deficit", "resistance training", "protein intake", "sleep quality");
+    }
+}

--- a/mds/src/test/java/com/marketinghub/mds/search/MechanismCandidateBuilderTest.java
+++ b/mds/src/test/java/com/marketinghub/mds/search/MechanismCandidateBuilderTest.java
@@ -1,0 +1,66 @@
+package com.marketinghub.mds.search;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MechanismCandidateBuilderTest {
+
+    private final MechanismCandidateBuilder builder = new MechanismCandidateBuilder(new ActiveComponentExtractor());
+
+    @Test
+    void shouldBuildCandidateAndMechanismSpec() {
+        ScreenedEvidence first = new ScreenedEvidence(
+                "pubmed",
+                "doc-1",
+                "Calorie deficit and resistance training",
+                "Includes protein intake strategy.",
+                "",
+                "",
+                "2024",
+                List.of("small sample"),
+                "alta",
+                "alta",
+                List.of("randomized"),
+                0.8,
+                0.6,
+                0.74
+        );
+        ScreenedEvidence second = new ScreenedEvidence(
+                "crossref",
+                "doc-2",
+                "Calorie deficit with sleep quality protocol",
+                "Additional behavioral adherence recommendation.",
+                "",
+                "",
+                "2023",
+                List.of("pilot"),
+                "moderada",
+                "moderada",
+                List.of("cohort"),
+                0.6,
+                0.4,
+                0.58
+        );
+
+        var result = builder.build(
+                55L,
+                List.of(first, second),
+                Map.of("doc-1", "alta", "doc-2", "moderada"),
+                Map.of("doc-1", 101L, "doc-2", 102L)
+        );
+
+        assertThat(result.candidateArtifacts()).hasSize(1);
+        assertThat(result.mechanismSpecDraft()).isNotNull();
+        assertThat(result.supportingEvidenceArtifactIds()).containsExactlyInAnyOrder(101L, 102L);
+
+        var spec = builder.buildMechanismSpec(result.mechanismSpecDraft(), 201L, result.supportingEvidenceArtifactIds());
+
+        assertThat(spec).isNotNull();
+        assertThat(spec.artifactType()).isEqualTo("mechanismSpec");
+        assertThat(spec.parentArtifactIds()).contains(201L, 101L, 102L);
+    }
+}

--- a/mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+++ b/mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
@@ -35,6 +35,8 @@ class MechanismDiscoveryPipelineServiceTest {
     private EvidenceConfidenceService evidenceConfidenceService;
     @Mock
     private EvidenceItemBuilder evidenceItemBuilder;
+    @Mock
+    private MechanismCandidateBuilder mechanismCandidateBuilder;
 
     @InjectMocks
     private MechanismDiscoveryPipelineService service;
@@ -92,28 +94,56 @@ class MechanismDiscoveryPipelineServiceTest {
                 .thenReturn(new com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto(
                         "evidenceItem", "v1", "v1", "DRAFT", "mds", "mds", java.util.Map.of("id", "ev-1"), null, List.of(101L)
                 ));
+        var mechanismCandidate = new com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto(
+                "mechanismCandidate", "v1", "v1", "DRAFT", "mds", "mds", java.util.Map.of("id", "mc-1"), null, List.of(102L)
+        );
+        var mechanismSpec = new com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto(
+                "mechanismSpec", "v1", "v1", "DRAFT", "mds", "mds", java.util.Map.of("id", "ms-1"), null, List.of(103L, 102L)
+        );
+        when(mechanismCandidateBuilder.build(eq(10L), eq(List.of(screenedEvidence)), any(), eq(java.util.Map.of("pubmed:1", 102L))))
+                .thenReturn(new MechanismCandidateBuilder.MechanismBuildResult(
+                        List.of(mechanismCandidate),
+                        new MechanismCandidateBuilder.MechanismSpecDraft(
+                                10L,
+                                "mc-1",
+                                List.of("calorie deficit"),
+                                List.of("protein intake"),
+                                List.of("pilot"),
+                                "moderada",
+                                "justification"
+                        ),
+                        List.of(102L)
+                ));
+        when(mechanismCandidateBuilder.buildMechanismSpec(any(), eq(103L), eq(List.of(102L))))
+                .thenReturn(mechanismSpec);
 
         when(backendMdsClient.publishBatch(any()))
                 .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 2, List.of(100L, 101L)))
-                .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(102L)));
+                .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(102L)))
+                .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(103L)))
+                .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(104L)));
 
         service.execute(request);
 
         ArgumentCaptor<com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto> batchCaptor =
                 ArgumentCaptor.forClass(com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.class);
-        verify(backendMdsClient, times(2)).publishBatch(batchCaptor.capture());
+        verify(backendMdsClient, times(4)).publishBatch(batchCaptor.capture());
 
         List<com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto> batches = batchCaptor.getAllValues();
         assertThat(batches.get(0).artifacts()).extracting(a -> a.artifactType())
                 .containsExactly("mechanismEvidenceSearch", "sourceDocument");
         assertThat(batches.get(1).artifacts()).extracting(a -> a.artifactType())
                 .containsExactly("evidenceItem");
+        assertThat(batches.get(2).artifacts()).extracting(a -> a.artifactType())
+                .containsExactly("mechanismCandidate");
+        assertThat(batches.get(3).artifacts()).extracting(a -> a.artifactType())
+                .containsExactly("mechanismSpec");
 
         ArgumentCaptor<com.marketinghub.mds.dto.BackendSourceAccessPublishBatchRequestDto> sourceAccessCaptor =
                 ArgumentCaptor.forClass(com.marketinghub.mds.dto.BackendSourceAccessPublishBatchRequestDto.class);
         verify(backendMdsClient).publishSourceAccessBatch(sourceAccessCaptor.capture());
         assertThat(sourceAccessCaptor.getValue().records()).hasSize(1);
 
-        verify(backendMdsClient, times(3)).heartbeat(eq(10L), any());
+        verify(backendMdsClient, times(4)).heartbeat(eq(10L), any());
     }
 }


### PR DESCRIPTION
### Motivation
- Implement the strict Sprint 5 scope for the Mechanism Discovery Service (MDS): extract active components from prioritized evidence, produce mechanism candidates, select a recommended mechanism with justification and confidence, and persist/publish the resulting artefacts with lineage.
- Expose a backend read API so other modules can retrieve the recommended mechanism per request without the MDS accessing the database directly.

### Description
- Added active-component extraction and candidate/spec construction in the MDS module via `ActiveComponentExtractor` and `MechanismCandidateBuilder`, including grouping of recurring components, separation of essential/optional components, risk/limitation aggregation and confidence aggregation.
- Extended the pipeline in `MechanismDiscoveryPipelineService` to publish `mechanismCandidate` artifacts, select and publish a `mechanismSpec` (with lineage to supporting `evidenceItem` artifacts), and emit heartbeats for the new stages.
- Backend changes to persist/read the recommended mechanism: added repository query `findFirstByRequestIdAndArtifactTypeOrderByCreatedAtDescIdDesc`, response DTO `MdsRecommendedMechanismResponse`, service method `getRecommendedMechanismByRequest`, and controller endpoint `GET /api/internal/mds/requests/{id}/recommended-mechanism`.
- Tests and documentation: added unit tests for extractor and builder, updated pipeline unit test to verify candidate/spec publication and lineage, updated controller contract test for the new read endpoint, and updated Sprint 5 registration and the MDS deployment history (`plano_implementacao_mds_baseado_na_especificacao.md` and `protocolo_historico_implantacao_mds.md`).

### Testing
- Executed MDS unit tests: `cd mds && mvn test -Dtest=MechanismDiscoveryPipelineServiceTest,ActiveComponentExtractorTest,MechanismCandidateBuilderTest` and they completed successfully (all tests passed).
- Executed backend controller contract test: `cd backend/ads-service && mvn test -Dtest=MdsInternalControllerContractTest` and it completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e24514ffb48321b545028d64558744)