### PR TITLE
Add Nginx reverse-proxy and docker-compose deployment docs for MCP server

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -30,6 +30,8 @@ mvn -s settings.xml spring-boot:run
 
 ## Docker
 
+### Apenas o container do MCP (desenvolvimento/local)
+
 ```bash
 docker build -t marketinghub/mcp-server .
 docker run --rm -p 8096:8096 \
@@ -39,6 +41,29 @@ docker run --rm -p 8096:8096 \
   -e MCP_API_KEY=<token-forte> \
   marketinghub/mcp-server
 ```
+
+### MCP + Nginx (VPS em HTTP porta 80)
+
+O `docker-compose.yml` deste diretório sobe dois containers:
+
+- `mcp-server` (interno, exposto apenas na rede Docker em `8096`);
+- `nginx` (público, escutando na porta `80` e fazendo proxy para o MCP).
+
+```bash
+cd mcp-server
+docker compose up -d --build
+```
+
+Depois, valide:
+
+```bash
+curl -i http://mcpserverdigi.shop/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <MCP_API_KEY>' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+```
+
+Quando o certificado estiver pronto, basta ajustar o Nginx para `443` e redirecionar `80 -> 443`.
 
 ## Configuração no Codex Cloud (Plugin MCP)
 

--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -5,11 +5,23 @@ services:
       context: .
       dockerfile: Dockerfile
     image: marketinghub/mcp-server:latest
+    restart: unless-stopped
     environment:
       SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC}
       SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME:-marketing_hub_user}
       SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD:-${MYSQL_PASS:-}}
       MCP_SERVER_NAME: ${MCP_SERVER_NAME:-marketing-hub-mcp}
       MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}
+    expose:
+      - "8096"
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: marketinghub-mcp-nginx
+    restart: unless-stopped
+    depends_on:
+      - mcp-server
     ports:
-      - "8096:8096"
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro

--- a/mcp-server/nginx/default.conf
+++ b/mcp-server/nginx/default.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name mcpserverdigi.shop www.mcpserverdigi.shop;
+
+    location / {
+        proxy_pass http://mcp-server:8096;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a simple VPS-ready deployment that exposes the MCP endpoint on HTTP/80 behind Nginx as a reverse proxy.  
- Keep a local/development option to run only the MCP container without public exposure.  
- Improve operability with a restart policy and example Nginx configuration for common production setups.

### Description

- Added an `nginx` service to `mcp-server/docker-compose.yml`, switched `mcp-server` to use `expose: 8096` and added `restart: unless-stopped`, and mapped public port `80` on the Nginx container.  
- Added `mcp-server/nginx/default.conf` with a basic proxy configuration routing `/:` to `http://mcp-server:8096` and passing common proxy headers.  
- Expanded `mcp-server/README.md` with two deployment options: single-container development run and `MCP + Nginx (VPS in HTTP port 80)` using `docker compose up -d --build`, plus example `curl` checks and notes about switching to `443` when adding TLS.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29e45186c83219e1e9664841c2088)