### PR TITLE
MDS Sprint 6: publish practicalKnowledgePack, discovery report and backend query endpoints

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsArtifactSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsArtifactSummaryResponse.java
@@ -1,0 +1,10 @@
+package com.marketinghub.mds.dto;
+
+public record MdsArtifactSummaryResponse(
+        Long artifactId,
+        String artifactType,
+        String schemaVersion,
+        String version,
+        String status
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsReportResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsReportResponse.java
@@ -1,0 +1,14 @@
+package com.marketinghub.mds.dto;
+
+import java.util.Map;
+
+public record MdsReportResponse(
+        Long requestId,
+        Long artifactId,
+        String artifactType,
+        String schemaVersion,
+        String version,
+        String status,
+        Map<String, Object> content
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
@@ -8,4 +8,6 @@ public interface MdsArtifactRecordRepository extends JpaRepository<MdsArtifactRe
             Long requestId,
             String artifactType
     );
+
+    java.util.List<MdsArtifactRecord> findByRequestIdOrderByCreatedAtAscIdAsc(Long requestId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
@@ -8,9 +8,11 @@ import com.marketinghub.mds.MdsArtifactStatus;
 import com.marketinghub.mds.MdsRequest;
 import com.marketinghub.mds.dto.MdsArtifactPublishBatchRequest;
 import com.marketinghub.mds.dto.MdsArtifactPublishBatchResponse;
+import com.marketinghub.mds.dto.MdsArtifactSummaryResponse;
 import com.marketinghub.mds.dto.MdsLineageCreateRequest;
 import com.marketinghub.mds.dto.MdsLineageResponse;
 import com.marketinghub.mds.dto.MdsRecommendedMechanismResponse;
+import com.marketinghub.mds.dto.MdsReportResponse;
 import com.marketinghub.mds.repository.MdsArtifactLineageEdgeRepository;
 import com.marketinghub.mds.repository.MdsArtifactRecordRepository;
 import com.marketinghub.mds.repository.MdsRequestRepository;
@@ -96,6 +98,39 @@ public class MdsArtifactService {
                 record.getStatus().name(),
                 readContent(record.getContentJson())
         );
+    }
+
+    @Transactional(readOnly = true)
+    public MdsReportResponse getReportByRequest(Long requestId) {
+        MdsArtifactRecord record = artifactRecordRepository
+                .findFirstByRequestIdAndArtifactTypeOrderByCreatedAtDescIdDesc(requestId, "mechanismDiscoveryReport")
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "mechanism discovery report not found"));
+
+        return new MdsReportResponse(
+                requestId,
+                record.getId(),
+                record.getArtifactType(),
+                record.getSchemaVersion(),
+                record.getVersion(),
+                record.getStatus().name(),
+                readContent(record.getContentJson())
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<MdsArtifactSummaryResponse> listArtifactsByRequest(Long requestId) {
+        if (!requestRepository.existsById(requestId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "mds request not found");
+        }
+        return artifactRecordRepository.findByRequestIdOrderByCreatedAtAscIdAsc(requestId).stream()
+                .map(record -> new MdsArtifactSummaryResponse(
+                        record.getId(),
+                        record.getArtifactType(),
+                        record.getSchemaVersion(),
+                        record.getVersion(),
+                        record.getStatus().name()
+                ))
+                .toList();
     }
 
     private MdsLineageResponse createLineage(Long parentArtifactId, Long childArtifactId, String relationType) {

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
@@ -93,6 +93,16 @@ public class MdsInternalController {
         return artifactService.getRecommendedMechanismByRequest(id);
     }
 
+    @GetMapping("/reports/{id}")
+    public MdsReportResponse getReport(@PathVariable Long id) {
+        return artifactService.getReportByRequest(id);
+    }
+
+    @GetMapping("/requests/{id}/artifacts")
+    public List<MdsArtifactSummaryResponse> listArtifactsByRequest(@PathVariable Long id) {
+        return artifactService.listArtifactsByRequest(id);
+    }
+
     @GetMapping("/health")
     public Map<String, String> health() {
         return Map.of("status", "ok", "module", "mds-backend-orchestration");

--- a/backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
@@ -170,6 +170,41 @@ class MdsInternalControllerContractTest {
                 .andExpect(jsonPath("$.content.recommendedMechanismCandidateKey").value("mc-1"));
     }
 
+    @Test
+    void shouldGetDiscoveryReportByRequest() throws Exception {
+        when(artifactService.getReportByRequest(12L))
+                .thenReturn(new com.marketinghub.mds.dto.MdsReportResponse(
+                        12L,
+                        501L,
+                        "mechanismDiscoveryReport",
+                        "v1",
+                        "v1",
+                        "DRAFT",
+                        java.util.Map.of("status", "SUCCESS")
+                ));
+
+        mockMvc.perform(get("/api/internal/mds/reports/12"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value(12))
+                .andExpect(jsonPath("$.artifactId").value(501))
+                .andExpect(jsonPath("$.artifactType").value("mechanismDiscoveryReport"))
+                .andExpect(jsonPath("$.content.status").value("SUCCESS"));
+    }
+
+    @Test
+    void shouldListArtifactsByRequest() throws Exception {
+        when(artifactService.listArtifactsByRequest(12L))
+                .thenReturn(java.util.List.of(
+                        new com.marketinghub.mds.dto.MdsArtifactSummaryResponse(401L, "mechanismSpec", "v1", "v1", "DRAFT"),
+                        new com.marketinghub.mds.dto.MdsArtifactSummaryResponse(402L, "practicalKnowledgePack", "v1", "v1", "DRAFT")
+                ));
+
+        mockMvc.perform(get("/api/internal/mds/requests/12/artifacts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].artifactId").value(401))
+                .andExpect(jsonPath("$[1].artifactType").value("practicalKnowledgePack"));
+    }
+
     private MdsRequestStatusResponse response(MdsRequestStatus status) {
         return new MdsRequestStatusResponse(
                 7L,

--- a/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+++ b/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
@@ -717,39 +717,32 @@ Fechar a V1 com artefatos realmente reutilizáveis pelo restante do Marketing Hu
 **Status:** `CONCLUIDO`
 
 **O que foi concluído:**
-- Implementada formulação de pergunta de mecanismo (`MechanismQuestionBuilder`) e planejamento de queries por fonte (`SearchQueryPlanBuilder`) no módulo `mds/`.
-- Implementados clientes reais de busca estruturada para PubMed/NCBI E-utilities e Crossref, com execução via `SearchExecutionService`.
-- Pipeline do MDS passou a publicar `mechanismEvidenceSearch` e `sourceDocument` com query rastreável, metadados normalizados e classificação inicial de acesso/permissão.
-- Backend recebeu suporte explícito para persistência de `source_access_record` por lote via endpoint interno dedicado (`/api/internal/mds/source-access/publish-batch`).
-- Contratos de teste foram atualizados no backend e no módulo `mds/` para cobrir o fluxo novo de Sprint 3.
+- Implementado `PracticalKnowledgePackBuilder` no módulo `mds/`, com montagem das quatro saídas exigidas nesta sprint: técnica, executiva, prática para design de produto e simplificada para consumidor final.
+- Implementado `DiscoveryReportBuilder` no módulo `mds/` para montar e publicar `mechanismDiscoveryReport` com métricas operacionais e referências dos artefatos finais da request.
+- Pipeline principal (`MechanismDiscoveryPipelineService`) atualizado para publicar, em sequência, `mechanismSpec`, `practicalKnowledgePack` e `mechanismDiscoveryReport`, além de heartbeats das etapas finais de `pack-building` e `reporting`.
+- Backend atualizado com os endpoints de consulta previstos para Sprint 6: `GET /api/internal/mds/reports/{id}` e `GET /api/internal/mds/requests/{id}/artifacts`.
+- Testes de contrato do backend e testes unitários do pipeline do `mds/` atualizados para validar publicação completa de Sprint 6.
 
 **O que ficou pendente para a próxima sprint:**
-- Deduplicação avançada de `sourceDocument` por DOI/PMID/PMCID/título/URL canônica.
-- Triagem científica estruturada com critérios de elegibilidade e priorização.
-- Construção e persistência de `evidenceItem` com classificação de confiança.
+- Observabilidade avançada por estágio (métricas detalhadas e painéis operacionais).
+- Estratégia de retries/retomada para falhas transitórias em integrações externas.
+- Hardening operacional e cobertura adicional de testes de integração ponta a ponta.
 
 **Riscos / observações:**
-- Os clientes externos de busca dependem de disponibilidade e limites das APIs públicas (NCBI e Crossref), podendo reduzir volume em execuções reais sem fallback adicional.
-- A classificação `accessClass` / `permissionState` nesta sprint é inicial e heurística, devendo ser refinada na Sprint 4 junto com triagem.
+- O `practicalKnowledgePack` inicial usa regras determinísticas para compor as quatro versões de saída; refinamento semântico mais profundo fica para hardening posterior.
+- O endpoint de relatório retorna a versão mais recente de `mechanismDiscoveryReport` por request; políticas adicionais de auditoria histórica podem ser evoluídas na Sprint 7.
+- A etapa de publicação final depende da geração prévia de `mechanismSpec`; requests sem mecanismo recomendado continuam sem relatório final.
 
 **Arquivos alterados/criados:**
+- mds/src/main/java/com/marketinghub/mds/search/PracticalKnowledgePackBuilder.java
+- mds/src/main/java/com/marketinghub/mds/search/DiscoveryReportBuilder.java
 - mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
-- mds/src/main/java/com/marketinghub/mds/client/BackendMdsClient.java
-- mds/src/main/java/com/marketinghub/mds/dto/BackendSourceAccessPublishBatchRequestDto.java
-- mds/src/main/java/com/marketinghub/mds/dto/BackendSourceAccessPublishBatchResponseDto.java
-- mds/src/main/java/com/marketinghub/mds/search/MechanismQuestion.java
-- mds/src/main/java/com/marketinghub/mds/search/MechanismQuestionBuilder.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchQueryPlan.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchQueryPlanBuilder.java
-- mds/src/main/java/com/marketinghub/mds/search/SearchExecutionService.java
-- mds/src/main/java/com/marketinghub/mds/search/EvidenceSearchClient.java
-- mds/src/main/java/com/marketinghub/mds/search/PubmedSearchClient.java
-- mds/src/main/java/com/marketinghub/mds/search/CrossrefSearchClient.java
 - mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
 - backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsSourceAccessService.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsSourceAccessPublishBatchRequest.java
-- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsSourceAccessPublishBatchResponse.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsReportResponse.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsArtifactSummaryResponse.java
 - backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
 - docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
 - docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md

--- a/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+++ b/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
@@ -774,3 +774,74 @@ Requests com evidência priorizada agora geram `mechanismCandidate`, escolhem um
 **Próximo passo sugerido:**
 
 Implementar a Sprint 6 para publicação de `practicalKnowledgePack`, relatório final e fechamento completo do pacote de saída do MDS.
+
+## [2026-04-17] — Etapa: sprint 6 - practicalKnowledgePack, relatório final e publicação completa
+
+**Status:** `CONCLUIDO`
+
+**Resumo:**
+
+A Sprint 6 foi implementada com publicação completa dos artefatos finais (`practicalKnowledgePack` e `mechanismDiscoveryReport`) e com os endpoints de consulta de relatório/listagem de artefatos no backend.
+
+**Objetivo da etapa:**
+
+Fechar o fluxo V1 do MDS com saída reutilizável por outros módulos, relatório final consultável e contratos de leitura alinhados ao plano da sprint.
+
+**O que foi implementado:**
+
+- criação de `PracticalKnowledgePackBuilder` para gerar as quatro variantes exigidas na sprint (técnica, executiva, prática para design de produto e simplificada para consumidor final);
+- criação de `DiscoveryReportBuilder` para consolidar status final, métricas operacionais e referências dos artefatos de saída;
+- atualização do `MechanismDiscoveryPipelineService` para publicar `mechanismSpec`, `practicalKnowledgePack` e `mechanismDiscoveryReport` em sequência, com heartbeat de `pack-building` e `reporting`;
+- criação do endpoint `GET /api/internal/mds/reports/{id}` para recuperar relatório final por request;
+- criação do endpoint `GET /api/internal/mds/requests/{id}/artifacts` para listar artefatos publicados da request;
+- atualização dos testes de contrato e de pipeline para cobrir o fluxo completo da Sprint 6.
+
+**Arquivos alterados/criados:**
+
+- mds/src/main/java/com/marketinghub/mds/search/PracticalKnowledgePackBuilder.java
+- mds/src/main/java/com/marketinghub/mds/search/DiscoveryReportBuilder.java
+- mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+- mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsInternalController.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsArtifactService.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactRecordRepository.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsReportResponse.java
+- backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsArtifactSummaryResponse.java
+- backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsInternalControllerContractTest.java
+- docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+- docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+
+**Tabelas / persistência afetadas:**
+
+- artifact_record (novos tipos persistidos: `practicalKnowledgePack` e `mechanismDiscoveryReport`)
+- artifact_lineage_edge (lineage adicional entre `evidenceItem`, `mechanismSpec`, `practicalKnowledgePack` e `mechanismDiscoveryReport`)
+
+**APIs / endpoints / contratos afetados:**
+
+- `POST /api/internal/mds/artifacts/publish-batch` (uso expandido para artefatos finais da Sprint 6)
+- `GET /api/internal/mds/reports/{id}` (novo endpoint)
+- `GET /api/internal/mds/requests/{id}/artifacts` (novo endpoint)
+
+**Artefatos / schemas impactados:**
+
+- mds.practicalKnowledgePack.v1
+- mds.mechanismDiscoveryReport.v1
+- mds.mechanismSpec.v1
+
+**Testes executados:**
+
+- `cd mds && mvn test -Dtest=MechanismDiscoveryPipelineServiceTest`
+- `cd backend/ads-service && mvn test -Dtest=MdsInternalControllerContractTest`
+
+**Resultado observado:**
+
+Requests com mecanismo recomendado passam a produzir pacote prático e relatório final persistidos no backend, com leitura por endpoint e listagem dos artefatos por request.
+
+**Limitações / pendências:**
+
+- composição textual do `practicalKnowledgePack` permanece heurística e pode evoluir em qualidade semântica na próxima sprint;
+- observabilidade avançada, retries sofisticados e hardening operacional seguem pendentes para Sprint 7.
+
+**Próximo passo sugerido:**
+
+Executar Sprint 7 com foco em observabilidade, hardening operacional e ampliação de testes de integração.

--- a/mds/src/main/java/com/marketinghub/mds/search/DiscoveryReportBuilder.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/DiscoveryReportBuilder.java
@@ -1,0 +1,52 @@
+package com.marketinghub.mds.search;
+
+import com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class DiscoveryReportBuilder {
+
+    public ArtifactPayloadDto build(Long requestId,
+                                    String question,
+                                    int rawCount,
+                                    int dedupedCount,
+                                    int screenedCount,
+                                    int evidenceItemCount,
+                                    int mechanismCandidateCount,
+                                    Long mechanismSpecArtifactId,
+                                    Long practicalKnowledgePackArtifactId,
+                                    List<Long> parentArtifactIds) {
+        Map<String, Object> content = new LinkedHashMap<>();
+        content.put("requestId", requestId);
+        content.put("question", question);
+        content.put("status", "SUCCESS");
+        content.put("summary", "Fluxo completo da descoberta executado com publicação final de artefatos.");
+        content.put("metrics", Map.of(
+                "rawResultCount", rawCount,
+                "dedupedResultCount", dedupedCount,
+                "screenedResultCount", screenedCount,
+                "evidenceItemCount", evidenceItemCount,
+                "mechanismCandidateCount", mechanismCandidateCount
+        ));
+        content.put("output", Map.of(
+                "mechanismSpecArtifactId", mechanismSpecArtifactId,
+                "practicalKnowledgePackArtifactId", practicalKnowledgePackArtifactId
+        ));
+
+        return new ArtifactPayloadDto(
+                "mechanismDiscoveryReport",
+                "v1",
+                "v1",
+                "DRAFT",
+                "mds",
+                "mds",
+                content,
+                null,
+                parentArtifactIds
+        );
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/search/PracticalKnowledgePackBuilder.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/PracticalKnowledgePackBuilder.java
@@ -1,0 +1,73 @@
+package com.marketinghub.mds.search;
+
+import com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class PracticalKnowledgePackBuilder {
+
+    public ArtifactPayloadDto build(Long requestId,
+                                    MechanismCandidateBuilder.MechanismSpecDraft mechanismSpecDraft,
+                                    List<Long> parentArtifactIds) {
+        Map<String, Object> content = new LinkedHashMap<>();
+        content.put("requestId", requestId);
+        content.put("recommendedMechanismCandidateKey", mechanismSpecDraft.recommendedCandidateKey());
+        content.put("confidenceLevel", mechanismSpecDraft.confidenceLevel());
+        content.put("activeComponents", mechanismSpecDraft.essentialComponents());
+        content.put("supportingEvidenceThemes", mechanismSpecDraft.riskOrLimitations());
+        content.put("technicalVersion", buildTechnical(mechanismSpecDraft));
+        content.put("executiveVersion", buildExecutive(mechanismSpecDraft));
+        content.put("productDesignVersion", buildProductDesign(mechanismSpecDraft));
+        content.put("consumerVersion", buildConsumer(mechanismSpecDraft));
+
+        return new ArtifactPayloadDto(
+                "practicalKnowledgePack",
+                "v1",
+                "v1",
+                "DRAFT",
+                "mds",
+                "mds",
+                content,
+                null,
+                parentArtifactIds
+        );
+    }
+
+    private Map<String, Object> buildTechnical(MechanismCandidateBuilder.MechanismSpecDraft mechanismSpecDraft) {
+        return Map.of(
+                "summary", mechanismSpecDraft.selectionJustification(),
+                "behavioralLevers", mechanismSpecDraft.optionalComponents(),
+                "activeComponents", mechanismSpecDraft.essentialComponents()
+        );
+    }
+
+    private Map<String, Object> buildExecutive(MechanismCandidateBuilder.MechanismSpecDraft mechanismSpecDraft) {
+        return Map.of(
+                "thesis", "Mecanismo recomendado com base em evidências priorizadas.",
+                "confidenceLevel", mechanismSpecDraft.confidenceLevel(),
+                "recommendedMechanismCandidateKey", mechanismSpecDraft.recommendedCandidateKey()
+        );
+    }
+
+    private Map<String, Object> buildProductDesign(MechanismCandidateBuilder.MechanismSpecDraft mechanismSpecDraft) {
+        return Map.of(
+                "designGuidelines", List.of(
+                        "Priorizar fricção baixa para adesão inicial.",
+                        "Explícitar gatilhos comportamentais no onboarding.",
+                        "Ancorar mensagens nos componentes ativos identificados."
+                ),
+                "behavioralLevers", mechanismSpecDraft.optionalComponents()
+        );
+    }
+
+    private Map<String, Object> buildConsumer(MechanismCandidateBuilder.MechanismSpecDraft mechanismSpecDraft) {
+        return Map.of(
+                "message", "Este método combina hábitos-chave para aumentar consistência e resultado.",
+                "focusComponents", mechanismSpecDraft.essentialComponents()
+        );
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+++ b/mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
@@ -8,9 +8,11 @@ import com.marketinghub.mds.dto.BackendSourceAccessPublishBatchRequestDto;
 import com.marketinghub.mds.search.EvidenceConfidenceService;
 import com.marketinghub.mds.search.EvidenceItemBuilder;
 import com.marketinghub.mds.search.EvidenceScreeningService;
+import com.marketinghub.mds.search.DiscoveryReportBuilder;
 import com.marketinghub.mds.search.MechanismQuestion;
 import com.marketinghub.mds.search.MechanismQuestionBuilder;
 import com.marketinghub.mds.search.MechanismCandidateBuilder;
+import com.marketinghub.mds.search.PracticalKnowledgePackBuilder;
 import com.marketinghub.mds.search.ScreenedEvidence;
 import com.marketinghub.mds.search.SearchExecutionService;
 import com.marketinghub.mds.search.SearchQueryPlan;
@@ -35,6 +37,8 @@ public class MechanismDiscoveryPipelineService {
     private final EvidenceConfidenceService evidenceConfidenceService;
     private final EvidenceItemBuilder evidenceItemBuilder;
     private final MechanismCandidateBuilder mechanismCandidateBuilder;
+    private final PracticalKnowledgePackBuilder practicalKnowledgePackBuilder;
+    private final DiscoveryReportBuilder discoveryReportBuilder;
 
     public MechanismDiscoveryPipelineService(BackendMdsClient backendMdsClient,
                                              MechanismQuestionBuilder mechanismQuestionBuilder,
@@ -44,7 +48,9 @@ public class MechanismDiscoveryPipelineService {
                                              EvidenceScreeningService evidenceScreeningService,
                                              EvidenceConfidenceService evidenceConfidenceService,
                                              EvidenceItemBuilder evidenceItemBuilder,
-                                             MechanismCandidateBuilder mechanismCandidateBuilder) {
+                                             MechanismCandidateBuilder mechanismCandidateBuilder,
+                                             PracticalKnowledgePackBuilder practicalKnowledgePackBuilder,
+                                             DiscoveryReportBuilder discoveryReportBuilder) {
         this.backendMdsClient = backendMdsClient;
         this.mechanismQuestionBuilder = mechanismQuestionBuilder;
         this.searchQueryPlanBuilder = searchQueryPlanBuilder;
@@ -54,6 +60,8 @@ public class MechanismDiscoveryPipelineService {
         this.evidenceConfidenceService = evidenceConfidenceService;
         this.evidenceItemBuilder = evidenceItemBuilder;
         this.mechanismCandidateBuilder = mechanismCandidateBuilder;
+        this.practicalKnowledgePackBuilder = practicalKnowledgePackBuilder;
+        this.discoveryReportBuilder = discoveryReportBuilder;
     }
 
     public void execute(BackendMdsRequestDto request) {
@@ -183,6 +191,8 @@ public class MechanismDiscoveryPipelineService {
                 confidenceBySourceDocumentId,
                 evidenceArtifactIdsBySourceDocumentId
         );
+        Long mechanismSpecArtifactId = null;
+        Long practicalKnowledgePackArtifactId = null;
         if (!mechanismBuild.candidateArtifacts().isEmpty()) {
             var candidatePublishResponse = backendMdsClient.publishBatch(
                     new BackendArtifactPublishBatchRequestDto(request.id(), mechanismBuild.candidateArtifacts())
@@ -197,15 +207,61 @@ public class MechanismDiscoveryPipelineService {
                     mechanismBuild.supportingEvidenceArtifactIds()
             );
             if (mechanismSpec != null) {
-                backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), List.of(mechanismSpec)));
+                var mechanismSpecResponse = backendMdsClient.publishBatch(
+                        new BackendArtifactPublishBatchRequestDto(request.id(), List.of(mechanismSpec))
+                );
+                if (!mechanismSpecResponse.artifactIds().isEmpty()) {
+                    mechanismSpecArtifactId = mechanismSpecResponse.artifactIds().get(0);
+                }
+
+                List<Long> practicalPackParents = new ArrayList<>(mechanismBuild.supportingEvidenceArtifactIds());
+                if (mechanismSpecArtifactId != null) {
+                    practicalPackParents.add(mechanismSpecArtifactId);
+                }
+                ArtifactPayloadDto practicalKnowledgePack = practicalKnowledgePackBuilder.build(
+                        request.id(),
+                        mechanismBuild.mechanismSpecDraft(),
+                        practicalPackParents
+                );
+                var practicalKnowledgePackResponse = backendMdsClient.publishBatch(
+                        new BackendArtifactPublishBatchRequestDto(request.id(), List.of(practicalKnowledgePack))
+                );
+                if (!practicalKnowledgePackResponse.artifactIds().isEmpty()) {
+                    practicalKnowledgePackArtifactId = practicalKnowledgePackResponse.artifactIds().get(0);
+                }
             }
         }
 
         backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
-                "mechanism-building",
-                "mechanism candidates and mechanism spec published",
+                "pack-building",
+                "mechanism spec and practical knowledge pack published",
                 Map.of("mechanismCandidateCount", mechanismBuild.candidateArtifacts().size())
         ));
+
+        if (mechanismSpecArtifactId != null && practicalKnowledgePackArtifactId != null) {
+            List<Long> reportParents = new ArrayList<>(mechanismBuild.supportingEvidenceArtifactIds());
+            reportParents.add(mechanismSpecArtifactId);
+            reportParents.add(practicalKnowledgePackArtifactId);
+
+            ArtifactPayloadDto discoveryReport = discoveryReportBuilder.build(
+                    request.id(),
+                    question.text(),
+                    rawHits.size(),
+                    dedupedHits.size(),
+                    prioritized.size(),
+                    evidenceItems.size(),
+                    mechanismBuild.candidateArtifacts().size(),
+                    mechanismSpecArtifactId,
+                    practicalKnowledgePackArtifactId,
+                    reportParents
+            );
+            backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), List.of(discoveryReport)));
+            backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
+                    "reporting",
+                    "mechanism discovery report published",
+                    Map.of("reportPublished", true)
+            ));
+        }
     }
 
     private String resolveAccessClass(SourceSearchHit hit) {

--- a/mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+++ b/mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
@@ -37,6 +37,10 @@ class MechanismDiscoveryPipelineServiceTest {
     private EvidenceItemBuilder evidenceItemBuilder;
     @Mock
     private MechanismCandidateBuilder mechanismCandidateBuilder;
+    @Mock
+    private PracticalKnowledgePackBuilder practicalKnowledgePackBuilder;
+    @Mock
+    private DiscoveryReportBuilder discoveryReportBuilder;
 
     @InjectMocks
     private MechanismDiscoveryPipelineService service;
@@ -100,6 +104,12 @@ class MechanismDiscoveryPipelineServiceTest {
         var mechanismSpec = new com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto(
                 "mechanismSpec", "v1", "v1", "DRAFT", "mds", "mds", java.util.Map.of("id", "ms-1"), null, List.of(103L, 102L)
         );
+        var practicalKnowledgePack = new com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto(
+                "practicalKnowledgePack", "v1", "v1", "DRAFT", "mds", "mds", java.util.Map.of("id", "pk-1"), null, List.of(103L, 102L)
+        );
+        var mechanismDiscoveryReport = new com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.ArtifactPayloadDto(
+                "mechanismDiscoveryReport", "v1", "v1", "DRAFT", "mds", "mds", java.util.Map.of("id", "rp-1"), null, List.of(103L, 104L, 102L)
+        );
         when(mechanismCandidateBuilder.build(eq(10L), eq(List.of(screenedEvidence)), any(), eq(java.util.Map.of("pubmed:1", 102L))))
                 .thenReturn(new MechanismCandidateBuilder.MechanismBuildResult(
                         List.of(mechanismCandidate),
@@ -116,18 +126,23 @@ class MechanismDiscoveryPipelineServiceTest {
                 ));
         when(mechanismCandidateBuilder.buildMechanismSpec(any(), eq(103L), eq(List.of(102L))))
                 .thenReturn(mechanismSpec);
+        when(practicalKnowledgePackBuilder.build(eq(10L), any(), any())).thenReturn(practicalKnowledgePack);
+        when(discoveryReportBuilder.build(eq(10L), eq("q1"), eq(1), eq(1), eq(1), eq(1), eq(1), any(), any(), any()))
+                .thenReturn(mechanismDiscoveryReport);
 
         when(backendMdsClient.publishBatch(any()))
                 .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 2, List.of(100L, 101L)))
                 .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(102L)))
                 .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(103L)))
-                .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(104L)));
+                .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(104L)))
+                .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(105L)))
+                .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(106L)));
 
         service.execute(request);
 
         ArgumentCaptor<com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto> batchCaptor =
                 ArgumentCaptor.forClass(com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.class);
-        verify(backendMdsClient, times(4)).publishBatch(batchCaptor.capture());
+        verify(backendMdsClient, times(6)).publishBatch(batchCaptor.capture());
 
         List<com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto> batches = batchCaptor.getAllValues();
         assertThat(batches.get(0).artifacts()).extracting(a -> a.artifactType())
@@ -138,12 +153,16 @@ class MechanismDiscoveryPipelineServiceTest {
                 .containsExactly("mechanismCandidate");
         assertThat(batches.get(3).artifacts()).extracting(a -> a.artifactType())
                 .containsExactly("mechanismSpec");
+        assertThat(batches.get(4).artifacts()).extracting(a -> a.artifactType())
+                .containsExactly("practicalKnowledgePack");
+        assertThat(batches.get(5).artifacts()).extracting(a -> a.artifactType())
+                .containsExactly("mechanismDiscoveryReport");
 
         ArgumentCaptor<com.marketinghub.mds.dto.BackendSourceAccessPublishBatchRequestDto> sourceAccessCaptor =
                 ArgumentCaptor.forClass(com.marketinghub.mds.dto.BackendSourceAccessPublishBatchRequestDto.class);
         verify(backendMdsClient).publishSourceAccessBatch(sourceAccessCaptor.capture());
         assertThat(sourceAccessCaptor.getValue().records()).hasSize(1);
 
-        verify(backendMdsClient, times(4)).heartbeat(eq(10L), any());
+        verify(backendMdsClient, times(5)).heartbeat(eq(10L), any());
     }
 }


### PR DESCRIPTION
### Motivation
- Fechar estritamente o escopo da Sprint 6 do MDS conforme os artefatos e contratos canônicos, entregando o `practicalKnowledgePack` e o `mechanismDiscoveryReport` para consumo pelo ecossistema.
- Garantir que a persistência e leitura dos artefatos sigam a regra do repositório (somente o backend acessa MySQL) e expor endpoints de consulta operacionais para reuso e auditabilidade.

### Description
- Adiciona os builders do lado do MDS para os artefatos finais: `PracticalKnowledgePackBuilder` (`mds/src/main/java/.../PracticalKnowledgePackBuilder.java`) e `DiscoveryReportBuilder` (`mds/src/main/java/.../DiscoveryReportBuilder.java`).
- Atualiza o pipeline `MechanismDiscoveryPipelineService` para publicar em sequência `mechanismSpec` → `practicalKnowledgePack` → `mechanismDiscoveryReport`, com heartbeats finais de `pack-building` e `reporting` (`mds/src/main/java/.../MechanismDiscoveryPipelineService.java`).
- Expande o backend com DTOs e APIs de consulta: `MdsReportResponse`, `MdsArtifactSummaryResponse`, novos métodos em `MdsArtifactService` (`getReportByRequest`, `listArtifactsByRequest`), repositório ordenado `findByRequestIdOrderByCreatedAtAscIdAsc` e endpoints `GET /api/internal/mds/reports/{id}` e `GET /api/internal/mds/requests/{id}/artifacts` (`backend/ads-service/src/main/java/...`).
- Atualiza testes e documentação: ajusta `MechanismDiscoveryPipelineServiceTest` e `MdsInternalControllerContractTest` para cobrir o fluxo completo da Sprint 6 e atualiza o bloco “Registro do Codex ao final da sprint” no plano e a entrada cumulativa no protocolo histórico (docs under `docs/novos-modulos/MDS/`).

### Testing
- Executed `cd mds && mvn -q test -Dtest=MechanismDiscoveryPipelineServiceTest`, which passed for the updated pipeline test that validates publication of evidence, mechanismSpec, practicalKnowledgePack and mechanismDiscoveryReport.
- Executed `cd backend/ads-service && mvn -q test -Dtest=MdsInternalControllerContractTest`, which passed and validates the new controller contracts for report retrieval and artifact listing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e248d24c1c8321bda9037b04b3358a)