### PR TITLE
Normalize escaped HTML attribute artifacts and accept escaped quotes/newline tokens

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -2746,9 +2746,28 @@ public class ExperimentPipelineGenerationService {
             return "";
         }
         String normalized = value.trim();
+        normalized = normalizeEscapedAttributeArtifacts(normalized);
         normalized = decodeCommonHtmlEntities(normalized);
+        normalized = normalizeEscapedAttributeArtifacts(normalized);
         normalized = stripWrappingQuotes(normalized);
         return normalized.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizeEscapedAttributeArtifacts(String value) {
+        return value
+                .replace("\\n", " ")
+                .replace("\\r", " ")
+                .replace("\\t", " ")
+                .replace("\\&quot;", "&quot;")
+                .replace("\\&#34;", "&#34;")
+                .replace("\\&#x22;", "&#x22;")
+                .replace("\\&#X22;", "&#X22;")
+                .replace("\\&apos;", "&apos;")
+                .replace("\\&#39;", "&#39;")
+                .replace("\\&#x27;", "&#x27;")
+                .replace("\\&#X27;", "&#X27;")
+                .replace("\\\"", "\"")
+                .replace("\\'", "'");
     }
 
     private String decodeCommonHtmlEntities(String value) {
@@ -2785,8 +2804,12 @@ public class ExperimentPipelineGenerationService {
         }
         String lower = value.toLowerCase(Locale.ROOT);
         return lower.contains("&quot;")
+                || lower.contains("\\&quot;")
                 || lower.contains("&#34;")
-                || lower.contains("&#x22;");
+                || lower.contains("\\&#34;")
+                || lower.contains("&#x22;")
+                || lower.contains("\\&#x22;")
+                || lower.contains("\\\"");
     }
 
     private record FormFieldContract(String name, String type, boolean required) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -648,6 +648,33 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void completeJobAcceptsHtmlWhenSurfaceAttributesContainEscapedEncodedQuotesAndNewlineTokens() {
+        Experiment experiment = buildLandingHtmlValidationExperiment(208L);
+        ExperimentPipelineGenerationJob job = createLandingHtmlJob(experiment);
+
+        service.completeJob(job.getId(), landingHtmlCompletionRequest("""
+                <!doctype html><html><body>
+                <section data-section-id='\\&quot;hero\\&quot;\\n'
+                         data-surface-token='\\&quot;surface-base\\&quot;\\n'
+                         data-surface-style='\\&#34;band\\&#34;\\n'
+                         data-surface-contrast='\\&#x22;normal\\&#x22;\\n'>
+                  <img src='https://cdn.example.com/hero.jpg' alt='Hero'
+                       data-image-section-id='hero'
+                       data-image-binding-key='hero_pain_anchor'
+                       data-image-role='Hero Pain Anchor'
+                       data-conversion-role='grab-attention'
+                       data-attention-priority='high'
+                       data-visual-weight='primary'
+                       data-distance-to-cta='near'
+                       data-supports-form-conversion='true' />
+                  <form id='lead-capture-primary'><input type='text' name='nome' required /><input type='email' name='email' required /><input type='tel' name='whatsapp' /></form>
+                </section></body></html>
+                """));
+
+        assertNotNull(experiment.getLandingPageHtml());
+    }
+
+    @Test
     void completeJobSupportsLegacyFallbackWhenPlanningAndHtmlDoNotSendBindingKey() {
         Experiment experiment = buildLandingHtmlValidationExperiment(205L);
         experiment.setLandingPageImagePlanning("""

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -305,7 +305,7 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 > - a resposta do modelo para a etapa `landingPageHtml` deve ser **HTML puro** (documento final completo);
 > - é proibido retornar envelope JSON, markdown, bloco ``` ou campo textual contendo JSON serializado;
 > - o backend do Lead Portal **não** deve tentar “desempacotar” HTML de payload misto/JSON: entradas fora de HTML puro devem ser rejeitadas.
-> - para atributos canônicos de binding/superfície no HTML (`data-section-id`, `data-surface-token`, `data-surface-style`, `data-surface-contrast`), o backend normaliza artefatos de aspas codificadas (`&quot;`, `&#34;`, `&#x22;`) antes da validação estrita e registra warning operacional para correção no worker/prompt.
+> - para atributos canônicos de binding/superfície no HTML (`data-section-id`, `data-surface-token`, `data-surface-style`, `data-surface-contrast`), o backend normaliza artefatos de serialização antes da validação estrita: aspas codificadas (`&quot;`, `&#34;`, `&#x22;`), versões escapadas com barra invertida (ex.: `\\&quot;`) e tokens de quebra de linha escapados (`\\n`, `\\r`, `\\t`). O warning operacional deve permanecer para correção definitiva no worker/prompt.
 
 ```json
 {


### PR DESCRIPTION
### Motivation
- The pipeline needs to robustly handle HTML attributes that contain serialization artifacts such as escaped quotes and escaped newline/tab tokens so valid landing HTML is not rejected. 
- The canonical contract for landing page attributes must reflect normalization of both encoded entities and escaped serialization tokens prior to strict validation.

### Description
- Added `normalizeEscapedAttributeArtifacts` to convert escaped newline/tab tokens and backslash-escaped HTML entity/artifact forms into their unescaped equivalents. 
- Updated `normalizeHtmlAttr` to call `normalizeEscapedAttributeArtifacts` before and after `decodeCommonHtmlEntities` to handle both pre- and post-decoding escape patterns. 
- Expanded `containsEncodedQuoteArtifact` to detect backslash-escaped entity forms and escaped double-quote sequences. 
- Added a unit test `completeJobAcceptsHtmlWhenSurfaceAttributesContainEscapedEncodedQuotesAndNewlineTokens` to validate acceptance of attributes with `\&quot;`, `\&#34;`, `\&#x22;`, and `\n` tokens, and updated the canonical docs to document the normalization behavior.

### Testing
- Ran the unit test suite including `ExperimentPipelineGenerationServiceTest` with the new test `completeJobAcceptsHtmlWhenSurfaceAttributesContainEscapedEncodedQuotesAndNewlineTokens`, and all tests passed. 
- Existing landing HTML validation tests were run and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e925823aa483218c33fc945aea6126)