### PR TITLE
Sprint 1 MOIS: fundação do backend e stubs de API

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisArtifactDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisArtifactDtos.java
@@ -1,0 +1,24 @@
+package com.marketinghub.mois.dto;
+
+import java.time.Instant;
+import java.util.Map;
+
+public final class MoisArtifactDtos {
+
+    private MoisArtifactDtos() {
+    }
+
+    public record ArtifactEnvelopeResponse(
+            String artifactId,
+            String artifactType,
+            String schemaVersion,
+            String status,
+            String module,
+            Instant createdAt,
+            Instant updatedAt,
+            Map<String, Object> lineage,
+            Map<String, Object> metadata,
+            Map<String, Object> content
+    ) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisDiscoveryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisDiscoveryDtos.java
@@ -1,0 +1,58 @@
+package com.marketinghub.mois.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public final class MoisDiscoveryDtos {
+
+    private MoisDiscoveryDtos() {
+    }
+
+    public record CreateDiscoveryRequest(
+            @NotBlank String nicheName,
+            @NotBlank String marketTheme,
+            String painOrOutcomeFocus,
+            List<String> seedQueries,
+            List<String> seedUrls,
+            List<String> channels,
+            String country,
+            String language,
+            Map<String, Object> discoveryPolicy
+    ) {
+    }
+
+    public record DiscoveryRequestAcceptedResponse(String requestId, String status) {
+    }
+
+    public record DiscoveryRequestSummaryResponse(
+            String requestId,
+            String nicheName,
+            String marketTheme,
+            String painOrOutcomeFocus,
+            String status,
+            Instant createdAt
+    ) {
+    }
+
+    public record ArtifactRefResponse(String artifactId, String artifactType, String schemaVersion) {
+    }
+
+    public record DiscoveryRequestDetailResponse(
+            String requestId,
+            String nicheName,
+            String marketTheme,
+            String painOrOutcomeFocus,
+            String status,
+            Instant createdAt,
+            List<ArtifactRefResponse> artifacts
+    ) {
+    }
+
+    public record DiscoveryRequestListResponse(List<DiscoveryRequestSummaryResponse> items) {
+    }
+
+    public record AsyncAcceptedResponse(String status, String correlationId) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisInsightDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisInsightDtos.java
@@ -1,0 +1,39 @@
+package com.marketinghub.mois.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class MoisInsightDtos {
+
+    private MoisInsightDtos() {
+    }
+
+    public record InsightReportSummaryResponse(
+            String reportId,
+            String requestId,
+            String nicheName,
+            String marketTheme,
+            String status,
+            Instant createdAt
+    ) {
+    }
+
+    public record InsightReportResponse(
+            String reportId,
+            String requestId,
+            String nicheName,
+            String marketTheme,
+            String status,
+            Instant createdAt,
+            List<String> repeatedPromises,
+            List<String> repeatedProofPatterns,
+            List<String> pricingPatterns,
+            List<String> funnelPatterns,
+            List<String> gapOpportunities,
+            List<String> recommendedNextActions
+    ) {
+    }
+
+    public record InsightReportListResponse(List<InsightReportSummaryResponse> items) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisOfferDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisOfferDtos.java
@@ -1,0 +1,44 @@
+package com.marketinghub.mois.dto;
+
+import java.util.List;
+
+public final class MoisOfferDtos {
+
+    private MoisOfferDtos() {
+    }
+
+    public record OfferCardSummaryResponse(
+            String offerId,
+            String requestId,
+            String nicheName,
+            String offerName,
+            String sellerOrBrand,
+            String corePromise,
+            String primaryOfferType,
+            String mainPrice,
+            Double confidence
+    ) {
+    }
+
+    public record OfferCardResponse(
+            String offerId,
+            String requestId,
+            String nicheName,
+            String offerName,
+            String sellerOrBrand,
+            String corePromise,
+            String primaryOfferType,
+            String mainPrice,
+            Double confidence,
+            List<String> deliverables,
+            List<String> pricePoints,
+            String proofSummary,
+            String mechanismClaimSummary,
+            String funnelPatternSummary,
+            List<MoisDiscoveryDtos.ArtifactRefResponse> sourceArtifacts
+    ) {
+    }
+
+    public record OfferCardListResponse(List<OfferCardSummaryResponse> items) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisApiStubService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisApiStubService.java
@@ -1,0 +1,167 @@
+package com.marketinghub.mois.service;
+
+import com.marketinghub.mois.dto.MoisArtifactDtos;
+import com.marketinghub.mois.dto.MoisDiscoveryDtos;
+import com.marketinghub.mois.dto.MoisInsightDtos;
+import com.marketinghub.mois.dto.MoisOfferDtos;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MoisApiStubService {
+
+    private static final MoisDiscoveryDtos.ArtifactRefResponse SAMPLE_ARTIFACT_REF =
+            new MoisDiscoveryDtos.ArtifactRefResponse(
+                    "mois-art-001",
+                    "mois.marketOfferDiscoveryRequest.v1",
+                    "v1"
+            );
+
+    public MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse createDiscoveryRequest(
+            MoisDiscoveryDtos.CreateDiscoveryRequest request
+    ) {
+        return new MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse(
+                UUID.randomUUID().toString(),
+                "ACCEPTED"
+        );
+    }
+
+    public MoisDiscoveryDtos.DiscoveryRequestListResponse listDiscoveryRequests(
+            String status,
+            String nicheName,
+            String marketTheme
+    ) {
+        return new MoisDiscoveryDtos.DiscoveryRequestListResponse(List.of(sampleDiscoverySummary()));
+    }
+
+    public Optional<MoisDiscoveryDtos.DiscoveryRequestDetailResponse> getDiscoveryRequest(String requestId) {
+        if (!"mois-req-001".equals(requestId)) {
+            return Optional.empty();
+        }
+        return Optional.of(new MoisDiscoveryDtos.DiscoveryRequestDetailResponse(
+                "mois-req-001",
+                "personal trainer",
+                "retencao de alunos",
+                "agenda previsivel sem desconto",
+                "DRAFT",
+                Instant.parse("2026-04-22T00:00:00Z"),
+                List.of(SAMPLE_ARTIFACT_REF)
+        ));
+    }
+
+    public MoisDiscoveryDtos.AsyncAcceptedResponse runDiscoveryRequest(String requestId) {
+        return new MoisDiscoveryDtos.AsyncAcceptedResponse("ACCEPTED", "mois-run-" + requestId);
+    }
+
+    public MoisOfferDtos.OfferCardListResponse listOffers(String requestId, String nicheName, String sellerOrBrand) {
+        return new MoisOfferDtos.OfferCardListResponse(List.of(sampleOfferSummary()));
+    }
+
+    public Optional<MoisOfferDtos.OfferCardResponse> getOffer(String offerId) {
+        if (!"mois-offer-001".equals(offerId)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new MoisOfferDtos.OfferCardResponse(
+                "mois-offer-001",
+                "mois-req-001",
+                "personal trainer",
+                "Agenda Cheia Sem Desconto",
+                "Studio Exemplo",
+                "Agenda previsivel com onboarding estruturado",
+                "mentoria",
+                "R$ 1.497",
+                0.79,
+                List.of("diagnostico inicial", "check-ins semanais"),
+                List.of("R$ 1.497 a vista", "12x R$ 149"),
+                "Provas com depoimentos e antes/depois",
+                "Mecanismo alegado de ciclo guiado de 8 semanas",
+                "Captura por landing + WhatsApp",
+                List.of(SAMPLE_ARTIFACT_REF)
+        ));
+    }
+
+    public MoisInsightDtos.InsightReportListResponse listInsightReports(String requestId, String nicheName) {
+        return new MoisInsightDtos.InsightReportListResponse(List.of(sampleInsightSummary()));
+    }
+
+    public Optional<MoisInsightDtos.InsightReportResponse> getInsightReport(String reportId) {
+        if (!"mois-report-001".equals(reportId)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new MoisInsightDtos.InsightReportResponse(
+                "mois-report-001",
+                "mois-req-001",
+                "personal trainer",
+                "retencao de alunos",
+                "DRAFT",
+                Instant.parse("2026-04-22T00:10:00Z"),
+                List.of("resultado em 8 semanas"),
+                List.of("depoimentos com antes/depois"),
+                List.of("ticket medio entre R$ 1.200 e R$ 1.800"),
+                List.of("lead capture via landing e follow-up no WhatsApp"),
+                List.of("lacuna de oferta para onboarding de primeira semana"),
+                List.of("validar diferencial de onboarding no proximo experimento")
+        ));
+    }
+
+    public Optional<MoisArtifactDtos.ArtifactEnvelopeResponse> getArtifact(String artifactId) {
+        if (!"mois-art-001".equals(artifactId)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new MoisArtifactDtos.ArtifactEnvelopeResponse(
+                "mois-art-001",
+                "mois.marketOfferDiscoveryRequest.v1",
+                "v1",
+                "DRAFT",
+                "MOIS",
+                Instant.parse("2026-04-22T00:00:00Z"),
+                Instant.parse("2026-04-22T00:00:00Z"),
+                Map.of("requestId", "mois-req-001"),
+                Map.of("source", "stub"),
+                Map.of("nicheName", "personal trainer", "marketTheme", "retencao de alunos")
+        ));
+    }
+
+    private MoisDiscoveryDtos.DiscoveryRequestSummaryResponse sampleDiscoverySummary() {
+        return new MoisDiscoveryDtos.DiscoveryRequestSummaryResponse(
+                "mois-req-001",
+                "personal trainer",
+                "retencao de alunos",
+                "agenda previsivel sem desconto",
+                "DRAFT",
+                Instant.parse("2026-04-22T00:00:00Z")
+        );
+    }
+
+    private MoisOfferDtos.OfferCardSummaryResponse sampleOfferSummary() {
+        return new MoisOfferDtos.OfferCardSummaryResponse(
+                "mois-offer-001",
+                "mois-req-001",
+                "personal trainer",
+                "Agenda Cheia Sem Desconto",
+                "Studio Exemplo",
+                "Agenda previsivel com onboarding estruturado",
+                "mentoria",
+                "R$ 1.497",
+                0.79
+        );
+    }
+
+    private MoisInsightDtos.InsightReportSummaryResponse sampleInsightSummary() {
+        return new MoisInsightDtos.InsightReportSummaryResponse(
+                "mois-report-001",
+                "mois-req-001",
+                "personal trainer",
+                "retencao de alunos",
+                "DRAFT",
+                Instant.parse("2026-04-22T00:10:00Z")
+        );
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
@@ -1,0 +1,97 @@
+package com.marketinghub.mois.web;
+
+import com.marketinghub.mois.dto.MoisArtifactDtos;
+import com.marketinghub.mois.dto.MoisDiscoveryDtos;
+import com.marketinghub.mois.dto.MoisInsightDtos;
+import com.marketinghub.mois.dto.MoisOfferDtos;
+import com.marketinghub.mois.service.MoisApiStubService;
+import jakarta.validation.Valid;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/v1/mois")
+@RequiredArgsConstructor
+public class MoisController {
+
+    private final MoisApiStubService service;
+
+    @PostMapping("/discovery-requests")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse createDiscoveryRequest(
+            @Valid @RequestBody MoisDiscoveryDtos.CreateDiscoveryRequest request
+    ) {
+        return service.createDiscoveryRequest(request);
+    }
+
+    @GetMapping("/discovery-requests")
+    public MoisDiscoveryDtos.DiscoveryRequestListResponse listDiscoveryRequests(
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String nicheName,
+            @RequestParam(required = false) String marketTheme
+    ) {
+        return service.listDiscoveryRequests(status, nicheName, marketTheme);
+    }
+
+    @GetMapping("/discovery-requests/{requestId}")
+    public MoisDiscoveryDtos.DiscoveryRequestDetailResponse getDiscoveryRequest(@PathVariable String requestId) {
+        return service.getDiscoveryRequest(requestId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "discovery request not found"));
+    }
+
+    @PostMapping("/discovery-requests/{requestId}/run")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public MoisDiscoveryDtos.AsyncAcceptedResponse runDiscoveryRequest(@PathVariable String requestId) {
+        return service.runDiscoveryRequest(requestId);
+    }
+
+    @GetMapping("/offers")
+    public MoisOfferDtos.OfferCardListResponse listOffers(
+            @RequestParam(required = false) String requestId,
+            @RequestParam(required = false) String nicheName,
+            @RequestParam(required = false) String sellerOrBrand
+    ) {
+        return service.listOffers(requestId, nicheName, sellerOrBrand);
+    }
+
+    @GetMapping("/offers/{offerId}")
+    public MoisOfferDtos.OfferCardResponse getOffer(@PathVariable String offerId) {
+        return service.getOffer(offerId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "offer not found"));
+    }
+
+    @GetMapping("/insight-reports")
+    public MoisInsightDtos.InsightReportListResponse listInsightReports(
+            @RequestParam(required = false) String requestId,
+            @RequestParam(required = false) String nicheName
+    ) {
+        return service.listInsightReports(requestId, nicheName);
+    }
+
+    @GetMapping("/insight-reports/{reportId}")
+    public MoisInsightDtos.InsightReportResponse getInsightReport(@PathVariable String reportId) {
+        return service.getInsightReport(reportId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "insight report not found"));
+    }
+
+    @GetMapping("/artifacts/{artifactId}")
+    public MoisArtifactDtos.ArtifactEnvelopeResponse getArtifact(@PathVariable String artifactId) {
+        return service.getArtifact(artifactId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "artifact not found"));
+    }
+
+    @GetMapping("/health")
+    public Map<String, String> health() {
+        return Map.of("status", "ok", "module", "mois-backend-stub");
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
@@ -1,0 +1,113 @@
+package com.marketinghub.mois.web;
+
+import com.marketinghub.mois.dto.MoisDiscoveryDtos;
+import com.marketinghub.mois.dto.MoisOfferDtos;
+import com.marketinghub.mois.service.MoisApiStubService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MoisController.class)
+class MoisControllerContractTest {
+
+    @SpringBootApplication
+    static class TestConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MoisApiStubService service;
+
+    @Test
+    void shouldAcceptDiscoveryRequest() throws Exception {
+        when(service.createDiscoveryRequest(any(MoisDiscoveryDtos.CreateDiscoveryRequest.class)))
+                .thenReturn(new MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse("mois-req-123", "ACCEPTED"));
+
+        mockMvc.perform(post("/api/v1/mois/discovery-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "nicheName": "personal trainer",
+                                  "marketTheme": "retencao de alunos"
+                                }
+                                """))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.requestId").value("mois-req-123"))
+                .andExpect(jsonPath("$.status").value("ACCEPTED"));
+    }
+
+    @Test
+    void shouldReturnValidationErrorWhenRequiredFieldsMissing() throws Exception {
+        mockMvc.perform(post("/api/v1/mois/discovery-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnDiscoveryRequestDetail() throws Exception {
+        when(service.getDiscoveryRequest(eq("mois-req-001")))
+                .thenReturn(Optional.of(new MoisDiscoveryDtos.DiscoveryRequestDetailResponse(
+                        "mois-req-001",
+                        "personal trainer",
+                        "retencao de alunos",
+                        "agenda previsivel sem desconto",
+                        "DRAFT",
+                        Instant.parse("2026-04-22T00:00:00Z"),
+                        List.of(new MoisDiscoveryDtos.ArtifactRefResponse("mois-art-001", "mois.marketOfferDiscoveryRequest.v1", "v1"))
+                )));
+
+        mockMvc.perform(get("/api/v1/mois/discovery-requests/mois-req-001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value("mois-req-001"))
+                .andExpect(jsonPath("$.artifacts[0].artifactId").value("mois-art-001"));
+    }
+
+    @Test
+    void shouldReturn404WhenOfferDoesNotExist() throws Exception {
+        when(service.getOffer(eq("unknown-offer"))).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/mois/offers/unknown-offer"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturnOfferListContract() throws Exception {
+        when(service.listOffers(any(), any(), any()))
+                .thenReturn(new MoisOfferDtos.OfferCardListResponse(List.of(
+                        new MoisOfferDtos.OfferCardSummaryResponse(
+                                "mois-offer-001",
+                                "mois-req-001",
+                                "personal trainer",
+                                "Agenda Cheia Sem Desconto",
+                                "Studio Exemplo",
+                                "Agenda previsivel com onboarding estruturado",
+                                "mentoria",
+                                "R$ 1.497",
+                                0.79
+                        )
+                )));
+
+        mockMvc.perform(get("/api/v1/mois/offers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].offerId").value("mois-offer-001"))
+                .andExpect(jsonPath("$.items[0].confidence").value(0.79));
+    }
+}

--- a/docs/novos-modulos/MOIS/ini.md
+++ b/docs/novos-modulos/MOIS/ini.md
@@ -34,6 +34,11 @@ Ele não substitui o OPRM nem o MDS:
    - contrato-base para o backend e consumidores internos
    - serve como ponto de partida para implementação pelo Codex
 
+5. `mois_backend_sprint1_execucao.md`
+   - nota técnica da execução da Sprint 1 no backend
+   - lista endpoints stub e decisões de escopo
+   - registra pendências que devem seguir para a Sprint 2
+
 ## Direção arquitetural resumida
 
 - O **backend/domínio** continua sendo a fonte de verdade das regras e contratos.

--- a/docs/novos-modulos/MOIS/mois_backend_sprint1_execucao.md
+++ b/docs/novos-modulos/MOIS/mois_backend_sprint1_execucao.md
@@ -1,0 +1,49 @@
+# MOIS — Backend Sprint 1 (fundação)
+
+## Objetivo
+
+Registrar a implementação técnica mínima da Sprint 1 do MOIS no `backend/ads-service`, mantendo o módulo em formato de stub contratual e sem antecipar persistência de banco ou enriquecimentos de sprints posteriores.
+
+## Escopo implementado
+
+- criação do pacote backend `com.marketinghub.mois` com separação em `dto`, `service` e `web`;
+- criação do controller REST base `MoisController` com endpoints de contrato inicial;
+- criação de DTOs iniciais de request/response alinhados ao `openapi_mois_backend_stub.yaml`;
+- criação de serviço stub (`MoisApiStubService`) para respostas controladas e previsíveis;
+- criação de testes de contrato web (`MoisControllerContractTest`) para validações essenciais de Sprint 1.
+
+## Endpoints stub implementados
+
+Base path: `/api/v1/mois`
+
+- `POST /discovery-requests`
+- `GET /discovery-requests`
+- `GET /discovery-requests/{requestId}`
+- `POST /discovery-requests/{requestId}/run`
+- `GET /offers`
+- `GET /offers/{offerId}`
+- `GET /insight-reports`
+- `GET /insight-reports/{reportId}`
+- `GET /artifacts/{artifactId}`
+- `GET /health`
+
+## Decisões importantes
+
+1. **Sem banco na Sprint 1**
+   - não foram criadas tabelas, entidades JPA ou migrations;
+   - a camada retorna dados stub para validar contratos e bootstrap.
+
+2. **Contrato-first**
+   - os DTOs seguem a nomenclatura e estrutura do OpenAPI inicial do MOIS;
+   - os códigos HTTP principais (202, 200, 404, 400) já estão modelados.
+
+3. **Compatibilidade incremental**
+   - o módulo foi adicionado sem alterar endpoints existentes de outros domínios;
+   - o caminho `/api/v1/mois` evita colisões com módulos legados.
+
+## Pendências intencionais para Sprint 2
+
+- persistência inicial (`marketOfferDiscoveryRequest`, snapshots e cards);
+- lineage persistido e consultável;
+- migrations Liquibase MySQL 5.7;
+- integração com infraestrutura reaproveitável de pesquisa/snapshot.

--- a/docs/novos-modulos/MOIS/mois_plano_implementacao_sprints.md
+++ b/docs/novos-modulos/MOIS/mois_plano_implementacao_sprints.md
@@ -136,49 +136,52 @@ A sprint termina quando o módulo existir de forma clara no repositório, conseg
 ### Fechamento da Sprint pelo Codex
 
 **Status da sprint:**
-- [ ] Concluída integralmente
+- [x] Concluída integralmente
 - [ ] Concluída parcialmente
 - [ ] Não concluída
 
 **O que foi implementado nesta sprint:**
-- 
-- 
-- 
+- Estrutura inicial do módulo MOIS no backend (`com.marketinghub.mois`) com separação em `dto`, `service` e `web`.
+- Stub de endpoints REST do MOIS implementado em `/api/v1/mois` com contratos iniciais de discovery, offers, reports e artifacts.
+- DTOs de request/response alinhados ao OpenAPI stub e teste de contrato web cobrindo cenários principais (aceite, validação e 404).
 
 **Arquivos criados ou alterados:**
-- 
-- 
-- 
+- `backend/ads-service/src/main/java/com/marketinghub/mois/dto/*`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisApiStubService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java`
+- `docs/novos-modulos/MOIS/mois_backend_sprint1_execucao.md`
+- `docs/novos-modulos/MOIS/ini.md`
 
 **Contratos, endpoints ou artefatos afetados:**
-- 
-- 
-- 
+- Contrato HTTP inicial do módulo MOIS conforme `openapi_mois_backend_stub.yaml`.
+- Endpoints de stub disponibilizados em `/api/v1/mois/*` para discovery, offers, insight-reports e artifacts.
+- Artefatos canônicos ainda em modo representacional (stub), sem persistência de banco nesta sprint.
 
 **Testes executados:**
-- 
-- 
-- 
+- `mvn -Dtest=MoisControllerContractTest test` (backend/ads-service) cobrindo contrato mínimo do controller MOIS.
+- Validação de build limitada ao escopo do módulo MOIS (não foi executada suíte completa do backend nesta sprint).
+- Sem testes de persistência, pois banco/migrations são escopo da Sprint 2.
 
 **Pendências que ficaram abertas:**
-- 
-- 
-- 
+- Persistência real de `marketOfferDiscoveryRequest`, snapshots e `marketOfferCard`.
+- Lineage mínimo persistido entre request, snapshot e artefatos derivados.
+- Migrations Liquibase e entidades/repositórios JPA do domínio MOIS.
 
 **Motivo das pendências:**
-- 
-- 
-- 
+- Esses itens pertencem explicitamente ao escopo da Sprint 2 no plano.
+- Sprint 1 tem foco em fundação, contrato e bootstrap do módulo.
+- Evitou-se antecipar decisões de dados para manter incrementalidade e baixo risco.
 
 **Impacto das pendências no sistema:**
-- 
-- 
-- 
+- Módulo disponível apenas como stub contratual, sem estado persistido.
+- Ainda não há histórico consultável real de execuções/discovery.
+- Integrações posteriores dependem da Sprint 2 para dados confiáveis em banco.
 
 **Orientação obrigatória para a sprint seguinte:**
-- 
-- 
-- 
+- Implementar persistência mínima de request/snapshot/card com IDs, status e timestamps.
+- Criar lineage mínimo consultável e validar contrato de leitura com dados reais.
+- Adicionar migrations Liquibase MySQL 5.7 e testes de serviço/repositório do MOIS.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Implementar a Sprint 1 do plano MOIS criando a fundação do módulo no backend e garantindo contratos HTTP iniciais alinhados ao `openapi_mois_backend_stub.yaml`.
- Fornecer um bootstrap seguro e sem persistência para validar o contrato entre consumidores e o backend antes de avançar para migrations e entidades.
- Preservar compatibilidade com o ecossistema existente do Marketing Hub evitando alterações no banco de dados nesta sprint.

### Description
- Adiciona o pacote `com.marketinghub.mois` com subpacotes `dto`, `service` e `web` e DTOs iniciais em `backend/ads-service/src/main/java/com/marketinghub/mois/dto/*` para os artefatos do MOIS.
- Implementa o serviço stub `MoisApiStubService` que fornece respostas controladas e amostras representacionais para discovery, offers, insight reports e artifacts.
- Expõe o controller REST `MoisController` sob o caminho base `/api/v1/mois` com endpoints de sprint 1: `POST/GET /discovery-requests`, `POST /discovery-requests/{requestId}/run`, `GET /offers`, `GET /offers/{offerId}`, `GET /insight-reports`, `GET /insight-reports/{reportId}`, `GET /artifacts/{artifactId}` e `GET /health`.
- Adiciona testes de contrato web `MoisControllerContractTest` e documentação de execução/fechamento da Sprint 1 em `docs/novos-modulos/MOIS/mois_backend_sprint1_execucao.md`, além de atualizar `ini.md` e o plano de sprints com o fechamento desta sprint.

### Testing
- Executado `cd backend/ads-service && mvn -Dtest=MoisControllerContractTest test`, que passou com sucesso (5 testes, 0 falhas).
- A validação de payload obrigatório e casos de 202/400/404 foram cobertos pelos testes de contrato (`MockMvc`).
- A suíte completa do backend (`mvn test`) não foi executada nesta entrega, e migrations/integração com banco ficam para a Sprint 2.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9193c673083218f6ee75193974a6d)