### PR TITLE
Fix instant form pending flow navigation and add clear action CTAs

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import axios from "axios";
 import { toast } from "react-toastify";
@@ -70,6 +70,7 @@ export default function ExperimentDetailPage() {
   );
   const { data: presets } = useMetricPresets();
   const [tab, setTab] = useState("overview");
+  const tabsSectionRef = useRef<HTMLDivElement | null>(null);
   const [journeyError, setJourneyError] = useState<string | null>(null);
   const { data: facebookConfig, isLoading: isLoadingFacebookConfig } =
     useFacebookConfigurationStatus();
@@ -332,6 +333,15 @@ export default function ExperimentDetailPage() {
     isReadyForFacebook && data.platform === "FACEBOOK";
   const releaseButtonDisabled =
     releaseInProgress || !canReleaseExperiment || isLoadingReadiness;
+  const openInstantFormActions = () => {
+    setTab("instant-form");
+    window.requestAnimationFrame(() => {
+      tabsSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
+  };
 
   const configurationChecklist: ChecklistItem[] = [
     {
@@ -416,8 +426,8 @@ export default function ExperimentDetailPage() {
             action: experimentInstantForm
               ? instantFormReadyForCampaign
                 ? undefined
-                : () => setTab("instant-form")
-              : () => setTab("instant-form"),
+                : openInstantFormActions
+              : openInstantFormActions,
             actionLabel:
               experimentInstantForm && instantFormReadyForCampaign
                 ? undefined
@@ -1190,7 +1200,8 @@ export default function ExperimentDetailPage() {
           </div>
         </div>
       ) : null}
-      <Tabs.Root value={tab} onValueChange={setTab} className="mt-3">
+      <div ref={tabsSectionRef}>
+        <Tabs.Root value={tab} onValueChange={setTab} className="mt-3">
         <Tabs.List className="nav nav-tabs">
           <Tabs.Trigger value="overview" className="nav-link">
             Overview
@@ -1312,7 +1323,8 @@ export default function ExperimentDetailPage() {
             adCopy={data?.adCopy}
           />
         </Tabs.Content>
-      </Tabs.Root>
+        </Tabs.Root>
+      </div>
       {isResetModalOpen ? (
         <div
           className="modal d-block"

--- a/frontend/src/pages/experiment/InstantFormsTab.tsx
+++ b/frontend/src/pages/experiment/InstantFormsTab.tsx
@@ -88,6 +88,9 @@ export default function InstantFormsTab({ experiment, steps }: InstantFormsTabPr
   }, [availableForms, experiment.facebookInstantForm, selectedFormId]);
 
   const hasForms = availableForms.length > 0;
+  const metaInstantFormsUrl = selectedForm?.facebookPageExternalId
+    ? `https://business.facebook.com/latest/instant_forms/?page_id=${selectedForm.facebookPageExternalId}`
+    : "https://business.facebook.com/latest/instant_forms/";
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -343,6 +346,27 @@ export default function InstantFormsTab({ experiment, steps }: InstantFormsTabPr
           <div className="alert alert-warning small py-2 px-3 mb-3" role="alert">
             Para liberar campanhas, o instant form precisa estar <strong>aprovado</strong> e{" "}
             <strong>publicado</strong> na Meta.
+          </div>
+        ) : null}
+        {(!form.approved || !form.published) ? (
+          <div className="border rounded-3 p-3 mb-3 bg-light">
+            <p className="fw-semibold mb-2">Ações pendentes para destravar a campanha</p>
+            <div className="d-flex flex-wrap gap-2">
+              <Link
+                to={`/experiments/${experiment.id}/instant-forms/${form.id}`}
+                className="btn btn-primary"
+              >
+                1) Aprovar no Marketing Hub
+              </Link>
+              <a
+                href={metaInstantFormsUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="btn btn-outline-primary"
+              >
+                2) Publicar no Meta Instant Forms
+              </a>
+            </div>
           </div>
         ) : null}
         <dl className="row mb-0">


### PR DESCRIPTION
### Motivation

- Usuários relataram que o link para o instant form parecia não fazer nada quando o formulário estava pendente; era necessário direcionar o usuário ao local correto e expor as duas ações faltantes (aprovação e publicação).

### Description

- Atualiza a ação do checklist para abrir a aba `instant-form` e rolar suavemente até a seção de abas usando um `ref` e `scrollIntoView` em `ExperimentDetailPage.tsx`.
- Envolve a área de abas com um `div` referenciado e expõe a função `openInstantFormActions` para centralizar a navegação/scroll. (`frontend/src/pages/experiment/ExperimentDetailPage.tsx`).
- Adiciona um bloco visual de "Ações pendentes" na aba Instant Forms com dois botões claramente rotulados: `1) Aprovar no Marketing Hub` (navega para o detalhamento interno) e `2) Publicar no Meta Instant Forms` (link externo), e constrói a URL do Meta Instant Forms a partir de `facebookPageExternalId`. (`frontend/src/pages/experiment/InstantFormsTab.tsx`).
- O link externo abre em nova aba (`target="_blank"`) conforme a convenção do projeto e preserva o comportamento assíncrono/indicadores de carregamento já existentes.

### Testing

- Executei `npm --prefix frontend run typecheck`; o tipo-check falhou por dependências de tipos ausentes no ambiente (erros para `@testing-library/jest-dom`, `vite/client` e `vitest/globals`).
- Código modificado foi commitado localmente com a mensagem `Fix instant form pending flow navigation and action CTAs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b3ba12888321a9fdd42e4defd468)