### PR TITLE
Inject Meta (Facebook) Pixel into published lead portal HTML for approved experiment flows

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublicationRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublicationRequest.java
@@ -41,6 +41,9 @@ public record LeadPortalFlowPublicationRequest(
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final Pattern IMAGE_SRC_PATTERN = Pattern.compile("<img[^>]+src=[\"']([^\"']+)[\"']",
             Pattern.CASE_INSENSITIVE);
+    private static final Pattern PIXEL_MARKER_PATTERN = Pattern.compile(
+            "fbq\\s*\\(|fbevents\\.js|connect\\.facebook\\.net",
+            Pattern.CASE_INSENSITIVE);
 
     public static LeadPortalFlowPublicationRequest from(LeadPortalFlow flow) {
         return from(flow, null);
@@ -59,12 +62,13 @@ public record LeadPortalFlowPublicationRequest(
         String facebookPixelId = flow.getMarketNiche() != null ? flow.getMarketNiche().getFacebookPixelId() : null;
         String facebookPixelCode = flow.getMarketNiche() != null ? flow.getMarketNiche().getFacebookPixelCode() : null;
         Instant facebookPixelCreatedAt = flow.getMarketNiche() != null ? flow.getMarketNiche().getFacebookPixelCreatedAt() : null;
+        String htmlWithPixel = injectFacebookPixelWhenEligible(flow, flow.getCustomFormHtml(), facebookPixelId);
         return new LeadPortalFlowPublicationRequest(
                 flow.getSlug(),
                 flow.getName(),
                 flow.getDescription(),
-                flow.getCustomFormHtml(),
-                flow.getCustomFormHtml(),
+                htmlWithPixel,
+                htmlWithPixel,
                 resolveRenderMode(flow),
                 new FormSpec(flow.getQuestions().stream()
                         .map(LeadPortalFlowPublicationRequest::toQuestion)
@@ -80,6 +84,66 @@ public record LeadPortalFlowPublicationRequest(
                 facebookPixelId,
                 facebookPixelCode,
                 facebookPixelCreatedAt);
+    }
+
+    private static String injectFacebookPixelWhenEligible(LeadPortalFlow flow, String customFormHtml, String facebookPixelId) {
+        if (!isEligibleForNichePixelInjection(flow)) {
+            return customFormHtml;
+        }
+        if (!StringUtils.hasText(customFormHtml) || !StringUtils.hasText(facebookPixelId)) {
+            return customFormHtml;
+        }
+        if (PIXEL_MARKER_PATTERN.matcher(customFormHtml).find()) {
+            return customFormHtml;
+        }
+        String pixelSnippet = buildPixelSnippet(facebookPixelId);
+        if (containsIgnoreCase(customFormHtml, "</head>")) {
+            return replaceFirstIgnoreCase(customFormHtml, "</head>", pixelSnippet + "\n</head>");
+        }
+        if (containsIgnoreCase(customFormHtml, "<body")) {
+            return replaceFirstIgnoreCase(customFormHtml, "<body", pixelSnippet + "\n<body");
+        }
+        return pixelSnippet + "\n" + customFormHtml;
+    }
+
+    private static boolean isEligibleForNichePixelInjection(LeadPortalFlow flow) {
+        return flow != null
+                && flow.isApproved()
+                && flow.getExperiment() != null;
+    }
+
+    private static String buildPixelSnippet(String facebookPixelId) {
+        String escapedPixelId = escapeEcmaScript(facebookPixelId.trim());
+        return """
+                <!-- Meta Pixel Code -->
+                <script>
+                  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+                  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+                  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+                  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script',
+                  'https://connect.facebook.net/en_US/fbevents.js');
+                  fbq('init', '%s');
+                  fbq('track', 'PageView');
+                </script>
+                <noscript><img height="1" width="1" style="display:none"
+                  src="https://www.facebook.com/tr?id=%s&ev=PageView&noscript=1"
+                /></noscript>
+                <!-- End Meta Pixel Code -->
+                """.formatted(escapedPixelId, escapedPixelId).trim();
+    }
+
+    private static String escapeEcmaScript(String rawValue) {
+        return rawValue
+                .replace("\\", "\\\\")
+                .replace("'", "\\'");
+    }
+
+    private static boolean containsIgnoreCase(String source, String token) {
+        return source.toLowerCase().contains(token.toLowerCase());
+    }
+
+    private static String replaceFirstIgnoreCase(String source, String target, String replacement) {
+        return source.replaceFirst("(?i)" + Pattern.quote(target), Matcher.quoteReplacement(replacement));
     }
 
     private static String resolveRenderMode(LeadPortalFlow flow) {

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublicationRequestTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublicationRequestTest.java
@@ -6,6 +6,7 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.LeadPortalSimpleFormStyle;
 import com.marketinghub.leadportal.LeadPortalSimpleFormStyleDefinition;
+import com.marketinghub.niche.MarketNiche;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -108,6 +109,49 @@ class LeadPortalFlowPublicationRequestTest {
         assertThat(payload.renderMode()).isEqualTo("legacy-html");
         assertThat(payload.simpleFormStyle().definition()).isNotNull();
         assertThat(payload.simpleFormStyle().definition().heroImageUrl()).isEqualTo(overrideImage);
+    }
+
+    @Test
+    void fromInjectsNichePixelIntoLandingHtmlWhenFlowIsApprovedAndLinkedToExperiment() {
+        MarketNiche niche = MarketNiche.builder()
+                .facebookPixelId("1234567890")
+                .build();
+        LeadPortalFlow flow = LeadPortalFlow.builder()
+                .slug("exp-12-landing")
+                .name("Flow")
+                .approved(true)
+                .experiment(Experiment.builder().id(12L).build())
+                .marketNiche(niche)
+                .customFormHtml("<html><head><title>Landing</title></head><body><form></form></body></html>")
+                .questions(List.of())
+                .build();
+
+        LeadPortalFlowPublicationRequest payload = LeadPortalFlowPublicationRequest.from(flow);
+
+        assertThat(payload.customFormHtml()).contains("fbq('init', '1234567890')");
+        assertThat(payload.customFormHtml()).contains("fbevents.js");
+        assertThat(payload.legacyPreviewHtml()).contains("tr?id=1234567890&ev=PageView&noscript=1");
+    }
+
+    @Test
+    void fromDoesNotInjectNichePixelWhenFlowIsNotEligibleForExperimentPublication() {
+        MarketNiche niche = MarketNiche.builder()
+                .facebookPixelId("1234567890")
+                .build();
+        String originalHtml = "<html><head><title>Landing</title></head><body><form></form></body></html>";
+        LeadPortalFlow flow = LeadPortalFlow.builder()
+                .slug("flow-manual")
+                .name("Flow")
+                .approved(false)
+                .marketNiche(niche)
+                .customFormHtml(originalHtml)
+                .questions(List.of())
+                .build();
+
+        LeadPortalFlowPublicationRequest payload = LeadPortalFlowPublicationRequest.from(flow);
+
+        assertThat(payload.customFormHtml()).isEqualTo(originalHtml);
+        assertThat(payload.customFormHtml()).doesNotContain("fbevents.js");
     }
 
     private LeadPortalSimpleFormStyleDefinition sampleDefinition(String heroImageUrl) {


### PR DESCRIPTION
### Motivation
- Automatically include a Market Niche Meta (Facebook) Pixel snippet into published lead portal HTML for flows that are approved and linked to an experiment to enable tracking without manual edits.
- Avoid double-injecting or conflicting snippets by detecting existing pixel markers in the HTML.

### Description
- Added a `PIXEL_MARKER_PATTERN` and a new `injectFacebookPixelWhenEligible` flow that injects a generated pixel snippet into `customFormHtml` when `isEligibleForNichePixelInjection` returns true and no pixel markers already exist.
- Implemented helpers `buildPixelSnippet`, `escapeEcmaScript`, `containsIgnoreCase`, and `replaceFirstIgnoreCase` to safely construct and place the snippet before `</head>`, before the first `<body`, or at the top of the document.
- Updated `from(LeadPortalFlow, String)` to use the injected HTML (`htmlWithPixel`) for both `customFormHtml` and `legacyPreviewHtml` where applicable.
- Added tests and a `MarketNiche` import to `LeadPortalFlowPublicationRequestTest` covering successful injection for an approved experiment flow and non-injection when a flow is not eligible.

### Testing
- Ran the unit tests in `LeadPortalFlowPublicationRequestTest`, including the new tests `fromInjectsNichePixelIntoLandingHtmlWhenFlowIsApprovedAndLinkedToExperiment` and `fromDoesNotInjectNichePixelWhenFlowIsNotEligibleForExperimentPublication`, and they passed.
- Existing tests for image selection (`fromPrioritizesPipelineImageFromImagePlanning`) were executed and remained passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d8098f1c8321a400ef889f1e0f5d)