### PR TITLE
Add GitHub Actions workflow and deploy script to build and deploy MCP server

### DIFF
--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -1,0 +1,90 @@
+name: MCP Server - Build and Deploy
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "mcp-server/**"
+      - "deploy/**"
+      - ".github/workflows/mcp-server.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-mcp-server-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MCP_VPS_IP: 191.252.210.83
+  VPS_USER: root
+  DEPLOY_DIR: /opt/marketinghub/containers
+  MCP_IMAGE: marketinghub-mcp-server
+
+permissions:
+  contents: read
+
+jobs:
+  mcp-image:
+    name: MCP - build image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Run unit tests
+        working-directory: mcp-server
+        run: mvn -B -s settings.xml test
+
+      - name: Build Docker image
+        run: docker build -f mcp-server/Dockerfile -t ${MCP_IMAGE}:${{ github.sha }} mcp-server
+
+      - name: Save image as artifact
+        run: docker save ${MCP_IMAGE}:${{ github.sha }} -o mcp-server-image.tar
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: mcp-server-image
+          path: mcp-server-image.tar
+          retention-days: 1
+
+  deploy-mcp:
+    name: Deploy MCP server
+    runs-on: ubuntu-latest
+    needs: [mcp-image]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download MCP image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: mcp-server-image
+          path: artifacts
+
+      - name: Add SSH key
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.VPS_SSH_CHAVE }}
+
+      - name: Add MCP VPS to known_hosts
+        run: ssh-keyscan -4 -p 22 -t rsa,ecdsa,ed25519 -H ${MCP_VPS_IP} >> ~/.ssh/known_hosts
+
+      - name: Copy deployment descriptors
+        run: |
+          ssh ${VPS_USER}@${MCP_VPS_IP} "mkdir -p ${DEPLOY_DIR}"
+          rsync -az --delete deploy/ ${VPS_USER}@${MCP_VPS_IP}:${DEPLOY_DIR}/
+
+      - name: Upload MCP image to VPS
+        run: scp artifacts/mcp-server-image.tar ${VPS_USER}@${MCP_VPS_IP}:/tmp/mcp-server-image.tar
+
+      - name: Apply MCP stack
+        env:
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          ssh ${VPS_USER}@${MCP_VPS_IP} "chmod +x ${DEPLOY_DIR}/bin/apply-mcp-only.sh"
+          ssh ${VPS_USER}@${MCP_VPS_IP} \
+            "IMAGE_TAG=${GIT_SHA} MCP_TAR=/tmp/mcp-server-image.tar MCP_IMAGE=${MCP_IMAGE} DEPLOY_DIR=${DEPLOY_DIR} /bin/bash ${DEPLOY_DIR}/bin/apply-mcp-only.sh"

--- a/deploy/bin/apply-mcp-only.sh
+++ b/deploy/bin/apply-mcp-only.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEPLOY_DIR=${DEPLOY_DIR:-/opt/marketinghub/containers}
+MCP_TAR=${MCP_TAR:-/tmp/mcp-server-image.tar}
+MCP_IMAGE=${MCP_IMAGE:-marketinghub-mcp-server}
+IMAGE_TAG=${IMAGE_TAG:-latest}
+
+mkdir -p "${DEPLOY_DIR}"
+cd "${DEPLOY_DIR}"
+
+if [[ -f "${MCP_TAR}" ]]; then
+  docker load -i "${MCP_TAR}"
+fi
+
+if [[ "${IMAGE_TAG}" != "latest" ]]; then
+  if docker image inspect "${MCP_IMAGE}:${IMAGE_TAG}" >/dev/null 2>&1; then
+    docker tag "${MCP_IMAGE}:${IMAGE_TAG}" "${MCP_IMAGE}:latest"
+  else
+    echo "[apply-mcp-only.sh] Aviso: imagem ${MCP_IMAGE}:${IMAGE_TAG} não encontrada; mantendo latest atual." >&2
+  fi
+fi
+
+cleanup_previous_tags() {
+  local repository="$1"
+  local keep_tag="$2"
+
+  docker image ls "${repository}" --format '{{.Repository}}:{{.Tag}}' \
+    | awk -F':' -v keep_tag="${keep_tag}" '$2 != "<none>" && $2 != keep_tag {print $0}' \
+    | xargs -r docker image rm >/dev/null 2>&1 || true
+}
+
+# Atualiza somente o MCP Server sem reiniciar outros serviços.
+MCP_SERVER_IMAGE="${MCP_IMAGE}" \
+MCP_SERVER_IMAGE_TAG=latest \
+docker compose up -d --no-deps mcp-server
+
+cleanup_previous_tags "${MCP_IMAGE}" "latest"
+
+docker image prune -f >/dev/null 2>&1 || true
+rm -f "${MCP_TAR}" >/dev/null 2>&1 || true


### PR DESCRIPTION
### Motivation
- Automate building, testing and packaging of the MCP server Docker image and streamline deployment to the VPS. 
- Provide a repeatable CI pipeline that uploads a saved Docker image artifact for remote deployment. 
- Enable applying MCP-only updates on the target host without restarting unrelated services.

### Description
- Add a new workflow `mcp-server.yml` that builds the MCP server image, runs Maven unit tests using `mvn -B -s settings.xml test`, saves the image with `docker save`, and uploads it as an artifact. 
- Add a deploy job that downloads the image artifact, sets up SSH (`webfactory/ssh-agent`), syncs `deploy/` descriptors with `rsync`, copies the tarball to the VPS, and invokes a remote deployment script with environment variables including `IMAGE_TAG` and `MCP_IMAGE`. 
- Add `deploy/bin/apply-mcp-only.sh` which loads the uploaded image, retags the image to `latest` if present, runs `docker compose up -d --no-deps mcp-server` to update only the MCP service, cleans up old image tags, and prunes images.

### Testing
- No automated tests were executed as part of this PR itself; the workflow configures the CI to run `mvn -B -s settings.xml test` in the `mcp-image` job when the workflow runs. 
- The workflow also includes artifact upload/download (`actions/upload-artifact` / `actions/download-artifact`) and SSH/rsync/scp steps that will be exercised by the CI deployment job when triggered. 
- The deployment script contains defensive checks and uses `set -euo pipefail` to fail fast during automated runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2897cd0b48321aee88a494a49ad88)