### PR TITLE
Prevent starting a pipeline stage when another stage is active; add repo query and conflict handling

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/repository/ExperimentPipelineGenerationJobRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/repository/ExperimentPipelineGenerationJobRepository.java
@@ -19,6 +19,10 @@ public interface ExperimentPipelineGenerationJobRepository extends JpaRepository
             ExperimentPipelineSection section,
             Collection<ExperimentPipelineGenerationJobStatus> statuses);
 
+    List<ExperimentPipelineGenerationJob> findByExperimentIdAndStatusInOrderByCreatedAtDesc(
+            Long experimentId,
+            Collection<ExperimentPipelineGenerationJobStatus> statuses);
+
     List<ExperimentPipelineGenerationJob> findByStatusOrderByCreatedAtAsc(ExperimentPipelineGenerationJobStatus status,
                                                                           Pageable pageable);
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -76,6 +76,9 @@ public class ExperimentPipelineGenerationService {
     private static final String DEFAULT_MODEL = "gpt-5.2";
     private static final Duration STALE_PENDING_TIMEOUT = Duration.ofMinutes(10);
     private static final Duration STALE_PROCESSING_TIMEOUT = Duration.ofMinutes(20);
+    private static final Set<ExperimentPipelineGenerationJobStatus> ACTIVE_JOB_STATUSES = Set.of(
+            ExperimentPipelineGenerationJobStatus.PENDING,
+            ExperimentPipelineGenerationJobStatus.PROCESSING);
     private static final String COMMON_CAMPAIGN_ASSET_RULES = """
             Você cria ativos de campanha para o Marketing Hub.
 
@@ -135,14 +138,22 @@ public class ExperimentPipelineGenerationService {
         validatePredecessor(experiment, section);
 
         List<ExperimentPipelineGenerationJob> activeJobs = jobRepository
-                .findByExperimentIdAndSectionAndStatusInOrderByCreatedAtDesc(
-                        experimentId,
-                        section,
-                        Set.of(ExperimentPipelineGenerationJobStatus.PENDING, ExperimentPipelineGenerationJobStatus.PROCESSING));
+                .findByExperimentIdAndStatusInOrderByCreatedAtDesc(experimentId, ACTIVE_JOB_STATUSES);
         boolean hasActiveJob = markStaleJobsAsFailed(activeJobs);
-        if (!hasActiveJob) {
-            enqueueJob(experiment, section, request);
+        if (hasActiveJob) {
+            ExperimentPipelineGenerationJob activeJob = activeJobs.stream()
+                    .filter(candidate -> candidate.getStatus() == ExperimentPipelineGenerationJobStatus.PENDING
+                            || candidate.getStatus() == ExperimentPipelineGenerationJobStatus.PROCESSING)
+                    .findFirst()
+                    .orElse(null);
+            String activeSection = activeJob != null && activeJob.getSection() != null
+                    ? activeJob.getSection().path()
+                    : "desconhecida";
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Já existe etapa em execução para este experimento (" + activeSection + "). "
+                            + "A fila automática deve seguir ordem sequencial.");
         }
+        enqueueJob(experiment, section, request);
         return experimentMapper.toDto(experiment);
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -156,9 +156,8 @@ class ExperimentPipelineGenerationServiceTest {
         experiment.setLandingPageCopy("{\"landingPageCopy\":\"predecessor-ready\"}");
 
         when(experimentRepository.findById(12L)).thenReturn(Optional.of(experiment));
-        when(jobRepository.findByExperimentIdAndSectionAndStatusInOrderByCreatedAtDesc(
+        when(jobRepository.findByExperimentIdAndStatusInOrderByCreatedAtDesc(
                 12L,
-                ExperimentPipelineSection.LANDING_PAGE_WIREFRAME,
                 Set.of(ExperimentPipelineGenerationJobStatus.PENDING, ExperimentPipelineGenerationJobStatus.PROCESSING)))
                 .thenReturn(List.of());
         when(jobRepository.findLatestCompletedPerSectionByExperimentId(12L, null))
@@ -196,9 +195,8 @@ class ExperimentPipelineGenerationServiceTest {
         experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":\"persisted\"}");
 
         when(experimentRepository.findById(13L)).thenReturn(Optional.of(experiment));
-        when(jobRepository.findByExperimentIdAndSectionAndStatusInOrderByCreatedAtDesc(
+        when(jobRepository.findByExperimentIdAndStatusInOrderByCreatedAtDesc(
                 13L,
-                ExperimentPipelineSection.LANDING_PAGE_WIREFRAME,
                 Set.of(ExperimentPipelineGenerationJobStatus.PENDING, ExperimentPipelineGenerationJobStatus.PROCESSING)))
                 .thenReturn(List.of());
         when(jobRepository.findLatestCompletedPerSectionByExperimentId(13L, null)).thenReturn(List.of());
@@ -214,6 +212,34 @@ class ExperimentPipelineGenerationServiceTest {
                     && !prompt.contains("Wireframe da landing:")
                     && !prompt.contains("Planejamento de imagens da landing:");
         }));
+    }
+
+    @Test
+    void generateRejectsNewStageWhenAnotherStageIsAlreadyActiveForExperiment() {
+        Experiment experiment = new Experiment();
+        experiment.setId(14L);
+        experiment.setCampaignAngle("{\"campaignAngle\":\"ok\"}");
+
+        ExperimentPipelineGenerationJob activeJob = ExperimentPipelineGenerationJob.builder()
+                .id(UUID.randomUUID())
+                .experiment(experiment)
+                .section(ExperimentPipelineSection.CAMPAIGN_ANGLE)
+                .status(ExperimentPipelineGenerationJobStatus.PROCESSING)
+                .stage(ExperimentPipelineGenerationJobStage.SENT_TO_OPENAI)
+                .build();
+
+        when(experimentRepository.findById(14L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.findByExperimentIdAndStatusInOrderByCreatedAtDesc(
+                14L,
+                Set.of(ExperimentPipelineGenerationJobStatus.PENDING, ExperimentPipelineGenerationJobStatus.PROCESSING)))
+                .thenReturn(List.of(activeJob));
+
+        ResponseStatusException error = assertThrows(ResponseStatusException.class,
+                () -> service.generate(14L, ExperimentPipelineSection.AD_COPY, new ExperimentPipelineGenerationRequest()));
+
+        assertEquals(409, error.getStatusCode().value());
+        assertTrue(error.getReason().contains("ordem sequencial"));
+        verify(jobRepository, never()).save(any(ExperimentPipelineGenerationJob.class));
     }
 
     private ExperimentPipelineGenerationJob completedJob(Experiment experiment,


### PR DESCRIPTION
### Motivation

- Avoid running multiple pipeline stages concurrently for the same `Experiment` by detecting active jobs across sections and rejecting new stage enqueues.

### Description

- Added repository method `findByExperimentIdAndStatusInOrderByCreatedAtDesc` to fetch jobs for an experiment by `status` set.
- Introduced `ACTIVE_JOB_STATUSES` (`PENDING`, `PROCESSING`) and replaced the previous section-scoped lookup with a global active-job check in `generate`.
- Changed `generate` to throw a `409 CONFLICT` `ResponseStatusException` with a clear message when another stage is active, and only `enqueueJob` when no active job exists.
- Updated unit tests to use the new repository method and added `generateRejectsNewStageWhenAnotherStageIsAlreadyActiveForExperiment` to assert the conflict behavior and that no job is saved.

### Testing

- Ran unit tests in `ExperimentPipelineGenerationServiceTest`, including the new `generateRejectsNewStageWhenAnotherStageIsAlreadyActiveForExperiment` test, and they passed locally (`mvn -Dtest=ExperimentPipelineGenerationServiceTest test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8285becd88321aef85fea6d0a1b77)