### PR TITLE
Refatora prompts do pipeline de experimento para alinhamento canônico e foco comercial

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/campaign-angle.md
+++ b/ai-worker/src/main/resources/prompts/experiment/campaign-angle.md
@@ -4,33 +4,35 @@ artifact_target: campaignAngle
 
 SYSTEM_INSTRUCTIONS
 Você está na etapa de definição de ângulo de campanha para Meta Ads + landing page.
-Crie a base estratégica de uma campanha Meta Ads + landing page para este produto.
+Crie um único ângulo comercial com alta capacidade de venda, mantendo compatibilidade estrita com o artefato canônico `campaignAngle`.
+
+Prioridade obrigatória de insumos (usar nesta ordem):
+1. OFFER_COMMERCIAL_SUMMARY
+2. PROOF_SUMMARY
+3. MECHANISM_SUMMARY
+4. RESULT_SUMMARY
+5. PAIN_SUMMARY
 
 Regras fixas da etapa:
-1. Defina 1 dor principal e 1 transformação principal, mantendo foco comercial.
-2. A promessa central deve ser simples, direta e fácil de entender em poucos segundos.
-3. O anúncio deve abrir por dor ou resultado, e a landing deve aprofundar o mesmo ângulo.
-4. O CTA precisa ser compatível com execução automatizada e alta escala.
-5. Não proponha nada fora do envelope real do produto.
-6. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
-7. Priorize os insumos na seguinte ordem: OFFER_COMMERCIAL_SUMMARY → PROOF_SUMMARY → MECHANISM_SUMMARY → RESULT_SUMMARY → PAIN_SUMMARY.
-8. Se existir CTA concreta em OFFER_COMMERCIAL_SUMMARY, não use CTA genérica.
-9. Se houver prova pré-venda concreta em PROOF_SUMMARY, reflita essa prova no hook, promise e landingMatchLine.
-10. Se houver entregáveis concretos no contexto comercial, evite reduzir a oferta a rótulos vagos como “plano”, “roteiro” ou “sequência”.
+1. O ângulo deve ser single-minded: uma única ideia central.
+2. Escolha 1 dor ou desejo principal, 1 promessa principal, 1 prova/mecanismo de sustentação e 1 CTA principal.
+3. Se houver CTA concreta em OFFER_COMMERCIAL_SUMMARY, ela deve prevalecer sobre rótulos genéricos.
+4. Se houver prova pré-venda concreta em PROOF_SUMMARY, ela deve influenciar hook, promise e messageMatch.
+5. Se houver entregáveis concretos em OFFER_COMMERCIAL_SUMMARY, não reduza a oferta a rótulos vagos como “plano”, “roteiro” ou “sequência”.
+6. O hook deve abrir por dor, desejo ou ganho de forma comercial, clara e específica.
+7. A promise deve ser construída prioritariamente com RESULT_SUMMARY + PROOF_SUMMARY + OFFER_COMMERCIAL_SUMMARY, e não apenas com dor.
+8. O messageMatch deve preparar continuidade natural entre anúncio e landing page, repetindo promessa e CTA em linguagem consistente.
+9. Objections deve focar ceticismos reais de conversão pré-clique, sem criar objeções fora dos dados.
+10. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
 
 OUTPUT_CONTRACT
-Responda em JSON válido e estritamente aderente ao artefato `campaignAngle`.
+Responda em JSON válido e estritamente aderente ao artefato canônico `campaignAngle`.
 Campos obrigatórios:
-- primaryPromise
-- primaryPain
-- mechanismSummary
-- proofSummary
-- cta
-- singleMindedPromise
-- primaryCTA
-- landingMatchLine
-- funnelStage
-- tone
+- visualAngle
+- hook
+- promise
+- objections
+- messageMatch

--- a/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
@@ -11,9 +11,11 @@ Regras fixas da etapa:
 3. `hero.ctaLabel`, `primaryCTA` e todos os `ctaBlocks` devem manter o mesmo CTA aprovado.
 4. `bodySections` deve ter no mínimo quatro blocos cobrindo dor, mecanismo, prova e oferta.
 5. `faq` deve conter no mínimo três perguntas com `objectionTag`.
-6. `consistencyChecks` deve incluir CTA_MATCH, PROMISE_MATCH, GOOGLE_LANDING_BEST_PRACTICES, DELIVERABLE_CLARITY, DELIVERABLE_TO_OUTCOME_LINK e CTA_SPECIFICITY.
-7. `complianceNotes` deve reforçar entrega digital via IA, sem consultoria humana.
-8. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
+6. `consistencyChecks` deve incluir CTA_MATCH, PROMISE_MATCH e GOOGLE_LANDING_BEST_PRACTICES.
+7. Os valores de `consistencyChecks.status` devem ser exatamente: PASS, FAIL ou WARNING.
+8. `complianceNotes` deve reforçar entrega digital via IA, sem consultoria humana.
+9. Priorize concretude comercial: manter nome de entregáveis, prova visível e CTA tangível quando disponíveis nos resumos estruturados.
+10. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -23,12 +25,11 @@ Responda em JSON válido e estritamente aderente ao artefato `landingPageCopy`.
 Campos obrigatórios:
 - pageGoal
 - messageMatchSource
-- messageMatchSource,
 - messageMatchNotes
 - primaryCTA
+- complianceNotes
 - hero { eyebrow, headline, subheadline, promise, supportingCopy, proofBadge, microcopy, ctaLabel, ctaUrl, ctaMatchNotes }
 - bodySections[] com sectionId, sectionType, title, summary, bullets, copy, ctaSupport, sectionDependsOn, messageMatchNotes
 - ctaBlocks[] com placement, ctaVariant, ctaLabel, ctaUrl, matchAdCta, ctaSupport, messageMatchNotes
 - faq[] com question, answer, objectionTag
-- consistencyChecks[] com check, status (PASS/WARN/FAIL), details
-- complianceNotes
+- consistencyChecks[] com check, status (PASS/FAIL/WARNING), details

--- a/ai-worker/src/main/resources/prompts/experiment/landing-html.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-html.md
@@ -16,10 +16,11 @@ Regras fixas da etapa:
 8. Não invente estrutura visual fora de wireframe/plano de imagens sem justificar em `consistencyChecks`.
 9. Não use bibliotecas externas.
 10. Renderize imagens apenas para itens listados em `landingPageImagePlanning.images[]`.
-11. Toda tag `<img>` deve usar `src` absoluto válido e `altText` do planejamento.
+11. Toda tag `<img>` deve usar `src` absoluto válido e `alt` descritivo derivado de `sectionName + imageRole + sectionVisualGoal` do planejamento.
 12. No mobile (<=768px), respeite `preferredMobilePlacement` e evite overlap de texto/imagem.
 13. Após envio do formulário, exiba mensagem clara orientando o usuário a aguardar e-mail com a prévia.
-14. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
+14. Garanta continuidade comercial: promessa, prova visível e CTA devem permanecer consistentes do topo ao fechamento da página.
+15. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -28,5 +29,7 @@ OUTPUT_CONTRACT
 Responda em JSON válido e estritamente aderente ao artefato `landingPageHtml`.
 Campos obrigatórios:
 - htmlDocument
+- formSpec
 - summary
-- consistencyChecks[] com CTA_MATCH, PROMISE_MATCH, IMAGE_PLAN_BINDING, SURFACE_SPEC_BINDING, FORM_SPEC_BINDING, FORM_USABILITY, SECTION_THEME_VARIATION, PREVIEW_CONCRETENESS e ARTIFACT_SCHEMA_COMPATIBILITY
+- imagePlacementContract
+- consistencyChecks[] com CTA_MATCH, PROMISE_MATCH, IMAGE_PLAN_BINDING, SURFACE_SPEC_BINDING, FORM_SPEC_BINDING e FORM_USABILITY

--- a/ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md
@@ -11,12 +11,13 @@ Regras fixas da etapa:
 3. `imagePrompt` deve ser específico para a seção e coerente com o ângulo/copy aprovados.
 4. Defina `dimensions.desktop` e `dimensions.mobile`.
 5. Inclua `safeMargins` e `textOverlayGuidance` quando houver texto sobre imagem.
-6. Sempre preencha `altText` descritivo.
+6. Não incluir `altText` no output: este campo não faz parte do artefato canônico atual.
 7. Inclua `layoutBinding` completo com `preferredDesktopPlacement` e `preferredMobilePlacement`.
 8. Inclua `attentionPriority`, `visualWeight`, `distanceToCTA`, `supportsFormConversion` e `formRelationNotes`.
 9. Inclua `complianceNotes` e `negativePrompt` para evitar ruído visual e promessas indevidas.
-10. `consistencyChecks` deve incluir IMAGE_MESSAGE_MATCH, VISUAL_HIERARCHY, CTA_CONTINUITY e PREVIEW_CONCRETENESS.
-11. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
+10. `consistencyChecks` deve incluir IMAGE_MESSAGE_MATCH, VISUAL_HIERARCHY e CTA_CONTINUITY.
+11. Priorize prova visível e continuidade anúncio→landing na direção visual quando disponíveis nos resumos estruturados.
+12. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}

--- a/ai-worker/src/main/resources/prompts/experiment/landing-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-wireframe.md
@@ -8,15 +8,14 @@ Você está na etapa de wireframe textual (sem HTML final), mobile-first.
 Regras fixas da etapa:
 1. `pageGoal` deve explicitar a ação principal esperada da página.
 2. `variantLayoutId` deve ser um entre: form-first, proof-first, story-first.
-3. `sectionOrder` deve mapear ordem, objetivo e dependências de message match por seção.
-4. Cada seção deve incluir `mobilePriorityScore`, `dropOffRisk`, `mediaSlot` e `compositionNotes`.
+3. `sectionOrder` deve mapear ordem, objetivo, dependências de message match e variação intencional de seção via `surfaceSpec` + `uiNotes`.
+4. Cada seção deve incluir todos os campos canônicos de `sectionOrder`, incluindo `surfaceSpec` e `ctaSlot`.
 5. Se houver CTA na seção, preencher `ctaSlot` com `hasCta`, `ctaLabel`, `ctaVariant`, `matchAdCta` e `notes`.
 6. `formPlacementNotes` deve informar momento de exposição do formulário e estratégia sticky quando aplicável.
-7. `consistencyChecks` deve incluir CTA_MATCH, EXPERIENCE_CONTINUITY e SECTION_THEME_VARIATION.
+7. `consistencyChecks` deve incluir no mínimo CTA_MATCH e EXPERIENCE_CONTINUITY.
 8. Defina `formSpec` como contrato funcional do formulário (campos, consentimento e successState).
-9. `backgroundColorStrategy` deve orientar variação intencional de cores de fundo entre seções para melhorar escaneabilidade.
-10. Não converter para HTML final nesta etapa.
-11. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
+9. Não converter para HTML final nesta etapa.
+10. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -26,12 +25,9 @@ Responda em JSON válido e estritamente aderente ao artefato `landingPageWirefra
 Campos obrigatórios:
 - pageGoal
 - variantLayoutId
-- messageMatchSummary
-- sectionOrder[]
+- sectionOrder[] com sectionId, sectionName, objective, contentType, copySource, uiNotes, messageMatchDependency, sectionDependsOn, mobilePriorityScore, dropOffRisk, surfaceSpec, ctaSlot
 - mobilePriorityNotes
 - ctaPlacementNotes
 - formPlacementNotes
-- backgroundColorStrategy
-- textImageBalanceNotes
-- formSpec
 - consistencyChecks[]
+- formSpec


### PR DESCRIPTION
### Motivation
- Corrigir desalinhamentos entre prompts do pipeline de experimento e o esquema canônico de artefatos para garantir compatibilidade e continuidade anúncio→landing. 
- Aumentar a capacidade de venda do artefato `campaignAngle` tornando-o single-minded e priorizando os novos resumos estruturados como insumos comerciais.

### Description
- Atualiza `ai-worker/src/main/resources/prompts/experiment/campaign-angle.md` para produzir estritamente o artefato canônico `campaignAngle` (`visualAngle`, `hook`, `promise`, `objections`, `messageMatch`) e priorizar insumos na ordem `offerCommercialSummary`, `proofSummary`, `mechanismSummary`, `resultSummary`, `painSummary`, com regras comerciais single-minded e CTA/prova concretos.
- Alinha `landing-copy.md` aos campos canônicos corrigindo `consistencyChecks.status` para `PASS | FAIL | WARNING`, removendo duplicidade e reforçando prioridade por concretude comercial dos entregáveis e CTA.
- Ajusta `landing-wireframe.md` para exigir apenas os campos canônicos da seção (`surfaceSpec`, `ctaSlot`, etc.) e remove requisitos fora do schema (ex.: `mediaSlot`, `backgroundColorStrategy`, `messageMatchSummary`).
- Modifica `landing-image-planning.md` para não exigir `altText` (não-canônico), normalizar checks canônicos (`IMAGE_MESSAGE_MATCH`, `VISUAL_HIERARCHY`, `CTA_CONTINUITY`) e priorizar prova visual e continuidade anúncio→landing.
- Atualiza `landing-html.md` para consumir apenas contratos canônicos aprovados, exigir `formSpec` e `imagePlacementContract`, derivar `alt` descritivo a partir de campos canônicos do planning e reforçar continuidade comercial no output.

### Testing
- Executadas buscas e validações textuais: `rg --files -g 'AGENTS.md' -g 'AGNETS.md'` (sucesso). 
- Validações de conteúdo e consistência: `rg -n "altText|PASS/WARN/FAIL|landingMatchLine|primaryPromise|messageMatchSummary|backgroundColorStrategy|textImageBalanceNotes|mediaSlot|compositionNotes" ai-worker/src/main/resources/prompts/experiment` (sucesso).
- Checagem de diff por estilo/erros: `git -C /workspace/marketing-hub diff --check` (sucesso).
- Commit das alterações realizado com mensagem de mudança (sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5568dbe2c8321aee513e693787a0d)