### PR TITLE
Corrige desvio controlado entre Planejamento de Imagens e HTML da Landing

### DIFF
--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -38,6 +38,29 @@ Regra canônica:
 - uma etapa só pode iniciar quando a etapa anterior estiver em `COMPLETED`.
 - avanço fora de ordem é drift e deve ser bloqueado no backend.
 
+### 3.1 Desvio controlado obrigatório entre planejamento e HTML
+
+Entre as etapas `landingPageImagePlanning` e `landingPageHtml`, existe um
+**desvio controlado obrigatório** para geração das imagens finais da landing.
+
+Fluxo canônico:
+
+1. `landingPageImagePlanning` conclui em `COMPLETED`;
+2. sistema dispara a geração de imagens planejadas (`framework images`);
+3. fila entra em `WAITING_DEPENDENCY` enquanto houver item em `PLANNED`,
+   `PENDING` ou `PROCESSING`;
+4. após concluir (ou consolidar erro tratável) os itens de imagem, a fila
+   retorna ao trilho principal e só então libera `landingPageHtml`.
+
+Regras mandatórias:
+
+- `landingPageHtml` não pode iniciar enquanto a geração de imagens estiver em
+  andamento.
+- o retorno ao trilho principal deve ser automático (sem exigir ação manual
+  quando não houver bloqueio).
+- se houver falha na geração de imagens, a UI deve apresentar causa e ação
+  recomendada antes de permitir retomada.
+
 ## 4. Estados da fila automática
 
 Estados permitidos para execução da fila:
@@ -115,6 +138,9 @@ A UI deve exibir, no mínimo:
 - etapa atual, próximas etapas e etapa concluída mais recente;
 - mensagem de progresso em linguagem clara (`message`);
 - orientação objetiva de ação/inação (`userGuidance`), por exemplo: “aguarde a conclusão desta etapa”.
+- quando houver desvio controlado para geração de imagens, explicitar que o
+  fluxo saiu temporariamente de `landingPageImagePlanning`, está gerando imagens
+  e retornará automaticamente para `landingPageHtml`.
 
 ### 8.2 Bloqueios obrigatórios de ação
 

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -1168,10 +1168,29 @@ export default function ExperimentContentGenerationTab({
   );
   const [isAutoQueueRunning, setIsAutoQueueRunning] = useState(false);
   const lastCompletedLandingPlanningRef = useRef<number | null>(null);
+  const imageGenerationWaitToastRef = useRef<string | null>(null);
 
   const jobsQuery = useExperimentPipelineJobs(experimentId);
   const frameworkImageStatusQuery = useFrameworkImageStatuses(experimentId);
   const generateFrameworkImages = useGenerateFrameworkImages(experimentId);
+  const frameworkImageStatuses = frameworkImageStatusQuery.data ?? [];
+  const hasFrameworkImages = frameworkImageStatuses.length > 0;
+  const hasFrameworkImagesInFlight = frameworkImageStatuses.some((item) =>
+    isFrameworkImageStatusInFlight(item.status),
+  );
+  const hasFrameworkImageFailure = frameworkImageStatuses.some(
+    (item) => item.status?.toUpperCase() === "FAILED",
+  );
+  const hasFrameworkImageReady = frameworkImageStatuses.some(
+    (item) => item.status?.toUpperCase() === "COMPLETED",
+  );
+  const shouldWaitLandingHtmlForImages =
+    autoQueue.isActive &&
+    autoQueue.waitingFor === "landing-image-planning" &&
+    autoQueue.pending[0] === "landing-html" &&
+    (frameworkImageStatusQuery.isLoading ||
+      !hasFrameworkImages ||
+      hasFrameworkImagesInFlight);
 
   const requestsFromBackend = useMemo(
     () =>
@@ -1639,6 +1658,7 @@ export default function ExperimentContentGenerationTab({
 
   useEffect(() => {
     if (!autoQueue.isActive || !autoQueue.waitingFor || isAutoQueueRunning) {
+      imageGenerationWaitToastRef.current = null;
       return;
     }
 
@@ -1657,11 +1677,39 @@ export default function ExperimentContentGenerationTab({
 
     if (autoQueue.pending.length === 0) {
       setAutoQueue(AUTO_QUEUE_INITIAL_STATE);
+      imageGenerationWaitToastRef.current = null;
       toast.success("Fila automática finalizada. Todas as etapas foram solicitadas.");
       return;
     }
 
     const [nextSectionKey, ...remaining] = autoQueue.pending;
+    if (
+      autoQueue.waitingFor === "landing-image-planning" &&
+      nextSectionKey === "landing-html"
+    ) {
+      const stillLoadingImageStatuses =
+        frameworkImageStatusQuery.isLoading || frameworkImageStatusQuery.isFetching;
+      const mustWaitForImages =
+        stillLoadingImageStatuses ||
+        !hasFrameworkImages ||
+        hasFrameworkImagesInFlight;
+
+      if (mustWaitForImages) {
+        if (!imageGenerationWaitToastRef.current) {
+          imageGenerationWaitToastRef.current = toast.info(
+            "Planejamento concluído. Aguardando geração das imagens para continuar com o HTML da landing.",
+            { autoClose: 6000 },
+          ) as unknown as string;
+        }
+        return;
+      }
+
+      imageGenerationWaitToastRef.current = null;
+      if (!hasFrameworkImageReady && !hasFrameworkImageFailure) {
+        return;
+      }
+    }
+
     const nextSection = sectionByKey[nextSectionKey];
     if (!nextSection) {
       setAutoQueue(AUTO_QUEUE_INITIAL_STATE);
@@ -1684,6 +1732,12 @@ export default function ExperimentContentGenerationTab({
     })();
   }, [
     autoQueue,
+    frameworkImageStatusQuery.isFetching,
+    frameworkImageStatusQuery.isLoading,
+    hasFrameworkImageFailure,
+    hasFrameworkImageReady,
+    hasFrameworkImages,
+    hasFrameworkImagesInFlight,
     isAutoQueueRunning,
     mergedRequestsBySection,
     requestSectionGeneration,
@@ -1934,6 +1988,12 @@ export default function ExperimentContentGenerationTab({
               aguardando conclusão de{" "}
               <strong>{getSectionLabel(autoQueue.waitingFor)}</strong>.
             </span>
+            {shouldWaitLandingHtmlForImages ? (
+              <span className="text-warning-emphasis">
+                Desvio controlado: gerando imagens da landing antes do HTML
+                final.
+              </span>
+            ) : null}
             <span className="badge text-bg-light">
               Próximas: {autoQueue.pending.length}
             </span>
@@ -1965,6 +2025,12 @@ export default function ExperimentContentGenerationTab({
 
         {CONTENT_GENERATION_SECTIONS.map((section) => (
           <Tabs.Content key={section.key} value={section.key} className="mt-3">
+            {(() => {
+              const isLandingHtmlBlockedByImageGeneration =
+                section.key === "landing-html" &&
+                (frameworkImageStatusQuery.isLoading ||
+                  hasFrameworkImagesInFlight);
+              return (
             <section className="card">
               <div className="card-body">
                 <div className="d-flex justify-content-between align-items-start flex-wrap gap-2">
@@ -1977,7 +2043,11 @@ export default function ExperimentContentGenerationTab({
                       type="button"
                       className="btn btn-outline-primary btn-sm"
                       onClick={() => void handleGenerateSection(section)}
-                      disabled={isGeneratingSection || autoQueue.isActive}
+                      disabled={
+                        isGeneratingSection ||
+                        autoQueue.isActive ||
+                        isLandingHtmlBlockedByImageGeneration
+                      }
                       title={`Solicita ao Worker IA a geração da etapa "${section.label}" com prompt canônico do pipeline.`}
                     >
                       {isGeneratingSection &&
@@ -1998,6 +2068,15 @@ export default function ExperimentContentGenerationTab({
                             aria-hidden="true"
                           />
                           Fila em execução...
+                        </span>
+                      ) : isLandingHtmlBlockedByImageGeneration ? (
+                        <span className="d-inline-flex align-items-center gap-1">
+                          <span
+                            className="spinner-border spinner-border-sm"
+                            role="status"
+                            aria-hidden="true"
+                          />
+                          Gerando imagens...
                         </span>
                       ) : (
                         "Gerar com IA"
@@ -2080,6 +2159,8 @@ export default function ExperimentContentGenerationTab({
 
               </div>
             </section>
+              );
+            })()}
           </Tabs.Content>
         ))}
       </Tabs.Root>
@@ -2174,6 +2255,13 @@ export default function ExperimentContentGenerationTab({
                   {request.customInstructions ? (
                     <small className="text-body-secondary">
                       Instruções enviadas: {request.customInstructions}
+                    </small>
+                  ) : null}
+                  {section.key === "landing-html" &&
+                  shouldWaitLandingHtmlForImages ? (
+                    <small className="text-warning-emphasis">
+                      Fluxo em desvio controlado: estamos gerando as imagens da
+                      landing para retomar automaticamente esta etapa ao final.
                     </small>
                   ) : null}
                   {invalidation ? (
@@ -2811,6 +2899,15 @@ const FRAMEWORK_IMAGE_STAGE_LABEL: Record<string, string> = {
   WEB_READY: "Versão web pronta",
   FAILED: "Falhou",
 };
+
+function isFrameworkImageStatusInFlight(status?: string) {
+  const normalized = status?.toUpperCase();
+  return (
+    normalized === "PLANNED" ||
+    normalized === "PENDING" ||
+    normalized === "PROCESSING"
+  );
+}
 
 function FrameworkImageGenerationPanel({
   statuses,


### PR DESCRIPTION
### Motivation
- O fluxo automático perdia a sequência entre o `Planejamento de Imagens da Landing` e o `HTML da Landing`, deixando o usuário sem feedback enquanto o worker de imagens processava os assets. 
- É necessário garantir que a geração de imagens seja tratada como etapa intermediária obrigatória e que a UI explique esse desvio para evitar confusão e avanços fora de ordem.

### Description
- Frontend: na `ExperimentContentGenerationTab` adicionei detecção dos status das "framework images" (`isFrameworkImageStatusInFlight`) e estados derivados (`hasFrameworkImages*`, `shouldWaitLandingHtmlForImages`) para decidir quando bloquear a progressão automática para `landing-html`.
- Frontend: implementei lógica de espera na fila automática que mostra um `toast` informativo enquanto as imagens estão sendo geradas e evita disparo automático/manual do `HTML da Landing` até que haja resultado (ou falha consolidada).
- Frontend: bloqueio do botão de geração do `landing-html`, feedback visual (badge/alert) explicando o desvio controlado e mensagem no card de acompanhamento para indicar que a etapa retornará automaticamente.
- Docs: atualizei `docs/canonical/experiments-automation-flow-canon.v1.md` acrescentando seção que documenta o "desvio controlado obrigatório" entre `landingPageImagePlanning` e `landingPageHtml` e regras de UX associadas.

### Testing
- Executei `cd frontend && npm run typecheck` e a checagem TypeScript passou sem erros após instalar dependências.
- Executei `cd frontend && npm run build` e a build de produção (`vite build`) finalizou com sucesso.
- Não foram executados testes end-to-end visuais neste ambiente; comportamento validado via build e inspeção estática do código.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e848486ee08321a48e67e84a8aa916)