### PR TITLE
Centraliza geração IA na hipótese e separa geração de resumo e de item

### DIFF
--- a/frontend/src/components/HypothesisFrameworkTabsView.tsx
+++ b/frontend/src/components/HypothesisFrameworkTabsView.tsx
@@ -436,6 +436,9 @@ export function HypothesisFrameworkTabsView({
     }
   };
 
+  const getSectionLabel = (section: HypothesisFrameworkSection) =>
+    SECTIONS.find((item) => item.id === section)?.label ?? section;
+
   const renderRows = (
     rows: Array<{ label: string; value?: string | null }>,
   ) => (
@@ -697,14 +700,14 @@ export function HypothesisFrameworkTabsView({
                   className="btn btn-outline-primary align-self-start"
                   onClick={() => handleGenerate(section.id)}
                   disabled={generate.isPending}
-                  title="Gera os campos completos desta aba usando o Worker IA."
+                  title={`Gera os campos completos de ${getSectionLabel(section.id)} usando o Worker IA.`}
                 >
                   {pendingSection === section.id && generate.isPending ? (
                     <span className="d-inline-flex align-items-center gap-1">
                       <Loader2 className="icon icon-sm spin" /> Gerando...
                     </span>
                   ) : (
-                    "Gerar com IA"
+                    `Gerar ${getSectionLabel(section.id)} com IA`
                   )}
                 </button>
                 <button
@@ -712,14 +715,14 @@ export function HypothesisFrameworkTabsView({
                   className="btn btn-outline-secondary align-self-start"
                   onClick={() => handleGenerateSummary(section.id)}
                   disabled={generate.isPending}
-                  title="Gera somente o resumo operacional desta aba com o mesmo modelo do framework."
+                  title={`Gera somente o resumo de ${getSectionLabel(section.id)} com o mesmo modelo do framework.`}
                 >
                   {pendingSummarySection === section.id && generate.isPending ? (
                     <span className="d-inline-flex align-items-center gap-1">
                       <Loader2 className="icon icon-sm spin" /> Gerando resumo...
                     </span>
                   ) : (
-                    "Gerar resumo com IA"
+                    `Gerar resumo de ${getSectionLabel(section.id)}`
                   )}
                 </button>
               </div>

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -153,17 +153,6 @@ const SECTION_REQUEST_INITIAL_STATE: Record<
   {} as Record<ContentGenerationSectionKey, SectionRequestState>,
 );
 
-const SECTION_DEFAULT_INSTRUCTIONS: Record<
-  ContentGenerationSectionKey,
-  string
-> = CONTENT_GENERATION_SECTIONS.reduce(
-  (acc, section) => ({
-    ...acc,
-    [section.key]: `Quantidade sugerida: ${section.defaultQuantity}`,
-  }),
-  {} as Record<ContentGenerationSectionKey, string>,
-);
-
 const JOB_SECTION_ALIASES: Record<string, ContentGenerationSectionKey> = {
   CAMPAIGN_ANGLE: "campaign-angle",
   AD_COPY: "ad-copy",
@@ -1051,10 +1040,6 @@ function getSectionLabel(sectionKey: ContentGenerationSectionKey) {
   return SECTION_LABEL_BY_KEY[sectionKey] ?? sectionKey;
 }
 
-function getDefaultInstructions(sectionKey: ContentGenerationSectionKey) {
-  return SECTION_DEFAULT_INSTRUCTIONS[sectionKey];
-}
-
 function normalizeJobSection(
   value?: string,
 ): ContentGenerationSectionKey | undefined {
@@ -1154,22 +1139,6 @@ export default function ExperimentContentGenerationTab({
       "landing-image-planning": false,
       "landing-html": false,
     });
-  const [isRequestingBySection, setIsRequestingBySection] = useState<
-    Record<ContentGenerationSectionKey, boolean>
-  >(() =>
-    CONTENT_GENERATION_SECTIONS.reduce(
-      (acc, section) => ({ ...acc, [section.key]: false }),
-      {} as Record<ContentGenerationSectionKey, boolean>,
-    ),
-  );
-  const [instructions, setInstructions] = useState<
-    Record<ContentGenerationSectionKey, string>
-  >(() =>
-    CONTENT_GENERATION_SECTIONS.reduce(
-      (acc, section) => ({ ...acc, [section.key]: "" }),
-      {} as Record<ContentGenerationSectionKey, string>,
-    ),
-  );
   const [requestsBySection, setRequestsBySection] = useState<
     Record<ContentGenerationSectionKey, SectionRequestState>
   >(() => ({ ...SECTION_REQUEST_INITIAL_STATE }));
@@ -1583,60 +1552,6 @@ export default function ExperimentContentGenerationTab({
     void loadAdCopy();
   }, [experimentId]);
 
-  const handleRequest = async (sectionKey: ContentGenerationSectionKey) => {
-    const requestedAt = new Date().toISOString();
-    const defaultInstructions = getDefaultInstructions(sectionKey);
-    const trimmedInstructions = instructions[sectionKey]?.trim();
-    const customInstructions = trimmedInstructions || defaultInstructions;
-
-    setIsRequestingBySection((previous) => ({
-      ...previous,
-      [sectionKey]: true,
-    }));
-    setRequestsBySection((previous) => ({
-      ...previous,
-      [sectionKey]: {
-        status: "PROCESSING",
-        requestedAt,
-        startedAt: undefined,
-        completedAt: undefined,
-        customInstructions,
-        errorMessage: undefined,
-        stageLabel: undefined,
-      },
-    }));
-
-    try {
-      const sectionPath = SECTION_API_PATHS[sectionKey];
-      await axios.post(
-        `/api/experiments/${experimentId}/pipeline/${sectionPath}/generate`,
-        {
-          customInstructions,
-        },
-      );
-
-      toast.success(
-        `Solicitação enviada para ${getSectionLabel(sectionKey)}. O Worker IA assumirá assim que possível.`,
-      );
-    } catch (error) {
-      const message = getErrorMessage(error);
-      setRequestsBySection((previous) => ({
-        ...previous,
-        [sectionKey]: {
-          ...previous[sectionKey],
-          status: "FAILED",
-          errorMessage: message,
-        },
-      }));
-      toast.error(message);
-    } finally {
-      setIsRequestingBySection((previous) => ({
-        ...previous,
-        [sectionKey]: false,
-      }));
-    }
-  };
-
   const handleDownloadReport = async () => {
     try {
       setIsDownloadingReport(true);
@@ -1901,43 +1816,6 @@ export default function ExperimentContentGenerationTab({
                   </div>
                 </div>
 
-                <div className="d-flex flex-column flex-lg-row gap-2 mt-4">
-                  <textarea
-                    className="form-control"
-                    rows={2}
-                    placeholder="Instruções extras para o Worker IA (opcional)"
-                    value={instructions[section.key]}
-                    onChange={(event) =>
-                      setInstructions((prev) => ({
-                        ...prev,
-                        [section.key]: event.target.value,
-                      }))
-                    }
-                  />
-                  <button
-                    type="button"
-                    className="btn btn-primary align-self-start"
-                    onClick={() => handleRequest(section.key)}
-                    disabled={isRequestingBySection[section.key]}
-                  >
-                    {isRequestingBySection[section.key] ? (
-                      <span className="d-inline-flex align-items-center gap-1">
-                        <span
-                          className="spinner-border spinner-border-sm"
-                          role="status"
-                          aria-hidden="true"
-                        />
-                        Enviando...
-                      </span>
-                    ) : (
-                      "Solicitar geração por IA"
-                    )}
-                  </button>
-                </div>
-                <small className="text-muted">
-                  Caso deixe em branco enviaremos:{" "}
-                  {getDefaultInstructions(section.key)}.
-                </small>
               </div>
             </section>
           </Tabs.Content>


### PR DESCRIPTION
### Motivation
- Consolidar o disparo de gerações IA na ficha da hipótese, evitando controles de geração duplicados no experimento e reduzindo risco de drift de comportamento entre telas. 
- Deixar explícita a distinção entre gerar o item completo e gerar apenas o resumo de cada seção do framework (Dor/Resultado/Mecanismo/Prova/Oferta) para clareza de UX e auditabilidade.

### Description
- Remove os controles de solicitação manual por seção na tela de experimento, eliminando a `textarea` de instruções, o botão `Solicitar geração por IA` e as lógicas/estados associados (`SECTION_DEFAULT_INSTRUCTIONS`, `isRequestingBySection`, `instructions`, `getDefaultInstructions`, `handleRequest`).
- Atualiza a view da hipótese para deixar rótulos e tooltips explícitos por seção, adicionando `getSectionLabel` e alterando os textos dos botões para diferenciar geração completa e geração de resumo (por exemplo `Gerar Dor com IA` vs `Gerar resumo de Dor`).
- Alterados arquivos: `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx` e `frontend/src/components/HypothesisFrameworkTabsView.tsx`.
- Nenhuma alteração em contratos backend, API nem no modelo de dados; mudança é comportamental/UX no frontend para centralizar o fluxo de geração.

### Testing
- Executado `npm install` no diretório `frontend` com sucesso.
- Executado `npm run build` em `frontend` e o build completou com sucesso (Vite build).
- Executado `npm run test -- --run src/pages/experiment/ExperimentContentGenerationTab.report.test.ts` e o teste direcionado passou (3 testes OK).
- Executado `npm run test` (suite completa); a suite apresentou falhas preexistentes não relacionadas à mudança (3 testes falhando e 1 erro unhandled, incluindo falhas em testes que usam `toHaveValue` e um `TypeError` vindo de `GlobalAutomationAlerts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f6e11b388321bf31b9320a15f32f)