### PR TITLE
Add USER_STOPPED to experiment.status (MySQL 5.7) and update changelog/docs

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2037_04_22__ensure_experiment_status_user_stopped_mysql57.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/V2037_04_22__ensure_experiment_status_user_stopped_mysql57.yaml
@@ -1,0 +1,40 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2037-04-22-ensure-experiment-status-user-stopped-mysql57
+      author: assistant
+      preConditions:
+        onFail: MARK_RAN
+        dbms:
+          type: mysql
+        sqlCheck:
+          expectedResult: "1"
+          sql: |
+            SELECT CASE
+                     WHEN EXISTS (
+                       SELECT 1
+                       FROM information_schema.columns
+                       WHERE table_schema = DATABASE()
+                         AND table_name = 'experiment'
+                         AND column_name = 'status'
+                         AND data_type = 'enum'
+                         AND column_type NOT LIKE '%''USER_STOPPED''%'
+                     ) THEN 1
+                     ELSE 0
+                   END;
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment
+                MODIFY COLUMN status ENUM(
+                  'PLANNED',
+                  'RUNNING',
+                  'PAUSED',
+                  'VALIDATED',
+                  'INVALIDATED',
+                  'INCONCLUSIVE',
+                  'FINISHED',
+                  'FAILED',
+                  'USER_STOPPED'
+                ) NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -15,6 +15,9 @@ databaseChangeLog:
       file: changesets/2037-04-15-facebook-campaign-stop.yaml
       relativeToChangelogFile: true
   - include:
+      file: V2037_04_22__ensure_experiment_status_user_stopped_mysql57.yaml
+      relativeToChangelogFile: true
+  - include:
       file: V2037_04_09__lead_portal_flow_prompt_email_requirement.sql
       relativeToChangelogFile: true
   - include:

--- a/docs/modelo-dados.md
+++ b/docs/modelo-dados.md
@@ -1240,7 +1240,7 @@ visual_proof|proof_type|varchar(255)|YES|NULL||
   - `expense`: Campo usado para armazenar informações de **expense**. (tipo `decimal(10,2)`; opcional).
   - `total_cost`: Campo usado para armazenar informações de **total custo**. (tipo `decimal(12,2)`; opcional).
   - `lead_portal_flow_model`: Campo usado para armazenar informações de **lead portal flow model**. (tipo `varchar(191)`; opcional).
-  - `status`: Status atual do registro no fluxo de negócio. (tipo `enum('PLANNED','RUNNING','PAUSED','VALIDATED','INVALIDATED','INCONCLUSIVE','FINISHED','FAILED')`; opcional).
+  - `status`: Status atual do registro no fluxo de negócio. (tipo `enum('PLANNED','RUNNING','PAUSED','VALIDATED','INVALIDATED','INCONCLUSIVE','FINISHED','FAILED','USER_STOPPED')` ou `varchar(32)` em ambientes já migrados; opcional).
 
 ### `experiment_adset_job`
 - **Finalidade da tabela:** Armazena informações operacionais e analíticas associadas ao ciclo de experimentos.


### PR DESCRIPTION
### Motivation
- Ensure the `experiment.status` enum includes a `USER_STOPPED` state so experiments can be marked explicitly when stopped by users.
- Apply the change safely for MySQL 5.7 instances only and avoid altering already-migrated schemas.
- Keep the project changelog and documentation in sync with the schema change.

### Description
- Add a new Liquibase changeset `V2037_04_22__ensure_experiment_status_user_stopped_mysql57.yaml` that alters the `experiment.status` column to include `'USER_STOPPED'` for MySQL databases and only runs when the enum doesn't already contain that value via a `sqlCheck` precondition.
- Include the new changeset in `db/changelog/db.changelog-master.yaml` by adding an `include` entry for `V2037_04_22__ensure_experiment_status_user_stopped_mysql57.yaml`.
- Update `docs/modelo-dados.md` to document the added `'USER_STOPPED'` enum value and note that migrated environments may use a `varchar(32)` representation.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9031dcc1083219dec48cd0f1a3edc)