### PR TITLE
Handle specific HTTP client errors for lead portal publication and legacy asset fetching; add tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublisher.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublisher.java
@@ -2,11 +2,15 @@ package com.marketinghub.leadportal.integration;
 
 import com.marketinghub.leadportal.LeadPortalFlow;
 import java.net.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -16,6 +20,10 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 @Component
 public class LeadPortalFlowPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(LeadPortalFlowPublisher.class);
+    private static final String SIMPLE_FLOW_MANAGED_MESSAGE =
+            "Fluxos simples são gerenciados automaticamente e não podem ser editados.";
 
     private final RestTemplate restTemplate;
     private final LeadPortalIntegrationProperties properties;
@@ -40,6 +48,15 @@ public class LeadPortalFlowPublisher {
         headers.setContentType(MediaType.APPLICATION_JSON);
         try {
             restTemplate.put(uri, new HttpEntity<>(payload, headers));
+        } catch (HttpClientErrorException ex) {
+            if (ex.getStatusCode() == HttpStatus.BAD_REQUEST && isManagedSimpleFlowRejection(ex)) {
+                log.info(
+                        "Skipping publication for managed simple flow '{}': {}",
+                        flow.getSlug(),
+                        SIMPLE_FLOW_MANAGED_MESSAGE);
+                return;
+            }
+            throw new LeadPortalPublicationException("Failed to publish lead portal flow " + flow.getSlug(), ex);
         } catch (RestClientException ex) {
             throw new LeadPortalPublicationException("Failed to publish lead portal flow " + flow.getSlug(), ex);
         }
@@ -65,5 +82,10 @@ public class LeadPortalFlowPublisher {
                 .path("/api/flows/{slug}")
                 .buildAndExpand(slug)
                 .toUri();
+    }
+
+    private boolean isManagedSimpleFlowRejection(HttpClientErrorException ex) {
+        String body = ex.getResponseBodyAsString();
+        return body != null && body.contains(SIMPLE_FLOW_MANAGED_MESSAGE);
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublisherTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/integration/LeadPortalFlowPublisherTest.java
@@ -1,0 +1,78 @@
+package com.marketinghub.leadportal.integration;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.leadportal.LeadPortalFlow;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+class LeadPortalFlowPublisherTest {
+
+    private RestTemplate restTemplate;
+    private ExperimentHeroImageResolver heroImageResolver;
+    private LeadPortalFlowPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        heroImageResolver = mock(ExperimentHeroImageResolver.class);
+        when(heroImageResolver.resolve(any())).thenReturn(Optional.empty());
+
+        LeadPortalIntegrationProperties properties = new LeadPortalIntegrationProperties();
+        properties.setEnabled(true);
+        properties.setBaseUrl("https://lead-portal.example.com");
+
+        publisher = new LeadPortalFlowPublisher(restTemplate, properties, heroImageResolver);
+    }
+
+    @Test
+    void shouldIgnoreManagedSimpleFlowBadRequest() {
+        LeadPortalFlow flow = new LeadPortalFlow();
+        flow.setSlug("formulario-simples-personal-trainer");
+
+        HttpClientErrorException badRequest =
+                HttpClientErrorException.create(
+                        HttpStatus.BAD_REQUEST,
+                        "Bad Request",
+                        HttpHeaders.EMPTY,
+                        """
+                        {"error":"Fluxos simples são gerenciados automaticamente e não podem ser editados."}
+                        """.getBytes(StandardCharsets.UTF_8),
+                        StandardCharsets.UTF_8);
+        org.mockito.Mockito.doThrow(badRequest).when(restTemplate).put(any(), any());
+
+        assertThatCode(() -> publisher.publish(flow)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldPropagateOtherBadRequestAsPublicationException() {
+        LeadPortalFlow flow = new LeadPortalFlow();
+        flow.setSlug("flow-abc");
+
+        HttpClientErrorException badRequest =
+                HttpClientErrorException.create(
+                        HttpStatus.BAD_REQUEST,
+                        "Bad Request",
+                        HttpHeaders.EMPTY,
+                        """
+                        {"error":"validation failed"}
+                        """.getBytes(StandardCharsets.UTF_8),
+                        StandardCharsets.UTF_8);
+        org.mockito.Mockito.doThrow(badRequest).when(restTemplate).put(any(), any());
+
+        assertThatThrownBy(() -> publisher.publish(flow))
+                .isInstanceOf(LeadPortalPublicationException.class)
+                .hasMessageContaining("flow-abc");
+    }
+}

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/LegacyAssetClient.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/LegacyAssetClient.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -47,6 +48,13 @@ public class LegacyAssetClient {
                     : null;
             String filename = extractFileName(url, response);
             return Optional.of(new DownloadedAsset(response.getBody(), contentType, filename));
+        } catch (HttpClientErrorException ex) {
+            if (ex.getStatusCode().value() == 404) {
+                log.info("Legacy asset not found (404), skipping migration for '{}'", url);
+                return Optional.empty();
+            }
+            log.warn("Legacy asset '{}' returned client error {}", url, ex.getStatusCode());
+            return Optional.empty();
         } catch (RestClientException ex) {
             log.warn("Failed to download legacy asset '{}'", url, ex);
             return Optional.empty();

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/LegacyAssetClientTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/LegacyAssetClientTest.java
@@ -1,0 +1,48 @@
+package com.marketinghub.leadportal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+class LegacyAssetClientTest {
+
+    private RestTemplate restTemplate;
+    private LegacyAssetClient client;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        client = new LegacyAssetClient(restTemplate);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenLegacyAssetIsNotFound() {
+        when(restTemplate.exchange(eq("http://legacy.example.com/uploads/missing.png"), eq(HttpMethod.GET), eq(null), eq(byte[].class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+        Optional<LegacyAssetClient.DownloadedAsset> result =
+                client.fetch("http://legacy.example.com/uploads/missing.png");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyOnOtherClientErrors() {
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), eq(null), eq(byte[].class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        Optional<LegacyAssetClient.DownloadedAsset> result = client.fetch("http://legacy.example.com/uploads/invalid.png");
+
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
### Motivation

- Avoid failing publication for lead portal flows that are managed and cannot be edited by recognizing a specific 400 response and skipping publication.
- Treat missing legacy assets (404) as a non-fatal condition during migration and avoid noisy errors for client-side HTTP failures.

### Description

- Added `HttpClientErrorException` handling to `LeadPortalFlowPublisher` to detect a managed simple-flow rejection message, log it, and skip publication instead of failing. 
- Added a logger, constant message string, and helper `isManagedSimpleFlowRejection` to `LeadPortalFlowPublisher`.
- Added `HttpClientErrorException` handling to `LegacyAssetClient` to return `Optional.empty()` for 404 responses and to log client errors for other 4xx responses.
- Added unit tests `LeadPortalFlowPublisherTest` (covers ignoring the managed simple-flow 400 and propagating other 400 responses) and `LegacyAssetClientTest` (covers 404 and other client error behavior).

### Testing

- Ran `LeadPortalFlowPublisherTest` which contains two unit tests and they passed.
- Ran `LegacyAssetClientTest` which contains two unit tests and they passed.
- Module unit tests including the new tests completed successfully with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7fe4242f883219dcb4d60e995bf06)