### PR TITLE
Força campanhas a rodarem apenas no Instagram

### DIFF
--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -20,6 +20,7 @@
 - Em `geo_locations` descarte chaves que não sejam texto e remova `regions` cujos `key` não sejam numéricos para manter a compatibilidade com a Graph API.
 - Quando o destino do experimento for um formulário de leads, ajuste o conjunto de anúncios para `destination_type = ON_AD`, force `optimization_goal = LEAD_GENERATION` e não envie `link` externo no criativo; utilize apenas `call_to_action.value.lead_gen_form_id`.
 - Na criação de ad sets de campanha, manter `targeting_automation.advantage_audience = 0` para garantir o público Advantage+ desabilitado por padrão.
+- Na criação de ad sets de campanha, manter placements exclusivos de Instagram (`publisher_platforms=["instagram"]` e `instagram_positions=["stream","story","reels","explore"]`), removendo placements de Facebook, Audience Network e Messenger.
 - Quando não houver `instagramAccount` no experimento, utilize o `defaultInstagramActorId` configurado ou o identificador vindo do criativo, seguindo sem `instagram_user_id` se nenhum valor estiver disponível.
 - Identificadores de instant form no formato `ai_form_*` devem ser normalizados para `form_*` antes de chamar a Graph API.
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -145,7 +145,12 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    campo `instagramAccount` retornado pelo backend ou o `defaultInstagramActorId`
    configurado na conta e popula `instagram_user_id` quando disponível. Caso
    nenhum identificador esteja disponível, o worker registra o aviso e segue
-   sem `instagram_user_id`, permitindo veiculação apenas no Facebook.
+   sem `instagram_user_id`, mantendo a criação do criativo para preservar
+   compatibilidade de conta.
+   O conjunto de anúncios é sempre normalizado para veiculação exclusiva no
+   Instagram (`publisher_platforms=["instagram"]` e
+   `instagram_positions=["stream","story","reels","explore"]`), removendo
+   placements de Facebook, Audience Network e Messenger.
    Opcionalmente o fluxo inclui mensagem e call-to-action vindos do próprio
    criativo. A imagem é sempre veiculada via `link_data.picture` — não há hash
    salvo na biblioteca —, garantindo que o anúncio utilize exatamente o ativo
@@ -406,8 +411,9 @@ de [códigos de erro da Marketing API](https://developers.facebook.com/docs/mark
 para confirmar os requisitos de permissão. Quando o erro vem acompanhado do
 `error_subcode = 1815199` ("A conta de anúncios não tem acesso a esta conta do
 Instagram"), o worker tenta novamente criar o criativo sem enviar o
-`instagram_user_id`, permitindo que a campanha prossiga apenas com o Facebook
-quando a conta não possui acesso ao Instagram informado pelo backend. Caso o
+`instagram_user_id` para reduzir falhas de permissão no nível do criativo.
+Mesmo nesse fallback, os conjuntos seguem com placements exclusivos de
+Instagram. Caso o
 Facebook ainda rejeite a requisição — seja por outras permissões ausentes ou
 por continuar exigindo o Instagram — o worker marca automaticamente o
 experimento como `FAILED` via

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -350,9 +350,22 @@ public class FacebookAdsService {
         }
 
         forceBrazilWideTargeting(targeting);
+        forceInstagramOnlyPlacements(targeting);
         disableAdvantageAudience(targeting);
 
         return targeting;
+    }
+
+    private void forceInstagramOnlyPlacements(Map<String, Object> targeting) {
+        if (targeting == null) {
+            return;
+        }
+
+        targeting.put("publisher_platforms", List.of("instagram"));
+        targeting.put("instagram_positions", List.of("stream", "story", "reels", "explore"));
+        targeting.remove("facebook_positions");
+        targeting.remove("audience_network_positions");
+        targeting.remove("messenger_positions");
     }
 
     private void disableAdvantageAudience(Map<String, Object> targeting) {

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -119,6 +119,14 @@ class FacebookAdsServiceTest {
         assertFalse(body.has("bid_amount"));
         assertEquals("BR", body.get("targeting").get("geo_locations").get("countries").get(0).asText());
         assertEquals(0, body.get("targeting").get("targeting_automation").get("advantage_audience").asInt());
+        assertEquals("instagram", body.get("targeting").get("publisher_platforms").get(0).asText());
+        assertEquals("stream", body.get("targeting").get("instagram_positions").get(0).asText());
+        assertEquals("story", body.get("targeting").get("instagram_positions").get(1).asText());
+        assertEquals("reels", body.get("targeting").get("instagram_positions").get(2).asText());
+        assertEquals("explore", body.get("targeting").get("instagram_positions").get(3).asText());
+        assertFalse(body.get("targeting").has("facebook_positions"));
+        assertFalse(body.get("targeting").has("audience_network_positions"));
+        assertFalse(body.get("targeting").has("messenger_positions"));
         assertEquals("42", body.get("promoted_object").get("page_id").asText());
         assertEquals("222", id);
     }
@@ -146,6 +154,38 @@ class FacebookAdsServiceTest {
         JsonNode body = objectMapper.readTree(recorded.getBody().inputStream());
         assertEquals("COST_CAP", body.get("bid_strategy").asText());
         assertEquals("200", body.get("bid_amount").asText());
+    }
+
+    @Test
+    void createAdSetForcesInstagramOnlyPlacements() throws Exception {
+        server.enqueueResponse(new MockResponse().setBody("{\"id\":\"777\"}")
+            .addHeader("Content-Type", "application/json"));
+        String targetingJson = "{\"publisher_platforms\":[\"facebook\"],\"facebook_positions\":[\"feed\"],\"instagram_positions\":[\"story\"],\"messenger_positions\":[\"messenger_home\"],\"geo_locations\":{\"countries\":[\"BR\"]}}";
+        FacebookAdsService.AdSetRequest request = new FacebookAdsService.AdSetRequest(
+            "Camp - Ad Set",
+            "123",
+            "1500",
+            "IMPRESSIONS",
+            "LINK_CLICKS",
+            "WEBSITE",
+            "LOWEST_COST_WITHOUT_CAP",
+            "200",
+            "42",
+            "BR",
+            targetingJson,
+            Collections.emptyList()
+        );
+
+        service.createAdSet("1", request);
+
+        RecordedRequest recorded = takeRequest("request");
+        JsonNode targeting = objectMapper.readTree(recorded.getBody().inputStream()).get("targeting");
+        assertEquals(1, targeting.get("publisher_platforms").size());
+        assertEquals("instagram", targeting.get("publisher_platforms").get(0).asText());
+        assertEquals(4, targeting.get("instagram_positions").size());
+        assertFalse(targeting.has("facebook_positions"));
+        assertFalse(targeting.has("audience_network_positions"));
+        assertFalse(targeting.has("messenger_positions"));
     }
 
 


### PR DESCRIPTION
### Motivation
- Garantir que todos os ad sets criados pelo worker veiculem exclusivamente no inventário do Instagram conforme requisito de direcionamento (`vamos direcionar todas as campanhas somente para instagram`).

### Description
- Adiciona `forceInstagramOnlyPlacements` em `FacebookAdsService` e chama-a durante a normalização de `targeting`, definindo `publisher_platforms = ["instagram"]` e `instagram_positions = ["stream","story","reels","explore"]` enquanto remove `facebook_positions`, `audience_network_positions` e `messenger_positions`.
- Atualiza e adiciona assertions em `FacebookAdsServiceTest` para validar o comportamento padrão e o override quando `targetingJson` contém placements conflitantes.
- Atualiza a documentação operacional do módulo (`README.md` e `AGENTS.md`) para registrar a nova regra de campanhas Instagram-only.

### Testing
- Executado: `cd facebook-ads-worker && mvn -q -Dtest=FacebookAdsServiceTest test` and unit tests for `FacebookAdsServiceTest` were run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58c82bd1c83219141a9b4acc5b5f3)