### PR TITLE
fix(mcp-server): make database host configurable via env vars

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -64,8 +64,8 @@ services:
     depends_on:
       - backend
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC
-      SPRING_DATASOURCE_USERNAME: marketing_hub_user
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:mysql://${DB_HOST:-d555d.vps-kinghost.net}:${DB_PORT:-3306}/${DB_NAME:-marketinghubdb}?useSSL=false&serverTimezone=UTC}
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME:-${DB_USERNAME:-marketing_hub_user}}
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASS}
       MCP_SERVER_NAME: ${MCP_SERVER_NAME:-marketing-hub-mcp}
       MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -5,10 +5,10 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 ## Objetivo
 
 - Rodar no mesmo VPS do backend.
-- Usar conexão MySQL fixa do ambiente produtivo:
-  - URL: `jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC`
-  - usuário: `marketing_hub_user`
-  - senha via `MYSQL_PASS` carregada do `.env` do host em `/opt/marketinghub/containers/.env`.
+- Usar conexão MySQL via variáveis de ambiente (com defaults de produção):
+  - URL via `SPRING_DATASOURCE_URL` (ou composição por `DB_HOST`/`DB_PORT`/`DB_NAME`).
+  - usuário via `SPRING_DATASOURCE_USERNAME` (ou `DB_USERNAME`).
+  - senha via `SPRING_DATASOURCE_PASSWORD`/`MYSQL_PASS` carregada do `.env` do host em `/opt/marketinghub/containers/.env`.
 - Expor ferramentas iniciais para diagnóstico e expansão futura.
 
 ## Ferramentas MCP iniciais
@@ -110,6 +110,12 @@ O `mcp-server` foi configurado para usar `MYSQL_PASS` do arquivo `.env` no host:
 
 - caminho: `/opt/marketinghub/containers/.env`
 - variável obrigatória: `MYSQL_PASS=...`
+- variáveis opcionais para ajustar host/porta/schema sem rebuild:
+  - `DB_HOST=...`
+  - `DB_PORT=3306`
+  - `DB_NAME=marketinghubdb`
+  - `DB_USERNAME=marketing_hub_user`
+  - (ou defina diretamente `SPRING_DATASOURCE_URL` / `SPRING_DATASOURCE_USERNAME`)
 
 Esse `.env` é exclusivo do servidor e **não deve ser propagado, versionado ou injetado no processo do GitHub Actions**.
 

--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     image: marketinghub/mcp-server:latest
     restart: unless-stopped
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC
-      SPRING_DATASOURCE_USERNAME: marketing_hub_user
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:mysql://${DB_HOST:-d555d.vps-kinghost.net}:${DB_PORT:-3306}/${DB_NAME:-marketinghubdb}?useSSL=false&serverTimezone=UTC}
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME:-${DB_USERNAME:-marketing_hub_user}}
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASS}
       MCP_SERVER_NAME: ${MCP_SERVER_NAME:-marketing-hub-mcp}
       MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -5,8 +5,8 @@ spring:
   application:
     name: mcp-server
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb?useSSL=false&serverTimezone=UTC}
-    username: ${SPRING_DATASOURCE_USERNAME:marketing_hub_user}
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://${DB_HOST:d555d.vps-kinghost.net}:${DB_PORT:3306}/${DB_NAME:marketinghubdb}?useSSL=false&serverTimezone=UTC}
+    username: ${SPRING_DATASOURCE_USERNAME:${DB_USERNAME:marketing_hub_user}}
     password: ${SPRING_DATASOURCE_PASSWORD:${MYSQL_PASS:}}
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:


### PR DESCRIPTION
### Motivation
- The MCP server was still attempting to connect to a hardcoded production MySQL host and user, causing connection failures when deployed into environments with different DB endpoints.

### Description
- Updated `mcp-server/src/main/resources/application.yml` to accept `SPRING_DATASOURCE_URL` or to compose the JDBC URL from `DB_HOST`/`DB_PORT`/`DB_NAME`, and to fallback `SPRING_DATASOURCE_USERNAME` to `DB_USERNAME` with sane defaults.
- Updated `mcp-server/docker-compose.yml` and `deploy/docker-compose.yml` to interpolate `SPRING_DATASOURCE_URL` and `SPRING_DATASOURCE_USERNAME` from environment variables (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`) instead of using hardcoded values.
- Documented the optional DB environment variables and the alternative `SPRING_DATASOURCE_*` overrides in `mcp-server/README.md` so the host/port/schema/user can be changed without rebuilding the image.
- Preserved existing password handling via `MYSQL_PASS` / `SPRING_DATASOURCE_PASSWORD` to keep current host `.env` workflows intact.

### Testing
- Ran the module test suite with `cd mcp-server && mvn -q test` which completed successfully.
- The Spring test context started and Hikari initialized during the tests without failing to load the configuration, indicating the new env-driven datasource defaults are valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7798b84b083218c0e7fab0fb51f83)