### PR TITLE
Switch default Lead Portal log path to remote HTTP endpoint

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -42,7 +42,7 @@ O tool `java_module_logs` lê os arquivos de log do Spring Boot configurados em:
 
 - `MCP_LOG_BACKEND_PATH` (default `http://191.252.181.168:8000/ops-mh-observability-v2/backend-log-stream-x9k`);
 - `MCP_LOG_AI_WORKER_PATH` (default `/var/log/ai-worker/application.log`);
-- `MCP_LOG_LEAD_PORTAL_PATH` (default `/app/data/logs/lead-portal-backend.log`);
+- `MCP_LOG_LEAD_PORTAL_PATH` (default `https://oportunidadebrasil.shop/api/ops-lp-observability-v2/logfile`);
 - `MCP_LOG_FACEBOOK_ADS_PATH` (default `/var/log/facebook-ads-worker/application.log`).
 
 Limite máximo por chamada: `MCP_LOG_MAX_LINES` (default `500`).

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -29,6 +29,6 @@ mcp:
   logs:
     backend-path: ${MCP_LOG_BACKEND_PATH:http://191.252.181.168:8000/ops-mh-observability-v2/backend-log-stream-x9k}
     ai-worker-path: ${MCP_LOG_AI_WORKER_PATH:/var/log/ai-worker/application.log}
-    lead-portal-path: ${MCP_LOG_LEAD_PORTAL_PATH:/app/data/logs/lead-portal-backend.log}
+    lead-portal-path: ${MCP_LOG_LEAD_PORTAL_PATH:https://oportunidadebrasil.shop/api/ops-lp-observability-v2/logfile}
     facebook-ads-path: ${MCP_LOG_FACEBOOK_ADS_PATH:/var/log/facebook-ads-worker/application.log}
     max-lines: ${MCP_LOG_MAX_LINES:500}


### PR DESCRIPTION
### Motivation
- Replace the local Lead Portal log file default with a remote HTTP endpoint to enable centralized/log-stream access and align configuration with current observability setup.

### Description
- Update `mcp-server/src/main/resources/application.yml` to set `mcp.logs.lead-portal-path` default to `https://oportunidadebrasil.shop/api/ops-lp-observability-v2/logfile` and mirror the same default in `mcp-server/README.md` (previously `/app/data/logs/lead-portal-backend.log`).

### Testing
- No automated tests were added or modified and no automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7faf7252c83219961a3fa6a3929c6)