### PR TITLE
Auto-select MCP Nginx config, enable HTTPS after cert issuance, and include nginx files in deploy

### DIFF
--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -77,6 +77,8 @@ jobs:
         run: |
           ssh ${VPS_USER}@${MCP_VPS_IP} "mkdir -p ${DEPLOY_DIR}"
           rsync -az --delete deploy/ ${VPS_USER}@${MCP_VPS_IP}:${DEPLOY_DIR}/
+          ssh ${VPS_USER}@${MCP_VPS_IP} "mkdir -p ${DEPLOY_DIR}/nginx/mcp"
+          rsync -az --delete mcp-server/nginx/ ${VPS_USER}@${MCP_VPS_IP}:${DEPLOY_DIR}/nginx/mcp/
 
       - name: Upload MCP image to VPS
         run: scp artifacts/mcp-server-image.tar ${VPS_USER}@${MCP_VPS_IP}:/tmp/mcp-server-image.tar

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -98,7 +98,12 @@ Se você estiver no host e receber erro como `./scripts/issue-letsencrypt-cert.s
    cd /opt/marketinghub/containers
    EMAIL=paulofore@gmail.com ./bin/issue-mcp-letsencrypt-cert.sh
    ```
-4. Ative HTTPS no Nginx do MCP:
+4. Aplique o stack do MCP (o script escolhe `default.conf` automaticamente quando os arquivos `fullchain.pem` e `privkey.pem` existem):
+   ```bash
+   cd /opt/marketinghub/containers
+   ./bin/apply-mcp-only.sh
+   ```
+5. (Opcional) Forçar manualmente HTTPS no Nginx do MCP:
    ```bash
    cd /opt/marketinghub/containers
    MCP_NGINX_CONF=default.conf docker compose up -d --no-deps mcp-nginx

--- a/deploy/bin/apply-mcp-only.sh
+++ b/deploy/bin/apply-mcp-only.sh
@@ -10,6 +10,21 @@ mkdir -p "${DEPLOY_DIR}"
 cd "${DEPLOY_DIR}"
 mkdir -p ./volumes/mcp/certbot/www ./volumes/mcp/certbot/conf
 
+resolve_mcp_nginx_conf() {
+  if [[ -n "${MCP_NGINX_CONF:-}" ]]; then
+    echo "${MCP_NGINX_CONF}"
+    return
+  fi
+
+  if [[ -f "./volumes/mcp/certbot/conf/live/mcpserverdigi.shop/fullchain.pem" \
+     && -f "./volumes/mcp/certbot/conf/live/mcpserverdigi.shop/privkey.pem" ]]; then
+    echo "default.conf"
+    return
+  fi
+
+  echo "default.http.conf"
+}
+
 if [[ -f "${MCP_TAR}" ]]; then
   docker load -i "${MCP_TAR}"
 fi
@@ -32,8 +47,12 @@ cleanup_previous_tags() {
 }
 
 # Atualiza somente o MCP Server e o Nginx dedicado do MCP sem reiniciar outros serviços.
+MCP_NGINX_CONF_RESOLVED="$(resolve_mcp_nginx_conf)"
+echo "[apply-mcp-only.sh] Usando MCP_NGINX_CONF=${MCP_NGINX_CONF_RESOLVED}"
+
 MCP_SERVER_IMAGE="${MCP_IMAGE}" \
 MCP_SERVER_IMAGE_TAG=latest \
+MCP_NGINX_CONF="${MCP_NGINX_CONF_RESOLVED}" \
 docker compose up -d --no-deps mcp-server mcp-nginx
 
 cleanup_previous_tags "${MCP_IMAGE}" "latest"

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -118,12 +118,20 @@ Esse script adiciona hardening importante:
 - chave ECDSA (`secp384r1`), mais moderna e menor que RSA 4096;
 - `umask 077` + ajuste de permissões (`privkey.pem` com `600`);
 - suporta staging com `USE_STAGING=true` para validar antes da emissão real.
+- após emitir com sucesso, ativa automaticamente o Nginx com `MCP_NGINX_CONF=default.conf`.
 
 Teste em staging antes da emissão final:
 
 ```bash
 cd mcp-server
 EMAIL=paulofore@gmail.com USE_STAGING=true ./scripts/issue-letsencrypt-cert.sh
+```
+
+Se quiser emitir sem alternar o Nginx automaticamente para TLS:
+
+```bash
+cd mcp-server
+EMAIL=paulofore@gmail.com SWITCH_TO_HTTPS=false ./scripts/issue-letsencrypt-cert.sh
 ```
 
 Para ambiente de deploy em `/opt/marketinghub/containers`, preserve os volumes corretos:

--- a/mcp-server/scripts/issue-letsencrypt-cert.sh
+++ b/mcp-server/scripts/issue-letsencrypt-cert.sh
@@ -19,6 +19,7 @@ ALT_DOMAIN="${ALT_DOMAIN:-www.mcpserverdigi.shop}"
 EMAIL="${EMAIL:-}"
 CERTBOT_IMAGE="${CERTBOT_IMAGE:-certbot/certbot:latest}"
 USE_STAGING="${USE_STAGING:-false}"
+SWITCH_TO_HTTPS="${SWITCH_TO_HTTPS:-true}"
 
 # Diretório padrão local do módulo mcp-server.
 # Em produção, pode apontar para: /opt/marketinghub/containers/volumes/mcp/certbot
@@ -70,3 +71,36 @@ find "${CONF_DIR}" -type f ! -name 'privkey.pem' -exec chmod 644 {} \; || true
 
 echo "[OK] Processo finalizado."
 echo "[OK] Arquivos esperados em: ${CONF_DIR}/live/${DOMAIN}/"
+
+if [[ "${SWITCH_TO_HTTPS}" != "true" ]]; then
+  echo "[INFO] SWITCH_TO_HTTPS=false, mantendo Nginx no modo atual."
+  exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[WARN] Docker não encontrado no PATH. Ative HTTPS manualmente com:"
+  echo "       MCP_NGINX_CONF=default.conf docker compose up -d nginx"
+  exit 0
+fi
+
+if [[ ! -f "${MCP_DIR}/docker-compose.yml" ]]; then
+  echo "[WARN] docker-compose.yml não encontrado em ${MCP_DIR}."
+  echo "       Ative HTTPS manualmente com:"
+  echo "       MCP_NGINX_CONF=default.conf docker compose up -d nginx"
+  exit 0
+fi
+
+if [[ ! -f "${CONF_DIR}/live/${DOMAIN}/fullchain.pem" || ! -f "${CONF_DIR}/live/${DOMAIN}/privkey.pem" ]]; then
+  echo "[ERRO] Certificado emitido, mas arquivos esperados não foram encontrados em:"
+  echo "       ${CONF_DIR}/live/${DOMAIN}/"
+  exit 1
+fi
+
+echo "[INFO] Ativando Nginx com TLS (MCP_NGINX_CONF=default.conf)..."
+(
+  cd "${MCP_DIR}"
+  MCP_NGINX_CONF=default.conf docker compose up -d --force-recreate --no-deps nginx
+  MCP_NGINX_CONF=default.conf docker compose exec nginx nginx -t
+)
+
+echo "[OK] HTTPS ativado no Nginx."


### PR DESCRIPTION
### Motivation
- Automatically choose the appropriate Nginx configuration for the MCP based on presence of Let's Encrypt certificates and reduce manual steps to enable HTTPS.
- Allow the certificate issuance script to optionally switch the Nginx service to TLS mode after successful issuance to streamline deployments.
- Ensure the deploy pipeline copies the MCP-specific Nginx configuration to the target host.

### Description
- Added `resolve_mcp_nginx_conf()` to `deploy/bin/apply-mcp-only.sh` to emit `default.conf` when `fullchain.pem` and `privkey.pem` exist and `default.http.conf` otherwise, and pass the resolved value to `docker compose` via `MCP_NGINX_CONF`.
- Enhanced `mcp-server/scripts/issue-letsencrypt-cert.sh` with a `SWITCH_TO_HTTPS` flag (default `true`) that, after successful certificate issuance, verifies environment prerequisites, activates Nginx with `MCP_NGINX_CONF=default.conf`, and runs `nginx -t` to validate configuration.
- Updated `.github/workflows/mcp-server.yml` to rsync `mcp-server/nginx/` into `${DEPLOY_DIR}/nginx/mcp` on the VPS and create the target directory during the `deploy-mcp` job.
- Updated documentation in `deploy/README.md` and `mcp-server/README.md` to reflect the new `apply-mcp-only.sh` behavior and the automatic/optional HTTPS activation flow.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d38416548321912382bbc232b905)