### PR TITLE
Preserve VPS .env when syncing MCP deploy descriptors

### DIFF
--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Copy deployment descriptors
         run: |
           ssh ${VPS_USER}@${MCP_VPS_IP} "mkdir -p ${DEPLOY_DIR}"
-          rsync -az --delete --exclude 'volumes/' deploy/ ${VPS_USER}@${MCP_VPS_IP}:${DEPLOY_DIR}/
+          rsync -az --delete --exclude 'volumes/' --exclude '.env' --filter='P .env' deploy/ ${VPS_USER}@${MCP_VPS_IP}:${DEPLOY_DIR}/
           ssh ${VPS_USER}@${MCP_VPS_IP} "mkdir -p ${DEPLOY_DIR}/nginx/mcp"
           rsync -az --delete mcp-server/nginx/ ${VPS_USER}@${MCP_VPS_IP}:${DEPLOY_DIR}/nginx/mcp/
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,6 +22,8 @@ O diretório `deploy/` contém os artefatos de deploy. Atualmente os deploys est
 | `VIDEO_MANAGEMENT_PORT` | Porta exposta externamente | `8095` |
 
 > **Importante:** por padrão o poller fica desativado até que o backend esteja totalmente pronto para entregar jobs reais. Basta exportar `VIDEO_JOBS_POLLING_ENABLED=true` antes de rodar `apply.sh` para habilitar.
+>
+> **Nota operacional (MCP/VPS):** mantenha o arquivo de ambiente em `${DEPLOY_DIR}/.env` no servidor. O pipeline de deploy do MCP sincroniza `deploy/` com `rsync --delete`, mas preserva explicitamente o `.env` remoto para não apagar segredos locais.
 
 Esse fluxo (`apply.sh`) permanece para atualizar somente backend/frontend no host principal.
 


### PR DESCRIPTION
### Motivation

- Evitar que o `rsync --delete` usado pelo pipeline apague o arquivo de ambiente remoto `.env` que contém segredos e configurações do VPS. 
- Garantir que o diretório `deploy/` (onde está o `docker-compose.yml` e scripts de apply) continue sendo sincronizado automaticamente sem perder variáveis sensíveis mantidas no servidor.

### Description

- Atualizei o passo `Copy deployment descriptors` em ` .github/workflows/mcp-server.yml` para adicionar `--exclude '.env'` e `--filter='P .env'` ao `rsync` que envia `deploy/` para `${DEPLOY_DIR}`, mantendo `--delete` para os demais arquivos. 
- Mantive o envio separado de `mcp-server/nginx/` sem alterações ao seu `rsync`. 
- Adicionei uma nota operacional em `deploy/README.md` instruindo a manter `${DEPLOY_DIR}/.env` no VPS e informando que o pipeline preserva esse arquivo.

### Testing

- Inspeção do YAML com `rg` e `nl` confirmou que a linha `rsync -az --delete --exclude 'volumes/' --exclude '.env' --filter='P .env' deploy/ ${VPS_USER}@${MCP_VPS_IP}:${DEPLOY_DIR}/` está presente e que `--delete` foi preservado; a verificação obteve sucesso. 
- `git status --short` confirmou os dois arquivos modificados e o commit com `git commit -m "Preserve remote .env during MCP deploy rsync"` foi realizado com sucesso. 
- Todas as validações automáticas realizadas por inspeção de arquivo e controle de versão concluíram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e773f72db083219ae85478c1c88f0c)