### PR TITLE
mcp-server: add missing public Java module log URLs

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -17,7 +17,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `db_list_tables`: lista todas as tabelas disponíveis no schema atual.
 - `db_read_table`: lê dados de uma tabela com paginação (`table`, `limit`, `offset`).
 - `db_query`: executa SQL de leitura (`SELECT`/`WITH`) com limite de linhas.
-- `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`).
+- `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`).
 
 ## Executar localmente
 
@@ -41,9 +41,11 @@ mvn -s settings.xml spring-boot:run
 O tool `java_module_logs` lê os arquivos de log do Spring Boot configurados em:
 
 - `MCP_LOG_BACKEND_PATH` (default `http://191.252.181.168:8000/ops-mh-observability-v2/backend-log-stream-x9k`);
-- `MCP_LOG_AI_WORKER_PATH` (default `/var/log/ai-worker/application.log`);
+- `MCP_LOG_AI_WORKER_PATH` (default `http://191.252.120.96:4567/worker-observability/logfile`);
 - `MCP_LOG_LEAD_PORTAL_PATH` (default `https://oportunidadebrasil.shop/api/ops-lp-observability-v2/logfile`);
-- `MCP_LOG_FACEBOOK_ADS_PATH` (default `/var/log/facebook-ads-worker/application.log`).
+- `MCP_LOG_FACEBOOK_ADS_PATH` (default `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`);
+- `MCP_LOG_EMAIL_SERVICE_PATH` (default `http://191.252.120.96:8086/ops-email-gateway-7xk9/email-service-audit-log`);
+- `MCP_LOG_LEAD_PORTAL_PAYMENT_PATH` (default `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`).
 
 Limite máximo por chamada: `MCP_LOG_MAX_LINES` (default `500`).
 

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -20,6 +20,8 @@ public record McpProperties(
             @NotBlank String aiWorkerPath,
             @NotBlank String leadPortalPath,
             @NotBlank String facebookAdsPath,
+            @NotBlank String emailServicePath,
+            @NotBlank String leadPortalPaymentPath,
             @Positive int maxLines
     ) {
     }

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -114,12 +114,13 @@ public class McpController {
                     ),
                     Map.of(
                             "name", "java_module_logs",
-                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads).",
+                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment).",
                             "inputSchema", Map.of(
                                     "type", "object",
                                     "properties", Map.of(
                                             "module", Map.of("type", "string",
-                                                    "enum", List.of("backend", "ai-worker", "lead-portal", "facebook-ads"),
+                                                    "enum", List.of("backend", "ai-worker", "lead-portal", "facebook-ads",
+                                                            "email-service", "lead-portal-payment"),
                                                     "description", "Módulo Java para consultar logs."),
                                             "lines", Map.of("type", "integer", "minimum", 1,
                                                     "maximum", moduleLogService.maxLines(),

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -132,6 +132,8 @@ public class ModuleLogService {
             case "ai-worker" -> properties.logs().aiWorkerPath();
             case "lead-portal" -> properties.logs().leadPortalPath();
             case "facebook-ads" -> properties.logs().facebookAdsPath();
+            case "email-service" -> properties.logs().emailServicePath();
+            case "lead-portal-payment" -> properties.logs().leadPortalPaymentPath();
             default -> throw new IllegalArgumentException("Unknown module: " + module);
         };
     }
@@ -143,8 +145,9 @@ public class ModuleLogService {
 
         String normalized = module.trim().toLowerCase();
         return switch (normalized) {
-            case "backend", "ai-worker", "lead-portal", "facebook-ads" -> normalized;
-            default -> throw new IllegalArgumentException("module must be one of: backend, ai-worker, lead-portal, facebook-ads");
+            case "backend", "ai-worker", "lead-portal", "facebook-ads", "email-service", "lead-portal-payment" -> normalized;
+            default -> throw new IllegalArgumentException(
+                    "module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment");
         };
     }
 

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -28,7 +28,9 @@ mcp:
   api-key: ${MCP_API_KEY:}
   logs:
     backend-path: ${MCP_LOG_BACKEND_PATH:http://191.252.181.168:8000/ops-mh-observability-v2/backend-log-stream-x9k}
-    ai-worker-path: ${MCP_LOG_AI_WORKER_PATH:/var/log/ai-worker/application.log}
+    ai-worker-path: ${MCP_LOG_AI_WORKER_PATH:http://191.252.120.96:4567/worker-observability/logfile}
     lead-portal-path: ${MCP_LOG_LEAD_PORTAL_PATH:https://oportunidadebrasil.shop/api/ops-lp-observability-v2/logfile}
-    facebook-ads-path: ${MCP_LOG_FACEBOOK_ADS_PATH:/var/log/facebook-ads-worker/application.log}
+    facebook-ads-path: ${MCP_LOG_FACEBOOK_ADS_PATH:http://191.252.120.96:8082/public/runtime-logs/tail?lines=300}
+    email-service-path: ${MCP_LOG_EMAIL_SERVICE_PATH:http://191.252.120.96:8086/ops-email-gateway-7xk9/email-service-audit-log}
+    lead-portal-payment-path: ${MCP_LOG_LEAD_PORTAL_PAYMENT_PATH:http://191.252.102.54:8092/api/v1/logs/runtime?lines=200}
     max-lines: ${MCP_LOG_MAX_LINES:500}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -42,6 +42,9 @@ class McpControllerTest {
         registry.add("mcp.logs.ai-worker-path", () -> TEST_LOG_DIR.resolve("ai-worker.log").toString());
         registry.add("mcp.logs.lead-portal-path", () -> TEST_LOG_DIR.resolve("lead-portal.log").toString());
         registry.add("mcp.logs.facebook-ads-path", () -> TEST_LOG_DIR.resolve("facebook-ads.log").toString());
+        registry.add("mcp.logs.email-service-path", () -> TEST_LOG_DIR.resolve("email-service.log").toString());
+        registry.add("mcp.logs.lead-portal-payment-path",
+                () -> TEST_LOG_DIR.resolve("lead-portal-payment.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
     }
 
@@ -172,7 +175,8 @@ class McpControllerTest {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.error.code").value(-32602))
-                .andExpect(jsonPath("$.error.message").value("module must be one of: backend, ai-worker, lead-portal, facebook-ads"));
+                .andExpect(jsonPath("$.error.message")
+                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment"));
     }
 
     @Test
@@ -208,6 +212,9 @@ class McpControllerApiKeyEnabledTest {
         registry.add("mcp.logs.ai-worker-path", () -> TEST_LOG_DIR.resolve("ai-worker.log").toString());
         registry.add("mcp.logs.lead-portal-path", () -> TEST_LOG_DIR.resolve("lead-portal.log").toString());
         registry.add("mcp.logs.facebook-ads-path", () -> TEST_LOG_DIR.resolve("facebook-ads.log").toString());
+        registry.add("mcp.logs.email-service-path", () -> TEST_LOG_DIR.resolve("email-service.log").toString());
+        registry.add("mcp.logs.lead-portal-payment-path",
+                () -> TEST_LOG_DIR.resolve("lead-portal-payment.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
     }
 


### PR DESCRIPTION
### Motivation
- Alinhar o MCP com as URLs públicas de logs usadas em operação, expondo todos os módulos Java observáveis (incluindo serviços que faltavam).
- Permitir que o tool `java_module_logs` leia logs de `email-service` e `lead-portal-payment` além dos módulos já suportados.

### Description
- Adicionadas novas propriedades de logs ao binding tipado `McpProperties.Logs`: `emailServicePath` e `leadPortalPaymentPath`.
- Atualizados defaults em `mcp-server/src/main/resources/application.yml` para usar URLs públicas para `ai-worker` e `facebook-ads` e incluir `email-service` e `lead-portal-payment` padrões.
- Estendida a lógica em `ModuleLogService` para resolver paths e em `McpController` para expor os novos módulos no schema do tool `java_module_logs` (`enum` e descrição atualizada).
- Atualizados `README.md` e testes (`McpControllerTest`) para cobrir as novas propriedades e a mensagem de validação de módulos aceitos.

### Testing
- Executado `curl -sS https://mcpserverdigi.shop/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'` e o `tools/list` passou mostrando os módulos atualizados.
- Executado `mvn -q test` dentro de `mcp-server/` e todos os testes unitários relacionados passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9131336ac8321ad9be6efe39d16e1)