### PR TITLE
Corrige filtro de schema em listTables para compatibilidade H2/MySQL

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/DatabaseDiagnosticsService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/DatabaseDiagnosticsService.java
@@ -32,7 +32,7 @@ public class DatabaseDiagnosticsService {
                 """
                         SELECT TABLE_NAME
                         FROM INFORMATION_SCHEMA.TABLES
-                        WHERE UPPER(TABLE_SCHEMA) = UPPER(DATABASE())
+                        WHERE UPPER(TABLE_SCHEMA) = UPPER(SCHEMA())
                           AND TABLE_TYPE = 'BASE TABLE'
                         ORDER BY TABLE_NAME
                         """,


### PR DESCRIPTION
### Motivation
- O teste `McpControllerTest.shouldListDatabaseTables` falhou porque a consulta a `INFORMATION_SCHEMA.TABLES` dependia de comportamento de catálogo (`DATABASE()`/TABLE_CATALOG) que difere entre MySQL e o modo de compatibilidade H2, provocando contagens inesperadas de tabelas ou inclusão de tabelas de sistema.

### Description
- Atualizei a consulta em `DatabaseDiagnosticsService.listTables()` para filtrar por `UPPER(TABLE_SCHEMA) = UPPER(SCHEMA())`, garantindo que apenas o schema atual seja listado tanto no MySQL quanto no H2 de testes.
- A alteração é localizada em `mcp-server/src/main/java/com/marketinghub/mcpserver/service/DatabaseDiagnosticsService.java` e não altera o contrato HTTP nem os formatos de retorno (`database`, `tableCount`, `tables`).

### Testing
- Executei `mvn -Dtest=McpControllerTest test` durante o diagnóstico e reproduzi a falha relacionada ao `tableCount` antes da correção.
- Executei `cd mcp-server && mvn test` após a correção e a suíte do módulo passou com sucesso (`Tests run: 9, Failures: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69b46c2d48321a65b0207981055c0)