### PR TITLE
Require Instant Forms to be approved and published before enabling campaigns and display publication status

### DIFF
--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -36,6 +36,8 @@ export interface FacebookInstantFormSummary {
   prompt?: string | null;
   approved?: boolean;
   approvedAt?: string | null;
+  published?: boolean;
+  publishedAt?: string | null;
 }
 
 export interface ExperimentCampaignMetric {

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -254,6 +254,10 @@ export default function ExperimentDetailPage() {
   const experimentPage = data.facebookPage;
   const hasExperimentPage = Boolean(experimentPage?.pageId);
   const experimentInstantForm = data.facebookInstantForm;
+  const instantFormApproved = Boolean(experimentInstantForm?.approved);
+  const instantFormPublished = Boolean(experimentInstantForm?.published);
+  const instantFormReadyForCampaign =
+    Boolean(experimentInstantForm) && instantFormApproved && instantFormPublished;
   const instagramAccount = data.instagramAccount;
   const hasInstagramAccount = Boolean(instagramAccount);
   const facebookWorker = facebookConfig?.worker;
@@ -402,17 +406,22 @@ export default function ExperimentDetailPage() {
       ? [
           {
             id: "instant-form",
-            title: "Instant form vinculado",
-            isMet: Boolean(experimentInstantForm),
+            title: "Instant form aprovado e publicado",
+            isMet: instantFormReadyForCampaign,
             hint: experimentInstantForm
-              ? `O formulário ${experimentInstantForm.name}${experimentInstantForm.facebookFormId ? ` (${experimentInstantForm.facebookFormId})` : ""} será usado na captura.`
+              ? instantFormReadyForCampaign
+                ? `O formulário ${experimentInstantForm.name}${experimentInstantForm.facebookFormId ? ` (${experimentInstantForm.facebookFormId})` : ""} está aprovado e publicado para a campanha.`
+                : `O formulário ${experimentInstantForm.name} está vinculado, mas ainda precisa ${instantFormApproved ? "" : "de aprovação"}${!instantFormApproved && !instantFormPublished ? " e " : ""}${instantFormPublished ? "" : "de publicação na Meta"} para liberar a campanha.`
               : "Associe um instant form compatível na aba Instant Forms para destravar a etapa de captura.",
             action: experimentInstantForm
-              ? undefined
+              ? instantFormReadyForCampaign
+                ? undefined
+                : () => setTab("instant-form")
               : () => setTab("instant-form"),
-            actionLabel: experimentInstantForm
-              ? undefined
-              : "Ir para Instant Forms",
+            actionLabel:
+              experimentInstantForm && instantFormReadyForCampaign
+                ? undefined
+                : "Ir para Instant Forms",
           },
         ]
       : []),

--- a/frontend/src/pages/experiment/InstantFormsTab.tsx
+++ b/frontend/src/pages/experiment/InstantFormsTab.tsx
@@ -338,53 +338,70 @@ export default function InstantFormsTab({ experiment, steps }: InstantFormsTabPr
     }
 
     return (
-      <dl className="row mb-0">
-        <dt className="col-sm-4">Formulário</dt>
-        <dd className="col-sm-8">{form.name}</dd>
-        <dt className="col-sm-4">ID Meta</dt>
-        <dd className="col-sm-8">{form.facebookFormId ?? "—"}</dd>
-        <dt className="col-sm-4">Página</dt>
-        <dd className="col-sm-8">{form.facebookPageName}</dd>
-        <dt className="col-sm-4">Status</dt>
-        <dd className="col-sm-8">{describeStatus(form.status)}</dd>
-        <dt className="col-sm-4">Idioma</dt>
-        <dd className="col-sm-8">{form.locale ?? "—"}</dd>
-        <dt className="col-sm-4">Links</dt>
-        <dd className="col-sm-8">
-          <div className="d-flex flex-column gap-1">
-            {form.followUpActionUrl ? (
-              <div className="d-flex flex-column gap-1">
-                <a href={form.followUpActionUrl} target="_blank" rel="noreferrer" className="small">
-                  Página de agradecimento
-                </a>
-                <span className="text-muted small text-break">{form.followUpActionUrl}</span>
-              </div>
-            ) : null}
-            {form.privacyPolicyUrl ? (
-              <div className="d-flex flex-column gap-1">
-                <a href={form.privacyPolicyUrl} target="_blank" rel="noreferrer" className="small">
-                  Política de privacidade
-                </a>
-                <span className="text-muted small text-break">{form.privacyPolicyUrl}</span>
-              </div>
-            ) : null}
+      <>
+        {(!form.approved || !form.published) ? (
+          <div className="alert alert-warning small py-2 px-3 mb-3" role="alert">
+            Para liberar campanhas, o instant form precisa estar <strong>aprovado</strong> e{" "}
+            <strong>publicado</strong> na Meta.
           </div>
-        </dd>
-        <dt className="col-sm-4">Aprovação</dt>
-        <dd className="col-sm-8">
-          <span className={`badge ${form.approved ? "text-bg-success" : "text-bg-secondary"}`}>
-            {form.approved ? "Aprovado" : "Pendente"}
-          </span>
-          {form.approvedAt ? (
-            <span className="text-muted small ms-2">{formatDatetime(form.approvedAt)}</span>
-          ) : null}
-          <div>
-            <Link to={`/experiments/${experiment.id}/instant-forms/${form.id}`} className="btn btn-link btn-sm px-0">
-              Abrir detalhamento
-            </Link>
-          </div>
-        </dd>
-      </dl>
+        ) : null}
+        <dl className="row mb-0">
+          <dt className="col-sm-4">Formulário</dt>
+          <dd className="col-sm-8">{form.name}</dd>
+          <dt className="col-sm-4">ID Meta</dt>
+          <dd className="col-sm-8">{form.facebookFormId ?? "—"}</dd>
+          <dt className="col-sm-4">Página</dt>
+          <dd className="col-sm-8">{form.facebookPageName}</dd>
+          <dt className="col-sm-4">Status</dt>
+          <dd className="col-sm-8">{describeStatus(form.status)}</dd>
+          <dt className="col-sm-4">Idioma</dt>
+          <dd className="col-sm-8">{form.locale ?? "—"}</dd>
+          <dt className="col-sm-4">Links</dt>
+          <dd className="col-sm-8">
+            <div className="d-flex flex-column gap-1">
+              {form.followUpActionUrl ? (
+                <div className="d-flex flex-column gap-1">
+                  <a href={form.followUpActionUrl} target="_blank" rel="noreferrer" className="small">
+                    Página de agradecimento
+                  </a>
+                  <span className="text-muted small text-break">{form.followUpActionUrl}</span>
+                </div>
+              ) : null}
+              {form.privacyPolicyUrl ? (
+                <div className="d-flex flex-column gap-1">
+                  <a href={form.privacyPolicyUrl} target="_blank" rel="noreferrer" className="small">
+                    Política de privacidade
+                  </a>
+                  <span className="text-muted small text-break">{form.privacyPolicyUrl}</span>
+                </div>
+              ) : null}
+            </div>
+          </dd>
+          <dt className="col-sm-4">Aprovação</dt>
+          <dd className="col-sm-8">
+            <span className={`badge ${form.approved ? "text-bg-success" : "text-bg-secondary"}`}>
+              {form.approved ? "Aprovado" : "Pendente"}
+            </span>
+            {form.approvedAt ? (
+              <span className="text-muted small ms-2">{formatDatetime(form.approvedAt)}</span>
+            ) : null}
+          </dd>
+          <dt className="col-sm-4">Publicação</dt>
+          <dd className="col-sm-8">
+            <span className={`badge ${form.published ? "text-bg-success" : "text-bg-secondary"}`}>
+              {form.published ? "Publicado" : "Pendente"}
+            </span>
+            {form.publishedAt ? (
+              <span className="text-muted small ms-2">{formatDatetime(form.publishedAt)}</span>
+            ) : null}
+            <div>
+              <Link to={`/experiments/${experiment.id}/instant-forms/${form.id}`} className="btn btn-link btn-sm px-0">
+                Abrir detalhamento
+              </Link>
+            </div>
+          </dd>
+        </dl>
+      </>
     );
   };
 


### PR DESCRIPTION
### Motivation

- Prevent campaigns from being considered ready when an Instant Form is linked but not both approved and published in Meta.
- Surface publication state and timestamps in the UI so operators can see why a form is blocking the flow.
- Add missing API fields to represent publication state returned by backend responses.

### Description

- Added `published` and `publishedAt` to `FacebookInstantFormSummary` in `frontend/src/api/experiment/useExperiments.ts`.
- In `ExperimentDetailPage.tsx`, compute `instantFormReadyForCampaign` requiring both `approved` and `published`, update checklist title/hint/action and navigation to reflect the new readiness logic.
- In `InstantFormsTab.tsx`, show a warning banner when a selected form is not both approved and published, display a `Publicado` badge and `publishedAt` timestamp, and keep the approval badge and `approvedAt` timestamp.
- Adjusted labels and action enabling so the Instant Forms checklist only unlocks when the form is approved and published.

### Testing

- Ran TypeScript typecheck and ESLint locally via the frontend build commands (`yarn build` / `yarn lint`) and the checks completed without errors.
- Executed the frontend unit tests (`yarn test`) and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e782ee4bf88321ba37fced452e7d7c)