### PR TITLE
feat(mcp-server): add MCP tool to read Java module logs

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -14,6 +14,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `db_list_tables`: lista todas as tabelas disponíveis no schema atual.
 - `db_read_table`: lê dados de uma tabela com paginação (`table`, `limit`, `offset`).
 - `db_query`: executa SQL de leitura (`SELECT`/`WITH`) com limite de linhas.
+- `java_module_logs`: retorna tail de logs dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`).
 
 ## Executar localmente
 
@@ -31,6 +32,17 @@ mvn -s settings.xml spring-boot:run
 
 - Se `MCP_API_KEY` estiver definido, o endpoint `/mcp` exige `Authorization: Bearer <MCP_API_KEY>`.
 - Se `MCP_API_KEY` estiver vazio, o endpoint permanece aberto (apenas para ambientes internos/controlados).
+
+## Logs dos módulos Java
+
+O tool `java_module_logs` lê os arquivos configurados em:
+
+- `MCP_LOG_BACKEND_PATH` (default `/app/logs/marketinghub-backend.log`);
+- `MCP_LOG_AI_WORKER_PATH` (default `/var/log/ai-worker/application.log`);
+- `MCP_LOG_LEAD_PORTAL_PATH` (default `/app/data/logs/lead-portal-backend.log`);
+- `MCP_LOG_FACEBOOK_ADS_PATH` (default `/var/log/facebook-ads-worker/application.log`).
+
+Limite máximo por chamada: `MCP_LOG_MAX_LINES` (default `500`).
 
 ## Docker
 

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -1,11 +1,26 @@
 package com.marketinghub.mcpserver.config;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 @Validated
 @ConfigurationProperties(prefix = "mcp")
-public record McpProperties(@NotBlank String serverName, @NotBlank String serverVersion, String apiKey) {
+public record McpProperties(
+        @NotBlank String serverName,
+        @NotBlank String serverVersion,
+        String apiKey,
+        @NotNull @Valid Logs logs
+) {
+    public record Logs(
+            @NotBlank String backendPath,
+            @NotBlank String aiWorkerPath,
+            @NotBlank String leadPortalPath,
+            @NotBlank String facebookAdsPath,
+            @Positive int maxLines
+    ) {
+    }
 }
-

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -2,6 +2,7 @@ package com.marketinghub.mcpserver.controller;
 
 import com.marketinghub.mcpserver.config.McpProperties;
 import com.marketinghub.mcpserver.service.DatabaseDiagnosticsService;
+import com.marketinghub.mcpserver.service.ModuleLogService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -27,10 +28,14 @@ public class McpController {
 
     private final McpProperties properties;
     private final DatabaseDiagnosticsService databaseDiagnosticsService;
+    private final ModuleLogService moduleLogService;
 
-    public McpController(McpProperties properties, DatabaseDiagnosticsService databaseDiagnosticsService) {
+    public McpController(McpProperties properties,
+                         DatabaseDiagnosticsService databaseDiagnosticsService,
+                         ModuleLogService moduleLogService) {
         this.properties = properties;
         this.databaseDiagnosticsService = databaseDiagnosticsService;
+        this.moduleLogService = moduleLogService;
     }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
@@ -105,6 +110,21 @@ public class McpController {
                                                     "description", "Limite de linhas quando a query não tiver LIMIT. Padrão: 100.")),
                                     "required", List.of("query"),
                                     "additionalProperties", false)
+                    ),
+                    Map.of(
+                            "name", "java_module_logs",
+                            "description", "Retorna as últimas linhas de logs dos módulos Java (backend, ai-worker, lead-portal, facebook-ads).",
+                            "inputSchema", Map.of(
+                                    "type", "object",
+                                    "properties", Map.of(
+                                            "module", Map.of("type", "string",
+                                                    "enum", List.of("backend", "ai-worker", "lead-portal", "facebook-ads"),
+                                                    "description", "Módulo Java para consultar logs."),
+                                            "lines", Map.of("type", "integer", "minimum", 1,
+                                                    "maximum", moduleLogService.maxLines(),
+                                                    "description", "Quantidade de linhas do final do arquivo de log. Padrão: 200.")),
+                                    "required", List.of("module"),
+                                    "additionalProperties", false)
                     )))));
             case "tools/call" -> ResponseEntity.ok(callTool(id, request));
             default -> ResponseEntity.ok(error(id, -32601, "Method not found: " + method));
@@ -140,6 +160,7 @@ public class McpController {
                         "Database tables");
                 case "db_read_table" -> callReadTable(id, arguments);
                 case "db_query" -> callQueryTool(id, arguments);
+                case "java_module_logs" -> callJavaModuleLogsTool(id, arguments);
                 default -> error(id, -32602, "Unknown tool: " + toolName);
             };
         } catch (IllegalArgumentException ex) {
@@ -190,6 +211,21 @@ public class McpController {
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
             return error(id, -32603, "Failed to execute query: " + ex.getMessage());
+        }
+    }
+
+    private Map<String, Object> callJavaModuleLogsTool(Object id, Map<String, Object> arguments) {
+        String module = stringArgument(arguments, "module");
+        Integer lines = intArgument(arguments, "lines");
+
+        try {
+            Map<String, Object> result = moduleLogService.readModuleLogs(module, lines);
+            return successToolResult(id, result,
+                    "Read " + result.get("returnedLines") + " log lines from module " + result.get("module"));
+        } catch (IllegalArgumentException ex) {
+            return error(id, -32602, ex.getMessage());
+        } catch (Exception ex) {
+            return error(id, -32603, "Failed to read module logs: " + ex.getMessage());
         }
     }
 

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -1,0 +1,105 @@
+package com.marketinghub.mcpserver.service;
+
+import com.marketinghub.mcpserver.config.McpProperties;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Service
+public class ModuleLogService {
+
+    private static final int DEFAULT_LINES = 200;
+
+    private final McpProperties properties;
+
+    public ModuleLogService(McpProperties properties) {
+        this.properties = properties;
+    }
+
+    public int maxLines() {
+        return properties.logs().maxLines();
+    }
+
+    public Map<String, Object> readModuleLogs(String module, Integer requestedLines) {
+        String normalizedModule = normalizeModule(module);
+        int lines = sanitizeLines(requestedLines);
+        String configuredPath = modulePath(normalizedModule);
+
+        if (!StringUtils.hasText(configuredPath)) {
+            throw new IllegalArgumentException("No log path configured for module: " + normalizedModule);
+        }
+
+        Path path = Path.of(configuredPath);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("module", normalizedModule);
+        response.put("path", path.toString());
+
+        if (!Files.exists(path)) {
+            response.put("exists", false);
+            response.put("requestedLines", lines);
+            response.put("returnedLines", 0);
+            response.put("lines", List.of());
+            return response;
+        }
+
+        try (Stream<String> stream = Files.lines(path, StandardCharsets.UTF_8)) {
+            List<String> rows = stream
+                    .skip(Math.max(0, countLines(path) - lines))
+                    .toList();
+
+            response.put("exists", true);
+            response.put("sizeBytes", Files.size(path));
+            response.put("requestedLines", lines);
+            response.put("returnedLines", rows.size());
+            response.put("lines", rows);
+            return response;
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Failed to read log file: " + ex.getMessage());
+        }
+    }
+
+    private long countLines(Path path) throws IOException {
+        try (Stream<String> stream = Files.lines(path, StandardCharsets.UTF_8)) {
+            return stream.count();
+        }
+    }
+
+    private String modulePath(String module) {
+        return switch (module) {
+            case "backend" -> properties.logs().backendPath();
+            case "ai-worker" -> properties.logs().aiWorkerPath();
+            case "lead-portal" -> properties.logs().leadPortalPath();
+            case "facebook-ads" -> properties.logs().facebookAdsPath();
+            default -> throw new IllegalArgumentException("Unknown module: " + module);
+        };
+    }
+
+    private String normalizeModule(String module) {
+        if (!StringUtils.hasText(module)) {
+            throw new IllegalArgumentException("module is required");
+        }
+
+        String normalized = module.trim().toLowerCase();
+        return switch (normalized) {
+            case "backend", "ai-worker", "lead-portal", "facebook-ads" -> normalized;
+            default -> throw new IllegalArgumentException("module must be one of: backend, ai-worker, lead-portal, facebook-ads");
+        };
+    }
+
+    private int sanitizeLines(Integer requestedLines) {
+        int lines = requestedLines == null ? DEFAULT_LINES : requestedLines;
+        if (lines < 1 || lines > maxLines()) {
+            throw new IllegalArgumentException("lines must be between 1 and " + maxLines());
+        }
+        return lines;
+    }
+}

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -26,3 +26,9 @@ mcp:
   server-name: ${MCP_SERVER_NAME:marketing-hub-mcp}
   server-version: ${MCP_SERVER_VERSION:1.0.0}
   api-key: ${MCP_API_KEY:}
+  logs:
+    backend-path: ${MCP_LOG_BACKEND_PATH:/app/logs/marketinghub-backend.log}
+    ai-worker-path: ${MCP_LOG_AI_WORKER_PATH:/var/log/ai-worker/application.log}
+    lead-portal-path: ${MCP_LOG_LEAD_PORTAL_PATH:/app/data/logs/lead-portal-backend.log}
+    facebook-ads-path: ${MCP_LOG_FACEBOOK_ADS_PATH:/var/log/facebook-ads-worker/application.log}
+    max-lines: ${MCP_LOG_MAX_LINES:500}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -11,6 +11,10 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -19,6 +23,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 class McpControllerTest {
+
+    private static final Path TEST_LOG_DIR = Path.of("target/test-logs");
 
     @Autowired
     private MockMvc mockMvc;
@@ -32,14 +38,24 @@ class McpControllerTest {
         registry.add("spring.datasource.driver-class-name", () -> "org.h2.Driver");
         registry.add("spring.datasource.username", () -> "sa");
         registry.add("spring.datasource.password", () -> "");
+        registry.add("mcp.logs.backend-path", () -> TEST_LOG_DIR.resolve("backend.log").toString());
+        registry.add("mcp.logs.ai-worker-path", () -> TEST_LOG_DIR.resolve("ai-worker.log").toString());
+        registry.add("mcp.logs.lead-portal-path", () -> TEST_LOG_DIR.resolve("lead-portal.log").toString());
+        registry.add("mcp.logs.facebook-ads-path", () -> TEST_LOG_DIR.resolve("facebook-ads.log").toString());
+        registry.add("mcp.logs.max-lines", () -> "500");
     }
 
     @BeforeEach
-    void setupDatabase() {
+    void setupDatabase() throws Exception {
         jdbcTemplate.execute("DROP TABLE IF EXISTS leads");
         jdbcTemplate.execute("CREATE TABLE leads (id BIGINT PRIMARY KEY, name VARCHAR(100), email VARCHAR(150))");
         jdbcTemplate.update("INSERT INTO leads (id, name, email) VALUES (?,?,?)", 1L, "Ana", "ana@example.com");
         jdbcTemplate.update("INSERT INTO leads (id, name, email) VALUES (?,?,?)", 2L, "Bruno", "bruno@example.com");
+
+        Files.createDirectories(TEST_LOG_DIR);
+        Files.writeString(TEST_LOG_DIR.resolve("backend.log"),
+                "line-1\nline-2\nline-3\n",
+                StandardCharsets.UTF_8);
     }
 
     @Test
@@ -132,11 +148,39 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.error.code").value(-32602))
                 .andExpect(jsonPath("$.error.message").value("only SELECT queries are allowed"));
     }
+
+    @Test
+    void shouldReadJavaModuleLogs() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"java_module_logs","arguments":{"module":"backend","lines":2}}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.structuredContent.module").value("backend"))
+                .andExpect(jsonPath("$.result.structuredContent.returnedLines").value(2))
+                .andExpect(jsonPath("$.result.structuredContent.lines[0]").value("line-2"))
+                .andExpect(jsonPath("$.result.structuredContent.lines[1]").value("line-3"));
+    }
+
+    @Test
+    void shouldRejectInvalidJavaModuleName() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"java_module_logs","arguments":{"module":"unknown"}}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.error.code").value(-32602))
+                .andExpect(jsonPath("$.error.message").value("module must be one of: backend, ai-worker, lead-portal, facebook-ads"));
+    }
 }
 
 @SpringBootTest(properties = "mcp.api-key=super-secret")
 @AutoConfigureMockMvc
 class McpControllerApiKeyEnabledTest {
+
+    private static final Path TEST_LOG_DIR = Path.of("target/test-logs-api-key");
 
     @Autowired
     private MockMvc mockMvc;
@@ -147,6 +191,11 @@ class McpControllerApiKeyEnabledTest {
         registry.add("spring.datasource.driver-class-name", () -> "org.h2.Driver");
         registry.add("spring.datasource.username", () -> "sa");
         registry.add("spring.datasource.password", () -> "");
+        registry.add("mcp.logs.backend-path", () -> TEST_LOG_DIR.resolve("backend.log").toString());
+        registry.add("mcp.logs.ai-worker-path", () -> TEST_LOG_DIR.resolve("ai-worker.log").toString());
+        registry.add("mcp.logs.lead-portal-path", () -> TEST_LOG_DIR.resolve("lead-portal.log").toString());
+        registry.add("mcp.logs.facebook-ads-path", () -> TEST_LOG_DIR.resolve("facebook-ads.log").toString());
+        registry.add("mcp.logs.max-lines", () -> "500");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Provide a single MCP tool to fetch recent log tails from the Java modules used in the platform for easier diagnostics (backend, ai-worker, lead-portal, facebook-ads).

### Description

- Added `ModuleLogService` to normalize module names, validate `lines` limits, resolve configured log file paths and return tail + metadata (`exists`, `sizeBytes`, `returnedLines`, `lines`).
- Exposed a new MCP tool `java_module_logs` in `McpController` (available in `tools/list` and via `tools/call`) that invokes `ModuleLogService` and returns structured results.
- Extended `McpProperties` with a `logs` group (`backendPath`, `aiWorkerPath`, `leadPortalPath`, `facebookAdsPath`, `maxLines`) and wired defaults in `application.yml` using environment variables (`MCP_LOG_*`).
- Added integration-style tests in `McpControllerTest` covering successful tail read (`shouldReadJavaModuleLogs`) and invalid module validation (`shouldRejectInvalidJavaModuleName`), and documented the new tool and env vars in `mcp-server/README.md`.

### Testing

- Added tests in `mcp-server/src/test/java/.../McpControllerTest.java` that exercise the `java_module_logs` tool and invalid-module handling and update dynamic properties for test log paths.
- Attempted to run `cd mcp-server && mvn -s settings.xml test`, but the CI run failed in this environment because Maven could not resolve the Spring Boot parent POM due to network access to `repo.maven.apache.org` being unavailable; the failure is environmental and not related to the new logic.
- Unit tests are present and expected to pass in a normal network-enabled CI; manual verification in a networked environment is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ba84639c83219d1af89b66b62fbf)