### PR TITLE
feat(frontend): exportar framework completo da hipótese em Markdown

### DIFF
--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -126,6 +126,24 @@ export default function HypothesisDetailPage() {
     { label: "Entrega", value: data.entrega },
   ];
 
+  const framework = data.framework;
+
+  const buildFrameworkSectionMarkdown = (
+    title: string,
+    fields: Array<{ label: string; value?: string | number | null }>,
+    summary?: string,
+  ) => {
+    const fieldsMd = fields
+      .map(({ label, value }) => `- **${label}:** ${value ?? ""}`)
+      .join("\n");
+
+    return (
+      `## ${title}\n\n` +
+      `${fieldsMd}\n\n` +
+      `**Resumo do item:**\n${summary ?? ""}\n`
+    );
+  };
+
   const handleSaveMarkdown = () => {
     const nicheMd =
       `# Nicho: ${niche?.name ?? ""}\n\n` +
@@ -181,7 +199,100 @@ ${data.uniqueMechanism ?? ""}
       `**Entrega:**
 ${data.entrega ?? ""}
 `;
-    const md = `${nicheMd}\n\n${hypothesisMd}`;
+
+    const frameworkMd =
+      `# Framework da hipótese\n\n` +
+      buildFrameworkSectionMarkdown(
+        "Dor",
+        [
+          { label: "Dor superficial", value: framework?.pain?.surface },
+          { label: "Dor raiz", value: framework?.pain?.root },
+          { label: "Dor emocional", value: framework?.pain?.emotional },
+          { label: "Dor social", value: framework?.pain?.social },
+          { label: "Custo da inação", value: framework?.pain?.cost },
+        ],
+        framework?.pain?.summary,
+      ) +
+      "\n" +
+      buildFrameworkSectionMarkdown(
+        "Resultado",
+        [
+          {
+            label: "Resultado desejado",
+            value: framework?.result?.desiredResult,
+          },
+          {
+            label: "Identidade desejada",
+            value: framework?.result?.desiredIdentity,
+          },
+          {
+            label: "Resultado de negócio",
+            value: framework?.result?.businessOutcome,
+          },
+          {
+            label: "Sinal de sucesso",
+            value: framework?.result?.successSignal,
+          },
+        ],
+        framework?.result?.summary,
+      ) +
+      "\n" +
+      buildFrameworkSectionMarkdown(
+        "Mecanismo",
+        [
+          { label: "Mecanismo central", value: framework?.mechanism?.core },
+          { label: "Mecanismo único", value: framework?.mechanism?.unique },
+          { label: "Evidência visível", value: framework?.mechanism?.visible },
+          {
+            label: "Fator de credibilidade",
+            value: framework?.mechanism?.believability,
+          },
+        ],
+        framework?.mechanism?.summary,
+      ) +
+      "\n" +
+      buildFrameworkSectionMarkdown(
+        "Prova",
+        [
+          { label: "Tipo de prova", value: framework?.proof?.type },
+          { label: "Ativo de prova", value: framework?.proof?.asset },
+          { label: "Mensagem", value: framework?.proof?.message },
+          {
+            label: "Estágio de entrega",
+            value: framework?.proof?.deliveryStage,
+          },
+        ],
+        framework?.proof?.summary,
+      ) +
+      "\n" +
+      buildFrameworkSectionMarkdown(
+        "Oferta",
+        [
+          { label: "Nome da oferta", value: framework?.offer?.name },
+          {
+            label: "Promessa central",
+            value: framework?.offer?.corePromise,
+          },
+          {
+            label: "Entregáveis",
+            value: framework?.offer?.deliverables,
+          },
+          {
+            label: "Reversão de risco",
+            value: framework?.offer?.riskReversal,
+          },
+          {
+            label: "Lógica de preço",
+            value: framework?.offer?.priceLogic,
+          },
+          { label: "Preço", value: framework?.offer?.priceAmount },
+          { label: "Tipo da oferta", value: framework?.offer?.offerType },
+          { label: "Call to action", value: framework?.offer?.cta },
+        ],
+        framework?.offer?.summary,
+      );
+
+    const md = `${nicheMd}\n\n${hypothesisMd}\n\n${frameworkMd}`;
     const blob = new Blob([md], { type: "text/markdown" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");


### PR DESCRIPTION
### Motivation

- Gerar a partir da tela de detalhe da hipótese um relatório Markdown que contenha todos os itens do framework (Dor, Resultado, Mecanismo, Prova, Oferta) e o resumo de cada item para facilitar documentação e revisão.

### Description

- Adicionada a extração do `framework` da hipótese e o gerador reutilizável `buildFrameworkSectionMarkdown` em `frontend/src/pages/hypothesis/HypothesisDetailPage.tsx` para montar cada seção do framework com seus campos e o `Resumo do item`.
- Atualizada a ação `handleSaveMarkdown` para concatenar o conteúdo já existente de nicho/hipótese com a nova seção `# Framework da hipótese` contendo os blocos `Dor`, `Resultado`, `Mecanismo`, `Prova` e `Oferta` e seus respectivos campos.
- O arquivo gerado mantém o formato Markdown e continua sendo baixado via `Blob` com nome `${niche?.name ?? "nicho"}-${data.title}.md`.

### Testing

- Executado `cd frontend && npm install` e a instalação das dependências foi concluída com sucesso.
- Executado `cd frontend && npm run build` e o build finalizou com sucesso (após instalar dependências), embora tenha exibido avisos de chunk grande; build bem-sucedido.
- Não foram executados testes unitários automatizados neste PR (apenas validação de build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58e8b500483218ab902d0677cfbaf)