### PR TITLE
Automatiza bootstrap TLS do MCP e preserva certificados no deploy

### DIFF
--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -18,6 +18,7 @@ env:
   VPS_USER: root
   DEPLOY_DIR: /opt/marketinghub/containers
   MCP_IMAGE: marketinghub-mcp-server
+  MCP_CERTBOT_EMAIL: paulofore@gmail.com
 
 permissions:
   contents: read
@@ -76,7 +77,7 @@ jobs:
       - name: Copy deployment descriptors
         run: |
           ssh ${VPS_USER}@${MCP_VPS_IP} "mkdir -p ${DEPLOY_DIR}"
-          rsync -az --delete deploy/ ${VPS_USER}@${MCP_VPS_IP}:${DEPLOY_DIR}/
+          rsync -az --delete --exclude 'volumes/' deploy/ ${VPS_USER}@${MCP_VPS_IP}:${DEPLOY_DIR}/
           ssh ${VPS_USER}@${MCP_VPS_IP} "mkdir -p ${DEPLOY_DIR}/nginx/mcp"
           rsync -az --delete mcp-server/nginx/ ${VPS_USER}@${MCP_VPS_IP}:${DEPLOY_DIR}/nginx/mcp/
 
@@ -89,4 +90,4 @@ jobs:
         run: |
           ssh ${VPS_USER}@${MCP_VPS_IP} "chmod +x ${DEPLOY_DIR}/bin/apply-mcp-only.sh"
           ssh ${VPS_USER}@${MCP_VPS_IP} \
-            "IMAGE_TAG=${GIT_SHA} MCP_TAR=/tmp/mcp-server-image.tar MCP_IMAGE=${MCP_IMAGE} DEPLOY_DIR=${DEPLOY_DIR} MCP_NGINX_CONF=default.conf /bin/bash ${DEPLOY_DIR}/bin/apply-mcp-only.sh"
+            "IMAGE_TAG=${GIT_SHA} MCP_TAR=/tmp/mcp-server-image.tar MCP_IMAGE=${MCP_IMAGE} DEPLOY_DIR=${DEPLOY_DIR} EMAIL=${MCP_CERTBOT_EMAIL} /bin/bash ${DEPLOY_DIR}/bin/apply-mcp-only.sh"

--- a/deploy/bin/apply-mcp-only.sh
+++ b/deploy/bin/apply-mcp-only.sh
@@ -5,10 +5,20 @@ DEPLOY_DIR=${DEPLOY_DIR:-/opt/marketinghub/containers}
 MCP_TAR=${MCP_TAR:-/tmp/mcp-server-image.tar}
 MCP_IMAGE=${MCP_IMAGE:-marketinghub-mcp-server}
 IMAGE_TAG=${IMAGE_TAG:-latest}
+DOMAIN=${DOMAIN:-mcpserverdigi.shop}
+ALT_DOMAIN=${ALT_DOMAIN:-www.mcpserverdigi.shop}
+EMAIL=${EMAIL:-}
+CERTBOT_IMAGE=${CERTBOT_IMAGE:-certbot/certbot:latest}
+USE_STAGING=${USE_STAGING:-false}
 
 mkdir -p "${DEPLOY_DIR}"
 cd "${DEPLOY_DIR}"
 mkdir -p ./volumes/mcp/certbot/www ./volumes/mcp/certbot/conf
+
+certificate_exists() {
+  [[ -f "./volumes/mcp/certbot/conf/live/${DOMAIN}/fullchain.pem" \
+    && -f "./volumes/mcp/certbot/conf/live/${DOMAIN}/privkey.pem" ]]
+}
 
 resolve_mcp_nginx_conf() {
   if [[ -n "${MCP_NGINX_CONF:-}" ]]; then
@@ -16,13 +26,64 @@ resolve_mcp_nginx_conf() {
     return
   fi
 
-  if [[ -f "./volumes/mcp/certbot/conf/live/mcpserverdigi.shop/fullchain.pem" \
-     && -f "./volumes/mcp/certbot/conf/live/mcpserverdigi.shop/privkey.pem" ]]; then
+  if certificate_exists; then
     echo "default.conf"
     return
   fi
 
   echo "default.http.conf"
+}
+
+run_mcp_compose() {
+  local nginx_conf="$1"
+
+  MCP_SERVER_IMAGE="${MCP_IMAGE}" \
+  MCP_SERVER_IMAGE_TAG=latest \
+  MCP_NGINX_CONF="${nginx_conf}" \
+  docker compose up -d --no-deps mcp-server mcp-nginx
+}
+
+issue_certificate_if_needed() {
+  if certificate_exists; then
+    return
+  fi
+
+  if [[ -z "${EMAIL}" ]]; then
+    echo "[apply-mcp-only.sh] Aviso: certificado ausente e EMAIL não informado. Mantendo HTTP até nova execução com EMAIL." >&2
+    return
+  fi
+
+  local staging_flags=()
+  if [[ "${USE_STAGING}" == "true" ]]; then
+    staging_flags+=("--test-cert")
+  fi
+
+  echo "[apply-mcp-only.sh] Certificado ausente. Solicitando Let's Encrypt via HTTP-01 para ${DOMAIN} (${ALT_DOMAIN})."
+  docker run --rm \
+    -v "./volumes/mcp/certbot/www:/var/www/certbot" \
+    -v "./volumes/mcp/certbot/conf:/etc/letsencrypt" \
+    "${CERTBOT_IMAGE}" certonly --webroot \
+    -w /var/www/certbot \
+    -d "${DOMAIN}" -d "${ALT_DOMAIN}" \
+    --email "${EMAIL}" \
+    --agree-tos \
+    --no-eff-email \
+    --non-interactive \
+    --keep-until-expiring \
+    --preferred-challenges http-01 \
+    --key-type ecdsa \
+    --elliptic-curve secp384r1 \
+    "${staging_flags[@]}"
+
+  if certificate_exists; then
+    echo "[apply-mcp-only.sh] Certificado encontrado após emissão. Reiniciando MCP Nginx em HTTPS."
+    MCP_SERVER_IMAGE="${MCP_IMAGE}" \
+    MCP_SERVER_IMAGE_TAG=latest \
+    MCP_NGINX_CONF=default.conf \
+    docker compose up -d --force-recreate --no-deps mcp-nginx
+  else
+    echo "[apply-mcp-only.sh] Aviso: emissão finalizada sem certificado detectado. Mantendo HTTP." >&2
+  fi
 }
 
 if [[ -f "${MCP_TAR}" ]]; then
@@ -49,11 +110,11 @@ cleanup_previous_tags() {
 # Atualiza somente o MCP Server e o Nginx dedicado do MCP sem reiniciar outros serviços.
 MCP_NGINX_CONF_RESOLVED="$(resolve_mcp_nginx_conf)"
 echo "[apply-mcp-only.sh] Usando MCP_NGINX_CONF=${MCP_NGINX_CONF_RESOLVED}"
+run_mcp_compose "${MCP_NGINX_CONF_RESOLVED}"
 
-MCP_SERVER_IMAGE="${MCP_IMAGE}" \
-MCP_SERVER_IMAGE_TAG=latest \
-MCP_NGINX_CONF="${MCP_NGINX_CONF_RESOLVED}" \
-docker compose up -d --no-deps mcp-server mcp-nginx
+if [[ -z "${MCP_NGINX_CONF:-}" ]]; then
+  issue_certificate_if_needed
+fi
 
 cleanup_previous_tags "${MCP_IMAGE}" "latest"
 


### PR DESCRIPTION
### Motivation
- Evitar perda de certificados Let’s Encrypt durante redeploys ao não sobrescrever o diretório persistente `volumes/` e permitir um fluxo automático de ativação de HTTPS.
- Garantir que o MCP suba em HTTPS quando o certificado já existir e, caso contrário, subir em HTTP para responder ao desafio ACME e depois alternar para HTTPS automaticamente.
- Fornecer um caminho automatizado para solicitar certificados via `certbot` usando um e-mail configurável.

### Description
- Adiciona `MCP_CERTBOT_EMAIL` ao workflow de deploy e altera o `rsync` para `--exclude 'volumes/'`, preservando arquivos persistentes como os certificados; o deploy remoto agora recebe `EMAIL=${MCP_CERTBOT_EMAIL}`. 
- Remove a força de `MCP_NGINX_CONF=default.conf` no deploy remoto para permitir que o script escolha entre `default.conf` (HTTPS) ou `default.http.conf` (HTTP) automaticamente.
- Estende `deploy/bin/apply-mcp-only.sh` com variáveis `DOMAIN`, `ALT_DOMAIN`, `EMAIL`, `CERTBOT_IMAGE` e `USE_STAGING`, além das funções `certificate_exists`, `run_mcp_compose` e `issue_certificate_if_needed` para: detectar certificado existente, subir em HTTP quando ausente, emitir certificado via `certbot` (webroot HTTP-01) e reiniciar o Nginx em HTTPS após emissão.
- Mantém compatibilidade com o fluxo anterior de deploy (carrega imagem tar, faz tag e remove tags antigas) e só executa a emissão automática quando `MCP_NGINX_CONF` não for explicitamente definido.

### Testing
- `bash -n deploy/bin/apply-mcp-only.sh` foi executado com sucesso para validar a sintaxe do script de deploy.
- Validação do workflow YAML foi feita com `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mcp-server.yml')"` e retornou OK.
- Tentativa de validar com Python falhou devido à ausência do módulo `yaml` no ambiente (falso negativo local), portanto a validação principal foi feita via `ruby` e checagem de sintaxe shell.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ee6028688321b8715fbb509ffe17)