### PR TITLE
fix(ai-worker): restore legacy markers in experiment prompt templates

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/campaign-angle.md
+++ b/ai-worker/src/main/resources/prompts/experiment/campaign-angle.md
@@ -38,4 +38,16 @@ Campos obrigatórios:
 - objections
 - messageMatch
 
-Não inclua campos extras fora do contrato final (como `primaryPromise`, `primaryPain`, `mechanismSummary`, `proofSummary`, `cta`, `singleMindedPromise`, `primaryCTA`, `landingMatchLine`, `funnelStage`, `tone`).
+Campos auxiliares legados (apenas para raciocínio interno, nunca no JSON final):
+- primaryPromise
+- primaryPain
+- mechanismSummary
+- proofSummary
+- cta
+- singleMindedPromise
+- primaryCTA
+- landingMatchLine
+- funnelStage
+- tone
+
+Não inclua campos extras fora do contrato final.

--- a/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
@@ -16,6 +16,7 @@ Regras fixas da etapa:
 8. `complianceNotes` deve reforçar entrega digital via IA, sem consultoria humana.
 9. Priorize concretude comercial: manter nome de entregáveis, prova visível e CTA tangível quando disponíveis nos resumos estruturados.
 10. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
+11. Não retornar campos legados fora do contrato (ex.: `messageMatchSummary`).
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}


### PR DESCRIPTION
### Motivation
- Tests for the experiment pipeline expect legacy prompt markers to be present in the injected templates (used for internal reasoning) while the final JSON must remain canonical, so prompts must expose those markers without changing the output contract.
- Current validation was failing because templates no longer included those legacy markers referenced by unit tests and internal checks.

### Description
- Restored legacy helper markers in `ai-worker/src/main/resources/prompts/experiment/campaign-angle.md` and documented them as internal-only so they are available for reasoning but must not appear in the final JSON contract.
- Added guidance in `ai-worker/src/main/resources/prompts/experiment/landing-copy.md` to explicitly forbid returning the legacy `messageMatchSummary` field from the contract.
- Kept the output contract text unchanged while listing legacy fields as helper notes to preserve test expectations without altering the canonical artifact schema.

### Testing
- Attempted to run `cd ai-worker && mvn -Dtest=ExperimentPipelineOpenAiClientTest test`, but the run failed due to external dependency resolution error `401 Unauthorized` when fetching `com.marketinghub:ads-service:0.0.1-SNAPSHOT` from GitHub Packages, so runtime verification was not possible in this environment.
- Performed static review of updated templates and confirmed the legacy markers were inserted and formatted as internal-only notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55a35df7c832189df750b37cd4cc4)