### PR TITLE
Enforce sequential experiment pipeline orchestration

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationService.java
@@ -216,6 +216,29 @@ public class FrameworkImageGenerationService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public boolean allPlanningImagesCompleted(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Experimento não encontrado"));
+        List<PlanningItem> items = parsePlanningItems(experiment).stream()
+                .filter(item -> StringUtils.hasText(item.prompt()))
+                .toList();
+        if (items.isEmpty()) {
+            return true;
+        }
+        Map<String, FrameworkImageGenerationJob> latestByItem = new LinkedHashMap<>();
+        for (FrameworkImageGenerationJob job : jobRepository.findByExperimentIdOrderByCreatedAtDesc(experimentId)) {
+            latestByItem.putIfAbsent(job.getPlanningItemKey(), job);
+        }
+        for (PlanningItem item : items) {
+            FrameworkImageGenerationJob latest = latestByItem.get(item.planningItemKey());
+            if (latest == null || latest.getStatus() != FrameworkImageGenerationJobStatus.COMPLETED) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Transactional
     public int failStaleProcessingJobs(Instant staleBefore, int limit, String staleReason) {
         List<FrameworkImageGenerationJob> staleJobs = jobRepository.findByStatusAndStartedAtBeforeOrderByStartedAtAsc(

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/ExperimentPipelineSection.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/ExperimentPipelineSection.java
@@ -27,6 +27,15 @@ public enum ExperimentPipelineSection {
         return predecessor;
     }
 
+    public ExperimentPipelineSection successor() {
+        for (ExperimentPipelineSection section : values()) {
+            if (section.predecessor == this) {
+                return section;
+            }
+        }
+        return null;
+    }
+
     public static ExperimentPipelineSection fromPath(String raw) {
         if (!StringUtils.hasText(raw)) {
             throw new IllegalArgumentException("Section is required");

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -16,6 +16,7 @@ import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationJobS
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationRequest;
 import com.marketinghub.experiment.pipeline.dto.internal.ExperimentPipelineGenerationJobCompletionRequest;
 import com.marketinghub.experiment.pipeline.dto.internal.ExperimentPipelineGenerationJobDto;
+import com.marketinghub.experiment.frameworkimage.service.FrameworkImageGenerationService;
 import com.marketinghub.experiment.pipeline.repository.ExperimentPipelineGenerationJobRepository;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.hypothesis.dto.HypothesisFrameworkDto;
@@ -101,6 +102,7 @@ public class ExperimentPipelineGenerationService {
     private final LeadPortalFlowPublisher leadPortalFlowPublisher;
     private final ObjectMapper objectMapper;
     private final LandingPageImageInjector landingPageImageInjector;
+    private final FrameworkImageGenerationService frameworkImageGenerationService;
 
     public ExperimentPipelineGenerationService(ExperimentRepository experimentRepository,
                                                ExperimentPipelineGenerationJobRepository jobRepository,
@@ -109,7 +111,8 @@ public class ExperimentPipelineGenerationService {
                                                LeadPortalFlowRepository leadPortalFlowRepository,
                                                LeadPortalFlowPublisher leadPortalFlowPublisher,
                                                ObjectMapper objectMapper,
-                                               LandingPageImageInjector landingPageImageInjector) {
+                                               LandingPageImageInjector landingPageImageInjector,
+                                               FrameworkImageGenerationService frameworkImageGenerationService) {
         this.experimentRepository = experimentRepository;
         this.jobRepository = jobRepository;
         this.experimentMapper = experimentMapper;
@@ -118,6 +121,7 @@ public class ExperimentPipelineGenerationService {
         this.leadPortalFlowPublisher = leadPortalFlowPublisher;
         this.objectMapper = objectMapper;
         this.landingPageImageInjector = landingPageImageInjector;
+        this.frameworkImageGenerationService = frameworkImageGenerationService;
     }
 
     @Transactional
@@ -359,6 +363,8 @@ public class ExperimentPipelineGenerationService {
         job.setCostUsd(estimatedCost);
         job.setErrorMessage(null);
         job.setFinishedAt(Instant.now());
+
+        enqueueNextAutomaticStep(job, request);
     }
 
     @Transactional
@@ -419,6 +425,42 @@ public class ExperimentPipelineGenerationService {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "A seção " + section.path() + " depende da seção " + predecessor.path() + " já concluída");
         }
+        if (section == ExperimentPipelineSection.LANDING_PAGE_HTML
+                && !frameworkImageGenerationService.allPlanningImagesCompleted(experiment.getId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "A seção landing-page-html depende da geração completa das imagens planejadas da landing");
+        }
+    }
+
+    private void enqueueNextAutomaticStep(ExperimentPipelineGenerationJob job,
+                                          ExperimentPipelineGenerationJobCompletionRequest request) {
+        if (job == null || job.getExperiment() == null || job.getExperiment().getId() == null) {
+            return;
+        }
+        Long experimentId = job.getExperiment().getId();
+        ExperimentPipelineSection section = job.getSection();
+
+        if (section == ExperimentPipelineSection.LANDING_PAGE_IMAGE_PLANNING) {
+            frameworkImageGenerationService.enqueueJobsForExperiment(experimentId);
+            if (frameworkImageGenerationService.allPlanningImagesCompleted(experimentId)) {
+                enqueueJob(job.getExperiment(), ExperimentPipelineSection.LANDING_PAGE_HTML, deriveFollowUpRequest(request));
+            }
+            return;
+        }
+
+        ExperimentPipelineSection successor = section.successor();
+        if (successor == null) {
+            return;
+        }
+        enqueueJob(job.getExperiment(), successor, deriveFollowUpRequest(request));
+    }
+
+    private ExperimentPipelineGenerationRequest deriveFollowUpRequest(ExperimentPipelineGenerationJobCompletionRequest request) {
+        ExperimentPipelineGenerationRequest followUp = new ExperimentPipelineGenerationRequest();
+        if (request != null && StringUtils.hasText(request.rawResponse())) {
+            followUp.setCustomInstructions("Continuação automática do pipeline.");
+        }
+        return followUp;
     }
 
     private boolean markStaleJobsAsFailed(List<ExperimentPipelineGenerationJob> activeJobs) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -10,6 +10,7 @@ import com.marketinghub.experiment.pipeline.ExperimentPipelineGenerationJobStatu
 import com.marketinghub.experiment.pipeline.ExperimentPipelineSection;
 import com.marketinghub.experiment.pipeline.dto.internal.ExperimentPipelineGenerationJobCompletionRequest;
 import com.marketinghub.experiment.pipeline.repository.ExperimentPipelineGenerationJobRepository;
+import com.marketinghub.experiment.frameworkimage.service.FrameworkImageGenerationService;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.argThat;
 
 @ExtendWith(MockitoExtension.class)
 class ExperimentPipelineGenerationServiceTest {
@@ -57,6 +59,8 @@ class ExperimentPipelineGenerationServiceTest {
     private LeadPortalFlowPublisher leadPortalFlowPublisher;
     @Mock
     private LandingPageImageInjector landingPageImageInjector;
+    @Mock
+    private FrameworkImageGenerationService frameworkImageGenerationService;
 
     private ExperimentPipelineGenerationService service;
 
@@ -70,7 +74,8 @@ class ExperimentPipelineGenerationServiceTest {
                 leadPortalFlowRepository,
                 leadPortalFlowPublisher,
                 new ObjectMapper(),
-                landingPageImageInjector);
+                landingPageImageInjector,
+                frameworkImageGenerationService);
     }
 
     @Test
@@ -353,6 +358,52 @@ class ExperimentPipelineGenerationServiceTest {
                 """));
 
         assertNotNull(experiment.getLandingPageHtml());
+    }
+
+    @Test
+    void completeJobAutomaticallyEnqueuesSuccessorSection() {
+        Experiment experiment = new Experiment();
+        experiment.setId(301L);
+
+        UUID jobId = UUID.randomUUID();
+        ExperimentPipelineGenerationJob job = ExperimentPipelineGenerationJob.builder()
+                .id(jobId)
+                .experiment(experiment)
+                .section(ExperimentPipelineSection.AD_COPY)
+                .status(ExperimentPipelineGenerationJobStatus.PROCESSING)
+                .stage(ExperimentPipelineGenerationJobStage.SENT_TO_OPENAI)
+                .model("gpt-5.2")
+                .prompt("prompt")
+                .build();
+        when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
+
+        service.completeJob(jobId, new ExperimentPipelineGenerationJobCompletionRequest(
+                "{\"adCopy\":{\"headline\":\"teste\"}}",
+                "{\"id\":\"resp_copy\"}",
+                "{\"model\":\"gpt-5.2\"}",
+                40,
+                20,
+                null));
+
+        verify(jobRepository).save(argThat(saved ->
+                saved.getSection() == ExperimentPipelineSection.AD_IMAGE_BRIEFING
+                        && saved.getExperiment() == experiment
+                        && saved.getStatus() == ExperimentPipelineGenerationJobStatus.PENDING));
+    }
+
+    @Test
+    void generateLandingHtmlFailsWhenPlannedImagesAreNotFullyGenerated() {
+        Experiment experiment = new Experiment();
+        experiment.setId(302L);
+        experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":{\"images\":[{\"sectionId\":\"hero\",\"imagePrompt\":\"x\"}]}}");
+
+        when(experimentRepository.findById(302L)).thenReturn(Optional.of(experiment));
+        when(frameworkImageGenerationService.allPlanningImagesCompleted(302L)).thenReturn(false);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.generate(302L, ExperimentPipelineSection.LANDING_PAGE_HTML, new com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationRequest()));
+
+        assertTrue(ex.getReason().contains("geração completa das imagens"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Ensure the experiment pipeline runs strictly sequentially so each section only starts after its predecessor has completed. 
- Prevent `landing-page-html` generation until all images planned by `landing-page-image-planning` are produced to avoid inconsistent artifacts.

### Description
- Add an explicit `successor()` helper to `ExperimentPipelineSection` to traverse the pipeline order programmatically. 
- Injected `FrameworkImageGenerationService` into `ExperimentPipelineGenerationService` and added `enqueueNextAutomaticStep(...)` so `completeJob(...)` automatically enqueues the downstream section (or triggers framework-image jobs after image planning). 
- Gate `landing-page-html` generation in `validatePredecessor(...)` by calling `FrameworkImageGenerationService#allPlanningImagesCompleted(...)` and added that completeness method to `FrameworkImageGenerationService`. 
- Added/updated unit tests in `ExperimentPipelineGenerationServiceTest` to cover automatic successor enqueueing and blocking `landing-page-html` when planned images are not finished, and updated test setup to mock the new dependency.

### Testing
- Unit tests added: `completeJobAutomaticallyEnqueuesSuccessorSection` and `generateLandingHtmlFailsWhenPlannedImagesAreNotFullyGenerated` in `backend/ads-service/src/test/java/.../ExperimentPipelineGenerationServiceTest.java`. 
- Attempted to run `mvn -s ../settings.xml -Dtest=ExperimentPipelineGenerationServiceTest,ExperimentPipelineSectionTest test` in `backend/ads-service`, but the command failed due to the environment being unable to resolve parent POM from Maven Central (network unavailable), so tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5afa808f08321b0b339c2cd80506d)