### PR TITLE
feat(frontend): show AI generation timestamp and prompt in framework summary

### DIFF
--- a/frontend/src/components/HypothesisFrameworkTabsView.tsx
+++ b/frontend/src/components/HypothesisFrameworkTabsView.tsx
@@ -2,6 +2,7 @@ import { Fragment, useMemo, useState } from "react";
 import * as Tabs from "@radix-ui/react-tabs";
 import { Loader2 } from "lucide-react";
 import axios from "axios";
+import { useQuery } from "@tanstack/react-query";
 import { toast } from "react-toastify";
 import type { HypothesisFramework } from "../api/hypothesis/types";
 import { normalizeFramework } from "../api/hypothesis/types";
@@ -64,6 +65,12 @@ interface FrameworkGenerationReportRecord extends AiGenerationRecord {
     generationTypeLabel: string;
     generationOrder: number;
   };
+}
+
+interface SectionSummaryGenerationMetadata {
+  createdAt?: string;
+  prompt?: string;
+  isSummary: boolean;
 }
 
 const REPORT_SECTION_ORDER: HypothesisFrameworkSection[] = [
@@ -251,6 +258,23 @@ export function HypothesisFrameworkTabsView({
   >(SECTION_REQUEST_INITIAL_STATE);
   const jobsQuery = useFrameworkGenerationJobs(hypothesisId);
   const generate = useGenerateFrameworkSection(hypothesisId, nicheId);
+  const generationsQuery = useQuery({
+    queryKey: ["hypothesis-framework-generations", hypothesisId],
+    enabled: Boolean(hypothesisId),
+    queryFn: async () => {
+      if (!hypothesisId) return [] as AiGenerationRecord[];
+      const { data: response } = await axios.get<PageResponse<AiGenerationRecord>>(
+        "/api/ai/generations",
+        {
+          params: {
+            referenceId: hypothesisId,
+            size: 100,
+          },
+        },
+      );
+      return response.content ?? [];
+    },
+  });
 
   const requestsFromBackendByKind = useMemo(() => {
     const grouped: Record<
@@ -313,6 +337,49 @@ export function HypothesisFrameworkTabsView({
   );
 
   const summaryRequestsBySection = requestsFromBackendByKind.SUMMARY;
+
+  const summaryGenerationMetadataBySection = useMemo(
+    () =>
+      (generationsQuery.data ?? []).reduce<
+        Partial<
+          Record<HypothesisFrameworkSection, SectionSummaryGenerationMetadata>
+        >
+      >((acc, generation) => {
+        const domain = generation.domain ?? "";
+        if (!domain.startsWith("hypothesis.framework.")) {
+          return acc;
+        }
+
+        const suffix = domain.replace("hypothesis.framework.", "");
+        const isSummaryDomain = suffix.endsWith(".summary");
+        const sectionKey = (isSummaryDomain
+          ? suffix.replace(".summary", "")
+          : suffix) as HypothesisFrameworkSection;
+        if (!SECTIONS.some((section) => section.id === sectionKey)) {
+          return acc;
+        }
+
+        const currentTimestamp = parseTimestamp(generation.createdAt) ?? 0;
+        const previousTimestamp =
+          parseTimestamp(acc[sectionKey]?.createdAt) ?? -1;
+        const shouldPrioritizeExistingSummary =
+          Boolean(acc[sectionKey]?.isSummary) && !isSummaryDomain;
+        if (shouldPrioritizeExistingSummary) {
+          return acc;
+        }
+        if (currentTimestamp < previousTimestamp) {
+          return acc;
+        }
+
+        acc[sectionKey] = {
+          createdAt: generation.createdAt,
+          prompt: generation.prompt,
+          isSummary: isSummaryDomain,
+        };
+        return acc;
+      }, {}),
+    [generationsQuery.data],
+  );
 
   const invalidationBySection = useMemo(() => {
     const bySection: Partial<
@@ -699,6 +766,19 @@ export function HypothesisFrameworkTabsView({
                   {getSummaryLabel(section.id)}
                 </div>
                 <div>{getSummary(section.id)?.trim() || "-"}</div>
+                <div className="small text-body-secondary mt-2 d-flex flex-column gap-1">
+                  <span>
+                    <strong>Data/hora da geração:</strong>{" "}
+                    {formatDateTime(
+                      summaryGenerationMetadataBySection[section.id]?.createdAt,
+                    )}
+                  </span>
+                  <span>
+                    <strong>Prompt usado:</strong>{" "}
+                    {summaryGenerationMetadataBySection[section.id]?.prompt?.trim() ||
+                      "Sem prompt registrado."}
+                  </span>
+                </div>
               </div>
               <div className="d-flex flex-column flex-md-row gap-2 mt-3">
                 <textarea


### PR DESCRIPTION
### Motivation
- Improve traceability of AI-generated content in the Hypothesis Framework UI by surfacing when a summary was generated and which prompt produced it, aligning with the project canon for AI artifact metadata. 
- Meet the requirement that Worker IA outputs and prompts be auditable and discoverable in the frontend summary view.

### Description
- Added a `useQuery` call to fetch AI generations for the hypothesis from `GET /api/ai/generations` and introduced the `generationsQuery` lookup. 
- Implemented `summaryGenerationMetadataBySection` (with `SectionSummaryGenerationMetadata` type) that reduces generations to the most relevant per section, prioritizing `*.summary` domains when present and keeping `createdAt` and `prompt`. 
- Rendered the metadata under each section summary in `HypothesisFrameworkTabsView` showing `Data/hora da geração` and `Prompt usado`. 
- Small typings and imports added (`useQuery`), and UI markup/styling inserted inside the existing summary card without changing backend contracts.

### Testing
- Executed `cd frontend && npm install` and it completed successfully. 
- Executed `cd frontend && npm run build` and the production build completed successfully (with standard bundle-size warnings). 
- Executed `cd frontend && npm run test -- --run`; the test run completed but reported pre-existing/irrelevant failures in unrelated suites (examples: `CriativosTab.test.tsx` had 2 failures, `NicheFlow.test.tsx` 1 failure, other unrelated failures/timeout and assertion issues). The tests that exercise the changed file did not introduce new failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54c029f5c8321a3ec96dac4853555)