### PR TITLE
MDS Sprint 7: operational hardening, observability and retry tests

### DIFF
--- a/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+++ b/docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
@@ -801,19 +801,42 @@ Estabilizar a V1 para que ela seja operável no ecossistema do Marketing Hub.
 - dashboards operacionais.
 
 ### Registro do Codex ao final da sprint
-**Status:** `NAO_INICIADA`
+**Status:** `CONCLUIDO`
 
 **O que foi concluído:**
-- 
+- Implementados retries controlados por fonte no `SearchExecutionService`, com tentativas configuráveis e backoff para falhas transitórias.
+- Implementados timeouts por fonte no `PubmedSearchClient` e `CrossrefSearchClient` via propriedades do módulo (`mds.search.timeout-ms`), reduzindo risco de bloqueio indefinido em integrações externas.
+- Implementada classificação operacional de falhas recuperáveis vs não recuperáveis no `MdsLoopRunner`, publicando `failureStage` coerente (`recoverable_external`, `non_recoverable_pipeline` ou `pipeline`) ao backend.
+- Adicionada observabilidade de pipeline no `MechanismDiscoveryPipelineService` com:
+  - log de resumo operacional por request contendo os campos mínimos exigidos (requestId, market, problem, desiredOutcome, searchSources, selectedEvidenceCount, mechanismCandidateCount, chosenMechanismId, confidenceLevel);
+  - métricas por etapa (`mds.pipeline.stage.duration`, `mds.pipeline.stage.success`, `mds.pipeline.stage.failure`) e métrica global (`mds.pipeline.duration`).
+- Exposição de endpoint de métricas no Actuator (`management.endpoints.web.exposure.include` inclui `metrics`) mantendo healthcheck já disponível em `/internal/mechanism-discovery/actuator/health`.
+- Ampliação da cobertura de testes com novo teste de falha de fonte externa e retries (`SearchExecutionServiceTest`) e ajuste do teste de pipeline (`MechanismDiscoveryPipelineServiceTest`) para validar execução com instrumentação de métricas.
 
 **O que ficou pendente para a próxima sprint ou fase:**
-- 
+- Dashboards operacionais dedicados (visualização externa das métricas desta sprint).
+- Ampliação de testes de integração end-to-end com ambientes reais de fontes externas.
+- Estratégia de retry/backoff adaptativa por tipo de erro HTTP (atualmente a política é uniforme por fonte).
 
 **Riscos / observações:**
-- 
+- O retry atual prioriza previsibilidade operacional e simplicidade; cenários de throttling com janelas variáveis podem exigir política adaptativa futura.
+- O pipeline segue em modo fail-fast quando todas as fontes configuradas falham na etapa de busca; isso melhora diagnóstico, mas pode reduzir throughput em janelas de indisponibilidade externa.
+- A classificação de falhas no loop depende do tipo de exceção propagada; novas integrações de fonte devem preservar essa convenção para manter consistência operacional.
 
 **Arquivos alterados/criados:**
-- 
+- mds/src/main/java/com/marketinghub/mds/config/MdsProperties.java
+- mds/src/main/java/com/marketinghub/mds/search/SearchExecutionService.java
+- mds/src/main/java/com/marketinghub/mds/search/PubmedSearchClient.java
+- mds/src/main/java/com/marketinghub/mds/search/CrossrefSearchClient.java
+- mds/src/main/java/com/marketinghub/mds/search/RecoverableSourceException.java
+- mds/src/main/java/com/marketinghub/mds/search/NonRecoverablePipelineException.java
+- mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+- mds/src/main/java/com/marketinghub/mds/service/MdsLoopRunner.java
+- mds/src/main/resources/application.yml
+- mds/src/test/java/com/marketinghub/mds/search/SearchExecutionServiceTest.java
+- mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+- docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+- docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
 
 ---
 

--- a/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+++ b/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
@@ -845,3 +845,76 @@ Requests com mecanismo recomendado passam a produzir pacote prático e relatóri
 **Próximo passo sugerido:**
 
 Executar Sprint 7 com foco em observabilidade, hardening operacional e ampliação de testes de integração.
+
+## [2026-04-17] — Etapa: sprint 7 - testes, observabilidade e hardening operacional
+
+**Status:** `CONCLUIDO`
+
+**Resumo:**
+
+A Sprint 7 foi implementada no módulo `mds/` com hardening operacional na busca de fontes externas (timeouts + retries), classificação explícita de falhas recuperáveis/não recuperáveis, instrumentação de métricas por etapa e ampliação da suíte de testes de falha/retry.
+
+**Objetivo da etapa:**
+
+Estabilizar a V1 do MDS para operação previsível no ecossistema do Marketing Hub, melhorando diagnósticos, comportamento em falhas transitórias e cobertura de testes alinhada ao plano da sprint.
+
+**O que foi implementado:**
+
+- configuração de busca adicionada em `MdsProperties` (`timeoutMs`, `retryMaxAttempts`, `retryBackoffMs`) com variáveis de ambiente no `application.yml`;
+- implementação de retries controlados no `SearchExecutionService`, com erro previsível (`RecoverableSourceException`) quando todas as fontes falham;
+- implementação de timeout por fonte em `PubmedSearchClient` e `CrossrefSearchClient` usando `SimpleClientHttpRequestFactory`;
+- criação das exceções `RecoverableSourceException` e `NonRecoverablePipelineException` para separar falhas recuperáveis externas de falhas internas não recuperáveis;
+- atualização do `MdsLoopRunner` para classificar e propagar `failureStage` coerente (`recoverable_external`, `non_recoverable_pipeline`, `pipeline`);
+- instrumentação no `MechanismDiscoveryPipelineService` com métricas por etapa (`success/failure/duration`) e log de resumo operacional com os campos mandatórios da sprint;
+- inclusão do endpoint Actuator de métricas (`/actuator/metrics`) na configuração exposta;
+- criação de `SearchExecutionServiceTest` cobrindo retry bem-sucedido e falha previsível quando todas as fontes externas falham;
+- ajuste de `MechanismDiscoveryPipelineServiceTest` para manter validação do pipeline completo com `MeterRegistry` ativo.
+
+**Arquivos alterados/criados:**
+
+- mds/src/main/java/com/marketinghub/mds/config/MdsProperties.java
+- mds/src/main/java/com/marketinghub/mds/search/SearchExecutionService.java
+- mds/src/main/java/com/marketinghub/mds/search/PubmedSearchClient.java
+- mds/src/main/java/com/marketinghub/mds/search/CrossrefSearchClient.java
+- mds/src/main/java/com/marketinghub/mds/search/RecoverableSourceException.java
+- mds/src/main/java/com/marketinghub/mds/search/NonRecoverablePipelineException.java
+- mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+- mds/src/main/java/com/marketinghub/mds/service/MdsLoopRunner.java
+- mds/src/main/resources/application.yml
+- mds/src/test/java/com/marketinghub/mds/search/SearchExecutionServiceTest.java
+- mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+- docs/novos-modulos/MDS/plano_implementacao_mds_baseado_na_especificacao.md
+- docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+
+**Tabelas / persistência afetadas:**
+
+- `nenhuma`
+
+**APIs / endpoints / contratos afetados:**
+
+- `GET /internal/mechanism-discovery/actuator/health` (mantido)
+- `GET /actuator/metrics` (passa a estar exposto para observabilidade)
+- contrato backend ↔ MDS sem breaking change estrutural; sem alteração de payloads persistidos.
+
+**Artefatos / schemas impactados:**
+
+- `nenhum` (sem mudança de schema de artefatos canônicos nesta sprint)
+
+**Testes executados:**
+
+- `cd mds && mvn test`
+- `cd backend/ads-service && mvn -Dtest=MdsInternalControllerContractTest test`
+
+**Resultado observado:**
+
+O pipeline do MDS passou a reagir de forma previsível a falhas transitórias de fonte externa, com tentativas controladas e classificação explícita de erro, ao mesmo tempo em que fornece telemetria mínima por etapa e logs de diagnóstico operacional consistentes.
+
+**Limitações / pendências:**
+
+- dashboards operacionais não foram implementados nesta sprint (apenas emissão de métricas e logs);
+- política de retry/backoff ainda é uniforme por fonte/tipo de erro;
+- cobertura de integração real com indisponibilidade intermitente de provedores externos ainda depende de ambiente controlado de teste.
+
+**Próximo passo sugerido:**
+
+Abrir a próxima fase fora da Sprint 7 para evolução de dashboards, política adaptativa de retry por tipo de erro e testes end-to-end com cenários reais de indisponibilidade externa.

--- a/mds/src/main/java/com/marketinghub/mds/config/MdsProperties.java
+++ b/mds/src/main/java/com/marketinghub/mds/config/MdsProperties.java
@@ -7,6 +7,7 @@ public class MdsProperties {
     private boolean loopEnabled = true;
     private int pollLimit = 5;
     private Backend backend = new Backend();
+    private Search search = new Search();
 
     public boolean isLoopEnabled() {
         return loopEnabled;
@@ -32,6 +33,14 @@ public class MdsProperties {
         this.backend = backend;
     }
 
+    public Search getSearch() {
+        return search;
+    }
+
+    public void setSearch(Search search) {
+        this.search = search;
+    }
+
     public static class Backend {
         private String baseUrl = "http://localhost:8080";
         private String workerId = "mds-worker-local";
@@ -50,6 +59,36 @@ public class MdsProperties {
 
         public void setWorkerId(String workerId) {
             this.workerId = workerId;
+        }
+    }
+
+    public static class Search {
+        private int timeoutMs = 5000;
+        private int retryMaxAttempts = 2;
+        private int retryBackoffMs = 250;
+
+        public int getTimeoutMs() {
+            return timeoutMs;
+        }
+
+        public void setTimeoutMs(int timeoutMs) {
+            this.timeoutMs = timeoutMs;
+        }
+
+        public int getRetryMaxAttempts() {
+            return retryMaxAttempts;
+        }
+
+        public void setRetryMaxAttempts(int retryMaxAttempts) {
+            this.retryMaxAttempts = retryMaxAttempts;
+        }
+
+        public int getRetryBackoffMs() {
+            return retryBackoffMs;
+        }
+
+        public void setRetryBackoffMs(int retryBackoffMs) {
+            this.retryBackoffMs = retryBackoffMs;
         }
     }
 }

--- a/mds/src/main/java/com/marketinghub/mds/search/CrossrefSearchClient.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/CrossrefSearchClient.java
@@ -1,8 +1,10 @@
 package com.marketinghub.mds.search;
 
+import com.marketinghub.mds.config.MdsProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,8 +15,12 @@ public class CrossrefSearchClient implements EvidenceSearchClient {
 
     private final RestClient restClient;
 
-    public CrossrefSearchClient() {
-        this.restClient = RestClient.builder().build();
+    public CrossrefSearchClient(MdsProperties properties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        int timeoutMs = Math.max(500, properties.getSearch().getTimeoutMs());
+        factory.setConnectTimeout(timeoutMs);
+        factory.setReadTimeout(timeoutMs);
+        this.restClient = RestClient.builder().requestFactory(factory).build();
     }
 
     @Override
@@ -74,7 +80,7 @@ public class CrossrefSearchClient implements EvidenceSearchClient {
 
             return hits;
         } catch (Exception ex) {
-            return List.of();
+            throw new RecoverableSourceException("crossref source call failed", ex);
         }
     }
 }

--- a/mds/src/main/java/com/marketinghub/mds/search/NonRecoverablePipelineException.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/NonRecoverablePipelineException.java
@@ -1,0 +1,11 @@
+package com.marketinghub.mds.search;
+
+public class NonRecoverablePipelineException extends RuntimeException {
+    public NonRecoverablePipelineException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NonRecoverablePipelineException(String message) {
+        super(message);
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/search/PubmedSearchClient.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/PubmedSearchClient.java
@@ -1,8 +1,10 @@
 package com.marketinghub.mds.search;
 
+import com.marketinghub.mds.config.MdsProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,8 +17,12 @@ public class PubmedSearchClient implements EvidenceSearchClient {
 
     private final RestClient restClient;
 
-    public PubmedSearchClient() {
-        this.restClient = RestClient.builder().build();
+    public PubmedSearchClient(MdsProperties properties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        int timeoutMs = Math.max(500, properties.getSearch().getTimeoutMs());
+        factory.setConnectTimeout(timeoutMs);
+        factory.setReadTimeout(timeoutMs);
+        this.restClient = RestClient.builder().requestFactory(factory).build();
     }
 
     @Override
@@ -86,7 +92,7 @@ public class PubmedSearchClient implements EvidenceSearchClient {
             }
             return hits;
         } catch (Exception ex) {
-            return List.of();
+            throw new RecoverableSourceException("pubmed source call failed", ex);
         }
     }
 }

--- a/mds/src/main/java/com/marketinghub/mds/search/RecoverableSourceException.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/RecoverableSourceException.java
@@ -1,0 +1,11 @@
+package com.marketinghub.mds.search;
+
+public class RecoverableSourceException extends RuntimeException {
+    public RecoverableSourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RecoverableSourceException(String message) {
+        super(message);
+    }
+}

--- a/mds/src/main/java/com/marketinghub/mds/search/SearchExecutionService.java
+++ b/mds/src/main/java/com/marketinghub/mds/search/SearchExecutionService.java
@@ -1,5 +1,8 @@
 package com.marketinghub.mds.search;
 
+import com.marketinghub.mds.config.MdsProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -10,21 +13,65 @@ import java.util.stream.Collectors;
 
 @Service
 public class SearchExecutionService {
+    private static final Logger log = LoggerFactory.getLogger(SearchExecutionService.class);
     private final Map<String, EvidenceSearchClient> clientsBySource;
+    private final int retryMaxAttempts;
+    private final int retryBackoffMs;
 
-    public SearchExecutionService(List<EvidenceSearchClient> clients) {
+    public SearchExecutionService(List<EvidenceSearchClient> clients,
+                                  MdsProperties properties) {
         this.clientsBySource = clients.stream().collect(Collectors.toMap(c -> c.source().toLowerCase(), Function.identity()));
+        this.retryMaxAttempts = Math.max(1, properties.getSearch().getRetryMaxAttempts());
+        this.retryBackoffMs = Math.max(0, properties.getSearch().getRetryBackoffMs());
     }
 
     public List<SourceSearchHit> execute(List<SearchQueryPlan> plans) {
         List<SourceSearchHit> hits = new ArrayList<>();
+        int sourcesWithFailure = 0;
         for (SearchQueryPlan plan : plans) {
             EvidenceSearchClient client = clientsBySource.get(plan.source().toLowerCase());
             if (client == null) {
                 continue;
             }
-            hits.addAll(client.search(plan.query(), plan.limit()));
+            try {
+                hits.addAll(searchWithRetry(client, plan));
+            } catch (RecoverableSourceException ex) {
+                sourcesWithFailure++;
+                log.warn("mds-source-recoverable-failure source={} query={} attempts={} reason={}",
+                        plan.source(), plan.query(), retryMaxAttempts, ex.getMessage());
+            }
+        }
+
+        if (!plans.isEmpty() && sourcesWithFailure == plans.size()) {
+            throw new RecoverableSourceException("all configured sources failed during evidence search");
         }
         return hits;
+    }
+
+    private List<SourceSearchHit> searchWithRetry(EvidenceSearchClient client, SearchQueryPlan plan) {
+        RuntimeException lastException = null;
+        for (int attempt = 1; attempt <= retryMaxAttempts; attempt++) {
+            try {
+                return client.search(plan.query(), plan.limit());
+            } catch (RuntimeException ex) {
+                lastException = ex;
+                if (attempt < retryMaxAttempts) {
+                    sleepBackoff();
+                }
+            }
+        }
+        throw new RecoverableSourceException("source " + plan.source() + " exhausted retry attempts", lastException);
+    }
+
+    private void sleepBackoff() {
+        if (retryBackoffMs <= 0) {
+            return;
+        }
+        try {
+            Thread.sleep(retryBackoffMs);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new NonRecoverablePipelineException("search retry backoff interrupted", ex);
+        }
     }
 }

--- a/mds/src/main/java/com/marketinghub/mds/service/MdsLoopRunner.java
+++ b/mds/src/main/java/com/marketinghub/mds/service/MdsLoopRunner.java
@@ -3,6 +3,8 @@ package com.marketinghub.mds.service;
 import com.marketinghub.mds.client.BackendMdsClient;
 import com.marketinghub.mds.config.MdsProperties;
 import com.marketinghub.mds.dto.*;
+import com.marketinghub.mds.search.NonRecoverablePipelineException;
+import com.marketinghub.mds.search.RecoverableSourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -50,12 +52,23 @@ public class MdsLoopRunner {
             backendMdsClient.complete(request.id(), new BackendCompleteRequestDto("mds pipeline finished"));
             log.info("mds-request-complete requestId={} correlationId={}", request.id(), request.correlationId());
         } catch (Exception ex) {
-            log.error("mds-request-failed requestId={} error={}", request.id(), ex.getMessage(), ex);
+            String failureType = resolveFailureType(ex);
+            log.error("mds-request-failed requestId={} failureType={} error={}", request.id(), failureType, ex.getMessage(), ex);
             backendMdsClient.fail(request.id(), new BackendFailRequestDto(
                     ex.getMessage(),
-                    "pipeline",
-                    "processing failed"
+                    failureType,
+                    failureType.equals("recoverable_external") ? "processing failed with recoverable source error" : "processing failed"
             ));
         }
+    }
+
+    private String resolveFailureType(Exception ex) {
+        if (ex instanceof RecoverableSourceException) {
+            return "recoverable_external";
+        }
+        if (ex instanceof NonRecoverablePipelineException) {
+            return "non_recoverable_pipeline";
+        }
+        return "pipeline";
     }
 }

--- a/mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
+++ b/mds/src/main/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineService.java
@@ -19,6 +19,10 @@ import com.marketinghub.mds.search.SearchQueryPlan;
 import com.marketinghub.mds.search.SearchQueryPlanBuilder;
 import com.marketinghub.mds.search.SourceDedupService;
 import com.marketinghub.mds.search.SourceSearchHit;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -28,6 +32,7 @@ import java.util.Map;
 
 @Service
 public class MechanismDiscoveryPipelineService {
+    private static final Logger log = LoggerFactory.getLogger(MechanismDiscoveryPipelineService.class);
     private final BackendMdsClient backendMdsClient;
     private final MechanismQuestionBuilder mechanismQuestionBuilder;
     private final SearchQueryPlanBuilder searchQueryPlanBuilder;
@@ -39,6 +44,7 @@ public class MechanismDiscoveryPipelineService {
     private final MechanismCandidateBuilder mechanismCandidateBuilder;
     private final PracticalKnowledgePackBuilder practicalKnowledgePackBuilder;
     private final DiscoveryReportBuilder discoveryReportBuilder;
+    private final MeterRegistry meterRegistry;
 
     public MechanismDiscoveryPipelineService(BackendMdsClient backendMdsClient,
                                              MechanismQuestionBuilder mechanismQuestionBuilder,
@@ -50,7 +56,8 @@ public class MechanismDiscoveryPipelineService {
                                              EvidenceItemBuilder evidenceItemBuilder,
                                              MechanismCandidateBuilder mechanismCandidateBuilder,
                                              PracticalKnowledgePackBuilder practicalKnowledgePackBuilder,
-                                             DiscoveryReportBuilder discoveryReportBuilder) {
+                                             DiscoveryReportBuilder discoveryReportBuilder,
+                                             MeterRegistry meterRegistry) {
         this.backendMdsClient = backendMdsClient;
         this.mechanismQuestionBuilder = mechanismQuestionBuilder;
         this.searchQueryPlanBuilder = searchQueryPlanBuilder;
@@ -62,29 +69,32 @@ public class MechanismDiscoveryPipelineService {
         this.mechanismCandidateBuilder = mechanismCandidateBuilder;
         this.practicalKnowledgePackBuilder = practicalKnowledgePackBuilder;
         this.discoveryReportBuilder = discoveryReportBuilder;
+        this.meterRegistry = meterRegistry;
     }
 
     public void execute(BackendMdsRequestDto request) {
-        MechanismQuestion question = mechanismQuestionBuilder.build(request);
-        List<SearchQueryPlan> plans = searchQueryPlanBuilder.buildPlans(question);
-        List<SourceSearchHit> rawHits = searchExecutionService.execute(plans);
+        Timer.Sample pipelineTimer = Timer.start(meterRegistry);
+        try {
+            MechanismQuestion question = mechanismQuestionBuilder.build(request);
+            List<SearchQueryPlan> plans = searchQueryPlanBuilder.buildPlans(question);
+            List<SourceSearchHit> rawHits = timeStage("search", () -> searchExecutionService.execute(plans));
 
-        List<SourceSearchHit> dedupedHits = sourceDedupService.deduplicate(rawHits);
-        backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
-                "dedup-normalize",
-                "deduplication finished",
-                Map.of("rawCount", rawHits.size(), "dedupedCount", dedupedHits.size())
-        ));
+            List<SourceSearchHit> dedupedHits = timeStage("dedup-normalize", () -> sourceDedupService.deduplicate(rawHits));
+            backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
+                    "dedup-normalize",
+                    "deduplication finished",
+                    Map.of("rawCount", rawHits.size(), "dedupedCount", dedupedHits.size())
+            ));
 
-        List<ScreenedEvidence> screened = evidenceScreeningService.screen(request, dedupedHits);
-        List<ScreenedEvidence> prioritized = evidenceScreeningService.prioritize(screened, 12);
-        backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
-                "screening",
-                "screening finished",
-                Map.of("eligibleCount", screened.size(), "prioritizedCount", prioritized.size())
-        ));
+            List<ScreenedEvidence> screened = timeStage("screening", () -> evidenceScreeningService.screen(request, dedupedHits));
+            List<ScreenedEvidence> prioritized = evidenceScreeningService.prioritize(screened, 12);
+            backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
+                    "screening",
+                    "screening finished",
+                    Map.of("eligibleCount", screened.size(), "prioritizedCount", prioritized.size())
+            ));
 
-        ArtifactPayloadDto evidenceSearch = new ArtifactPayloadDto(
+            ArtifactPayloadDto evidenceSearch = new ArtifactPayloadDto(
                 "mechanismEvidenceSearch",
                 "v1",
                 "v1",
@@ -103,10 +113,10 @@ public class MechanismDiscoveryPipelineService {
                 List.of()
         );
 
-        List<ArtifactPayloadDto> sourceDocumentArtifacts = new ArrayList<>();
-        List<BackendSourceAccessPublishBatchRequestDto.SourceAccessPayloadDto> sourceAccessRecords = new ArrayList<>();
+            List<ArtifactPayloadDto> sourceDocumentArtifacts = new ArrayList<>();
+            List<BackendSourceAccessPublishBatchRequestDto.SourceAccessPayloadDto> sourceAccessRecords = new ArrayList<>();
 
-        for (SourceSearchHit hit : dedupedHits) {
+            for (SourceSearchHit hit : dedupedHits) {
             String accessClass = resolveAccessClass(hit);
             String permissionState = resolvePermissionState(hit);
 
@@ -142,125 +152,156 @@ public class MechanismDiscoveryPipelineService {
                     hit.licenseText(),
                     hit.url()
             ));
-        }
+            }
 
-        List<ArtifactPayloadDto> sourceBatch = new ArrayList<>();
-        sourceBatch.add(evidenceSearch);
-        sourceBatch.addAll(sourceDocumentArtifacts);
-        var sourcePublishResponse = backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), sourceBatch));
+            List<ArtifactPayloadDto> sourceBatch = new ArrayList<>();
+            sourceBatch.add(evidenceSearch);
+            sourceBatch.addAll(sourceDocumentArtifacts);
+            var sourcePublishResponse = timeStage("source-publish",
+                    () -> backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), sourceBatch)));
 
-        if (!sourceAccessRecords.isEmpty()) {
-            backendMdsClient.publishSourceAccessBatch(new BackendSourceAccessPublishBatchRequestDto(sourceAccessRecords));
-        }
+            if (!sourceAccessRecords.isEmpty()) {
+                backendMdsClient.publishSourceAccessBatch(new BackendSourceAccessPublishBatchRequestDto(sourceAccessRecords));
+            }
 
-        Map<String, Long> sourceArtifactIdsBySourceDocumentId = new LinkedHashMap<>();
-        List<Long> sourceArtifactIds = sourcePublishResponse.artifactIds().stream().skip(1).toList();
-        for (int i = 0; i < dedupedHits.size() && i < sourceArtifactIds.size(); i++) {
-            sourceArtifactIdsBySourceDocumentId.put(dedupedHits.get(i).sourceDocumentId(), sourceArtifactIds.get(i));
-        }
+            Map<String, Long> sourceArtifactIdsBySourceDocumentId = new LinkedHashMap<>();
+            List<Long> sourceArtifactIds = sourcePublishResponse.artifactIds().stream().skip(1).toList();
+            for (int i = 0; i < dedupedHits.size() && i < sourceArtifactIds.size(); i++) {
+                sourceArtifactIdsBySourceDocumentId.put(dedupedHits.get(i).sourceDocumentId(), sourceArtifactIds.get(i));
+            }
 
-        List<ArtifactPayloadDto> evidenceItems = new ArrayList<>();
-        Map<String, String> confidenceBySourceDocumentId = new LinkedHashMap<>();
-        for (ScreenedEvidence screenedEvidence : prioritized) {
+            List<ArtifactPayloadDto> evidenceItems = new ArrayList<>();
+            Map<String, String> confidenceBySourceDocumentId = new LinkedHashMap<>();
+            for (ScreenedEvidence screenedEvidence : prioritized) {
             String confidenceLevel = evidenceConfidenceService.classify(screenedEvidence);
             confidenceBySourceDocumentId.put(screenedEvidence.sourceDocumentId(), confidenceLevel);
             Long parentArtifactId = sourceArtifactIdsBySourceDocumentId.get(screenedEvidence.sourceDocumentId());
             evidenceItems.add(evidenceItemBuilder.build(request.id(), screenedEvidence, confidenceLevel,
                     parentArtifactId == null ? List.of() : List.of(parentArtifactId)));
-        }
-
-        Map<String, Long> evidenceArtifactIdsBySourceDocumentId = new LinkedHashMap<>();
-        if (!evidenceItems.isEmpty()) {
-            var evidencePublishResponse =
-                    backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), evidenceItems));
-            List<Long> evidenceArtifactIds = evidencePublishResponse.artifactIds();
-            for (int i = 0; i < prioritized.size() && i < evidenceArtifactIds.size(); i++) {
-                evidenceArtifactIdsBySourceDocumentId.put(prioritized.get(i).sourceDocumentId(), evidenceArtifactIds.get(i));
             }
-        }
 
-        backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
-                "evidence-analysis",
-                "evidence items published",
-                Map.of("evidenceItemCount", evidenceItems.size())
-        ));
+            Map<String, Long> evidenceArtifactIdsBySourceDocumentId = new LinkedHashMap<>();
+            if (!evidenceItems.isEmpty()) {
+                var evidencePublishResponse = timeStage("evidence-publish",
+                        () -> backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), evidenceItems)));
+                List<Long> evidenceArtifactIds = evidencePublishResponse.artifactIds();
+                for (int i = 0; i < prioritized.size() && i < evidenceArtifactIds.size(); i++) {
+                    evidenceArtifactIdsBySourceDocumentId.put(prioritized.get(i).sourceDocumentId(), evidenceArtifactIds.get(i));
+                }
+            }
 
-        var mechanismBuild = mechanismCandidateBuilder.build(
+            backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
+                    "evidence-analysis",
+                    "evidence items published",
+                    Map.of("evidenceItemCount", evidenceItems.size())
+            ));
+
+            var mechanismBuild = timeStage("mechanism-building", () -> mechanismCandidateBuilder.build(
                 request.id(),
                 prioritized,
                 confidenceBySourceDocumentId,
                 evidenceArtifactIdsBySourceDocumentId
-        );
-        Long mechanismSpecArtifactId = null;
-        Long practicalKnowledgePackArtifactId = null;
-        if (!mechanismBuild.candidateArtifacts().isEmpty()) {
-            var candidatePublishResponse = backendMdsClient.publishBatch(
-                    new BackendArtifactPublishBatchRequestDto(request.id(), mechanismBuild.candidateArtifacts())
-            );
-            Long selectedCandidateArtifactId = candidatePublishResponse.artifactIds().isEmpty()
-                    ? null
-                    : candidatePublishResponse.artifactIds().get(0);
+            ));
+            Long mechanismSpecArtifactId = null;
+            Long practicalKnowledgePackArtifactId = null;
+            if (!mechanismBuild.candidateArtifacts().isEmpty()) {
+                var candidatePublishResponse = backendMdsClient.publishBatch(
+                        new BackendArtifactPublishBatchRequestDto(request.id(), mechanismBuild.candidateArtifacts())
+                );
+                Long selectedCandidateArtifactId = candidatePublishResponse.artifactIds().isEmpty()
+                        ? null
+                        : candidatePublishResponse.artifactIds().get(0);
 
-            ArtifactPayloadDto mechanismSpec = mechanismCandidateBuilder.buildMechanismSpec(
+                ArtifactPayloadDto mechanismSpec = mechanismCandidateBuilder.buildMechanismSpec(
                     mechanismBuild.mechanismSpecDraft(),
                     selectedCandidateArtifactId,
                     mechanismBuild.supportingEvidenceArtifactIds()
             );
-            if (mechanismSpec != null) {
-                var mechanismSpecResponse = backendMdsClient.publishBatch(
-                        new BackendArtifactPublishBatchRequestDto(request.id(), List.of(mechanismSpec))
-                );
-                if (!mechanismSpecResponse.artifactIds().isEmpty()) {
-                    mechanismSpecArtifactId = mechanismSpecResponse.artifactIds().get(0);
-                }
+                if (mechanismSpec != null) {
+                    var mechanismSpecResponse = backendMdsClient.publishBatch(
+                            new BackendArtifactPublishBatchRequestDto(request.id(), List.of(mechanismSpec))
+                    );
+                    if (!mechanismSpecResponse.artifactIds().isEmpty()) {
+                        mechanismSpecArtifactId = mechanismSpecResponse.artifactIds().get(0);
+                    }
 
-                List<Long> practicalPackParents = new ArrayList<>(mechanismBuild.supportingEvidenceArtifactIds());
-                if (mechanismSpecArtifactId != null) {
-                    practicalPackParents.add(mechanismSpecArtifactId);
-                }
-                ArtifactPayloadDto practicalKnowledgePack = practicalKnowledgePackBuilder.build(
-                        request.id(),
-                        mechanismBuild.mechanismSpecDraft(),
-                        practicalPackParents
-                );
-                var practicalKnowledgePackResponse = backendMdsClient.publishBatch(
-                        new BackendArtifactPublishBatchRequestDto(request.id(), List.of(practicalKnowledgePack))
-                );
-                if (!practicalKnowledgePackResponse.artifactIds().isEmpty()) {
-                    practicalKnowledgePackArtifactId = practicalKnowledgePackResponse.artifactIds().get(0);
+                    List<Long> practicalPackParents = new ArrayList<>(mechanismBuild.supportingEvidenceArtifactIds());
+                    if (mechanismSpecArtifactId != null) {
+                        practicalPackParents.add(mechanismSpecArtifactId);
+                    }
+                    ArtifactPayloadDto practicalKnowledgePack = timeStage("pack-building", () -> practicalKnowledgePackBuilder.build(
+                            request.id(),
+                            mechanismBuild.mechanismSpecDraft(),
+                            practicalPackParents
+                    ));
+                    var practicalKnowledgePackResponse = backendMdsClient.publishBatch(
+                            new BackendArtifactPublishBatchRequestDto(request.id(), List.of(practicalKnowledgePack))
+                    );
+                    if (!practicalKnowledgePackResponse.artifactIds().isEmpty()) {
+                        practicalKnowledgePackArtifactId = practicalKnowledgePackResponse.artifactIds().get(0);
+                    }
                 }
             }
-        }
 
-        backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
-                "pack-building",
-                "mechanism spec and practical knowledge pack published",
-                Map.of("mechanismCandidateCount", mechanismBuild.candidateArtifacts().size())
-        ));
-
-        if (mechanismSpecArtifactId != null && practicalKnowledgePackArtifactId != null) {
-            List<Long> reportParents = new ArrayList<>(mechanismBuild.supportingEvidenceArtifactIds());
-            reportParents.add(mechanismSpecArtifactId);
-            reportParents.add(practicalKnowledgePackArtifactId);
-
-            ArtifactPayloadDto discoveryReport = discoveryReportBuilder.build(
-                    request.id(),
-                    question.text(),
-                    rawHits.size(),
-                    dedupedHits.size(),
-                    prioritized.size(),
-                    evidenceItems.size(),
-                    mechanismBuild.candidateArtifacts().size(),
-                    mechanismSpecArtifactId,
-                    practicalKnowledgePackArtifactId,
-                    reportParents
-            );
-            backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), List.of(discoveryReport)));
             backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
-                    "reporting",
-                    "mechanism discovery report published",
-                    Map.of("reportPublished", true)
+                    "pack-building",
+                    "mechanism spec and practical knowledge pack published",
+                    Map.of("mechanismCandidateCount", mechanismBuild.candidateArtifacts().size())
             ));
+
+            if (mechanismSpecArtifactId != null && practicalKnowledgePackArtifactId != null) {
+                List<Long> reportParents = new ArrayList<>(mechanismBuild.supportingEvidenceArtifactIds());
+                reportParents.add(mechanismSpecArtifactId);
+                reportParents.add(practicalKnowledgePackArtifactId);
+
+                ArtifactPayloadDto discoveryReport = discoveryReportBuilder.build(
+                        request.id(),
+                        question.text(),
+                        rawHits.size(),
+                        dedupedHits.size(),
+                        prioritized.size(),
+                        evidenceItems.size(),
+                        mechanismBuild.candidateArtifacts().size(),
+                        mechanismSpecArtifactId,
+                        practicalKnowledgePackArtifactId,
+                        reportParents
+                );
+                backendMdsClient.publishBatch(new BackendArtifactPublishBatchRequestDto(request.id(), List.of(discoveryReport)));
+                backendMdsClient.heartbeat(request.id(), new com.marketinghub.mds.dto.BackendHeartbeatRequestDto(
+                        "reporting",
+                        "mechanism discovery report published",
+                        Map.of("reportPublished", true)
+                ));
+            }
+
+            log.info(
+                    "mds-pipeline-summary requestId={} market={} problem={} desiredOutcome={} searchSources={} selectedEvidenceCount={} mechanismCandidateCount={} chosenMechanismId={} confidenceLevel={}",
+                    request.id(),
+                    request.market(),
+                    request.problem(),
+                    request.desiredOutcome(),
+                    plans.stream().map(SearchQueryPlan::source).toList(),
+                    prioritized.size(),
+                    mechanismBuild.candidateArtifacts().size(),
+                    mechanismBuild.mechanismSpecDraft() != null ? mechanismBuild.mechanismSpecDraft().recommendedCandidateKey() : "",
+                    mechanismBuild.mechanismSpecDraft() != null ? mechanismBuild.mechanismSpecDraft().confidenceLevel() : ""
+            );
+        } finally {
+            pipelineTimer.stop(meterRegistry.timer("mds.pipeline.duration"));
+        }
+    }
+
+    private <T> T timeStage(String stage, java.util.function.Supplier<T> supplier) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            T value = supplier.get();
+            meterRegistry.counter("mds.pipeline.stage.success", "stage", stage).increment();
+            return value;
+        } catch (RuntimeException ex) {
+            meterRegistry.counter("mds.pipeline.stage.failure", "stage", stage).increment();
+            throw ex;
+        } finally {
+            sample.stop(meterRegistry.timer("mds.pipeline.stage.duration", "stage", stage));
         }
     }
 

--- a/mds/src/main/resources/application.yml
+++ b/mds/src/main/resources/application.yml
@@ -9,12 +9,16 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,metrics
 
 mds:
   loop-enabled: true
   loop-interval-ms: 15000
   poll-limit: 5
+  search:
+    timeout-ms: ${MDS_SEARCH_TIMEOUT_MS:5000}
+    retry-max-attempts: ${MDS_SEARCH_RETRY_MAX_ATTEMPTS:2}
+    retry-backoff-ms: ${MDS_SEARCH_RETRY_BACKOFF_MS:250}
   backend:
     base-url: ${MDS_BACKEND_BASE_URL:http://localhost:8080}
     worker-id: ${MDS_WORKER_ID:mds-worker-local}

--- a/mds/src/test/java/com/marketinghub/mds/search/SearchExecutionServiceTest.java
+++ b/mds/src/test/java/com/marketinghub/mds/search/SearchExecutionServiceTest.java
@@ -1,0 +1,91 @@
+package com.marketinghub.mds.search;
+
+import com.marketinghub.mds.config.MdsProperties;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SearchExecutionServiceTest {
+
+    @Test
+    void shouldRetryAndSucceedWhenSourceFailsOnce() {
+        AtomicInteger attempts = new AtomicInteger();
+        EvidenceSearchClient flakyClient = new EvidenceSearchClient() {
+            @Override
+            public String source() {
+                return "pubmed";
+            }
+
+            @Override
+            public List<SourceSearchHit> search(String query, int limit) {
+                if (attempts.getAndIncrement() == 0) {
+                    throw new RuntimeException("temporary timeout");
+                }
+                return List.of(new SourceSearchHit(
+                        "pubmed",
+                        "pubmed:1",
+                        null,
+                        "title",
+                        null,
+                        "https://pubmed.ncbi.nlm.nih.gov/1/",
+                        "2024",
+                        null,
+                        true,
+                        true,
+                        true,
+                        List.of()
+                ));
+            }
+        };
+
+        SearchExecutionService service = new SearchExecutionService(List.of(flakyClient), properties());
+
+        List<SourceSearchHit> hits = service.execute(List.of(new SearchQueryPlan("pubmed", "query", 5)));
+
+        assertThat(hits).hasSize(1);
+        assertThat(attempts.get()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldFailPredictablyWhenAllSourcesFail() {
+        EvidenceSearchClient alwaysFailingPubmed = failingClient("pubmed");
+        EvidenceSearchClient alwaysFailingCrossref = failingClient("crossref");
+
+        SearchExecutionService service = new SearchExecutionService(
+                List.of(alwaysFailingPubmed, alwaysFailingCrossref),
+                properties()
+        );
+
+        assertThatThrownBy(() -> service.execute(List.of(
+                new SearchQueryPlan("pubmed", "q1", 3),
+                new SearchQueryPlan("crossref", "q2", 3)
+        )))
+                .isInstanceOf(RecoverableSourceException.class)
+                .hasMessageContaining("all configured sources failed");
+    }
+
+    private EvidenceSearchClient failingClient(String source) {
+        return new EvidenceSearchClient() {
+            @Override
+            public String source() {
+                return source;
+            }
+
+            @Override
+            public List<SourceSearchHit> search(String query, int limit) {
+                throw new RuntimeException("network down");
+            }
+        };
+    }
+
+    private MdsProperties properties() {
+        MdsProperties props = new MdsProperties();
+        props.getSearch().setRetryMaxAttempts(2);
+        props.getSearch().setRetryBackoffMs(0);
+        return props;
+    }
+}

--- a/mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
+++ b/mds/src/test/java/com/marketinghub/mds/service/MechanismDiscoveryPipelineServiceTest.java
@@ -4,10 +4,10 @@ import com.marketinghub.mds.client.BackendMdsClient;
 import com.marketinghub.mds.dto.BackendArtifactPublishBatchResponseDto;
 import com.marketinghub.mds.dto.BackendMdsRequestDto;
 import com.marketinghub.mds.search.*;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -42,8 +42,24 @@ class MechanismDiscoveryPipelineServiceTest {
     @Mock
     private DiscoveryReportBuilder discoveryReportBuilder;
 
-    @InjectMocks
     private MechanismDiscoveryPipelineService service;
+
+    private MechanismDiscoveryPipelineService newService() {
+        return new MechanismDiscoveryPipelineService(
+                backendMdsClient,
+                mechanismQuestionBuilder,
+                searchQueryPlanBuilder,
+                searchExecutionService,
+                sourceDedupService,
+                evidenceScreeningService,
+                evidenceConfidenceService,
+                evidenceItemBuilder,
+                mechanismCandidateBuilder,
+                practicalKnowledgePackBuilder,
+                discoveryReportBuilder,
+                new SimpleMeterRegistry()
+        );
+    }
 
     @Test
     void shouldPublishSourceDocumentsAndEvidenceItemsWithLineage() {
@@ -138,7 +154,7 @@ class MechanismDiscoveryPipelineServiceTest {
                 .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(105L)))
                 .thenReturn(new BackendArtifactPublishBatchResponseDto(10L, 1, List.of(106L)));
 
-        service.execute(request);
+        newService().execute(request);
 
         ArgumentCaptor<com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto> batchCaptor =
                 ArgumentCaptor.forClass(com.marketinghub.mds.dto.BackendArtifactPublishBatchRequestDto.class);


### PR DESCRIPTION
### Motivation
- Implementar estritamente a Sprint 7 do MDS (testes, observabilidade e hardening operacional) seguindo os artefatos canônicos e sem antecipar itens da Sprint 8. 
- Melhorar previsibilidade do pipeline frente a falhas transitórias em fontes externas e fornecer telemetria mínima por etapa para diagnóstico operacional.

### Description
- Adicionadas configurações de busca em `MdsProperties` (`mds.search.timeout-ms`, `retry-max-attempts`, `retry-backoff-ms`) e exposto `metrics` no Actuator (`application.yml`).
- Implementados retries controlados e backoff no `SearchExecutionService` com `RecoverableSourceException` quando todas as fontes falham, e timeouts por fonte em `PubmedSearchClient` e `CrossrefSearchClient` (via `SimpleClientHttpRequestFactory`).
- Separação de classes de erro para distinguir falhas recuperáveis vs não recuperáveis com `RecoverableSourceException` e `NonRecoverablePipelineException`, e classificação de `failureStage` no loop em `MdsLoopRunner` (`recoverable_external`, `non_recoverable_pipeline`, `pipeline`).
- Instrumentação de observabilidade no pipeline em `MechanismDiscoveryPipelineService` (métricas por etapa: `mds.pipeline.stage.duration`, `mds.pipeline.stage.success`, `mds.pipeline.stage.failure`, métrica global `mds.pipeline.duration`, e log resumo contendo `requestId`, `market`, `problem`, `desiredOutcome`, `searchSources`, `selectedEvidenceCount`, `mechanismCandidateCount`, `chosenMechanismId`, `confidenceLevel`).
- Testes: novo `SearchExecutionServiceTest` cobrindo retry e falha previsível, e ajuste de `MechanismDiscoveryPipelineServiceTest` para execução com `MeterRegistry`; documentação atualizada com o bloco de registro da Sprint 7 e entrada no protocolo histórico.
- Scope guard: nenhuma alteração de schema de artefatos ou persistência MySQL (backend continua único responsável pelo banco) e nada da Sprint 8 foi implementado.

### Testing
- Executados os testes do módulo MDS com `cd mds && mvn test`, que passaram com sucesso and confirmaram comportamento de retry, tratamento de exceções e execução do pipeline com métricas.
- Executado o contrato de backend `cd backend/ads-service && mvn -Dtest=MdsInternalControllerContractTest test`, que também passou com sucesso para os endpoints internos de MDS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e24c38ad088321aeb4297d0f777c47)