### PR TITLE
Fix Facebook campaign experiment listing test readiness fixtures

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -21,6 +21,9 @@ import com.marketinghub.facebookads.FacebookAdsAdRepository;
 import com.marketinghub.facebookads.FacebookAdsAdSet;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.FacebookAdsAdSetRepository;
+import com.marketinghub.creative.CreativeStatus;
+import com.marketinghub.creative.repository.CreativeRepository;
+import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.dto.LeadPortalExperimentMetricsDto;
 import com.marketinghub.leadportal.dto.LeadPortalExperimentUserDto;
 import com.marketinghub.leadportal.service.LeadPortalMetricsService;
@@ -82,6 +85,8 @@ class FacebookAdsCampaignControllerTest {
     AdSetRepository experimentAdSetRepository;
     @MockBean
     ExperimentTargetingSelectionRepository targetingSelectionRepository;
+    @MockBean
+    CreativeRepository creativeRepository;
 
     @MockBean
     LeadPortalMetricsService leadPortalMetricsService;
@@ -116,6 +121,12 @@ class FacebookAdsCampaignControllerTest {
                 .pageId("84")
                 .name("Estúdio")
                 .build();
+        var leadPortalFlow = LeadPortalFlow.builder()
+                .id(33L)
+                .name("Fluxo principal")
+                .slug("fluxo-principal")
+                .approved(true)
+                .build();
         var exp = Experiment.builder()
                 .id(1L)
                 .niche(niche)
@@ -131,7 +142,9 @@ class FacebookAdsCampaignControllerTest {
                 .journeyTemplate(journeyTemplate)
                 .facebookPage(page)
                 .instagramAccount(instagramAccount)
+                .leadPortalFlow(leadPortalFlow)
                 .build();
+        when(creativeRepository.existsByExperimentIdAndStatus(1L, CreativeStatus.READY)).thenReturn(true);
         when(targetingSelectionRepository.countByExperimentIdAndCandidateType(1L, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
         when(experimentService.listByStatusAndPlatform(
                 com.marketinghub.experiment.ExperimentStatus.PLANNED,


### PR DESCRIPTION
### Motivation
- The `listExperimentsByStatus` test expected `missingConfiguration` to be empty but the test fixture lacked the readiness prerequisites used by `ExperimentReadinessService`, causing a test failure.

### Description
- Added imports for `CreativeStatus`, `CreativeRepository` and corrected `LeadPortalFlow` import. 
- Added a `@MockBean CreativeRepository` and a mock `when(creativeRepository.existsByExperimentIdAndStatus(1L, CreativeStatus.READY)).thenReturn(true)` to simulate an approved creative. 
- Attached an approved `LeadPortalFlow` instance to the `Experiment` fixture so the lead-portal readiness check passes. 
- Updated the test fixture so `missingConfiguration` is empty as asserted by the test.

### Testing
- Ran the targeted test with `mvn -Dtest=FacebookAdsCampaignControllerTest#listExperimentsByStatus test`, which completed successfully with `BUILD SUCCESS` and `Tests run: 1, Failures: 0, Errors: 0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80b87dd948321a70fc933a48a1232)