### PR TITLE
Pass MCP_NGINX_CONF to deploy script in GitHub Actions

### DIFF
--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -89,4 +89,4 @@ jobs:
         run: |
           ssh ${VPS_USER}@${MCP_VPS_IP} "chmod +x ${DEPLOY_DIR}/bin/apply-mcp-only.sh"
           ssh ${VPS_USER}@${MCP_VPS_IP} \
-            "IMAGE_TAG=${GIT_SHA} MCP_TAR=/tmp/mcp-server-image.tar MCP_IMAGE=${MCP_IMAGE} DEPLOY_DIR=${DEPLOY_DIR} /bin/bash ${DEPLOY_DIR}/bin/apply-mcp-only.sh"
+            "IMAGE_TAG=${GIT_SHA} MCP_TAR=/tmp/mcp-server-image.tar MCP_IMAGE=${MCP_IMAGE} DEPLOY_DIR=${DEPLOY_DIR} MCP_NGINX_CONF=default.conf /bin/bash ${DEPLOY_DIR}/bin/apply-mcp-only.sh"


### PR DESCRIPTION
### Motivation
- Ensure the remote deploy script knows which nginx configuration to use by providing an explicit `MCP_NGINX_CONF=default.conf` when applying the MCP stack.

### Description
- Update `.github/workflows/mcp-server.yml` to include `MCP_NGINX_CONF=default.conf` in the `ssh` invocation that runs `apply-mcp-only.sh` on the VPS.

### Testing
- No automated tests were added or modified for this change; the update is limited to the deployment workflow and did not execute unit or integration tests as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e8c8ebd08321a3b37c264eea9410)