### PR TITLE
List lead portal flows by experiment ID and wire through controller/frontend/tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/service/LeadPortalFlowService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/service/LeadPortalFlowService.java
@@ -64,12 +64,8 @@ public class LeadPortalFlowService {
         if (experimentId == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "experimentId is required");
         }
-        Experiment experiment = attachExperiment(experimentId);
-        Long nicheId = experiment.getNiche() != null ? experiment.getNiche().getId() : null;
-        if (nicheId == null) {
-            return List.of();
-        }
-        return repository.findAllByMarketNicheIdOrderByCreatedAtDesc(nicheId);
+        attachExperiment(experimentId);
+        return repository.findAllByExperimentIdOrderByCreatedAtDesc(experimentId);
     }
 
     public List<LeadPortalFlow> listByMarketNiche(Long marketNicheId) {

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalFlowController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalFlowController.java
@@ -34,10 +34,10 @@ public class LeadPortalFlowController {
     public List<LeadPortalFlowDto> list(@RequestParam(value = "experimentId", required = false) Long experimentId,
                                             @RequestParam(value = "nicheId", required = false) Long nicheId) {
         List<LeadPortalFlow> flows;
-        if (nicheId != null) {
-            flows = service.listByMarketNiche(nicheId);
-        } else if (experimentId != null) {
+        if (experimentId != null) {
             flows = service.listByExperiment(experimentId);
+        } else if (nicheId != null) {
+            flows = service.listByMarketNiche(nicheId);
         } else {
             flows = service.listAll();
         }

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/service/LeadPortalFlowServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/service/LeadPortalFlowServiceTest.java
@@ -7,6 +7,7 @@ import com.marketinghub.leadportal.dto.UpdateLeadPortalFlowRequest;
 import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;
 import com.marketinghub.leadportal.integration.LeadPortalPublicationException;
 import com.marketinghub.leadportal.repository.LeadPortalFlowRepository;
+import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.niche.repository.MarketNicheRepository;
 import com.marketinghub.leadportal.repository.LeadPortalSimpleFormStyleRepository;
@@ -58,8 +59,8 @@ class LeadPortalFlowServiceTest {
                 .slug("fluxo")
                 .questions(new ArrayList<>())
                 .build();
-        when(repository.findById(1L)).thenReturn(Optional.of(flow));
-        when(repository.save(any(LeadPortalFlow.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(repository.findById(1L)).thenReturn(Optional.of(flow));
+        lenient().when(repository.save(any(LeadPortalFlow.class))).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
 
@@ -111,5 +112,19 @@ class LeadPortalFlowServiceTest {
         verify(flowPublisher).publish(flow);
         verify(flowPublisher, never()).remove(anyString());
         assertThat(updated.isApproved()).isTrue();
+    }
+
+    @Test
+    void listByExperimentFiltersByExperimentId() {
+        Experiment experiment = Experiment.builder().id(10L).build();
+        List<LeadPortalFlow> expected = List.of(flow);
+        when(experimentRepository.findById(10L)).thenReturn(Optional.of(experiment));
+        when(repository.findAllByExperimentIdOrderByCreatedAtDesc(10L)).thenReturn(expected);
+
+        List<LeadPortalFlow> result = service.listByExperiment(10L);
+
+        assertThat(result).isSameAs(expected);
+        verify(repository).findAllByExperimentIdOrderByCreatedAtDesc(10L);
+        verify(repository, never()).findAllByMarketNicheIdOrderByCreatedAtDesc(anyLong());
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalFlowControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalFlowControllerTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -256,8 +257,37 @@ class LeadPortalFlowControllerTest {
                         "fluxo-novo".equals(updatedFlow.getSlug())));
     }
 
+    @Test
+    void listByExperimentReturnsOnlyFlowsFromRequestedExperiment() throws Exception {
+        Experiment experimentA = createExperiment();
+        Experiment experimentB = createExperimentInNiche(experimentA.getNiche(), "Experimento Secundário");
+
+        repository.save(LeadPortalFlow.builder()
+                .name("Fluxo A")
+                .slug("fluxo-a")
+                .marketNiche(experimentA.getNiche())
+                .experiment(experimentA)
+                .build());
+        repository.save(LeadPortalFlow.builder()
+                .name("Fluxo B")
+                .slug("fluxo-b")
+                .marketNiche(experimentB.getNiche())
+                .experiment(experimentB)
+                .build());
+
+        mockMvc.perform(get("/api/lead-portal-flows")
+                        .param("experimentId", String.valueOf(experimentA.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].slug").value("fluxo-a"));
+    }
+
     private Experiment createExperiment() {
         MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Teste").build());
+        return createExperimentInNiche(niche, "Experimento Lead Portal");
+    }
+
+    private Experiment createExperimentInNiche(MarketNiche niche, String experimentName) {
         Hypothesis hypothesis = hypothesisRepository.save(Hypothesis.builder()
                 .title("Hipótese Teste")
                 .marketNiche(niche)
@@ -267,7 +297,7 @@ class LeadPortalFlowControllerTest {
                 .build());
         Experiment experiment = Experiment.builder()
                 .niche(niche)
-                .name("Experimento Lead Portal")
+                .name(experimentName)
                 .hypothesis("Resumo")
                 .hypothesisRef(hypothesis)
                 .journeyTemplate(template)

--- a/frontend/src/pages/experiment/LeadPortalFlowTab.tsx
+++ b/frontend/src/pages/experiment/LeadPortalFlowTab.tsx
@@ -24,7 +24,9 @@ type PreviewViewport = "desktop" | "mobile";
 export default function LeadPortalFlowTab({
   experiment,
 }: LeadPortalFlowTabProps) {
-  const { data: flows, isLoading, isError } = useLeadPortalFlows({ nicheId: experiment.nicheId });
+  const { data: flows, isLoading, isError } = useLeadPortalFlows({
+    experimentId: experiment.id,
+  });
   const requestFlows = useRequestLeadPortalFlows(experiment.id);
   const updateExperiment = useUpdateExperiment(experiment.id);
   const updateApproval = useUpdateLeadPortalFlowApproval();


### PR DESCRIPTION
### Motivation

- Make listing of lead portal flows scoped directly to an `experimentId` rather than deriving the niche from the experiment, enabling precise filtering by experiment.
- Ensure API, service, and UI consistently accept and prefer `experimentId` when present.
- Add tests to cover the new behavior and stabilize some existing test stubbing.

### Description

- Update `LeadPortalFlowService.listByExperiment` to validate the `experimentId` and call `repository.findAllByExperimentIdOrderByCreatedAtDesc(experimentId)` instead of deriving a niche and querying by niche id.
- Reorder controller request handling in `LeadPortalFlowController.list` so `experimentId` is checked before `nicheId` and flows are returned by the appropriate service method.
- Change frontend `LeadPortalFlowTab` to request flows using `experimentId` by passing `experiment.id` to `useLeadPortalFlows` instead of `nicheId`.
- Add and adjust tests: make repository stubbing in `LeadPortalFlowServiceTest` lenient, and add `listByExperimentFiltersByExperimentId` to verify the service calls the new repository method; add `listByExperimentReturnsOnlyFlowsFromRequestedExperiment` integration test in `LeadPortalFlowControllerTest`; add/import `Experiment` and helper `createExperimentInNiche` to support the tests.

### Testing

- Ran unit tests with `LeadPortalFlowServiceTest` which includes `listByExperimentFiltersByExperimentId`, and they passed.
- Ran integration/controller tests with `LeadPortalFlowControllerTest` including `listByExperimentReturnsOnlyFlowsFromRequestedExperiment`, and they passed.
- Executed the test suite via the build (`mvn test`) and all modified/new tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ccbe0e948321b5f903c38159d387)