### PR TITLE
Make MCP Nginx resilient when Let's Encrypt certs are missing

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -83,6 +83,6 @@ services:
       - "${MCP_NGINX_HTTP_PORT:-80}:80"
       - "${MCP_NGINX_HTTPS_PORT:-443}:443"
     volumes:
-      - ./nginx/mcp/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/mcp/${MCP_NGINX_CONF:-default.http.conf}:/etc/nginx/conf.d/default.conf:ro
       - ./volumes/mcp/certbot/www:/var/www/certbot:ro
       - ./volumes/mcp/certbot/conf:/etc/letsencrypt:ro

--- a/deploy/nginx/mcp/default.conf
+++ b/deploy/nginx/mcp/default.conf
@@ -12,7 +12,8 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
     server_name mcpserverdigi.shop www.mcpserverdigi.shop;
 
     ssl_certificate /etc/letsencrypt/live/mcpserverdigi.shop/fullchain.pem;

--- a/deploy/nginx/mcp/default.https.conf
+++ b/deploy/nginx/mcp/default.https.conf
@@ -12,7 +12,8 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
     server_name mcpserverdigi.shop www.mcpserverdigi.shop;
 
     ssl_certificate /etc/letsencrypt/live/mcpserverdigi.shop/fullchain.pem;

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -73,7 +73,15 @@ curl -i http://mcpserverdigi.shop/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 ```
 
-Quando o certificado estiver pronto, basta ajustar o Nginx para `443` e redirecionar `80 -> 443`.
+Por padrão, o compose sobe com `default.http.conf` (sem TLS obrigatório), evitando crash quando o certificado ainda não foi emitido.
+
+Para habilitar HTTPS após a emissão do certificado, use:
+
+```bash
+MCP_NGINX_CONF=default.conf docker compose up -d nginx
+```
+
+No deploy (`deploy/docker-compose.yml`), use a mesma variável de ambiente `MCP_NGINX_CONF` (por exemplo, `default.conf` ou `default.https.conf`).
 
 ## Configuração no Codex Cloud (Plugin MCP)
 

--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -32,6 +32,6 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/${MCP_NGINX_CONF:-default.http.conf}:/etc/nginx/conf.d/default.conf:ro
       - ./certbot/www:/var/www/certbot:ro
       - ./certbot/conf:/etc/letsencrypt:ro

--- a/mcp-server/nginx/default.http.conf
+++ b/mcp-server/nginx/default.http.conf
@@ -7,22 +7,6 @@ server {
     }
 
     location / {
-        return 301 https://$host$request_uri;
-    }
-}
-
-server {
-    listen 443 ssl;
-    http2 on;
-    server_name mcpserverdigi.shop www.mcpserverdigi.shop;
-
-    ssl_certificate /etc/letsencrypt/live/mcpserverdigi.shop/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/mcpserverdigi.shop/privkey.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:10m;
-
-    location / {
         proxy_pass http://mcp-server:8096;
         proxy_http_version 1.1;
         proxy_connect_timeout 10s;


### PR DESCRIPTION
### Motivation
- Nginx was failing to start when the Let's Encrypt artifacts under `/etc/letsencrypt/live/...` were absent, causing `cannot load certificate` errors and container crash.
- The MCP deployment must be able to come up (HTTP) while ACME/cert issuance is pending so the service remains reachable for health checks and diagnostics.
- Keep HTTPS configs available and avoid deprecated Nginx syntax warnings while allowing an easy switch to TLS once certificates exist.

### Description
- Make the Nginx config mount selectable via `MCP_NGINX_CONF` with a fallback to `default.http.conf` in `mcp-server/docker-compose.yml` and `deploy/docker-compose.yml` so the compose defaults to HTTP proxy mode instead of failing on missing certs.
- Add `mcp-server/nginx/default.http.conf` which exposes only HTTP and proxies requests to `mcp-server:8096`, including ACME challenge support under `/.well-known/acme-challenge/`.
- Update HTTPS configs (`mcp-server/nginx/default.conf`, `deploy/nginx/mcp/default.conf`, and `deploy/nginx/mcp/default.https.conf`) to replace the deprecated `listen 443 ssl http2;` with `listen 443 ssl;` and `http2 on;`.
- Document the new behaviour and how to enable HTTPS after cert issuance in `mcp-server/README.md` using `MCP_NGINX_CONF=default.conf docker compose up -d nginx`.

### Testing
- Performed static verification with `rg -n "listen 443 ssl http2"` to ensure deprecated directives were replaced, and the search returned no remaining matches in the updated MCP Nginx configs (success).
- Attempted to run `docker compose -f mcp-server/docker-compose.yml config` and `docker compose -f deploy/docker-compose.yml config` for a structural validation, but the runner environment lacks `docker` so the `docker compose config` checks could not be executed (environment limitation).
- Confirmed local file diffs and presence of the new `mcp-server/nginx/default.http.conf` file via repository inspection (static verification success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6b9cd6f288321b34a37bfb8687e9c)