### PR TITLE
mcp-server: harden Let's Encrypt certificate reissuance flow

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -101,6 +101,47 @@ MCP_NGINX_CONF=default.conf docker compose up -d nginx
 
 No deploy (`deploy/docker-compose.yml`), use a mesma variável de ambiente `MCP_NGINX_CONF` (por exemplo, `default.http.conf` ou `default.conf`).
 
+
+### Reemissão do certificado (fluxo mais seguro)
+
+No lugar de executar o comando manual direto, use o script versionado:
+
+```bash
+cd mcp-server
+EMAIL=paulofore@gmail.com ./scripts/issue-letsencrypt-cert.sh
+```
+
+Esse script adiciona hardening importante:
+
+- `--non-interactive` e parâmetros explícitos (menos chance de erro humano);
+- `--keep-until-expiring` (evita reemissões desnecessárias e rate-limit);
+- chave ECDSA (`secp384r1`), mais moderna e menor que RSA 4096;
+- `umask 077` + ajuste de permissões (`privkey.pem` com `600`);
+- suporta staging com `USE_STAGING=true` para validar antes da emissão real.
+
+Teste em staging antes da emissão final:
+
+```bash
+cd mcp-server
+EMAIL=paulofore@gmail.com USE_STAGING=true ./scripts/issue-letsencrypt-cert.sh
+```
+
+Para ambiente de deploy em `/opt/marketinghub/containers`, preserve os volumes corretos:
+
+```bash
+cd /opt/marketinghub/containers/mcp-server
+EMAIL=paulofore@gmail.com \
+DEPLOY_ROOT=/opt/marketinghub/containers/volumes/mcp/certbot \
+./scripts/issue-letsencrypt-cert.sh
+```
+
+Depois da emissão, ative TLS no Nginx:
+
+```bash
+cd mcp-server
+MCP_NGINX_CONF=default.conf docker compose up -d nginx
+```
+
 ### Erro comum: `cannot load certificate ... fullchain.pem`
 
 Se o Nginx falhar com esse erro, quase sempre é porque o volume montado em `/etc/letsencrypt` não contém os arquivos esperados pelo `ssl_certificate`.

--- a/mcp-server/scripts/issue-letsencrypt-cert.sh
+++ b/mcp-server/scripts/issue-letsencrypt-cert.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Emite (ou reemite) certificados Let's Encrypt para o MCP com boas práticas de segurança.
+# Uso:
+#   DOMAIN=mcpserverdigi.shop ALT_DOMAIN=www.mcpserverdigi.shop EMAIL=voce@dominio.com \
+#   ./scripts/issue-letsencrypt-cert.sh
+#
+# Opcional:
+#   CERTBOT_IMAGE=certbot/certbot:latest  # imagem do certbot
+#   USE_STAGING=true                      # usa ambiente staging da Let's Encrypt
+#   DEPLOY_ROOT=/opt/marketinghub/containers/volumes/mcp/certbot
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MCP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DOMAIN="${DOMAIN:-mcpserverdigi.shop}"
+ALT_DOMAIN="${ALT_DOMAIN:-www.mcpserverdigi.shop}"
+EMAIL="${EMAIL:-}"
+CERTBOT_IMAGE="${CERTBOT_IMAGE:-certbot/certbot:latest}"
+USE_STAGING="${USE_STAGING:-false}"
+
+# Diretório padrão local do módulo mcp-server.
+# Em produção, pode apontar para: /opt/marketinghub/containers/volumes/mcp/certbot
+DEPLOY_ROOT="${DEPLOY_ROOT:-${MCP_DIR}/certbot}"
+WWW_DIR="${DEPLOY_ROOT}/www"
+CONF_DIR="${DEPLOY_ROOT}/conf"
+
+if [[ -z "${EMAIL}" ]]; then
+  echo "[ERRO] Defina EMAIL com um endereço válido." >&2
+  exit 1
+fi
+
+mkdir -p "${WWW_DIR}" "${CONF_DIR}"
+
+# Restringe permissões para evitar exposição acidental dos arquivos privados.
+umask 077
+chmod 700 "${CONF_DIR}" || true
+
+STAGING_FLAGS=()
+if [[ "${USE_STAGING}" == "true" ]]; then
+  STAGING_FLAGS+=("--test-cert")
+  echo "[INFO] Modo staging habilitado (não gera certificado válido para produção)."
+fi
+
+echo "[INFO] Emitindo certificado para ${DOMAIN} e ${ALT_DOMAIN}"
+echo "[INFO] Diretório webroot: ${WWW_DIR}"
+echo "[INFO] Diretório de configuração/certificados: ${CONF_DIR}"
+
+docker run --rm \
+  -v "${WWW_DIR}:/var/www/certbot" \
+  -v "${CONF_DIR}:/etc/letsencrypt" \
+  "${CERTBOT_IMAGE}" certonly --webroot \
+  -w /var/www/certbot \
+  -d "${DOMAIN}" -d "${ALT_DOMAIN}" \
+  --email "${EMAIL}" \
+  --agree-tos \
+  --no-eff-email \
+  --non-interactive \
+  --keep-until-expiring \
+  --preferred-challenges http-01 \
+  --key-type ecdsa \
+  --elliptic-curve secp384r1 \
+  "${STAGING_FLAGS[@]}"
+
+# Mantém diretórios legíveis para o Nginx, mas com arquivos privados em permissão restrita.
+find "${CONF_DIR}" -type d -exec chmod 700 {} \; || true
+find "${CONF_DIR}" -type f -name 'privkey.pem' -exec chmod 600 {} \; || true
+find "${CONF_DIR}" -type f ! -name 'privkey.pem' -exec chmod 644 {} \; || true
+
+echo "[OK] Processo finalizado."
+echo "[OK] Arquivos esperados em: ${CONF_DIR}/live/${DOMAIN}/"


### PR DESCRIPTION
### Motivation

- Provide a repeatable, safer flow to (re)issue Let's Encrypt certificates for `mcp-server` to reduce human error and avoid rate limits. 
- Ensure private keys and Let’s Encrypt state are created with stricter permissions and a modern key type to improve security posture. 

### Description

- Add `mcp-server/scripts/issue-letsencrypt-cert.sh` which performs non-interactive issuance with `--keep-until-expiring`, uses ECDSA (`secp384r1`), supports a `USE_STAGING` mode, and hardens filesystem permissions (`umask 077`, `privkey.pem` -> `600`).
- Update `mcp-server/README.md` with a recommended reissuance workflow showing staging validation, `DEPLOY_ROOT` usage for deploy paths, and instructions to enable TLS in Nginx after successful issuance. 
- Keep compatibility with existing volume layout (`certbot/www` and `certbot/conf`) and allow overridable variables (`DOMAIN`, `ALT_DOMAIN`, `EMAIL`, `DEPLOY_ROOT`, `CERTBOT_IMAGE`).

### Testing

- Verified the script is syntactically valid with `bash -n mcp-server/scripts/issue-letsencrypt-cert.sh` and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cb19f3cc8321bbb0c73cb617a2eb)