### PR TITLE
chore(mcp-server): padroniza credenciais MySQL via MYSQL_PASS no host

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -64,9 +64,9 @@ services:
     depends_on:
       - backend
     environment:
-      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC}
-      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME:-marketing_hub_user}
-      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD:-${MYSQL_PASS:-}}
+      SPRING_DATASOURCE_URL: jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC
+      SPRING_DATASOURCE_USERNAME: marketing_hub_user
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASS}
       MCP_SERVER_NAME: ${MCP_SERVER_NAME:-marketing-hub-mcp}
       MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}
       TZ: America/Sao_Paulo

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -5,7 +5,10 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 ## Objetivo
 
 - Rodar no mesmo VPS do backend.
-- Reutilizar os mesmos parâmetros de conexão MySQL já usados pelo backend (`SPRING_DATASOURCE_*` / `MYSQL_PASS`).
+- Usar conexão MySQL fixa do ambiente produtivo:
+  - URL: `jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC`
+  - usuário: `marketing_hub_user`
+  - senha via `MYSQL_PASS` carregada do `.env` do host em `/opt/marketinghub/containers/.env`.
 - Expor ferramentas iniciais para diagnóstico e expansão futura.
 
 ## Ferramentas MCP iniciais
@@ -100,6 +103,15 @@ MCP_NGINX_CONF=default.conf docker compose up -d nginx
 ```
 
 No deploy (`deploy/docker-compose.yml`), use a mesma variável de ambiente `MCP_NGINX_CONF` (por exemplo, `default.http.conf` ou `default.conf`).
+
+### Variáveis de banco no host (sem GitHub Actions)
+
+O `mcp-server` foi configurado para usar `MYSQL_PASS` do arquivo `.env` no host:
+
+- caminho: `/opt/marketinghub/containers/.env`
+- variável obrigatória: `MYSQL_PASS=...`
+
+Esse `.env` é exclusivo do servidor e **não deve ser propagado, versionado ou injetado no processo do GitHub Actions**.
 
 
 ### Reemissão do certificado (fluxo mais seguro)

--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -7,9 +7,9 @@ services:
     image: marketinghub/mcp-server:latest
     restart: unless-stopped
     environment:
-      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC}
-      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME:-marketing_hub_user}
-      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD:-${MYSQL_PASS:-${MYSQL_PASSWORD:-}}}
+      SPRING_DATASOURCE_URL: jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC
+      SPRING_DATASOURCE_USERNAME: marketing_hub_user
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASS}
       MCP_SERVER_NAME: ${MCP_SERVER_NAME:-marketing-hub-mcp}
       MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}
     expose:

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC}
     username: ${SPRING_DATASOURCE_USERNAME:marketing_hub_user}
-    password: ${SPRING_DATASOURCE_PASSWORD:${MYSQL_PASS:${MYSQL_PASSWORD:}}}
+    password: ${SPRING_DATASOURCE_PASSWORD:${MYSQL_PASS:}}
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       initialization-fail-timeout: -1


### PR DESCRIPTION
### Motivation
- Garantir que o `mcp-server` aponte para o banco de produção correto (`d555d.vps-kinghost.net`) com usuário conhecido e que a senha seja obtida somente do host; isto evita injeção de credenciais pelo pipeline de CI/CD.
- Remover fallback inseguro para outras variáveis de senha e centralizar a origem do segredo em `MYSQL_PASS` no `.env` do host.
- Documentar claramente no README onde o segredo deve residir e que não deve ser incluído no processo do GitHub Actions.

### Description
- Atualizado `mcp-server/src/main/resources/application.yml` para usar `password: ${SPRING_DATASOURCE_PASSWORD:${MYSQL_PASS:}}`, removendo o fallback para `MYSQL_PASSWORD`.
- Ajustado `mcp-server/docker-compose.yml` para fixar a `SPRING_DATASOURCE_URL` e `SPRING_DATASOURCE_USERNAME` e ler `SPRING_DATASOURCE_PASSWORD` diretamente de `${MYSQL_PASS}`.
- Aplicada a mesma alteração em `deploy/docker-compose.yml` para garantir comportamento idêntico no host de deploy.
- Documentado em `mcp-server/README.md` a URL/usuário do MySQL e o uso obrigatório de `MYSQL_PASS` presente no arquivo de ambiente do host (`/opt/marketinghub/containers/.env`) e que esse `.env` não deve ser propagado ao CI/CD.

### Testing
- Executado `cd mcp-server && mvn -B -s settings.xml test`, que falhou no ambiente por falta de acesso de rede para baixar dependências Maven (erro: rede indisponível ao acessar Maven Central).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e770053df88321832596bb591ead43)