### PR TITLE
Set experiment followUpActionUrl when assigning lead portal flow

### DIFF
--- a/frontend/src/pages/experiment/LeadPortalFlowTab.tsx
+++ b/frontend/src/pages/experiment/LeadPortalFlowTab.tsx
@@ -60,7 +60,7 @@ export default function LeadPortalFlowTab({
     });
   };
 
-  const handleAssignFlow = async (flowId: number | null) => {
+  const handleAssignFlow = async (flow: LeadPortalFlow | null) => {
     const kpiTargetValue = experiment.kpiTarget ?? experiment.kpiTargetCpl;
     if (kpiTargetValue == null || experiment.metricPresetId == null) {
       setFeedback({
@@ -70,6 +70,8 @@ export default function LeadPortalFlowTab({
       });
       return;
     }
+    const flowId = flow?.id ?? null;
+    const followUpActionUrl = flow ? buildStandaloneFlowUrl(flow) : null;
     setPendingAssignmentId(flowId ?? 0);
     setFeedback(null);
     try {
@@ -92,7 +94,7 @@ export default function LeadPortalFlowTab({
         facebookPageId: experiment.facebookPage?.id ?? null,
         facebookInstantFormId: experiment.facebookInstantForm?.id ?? null,
         instagramAccountId: experiment.instagramAccount?.id ?? null,
-        followUpActionUrl: experiment.followUpActionUrl ?? null,
+        followUpActionUrl,
         leadPortalFlowId: flowId,
       });
       setFeedback({
@@ -276,7 +278,7 @@ export default function LeadPortalFlowTab({
                       <button
                         type="button"
                         className="btn btn-primary btn-sm"
-                        onClick={() => handleAssignFlow(flow.id)}
+                        onClick={() => handleAssignFlow(flow)}
                         disabled={isAssigning || updateExperiment.isPending}
                       >
                         {isAssigning || updateExperiment.isPending ? (


### PR DESCRIPTION
### Motivation

- Ensure the experiment's `followUpActionUrl` is set to the selected lead portal flow's standalone URL when assigning or unassigning a flow. 
- Accept the full `LeadPortalFlow` object in the assign handler to derive both the `leadPortalFlowId` and the `followUpActionUrl` instead of only the flow id.

### Description

- Updated `frontend/src/pages/experiment/LeadPortalFlowTab.tsx` to change the `handleAssignFlow` signature from accepting a `flowId` to accepting a `LeadPortalFlow | null` object. 
- Compute `flowId` and `followUpActionUrl` inside `handleAssignFlow` using `flow?.id` and `buildStandaloneFlowUrl(flow)` and include `followUpActionUrl` in the payload sent to `updateExperiment.mutateAsync`. 
- Updated the assign button to pass the full `flow` object (`onClick={() => handleAssignFlow(flow)}`) instead of `flow.id`.

### Testing

- Ran TypeScript build (`yarn build`) to ensure the change type-checks and the build succeeds, which passed. 
- Ran frontend unit tests (`yarn test`), which passed. 
- Ran linting (`yarn lint`) to verify code style, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d23979708321be60e0123f457455)