### PR TITLE
Serve standalone flow pages and expose standalone URL in admin UI

### DIFF
--- a/frontend/src/pages/experiment/LeadPortalFlowTab.tsx
+++ b/frontend/src/pages/experiment/LeadPortalFlowTab.tsx
@@ -1,7 +1,10 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import type { Experiment } from "../../api/experiment/useExperiments";
-import { useLeadPortalFlows } from "../../api/leadPortal/useLeadPortalFlows";
+import {
+  useLeadPortalFlows,
+  type LeadPortalFlow,
+} from "../../api/leadPortal/useLeadPortalFlows";
 import { useUpdateLeadPortalFlowApproval } from "../../api/leadPortal/useUpdateLeadPortalFlowApproval";
 import { useRequestLeadPortalFlows } from "../../api/experiment/useRequestLeadPortalFlows";
 import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
@@ -189,6 +192,7 @@ export default function LeadPortalFlowTab({
               pendingAssignmentId === flow.id ||
               (pendingAssignmentId === 0 && flow.id === assignedFlowId);
             const activeViewport = previewViewportByFlow[flow.id] ?? "desktop";
+            const standaloneFlowUrl = buildStandaloneFlowUrl(flow);
             return (
               <div key={flow.id} className="card border-0 shadow-sm">
                 <div className="card-body">
@@ -227,6 +231,18 @@ export default function LeadPortalFlowTab({
                             rel="noopener noreferrer"
                           >
                             {flow.publicUrl}
+                          </a>
+                        </p>
+                      ) : null}
+                      {standaloneFlowUrl ? (
+                        <p className="text-muted small mt-1 mb-0">
+                          URL standalone (sem fetch no frontend):{" "}
+                          <a
+                            href={standaloneFlowUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {standaloneFlowUrl}
                           </a>
                         </p>
                       ) : null}
@@ -520,6 +536,28 @@ function renderPreviewField(
         />
       );
   }
+}
+
+function buildStandaloneFlowUrl(flow: LeadPortalFlow): string | null {
+  const slug = flow.slug?.trim();
+  if (!slug) {
+    return null;
+  }
+
+  if (flow.publicUrl) {
+    try {
+      const parsed = new URL(flow.publicUrl);
+      return `${parsed.origin}/api/flows/${encodeURIComponent(slug)}/page`;
+    } catch {
+      // fallback para ambiente local ou URL parcial
+    }
+  }
+
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return `${window.location.origin}/api/flows/${encodeURIComponent(slug)}/page`;
+  }
+
+  return null;
 }
 
 function formatDate(value?: string | null) {

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/FlowController.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/FlowController.java
@@ -9,8 +9,11 @@ import com.marketinghub.leadportal.model.SimpleFormStyle;
 import com.marketinghub.leadportal.service.FlowService;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -64,6 +67,23 @@ public class FlowController {
         return FlowResponse.from(flowService.getAndTrackAccess(slug, accessMetadata));
     }
 
+    @GetMapping(value = "/{slug}/page", produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<String> getStandaloneFlowPage(
+            @PathVariable("slug") String slug,
+            HttpServletRequest request) {
+        FlowAccessMetadata accessMetadata = FlowAccessMetadata.from(request);
+        Flow flow = flowService.getAndTrackAccess(slug, accessMetadata);
+        String html = flow.customFormHtml();
+        if (!isStandaloneHtmlDocument(html)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .contentType(MediaType.TEXT_PLAIN)
+                    .body("Fluxo não possui HTML standalone.");
+        }
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_HTML)
+                .body(html);
+    }
+
     @DeleteMapping("/{slug}")
     public ResponseEntity<Void> deleteFlow(@PathVariable("slug") String slug) {
         flowService.delete(slug);
@@ -89,5 +109,15 @@ public class FlowController {
                 request.getDescription(),
                 request.getPlaceholder(),
                 options);
+    }
+
+    private boolean isStandaloneHtmlDocument(String html) {
+        if (html == null) {
+            return false;
+        }
+        String normalized = html.trim().toLowerCase(Locale.ROOT);
+        return normalized.startsWith("<!doctype")
+                || normalized.startsWith("<html")
+                || normalized.startsWith("<body");
     }
 }

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
@@ -240,6 +240,38 @@ class FlowControllerTest {
                 .andExpect(jsonPath("$.customFormRenderMode").value("STANDALONE_PAGE"));
     }
 
+    @Test
+    void getStandaloneFlowPageReturnsHtmlDocumentWithoutJsonFetch() throws Exception {
+        UpsertFlowRequest request = buildRequest();
+        request.setCustomFormHtml("{\"landingPageHtml\":{\"htmlDocument\":\"<!doctype html><html><body>Landing direta</body></html>\"}}");
+
+        mockMvc.perform(put("/api/flows/landing-direta")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/flows/landing-direta/page"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(content().string(containsString("<body>Landing direta</body>")));
+    }
+
+    @Test
+    void getStandaloneFlowPageReturnsConflictWhenFlowUsesIframeHtml() throws Exception {
+        UpsertFlowRequest request = buildRequest();
+        request.setCustomFormHtml("<section>Flow em iframe</section>");
+
+        mockMvc.perform(put("/api/flows/flow-iframe")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/flows/flow-iframe/page"))
+                .andExpect(status().isConflict())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+                .andExpect(content().string(containsString("HTML standalone")));
+    }
+
     private UpsertFlowRequest buildRequest() {
         FlowQuestionRequest question = new FlowQuestionRequest();
         question.setTitle("Qual o seu nome?");

--- a/lead-portal/frontend/src/pages/FlowPage.tsx
+++ b/lead-portal/frontend/src/pages/FlowPage.tsx
@@ -67,7 +67,8 @@ export default function FlowPage() {
   const customTemplateFormSpec = customTemplatePayload?.formSpec;
   const hasCustomTemplate = Boolean(customTemplateHtml);
   const shouldRenderStandaloneTemplate =
-    hasCustomTemplate && Boolean(customTemplateHtml) && flow?.customFormRenderMode === "STANDALONE_PAGE";
+    hasCustomTemplate &&
+    shouldRenderCustomTemplateAsStandalone(flow?.customFormRenderMode, customTemplateHtml);
   const customTemplateVariables = useMemo(() => {
     if (!hasCustomTemplate || !flow) {
       return null;
@@ -308,6 +309,23 @@ interface CustomFlowTemplateProps {
 }
 
 const TOKEN_REGEX = /\{\{\s*([a-zA-Z0-9_-]+)\s*\}\}/g;
+const STANDALONE_HTML_HINT = /^\s*(?:<!doctype|<html|<body)/i;
+
+function shouldRenderCustomTemplateAsStandalone(
+  customFormRenderMode?: "IFRAME" | "STANDALONE_PAGE" | null,
+  html?: string | null,
+): boolean {
+  if (customFormRenderMode === "STANDALONE_PAGE") {
+    return true;
+  }
+  if (customFormRenderMode === "IFRAME") {
+    return false;
+  }
+  if (!html) {
+    return false;
+  }
+  return STANDALONE_HTML_HINT.test(html);
+}
 
 function CustomFlowTemplate({
   html,


### PR DESCRIPTION
### Motivation
- Allow lead-portal flows that contain a full HTML document to be served directly as standalone pages without requiring JSON fetch/rendering in the frontend. 
- Make it easy for admins to open a standalone flow page from the experiment UI. 
- Prevent serving iframe/fragment HTML as a standalone page and return a clear error when requested.

### Description
- Backend: added `GET /api/flows/{slug}/page` which returns the stored `customFormHtml` as `text/html` when it is a standalone document, otherwise returns `409 Conflict` with a plain text message; introduced `isStandaloneHtmlDocument` helper to detect full HTML documents. 
- Frontend (lead-portal): added `shouldRenderCustomTemplateAsStandalone` in `FlowPage.tsx` to decide standalone rendering based on `customFormRenderMode` and an HTML heuristic, and used it to control `shouldRenderStandaloneTemplate`. 
- Frontend (admin UI): added `buildStandaloneFlowUrl` and display of a `URL standalone (sem fetch no frontend)` link in `LeadPortalFlowTab.tsx` so admins can open the direct standalone page for a flow. 
- Tests: added integration/unit tests in `FlowControllerTest` to verify successful HTML responses for standalone documents and `409` responses for non-standalone HTML.

### Testing
- Ran the backend unit tests including `FlowControllerTest`, and the new tests `getStandaloneFlowPageReturnsHtmlDocumentWithoutJsonFetch` and `getStandaloneFlowPageReturnsConflictWhenFlowUsesIframeHtml` passed. 
- Performed a frontend TypeScript build/typecheck and local dev build to ensure the new helpers compile and the admin UI renders the standalone link successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2c84e8f7c83218a15bb6fbdc1631a)