### PR TITLE
test: align FlowControllerTest with pure-HTML customFormHtml validation

### DIFF
--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
@@ -225,30 +225,30 @@ class FlowControllerTest {
 
 
     @Test
-    void getFlowConvertsLandingPagePayloadIntoHtmlDocument() throws Exception {
+    void upsertFlowRejectsJsonWrappedLandingPagePayload() throws Exception {
         UpsertFlowRequest request = buildRequest();
         request.setCustomFormHtml("{\"landingPageHtml\":{\"htmlDocument\":\"<html><body>Landing</body></html>\"}}");
 
         mockMvc.perform(put("/api/flows/landing-preview")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
-
-        mockMvc.perform(get("/api/flows/landing-preview"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.customFormHtml").value(containsString("<body>Landing</body>")))
-                .andExpect(jsonPath("$.customFormRenderMode").value("STANDALONE_PAGE"));
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString("customFormHtml deve ser HTML puro")));
     }
 
     @Test
     void getStandaloneFlowPageReturnsHtmlDocumentWithoutJsonFetch() throws Exception {
         UpsertFlowRequest request = buildRequest();
-        request.setCustomFormHtml("{\"landingPageHtml\":{\"htmlDocument\":\"<!doctype html><html><body>Landing direta</body></html>\"}}");
+        request.setCustomFormHtml("<!doctype html><html><body>Landing direta</body></html>");
 
         mockMvc.perform(put("/api/flows/landing-direta")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/flows/landing-direta"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.customFormRenderMode").value("STANDALONE_PAGE"));
 
         mockMvc.perform(get("/api/flows/landing-direta/page"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
### Motivation
- Alinhar os testes de integração do `FlowController` com o comportamento atual do backend, onde `CustomFormHtmlResolver` rejeita payloads JSON-encapsulados em `customFormHtml` e aceita apenas HTML puro.

### Description
- Atualizei `lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java` para esperar `400 Bad Request` quando `customFormHtml` conter wrapper JSON e para enviar HTML puro no teste de página standalone, além de adicionar a asserção de `customFormRenderMode = STANDALONE_PAGE` na recuperação do fluxo.

### Testing
- Executei `cd lead-portal/backend && mvn test -q` e a suíte de testes completou com sucesso (todos os testes passaram).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d97b90888321a87c2bb3895a8eda)