### PR TITLE
Audita logs do Lead Portal e remove configuração JPA legada

### DIFF
--- a/docs/operations/lead-portal-log-review-2026-04-21.md
+++ b/docs/operations/lead-portal-log-review-2026-04-21.md
@@ -1,0 +1,60 @@
+# Revisão de logs do Lead Portal — 2026-04-21
+
+## Contexto
+
+Solicitação: validar erros/warnings atuais do Lead Portal e comparar com os documentos canônicos para identificar se existem regras/funcionalidades ultrapassadas.
+
+## Evidência coletada
+
+Comandos executados:
+
+```bash
+curl -fsS https://oportunidadebrasil.shop/api/ops-lp-observability-v2/health
+curl -fsS https://oportunidadebrasil.shop/api/ops-lp-observability-v2/logfile | rg -n "ERROR|WARN|Exception|Caused by|Failed"
+```
+
+Resultado: sem `ERROR` no arquivo atual, apenas 3 `WARN` de inicialização.
+
+### Warnings encontrados
+
+1. `HHH000511`: MySQL 5.7 reportado como não suportado pelo dialect padrão do Hibernate 6.x.
+2. `HHH90000025`: configuração explícita de `hibernate.dialect` é desnecessária.
+3. `spring.jpa.open-in-view is enabled by default`.
+
+## Comparação com cânones
+
+### 1) MySQL 5.7
+
+- O contrato operacional do repositório determina MySQL 5.7 como padrão.
+- O warning do Hibernate indica incompatibilidade de suporte oficial mínimo (8.0+) no dialect atual.
+
+**Conclusão:** a funcionalidade de persistência ainda faz sentido e está funcionando, mas existe **dívida de compatibilidade tecnológica** (regra de plataforma canônica x baseline do framework atual).
+
+### 2) `hibernate.dialect` explícito
+
+- O warning aponta configuração redundante.
+- Não há regra canônica que obrigue setar esse dialeto explicitamente.
+
+**Conclusão:** manter essa propriedade não agrega valor de negócio; é legado técnico e pode ser removida com baixo risco.
+
+### 3) Open Session in View habilitado
+
+- O warning não representa quebra funcional imediata.
+- Pela governança canônica (“backend e domínio decidem; interfaces consomem”), evitar consultas implícitas na camada web tende a reduzir acoplamento e drift de comportamento.
+
+**Conclusão:** a funcionalidade atual “faz sentido” para operação, mas o default é pouco desejável para robustez. Recomendável desligar explicitamente após validação dos fluxos.
+
+## Veredito (o que está ultrapassado vs o que continua válido)
+
+- **Continua válido:** fluxo funcional do Lead Portal e observabilidade via endpoint `/api/ops-lp-observability-v2/*`.
+- **Potencialmente ultrapassado:**
+  - Dependência implícita do stack atual com MySQL 5.7 sem plano de migração/compatibilidade.
+  - Propriedade explícita `spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect`.
+  - Uso de `open-in-view` como default não explicitamente governado.
+
+## Ações recomendadas
+
+1. Planejar decisão canônica: manter MySQL 5.7 com dialect legado suportado **ou** migrar para MySQL 8 (registrar em ADR/cânone).
+2. Remover configuração explícita de dialect no `lead-portal/backend`.
+3. Testar e, se aprovado, definir `spring.jpa.open-in-view=false` no Lead Portal backend.
+4. Se houver runbook usando `/api/actuator/*`, atualizar para `/api/ops-lp-observability-v2/*` para evitar falso diagnóstico de erro.

--- a/lead-portal/backend/src/main/resources/application.properties
+++ b/lead-portal/backend/src/main/resources/application.properties
@@ -24,5 +24,4 @@ spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:Ab9!rG4wX8_tMq2Bz7#HpK5V
 spring.datasource.hikari.max-lifetime=${SPRING_DATASOURCE_HIKARI_MAX_LIFETIME:55000}
 spring.datasource.hikari.keepalive-time=${SPRING_DATASOURCE_HIKARI_KEEPALIVE_TIME:45000}
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC


### PR DESCRIPTION
### Motivation
- Auditar warnings atuais do Lead Portal, comparar com os cânones do repositório e eliminar configuração legada que gera warning de Hibernate para reduzir drift técnico.

### Description
- Adiciona relatório operacional `docs/operations/lead-portal-log-review-2026-04-21.md` com evidências, análise e recomendações;.
- Remove a propriedade redundante `spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect` de `lead-portal/backend/src/main/resources/application.properties` para evitar warning de configuração desnecessária.

### Testing
- Executado `mvn test` em `lead-portal/backend` com sucesso (`BUILD SUCCESS`, 40 testes, 0 falhas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80dd98a90832184006c8f1342428d)