### PR TITLE
feat(frontend): restore AI generation button in experiment pipeline tab

### DIFF
--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import * as Tabs from "@radix-ui/react-tabs";
 import axios from "axios";
@@ -1142,6 +1142,9 @@ export default function ExperimentContentGenerationTab({
   const [requestsBySection, setRequestsBySection] = useState<
     Record<ContentGenerationSectionKey, SectionRequestState>
   >(() => ({ ...SECTION_REQUEST_INITIAL_STATE }));
+  const [isGeneratingSection, setIsGeneratingSection] = useState(false);
+  const [pendingGenerationSection, setPendingGenerationSection] =
+    useState<ContentGenerationSectionKey | null>(null);
 
   const jobsQuery = useExperimentPipelineJobs(experimentId);
   const frameworkImageStatusQuery = useFrameworkImageStatuses(experimentId);
@@ -1429,51 +1432,40 @@ export default function ExperimentContentGenerationTab({
       (section) => section.key === activeSection,
     ) ?? CONTENT_GENERATION_SECTIONS[0];
 
-  useEffect(() => {
-    const loadCampaignAngles = async () => {
-      try {
-        setIsLoadingCampaignAngles(true);
-        const { data: response } = await axios.get<
-          PageResponse<AiGenerationRecord>
-        >("/api/ai/generations", {
+  const loadCampaignAngles = useCallback(async () => {
+    try {
+      setIsLoadingCampaignAngles(true);
+      const { data: response } = await axios.get<PageResponse<AiGenerationRecord>>(
+        "/api/ai/generations",
+        {
           params: {
             referenceId: experimentId,
             domain: "experiment.pipeline.campaign-angle",
             size: 20,
           },
-        });
+        },
+      );
 
-        const orderedByLatest = [...(response.content ?? [])]
-          .map((generation) => ({
-            ...generation,
-            fields: parseCampaignAnglePayload(generation.rawResponse),
-          }))
-          .sort(
-            (a, b) =>
-              (parseTimestamp(b.createdAt) ?? Number.MIN_SAFE_INTEGER) -
-              (parseTimestamp(a.createdAt) ?? Number.MIN_SAFE_INTEGER),
-          );
-        setCampaignAngleGenerations(orderedByLatest);
-      } catch {
-        toast.error("Não foi possível carregar os ângulos da campanha agora.");
-      } finally {
-        setIsLoadingCampaignAngles(false);
-      }
-    };
-
-    void loadCampaignAngles();
+      const orderedByLatest = [...(response.content ?? [])]
+        .map((generation) => ({
+          ...generation,
+          fields: parseCampaignAnglePayload(generation.rawResponse),
+        }))
+        .sort(
+          (a, b) =>
+            (parseTimestamp(b.createdAt) ?? Number.MIN_SAFE_INTEGER) -
+            (parseTimestamp(a.createdAt) ?? Number.MIN_SAFE_INTEGER),
+        );
+      setCampaignAngleGenerations(orderedByLatest);
+    } catch {
+      toast.error("Não foi possível carregar os ângulos da campanha agora.");
+    } finally {
+      setIsLoadingCampaignAngles(false);
+    }
   }, [experimentId]);
 
-  useEffect(() => {
-    const sectionsToLoad: HistorySectionKey[] = [
-      "image-prompt",
-      "landing-copy",
-      "landing-layout",
-      "landing-image-planning",
-      "landing-html",
-    ];
-
-    const loadSection = async (sectionKey: HistorySectionKey) => {
+  const loadSection = useCallback(
+    async (sectionKey: HistorySectionKey) => {
       try {
         setIsLoadingSectionGenerations((previous) => ({
           ...previous,
@@ -1509,48 +1501,112 @@ export default function ExperimentContentGenerationTab({
           [sectionKey]: false,
         }));
       }
-    };
+    },
+    [experimentId],
+  );
 
-    void Promise.all(
-      sectionsToLoad.map((sectionKey) => loadSection(sectionKey)),
-    );
-  }, [experimentId]);
-
-  useEffect(() => {
-    const loadAdCopy = async () => {
-      try {
-        setIsLoadingAdCopy(true);
-        const { data: response } = await axios.get<
-          PageResponse<AiGenerationRecord>
-        >("/api/ai/generations", {
+  const loadAdCopy = useCallback(async () => {
+    try {
+      setIsLoadingAdCopy(true);
+      const { data: response } = await axios.get<PageResponse<AiGenerationRecord>>(
+        "/api/ai/generations",
+        {
           params: {
             referenceId: experimentId,
             domain: "experiment.pipeline.ad-copy",
             size: 20,
           },
-        });
+        },
+      );
 
-        const orderedByLatest = [...(response.content ?? [])]
-          .map((generation) => ({
-            ...generation,
-            fields: parseAdCopyPayload(generation.rawResponse),
-          }))
-          .sort(
-            (a, b) =>
-              (parseTimestamp(b.createdAt) ?? Number.MIN_SAFE_INTEGER) -
-              (parseTimestamp(a.createdAt) ?? Number.MIN_SAFE_INTEGER),
-          );
+      const orderedByLatest = [...(response.content ?? [])]
+        .map((generation) => ({
+          ...generation,
+          fields: parseAdCopyPayload(generation.rawResponse),
+        }))
+        .sort(
+          (a, b) =>
+            (parseTimestamp(b.createdAt) ?? Number.MIN_SAFE_INTEGER) -
+            (parseTimestamp(a.createdAt) ?? Number.MIN_SAFE_INTEGER),
+        );
 
-        setAdCopyGenerations(orderedByLatest);
-      } catch {
-        toast.error("Não foi possível carregar os textos do anúncio agora.");
-      } finally {
-        setIsLoadingAdCopy(false);
-      }
-    };
-
-    void loadAdCopy();
+      setAdCopyGenerations(orderedByLatest);
+    } catch {
+      toast.error("Não foi possível carregar os textos do anúncio agora.");
+    } finally {
+      setIsLoadingAdCopy(false);
+    }
   }, [experimentId]);
+
+  useEffect(() => {
+    void loadCampaignAngles();
+  }, [loadCampaignAngles]);
+
+  useEffect(() => {
+    const sectionsToLoad: HistorySectionKey[] = [
+      "image-prompt",
+      "landing-copy",
+      "landing-layout",
+      "landing-image-planning",
+      "landing-html",
+    ];
+
+    void Promise.all(
+      sectionsToLoad.map((sectionKey) => loadSection(sectionKey)),
+    );
+  }, [loadSection]);
+
+  useEffect(() => {
+    void loadAdCopy();
+  }, [loadAdCopy]);
+
+  const handleGenerateSection = async (section: ContentGenerationSection) => {
+    const nowIso = new Date().toISOString();
+    setPendingGenerationSection(section.key);
+    setIsGeneratingSection(true);
+    setRequestsBySection((previous) => ({
+      ...previous,
+      [section.key]: {
+        status: "PROCESSING",
+        requestedAt: nowIso,
+      },
+    }));
+
+    try {
+      await axios.post(
+        `/api/experiments/${experimentId}/pipeline/${SECTION_API_PATHS[section.key]}/generate`,
+        {
+          quantity: section.defaultQuantity,
+          promptTemplate: SECTION_PROMPT_DEFAULTS[section.key],
+        },
+      );
+      toast.success(
+        `Solicitação de ${section.label.toLowerCase()} enviada para o Worker IA.`,
+      );
+      await jobsQuery.refetch();
+
+      if (section.key === "campaign-angle") {
+        await loadCampaignAngles();
+      } else if (section.key === "ad-copy") {
+        await loadAdCopy();
+      } else {
+        await loadSection(section.key);
+      }
+    } catch (error) {
+      setRequestsBySection((previous) => ({
+        ...previous,
+        [section.key]: {
+          status: "FAILED",
+          requestedAt: nowIso,
+          errorMessage: getErrorMessage(error),
+        },
+      }));
+      toast.error(getErrorMessage(error));
+    } finally {
+      setIsGeneratingSection(false);
+      setPendingGenerationSection(null);
+    }
+  };
 
   const handleDownloadReport = async () => {
     try {
@@ -1742,9 +1798,32 @@ export default function ExperimentContentGenerationTab({
                     <h5 className="card-title mb-1">{section.label}</h5>
                     <p className="text-muted mb-0">{section.description}</p>
                   </div>
-                  <span className="badge text-bg-light">
-                    Estrutura pronta para prompt
-                  </span>
+                  <div className="d-flex align-items-start flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className="btn btn-outline-primary btn-sm"
+                      onClick={() => void handleGenerateSection(section)}
+                      disabled={isGeneratingSection}
+                      title={`Solicita ao Worker IA a geração da etapa "${section.label}" com prompt canônico do pipeline.`}
+                    >
+                      {isGeneratingSection &&
+                      pendingGenerationSection === section.key ? (
+                        <span className="d-inline-flex align-items-center gap-1">
+                          <span
+                            className="spinner-border spinner-border-sm"
+                            role="status"
+                            aria-hidden="true"
+                          />
+                          Gerando com IA...
+                        </span>
+                      ) : (
+                        "Gerar com IA"
+                      )}
+                    </button>
+                    <span className="badge text-bg-light">
+                      Estrutura pronta para prompt
+                    </span>
+                  </div>
                 </div>
 
                 <div className="row g-3 mt-1">


### PR DESCRIPTION
### Motivation
- The per-section "Gerar com IA" action was removed by mistake and needs to be restored so users can trigger Worker IA generations from the experiment pipeline UI while keeping prompts and pipeline contracts consistent with canonical docs.

### Description
- Restored a `Gerar com IA` button in each pipeline section and added UI feedback with spinner and disabled state using `isGeneratingSection` and `pendingGenerationSection` to avoid concurrent clicks. 
- Implemented `handleGenerateSection` to call `POST /api/experiments/{id}/pipeline/{section}/generate`, mark local request state as `PROCESSING`/`FAILED`, and show toast notifications. 
- Refactored history loaders into reusable `useCallback` functions (`loadCampaignAngles`, `loadAdCopy`, `loadSection`) and reloaded relevant section data plus `jobsQuery.refetch()` after a generation completes. 
- Change is frontend-scoped and preserves the canonical pipeline prompt defaults via `SECTION_PROMPT_DEFAULTS` when issuing requests. 

### Testing
- Performed frontend dependency install with `cd frontend && npm install` and it completed successfully. 
- Built the frontend with `cd frontend && npm run build` and the production build succeeded. 
- Ran the test suite with `cd frontend && npm run test -- --run`; the suite executed but had pre-existing unrelated failures (3 failing tests and 1 unhandled error): failures observed in `FunnelBuilder`/`EditFunnelPage` (invalid Chai property `toHaveValue`), `NicheFlow` (missing test element), and an unhandled error in `GlobalAutomationAlerts`; these failures are not caused by the restored button change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e57a8f4e6883218e45d01a58271449)