### PR TITLE
Fix landing HTML surfaceSpec validation for unquoted data attributes

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -66,7 +66,8 @@ public class ExperimentPipelineGenerationService {
     private static final Pattern FORM_DATA_PATTERN = Pattern.compile("(?is)new\\s+FormData\\s*\\(\\s*form\\s*\\)");
     private static final Pattern SUBMIT_DISABLE_PATTERN = Pattern.compile("(?is)submitButton\\.disabled\\s*=\\s*true");
     private static final Pattern SUBMIT_ENABLE_PATTERN = Pattern.compile("(?is)submitButton\\.disabled\\s*=\\s*false");
-    private static final Pattern ATTRIBUTE_PATTERN = Pattern.compile("(?is)([a-zA-Z_:][-a-zA-Z0-9_:.]*)\\s*=\\s*([\"'])(.*?)\\2");
+    private static final Pattern ATTRIBUTE_PATTERN = Pattern.compile(
+            "(?is)([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\\s*=\\s*(?:\"([^\"]*)\"|'([^']*)'|([^\\s\"'=<>`]+)))?");
     private static final Pattern OPENING_TAG_PATTERN = Pattern.compile("(?is)<([a-z0-9:-]+)\\b[^>]*>");
     private static final Pattern IMG_TAG_PATTERN = Pattern.compile("(?is)<img\\b[^>]*>");
     private static final String DEFAULT_MODEL = "gpt-5.2";
@@ -2411,7 +2412,14 @@ public class ExperimentPipelineGenerationService {
         Map<String, String> attrs = new LinkedHashMap<>();
         Matcher matcher = ATTRIBUTE_PATTERN.matcher(tag);
         while (matcher.find()) {
-            attrs.put(matcher.group(1).toLowerCase(Locale.ROOT), matcher.group(3));
+            String value = matcher.group(2);
+            if (value == null) {
+                value = matcher.group(3);
+            }
+            if (value == null) {
+                value = matcher.group(4);
+            }
+            attrs.put(matcher.group(1).toLowerCase(Locale.ROOT), value == null ? "" : value);
         }
         return attrs;
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -356,6 +356,30 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void completeJobAcceptsHtmlWhenSurfaceAttributesAreUnquoted() {
+        Experiment experiment = buildLandingHtmlValidationExperiment(206L);
+        ExperimentPipelineGenerationJob job = createLandingHtmlJob(experiment);
+
+        service.completeJob(job.getId(), landingHtmlCompletionRequest("""
+                <!doctype html><html><body>
+                <section data-section-id=hero data-surface-token=surface-base data-surface-style=band data-surface-contrast=normal>
+                  <img src='https://cdn.example.com/hero.jpg' alt='Hero'
+                       data-image-section-id='hero'
+                       data-image-binding-key='hero_pain_anchor'
+                       data-image-role='Hero Pain Anchor'
+                       data-conversion-role='grab-attention'
+                       data-attention-priority='high'
+                       data-visual-weight='primary'
+                       data-distance-to-cta='near'
+                       data-supports-form-conversion='true' />
+                  <form id='lead-capture-primary'><input type='text' name='nome' required /><input type='email' name='email' required /><input type='tel' name='whatsapp' /></form>
+                </section></body></html>
+                """));
+
+        assertNotNull(experiment.getLandingPageHtml());
+    }
+
+    @Test
     void completeJobSupportsLegacyFallbackWhenPlanningAndHtmlDoNotSendBindingKey() {
         Experiment experiment = buildLandingHtmlValidationExperiment(205L);
         experiment.setLandingPageImagePlanning("""


### PR DESCRIPTION
### Motivation
- Landing HTML validation was producing HTTP 422 (`Divergência de superfície`) when the HTML contained valid but unquoted `data-*` attributes, because the attribute parser only extracted quoted values.
- The change increases robustness to equivalent HTML syntax variants emitted by generators while keeping the canonical artifact contract unchanged (`landingPageWireframe.sectionOrder.surfaceSpec`).

### Description
- Updated the HTML attribute regex (`ATTRIBUTE_PATTERN`) in `ExperimentPipelineGenerationService` to accept double-quoted, single-quoted, unquoted values and valueless boolean-style attributes via `ATTRIBUTE_PATTERN` and adjusted parsing accordingly in `parseHtmlAttributes`.
- Made `parseHtmlAttributes` read the correct regex capture groups and return empty string for valueless attributes to preserve presence semantics.
- Added a regression unit test `completeJobAcceptsHtmlWhenSurfaceAttributesAreUnquoted` in `ExperimentPipelineGenerationServiceTest` to verify `landing-page-html` completion succeeds when `data-surface-*` attributes are unquoted.
- Modified files: `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java` and `backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java`.

### Testing
- Ran targeted test command `cd backend/ads-service && mvn -s ../settings.xml -Dtest=ExperimentPipelineGenerationServiceTest test` but the run failed due to environment dependency resolution (`Network is unreachable` resolving parent POM), so tests could not be executed here.
- Added the new unit test which should pass in CI/local environments with network access and proper Maven settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a40bd8c48321acf77524c7a866b3)