### PR TITLE
Tighten experiment readiness checks: require READY creatives and approved lead portal flow, simplify validations

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.experiment.service;
 
+import com.marketinghub.creative.CreativeStatus;
 import com.marketinghub.creative.repository.CreativeRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
@@ -11,8 +12,6 @@ import com.marketinghub.facebookads.playbook.ExperimentAdSetWorkflow;
 import com.marketinghub.facebookads.playbook.ExperimentAdSetWorkflowStatus;
 import com.marketinghub.facebookads.playbook.repository.ExperimentAdSetSpecRepository;
 import com.marketinghub.facebookads.playbook.repository.ExperimentAdSetWorkflowRepository;
-import com.marketinghub.journey.model.JourneyStep;
-import com.marketinghub.journey.model.JourneyStimulusType;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.experiment.repository.ExperimentTargetingSelectionRepository;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -51,9 +49,9 @@ public class ExperimentReadinessService {
     public ExperimentReadinessSummaryDto summarize(Long experimentId) {
         Experiment experiment = experimentService.get(experimentId);
         long creativeCount = creativeRepository.countByExperimentId(experimentId);
-        boolean hasCreatives = creativeCount > 0;
+        boolean hasCreatives = hasApprovedCreative(experiment);
 
-        long leadPortalFlowCount = experiment.getLeadPortalFlow() != null ? 1L : 0L;
+        long leadPortalFlowCount = hasReadyLeadPortalFlow(experiment) ? 1L : 0L;
         boolean hasLeadPortalFlow = leadPortalFlowCount > 0;
 
         List<String> missingConfiguration = computeMissingConfiguration(experiment);
@@ -106,44 +104,11 @@ public class ExperimentReadinessService {
 
     public List<String> computeMissingConfiguration(Experiment experiment) {
         List<String> missing = new ArrayList<>();
-        if (!experiment.isCreativeApproved()) {
+        if (!hasApprovedCreative(experiment)) {
             missing.add("creativeApproval");
         }
-        if (experiment.getKpiTargetCpl() == null) {
-            missing.add("kpiTargetCpl");
-        }
-        if (experiment.getStopLossCpl() == null) {
-            missing.add("stopLossCpl");
-        }
-        if (experiment.getSampleSize() == null) {
-            missing.add("sampleSize");
-        }
-        if (experiment.getStartDate() == null) {
-            missing.add("startDate");
-        }
-        if (experiment.getEndDate() == null) {
-            missing.add("endDate");
-        }
-        if (experiment.getJourneyTemplate() == null) {
-            missing.add("journeyTemplate");
-        }
-        if (!StringUtils.hasText(resolveExperimentPageId(experiment))) {
-            missing.add("pageId");
-        }
-        if (experiment.getInstagramAccount() == null) {
-            missing.add("instagramAccount");
-        }
-        if (isNextStepInstantForm(experiment)) {
-            if (experiment.getFacebookInstantForm() == null) {
-                missing.add("facebookInstantForm");
-            } else {
-                if (!experiment.getFacebookInstantForm().isApproved()) {
-                    missing.add("facebookInstantFormApproval");
-                }
-                if (!experiment.getFacebookInstantForm().isPublished()) {
-                    missing.add("facebookInstantFormPublication");
-                }
-            }
+        if (!hasReadyLeadPortalFlow(experiment)) {
+            missing.add("leadPortalFlow");
         }
         if (!hasConfiguredTargeting(experiment)) {
             missing.add("targetingSelections");
@@ -166,6 +131,20 @@ public class ExperimentReadinessService {
             return false;
         }
         return hasReadyAdSetSpecs(experiment.getId()) || hasSelectedTargeting(experiment.getId());
+    }
+
+    private boolean hasApprovedCreative(Experiment experiment) {
+        if (experiment == null || experiment.getId() == null) {
+            return false;
+        }
+        return experiment.isCreativeApproved()
+                && creativeRepository.existsByExperimentIdAndStatus(experiment.getId(), CreativeStatus.READY);
+    }
+
+    private boolean hasReadyLeadPortalFlow(Experiment experiment) {
+        return experiment != null
+                && experiment.getLeadPortalFlow() != null
+                && experiment.getLeadPortalFlow().isApproved();
     }
 
     private boolean hasSelectedTargeting(Long experimentId) {
@@ -206,34 +185,6 @@ public class ExperimentReadinessService {
         }
         String validation = spec.getValidationStatus();
         return !StringUtils.hasText(validation) || "VALID".equalsIgnoreCase(validation.trim());
-    }
-
-    private String resolveExperimentPageId(Experiment experiment) {
-        if (experiment.getFacebookPage() == null) {
-            return null;
-        }
-        return experiment.getFacebookPage().getPageId();
-    }
-
-    private boolean isNextStepInstantForm(Experiment experiment) {
-        if (experiment.getJourneyTemplate() == null) {
-            return false;
-        }
-        List<JourneyStep> steps = experiment.getJourneyTemplate().getSteps();
-        if (steps == null || steps.isEmpty()) {
-            return false;
-        }
-        List<JourneyStep> ordered = steps.stream()
-                .sorted(Comparator.comparingInt(step -> step.getPosition() != null ? step.getPosition() : Integer.MAX_VALUE))
-                .toList();
-        JourneyStep previous = null;
-        for (JourneyStep step : ordered) {
-            if (previous != null && previous.getStimulusType() == JourneyStimulusType.AD) {
-                return step.getStimulusType() == JourneyStimulusType.INSTANT_FORM;
-            }
-            previous = step;
-        }
-        return false;
     }
 
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment.service;
 
 import com.marketinghub.creative.repository.CreativeRepository;
+import com.marketinghub.creative.CreativeStatus;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
@@ -54,6 +55,7 @@ class ExperimentReadinessServiceTest {
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentId(experimentId)).thenReturn(0L);
+        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(false);
         when(adSetWorkflowRepository.findByExperimentId(experimentId)).thenReturn(Optional.empty());
         when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
                 .thenReturn(0L);
@@ -77,10 +79,13 @@ class ExperimentReadinessServiceTest {
     void shouldReturnNoIssuesWhenEverythingIsReady() {
         Long experimentId = 8L;
         Experiment experiment = buildExperiment(experimentId, 18L);
-        experiment.setLeadPortalFlow(new LeadPortalFlow());
+        LeadPortalFlow flow = new LeadPortalFlow();
+        flow.setApproved(true);
+        experiment.setLeadPortalFlow(flow);
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentId(experimentId)).thenReturn(2L);
+        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
         when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
                 .thenReturn(1L);
 
@@ -97,10 +102,13 @@ class ExperimentReadinessServiceTest {
     void shouldReportTargetingIssueWhenThereIsNoApprovedJobTitleSelection() {
         Long experimentId = 11L;
         Experiment experiment = buildExperiment(experimentId, 19L);
-        experiment.setLeadPortalFlow(new LeadPortalFlow());
+        LeadPortalFlow flow = new LeadPortalFlow();
+        flow.setApproved(true);
+        experiment.setLeadPortalFlow(flow);
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentId(experimentId)).thenReturn(1L);
+        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
         when(adSetWorkflowRepository.findByExperimentId(experimentId)).thenReturn(Optional.empty());
         when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
                 .thenReturn(0L);
@@ -117,10 +125,13 @@ class ExperimentReadinessServiceTest {
     void shouldTreatReadyAdSetSpecsAsCompleteTargeting() {
         Long experimentId = 9L;
         Experiment experiment = buildExperiment(experimentId, 20L);
-        experiment.setLeadPortalFlow(new LeadPortalFlow());
+        LeadPortalFlow flow = new LeadPortalFlow();
+        flow.setApproved(true);
+        experiment.setLeadPortalFlow(flow);
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentId(experimentId)).thenReturn(1L);
+        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
 
         ExperimentAdSetWorkflow workflow = ExperimentAdSetWorkflow.builder()
                 .id(42L)
@@ -155,6 +166,7 @@ class ExperimentReadinessServiceTest {
         experiment.setId(experimentId);
         experiment.setNiche(niche);
         experiment.setHypothesisRef(hypothesis);
+        experiment.setCreativeApproved(true);
         return experiment;
     }
 


### PR DESCRIPTION
### Motivation

- Clarify and tighten the criteria used to determine if an experiment is ready by requiring creatives that are both approved on the experiment and in `READY` status, and requiring the lead portal flow to be approved. 
- Simplify readiness computation by removing several legacy configuration checks that were no longer needed for campaign readiness.

### Description

- Replaced the previous `creativeCount > 0` check with `hasApprovedCreative(experiment)`, which verifies `experiment.isCreativeApproved()` and `creativeRepository.existsByExperimentIdAndStatus(..., CreativeStatus.READY)`.
- Replaced the simple presence check for lead portal flow with `hasReadyLeadPortalFlow(experiment)` that ensures the flow is present and `isApproved()`.
- Simplified `computeMissingConfiguration` to only check for creative approval, ready lead portal flow, and targeting selections, removing many older checks such as KPI/sample dates/journey/instant form/page id/instagram account validations.
- Removed journey/instant-form and page-id resolution helpers and added `hasApprovedCreative` and `hasReadyLeadPortalFlow` helper methods to encapsulate the new readiness rules.

### Testing

- Updated and ran the unit tests in `ExperimentReadinessServiceTest` which mock the new `CreativeStatus`-based repository call and lead portal approval flag, and all tests in that class passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7fe60ed3c83218008b472798e39f0)