### PR TITLE
Ajusta prontidão: exigir `JOB_TITLE` aprovado e permitir payloads só com job titles

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentRepository.java
@@ -46,21 +46,7 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
               and exists (
                     select 1 from TargetingElement te
                     where te.niche = e.niche
-                      and te.type = com.marketinghub.targeting.TargetingElementType.INTEREST
-                      and te.status = com.marketinghub.targeting.TargetingElementStatus.APPROVED
-                      and (te.hypothesis is null or te.hypothesis = e.hypothesisRef)
-              )
-              and exists (
-                    select 1 from TargetingElement te
-                    where te.niche = e.niche
                       and te.type = com.marketinghub.targeting.TargetingElementType.JOB_TITLE
-                      and te.status = com.marketinghub.targeting.TargetingElementStatus.APPROVED
-                      and (te.hypothesis is null or te.hypothesis = e.hypothesisRef)
-              )
-              and exists (
-                    select 1 from TargetingElement te
-                    where te.niche = e.niche
-                      and te.type = com.marketinghub.targeting.TargetingElementType.BEHAVIOR
                       and te.status = com.marketinghub.targeting.TargetingElementStatus.APPROVED
                       and (te.hypothesis is null or te.hypothesis = e.hypothesisRef)
               )
@@ -126,21 +112,7 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
               and exists (
                     select 1 from TargetingElement te
                     where te.niche = e.niche
-                      and te.type = com.marketinghub.targeting.TargetingElementType.INTEREST
-                      and te.status = com.marketinghub.targeting.TargetingElementStatus.APPROVED
-                      and (te.hypothesis is null or te.hypothesis = e.hypothesisRef)
-              )
-              and exists (
-                    select 1 from TargetingElement te
-                    where te.niche = e.niche
                       and te.type = com.marketinghub.targeting.TargetingElementType.JOB_TITLE
-                      and te.status = com.marketinghub.targeting.TargetingElementStatus.APPROVED
-                      and (te.hypothesis is null or te.hypothesis = e.hypothesisRef)
-              )
-              and exists (
-                    select 1 from TargetingElement te
-                    where te.niche = e.niche
-                      and te.type = com.marketinghub.targeting.TargetingElementType.BEHAVIOR
                       and te.status = com.marketinghub.targeting.TargetingElementStatus.APPROVED
                       and (te.hypothesis is null or te.hypothesis = e.hypothesisRef)
               )

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentTargetingSelectionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/repository/ExperimentTargetingSelectionRepository.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment.repository;
 
 import com.marketinghub.experiment.ExperimentTargetingSelection;
+import com.marketinghub.targeting.TargetingCandidateType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,6 +10,7 @@ public interface ExperimentTargetingSelectionRepository extends JpaRepository<Ex
     List<ExperimentTargetingSelection> findByExperimentIdOrderByCandidateTypeAscTermAsc(Long experimentId);
 
     long countByExperimentId(Long experimentId);
+    long countByExperimentIdAndCandidateType(Long experimentId, TargetingCandidateType candidateType);
 
     void deleteByExperimentId(Long experimentId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -14,6 +14,7 @@ import com.marketinghub.facebookads.playbook.repository.ExperimentAdSetWorkflowR
 import com.marketinghub.journey.model.JourneyStep;
 import com.marketinghub.journey.model.JourneyStimulusType;
 import com.marketinghub.targeting.TargetingElementType;
+import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.experiment.repository.ExperimentTargetingSelectionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -83,7 +84,7 @@ public class ExperimentReadinessService {
                     ExperimentReadinessIssueType.TARGETING,
                     "Público não selecionado",
                     "Ainda não há nenhuma segmentação salva para este experimento.",
-                    "Acesse a aba Segmentação, marque ao menos um interesse, cargo ou comportamento com ID oficial da Meta e salve o público.",
+                    "Acesse a aba Segmentação, marque ao menos um cargo com ID oficial da Meta e salve o público.",
                     List.copyOf(missingTypes)
             ));
         }
@@ -155,9 +156,7 @@ public class ExperimentReadinessService {
             return List.of();
         }
         return List.of(
-                TargetingElementType.INTEREST,
-                TargetingElementType.JOB_TITLE,
-                TargetingElementType.BEHAVIOR
+                TargetingElementType.JOB_TITLE
         );
     }
 
@@ -173,7 +172,8 @@ public class ExperimentReadinessService {
         if (experimentId == null) {
             return false;
         }
-        return targetingSelectionRepository.countByExperimentId(experimentId) > 0;
+        return targetingSelectionRepository.countByExperimentIdAndCandidateType(
+                experimentId, TargetingCandidateType.WORK_POSITION) > 0;
     }
 
     private boolean hasReadyAdSetSpecs(Long experimentId) {

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentService.java
@@ -85,7 +85,7 @@ public class FacebookAdSetExperimentService {
         Map<TargetingElementType, List<TargetingElementDto>> mapped = new EnumMap<>(TargetingElementType.class);
         for (TargetingElementType type : TargetingElementType.values()) {
             List<TargetingElementDto> dtos = mapElements(nicheId, hypothesisId, type);
-            if (dtos.isEmpty()) {
+            if (type == TargetingElementType.JOB_TITLE && dtos.isEmpty()) {
                 return null;
             }
             mapped.put(type, dtos);

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.experiment;
 
+import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
@@ -7,6 +8,9 @@ import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import com.marketinghub.journey.model.JourneyTemplate;
 import com.marketinghub.journey.repository.JourneyTemplateRepository;
+import com.marketinghub.targeting.TargetingElement;
+import com.marketinghub.targeting.TargetingElementStatus;
+import com.marketinghub.targeting.TargetingElementType;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -117,5 +121,95 @@ class ExperimentRepositoryTest {
         assertThat(result)
                 .extracting(MarketNiche::getId)
                 .containsExactly(niche.getId());
+    }
+
+    @Test
+    void readyQueriesAcceptExperimentWithOnlyApprovedJobTitle() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche JT").build());
+        Hypothesis hypothesis = hypothesisRepository.save(Hypothesis.builder()
+                .marketNiche(niche)
+                .title("Hyp JT")
+                .build());
+        JourneyTemplate template = journeyTemplateRepository.save(JourneyTemplate.builder().name("Lifecycle").build());
+        InstagramAccount instagram = entityManager.merge(InstagramAccount.builder()
+                .name("IG")
+                .handle("job-title-only")
+                .code("ig-1")
+                .build());
+
+        Experiment experiment11 = repository.save(Experiment.builder()
+                .name("Experiment 11")
+                .niche(niche)
+                .hypothesisRef(hypothesis)
+                .journeyTemplate(template)
+                .platform(ExperimentPlatform.FACEBOOK)
+                .status(ExperimentStatus.PLANNED)
+                .creativeApproved(true)
+                .instagramAccount(instagram)
+                .build());
+
+        entityManager.persist(TargetingElement.builder()
+                .niche(niche)
+                .hypothesis(hypothesis)
+                .type(TargetingElementType.JOB_TITLE)
+                .term("CMO")
+                .status(TargetingElementStatus.APPROVED)
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Experiment> campaignReady = repository.findReadyForCampaign(
+                ExperimentStatus.PLANNED, ExperimentPlatform.FACEBOOK);
+        List<Experiment> adSetReady = repository.findAllReadyForAdSets(
+                ExperimentPlatform.FACEBOOK, List.of(ExperimentStatus.PLANNED));
+
+        assertThat(campaignReady).extracting(Experiment::getId).contains(experiment11.getId());
+        assertThat(adSetReady).extracting(Experiment::getId).contains(experiment11.getId());
+    }
+
+    @Test
+    void readyQueriesRejectExperimentWithoutApprovedJobTitle() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche no JT").build());
+        Hypothesis hypothesis = hypothesisRepository.save(Hypothesis.builder()
+                .marketNiche(niche)
+                .title("Hypothesis")
+                .build());
+        JourneyTemplate template = journeyTemplateRepository.save(JourneyTemplate.builder().name("Lifecycle").build());
+        InstagramAccount instagram = entityManager.merge(InstagramAccount.builder()
+                .name("IG")
+                .handle("missing-job-title")
+                .code("ig-2")
+                .build());
+
+        Experiment experiment = repository.save(Experiment.builder()
+                .name("Missing JT")
+                .niche(niche)
+                .hypothesisRef(hypothesis)
+                .journeyTemplate(template)
+                .platform(ExperimentPlatform.FACEBOOK)
+                .status(ExperimentStatus.PLANNED)
+                .creativeApproved(true)
+                .instagramAccount(instagram)
+                .build());
+
+        entityManager.persist(TargetingElement.builder()
+                .niche(niche)
+                .hypothesis(hypothesis)
+                .type(TargetingElementType.INTEREST)
+                .term("Remarketing")
+                .status(TargetingElementStatus.APPROVED)
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Experiment> campaignReady = repository.findReadyForCampaign(
+                ExperimentStatus.PLANNED, ExperimentPlatform.FACEBOOK);
+        List<Experiment> adSetReady = repository.findAllReadyForAdSets(
+                ExperimentPlatform.FACEBOOK, List.of(ExperimentStatus.PLANNED));
+
+        assertThat(campaignReady).extracting(Experiment::getId).doesNotContain(experiment.getId());
+        assertThat(adSetReady).extracting(Experiment::getId).doesNotContain(experiment.getId());
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -14,6 +14,7 @@ import com.marketinghub.facebookads.playbook.repository.ExperimentAdSetWorkflowR
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.experiment.repository.ExperimentTargetingSelectionRepository;
 import org.junit.jupiter.api.Test;
@@ -54,14 +55,15 @@ class ExperimentReadinessServiceTest {
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentId(experimentId)).thenReturn(0L);
         when(adSetWorkflowRepository.findByExperimentId(experimentId)).thenReturn(Optional.empty());
-        when(targetingSelectionRepository.countByExperimentId(experimentId)).thenReturn(0L);
+        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
+                .thenReturn(0L);
 
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
         assertThat(summary.hasCreatives()).isFalse();
         assertThat(summary.hasLeadPortalFlow()).isFalse();
         assertThat(summary.hasCompleteTargeting()).isFalse();
-        assertThat(summary.missingTargetingTypes()).containsExactlyInAnyOrder(TargetingElementType.values());
+        assertThat(summary.missingTargetingTypes()).containsExactly(TargetingElementType.JOB_TITLE);
         assertThat(summary.issues()).hasSize(3);
         assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
                 .containsExactlyInAnyOrder(
@@ -79,7 +81,8 @@ class ExperimentReadinessServiceTest {
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentId(experimentId)).thenReturn(2L);
-        when(targetingSelectionRepository.countByExperimentId(experimentId)).thenReturn(2L);
+        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
+                .thenReturn(1L);
 
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
@@ -88,6 +91,26 @@ class ExperimentReadinessServiceTest {
         assertThat(summary.hasCompleteTargeting()).isTrue();
         assertThat(summary.missingTargetingTypes()).isEmpty();
         assertThat(summary.issues()).isEmpty();
+    }
+
+    @Test
+    void shouldReportTargetingIssueWhenThereIsNoApprovedJobTitleSelection() {
+        Long experimentId = 11L;
+        Experiment experiment = buildExperiment(experimentId, 19L);
+        experiment.setLeadPortalFlow(new LeadPortalFlow());
+
+        when(experimentService.get(experimentId)).thenReturn(experiment);
+        when(creativeRepository.countByExperimentId(experimentId)).thenReturn(1L);
+        when(adSetWorkflowRepository.findByExperimentId(experimentId)).thenReturn(Optional.empty());
+        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
+                .thenReturn(0L);
+
+        ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
+
+        assertThat(summary.hasCompleteTargeting()).isFalse();
+        assertThat(summary.missingTargetingTypes()).containsExactly(TargetingElementType.JOB_TITLE);
+        assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
+                .contains(ExperimentReadinessIssueType.TARGETING);
     }
 
     @Test

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentServiceTest.java
@@ -169,4 +169,81 @@ class FacebookAdSetExperimentServiceTest {
         assertThat(dto.getTargeting().getBehaviors()).extracting(TargetingElementDto::getTerm)
                 .containsExactly("Engaged Shoppers");
     }
+
+    @Test
+    void listExperimentsReadyAcceptsOnlyApprovedJobTitle() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(5L);
+
+        UUID hypothesisId = UUID.randomUUID();
+        Hypothesis hypothesis = new Hypothesis();
+        hypothesis.setId(hypothesisId);
+        hypothesis.setMarketNiche(niche);
+
+        Experiment experiment = new Experiment();
+        experiment.setId(11L);
+        experiment.setName("Job title only");
+        experiment.setNiche(niche);
+        experiment.setHypothesisRef(hypothesis);
+        experiment.setStatus(ExperimentStatus.PLANNED);
+        experiment.setPlatform(ExperimentPlatform.FACEBOOK);
+        experiment.setCreativeApproved(true);
+
+        when(experimentRepository.findAllReadyForAdSets(eq(ExperimentPlatform.FACEBOOK), any()))
+                .thenReturn(List.of(experiment));
+        when(targetingElementRepository.findApprovedForExperiment(5L, TargetingElementType.INTEREST, hypothesisId))
+                .thenReturn(List.of());
+
+        TargetingElement jobTitle = TargetingElement.builder()
+                .id(2L)
+                .niche(niche)
+                .hypothesis(hypothesis)
+                .type(TargetingElementType.JOB_TITLE)
+                .term("CMO")
+                .build();
+        when(targetingElementRepository.findApprovedForExperiment(5L, TargetingElementType.JOB_TITLE, hypothesisId))
+                .thenReturn(List.of(jobTitle));
+        when(targetingElementRepository.findApprovedForExperiment(5L, TargetingElementType.BEHAVIOR, hypothesisId))
+                .thenReturn(List.of());
+
+        List<ExperimentReadyForAdSetDto> result = service.listExperimentsReadyForAdSets();
+
+        assertThat(result).hasSize(1);
+        ExperimentReadyForAdSetDto dto = result.getFirst();
+        assertThat(dto.getExperiment().getId()).isEqualTo(11L);
+        assertThat(dto.getTargeting().getInterests()).isEmpty();
+        assertThat(dto.getTargeting().getJobTitles()).extracting(TargetingElementDto::getTerm)
+                .containsExactly("CMO");
+        assertThat(dto.getTargeting().getBehaviors()).isEmpty();
+    }
+
+    @Test
+    void listExperimentsReadySkipsWhenApprovedJobTitleIsMissing() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(5L);
+
+        UUID hypothesisId = UUID.randomUUID();
+        Hypothesis hypothesis = new Hypothesis();
+        hypothesis.setId(hypothesisId);
+        hypothesis.setMarketNiche(niche);
+
+        Experiment experiment = new Experiment();
+        experiment.setId(12L);
+        experiment.setNiche(niche);
+        experiment.setHypothesisRef(hypothesis);
+        experiment.setStatus(ExperimentStatus.PLANNED);
+        experiment.setPlatform(ExperimentPlatform.FACEBOOK);
+        experiment.setCreativeApproved(true);
+
+        when(experimentRepository.findAllReadyForAdSets(eq(ExperimentPlatform.FACEBOOK), any()))
+                .thenReturn(List.of(experiment));
+        when(targetingElementRepository.findApprovedForExperiment(5L, TargetingElementType.INTEREST, hypothesisId))
+                .thenReturn(List.of());
+        when(targetingElementRepository.findApprovedForExperiment(5L, TargetingElementType.JOB_TITLE, hypothesisId))
+                .thenReturn(List.of());
+
+        List<ExperimentReadyForAdSetDto> result = service.listExperimentsReadyForAdSets();
+
+        assertThat(result).isEmpty();
+    }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdSetControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdSetControllerTest.java
@@ -93,5 +93,43 @@ class FacebookAdSetControllerTest {
                 .andExpect(jsonPath("$[0].hypothesis.id").value(hypothesisId.toString()))
                 .andExpect(jsonPath("$[0].targeting.interests[0].term").value("Remarketing"));
     }
-}
 
+    @Test
+    void experimentsReadySupportsPayloadWithOnlyJobTitleTargeting() throws Exception {
+        ExperimentDto experiment = new ExperimentDto();
+        experiment.setId(11L);
+        experiment.setName("Job title only");
+
+        MarketNicheDto niche = new MarketNicheDto();
+        niche.setId(7L);
+        niche.setName("Health");
+
+        HypothesisDto hypothesis = new HypothesisDto();
+        UUID hypothesisId = UUID.randomUUID();
+        hypothesis.setId(hypothesisId);
+        hypothesis.setTitle("Title");
+
+        TargetingElementDto jobTitle = TargetingElementDto.builder()
+                .id(2L)
+                .type(TargetingElementType.JOB_TITLE)
+                .term("CMO")
+                .marketNicheId(7L)
+                .hypothesisId(hypothesisId)
+                .build();
+
+        ExperimentReadyForAdSetDto dto = new ExperimentReadyForAdSetDto(
+                experiment,
+                niche,
+                hypothesis,
+                new TargetingPackageDto(List.of(), List.of(jobTitle), List.of()));
+
+        when(experimentService.listExperimentsReadyForAdSets()).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/facebook-adsets/experiments-ready"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].experiment.id").value(11))
+                .andExpect(jsonPath("$[0].targeting.interests").isEmpty())
+                .andExpect(jsonPath("$[0].targeting.jobTitles[0].term").value("CMO"))
+                .andExpect(jsonPath("$[0].targeting.behaviors").isEmpty());
+    }
+}


### PR DESCRIPTION
### Motivation
- Corrigir a regra de prontidão que exigia simultaneamente `INTEREST`, `JOB_TITLE` e `BEHAVIOR`, adotando a regra canônica de público manual (mínimo operacional = ao menos 1 `JOB_TITLE` aprovado). 
- Evitar que experimentos válidos no fluxo manual sejam bloqueados por ausência de interesses/comportamentos quando já há `JOB_TITLE` aprovado. 
- Preservar o caminho alternativo de playbook de ad sets (specs prontos) como mecanismo compatível de prontidão.

### Description
- Atualiza as consultas JPQL em `ExperimentRepository` (`findReadyForCampaign` e `findAllReadyForAdSets`) para somente exigir existência de `TargetingElement` do tipo `JOB_TITLE` com status `APPROVED` para nicho/hipótese. 
- Adiciona `countByExperimentIdAndCandidateType` em `ExperimentTargetingSelectionRepository` e ajusta `ExperimentReadinessService` para verificar seleções manuais usando `TargetingCandidateType.WORK_POSITION`, além de adaptar a mensagem e os tipos faltantes para focar em `JOB_TITLE`. 
- Ajusta `FacebookAdSetExperimentService.buildTargetingPackage` para tratar `INTEREST`/`BEHAVIOR` como opcionais e manter `JOB_TITLE` como obrigatório, permitindo payloads com apenas `jobTitles`. 
- Atualiza e adiciona testes em `ExperimentRepositoryTest`, `ExperimentReadinessServiceTest`, `FacebookAdSetExperimentServiceTest` e `FacebookAdSetControllerTest` cobrindo cenários válidos só com `JOB_TITLE`, cenários inválidos sem `JOB_TITLE` e a aceitação do endpoint `experiments-ready` com payloads contendo somente `jobTitles`, incluindo verificação explícita do experimento 11.

### Testing
- Executado `mvn -Dtest=ExperimentRepositoryTest,ExperimentReadinessServiceTest,FacebookAdSetExperimentServiceTest,FacebookAdSetControllerTest test` no módulo `backend/ads-service` e todas as suites mencionadas passaram com sucesso. 
- Os testes de integração de repositório confirmam que o experimento 11 agora aparece em `findReadyForCampaign` / `findAllReadyForAdSets` quando há apenas `JOB_TITLE` aprovado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7dd5f427c8321a0eaf471ee17454d)