### PR TITLE
Default Nginx to HTTP config and document certificate troubleshooting

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -83,6 +83,6 @@ services:
       - "${MCP_NGINX_HTTP_PORT:-80}:80"
       - "${MCP_NGINX_HTTPS_PORT:-443}:443"
     volumes:
-      - ./nginx/mcp/${MCP_NGINX_CONF:-default.conf}:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/mcp/${MCP_NGINX_CONF:-default.http.conf}:/etc/nginx/conf.d/default.conf:ro
       - ./volumes/mcp/certbot/www:/var/www/certbot:ro
       - ./volumes/mcp/certbot/conf:/etc/letsencrypt:ro

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -85,7 +85,7 @@ curl -i http://mcpserverdigi.shop/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 ```
 
-Por padrão, o compose sobe com `default.conf` (HTTPS habilitado).
+Por padrão, o compose sobe com `default.http.conf` (somente HTTP), para evitar loop de restart do Nginx quando os arquivos de certificado ainda não existem.
 
 Se precisar subir sem TLS temporariamente (por exemplo, antes da emissão do certificado), use:
 
@@ -93,7 +93,63 @@ Se precisar subir sem TLS temporariamente (por exemplo, antes da emissão do cer
 MCP_NGINX_CONF=default.http.conf docker compose up -d nginx
 ```
 
-No deploy (`deploy/docker-compose.yml`), use a mesma variável de ambiente `MCP_NGINX_CONF` (por exemplo, `default.conf` ou `default.https.conf`).
+Depois que os certificados forem emitidos e os arquivos existirem em `certbot/conf/live/mcpserverdigi.shop/`, habilite HTTPS explicitamente:
+
+```bash
+MCP_NGINX_CONF=default.conf docker compose up -d nginx
+```
+
+No deploy (`deploy/docker-compose.yml`), use a mesma variável de ambiente `MCP_NGINX_CONF` (por exemplo, `default.http.conf` ou `default.conf`).
+
+### Erro comum: `cannot load certificate ... fullchain.pem`
+
+Se o Nginx falhar com esse erro, quase sempre é porque o volume montado em `/etc/letsencrypt` não contém os arquivos esperados pelo `ssl_certificate`.
+
+Checklist rápido:
+
+1. Gere os certificados no mesmo diretório usado no `docker-compose.yml` do ambiente atual.
+2. Confirme no host:
+
+```bash
+ls -la certbot/conf/live/mcpserverdigi.shop/
+```
+
+3. Valide presença de `fullchain.pem` e `privkey.pem`.
+4. Só então suba o Nginx com `MCP_NGINX_CONF=default.conf`.
+
+### Como localizar os certificados no host
+
+Se você suspeita que os arquivos se perderam no host, procure por `fullchain.pem` e `privkey.pem` antes de subir o Nginx em HTTPS:
+
+```bash
+# dentro do diretório mcp-server
+find certbot -type f \( -name 'fullchain.pem' -o -name 'privkey.pem' \) 2>/dev/null
+```
+
+No deploy (raiz `deploy/`), o volume aponta para `volumes/mcp/certbot/conf`, então:
+
+```bash
+# dentro do diretório deploy
+find volumes/mcp/certbot/conf -type f \( -name 'fullchain.pem' -o -name 'privkey.pem' \) 2>/dev/null
+```
+
+Se nada for encontrado, reemita o certificado e valide novamente o caminho `live/mcpserverdigi.shop/` antes de ativar `default.conf`.
+
+> Dica importante: os comandos acima são **relativos ao diretório**.  
+> Se você rodar em `~` (home) e não dentro do projeto, o `find` pode retornar vazio mesmo com certificado existente em outro caminho.
+
+Exemplo com caminho absoluto (ajuste conforme seu host):
+
+```bash
+find /opt/marketinghub/containers/volumes/mcp/certbot/conf \
+  -type f \( -name 'fullchain.pem' -o -name 'privkey.pem' \) 2>/dev/null
+```
+
+Também vale validar se o volume que o Nginx monta é o mesmo em que o Certbot gravou:
+
+```bash
+docker compose -f /opt/marketinghub/containers/deploy/docker-compose.yml config | grep -n "/etc/letsencrypt"
+```
 
 ## Configuração no Codex Cloud (Plugin MCP)
 

--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -32,6 +32,6 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/${MCP_NGINX_CONF:-default.conf}:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/${MCP_NGINX_CONF:-default.http.conf}:/etc/nginx/conf.d/default.conf:ro
       - ./certbot/www:/var/www/certbot:ro
       - ./certbot/conf:/etc/letsencrypt:ro


### PR DESCRIPTION
### Motivation

- Prevent Nginx from entering a restart loop when TLS files are not yet present by defaulting the mounted config to a plain HTTP variant.
- Clarify deployment steps and common causes of SSL errors so operators know how and when to enable HTTPS.

### Description

- Change the default Nginx config mount in `deploy/docker-compose.yml` and `mcp-server/docker-compose.yml` from `default.conf` to `default.http.conf` so containers start using HTTP by default.
- Update `mcp-server/README.md` to explain the new default, how to switch to HTTPS with `MCP_NGINX_CONF`, and how to verify and locate `fullchain.pem` and `privkey.pem` before enabling TLS.
- Add a troubleshooting checklist and example `find`/`docker compose config` commands to help locate certificate files and validate compose configuration.

### Testing

- Validated both compose files with `docker compose -f mcp-server/docker-compose.yml config` which completed successfully. 
- Validated the deploy compose file with `docker compose -f deploy/docker-compose.yml config` which completed successfully.
- No unit tests were added or modified for these infra/documentation updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c7cea5208321aa42ffb0e918b549)