### PR TITLE
Add minimal template traceability metadata to experiment pipeline runtime

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -193,7 +193,7 @@ public class ExperimentPipelineOpenAiClient {
     private final ObjectMapper objectMapper;
     private final WebClient webClient;
     private final boolean enabled;
-    private final Map<String, String> promptTemplates;
+    private final Map<String, PromptTemplate> promptTemplates;
 
     public ExperimentPipelineOpenAiClient(WebClient.Builder builder,
                                           ObjectMapper objectMapper,
@@ -248,10 +248,11 @@ public class ExperimentPipelineOpenAiClient {
             String sectionContent = objectMapper.writeValueAsString(parsed);
             Integer inputTokens = response.usage() != null ? response.usage().effectiveInputTokens() : null;
             Integer outputTokens = response.usage() != null ? response.usage().effectiveOutputTokens() : null;
+            TemplateTrace templateTrace = resolveTemplateTrace(job, effectiveModel);
             return new ExperimentPipelineJobCompletionPayload(
                     sectionContent,
                     objectMapper.writeValueAsString(response),
-                    objectMapper.writeValueAsString(payload),
+                    buildTrackedRequestBodyJson(payload, templateTrace),
                     inputTokens,
                     outputTokens,
                     OpenAiCostEstimator.estimateUsd(effectiveModel, response.usage()));
@@ -489,11 +490,11 @@ public class ExperimentPipelineOpenAiClient {
     }
 
     private String appendSectionTemplate(String basePrompt, String templatePath, ExperimentPipelineJobDto job) {
-        String template = promptTemplates.get(templatePath);
-        if (!StringUtils.hasText(template)) {
+        PromptTemplate template = promptTemplates.get(templatePath);
+        if (template == null || !StringUtils.hasText(template.body())) {
             return basePrompt;
         }
-        return basePrompt + "\n\n" + applyTemplateVariables(template, templateVariables(job));
+        return basePrompt + "\n\n" + applyTemplateVariables(template.body(), templateVariables(job));
     }
 
     private Map<String, String> templateVariables(ExperimentPipelineJobDto job) {
@@ -528,8 +529,8 @@ public class ExperimentPipelineOpenAiClient {
         return resolved;
     }
 
-    private Map<String, String> loadPromptTemplates() {
-        Map<String, String> templates = new LinkedHashMap<>();
+    private Map<String, PromptTemplate> loadPromptTemplates() {
+        Map<String, PromptTemplate> templates = new LinkedHashMap<>();
         List<String> paths = List.of(
                 CAMPAIGN_ANGLE_TEMPLATE_PATH,
                 LANDING_COPY_TEMPLATE_PATH,
@@ -542,18 +543,120 @@ public class ExperimentPipelineOpenAiClient {
         return Map.copyOf(templates);
     }
 
-    private String readPromptTemplate(String path) {
+    private PromptTemplate readPromptTemplate(String path) {
         ClassPathResource resource = new ClassPathResource(path);
         try {
             if (!resource.exists()) {
                 log.warn("Template de prompt não encontrado no classpath: {}", path);
-                return "";
+                return PromptTemplate.empty(path);
             }
-            return StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8).trim();
+            return parsePromptTemplate(path, StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8));
         } catch (IOException ex) {
             log.warn("Falha ao carregar template de prompt {}: {}", path, ex.getMessage());
-            return "";
+            return PromptTemplate.empty(path);
         }
+    }
+
+    private PromptTemplate parsePromptTemplate(String path, String rawTemplate) {
+        if (!StringUtils.hasText(rawTemplate)) {
+            return PromptTemplate.empty(path);
+        }
+        String normalized = rawTemplate.replace("\r\n", "\n");
+        String[] lines = normalized.split("\n", -1);
+        Map<String, String> headerValues = new LinkedHashMap<>();
+        int bodyStartIndex = 0;
+        for (int index = 0; index < lines.length; index++) {
+            String currentLine = lines[index];
+            if (currentLine == null || currentLine.isBlank()) {
+                bodyStartIndex = index + 1;
+                break;
+            }
+            Matcher matcher = Pattern.compile("^\\s*([a-zA-Z_]+)\\s*:\\s*(.+?)\\s*$").matcher(currentLine);
+            if (!matcher.matches()) {
+                bodyStartIndex = index;
+                break;
+            }
+            String key = matcher.group(1).trim().toLowerCase(Locale.ROOT);
+            if (!"template_id".equals(key) && !"template_version".equals(key) && !"artifact_target".equals(key)) {
+                bodyStartIndex = index;
+                break;
+            }
+            headerValues.put(key, matcher.group(2).trim());
+            bodyStartIndex = index + 1;
+        }
+
+        String body = String.join("\n", java.util.Arrays.copyOfRange(lines, bodyStartIndex, lines.length)).trim();
+        String inferredTemplateId = inferTemplateId(path);
+        String templateId = headerValues.getOrDefault("template_id", inferredTemplateId);
+        String templateVersion = headerValues.getOrDefault("template_version", "unknown");
+        String artifactTarget = headerValues.getOrDefault("artifact_target", inferArtifactTarget(path));
+        return new PromptTemplate(path, body, templateId, templateVersion, artifactTarget);
+    }
+
+    private TemplateTrace resolveTemplateTrace(ExperimentPipelineJobDto job, String model) {
+        String path = resolveTemplatePath(job);
+        PromptTemplate template = path != null ? promptTemplates.get(path) : null;
+        if (template == null) {
+            return new TemplateTrace("unknown", "unknown", "unknown", model);
+        }
+        return new TemplateTrace(
+                StringUtils.hasText(template.templateId()) ? template.templateId() : inferTemplateId(path),
+                StringUtils.hasText(template.templateVersion()) ? template.templateVersion() : "unknown",
+                StringUtils.hasText(template.artifactTarget()) ? template.artifactTarget() : inferArtifactTarget(path),
+                model);
+    }
+
+    private String buildTrackedRequestBodyJson(Map<String, Object> payload, TemplateTrace trace) throws IOException {
+        Map<String, Object> tracked = new LinkedHashMap<>();
+        if (payload != null) {
+            tracked.putAll(payload);
+        }
+        tracked.put("templateTrace", Map.of(
+                "template_id", trace.templateId(),
+                "template_version", trace.templateVersion(),
+                "artifact_target", trace.artifactTarget(),
+                "model", trace.model()));
+        return objectMapper.writeValueAsString(tracked);
+    }
+
+    private String resolveTemplatePath(ExperimentPipelineJobDto job) {
+        if (isCampaignAngleSection(job)) {
+            return CAMPAIGN_ANGLE_TEMPLATE_PATH;
+        }
+        if (isLandingCopySection(job)) {
+            return LANDING_COPY_TEMPLATE_PATH;
+        }
+        if (isLandingLayoutSection(job)) {
+            return LANDING_WIREFRAME_TEMPLATE_PATH;
+        }
+        if (isLandingImagePlanningSection(job)) {
+            return LANDING_IMAGE_PLANNING_TEMPLATE_PATH;
+        }
+        if (isLandingHtmlSection(job)) {
+            return LANDING_HTML_TEMPLATE_PATH;
+        }
+        return null;
+    }
+
+    private String inferTemplateId(String path) {
+        if (!StringUtils.hasText(path)) {
+            return "unknown";
+        }
+        int slash = path.lastIndexOf('/');
+        String fileName = slash >= 0 ? path.substring(slash + 1) : path;
+        int dot = fileName.lastIndexOf('.');
+        return dot > 0 ? fileName.substring(0, dot) : fileName;
+    }
+
+    private String inferArtifactTarget(String path) {
+        return switch (path) {
+            case CAMPAIGN_ANGLE_TEMPLATE_PATH -> "campaignAngle";
+            case LANDING_COPY_TEMPLATE_PATH -> "landingPageCopy";
+            case LANDING_WIREFRAME_TEMPLATE_PATH -> "landingPageWireframe";
+            case LANDING_IMAGE_PLANNING_TEMPLATE_PATH -> "landingPageImagePlanning";
+            case LANDING_HTML_TEMPLATE_PATH -> "landingPageHtml";
+            default -> "unknown";
+        };
     }
 
     @SuppressWarnings("unchecked")
@@ -760,5 +863,23 @@ public class ExperimentPipelineOpenAiClient {
             fields.add(matcher.group(2).trim().toLowerCase(Locale.ROOT));
         }
         return fields.toString();
+    }
+
+    private record PromptTemplate(
+            String path,
+            String body,
+            String templateId,
+            String templateVersion,
+            String artifactTarget) {
+        private static PromptTemplate empty(String path) {
+            return new PromptTemplate(path, "", "unknown", "unknown", "unknown");
+        }
+    }
+
+    private record TemplateTrace(
+            String templateId,
+            String templateVersion,
+            String artifactTarget,
+            String model) {
     }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -625,6 +625,78 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(payload.get("model")).isEqualTo("gpt-5.2");
     }
 
+    @Test
+    void storesTemplateTraceInTrackedRequestBodyForLandingCopy() throws Exception {
+        AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(payloadRef)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        ExperimentPipelineJobDto job = new ExperimentPipelineJobDto(
+                UUID.randomUUID(),
+                22L,
+                "landing-page-copy",
+                "gpt-5.2",
+                "prompt",
+                """
+                        {
+                          "model": "gpt-5.2",
+                          "input": [
+                            {"role": "user", "content": "Prompt da landing"}
+                          ]
+                        }
+                        """,
+                Instant.now());
+
+        ExperimentPipelineJobCompletionPayload completionPayload = client.generate(job);
+        Map<String, Object> trackedRequest = MAPPER.readValue(completionPayload.requestBodyJson(), new TypeReference<>() {});
+        @SuppressWarnings("unchecked")
+        Map<String, Object> templateTrace = (Map<String, Object>) trackedRequest.get("templateTrace");
+        assertThat(templateTrace)
+                .containsEntry("template_id", "landing-copy")
+                .containsEntry("template_version", "v1")
+                .containsEntry("artifact_target", "landingPageCopy")
+                .containsEntry("model", "gpt-5.2");
+    }
+
+    @Test
+    void stripsTemplateHeaderFromPromptSentToOpenAi() {
+        AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(payloadRef)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        ExperimentPipelineJobDto job = new ExperimentPipelineJobDto(
+                UUID.randomUUID(),
+                23L,
+                "campaign-angle",
+                "gpt-5.2",
+                "prompt",
+                """
+                        {
+                          "model": "gpt-5.2",
+                          "input": [
+                            {"role": "user", "content": "Prompt base"}
+                          ]
+                        }
+                        """,
+                Instant.now());
+
+        client.generate(job);
+
+        Map<String, Object> payload = payloadRef.get();
+        @SuppressWarnings("unchecked")
+        var input = (java.util.List<Map<String, Object>>) payload.get("input");
+        String userPrompt = String.valueOf(input.get(0).get("content"));
+        assertThat(userPrompt).doesNotContain("template_id:");
+        assertThat(userPrompt).doesNotContain("template_version:");
+        assertThat(userPrompt).doesNotContain("artifact_target:");
+    }
+
     private ExchangeFunction capturePayloadExchange(AtomicReference<Map<String, Object>> payloadRef) {
         return capturePayloadExchange(payloadRef, "{\"content\":\"ok\"}");
     }


### PR DESCRIPTION
### Motivation
- Add minimal versioning and traceability for prompt templates used by the experiment pipeline so each generated artifact records which template and model produced it without changing the pipeline architecture or introducing new services or DB tables.

### Description
- Parse per-template headers (`template_id`, `template_version`, `artifact_target`) when loading files under `prompts/experiment/*` and represent templates as a `PromptTemplate` record in `ExperimentPipelineOpenAiClient`.
- Strip header lines from the prompt body sent to OpenAI and keep header data for runtime tracing via a `TemplateTrace` record resolved per-job section and model.
- Attach trace metadata into the completion payload by adding a `templateTrace` object into the serialized `requestBodyJson` returned in `ExperimentPipelineJobCompletionPayload`, containing `template_id`, `template_version`, `artifact_target` and `model`.
- Implement safe fallbacks when header metadata is absent by inferring `template_id` from filename, `artifact_target` from path, and using `unknown` for missing versions, and add two unit tests covering tracked metadata persistence and header stripping.
- Files changed: `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java` and `ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java`.

### Testing
- Added unit tests `storesTemplateTraceInTrackedRequestBodyForLandingCopy` and `stripsTemplateHeaderFromPromptSentToOpenAi` in `ExperimentPipelineOpenAiClientTest` that validate `templateTrace` persistence and that headers are not sent to OpenAI.
- Attempted to run the ai-worker tests with `cd ai-worker && mvn -s settings.xml test -Dtest=ExperimentPipelineOpenAiClientTest`, but the run failed in this environment due to an unresolved parent POM / network access to the Maven registry, so tests could not be executed here.
- Verified by inspection that all five targeted templates already include the required header fields (`template_id`, `template_version`, `artifact_target`) and therefore no template file edits were necessary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27790214083219671dc1ed4be7ccd)