### PR TITLE
Fix phase-4 outcome link check for concrete landing copy

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -91,7 +91,8 @@ public class ExperimentPipelineOpenAiClient {
     private static final List<String> CONCRETE_DELIVERABLE_TERMS = List.of(
             "checklist", "template", "roteiro", "guia", "planilha", "pdf", "video", "vídeo", "análise", "analise", "exemplo", "script", "modelo");
     private static final List<String> OUTCOME_TERMS = List.of(
-            "resultado", "reduz", "aumenta", "convers", "econom", "evita", "ganha", "melhor", "cresce", "escala");
+            "resultado", "reduz", "reduzir", "aumenta", "aumentar", "convers", "conversão", "conversao",
+            "econom", "evita", "ganha", "melhor", "cresce", "escala");
     private static final List<String> LINK_TERMS = List.of(
             "para", "assim", "isso", "porque", "com isso", "de forma", "ajuda");
     private static final Set<String> VAGUE_CTA_LABELS = Set.of(


### PR DESCRIPTION
### Motivation
- Phase-4 consistency heuristics could produce a false `WARN` for `DELIVERABLE_TO_OUTCOME_LINK` when generated Portuguese copy used common inflections/accents (e.g. infinitives or "conversão"), so the outcome-term detector needed to recognize those variants.

### Description
- Expanded the `OUTCOME_TERMS` list in `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java` to include additional Portuguese variants (`reduzir`, `aumentar`, `conversão`, `conversao`) so the `DELIVERABLE_TO_OUTCOME_LINK` check better detects outcome mentions.

### Testing
- Attempted to run `cd ai-worker && mvn -s settings.xml -Dtest=ExperimentPipelineOpenAiClientTest test`, but the build could not start because Maven failed to resolve the parent POM due to network/unreachable repository, so no test execution completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29aa325b083218a8190c20a77f836)