### PR TITLE
Fix stale prompt marker checks in experiment pipeline OpenAI client

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -60,8 +60,8 @@ public class ExperimentPipelineOpenAiClient {
     private static final String LANDING_IMAGE_PLANNING_TEMPLATE_PATH = "prompts/experiment/landing-image-planning.md";
     private static final String LANDING_HTML_TEMPLATE_PATH = "prompts/experiment/landing-html.md";
 
-    private static final String CAMPAIGN_ANGLE_MARKER = "- primaryPromise";
-    private static final String LANDING_COPY_MARKER = "messageMatchSource,";
+    private static final String CAMPAIGN_ANGLE_MARKER = "- visualAngle";
+    private static final String LANDING_COPY_MARKER = "- messageMatchSource";
     private static final String LANDING_WIREFRAME_MARKER = "variantLayoutId";
     private static final String LANDING_IMAGE_PLANNING_MARKER = "visualDirectionSummary";
     private static final String LANDING_HTML_MARKER = "htmlDocument";

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -64,7 +64,7 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("CASE_DATA");
         assertThat(userPrompt).contains("[CASE_DATA_BEGIN]");
         assertThat(userPrompt).contains("OUTPUT_CONTRACT");
-        assertThat(userPrompt).contains("- primaryPromise");
+        assertThat(userPrompt).contains("- visualAngle");
         assertThat(userPrompt).contains("- proofSummary");
         assertThat(userPrompt).contains("- singleMindedPromise");
         assertThat(userPrompt).contains("- primaryCTA");
@@ -143,7 +143,7 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("SYSTEM_INSTRUCTIONS");
         assertThat(userPrompt).contains("CASE_DATA");
         assertThat(userPrompt).contains("OUTPUT_CONTRACT");
-        assertThat(userPrompt).contains("messageMatchSource,");
+        assertThat(userPrompt).contains("- messageMatchSource");
         assertThat(userPrompt).contains("hero {");
         assertThat(userPrompt).contains("bodySections[]");
         assertThat(userPrompt).contains("ctaBlocks[]");


### PR DESCRIPTION
### Motivation
- CI tests were failing because prompt-injection detection and test assertions relied on legacy marker strings that no longer match the canonical prompt templates.
- The client must detect canonical required-field lines from the templates to avoid re-injecting templates and to keep unit tests stable.

### Description
- Updated `ExperimentPipelineOpenAiClient` to use `CAMPAIGN_ANGLE_MARKER = "- visualAngle"` and `LANDING_COPY_MARKER = "- messageMatchSource"` so marker checks match the canonical templates (`ai-worker/src/main/java/.../ExperimentPipelineOpenAiClient.java`).
- Aligned unit test assertions in `ExperimentPipelineOpenAiClientTest` to assert presence of the new marker strings during prompt enrichment (`ai-worker/src/test/java/.../ExperimentPipelineOpenAiClientTest.java`).

### Testing
- Verified textual replacements with `rg` to confirm the new markers are present in both implementation and tests using `rg -n "CAMPAIGN_ANGLE_MARKER|LANDING_COPY_MARKER|visualAngle|messageMatchSource"`.
- Attempted to run the focused test suite with `cd ai-worker && mvn -s settings.xml -Dtest=ExperimentPipelineOpenAiClientTest test`, but execution failed due to external Maven dependency resolution/network issues (unreachable repository), so full test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e575c6fa308321a0e24151318f6041)