### PR TITLE
Accept raw HTML responses for LANDING_PAGE_HTML in AI worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -1,6 +1,7 @@
 package com.marketinghub.worker.experimentpipeline;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.OpenAiCostEstimator;
 import com.marketinghub.worker.openai.OpenAiResponse;
@@ -265,7 +266,7 @@ public class ExperimentPipelineOpenAiClient {
                 throw new IllegalStateException("Resposta da OpenAI sem conteúdo JSON");
             }
             log.info("OpenAI content for job {}: {}", job.id(), content);
-            Map<String, Object> parsed = objectMapper.readValue(content, new TypeReference<>() {});
+            Map<String, Object> parsed = parseResponseContent(content, job);
             ensureLandingHtmlHasStaticFormContract(parsed, job);
             enrichConsistencyChecks(parsed, job);
             String sectionContent = objectMapper.writeValueAsString(parsed);
@@ -284,6 +285,16 @@ public class ExperimentPipelineOpenAiClient {
         }
     }
 
+
+    private Map<String, Object> parseResponseContent(String content, ExperimentPipelineJobDto job) throws JsonProcessingException {
+        String trimmedContent = content != null ? content.trim() : "";
+        if (isSection(job, "landing-page-html", "landing-html") && trimmedContent.startsWith("<")) {
+            Map<String, Object> landingPageHtml = new LinkedHashMap<>();
+            landingPageHtml.put("htmlDocument", content);
+            return new LinkedHashMap<>(Map.of("landingPageHtml", landingPageHtml));
+        }
+        return objectMapper.readValue(content, new TypeReference<>() {});
+    }
 
     @SuppressWarnings("unchecked")
     private void ensureLandingHtmlHasStaticFormContract(Map<String, Object> parsed, ExperimentPipelineJobDto job) {

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -642,6 +642,55 @@ class ExperimentPipelineOpenAiClientTest {
     }
 
     @Test
+    void acceptsRawHtmlResponseForLandingPageHtmlSection() throws Exception {
+        String openAiText = """
+                <!doctype html>
+                <html lang="pt-BR">
+                <body>
+                  <form id="lead-capture-primary">
+                    <div class="field"><label>Nome</label><input type="text" name="nome" required /></div>
+                    <div class="field"><label>Objetivo principal</label><select name="objetivo"><option>A</option></select></div>
+                  </form>
+                </body>
+                </html>
+                """;
+
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(new AtomicReference<>(), openAiText)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        ExperimentPipelineJobDto job = new ExperimentPipelineJobDto(
+                UUID.randomUUID(),
+                21L,
+                "LANDING_PAGE_HTML",
+                "gpt-5.2",
+                "prompt",
+                """
+                        {
+                          "model": "gpt-5.2",
+                          "input": [
+                            {"role": "user", "content": "Prompt da landing html"}
+                          ]
+                        }
+                        """,
+                Instant.now());
+
+        ExperimentPipelineJobCompletionPayload payload = client.generate(job);
+        Map<String, Object> content = MAPPER.readValue(payload.responseContent(), new TypeReference<>() {});
+        @SuppressWarnings("unchecked")
+        Map<String, Object> landingPageHtml = (Map<String, Object>) content.get("landingPageHtml");
+        String htmlDocument = String.valueOf(landingPageHtml.get("htmlDocument")).toLowerCase();
+
+        assertThat(htmlDocument).contains("name=\"nome\"");
+        assertThat(htmlDocument).contains("name=\"email\"");
+        assertThat(htmlDocument).contains("name=\"whatsapp\"");
+        assertThat(htmlDocument).doesNotContain("name=\"objetivo\"");
+        assertThat(htmlDocument).contains("action=\"/api/flows/{slug}/submissions\"");
+    }
+
+    @Test
     void enforcesGpt52ModelForEveryPipelineCall() {
         AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
         ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(


### PR DESCRIPTION
### Motivation

- The backend started requesting `LANDING_PAGE_HTML` as plain text (pure HTML) but the worker assumed every OpenAI response was JSON, causing `Falha ao gerar seção LANDING_PAGE_HTML` when raw HTML was returned. 

### Description

- Add `parseResponseContent(String, ExperimentPipelineJobDto)` to detect raw HTML responses for `LANDING_PAGE_HTML` and wrap them into the expected `landingPageHtml.htmlDocument` payload shape. 
- Replace the direct `objectMapper.readValue(content, ...)` call with `parseResponseContent(...)` to preserve the existing JSON parsing path for other sections. 
- Import `JsonProcessingException` and keep downstream normalization (`ensureLandingHtmlHasStaticFormContract`) and consistency checks unchanged. 
- Add unit test `acceptsRawHtmlResponseForLandingPageHtmlSection` in `ExperimentPipelineOpenAiClientTest` that verifies raw-HTML handling for the landing-page section. 

### Testing

- Attempted to run `mvn -f ai-worker/pom.xml -Dtest=ExperimentPipelineOpenAiClientTest test`, but the build failed during dependency resolution because the private artifact `com.marketinghub:ads-service:0.0.1-SNAPSHOT` could not be fetched from GitHub Packages (HTTP 401), so unit tests did not run to completion. 
- Tried to fetch runtime logs via `curl` to validate the original error, but the observability endpoints returned `Connection refused` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ed998c448321b6abb9fbd3d7df48)