### PR TITLE
Add global artifact exclusivity rule and reference it from experiments canon

### DIFF
--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -113,6 +113,7 @@ Regras mandatórias:
 - campos legados, snapshots antigos, cache em memória, retries e retomadas não podem “vazar” conteúdo de outro experimento;
 - qualquer tentativa de processar etapa com contexto de `experimentId` diferente deve ser tratada como erro de domínio e bloqueio (`BLOCKED`);
 - frontend, backend e workers devem preservar o mesmo escopo de isolamento por `experimentId` em toda transição de estado.
+- a classificação de exclusividade de artefatos deve seguir a regra global descrita em `system-governance-canon.v2.md`.
 
 Critério de conformidade:
 

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -29,6 +29,12 @@
 5. **Contratos entre módulos são explícitos e versionados.** Nenhum módulo pode depender de campos implícitos, estados informais ou convenções não registradas.
 6. **Mudanças relevantes exigem teste e documentação correspondente.** Regra operacional sem teste e sem contrato atualizado é candidata imediata a drift.
 
+## 3.1 Regra global de exclusividade de artefatos (todo o sistema)
+
+- Todo artefato gerado direta ou indiretamente por fluxos oficiais do sistema é **exclusivo do contexto de origem** (por exemplo `experimentId`, `leadId`, `campaignId` ou equivalente canônico do domínio).
+- Para um artefato ser classificado como **não exclusivo**, ele não pode ter sido produzido em nenhuma etapa de pipeline/fluxo oficial vinculada a um contexto específico.
+- Reuso de artefatos entre contextos distintos só é permitido quando houver contrato canônico explícito de compartilhamento no domínio correspondente.
+
 ## 4. Precedência Canônica
 
 Em caso de conflito, a precedência deve ser:


### PR DESCRIPTION
### Motivation

- Evitar vazamento de dados entre contextos (por exemplo `experimentId`) ao padronizar como artefatos são classificados e reaproveitados. 
- Centralizar a regra em um cânone sistema para reduzir drift entre backend, frontend e workers.
- Garantir que o fluxo de experimentos consuma a regra global de exclusividade em vez de decisões locais.

### Description

- Adiciona a seção `3.1 Regra global de exclusividade de artefatos (todo o sistema)` ao arquivo `system-governance-canon.v2.md` com definição de exclusividade e regras de reuso entre contextos. 
- Define que artefatos são exclusivos ao contexto de origem e que só podem ser reutilizados mediante contrato canônico explícito. 
- Atualiza `docs/canonical/experiments-automation-flow-canon.v1.md` para referenciar a regra global em `system-governance-canon.v2.md` como critério de classificação de exclusividade de artefatos. 

### Testing

- Nenhum teste automatizado foi executado porque a mudança é apenas de documentação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cfe7872883218bed7214d0cbb2cc)