### PR TITLE
Clarify that `java_module_logs` returns Spring Boot logs

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -17,7 +17,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `db_list_tables`: lista todas as tabelas disponíveis no schema atual.
 - `db_read_table`: lê dados de uma tabela com paginação (`table`, `limit`, `offset`).
 - `db_query`: executa SQL de leitura (`SELECT`/`WITH`) com limite de linhas.
-- `java_module_logs`: retorna tail de logs dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`).
+- `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`).
 
 ## Executar localmente
 
@@ -36,9 +36,9 @@ mvn -s settings.xml spring-boot:run
 - Se `MCP_API_KEY` estiver definido, o endpoint `/mcp` exige `Authorization: Bearer <MCP_API_KEY>`.
 - Se `MCP_API_KEY` estiver vazio, o endpoint permanece aberto (apenas para ambientes internos/controlados).
 
-## Logs dos módulos Java
+## Logs de Spring Boot dos módulos Java
 
-O tool `java_module_logs` lê os arquivos configurados em:
+O tool `java_module_logs` lê os arquivos de log do Spring Boot configurados em:
 
 - `MCP_LOG_BACKEND_PATH` (default `/app/logs/marketinghub-backend.log`);
 - `MCP_LOG_AI_WORKER_PATH` (default `/var/log/ai-worker/application.log`);

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -114,7 +114,7 @@ public class McpController {
                     ),
                     Map.of(
                             "name", "java_module_logs",
-                            "description", "Retorna as últimas linhas de logs dos módulos Java (backend, ai-worker, lead-portal, facebook-ads).",
+                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads).",
                             "inputSchema", Map.of(
                                     "type", "object",
                                     "properties", Map.of(


### PR DESCRIPTION
### Motivation

- Esclarecer que a tool `java_module_logs` devolve specifically os logs do Spring Boot dos módulos Java para evitar ambiguidade na operação e no uso do MCP. 
- Garantir que a documentação (`README`) e o metadado exposto por `tools/list` estejam alinhados com o comportamento real.

### Description

- Atualizei a descrição do tool `java_module_logs` em `mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java` para dizer que retorna as últimas linhas dos logs do Spring Boot dos módulos Java. 
- Ajustei `mcp-server/README.md` para refletir a mesma redação na lista de ferramentas e na seção de logs. 
- Alterações mínimas de texto sem impacto na lógica de execução do tool.

### Testing

- Executei os testes automatizados com `cd mcp-server && mvn -q -DskipTests=false test` e a suite do módulo `mcp-server` passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e776ab8e48832187717a58f6d447f5)