### PR TITLE
fix(mcp-server): improve startup resilience and add GET /mcp reachability endpoint

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -13,6 +13,10 @@ RUN --mount=type=cache,target=/root/.m2 mvn -s settings.xml -f pom.xml clean pac
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /workspace/target/app-exec.jar /app/app.jar
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -24,6 +24,7 @@ mvn -s settings.xml spring-boot:run
 ## Endpoints
 
 - `POST /mcp`: endpoint MCP via JSON-RPC (métodos `initialize`, `tools/list`, `tools/call`).
+- `GET /mcp`: endpoint de reachability (retorna metadados simples para smoke tests de rede/proxy).
 - `GET /actuator/health`: health-check para orquestração.
 
 ## Segurança
@@ -51,6 +52,12 @@ O `docker-compose.yml` deste diretório sobe dois containers:
 
 - `mcp-server` (interno, exposto apenas na rede Docker em `8096`);
 - `nginx` (público, escutando na porta `80` e fazendo proxy para o MCP).
+
+O compose aguarda o health-check do `mcp-server` (`/actuator/health`) antes de subir o Nginx, reduzindo erros de timeout durante boot.
+
+### Tolerância a indisponibilidade temporária do banco
+
+O MCP foi configurado para iniciar mesmo quando o MySQL está temporariamente indisponível. Assim, chamadas `initialize` e `tools/list` continuam respondendo enquanto a infraestrutura de banco é estabilizada.
 
 ```bash
 cd mcp-server

--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -14,13 +14,20 @@ services:
       MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}
     expose:
       - "8096"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8096/actuator/health >/dev/null || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 8
+      start_period: 30s
 
   nginx:
     image: nginx:1.27-alpine
     container_name: marketinghub-mcp-nginx
     restart: unless-stopped
     depends_on:
-      - mcp-server
+      mcp-server:
+        condition: service_healthy
     ports:
       - "80:80"
       - "443:443"

--- a/mcp-server/nginx/default.conf
+++ b/mcp-server/nginx/default.conf
@@ -24,6 +24,9 @@ server {
     location / {
         proxy_pass http://mcp-server:8096;
         proxy_http_version 1.1;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
 
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +31,17 @@ public class McpController {
     public McpController(McpProperties properties, DatabaseDiagnosticsService databaseDiagnosticsService) {
         this.properties = properties;
         this.databaseDiagnosticsService = databaseDiagnosticsService;
+    }
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> describeEndpoint() {
+        return ResponseEntity.ok(Map.of(
+                "name", properties.serverName(),
+                "version", properties.serverVersion(),
+                "endpoint", "/mcp",
+                "protocol", "json-rpc-2.0",
+                "hint", "Use HTTP POST with JSON-RPC methods initialize, tools/list, tools/call"
+        ));
     }
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -9,6 +9,12 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME:marketing_hub_user}
     password: ${SPRING_DATASOURCE_PASSWORD:${MYSQL_PASS:}}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      initialization-fail-timeout: -1
+      connection-timeout: ${DB_CONNECTION_TIMEOUT_MS:5000}
+      validation-timeout: ${DB_VALIDATION_TIMEOUT_MS:3000}
+      maximum-pool-size: ${DB_MAX_POOL_SIZE:10}
+      minimum-idle: ${DB_MIN_IDLE:0}
 
 management:
   endpoints:

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -50,6 +51,14 @@ class McpControllerTest {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.serverInfo.name").value("marketing-hub-mcp"));
+    }
+
+    @Test
+    void shouldExposeGetEndpointForReachabilityChecks() throws Exception {
+        mockMvc.perform(get("/mcp"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.endpoint").value("/mcp"))
+                .andExpect(jsonPath("$.protocol").value("json-rpc-2.0"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Connectivity reports showed upstream timeouts and proxy resets causing `POST /mcp` calls to return 503 during bootstrap, so light-weight reachability checks and more tolerant startup are needed.
- The Nginx proxy and container orchestration should wait for the backend to be healthy to avoid premature proxying and false negatives.

### Description

- Added a `GET /mcp` endpoint that returns simple metadata for smoke tests and reachability checks (no JSON-RPC required).
- Configured Hikari datasource options in `application.yml` (`initialization-fail-timeout: -1`, connection/validation timeouts, pool sizing) to allow the service to start when MySQL is temporarily unavailable.
- Added a Docker `healthcheck` for the `mcp-server` and made `nginx` depend on the service being healthy in `docker-compose.yml` so the proxy starts only after backend readiness.
- Tuned Nginx proxy timeouts (`proxy_connect_timeout`, `proxy_send_timeout`, `proxy_read_timeout`) and added `curl` to the runtime image in `Dockerfile` to support the container healthcheck, and updated tests and `README.md` accordingly.

### Testing

- Attempted to run `cd mcp-server && mvn -s settings.xml test`, but the build could not complete in this environment due to a network error resolving Maven parent POM from `repo.maven.apache.org`, so automated tests were not executed here.
- Unit tests were updated to cover the new `GET /mcp` reachability endpoint and remain available for CI once Maven repository access is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69edd9e748321931da2b140280cd4)