### PR TITLE
docs: add canonical uniqueness invariant to prevent duplicate Facebook campaigns per experiment

### DIFF
--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -6,6 +6,7 @@
 > - descreve o contrato de liberação, monitoramento do funil e dependências externas
 > - esclarece que para o público manual do experimento, 1 cargo (`JOB_TITLE`) aprovado já atende o mínimo operacional
 > - esclarece que o formulário de captação do experimento é do fluxo interno do Marketing Hub (não é o Instant Form nativo da Meta)
+> - adiciona invariante canônico de unicidade: um experimento não pode gerar campanhas duplicadas na mesma plataforma
 
 Este documento complementa o `system-governance-canon.v2.md` e passa a ser a fonte de verdade para prontidão, liberação e telemetria de campanhas de experimento no Facebook Ads Worker.
 
@@ -72,10 +73,11 @@ O cartão também lista itens operacionais que não travam o worker, mas devem s
 
 1. **Ação de liberação** – o botão **Liberar para o Facebook Ads Worker** marca `experiment.status = 'PLANNED'`, define `facebook_release_requested_at = now()` e zera o funil (descarta eventos anteriores à liberação).
 2. **Fila de publicação** – o worker consome `/api/facebook-campaigns/experiments-ready` apenas para experimentos com `status='PLANNED'` **e** `facebook_release_requested_at` preenchido. Alterar o status manualmente não substitui o botão.
-3. **Reprocessamentos** – apertar o botão novamente gera novo carimbo, limpa o funil e recoloca o experimento na fila (útil após reset de campanhas).
-4. **Persistência do carimbo** – `facebook_release_requested_at` permanece preenchido quando o status muda para `RUNNING` ou `PAUSED`, preservando o filtro do funil. Só muda no próximo clique.
-5. **Pixel worker** – a mesma liberação coloca o nicho na fila de criação de pixel enquanto `market_niche.facebook_pixel_id` estiver vazio. O worker consulta `/api/facebook-pixels/niches-ready` e só considera nichos com experimentos liberados (`facebook_release_requested_at` definido, `creative_approved=true`, `status IN ('PLANNED','RUNNING','PAUSED')` e plataforma Facebook). Ao registrar o pixel do nicho, todos os experimentos herdam o mesmo ID/HTML.
-6. **Execução registrada** – cada anúncio publicado referencia o valor de rastreamento (`utm_campaign`) exibido na UI junto com as conversões atribuídas.
+3. **Invariante de unicidade de campanha por experimento** – **é proibido** publicar duas campanhas ativas para o mesmo `experiment_id` na mesma plataforma. Se já existir campanha vinculada ao experimento, uma nova liberação deve operar em modo de atualização/reuso da campanha existente (ad sets/anúncios) e nunca criar uma segunda campanha paralela.
+4. **Reprocessamentos controlados** – um novo disparo de publicação só é permitido após evidência explícita de encerramento da campanha anterior (arquivada/finalizada/erro terminal com limpeza operacional). O reprocessamento mantém o mesmo vínculo canônico de campanha do experimento e não pode duplicar campanha.
+5. **Persistência do carimbo** – `facebook_release_requested_at` permanece preenchido quando o status muda para `RUNNING` ou `PAUSED`, preservando o filtro do funil. Só muda no próximo clique autorizado de reprocessamento.
+6. **Pixel worker** – a mesma liberação coloca o nicho na fila de criação de pixel enquanto `market_niche.facebook_pixel_id` estiver vazio. O worker consulta `/api/facebook-pixels/niches-ready` e só considera nichos com experimentos liberados (`facebook_release_requested_at` definido, `creative_approved=true`, `status IN ('PLANNED','RUNNING','PAUSED')` e plataforma Facebook). Ao registrar o pixel do nicho, todos os experimentos herdam o mesmo ID/HTML.
+7. **Execução registrada** – cada anúncio publicado referencia o valor de rastreamento (`utm_campaign`) exibido na UI junto com as conversões atribuídas.
 
 ## 8. Funil e telemetria operacional
 


### PR DESCRIPTION
### Motivation
- Prevent recurrence of an observed issue where `experiment` 5 was published as two separate Facebook campaigns by making the rule explicit in the canon. 
- Ensure UI, backend and workers share a single source-of-truth about campaign idempotency and reprocess behavior.

### Description
- Updated `docs/canonical/facebook-campaign-publication-canon.v1.md` to add a changelog entry stating the new canonical invariant that an experiment cannot generate duplicate campaigns on the same platform. 
- Added an explicit section in the release contract (section 7) introducing the `Invariante de unicidade de campanha por experimento` which forbids publishing two active campaigns for the same `experiment_id` and requires reuse/update of the existing campaign. 
- Clarified reprocessing behavior with `Reprocessamentos controlados` and adjusted the `facebook_release_requested_at` persistence rule to prevent creation of parallel campaigns during reprocesses.

### Testing
- Ran repository verification commands `git status --short` and `git diff -- docs/canonical/facebook-campaign-publication-canon.v1.md` to inspect the change, which completed successfully. 
- Committed the change with `git add` and `git commit`, which succeeded. 
- No automated unit or integration tests were required or executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8123dc09483218d9a993bf2db8c99)