### PR TITLE
Add HTTPS support and Let's Encrypt certbot volumes to mcp-server nginx

### DIFF
--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -23,5 +23,8 @@ services:
       - mcp-server
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./certbot/www:/var/www/certbot:ro
+      - ./certbot/conf:/etc/letsencrypt:ro

--- a/mcp-server/nginx/default.conf
+++ b/mcp-server/nginx/default.conf
@@ -2,6 +2,25 @@ server {
     listen 80;
     server_name mcpserverdigi.shop www.mcpserverdigi.shop;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name mcpserverdigi.shop www.mcpserverdigi.shop;
+
+    ssl_certificate /etc/letsencrypt/live/mcpserverdigi.shop/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mcpserverdigi.shop/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:10m;
+
     location / {
         proxy_pass http://mcp-server:8096;
         proxy_http_version 1.1;


### PR DESCRIPTION
### Motivation

- Enable HTTPS for the mcp-server site using Let's Encrypt and ensure ACME HTTP-01 challenges are served so certificates can be obtained and renewed.
- Redirect all HTTP traffic to HTTPS and keep existing proxying to the `mcp-server` backend.

### Description

- Update `docker-compose.yml` to publish port `443:443` and mount `./certbot/www` to `/var/www/certbot:ro` and `./certbot/conf` to `/etc/letsencrypt:ro` so nginx can serve ACME challenges and read certificates.
- Modify `nginx/default.conf` to add a `/.well-known/acme-challenge/` location and make the port 80 server return a `301` redirect to `https://$host$request_uri`.
- Add an HTTPS server block listening on `443 ssl http2` with `server_name` set to `mcpserverdigi.shop` and `www.mcpserverdigi.shop`, configure `ssl_certificate` and `ssl_certificate_key` paths under `/etc/letsencrypt/live/...`, enable `TLSv1.2`/`TLSv1.3`, and set basic SSL session settings.
- Keep the existing reverse proxy configuration that forwards `/` to `http://mcp-server:8096` and preserves the proxy headers and WebSocket upgrade headers.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66f37c6c08321a61a16ab44dbc699)