### PR TITLE
Scope prompt composition to predecessor chain and load latest completed section outputs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -922,24 +923,72 @@ public class ExperimentPipelineGenerationService {
         if (section.predecessor() == null) {
             return;
         }
-        if (StringUtils.hasText(experiment.getCampaignAngle())) {
-            sb.append("\nÂngulo da campanha:\n").append(experiment.getCampaignAngle().trim()).append("\n");
+        Map<ExperimentPipelineSection, String> completedOutputs = loadLatestCompletedOutputs(experiment);
+        appendSectionOutputIfEligible(sb, section, ExperimentPipelineSection.CAMPAIGN_ANGLE, "Ângulo da campanha", completedOutputs);
+        appendSectionOutputIfEligible(sb, section, ExperimentPipelineSection.AD_COPY, "Texto do anúncio", completedOutputs);
+        appendSectionOutputIfEligible(sb, section, ExperimentPipelineSection.AD_IMAGE_BRIEFING, "Briefing da imagem", completedOutputs);
+        appendSectionOutputIfEligible(sb, section, ExperimentPipelineSection.LANDING_PAGE_COPY, "Textos da landing", completedOutputs);
+        appendSectionOutputIfEligible(sb, section, ExperimentPipelineSection.LANDING_PAGE_WIREFRAME, "Wireframe da landing", completedOutputs);
+        appendSectionOutputIfEligible(sb, section, ExperimentPipelineSection.LANDING_PAGE_IMAGE_PLANNING, "Planejamento de imagens da landing", completedOutputs);
+    }
+
+    private boolean shouldIncludeSectionOutput(ExperimentPipelineSection targetSection,
+                                               ExperimentPipelineSection outputSection) {
+        if (targetSection == null || outputSection == null) {
+            return false;
         }
-        if (StringUtils.hasText(experiment.getAdCopy())) {
-            sb.append("\nTexto do anúncio:\n").append(experiment.getAdCopy().trim()).append("\n");
+        ExperimentPipelineSection cursor = targetSection.predecessor();
+        while (cursor != null) {
+            if (cursor == outputSection) {
+                return true;
+            }
+            cursor = cursor.predecessor();
         }
-        if (StringUtils.hasText(experiment.getAdImageBriefing())) {
-            sb.append("\nBriefing da imagem:\n").append(experiment.getAdImageBriefing().trim()).append("\n");
+        return false;
+    }
+
+    private void appendSectionOutputIfEligible(StringBuilder sb,
+                                               ExperimentPipelineSection targetSection,
+                                               ExperimentPipelineSection outputSection,
+                                               String label,
+                                               Map<ExperimentPipelineSection, String> completedOutputs) {
+        if (!shouldIncludeSectionOutput(targetSection, outputSection)) {
+            return;
         }
-        if (StringUtils.hasText(experiment.getLandingPageCopy())) {
-            sb.append("\nTextos da landing:\n").append(experiment.getLandingPageCopy().trim()).append("\n");
+        String content = completedOutputs.get(outputSection);
+        if (!StringUtils.hasText(content)) {
+            return;
         }
-        if (StringUtils.hasText(experiment.getLandingPageWireframe())) {
-            sb.append("\nWireframe da landing:\n").append(experiment.getLandingPageWireframe().trim()).append("\n");
+        sb.append("\n").append(label).append(":\n").append(content.trim()).append("\n");
+    }
+
+    private Map<ExperimentPipelineSection, String> loadLatestCompletedOutputs(Experiment experiment) {
+        if (experiment == null || experiment.getId() == null) {
+            return Map.of();
         }
-        if (StringUtils.hasText(experiment.getLandingPageImagePlanning())) {
-            sb.append("\nPlanejamento de imagens da landing:\n").append(experiment.getLandingPageImagePlanning().trim()).append("\n");
+        List<ExperimentPipelineGenerationJob> completedJobs =
+                jobRepository.findLatestCompletedPerSectionByExperimentId(experiment.getId(), null);
+        if (completedJobs == null || completedJobs.isEmpty()) {
+            return Map.of();
         }
+        Map<ExperimentPipelineSection, String> bySection = new EnumMap<>(ExperimentPipelineSection.class);
+        for (ExperimentPipelineGenerationJob completedJob : completedJobs) {
+            if (completedJob == null || completedJob.getSection() == null) {
+                continue;
+            }
+            String sectionContent = extractCompletedSectionContent(completedJob);
+            if (StringUtils.hasText(sectionContent)) {
+                bySection.put(completedJob.getSection(), sectionContent.trim());
+            }
+        }
+        return bySection;
+    }
+
+    private String extractCompletedSectionContent(ExperimentPipelineGenerationJob completedJob) {
+        if (completedJob == null) {
+            return "";
+        }
+        return firstNonBlank(completedJob.getResponseContent(), completedJob.getRawResponse());
     }
 
     private void applySectionContent(Experiment experiment,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -8,6 +8,7 @@ import com.marketinghub.experiment.pipeline.ExperimentPipelineGenerationJob;
 import com.marketinghub.experiment.pipeline.ExperimentPipelineGenerationJobStage;
 import com.marketinghub.experiment.pipeline.ExperimentPipelineGenerationJobStatus;
 import com.marketinghub.experiment.pipeline.ExperimentPipelineSection;
+import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationRequest;
 import com.marketinghub.experiment.pipeline.dto.internal.ExperimentPipelineGenerationJobCompletionRequest;
 import com.marketinghub.experiment.pipeline.repository.ExperimentPipelineGenerationJobRepository;
 import com.marketinghub.experiment.frameworkimage.service.FrameworkImageGenerationService;
@@ -29,6 +30,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -144,6 +146,87 @@ class ExperimentPipelineGenerationServiceTest {
         verify(experimentRepository, never()).save(any());
         verify(leadPortalFlowPublisher, never()).publish(any());
         assertEquals("<section>ok</section>", linkedFlow.getCustomFormHtml());
+    }
+
+    @Test
+    void generateWireframeKeepsPromptScopedToPredecessorChain() {
+        Experiment experiment = new Experiment();
+        experiment.setId(12L);
+        experiment.setName("Experimento 12");
+        experiment.setLandingPageCopy("{\"landingPageCopy\":\"predecessor-ready\"}");
+
+        when(experimentRepository.findById(12L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.findByExperimentIdAndSectionAndStatusInOrderByCreatedAtDesc(
+                12L,
+                ExperimentPipelineSection.LANDING_PAGE_WIREFRAME,
+                Set.of(ExperimentPipelineGenerationJobStatus.PENDING, ExperimentPipelineGenerationJobStatus.PROCESSING)))
+                .thenReturn(List.of());
+        when(jobRepository.findLatestCompletedPerSectionByExperimentId(12L, null))
+                .thenReturn(List.of(
+                        completedJob(experiment, ExperimentPipelineSection.CAMPAIGN_ANGLE, "{\"campaignAngle\":true}"),
+                        completedJob(experiment, ExperimentPipelineSection.AD_COPY, "{\"adCopy\":true}"),
+                        completedJob(experiment, ExperimentPipelineSection.AD_IMAGE_BRIEFING, "{\"adImageBriefing\":true}"),
+                        completedJob(experiment, ExperimentPipelineSection.LANDING_PAGE_COPY, "{\"landingPageCopy\":true}"),
+                        completedJob(experiment, ExperimentPipelineSection.LANDING_PAGE_WIREFRAME, "{\"landingPageWireframe\":\"legacy\"}"),
+                        completedJob(experiment, ExperimentPipelineSection.LANDING_PAGE_IMAGE_PLANNING, "{\"landingPageImagePlanning\":\"legacy\"}")));
+        when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(experimentMapper.toDto(experiment)).thenReturn(new ExperimentDto());
+
+        service.generate(12L, ExperimentPipelineSection.LANDING_PAGE_WIREFRAME, new ExperimentPipelineGenerationRequest());
+
+        verify(jobRepository).save(argThat(job -> {
+            String prompt = job.getPrompt();
+            return prompt != null
+                    && prompt.contains("Ângulo da campanha:")
+                    && prompt.contains("Texto do anúncio:")
+                    && prompt.contains("Briefing da imagem:")
+                    && prompt.contains("Textos da landing:")
+                    && !prompt.contains("Wireframe da landing:")
+                    && !prompt.contains("Planejamento de imagens da landing:");
+        }));
+    }
+
+    @Test
+    void generateWireframeDoesNotReusePersistedExperimentArtifactsWithoutCompletedJobs() {
+        Experiment experiment = new Experiment();
+        experiment.setId(13L);
+        experiment.setName("Experimento 13");
+        experiment.setLandingPageCopy("{\"landingPageCopy\":\"persisted\"}");
+        experiment.setLandingPageWireframe("{\"landingPageWireframe\":\"persisted\"}");
+        experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":\"persisted\"}");
+
+        when(experimentRepository.findById(13L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.findByExperimentIdAndSectionAndStatusInOrderByCreatedAtDesc(
+                13L,
+                ExperimentPipelineSection.LANDING_PAGE_WIREFRAME,
+                Set.of(ExperimentPipelineGenerationJobStatus.PENDING, ExperimentPipelineGenerationJobStatus.PROCESSING)))
+                .thenReturn(List.of());
+        when(jobRepository.findLatestCompletedPerSectionByExperimentId(13L, null)).thenReturn(List.of());
+        when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(experimentMapper.toDto(experiment)).thenReturn(new ExperimentDto());
+
+        service.generate(13L, ExperimentPipelineSection.LANDING_PAGE_WIREFRAME, new ExperimentPipelineGenerationRequest());
+
+        verify(jobRepository).save(argThat(job -> {
+            String prompt = job.getPrompt();
+            return prompt != null
+                    && !prompt.contains("Textos da landing:")
+                    && !prompt.contains("Wireframe da landing:")
+                    && !prompt.contains("Planejamento de imagens da landing:");
+        }));
+    }
+
+    private ExperimentPipelineGenerationJob completedJob(Experiment experiment,
+                                                         ExperimentPipelineSection section,
+                                                         String responseContent) {
+        return ExperimentPipelineGenerationJob.builder()
+                .id(UUID.randomUUID())
+                .experiment(experiment)
+                .section(section)
+                .status(ExperimentPipelineGenerationJobStatus.COMPLETED)
+                .stage(ExperimentPipelineGenerationJobStage.COMPLETED)
+                .responseContent(responseContent)
+                .build();
     }
 
     @Test

--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -79,6 +79,22 @@ Se algum critério falhar:
 - fila vai para `BLOCKED`;
 - próxima etapa não inicia.
 
+## 6.1 Regra canônica de isolamento entre experimentos (obrigatória)
+
+No pipeline de experimento, **as informações de um experimento não podem, em hipótese alguma, influenciar outro experimento**.
+
+Regras mandatórias:
+
+- toda leitura de artefato para compor prompt, contexto, validação ou retomada deve ser filtrada por `experimentId`;
+- outputs de etapas anteriores só podem ser reaproveitados quando forem fatos persistidos do **mesmo** `experimentId`;
+- campos legados, snapshots antigos, cache em memória, retries e retomadas não podem “vazar” conteúdo de outro experimento;
+- qualquer tentativa de processar etapa com contexto de `experimentId` diferente deve ser tratada como erro de domínio e bloqueio (`BLOCKED`);
+- frontend, backend e workers devem preservar o mesmo escopo de isolamento por `experimentId` em toda transição de estado.
+
+Critério de conformidade:
+
+- se não houver artefato predecessor concluído no mesmo `experimentId`, o pipeline deve operar sem esse contexto (nunca buscar em outro experimento).
+
 ## 7. Critérios de retomada
 
 Uma fila em `BLOCKED` só pode voltar para `RUNNING` quando:


### PR DESCRIPTION
### Motivation

- Prevent reuse of unrelated persisted experiment fields when composing prompts for a section by ensuring only outputs from completed jobs of the same experiment are considered.
- Centralize and simplify assembling previous-step outputs so prompt composition is consistent and respects the pipeline predecessor chain.
- Make the behavior explicit in documentation by adding an isolation rule to the canonical experiments flow.

### Description

- Reworked `appendPreviousOutputs` in `ExperimentPipelineGenerationService` to load latest completed outputs via `loadLatestCompletedOutputs` and append section outputs only when they are on the predecessor chain using `shouldIncludeSectionOutput` and `appendSectionOutputIfEligible`.
- Added `loadLatestCompletedOutputs` to query `jobRepository.findLatestCompletedPerSectionByExperimentId` and map results into an `EnumMap<ExperimentPipelineSection,String>`, and added `extractCompletedSectionContent` to prefer `responseContent` over `rawResponse`.
- Added unit tests `generateWireframeKeepsPromptScopedToPredecessorChain` and `generateWireframeDoesNotReusePersistedExperimentArtifactsWithoutCompletedJobs` to verify prompt scoping and the absence of leaking legacy persisted artifacts when no completed jobs exist, plus a `completedJob` helper factory in the test.
- Updated documentation `docs/canonical/experiments-automation-flow-canon.v1.md` with a mandatory isolation rule for experiment pipelines requiring all artifact reads to be filtered by `experimentId`.

### Testing

- Ran unit tests for `ExperimentPipelineGenerationServiceTest` including the two new tests `generateWireframeKeepsPromptScopedToPredecessorChain` and `generateWireframeDoesNotReusePersistedExperimentArtifactsWithoutCompletedJobs`, and they passed.
- Existing tests in the same suite were executed and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e81ef94054832183a5c7cdebd323d8)