### PR TITLE
Make HTTPS the default Nginx config and update docs

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -85,12 +85,12 @@ curl -i http://mcpserverdigi.shop/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 ```
 
-Por padrão, o compose sobe com `default.http.conf` (sem TLS obrigatório), evitando crash quando o certificado ainda não foi emitido.
+Por padrão, o compose sobe com `default.conf` (HTTPS habilitado).
 
-Para habilitar HTTPS após a emissão do certificado, use:
+Se precisar subir sem TLS temporariamente (por exemplo, antes da emissão do certificado), use:
 
 ```bash
-MCP_NGINX_CONF=default.conf docker compose up -d nginx
+MCP_NGINX_CONF=default.http.conf docker compose up -d nginx
 ```
 
 No deploy (`deploy/docker-compose.yml`), use a mesma variável de ambiente `MCP_NGINX_CONF` (por exemplo, `default.conf` ou `default.https.conf`).

--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -32,6 +32,6 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/${MCP_NGINX_CONF:-default.http.conf}:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/${MCP_NGINX_CONF:-default.conf}:/etc/nginx/conf.d/default.conf:ro
       - ./certbot/www:/var/www/certbot:ro
       - ./certbot/conf:/etc/letsencrypt:ro


### PR DESCRIPTION
### Motivation

- Ensure production deployments use HTTPS by default and align the compose defaults with the expected secure configuration.
- Provide an explicit instruction to run without TLS temporarily when certificates are not yet issued.

### Description

- Change the default Nginx config in `mcp-server/docker-compose.yml` from `default.http.conf` to `default.conf` so HTTPS is enabled by default. 
- Update `mcp-server/README.md` to reflect that the compose default is `default.conf` (HTTPS enabled) and to show how to start Nginx without TLS using `MCP_NGINX_CONF=default.http.conf docker compose up -d nginx`.
- Keep existing healthcheck and port mappings unchanged while clarifying deployment guidance for Codex Cloud plugin users.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c133f6508321b8aba889223e9790)