### PR TITLE
Use markdown list marker for campaign-angle template detection and update test

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -58,7 +58,7 @@ public class ExperimentPipelineOpenAiClient {
     private static final String LANDING_IMAGE_PLANNING_TEMPLATE_PATH = "prompts/experiment/landing-image-planning.md";
     private static final String LANDING_HTML_TEMPLATE_PATH = "prompts/experiment/landing-html.md";
 
-    private static final String CAMPAIGN_ANGLE_MARKER = "primaryPromise,";
+    private static final String CAMPAIGN_ANGLE_MARKER = "- primaryPromise";
     private static final String LANDING_COPY_MARKER = "messageMatchSource,";
     private static final String LANDING_WIREFRAME_MARKER = "variantLayoutId";
     private static final String LANDING_IMAGE_PLANNING_MARKER = "visualDirectionSummary";

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -64,11 +64,11 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("CASE_DATA");
         assertThat(userPrompt).contains("[CASE_DATA_BEGIN]");
         assertThat(userPrompt).contains("OUTPUT_CONTRACT");
-        assertThat(userPrompt).contains("primaryPromise,");
-        assertThat(userPrompt).contains("proofSummary,");
-        assertThat(userPrompt).contains("singleMindedPromise,");
-        assertThat(userPrompt).contains("primaryCTA,");
-        assertThat(userPrompt).contains("landingMatchLine,");
+        assertThat(userPrompt).contains("- primaryPromise");
+        assertThat(userPrompt).contains("- proofSummary");
+        assertThat(userPrompt).contains("- singleMindedPromise");
+        assertThat(userPrompt).contains("- primaryCTA");
+        assertThat(userPrompt).contains("- landingMatchLine");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- The campaign-angle prompt template now lists required fields as markdown bullets (e.g. `- primaryPromise`) so the previous comma-suffixed marker (`primaryPromise,`) no longer matched and caused a unit test to fail.

### Description
- Replace the campaign-angle presence marker from `"primaryPromise,"` to `"- primaryPromise"` in `ExperimentPipelineOpenAiClient` and update the test `prependsGlobalRulesAndCampaignAngleGuidanceForCampaignAngleSection` to assert the new list-form entries.

### Testing
- Attempted to run `cd ai-worker && mvn -s settings.xml -Dtest=ExperimentPipelineOpenAiClientTest test`, but the build failed to resolve the parent POM due to network repository access (`maven.pkg.github.com` / `repo1.maven.org`), so the updated test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e286a1eb1c8321b7502883b8ca0475)