### PR TITLE
Support HTTP log streams and set backend log path to remote URL

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -40,7 +40,7 @@ mvn -s settings.xml spring-boot:run
 
 O tool `java_module_logs` lê os arquivos de log do Spring Boot configurados em:
 
-- `MCP_LOG_BACKEND_PATH` (default `/app/logs/marketinghub-backend.log`);
+- `MCP_LOG_BACKEND_PATH` (default `http://191.252.181.168:8000/ops-mh-observability-v2/backend-log-stream-x9k`);
 - `MCP_LOG_AI_WORKER_PATH` (default `/var/log/ai-worker/application.log`);
 - `MCP_LOG_LEAD_PORTAL_PATH` (default `/app/data/logs/lead-portal-backend.log`);
 - `MCP_LOG_FACEBOOK_ADS_PATH` (default `/var/log/facebook-ads-worker/application.log`).

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -5,9 +5,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,11 +22,16 @@ import java.util.stream.Stream;
 public class ModuleLogService {
 
     private static final int DEFAULT_LINES = 200;
+    private static final Duration LOG_FETCH_TIMEOUT = Duration.ofSeconds(10);
 
     private final McpProperties properties;
+    private final HttpClient httpClient;
 
     public ModuleLogService(McpProperties properties) {
         this.properties = properties;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(LOG_FETCH_TIMEOUT)
+                .build();
     }
 
     public int maxLines() {
@@ -37,10 +47,14 @@ public class ModuleLogService {
             throw new IllegalArgumentException("No log path configured for module: " + normalizedModule);
         }
 
-        Path path = Path.of(configuredPath);
-
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("module", normalizedModule);
+
+        if (isHttpUrl(configuredPath)) {
+            return readLogsFromUrl(configuredPath, lines, response);
+        }
+
+        Path path = Path.of(configuredPath);
         response.put("path", path.toString());
 
         if (!Files.exists(path)) {
@@ -65,6 +79,45 @@ public class ModuleLogService {
         } catch (IOException ex) {
             throw new IllegalArgumentException("Failed to read log file: " + ex.getMessage());
         }
+    }
+
+    private Map<String, Object> readLogsFromUrl(String configuredUrl, int lines, Map<String, Object> response) {
+        response.put("path", configuredUrl);
+        response.put("source", "http");
+
+        HttpRequest request = HttpRequest.newBuilder(URI.create(configuredUrl))
+                .timeout(LOG_FETCH_TIMEOUT)
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<String> httpResponse = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            response.put("httpStatus", httpResponse.statusCode());
+
+            if (httpResponse.statusCode() < 200 || httpResponse.statusCode() >= 300) {
+                throw new IllegalArgumentException("Failed to read log stream URL: HTTP " + httpResponse.statusCode());
+            }
+
+            List<String> allLines = httpResponse.body().lines().toList();
+            int startIndex = Math.max(0, allLines.size() - lines);
+            List<String> tailLines = allLines.subList(startIndex, allLines.size());
+
+            response.put("exists", true);
+            response.put("requestedLines", lines);
+            response.put("returnedLines", tailLines.size());
+            response.put("lines", tailLines);
+            return response;
+        } catch (IOException | InterruptedException ex) {
+            if (ex instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new IllegalArgumentException("Failed to read log stream URL: " + ex.getMessage());
+        }
+    }
+
+    private boolean isHttpUrl(String value) {
+        String normalized = value.trim().toLowerCase();
+        return normalized.startsWith("http://") || normalized.startsWith("https://");
     }
 
     private long countLines(Path path) throws IOException {

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -27,7 +27,7 @@ mcp:
   server-version: ${MCP_SERVER_VERSION:1.0.0}
   api-key: ${MCP_API_KEY:}
   logs:
-    backend-path: ${MCP_LOG_BACKEND_PATH:/app/logs/marketinghub-backend.log}
+    backend-path: ${MCP_LOG_BACKEND_PATH:http://191.252.181.168:8000/ops-mh-observability-v2/backend-log-stream-x9k}
     ai-worker-path: ${MCP_LOG_AI_WORKER_PATH:/var/log/ai-worker/application.log}
     lead-portal-path: ${MCP_LOG_LEAD_PORTAL_PATH:/app/data/logs/lead-portal-backend.log}
     facebook-ads-path: ${MCP_LOG_FACEBOOK_ADS_PATH:/var/log/facebook-ads-worker/application.log}


### PR DESCRIPTION
### Motivation

- Allow the MCP server to read Spring Boot logs from an HTTP log stream in addition to local files so observability can use a remote log endpoint. 
- Update the default backend log configuration to point at the remote log stream used by the observability service.

### Description

- Implemented HTTP log fetching in `ModuleLogService` using `HttpClient` with a 10s timeout and added `readLogsFromUrl` to retrieve and tail the last N lines from an HTTP response. 
- Added `isHttpUrl` detection and updated `readModuleLogs` to branch between local file reading and HTTP fetching, returning metadata such as `httpStatus`, `source`, `requestedLines`, and `returnedLines`. 
- Preserved existing local-file behavior and error handling for file reads and added interruption handling for HTTP requests. 
- Changed the default `mcp.logs.backend-path` in `application.yml` and updated `mcp-server/README.md` to reflect the new default remote backend log URL.

### Testing

- Executed the project test suite with `mvn -DskipTests=false test` and the existing automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e3da1d3c8321a1bf8df80af754e5)