### PR TITLE
Ajusta checagens de consistência da fase 4 em ExperimentPipelineOpenAiClient

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -499,7 +499,7 @@ public class ExperimentPipelineOpenAiClient {
             return check("DELIVERABLE_TO_OUTCOME_LINK", "FAIL",
                     "A landing lista entregáveis sem conectar explicitamente com resultado esperado.");
         }
-        if (deliverableHits > 0 && (outcomeHits < 2 || linkHits < 2)) {
+        if (deliverableHits > 0 && (outcomeHits < 2 || linkHits == 0)) {
             return check("DELIVERABLE_TO_OUTCOME_LINK", "WARN",
                     "A conexão entre entregáveis e resultado existe, mas ainda está fraca.");
         }
@@ -580,8 +580,13 @@ public class ExperimentPipelineOpenAiClient {
         }
         boolean hasPreviewHints = containsAny(document, PREVIEW_TERMS);
         boolean hasBoundImage = document.contains("data-image-section-id=") || document.contains("data-image-binding-key=");
+        boolean hasImageNode = document.contains("<img") || document.contains("<picture")
+                || document.contains("background-image");
         if (hasPreviewHints && !hasBoundImage) {
-            return check("PREVIEW_CONCRETENESS", "FAIL", "Landing promete preview, mas não vincula imagem concreta.");
+            if (hasImageNode) {
+                return check("PREVIEW_CONCRETENESS", "FAIL", "Landing promete preview, mas não vincula imagem concreta.");
+            }
+            return check("PREVIEW_CONCRETENESS", "WARN", "HTML cita preview, porém sem bloco visual verificável.");
         }
         if (!hasPreviewHints && !hasBoundImage) {
             return check("PREVIEW_CONCRETENESS", "WARN", "HTML não evidencia preview visual concreto.");
@@ -667,8 +672,7 @@ public class ExperimentPipelineOpenAiClient {
             return check("ARTIFACT_SCHEMA_COMPATIBILITY", "FAIL",
                     "Artefato " + artifactName + " incompatível com campos obrigatórios: " + String.join(", ", missing) + ".");
         }
-        boolean hasEmptyCollection = requiredFields.stream()
-                .map(artifact::get)
+        boolean hasEmptyCollection = artifact.values().stream()
                 .anyMatch(value -> value instanceof List<?> list && list.isEmpty());
         if (hasEmptyCollection) {
             return check("ARTIFACT_SCHEMA_COMPATIBILITY", "WARN",


### PR DESCRIPTION
### Motivation
- Corrigir regras de avaliação de consistência da fase 4 onde status retornados (`PASS`/`WARN`/`FAIL`) não alinhavam com as expectativas dos testes para copy, CTA, wireframe e preview HTML.
- Evitar falsos `WARN`/`FAIL` quando já existem sinais semânticos suficientes na cópia ou quando o HTML menciona preview sem um bloco visual verificável.

### Description
- Ajusta a regra `DELIVERABLE_TO_OUTCOME_LINK` para só gerar `WARN` quando não houver termos de ligação (`linkHits == 0`) ao invés de exigir um número mínimo de hits de ligação; isso evita rebaixar cópias concretas que já possuem conexão semântica.
- Refinou `evaluatePreviewConcretenessFromHtml` para detectar nós de imagem (`<img`, `<picture`, `background-image`) e somente retornar `FAIL` quando houver nó visual presente sem binding; caso contrário retorna `WARN` quando há menção de preview sem bloco visual verificável.
- Alarga a detecção de coleções vazias em `evaluateArtifactSchemaCompatibility` para inspecionar todas as coleções top-level do artefato (usando `artifact.values()`), sinalizando `WARN` se qualquer coleção estiver vazia.

### Testing
- Tentativa de rodar testes unitários relevantes com `cd ai-worker && mvn -q -Dtest=ExperimentPipelineOpenAiClientTest#computesPhase4ChecksWithFailForGenericOfferAndVagueCta,ExperimentPipelineOpenAiClientTest#computesPhase4ChecksWithPassForConcreteCopy,ExperimentPipelineOpenAiClientTest#computesPhase4ChecksWithWarnAndFailAcrossWireframeImagePlanningAndHtml test` falhou devido a resolução de dependência privada (`com.marketinghub:ads-service`) retornando 401 no GitHub Packages; portanto os testes não puderam ser executados neste ambiente.
- As mudanças implementadas foram projetadas para alinhar o comportamento com as expectativas observadas nos relatórios de teste que apontavam divergências de status na classe `ExperimentPipelineOpenAiClientTest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28c88d6648321af09243a98a21261)