### PR TITLE
Propagate root cause when Lead Portal publication fails and add unit test; update README observability endpoints

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -56,6 +56,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.core.NestedExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -233,8 +234,12 @@ public class ExperimentPipelineGenerationService {
             try {
                 leadPortalFlowPublisher.publish(saved);
             } catch (LeadPortalPublicationException ex) {
+                String rootCauseMessage = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
+                String message = StringUtils.hasText(rootCauseMessage)
+                        ? "Falha ao publicar fluxo com o novo HTML da landing: " + rootCauseMessage
+                        : "Falha ao publicar fluxo com o novo HTML da landing";
                 throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
-                        "Falha ao publicar fluxo com o novo HTML da landing", ex);
+                        message, ex);
             }
         }
         return experimentMapper.toDto(experiment);

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -15,6 +15,7 @@ import com.marketinghub.experiment.frameworkimage.service.FrameworkImageGenerati
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;
+import com.marketinghub.leadportal.integration.LeadPortalPublicationException;
 import com.marketinghub.leadportal.repository.LeadPortalFlowRepository;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.ai.generation.service.AiWorkerGenerationService;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
 class ExperimentPipelineGenerationServiceTest {
@@ -146,6 +148,32 @@ class ExperimentPipelineGenerationServiceTest {
         verify(experimentRepository, never()).save(any());
         verify(leadPortalFlowPublisher, never()).publish(any());
         assertEquals("<section>ok</section>", linkedFlow.getCustomFormHtml());
+    }
+
+    @Test
+    void applyLandingHtmlToLeadPortalFormReturnsRootCauseWhenPublicationFails() {
+        LeadPortalFlow linkedFlow = new LeadPortalFlow();
+        linkedFlow.setId(901L);
+        linkedFlow.setSlug("existing-flow");
+        linkedFlow.setApproved(true);
+
+        Experiment experiment = new Experiment();
+        experiment.setId(15L);
+        experiment.setLandingPageHtml("<section>ok</section>");
+        experiment.setLeadPortalFlow(linkedFlow);
+
+        when(experimentRepository.findById(15L)).thenReturn(Optional.of(experiment));
+        when(leadPortalFlowRepository.findById(901L)).thenReturn(Optional.of(linkedFlow));
+        when(leadPortalFlowRepository.save(any(LeadPortalFlow.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(landingPageImageInjector.injectImages(15L, "<section>ok</section>")).thenReturn("<section>ok</section>");
+        doThrow(new LeadPortalPublicationException("failed", new RuntimeException("Connection refused")))
+                .when(leadPortalFlowPublisher).publish(any(LeadPortalFlow.class));
+
+        ResponseStatusException error = assertThrows(ResponseStatusException.class,
+                () -> service.applyLandingHtmlToLeadPortalForm(15L));
+
+        assertEquals(502, error.getStatusCode().value());
+        assertTrue(error.getReason().contains("Connection refused"));
     }
 
     @Test

--- a/lead-portal/README.md
+++ b/lead-portal/README.md
@@ -42,8 +42,8 @@ O ambiente dockerizado levanta três serviços:
 
 ### Observabilidade e logs
 
-- `GET /api/actuator/logfile`: retorna o conteúdo do arquivo configurado em `LOGGING_FILE_NAME`, permitindo baixar os logs recentes sem acessar o host.
-- `GET /api/actuator/loggers`: lista (e permite ajustar via `POST`) os níveis de log das classes gerenciadas pelo Spring Boot.
+- `GET /api/ops-lp-observability-v2/logfile`: retorna o conteúdo do arquivo configurado em `LOGGING_FILE_NAME`, permitindo baixar os logs recentes sem acessar o host.
+- `GET /api/ops-lp-observability-v2/loggers`: lista (e permite ajustar via `POST`) os níveis de log das classes gerenciadas pelo Spring Boot.
 
 Certifique-se de que o caminho informado em `LOGGING_FILE_NAME` pertença a um volume persistente (por exemplo, `/app/data/logs/lead-portal-backend.log` no Docker) para que o conteúdo sobreviva a recriações do container.
 


### PR DESCRIPTION
### Motivation

- Improve error transparency when publishing a Lead Portal flow by surfacing the most specific root-cause in the resulting `ResponseStatusException` message.
- Add a unit test to verify the root-cause is included when publication fails.
- Update the lead-portal README to reflect the adjusted observability actuator endpoint paths.

### Description

- Use `NestedExceptionUtils.getMostSpecificCause(ex).getMessage()` to extract the root cause message from `LeadPortalPublicationException` and include it in the `ResponseStatusException` reason text.
- Add an import for `org.springframework.core.NestedExceptionUtils` and adjust the `catch` block to build a message that includes the root-cause when present.
- Add `applyLandingHtmlToLeadPortalFormReturnsRootCauseWhenPublicationFails` unit test in `ExperimentPipelineGenerationServiceTest` which mocks `LeadPortalFlowPublisher.publish` to throw `LeadPortalPublicationException` wrapping a `RuntimeException` and asserts a 502 with the nested message.
- Update `lead-portal/README.md` to change the observability actuator endpoint paths to `/api/ops-lp-observability-v2/logfile` and `/api/ops-lp-observability-v2/loggers`.

### Testing

- Ran unit tests for `ExperimentPipelineGenerationServiceTest`, including the new `applyLandingHtmlToLeadPortalFormReturnsRootCauseWhenPublicationFails` test, and they passed.
- Existing tests for landing HTML application and wireframe generation were executed and remained green.
- No integration tests were changed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84c479980832182aabd8c273e4c8b)