### PR TITLE
Fix section label casing in hypothesis summary prompts

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisFrameworkGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisFrameworkGenerationService.java
@@ -855,7 +855,7 @@ public class HypothesisFrameworkGenerationService {
         Map<String, String> placeholders = new LinkedHashMap<>();
         placeholders.put("NICHE_NAME", hypothesis.getMarketNiche() != null ? hypothesis.getMarketNiche().getName() : "N/A");
         placeholders.put("HYPOTHESIS_TITLE", nonNull(hypothesis.getTitle()));
-        placeholders.put("SECTION_NAME", section.path());
+        placeholders.put("SECTION_NAME", section.name());
         placeholders.put("SECTION_SNAPSHOT", sectionSnapshot(snapshot, section));
         placeholders.put("CUSTOM_INSTRUCTIONS", StringUtils.hasText(customInstructions) ? customInstructions.trim() : "-");
         placeholders.put("PAIN_JSON", toJson(snapshot.getPain()));


### PR DESCRIPTION
### Motivation
- Unit test `HypothesisFrameworkGenerationServiceTest.generateSummaryOnlyUsesSectionTemplateAndStructuredSummarySchema` expects the prompt to include the section label in uppercase (e.g. `PAIN`), while the implementation used the section `path` (lowercase), causing a test failure.

### Description
- Updated `HypothesisFrameworkGenerationService` to populate the `SECTION_NAME` placeholder with the enum name (`section.name()`) instead of the path (`section.path()`), so generated summary prompts use the expected uppercase section labels (change in `backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisFrameworkGenerationService.java`).

### Testing
- Attempted to run the targeted test with `cd backend/ads-service && mvn -s ../settings.xml -Dtest=HypothesisFrameworkGenerationServiceTest test`, but test execution could not complete due to Maven dependency resolution failing in this environment (`Network is unreachable`) when fetching the parent POM from Maven Central.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4db483a308321b612329ec0f945f3)