### PR TITLE
Improve logging for ResponseStatusException and rejected model outputs in experiment pipeline

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -370,7 +370,19 @@ public class ExperimentPipelineGenerationService {
                 experiment != null ? experiment.getId() : null,
                 job.getSection(),
                 summarizePayloadKeys(request.responseContent()));
-        applySectionContent(experiment, job.getSection(), request.responseContent());
+        try {
+            applySectionContent(experiment, job.getSection(), request.responseContent());
+        } catch (ResponseStatusException ex) {
+            log.warn("Rejeição de output do modelo no completeJob (jobId={}, experimentId={}, section={}, status={}, reason={}, responseKeys={}, rejectedModelOutput={})",
+                    job.getId(),
+                    experiment != null ? experiment.getId() : null,
+                    job.getSection(),
+                    ex.getStatusCode().value(),
+                    ex.getReason(),
+                    summarizePayloadKeys(request.responseContent()),
+                    summarizeRejectedModelOutput(request.responseContent(), request.rawResponse()));
+            throw ex;
+        }
         if (job.getSection() == ExperimentPipelineSection.AD_COPY
                 || job.getSection() == ExperimentPipelineSection.AD_IMAGE_BRIEFING) {
             generationService.deleteByDomainAndReferenceId(
@@ -1388,6 +1400,15 @@ public class ExperimentPipelineGenerationService {
         } catch (Exception ignored) {
             return "[unparseable]";
         }
+    }
+
+    private String summarizeRejectedModelOutput(String responseContent, String rawResponse) {
+        String candidate = StringUtils.hasText(responseContent) ? responseContent : rawResponse;
+        if (!StringUtils.hasText(candidate)) {
+            return "[empty]";
+        }
+        String compact = candidate.replaceAll("\\s+", " ").trim();
+        return compact.length() > 4000 ? compact.substring(0, 4000) + "...(truncated)" : compact;
     }
 
     private String summarizeFormFields(List<FormFieldContract> fields) {

--- a/backend/ads-service/src/main/java/com/marketinghub/web/ApiExceptionHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/web/ApiExceptionHandler.java
@@ -36,6 +36,14 @@ public class ApiExceptionHandler {
         ResponseStatusException exception,
         HttpServletRequest request
     ) {
+        LOGGER.warn(
+            "ResponseStatusException tratado. status={}, method={}, uri={}, query={}, reason={}",
+            exception.getStatusCode().value(),
+            request.getMethod(),
+            request.getRequestURI(),
+            request.getQueryString(),
+            exception.getReason()
+        );
         return buildResponse(exception.getStatusCode(), exception.getReason(), request, null);
     }
 


### PR DESCRIPTION
### Motivation

- Provide richer diagnostics when model output is rejected during pipeline job completion to aid debugging of failed `applySectionContent` calls.  
- Preserve a compact snippet of large model responses in logs to avoid truncation surprises while keeping logs manageable.  
- Surface request context when `ResponseStatusException` is thrown to help correlate errors with incoming HTTP requests.

### Description

- Wrap `applySectionContent` in `completeJob` with a `try/catch` for `ResponseStatusException` and log a warning that includes job id, experiment id, section, status, reason, payload keys, and a truncated view of the rejected model output before rethrowing the exception.  
- Add `summarizeRejectedModelOutput` helper to compact whitespace and truncate long responses (with a 4000 character limit) for safer logging.  
- Add a `LOGGER.warn` in `ApiExceptionHandler.handleResponseStatusException` to include the HTTP method, request URI, query string, status, and reason when a `ResponseStatusException` is handled.

### Testing

- Ran backend unit tests for the ads-service module with `./mvnw -pl backend/ads-service test`, and all tests passed.  
- Verified the project compiles and the modified classes load without errors during basic startup validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e918abff348321b891edee50f6a99d)