### PR TITLE
Corrige mock de seleção de segmentação no teste FacebookAdsCampaignControllerTest

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -25,6 +25,7 @@ import com.marketinghub.leadportal.dto.LeadPortalExperimentMetricsDto;
 import com.marketinghub.leadportal.dto.LeadPortalExperimentUserDto;
 import com.marketinghub.leadportal.service.LeadPortalMetricsService;
 import com.marketinghub.experiment.repository.AdSetRepository;
+import com.marketinghub.targeting.TargetingCandidateType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -131,7 +132,7 @@ class FacebookAdsCampaignControllerTest {
                 .facebookPage(page)
                 .instagramAccount(instagramAccount)
                 .build();
-        when(targetingSelectionRepository.countByExperimentId(1L)).thenReturn(1L);
+        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(1L, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
         when(experimentService.listByStatusAndPlatform(
                 com.marketinghub.experiment.ExperimentStatus.PLANNED,
                 com.marketinghub.experiment.ExperimentPlatform.FACEBOOK))


### PR DESCRIPTION
### Motivation
- Ajustar o teste para refletir que a validação de readiness usa `countByExperimentIdAndCandidateType`, evitando que `missingConfiguration` contenha `targetingSelections` indevidamente.

### Description
- Atualiza `FacebookAdsCampaignControllerTest#listExperimentsByStatus` para importar `TargetingCandidateType` e mockar `countByExperimentIdAndCandidateType(1L, TargetingCandidateType.WORK_POSITION)` em vez de `countByExperimentId(1L)`.

### Testing
- Executado `mvn -Dtest=FacebookAdsCampaignControllerTest#listExperimentsByStatus test` e o teste passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e0cb827083219a2556b626227950)