### PR TITLE
Corrige duplicidade no funil ao filtrar eventos manuais

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelEventRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelEventRepository.java
@@ -29,13 +29,12 @@ public interface ExperimentFunnelEventRepository extends JpaRepository<Experimen
                    max(e.occurredAt) as lastEvent
             from ExperimentFunnelEvent e
             where e.experiment.id = :experimentId
-              and (e.source is null or e.source <> :excludedSource)
+              and (e.source is null or lower(trim(e.source)) = 'manual')
               and (:baseline is null or e.occurredAt > :baseline)
             group by e.stage
             """)
-    List<StageAggregation> aggregateByExperiment(@Param("experimentId") Long experimentId,
-                                                 @Param("excludedSource") String excludedSource,
-                                                 @Param("baseline") Instant baseline);
+    List<StageAggregation> aggregateManualByExperiment(@Param("experimentId") Long experimentId,
+                                                       @Param("baseline") Instant baseline);
 
     @Modifying
     @Query("delete from ExperimentFunnelEvent e where e.experiment.id = :experimentId")

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -190,10 +190,7 @@ public class ExperimentFunnelService {
     }
 
     private void applyManualEvents(Long experimentId, Instant baseline, Map<ExperimentFunnelStage, ExperimentFunnelStageDto> stages) {
-        for (StageAggregation agg : eventRepository.aggregateByExperiment(
-                experimentId,
-                ExperimentFunnelEventRepository.RENDER_COMPLETE_SOURCE,
-                baseline)) {
+        for (StageAggregation agg : eventRepository.aggregateManualByExperiment(experimentId, baseline)) {
             ExperimentFunnelStageDto dto = stages.get(agg.getStage());
             if (dto == null) {
                 continue;

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -186,9 +186,8 @@ export default function ExperimentFunnelTab({
           <div>
             <h5 className="card-title mb-1">Funil de vendas do experimento</h5>
             <p className="text-muted small mb-0">
-              Cada etapa consolida dados automáticos (Facebook Ads, Lead Portal e
-              e-mails) e eventos manuais, para dar visibilidade ao avanço das
-              leads no experimento.
+              Cada etapa consolida os eventos da jornada (anúncios, Lead Portal e
+              e-mails) para dar visibilidade ao avanço das leads no experimento.
             </p>
           </div>
           <button


### PR DESCRIPTION
### Motivation
- O funil estava duplicando contagens porque eventos automáticos acabavam sendo somados como manuais, e a distinção manual/automático na UI não é mais necessária.

### Description
- Atualiza `ExperimentFunnelEventRepository` adicionando `aggregateManualByExperiment` que filtra apenas eventos com `e.source` nulo ou igual a `'manual'` (após `lower(trim(...))`).
- Altera `ExperimentFunnelService` para usar `aggregateManualByExperiment` ao aplicar eventos manuais, evitando somar novamente métricas automáticas no `totalCount`.
- Simplifica o texto da tela em `ExperimentFunnelTab.tsx` para remover a menção explícita de "automático + manual" e refletir a visão consolidada da jornada.
- Arquivos modificados: `backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelEventRepository.java`, `backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java`, `frontend/src/pages/experiment/ExperimentFunnelTab.tsx`.

### Testing
- Executei os testes unitários backend com `cd backend/ads-service && mvn -q -Dtest=ExperimentFunnelServiceSubmissionTest,ExperimentFunnelServiceRenderCompleteTest,ExperimentFunnelDiagnosticServiceTest test` e os testes passaram.
- Tentei rodar o teste frontend com `cd frontend && npm run test -- ExperimentFunnelTab.test.tsx` mas ele falhou no ambiente porque o `vitest` não está disponível no `PATH`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2c90b54a08321b08d1fe94622efcb)