### PR TITLE
Fix MCP DB password fallback and null-safe JSON-RPC error responses

### DIFF
--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC}
       SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME:-marketing_hub_user}
-      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD:-${MYSQL_PASS:-}}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD:-${MYSQL_PASS:-${MYSQL_PASSWORD:-}}}
       MCP_SERVER_NAME: ${MCP_SERVER_NAME:-marketing-hub-mcp}
       MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}
     expose:

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RestController
@@ -277,20 +278,22 @@ public class McpController {
     }
 
     private Map<String, Object> success(Object id, Map<String, Object> result) {
-        return Map.of(
-                "jsonrpc", "2.0",
-                "id", id,
-                "result", result
-        );
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("jsonrpc", "2.0");
+        response.put("id", id);
+        response.put("result", result);
+        return response;
     }
 
     private Map<String, Object> error(Object id, int code, String message) {
-        return Map.of(
-                "jsonrpc", "2.0",
-                "id", id,
-                "error", Map.of(
-                        "code", code,
-                        "message", message)
-        );
+        Map<String, Object> errorPayload = new LinkedHashMap<>();
+        errorPayload.put("code", code);
+        errorPayload.put("message", message == null ? "Unexpected error" : message);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("jsonrpc", "2.0");
+        response.put("id", id);
+        response.put("error", errorPayload);
+        return response;
     }
 }

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC}
     username: ${SPRING_DATASOURCE_USERNAME:marketing_hub_user}
-    password: ${SPRING_DATASOURCE_PASSWORD:${MYSQL_PASS:}}
+    password: ${SPRING_DATASOURCE_PASSWORD:${MYSQL_PASS:${MYSQL_PASSWORD:}}}
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       initialization-fail-timeout: -1

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -174,6 +174,19 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.error.code").value(-32602))
                 .andExpect(jsonPath("$.error.message").value("module must be one of: backend, ai-worker, lead-portal, facebook-ads"));
     }
+
+    @Test
+    void shouldHandleErrorResponseWhenRequestIdIsNull() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","method":"unknown_method","params":{}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.jsonrpc").value("2.0"))
+                .andExpect(jsonPath("$.id").doesNotExist())
+                .andExpect(jsonPath("$.error.code").value(-32601));
+    }
 }
 
 @SpringBootTest(properties = "mcp.api-key=super-secret")


### PR DESCRIPTION
### Motivation
- Prevent the MCP server from starting or failing requests when the MySQL password env var is present under alternative names and avoid `Access denied ... (using password: NO)` due to missing password resolution. 
- Avoid `NullPointerException` when building JSON-RPC error responses for requests that omit `id` or provide a null error message, so diagnostic tools remain usable while the DB is unstable. 

### Description
- Replaced use of `Map.of(...)` in `McpController.success` and `McpController.error` with `LinkedHashMap` builders to allow `id` to be null and to produce null-safe JSON-RPC objects, and added an error message fallback (`"Unexpected error"`).
- Updated `mcp-server/src/main/resources/application.yml` to extend the datasource password fallback chain to `SPRING_DATASOURCE_PASSWORD:${MYSQL_PASS:${MYSQL_PASSWORD:}}` to accept `MYSQL_PASSWORD` as an additional source. 
- Aligned the `docker-compose.yml` environment variable fallback to the same chain for `SPRING_DATASOURCE_PASSWORD` so runtime injection via Compose matches Spring resolution. 
- Added a controller test `shouldHandleErrorResponseWhenRequestIdIsNull` to `McpControllerTest` that verifies the server returns a JSON-RPC error when `id` is absent without throwing an exception. 

### Testing
- Ran `mvn -s settings.xml test` in `mcp-server`, but the run failed due to network unavailability while resolving dependencies from Maven Central (error: `Network is unreachable`), so automated tests could not complete in this environment. 
- The repository unit tests were updated to include the new case `shouldHandleErrorResponseWhenRequestIdIsNull`, but execution was not possible here due to the dependency resolution failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e44924108321896abb8229fbde99)