### PR TITLE
docs: reforça independência e exclusividade de artefatos por experimento

### DIFF
--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -2,6 +2,12 @@
 
 Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 
+## Observação importante — independência dos experimentos
+
+- Cada experimento deve ser tratado de forma independente, sem reutilização implícita de artefatos entre experimentos.
+- **Critério canônico de exclusividade**: todo artefato gerado direta **ou** indiretamente pelo pipeline de um experimento é considerado **exclusivo daquele experimento**.
+- Portanto, para um artefato ser classificado como "não exclusivo", ele não pode ter sido produzido em nenhuma etapa do pipeline do experimento (incluindo derivações, transformações, consolidações ou enriquecimentos).
+
 ## Convenção de envelope (`artifact`)
 
 ```json


### PR DESCRIPTION
### Motivation
- Esclarecer a política canônica sobre propriedade de artefatos para garantir que artefatos gerados por um experimento não sejam reutilizados implicitamente por outros experimentos.

### Description
- Adiciona a seção "Observação importante — independência dos experimentos" em `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` definindo o critério canônico de exclusividade: todo artefato gerado direta ou indiretamente pelo pipeline de um experimento é exclusivo desse experimento, e para ser considerado não exclusivo o artefato não pode ter sido produzido em nenhuma etapa do pipeline do experimento.

### Testing
- Não há testes automatizados aplicáveis por se tratar de alteração documental; foram executadas checagens de integridade do repositório com `git diff -- docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` e `git status --short` que confirmaram a modificação do arquivo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cfe7872883218bed7214d0cbb2cc)