### PR TITLE
Add USER_STOPPED experiment status and UI action to record manual campaign stops

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentStatus.java
@@ -7,6 +7,7 @@ public enum ExperimentStatus {
     PLANNED,
     RUNNING,
     PAUSED,
+    USER_STOPPED,
     VALIDATED,
     INVALIDATED,
     INCONCLUSIVE,

--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -78,6 +78,7 @@ O cartão também lista itens operacionais que não travam o worker, mas devem s
 5. **Persistência do carimbo** – `facebook_release_requested_at` permanece preenchido quando o status muda para `RUNNING` ou `PAUSED`, preservando o filtro do funil. Só muda no próximo clique autorizado de reprocessamento.
 6. **Pixel worker** – a mesma liberação coloca o nicho na fila de criação de pixel enquanto `market_niche.facebook_pixel_id` estiver vazio. O worker consulta `/api/facebook-pixels/niches-ready` e só considera nichos com experimentos liberados (`facebook_release_requested_at` definido, `creative_approved=true`, `status IN ('PLANNED','RUNNING','PAUSED')` e plataforma Facebook). Ao registrar o pixel do nicho, todos os experimentos herdam o mesmo ID/HTML.
 7. **Execução registrada** – cada anúncio publicado referencia o valor de rastreamento (`utm_campaign`) exibido na UI junto com as conversões atribuídas.
+8. **Parada manual do operador** – a UI de Experimentos pode registrar `status='USER_STOPPED'` quando a campanha for interrompida por decisão humana. Esse status encerra o ciclo operacional no Hub e **não** recoloca o experimento na fila `/api/facebook-campaigns/experiments-ready` até uma nova liberação explícita.
 
 ## 8. Funil e telemetria operacional
 

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -381,6 +381,11 @@ erDiagram
 - O Facebook Ads Worker consome `/api/facebook-campaigns/stop-requests`, chama a Graph API para aplicar `status=PAUSED` e confirma via `/api/facebook-campaigns/{id}/stop-results`.
 - `stop_completed_at` registra quando a pausa efetiva foi confirmada e evita que o pedido volte para a fila.
 
+### Parada manual por decisão do usuário
+
+- Quando o operador decide interromper uma campanha por escolha própria na listagem de experimentos, o backend registra `experiment.status = USER_STOPPED`.
+- `USER_STOPPED` representa encerramento manual no Hub (distinto de `INVALIDATED`, que é auto-stop estatístico) e não entra na fila `/api/facebook-campaigns/experiments-ready` sem nova liberação explícita.
+
 ## Observações de implementação
 
 - Cada registro de `EXPERIMENT` guarda agora `stage`, `primary_variable` e `primary_metric`.

--- a/frontend/src/api/experiment/useUpdateExperimentStatus.ts
+++ b/frontend/src/api/experiment/useUpdateExperimentStatus.ts
@@ -2,17 +2,22 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import type { Experiment } from "./useExperiments";
 
-export function useUpdateExperimentStatus(id: string) {
+interface UpdateExperimentStatusInput {
+  id: string;
+  status: string;
+}
+
+export function useUpdateExperimentStatus() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (status: string) => {
+    mutationFn: async ({ id, status }: UpdateExperimentStatusInput) => {
       const { data } = await axios.patch<Experiment>(`/api/experiments/${id}/status`, null, {
         params: { status },
       });
       return data;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["experiment", id] });
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["experiment", variables.id] });
       queryClient.invalidateQueries({ queryKey: ["experiments"] });
     },
   });

--- a/frontend/src/pages/experiment/ExperimentListPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { useExperiments } from "../../api/experiment/useExperiments";
 import { useNiches } from "../../api/niche/useNiches";
+import { useUpdateExperimentStatus } from "../../api/experiment/useUpdateExperimentStatus";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
 import { useMemo, useState } from "react";
@@ -15,9 +16,11 @@ function parseDate(date?: string | null) {
 export default function ExperimentListPage() {
   const { data, isLoading } = useExperiments();
   const { data: niches } = useNiches();
+  const updateStatus = useUpdateExperimentStatus();
   const [search, setSearch] = useState("");
   const [status, setStatus] = useState("");
   const [niche, setNiche] = useState("");
+  const [stoppingExperimentId, setStoppingExperimentId] = useState<string | null>(null);
   const experiments = Array.isArray(data) ? data : [];
 
   const filtered = useMemo(() => {
@@ -36,6 +39,15 @@ export default function ExperimentListPage() {
       return bDate - aDate;
     });
   }, [filtered]);
+
+  async function handleUserStop(experimentId: string) {
+    setStoppingExperimentId(experimentId);
+    try {
+      await updateStatus.mutateAsync({ id: experimentId, status: "USER_STOPPED" });
+    } finally {
+      setStoppingExperimentId(null);
+    }
+  }
 
   if (isLoading) return <p>Carregando...</p>;
 
@@ -71,6 +83,7 @@ export default function ExperimentListPage() {
             <option value="PLANNED">PLANNED</option>
             <option value="RUNNING">RUNNING</option>
             <option value="PAUSED">PAUSED</option>
+            <option value="USER_STOPPED">USER_STOPPED</option>
             <option value="FINISHED">FINISHED</option>
             <option value="FAILED">FAILED</option>
           </select>
@@ -113,6 +126,21 @@ export default function ExperimentListPage() {
                   >
                     Duplicar
                   </Link>
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-warning ms-1"
+                    disabled={stoppingExperimentId === String(e.id)}
+                    onClick={() => handleUserStop(String(e.id))}
+                  >
+                    {stoppingExperimentId === String(e.id) && (
+                      <span
+                        className="spinner-border spinner-border-sm me-1"
+                        role="status"
+                        aria-hidden="true"
+                      />
+                    )}
+                    Parada do usuário
+                  </button>
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
### Motivation
- Operators need a way to mark campaigns they manually stopped from the experiments list so the system can record an explicit, operator-driven stop state.
- The experiment lifecycle and Facebook worker queue must distinguish automatic invalidation from manual stops to avoid unintended re-queuing.
- Update canonical documentation to reflect the new operator stop behaviour and its effect on the Facebook Ads Worker.

### Description
- Add a new enum value `USER_STOPPED` to `ExperimentStatus` in the backend to represent manual operator stops.
- Change the frontend status mutation hook to accept `{ id, status }` (`useUpdateExperimentStatus`) so callers can update an experiment directly from lists.
- Add a per-row button in the experiments list (`ExperimentListPage`) labeled "Parada do usuário" that calls the mutation, shows a spinner and disables while the request runs, and adds `USER_STOPPED` to the status filter.
- Update canonical docs (`docs/canonical/facebook-campaign-publication-canon.v1.md` and `docs/modelo-dados-experimento.md`) to document `USER_STOPPED` semantics and that it does not re-enter `/api/facebook-campaigns/experiments-ready` without an explicit re-release.

### Testing
- Ran backend unit tests with `cd backend && ./mvnw -f ads-service/pom.xml -Dtest=ExperimentServiceTest,ExperimentControllerTest test`, which completed successfully (all tests passed).
- Ran frontend typecheck with `cd frontend && npm run typecheck`, which failed in this environment due to missing type definition packages (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`).
- Attempted `cd frontend && npm run lint` but the project does not define a `lint` script (so no lint step was run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e813d536948321acbe9d8fbc933c30)