### PR TITLE
Improve MCP datasource URL diagnostics logging

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/DatabaseConnectionAttemptLogger.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/DatabaseConnectionAttemptLogger.java
@@ -8,11 +8,15 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
+import java.util.regex.Pattern;
 
 @Component
 public class DatabaseConnectionAttemptLogger {
 
     private static final Logger logger = LoggerFactory.getLogger(DatabaseConnectionAttemptLogger.class);
+    private static final Pattern JDBC_CREDENTIALS_PATTERN = Pattern.compile(
+            "(?i)(jdbc:[^:]+://)([^:@/]+):([^@/]+)@"
+    );
 
     private final String datasourceUrl;
     private final String datasourceUsername;
@@ -28,12 +32,21 @@ public class DatabaseConnectionAttemptLogger {
     @EventListener(ApplicationStartedEvent.class)
     public void logConnectionTarget() {
         DatabaseTarget databaseTarget = parseDatabaseTarget(datasourceUrl);
+        String sanitizedDatasourceUrl = sanitizeJdbcUrl(datasourceUrl);
         logger.info(
-                "Tentando conexão com banco de dados host='{}' port='{}' user='{}'",
+                "Tentando conexão com banco de dados jdbcUrl='{}' host='{}' port='{}' user='{}'",
+                sanitizedDatasourceUrl,
                 databaseTarget.host(),
                 databaseTarget.port(),
                 datasourceUsername
         );
+    }
+
+    private String sanitizeJdbcUrl(String jdbcUrl) {
+        if (jdbcUrl == null || jdbcUrl.isBlank()) {
+            return "unknown";
+        }
+        return JDBC_CREDENTIALS_PATTERN.matcher(jdbcUrl).replaceAll("$1$2:***@");
     }
 
     private DatabaseTarget parseDatabaseTarget(String jdbcUrl) {


### PR DESCRIPTION
### Motivation

- Facilitar o diagnóstico de qual `jdbc` exato o MCP está usando no startup para confirmar o host correto (`d555d.vps-kinghost.net`) enquanto evita vazar credenciais em logs.

### Description

- Atualiza `DatabaseConnectionAttemptLogger` em `mcp-server/src/main/java/com/marketinghub/mcpserver/config/DatabaseConnectionAttemptLogger.java` para incluir a `jdbcUrl` (sanitizada) na mensagem de log de tentativa de conexão.
- Adiciona um `Pattern` e o método `sanitizeJdbcUrl` para mascarar credenciais embutidas no formato `user:pass@` antes de logar.
- Mantém o log de `host`, `port` e `user` para troubleshooting rápido sem expor segredos.

### Testing

- Executou `mvn -s settings.xml -Dtest=DatabaseHostValidatorTest,com.marketinghub.mcpserver.controller.McpControllerTest test`, que **falhou** devido a indisponibilidade de rede ao baixar dependências Maven (não foi possível executar os testes unitários localmente).
- Nenhum outro teste automatizado foi executado no repositório alterado neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77eefc2c083218e2ccf8920785716)