### PR TITLE
Add database connection attempt logging to MCP server

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/DatabaseConnectionAttemptLogger.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/DatabaseConnectionAttemptLogger.java
@@ -1,0 +1,54 @@
+package com.marketinghub.mcpserver.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+@Component
+public class DatabaseConnectionAttemptLogger {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseConnectionAttemptLogger.class);
+
+    private final String datasourceUrl;
+    private final String datasourceUsername;
+
+    public DatabaseConnectionAttemptLogger(
+            @Value("${spring.datasource.url}") String datasourceUrl,
+            @Value("${spring.datasource.username}") String datasourceUsername
+    ) {
+        this.datasourceUrl = datasourceUrl;
+        this.datasourceUsername = datasourceUsername;
+    }
+
+    @EventListener(ApplicationStartedEvent.class)
+    public void logConnectionTarget() {
+        DatabaseTarget databaseTarget = parseDatabaseTarget(datasourceUrl);
+        logger.info(
+                "Tentando conexão com banco de dados host='{}' port='{}' user='{}'",
+                databaseTarget.host(),
+                databaseTarget.port(),
+                datasourceUsername
+        );
+    }
+
+    private DatabaseTarget parseDatabaseTarget(String jdbcUrl) {
+        try {
+            String withoutPrefix = jdbcUrl.replaceFirst("^jdbc:", "");
+            URI uri = URI.create(withoutPrefix);
+            String host = uri.getHost() == null ? "unknown" : uri.getHost();
+            String port = uri.getPort() == -1 ? "3306" : String.valueOf(uri.getPort());
+            return new DatabaseTarget(host, port);
+        } catch (RuntimeException ex) {
+            logger.warn("Não foi possível interpretar a URL do banco para log de diagnóstico: {}", jdbcUrl);
+            return new DatabaseTarget("unknown", "unknown");
+        }
+    }
+
+    private record DatabaseTarget(String host, String port) {
+    }
+}


### PR DESCRIPTION
### Motivation
- Log the database host, port and user before the MCP server attempts to connect to the database so operators can diagnose misconfigured `spring.datasource.url` values earlier in startup.
- Provide a safe parsing and sensible defaults so logging never fails startup when the JDBC URL format is unexpected.

### Description
- Add new component `DatabaseConnectionAttemptLogger` in `mcp-server/src/main/java/com/marketinghub/mcpserver/config/DatabaseConnectionAttemptLogger.java` that listens to `ApplicationStartedEvent` and emits an info log with host, port and user.
- Parse `spring.datasource.url` to extract host and port, default port to `3306` when absent, and fall back to `unknown` when the URL cannot be interpreted.
- Keep the username from `spring.datasource.username` and include it in the same log line for quick diagnostics.

### Testing
- Ran unit/integration tests with `mvn -f mcp-server/pom.xml test -q`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77d8305f88321884637d65dc743af)