### PR TITLE
mcp-server: fail fast when datasource points to invalid KingHost host

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -47,6 +47,15 @@ O tool `java_module_logs` lê os arquivos de log do Spring Boot configurados em:
 
 Limite máximo por chamada: `MCP_LOG_MAX_LINES` (default `500`).
 
+### Troubleshooting de conexão com MySQL
+
+Se aparecer erro como `Access denied for user 'marketing_hub_user'@'interface.vps-kinghost.net'`, o host configurado está incorreto.
+
+- Host **inválido**: `interface.vps-kinghost.net`
+- Host **correto**: `d555d.vps-kinghost.net`
+
+Garanta que `SPRING_DATASOURCE_URL` use o host correto. O `mcp-server` agora também falha no startup quando detecta o host inválido para evitar deploy com configuração incorreta.
+
 ## Docker
 
 ### Apenas o container do MCP (desenvolvimento/local)

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/DatabaseHostValidator.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/DatabaseHostValidator.java
@@ -1,0 +1,42 @@
+package com.marketinghub.mcpserver.config;
+
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseHostValidator {
+
+    private static final Logger log = LoggerFactory.getLogger(DatabaseHostValidator.class);
+    static final String INVALID_HOST = "interface.vps-kinghost.net";
+    static final String EXPECTED_HOST = "d555d.vps-kinghost.net";
+
+    private final String datasourceUrl;
+
+    public DatabaseHostValidator(@Value("${spring.datasource.url:}") String datasourceUrl) {
+        this.datasourceUrl = datasourceUrl;
+    }
+
+    @PostConstruct
+    void validate() {
+        if (usesInvalidHost(datasourceUrl)) {
+            throw new IllegalStateException(
+                    "spring.datasource.url está apontando para host inválido '"
+                            + INVALID_HOST
+                            + "'. Use '"
+                            + EXPECTED_HOST
+                            + "'."
+            );
+        }
+
+        if (datasourceUrl != null && datasourceUrl.contains(EXPECTED_HOST)) {
+            log.info("Datasource configurado com host correto: {}", EXPECTED_HOST);
+        }
+    }
+
+    static boolean usesInvalidHost(String url) {
+        return url != null && url.contains(INVALID_HOST);
+    }
+}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/config/DatabaseHostValidatorTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/config/DatabaseHostValidatorTest.java
@@ -1,0 +1,23 @@
+package com.marketinghub.mcpserver.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatabaseHostValidatorTest {
+
+    @Test
+    void shouldDetectInvalidKinghostInterfaceHost() {
+        String invalidUrl = "jdbc:mysql://interface.vps-kinghost.net:3306/marketinghubdb";
+
+        assertTrue(DatabaseHostValidator.usesInvalidHost(invalidUrl));
+    }
+
+    @Test
+    void shouldNotDetectValidHost() {
+        String validUrl = "jdbc:mysql://d555d.vps-kinghost.net:3306/marketinghubdb";
+
+        assertFalse(DatabaseHostValidator.usesInvalidHost(validUrl));
+    }
+}


### PR DESCRIPTION
### Motivation

- Production logs showed JDBC auth attempts from `marketing_hub_user@interface.vps-kinghost.net`, indicating the configured DB host was incorrect and causing access errors. 
- Prevent silent misconfigured deployments by failing fast during startup when the datasource points to the known-bad host. 

### Description

- Added `DatabaseHostValidator` (`mcp-server/src/main/java/com/marketinghub/mcpserver/config/DatabaseHostValidator.java`) which inspects `spring.datasource.url` on startup and throws `IllegalStateException` if it contains `interface.vps-kinghost.net`. 
- The validator logs a clear info message when the expected host `d555d.vps-kinghost.net` is present to aid diagnostics. 
- Added unit tests (`mcp-server/src/test/java/com/marketinghub/mcpserver/config/DatabaseHostValidatorTest.java`) covering detection of the invalid and valid hosts. 
- Documented troubleshooting guidance in `mcp-server/README.md` explaining the error and the correct DB host to use. 

### Testing

- Ran the unit tests with `mvn -f mcp-server/pom.xml test -Dtest=DatabaseHostValidatorTest` and they passed (`Tests run: 2, Failures: 0`). 
- Build/test run completed successfully and verifies the validator logic for both invalid and valid datasource URLs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77b04c4e483218d20f170b6c60b3c)