### PR TITLE
Fix compilation error in McpController tool name parsing

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -79,7 +79,8 @@ public class McpController {
             return error(id, -32602, "Invalid params");
         }
 
-        String toolName = String.valueOf(params.getOrDefault("name", ""));
+        Object toolNameValue = params.get("name");
+        String toolName = toolNameValue == null ? "" : String.valueOf(toolNameValue);
         if (!"db_health".equals(toolName)) {
             return error(id, -32602, "Unknown tool: " + toolName);
         }


### PR DESCRIPTION
### Motivation
- Fix a Java compilation failure in `McpController` caused by using `getOrDefault` on a `Map<?, ?>`, which produced a wildcard-capture error (`java.lang.String cannot be converted to capture#1 of ?`).

### Description
- Replace `params.getOrDefault("name", "")` with a null-safe read (`Object toolNameValue = params.get("name"); String toolName = toolNameValue == null ? "" : String.valueOf(toolNameValue);`) to avoid wildcard capture while preserving existing behavior.

### Testing
- Ran `cd mcp-server && mvn -s settings.xml test` but the build could not complete because Maven failed to download the Spring Boot parent POM from Maven Central due to network unreachability, so automated tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29a7662d083219b637ad63d8f5df4)