### PR TITLE
fix(deploy): default MCP nginx profile to HTTPS-enabled config

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -83,6 +83,6 @@ services:
       - "${MCP_NGINX_HTTP_PORT:-80}:80"
       - "${MCP_NGINX_HTTPS_PORT:-443}:443"
     volumes:
-      - ./nginx/mcp/${MCP_NGINX_CONF:-default.http.conf}:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/mcp/${MCP_NGINX_CONF:-default.conf}:/etc/nginx/conf.d/default.conf:ro
       - ./volumes/mcp/certbot/www:/var/www/certbot:ro
       - ./volumes/mcp/certbot/conf:/etc/letsencrypt:ro


### PR DESCRIPTION
### Motivation
- Ensure the MCP deploy starts with the TLS-enabled Nginx configuration by default so public HTTPS connections to `/mcp` are served properly instead of accidentally using an HTTP-only profile while publishing port 443.

### Description
- Change `MCP_NGINX_CONF` default in `deploy/docker-compose.yml` from `default.http.conf` to `default.conf`, so the deployed `mcp-nginx` container mounts the TLS-enabled Nginx config by default.

### Testing
- Parsed `deploy/docker-compose.yml` with Ruby (`YAML.load_file`) to validate YAML syntax and it returned `yaml_ok` (success).
- Attempted `docker compose config` validation but the command could not run in this environment (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c3aabb2883218cc0ec83b09dadb2)