### PR TITLE
Normalize encoded-quote artifacts in landing HTML surface attributes and warn during validation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -2415,7 +2415,7 @@ public class ExperimentPipelineGenerationService {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "HTML da landing vazio");
         }
 
-        List<SectionSurfaceContract> actualSurfaces = extractSectionSurfacesFromHtmlDocument(htmlDocument);
+        List<SectionSurfaceContract> actualSurfaces = extractSectionSurfacesFromHtmlDocument(experiment.getId(), htmlDocument);
         List<SectionSurfaceContract> expectedSorted = expectedSurfaces.stream()
                 .sorted(Comparator.comparing(SectionSurfaceContract::sectionId))
                 .toList();
@@ -2462,19 +2462,34 @@ public class ExperimentPipelineGenerationService {
         return surfaces;
     }
 
-    private List<SectionSurfaceContract> extractSectionSurfacesFromHtmlDocument(String htmlDocument) {
+    private List<SectionSurfaceContract> extractSectionSurfacesFromHtmlDocument(Long experimentId, String htmlDocument) {
         Map<String, SectionSurfaceContract> contractsBySectionId = new LinkedHashMap<>();
         Matcher tagMatcher = OPENING_TAG_PATTERN.matcher(htmlDocument);
         while (tagMatcher.find()) {
             String tag = tagMatcher.group();
             Map<String, String> attrs = parseHtmlAttributes(tag);
-            String sectionId = normalizeHtmlAttr(attrs.get("data-section-id"));
+            String rawSectionId = attrs.get("data-section-id");
+            String rawSurfaceToken = attrs.get("data-surface-token");
+            String rawStyle = attrs.get("data-surface-style");
+            String rawContrastMode = attrs.get("data-surface-contrast");
+            if (containsEncodedQuoteArtifact(rawSectionId)
+                    || containsEncodedQuoteArtifact(rawSurfaceToken)
+                    || containsEncodedQuoteArtifact(rawStyle)
+                    || containsEncodedQuoteArtifact(rawContrastMode)) {
+                log.warn("Validação landing HTML (experimentId={}): detectado valor de superfície com aspas codificadas; normalizando atributos. sectionIdRaw={}, surfaceTokenRaw={}, styleRaw={}, contrastRaw={}",
+                        experimentId,
+                        rawSectionId,
+                        rawSurfaceToken,
+                        rawStyle,
+                        rawContrastMode);
+            }
+            String sectionId = normalizeHtmlAttr(rawSectionId);
             if (!StringUtils.hasText(sectionId)) {
                 continue;
             }
-            String surfaceToken = normalizeHtmlAttr(attrs.get("data-surface-token"));
-            String style = normalizeHtmlAttr(attrs.get("data-surface-style"));
-            String contrastMode = normalizeHtmlAttr(attrs.get("data-surface-contrast"));
+            String surfaceToken = normalizeHtmlAttr(rawSurfaceToken);
+            String style = normalizeHtmlAttr(rawStyle);
+            String contrastMode = normalizeHtmlAttr(rawContrastMode);
             if (!StringUtils.hasText(surfaceToken) || !StringUtils.hasText(style) || !StringUtils.hasText(contrastMode)) {
                 continue;
             }
@@ -2706,7 +2721,51 @@ public class ExperimentPipelineGenerationService {
     }
 
     private String normalizeHtmlAttr(String value) {
-        return StringUtils.hasText(value) ? value.trim().toLowerCase(Locale.ROOT) : "";
+        if (!StringUtils.hasText(value)) {
+            return "";
+        }
+        String normalized = value.trim();
+        normalized = decodeCommonHtmlEntities(normalized);
+        normalized = stripWrappingQuotes(normalized);
+        return normalized.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String decodeCommonHtmlEntities(String value) {
+        return value
+                .replace("&quot;", "\"")
+                .replace("&#34;", "\"")
+                .replace("&#x22;", "\"")
+                .replace("&#X22;", "\"")
+                .replace("&apos;", "'")
+                .replace("&#39;", "'")
+                .replace("&#x27;", "'")
+                .replace("&#X27;", "'")
+                .replace("&amp;", "&");
+    }
+
+    private String stripWrappingQuotes(String value) {
+        String current = value;
+        boolean changed = true;
+        while (changed && StringUtils.hasText(current)) {
+            changed = false;
+            String trimmed = current.trim();
+            if (trimmed.length() >= 2 && ((trimmed.startsWith("\"") && trimmed.endsWith("\""))
+                    || (trimmed.startsWith("'") && trimmed.endsWith("'")))) {
+                current = trimmed.substring(1, trimmed.length() - 1).trim();
+                changed = true;
+            }
+        }
+        return current;
+    }
+
+    private boolean containsEncodedQuoteArtifact(String value) {
+        if (!StringUtils.hasText(value)) {
+            return false;
+        }
+        String lower = value.toLowerCase(Locale.ROOT);
+        return lower.contains("&quot;")
+                || lower.contains("&#34;")
+                || lower.contains("&#x22;");
     }
 
     private record FormFieldContract(String name, String type, boolean required) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -621,6 +621,33 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void completeJobAcceptsHtmlWhenSurfaceAttributesContainEncodedQuotes() {
+        Experiment experiment = buildLandingHtmlValidationExperiment(207L);
+        ExperimentPipelineGenerationJob job = createLandingHtmlJob(experiment);
+
+        service.completeJob(job.getId(), landingHtmlCompletionRequest("""
+                <!doctype html><html><body>
+                <section data-section-id='&quot;hero&quot;'
+                         data-surface-token='&quot;surface-base&quot;'
+                         data-surface-style='&#34;band&#34;'
+                         data-surface-contrast='&#x22;normal&#x22;'>
+                  <img src='https://cdn.example.com/hero.jpg' alt='Hero'
+                       data-image-section-id='hero'
+                       data-image-binding-key='hero_pain_anchor'
+                       data-image-role='Hero Pain Anchor'
+                       data-conversion-role='grab-attention'
+                       data-attention-priority='high'
+                       data-visual-weight='primary'
+                       data-distance-to-cta='near'
+                       data-supports-form-conversion='true' />
+                  <form id='lead-capture-primary'><input type='text' name='nome' required /><input type='email' name='email' required /><input type='tel' name='whatsapp' /></form>
+                </section></body></html>
+                """));
+
+        assertNotNull(experiment.getLandingPageHtml());
+    }
+
+    @Test
     void completeJobSupportsLegacyFallbackWhenPlanningAndHtmlDoNotSendBindingKey() {
         Experiment experiment = buildLandingHtmlValidationExperiment(205L);
         experiment.setLandingPageImagePlanning("""

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -305,6 +305,7 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 > - a resposta do modelo para a etapa `landingPageHtml` deve ser **HTML puro** (documento final completo);
 > - é proibido retornar envelope JSON, markdown, bloco ``` ou campo textual contendo JSON serializado;
 > - o backend do Lead Portal **não** deve tentar “desempacotar” HTML de payload misto/JSON: entradas fora de HTML puro devem ser rejeitadas.
+> - para atributos canônicos de binding/superfície no HTML (`data-section-id`, `data-surface-token`, `data-surface-style`, `data-surface-contrast`), o backend normaliza artefatos de aspas codificadas (`&quot;`, `&#34;`, `&#x22;`) antes da validação estrita e registra warning operacional para correção no worker/prompt.
 
 ```json
 {


### PR DESCRIPTION
### Motivation
- Landing HTML surface attributes sometimes contained encoded quote entities which caused strict surfaceSpec validation to fail because attribute values did not match the wireframe canonical tokens.

### Description
- Normalize surface-related HTML attributes by decoding common HTML entities and stripping wrapping quotes in `normalizeHtmlAttr` and add helpers `decodeCommonHtmlEntities`, `stripWrappingQuotes` and `containsEncodedQuoteArtifact`.
- Detect encoded-quote artifacts during HTML parsing in `extractSectionSurfacesFromHtmlDocument(Long, String)`, log a warning including the `experimentId` when artifacts are present, and continue normalization so validation can succeed.
- Updated the call site to pass `experiment.getId()` into `extractSectionSurfacesFromHtmlDocument` and added documentation note to the canonical artifacts doc describing the normalization behavior.

### Testing
- Ran the unit test `ExperimentPipelineGenerationServiceTest`, which includes the new `completeJobAcceptsHtmlWhenSurfaceAttributesContainEncodedQuotes` test, and it passed.
- Executed the service test class locally as part of the project test suite and observed all tests in the suite passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90449916c8321bced2e6d8ca21602)