### PR TITLE
MOIS Sprint 4: extração e persistência de sinais (promessa, prova, mecanismo, funil)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferFunnelPattern.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferFunnelPattern.java
@@ -1,0 +1,74 @@
+package com.marketinghub.mois;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "mois_offer_funnel_pattern")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MoisOfferFunnelPattern {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "request_pk", nullable = false)
+    private MoisDiscoveryRequest request;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_snapshot_pk")
+    private MoisSourceSnapshot sourceSnapshot;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "offer_card_pk", nullable = false)
+    private MoisOfferCard offerCard;
+
+    @Column(name = "artifact_id", nullable = false, unique = true, length = 64)
+    private String artifactId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private MoisArtifactStatus status;
+
+    @Column(name = "entry_asset_type", length = 128)
+    private String entryAssetType;
+
+    @Column(name = "lead_capture_fields_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String leadCaptureFieldsJson;
+
+    @Column(name = "cta_style", length = 128)
+    private String ctaStyle;
+
+    @Column(name = "next_step_hypothesis", length = 255)
+    private String nextStepHypothesis;
+
+    @Column(name = "delivery_format", length = 128)
+    private String deliveryFormat;
+
+    @Column(name = "upsell_visible")
+    private Boolean upsellVisible;
+
+    @Column(name = "retention_hint", length = 255)
+    private String retentionHint;
+
+    @Column(name = "confidence")
+    private Double confidence;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferMechanismClaim.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferMechanismClaim.java
@@ -1,0 +1,65 @@
+package com.marketinghub.mois;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "mois_offer_mechanism_claim")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MoisOfferMechanismClaim {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "request_pk", nullable = false)
+    private MoisDiscoveryRequest request;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_snapshot_pk")
+    private MoisSourceSnapshot sourceSnapshot;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "offer_card_pk", nullable = false)
+    private MoisOfferCard offerCard;
+
+    @Column(name = "artifact_id", nullable = false, unique = true, length = 64)
+    private String artifactId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private MoisArtifactStatus status;
+
+    @Column(name = "claim_text", nullable = false, columnDefinition = "LONGTEXT")
+    private String claimText;
+
+    @Column(name = "claim_category", length = 64)
+    private String claimCategory;
+
+    @Column(name = "claim_specificity", length = 64)
+    private String claimSpecificity;
+
+    @Column(name = "claim_risk_level", length = 64)
+    private String claimRiskLevel;
+
+    @Column(name = "confidence")
+    private Double confidence;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferPromiseSignal.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferPromiseSignal.java
@@ -1,0 +1,68 @@
+package com.marketinghub.mois;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "mois_offer_promise_signal")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MoisOfferPromiseSignal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "request_pk", nullable = false)
+    private MoisDiscoveryRequest request;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_snapshot_pk")
+    private MoisSourceSnapshot sourceSnapshot;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "offer_card_pk", nullable = false)
+    private MoisOfferCard offerCard;
+
+    @Column(name = "artifact_id", nullable = false, unique = true, length = 64)
+    private String artifactId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private MoisArtifactStatus status;
+
+    @Column(name = "promise_text", nullable = false, columnDefinition = "LONGTEXT")
+    private String promiseText;
+
+    @Column(name = "promise_type", length = 64)
+    private String promiseType;
+
+    @Column(name = "intensity", length = 32)
+    private String intensity;
+
+    @Column(name = "timeframe_claim", length = 128)
+    private String timeframeClaim;
+
+    @Column(name = "target_outcome", length = 255)
+    private String targetOutcome;
+
+    @Column(name = "confidence")
+    private Double confidence;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferProofSignal.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferProofSignal.java
@@ -1,0 +1,65 @@
+package com.marketinghub.mois;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "mois_offer_proof_signal")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MoisOfferProofSignal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "request_pk", nullable = false)
+    private MoisDiscoveryRequest request;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_snapshot_pk")
+    private MoisSourceSnapshot sourceSnapshot;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "offer_card_pk", nullable = false)
+    private MoisOfferCard offerCard;
+
+    @Column(name = "artifact_id", nullable = false, unique = true, length = 64)
+    private String artifactId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private MoisArtifactStatus status;
+
+    @Column(name = "proof_type", length = 64)
+    private String proofType;
+
+    @Column(name = "proof_text", nullable = false, columnDefinition = "LONGTEXT")
+    private String proofText;
+
+    @Column(name = "proof_strength_hypothesis", length = 64)
+    private String proofStrengthHypothesis;
+
+    @Column(name = "proof_location", length = 128)
+    private String proofLocation;
+
+    @Column(name = "confidence")
+    private Double confidence;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferFunnelPatternRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferFunnelPatternRepository.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.repository;
+
+import com.marketinghub.mois.MoisOfferFunnelPattern;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MoisOfferFunnelPatternRepository extends JpaRepository<MoisOfferFunnelPattern, Long> {
+    List<MoisOfferFunnelPattern> findByRequest_RequestIdOrderByCreatedAtAsc(String requestId);
+
+    List<MoisOfferFunnelPattern> findByOfferCard_ArtifactIdOrderByCreatedAtAsc(String offerId);
+
+    Optional<MoisOfferFunnelPattern> findByArtifactId(String artifactId);
+
+    long countByRequest_RequestId(String requestId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferMechanismClaimRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferMechanismClaimRepository.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.repository;
+
+import com.marketinghub.mois.MoisOfferMechanismClaim;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MoisOfferMechanismClaimRepository extends JpaRepository<MoisOfferMechanismClaim, Long> {
+    List<MoisOfferMechanismClaim> findByRequest_RequestIdOrderByCreatedAtAsc(String requestId);
+
+    List<MoisOfferMechanismClaim> findByOfferCard_ArtifactIdOrderByCreatedAtAsc(String offerId);
+
+    Optional<MoisOfferMechanismClaim> findByArtifactId(String artifactId);
+
+    long countByRequest_RequestId(String requestId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferPromiseSignalRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferPromiseSignalRepository.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.repository;
+
+import com.marketinghub.mois.MoisOfferPromiseSignal;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MoisOfferPromiseSignalRepository extends JpaRepository<MoisOfferPromiseSignal, Long> {
+    List<MoisOfferPromiseSignal> findByRequest_RequestIdOrderByCreatedAtAsc(String requestId);
+
+    List<MoisOfferPromiseSignal> findByOfferCard_ArtifactIdOrderByCreatedAtAsc(String offerId);
+
+    Optional<MoisOfferPromiseSignal> findByArtifactId(String artifactId);
+
+    long countByRequest_RequestId(String requestId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferProofSignalRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferProofSignalRepository.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.repository;
+
+import com.marketinghub.mois.MoisOfferProofSignal;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MoisOfferProofSignalRepository extends JpaRepository<MoisOfferProofSignal, Long> {
+    List<MoisOfferProofSignal> findByRequest_RequestIdOrderByCreatedAtAsc(String requestId);
+
+    List<MoisOfferProofSignal> findByOfferCard_ArtifactIdOrderByCreatedAtAsc(String offerId);
+
+    Optional<MoisOfferProofSignal> findByArtifactId(String artifactId);
+
+    long countByRequest_RequestId(String requestId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisApiStubService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisApiStubService.java
@@ -10,6 +10,10 @@ import com.marketinghub.mois.dto.MoisInsightDtos;
 import com.marketinghub.mois.dto.MoisOfferDtos;
 import com.marketinghub.mois.repository.MoisDiscoveryRequestRepository;
 import com.marketinghub.mois.repository.MoisOfferCardRepository;
+import com.marketinghub.mois.repository.MoisOfferFunnelPatternRepository;
+import com.marketinghub.mois.repository.MoisOfferMechanismClaimRepository;
+import com.marketinghub.mois.repository.MoisOfferProofSignalRepository;
+import com.marketinghub.mois.repository.MoisOfferPromiseSignalRepository;
 import com.marketinghub.mois.repository.MoisSourceSnapshotRepository;
 import com.marketinghub.mois.service.MoisResearchGateway.MoisDiscoveredSource;
 import com.marketinghub.mois.service.MoisResearchGateway.MoisResearchResult;
@@ -21,6 +25,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -36,6 +42,10 @@ public class MoisApiStubService {
     private final MoisDiscoveryRequestRepository discoveryRequestRepository;
     private final MoisSourceSnapshotRepository sourceSnapshotRepository;
     private final MoisOfferCardRepository offerCardRepository;
+    private final MoisOfferPromiseSignalRepository promiseSignalRepository;
+    private final MoisOfferProofSignalRepository proofSignalRepository;
+    private final MoisOfferMechanismClaimRepository mechanismClaimRepository;
+    private final MoisOfferFunnelPatternRepository funnelPatternRepository;
     private final ObjectMapper objectMapper;
     private final MoisResearchGateway researchGateway;
 
@@ -43,12 +53,20 @@ public class MoisApiStubService {
             MoisDiscoveryRequestRepository discoveryRequestRepository,
             MoisSourceSnapshotRepository sourceSnapshotRepository,
             MoisOfferCardRepository offerCardRepository,
+            MoisOfferPromiseSignalRepository promiseSignalRepository,
+            MoisOfferProofSignalRepository proofSignalRepository,
+            MoisOfferMechanismClaimRepository mechanismClaimRepository,
+            MoisOfferFunnelPatternRepository funnelPatternRepository,
             ObjectMapper objectMapper,
             MoisResearchGateway researchGateway
     ) {
         this.discoveryRequestRepository = discoveryRequestRepository;
         this.sourceSnapshotRepository = sourceSnapshotRepository;
         this.offerCardRepository = offerCardRepository;
+        this.promiseSignalRepository = promiseSignalRepository;
+        this.proofSignalRepository = proofSignalRepository;
+        this.mechanismClaimRepository = mechanismClaimRepository;
+        this.funnelPatternRepository = funnelPatternRepository;
         this.objectMapper = objectMapper;
         this.researchGateway = researchGateway;
     }
@@ -215,7 +233,7 @@ public class MoisApiStubService {
                 offers.stream().map(MoisOfferCard::getMainPrice).filter(s -> s != null && !s.isBlank()).distinct().toList(),
                 offers.stream().map(MoisOfferCard::getFunnelPatternSummary).filter(s -> s != null && !s.isBlank()).distinct().toList(),
                 List.of("Mapear lacunas de prova para próxima coleta"),
-                List.of("Executar Sprint 3 com descoberta real de fontes")
+                List.of("Executar Sprint 5 para consolidar sinais em relatório acionável")
         ));
     }
 
@@ -275,6 +293,106 @@ public class MoisApiStubService {
             ));
         }
 
+        Optional<MoisOfferPromiseSignal> promiseArtifact = promiseSignalRepository.findByArtifactId(artifactId);
+        if (promiseArtifact.isPresent()) {
+            MoisOfferPromiseSignal promise = promiseArtifact.get();
+            return Optional.of(new MoisArtifactDtos.ArtifactEnvelopeResponse(
+                    promise.getArtifactId(),
+                    "mois.marketOfferPromiseSignal.v1",
+                    "v1",
+                    promise.getStatus().name(),
+                    "MOIS",
+                    promise.getCreatedAt(),
+                    promise.getUpdatedAt(),
+                    Map.of("requestId", promise.getRequest().getRequestId(),
+                            "parentArtifactIds", buildOfferSignalParentIds(promise.getRequest().getRequestId(), promise.getOfferCard().getArtifactId(), promise.getSourceSnapshot())),
+                    Map.of("signalType", "promise"),
+                    Map.of(
+                            "promiseText", promise.getPromiseText(),
+                            "promiseType", promise.getPromiseType(),
+                            "intensity", promise.getIntensity(),
+                            "timeframeClaim", promise.getTimeframeClaim(),
+                            "targetOutcome", promise.getTargetOutcome(),
+                            "confidence", promise.getConfidence()
+                    )
+            ));
+        }
+
+        Optional<MoisOfferProofSignal> proofArtifact = proofSignalRepository.findByArtifactId(artifactId);
+        if (proofArtifact.isPresent()) {
+            MoisOfferProofSignal proof = proofArtifact.get();
+            return Optional.of(new MoisArtifactDtos.ArtifactEnvelopeResponse(
+                    proof.getArtifactId(),
+                    "mois.marketOfferProofSignal.v1",
+                    "v1",
+                    proof.getStatus().name(),
+                    "MOIS",
+                    proof.getCreatedAt(),
+                    proof.getUpdatedAt(),
+                    Map.of("requestId", proof.getRequest().getRequestId(),
+                            "parentArtifactIds", buildOfferSignalParentIds(proof.getRequest().getRequestId(), proof.getOfferCard().getArtifactId(), proof.getSourceSnapshot())),
+                    Map.of("signalType", "proof"),
+                    Map.of(
+                            "proofType", proof.getProofType(),
+                            "proofText", proof.getProofText(),
+                            "proofStrengthHypothesis", proof.getProofStrengthHypothesis(),
+                            "proofLocation", proof.getProofLocation(),
+                            "confidence", proof.getConfidence()
+                    )
+            ));
+        }
+
+        Optional<MoisOfferMechanismClaim> mechanismArtifact = mechanismClaimRepository.findByArtifactId(artifactId);
+        if (mechanismArtifact.isPresent()) {
+            MoisOfferMechanismClaim mechanism = mechanismArtifact.get();
+            return Optional.of(new MoisArtifactDtos.ArtifactEnvelopeResponse(
+                    mechanism.getArtifactId(),
+                    "mois.marketOfferMechanismClaim.v1",
+                    "v1",
+                    mechanism.getStatus().name(),
+                    "MOIS",
+                    mechanism.getCreatedAt(),
+                    mechanism.getUpdatedAt(),
+                    Map.of("requestId", mechanism.getRequest().getRequestId(),
+                            "parentArtifactIds", buildOfferSignalParentIds(mechanism.getRequest().getRequestId(), mechanism.getOfferCard().getArtifactId(), mechanism.getSourceSnapshot())),
+                    Map.of("signalType", "mechanism-claim"),
+                    Map.of(
+                            "claimText", mechanism.getClaimText(),
+                            "claimCategory", mechanism.getClaimCategory(),
+                            "claimSpecificity", mechanism.getClaimSpecificity(),
+                            "claimRiskLevel", mechanism.getClaimRiskLevel(),
+                            "confidence", mechanism.getConfidence()
+                    )
+            ));
+        }
+
+        Optional<MoisOfferFunnelPattern> funnelArtifact = funnelPatternRepository.findByArtifactId(artifactId);
+        if (funnelArtifact.isPresent()) {
+            MoisOfferFunnelPattern funnel = funnelArtifact.get();
+            return Optional.of(new MoisArtifactDtos.ArtifactEnvelopeResponse(
+                    funnel.getArtifactId(),
+                    "mois.marketOfferFunnelPattern.v1",
+                    "v1",
+                    funnel.getStatus().name(),
+                    "MOIS",
+                    funnel.getCreatedAt(),
+                    funnel.getUpdatedAt(),
+                    Map.of("requestId", funnel.getRequest().getRequestId(),
+                            "parentArtifactIds", buildOfferSignalParentIds(funnel.getRequest().getRequestId(), funnel.getOfferCard().getArtifactId(), funnel.getSourceSnapshot())),
+                    Map.of("signalType", "funnel-pattern"),
+                    Map.of(
+                            "entryAssetType", funnel.getEntryAssetType(),
+                            "leadCaptureFields", readStringList(funnel.getLeadCaptureFieldsJson()),
+                            "ctaStyle", funnel.getCtaStyle(),
+                            "nextStepHypothesis", funnel.getNextStepHypothesis(),
+                            "deliveryFormat", funnel.getDeliveryFormat(),
+                            "upsellVisible", funnel.getUpsellVisible(),
+                            "retentionHint", funnel.getRetentionHint(),
+                            "confidence", funnel.getConfidence()
+                    )
+            ));
+        }
+
         return offerCardRepository.findByArtifactId(artifactId).map(offer -> new MoisArtifactDtos.ArtifactEnvelopeResponse(
                 offer.getArtifactId(),
                 "mois.marketOfferCard.v1",
@@ -329,7 +447,9 @@ public class MoisApiStubService {
             MoisSourceSnapshot savedSnapshot = sourceSnapshotRepository.save(snapshot);
             if (collectedSource) {
                 collected++;
-                offerCardRepository.save(buildOfferFromSnapshot(request, savedSnapshot));
+                MoisOfferExtractionResult extraction = extractSignalsFromSnapshot(request, savedSnapshot);
+                MoisOfferCard offer = offerCardRepository.save(buildOfferFromSnapshot(request, savedSnapshot, extraction));
+                persistDerivedArtifacts(request, savedSnapshot, offer, extraction);
             }
         }
 
@@ -348,7 +468,11 @@ public class MoisApiStubService {
         return collected;
     }
 
-    private MoisOfferCard buildOfferFromSnapshot(MoisDiscoveryRequest request, MoisSourceSnapshot savedSnapshot) {
+    private MoisOfferCard buildOfferFromSnapshot(
+            MoisDiscoveryRequest request,
+            MoisSourceSnapshot savedSnapshot,
+            MoisOfferExtractionResult extraction
+    ) {
         return MoisOfferCard.builder()
                 .request(request)
                 .sourceSnapshot(savedSnapshot)
@@ -358,16 +482,16 @@ public class MoisApiStubService {
                 .sellerOrBrand("Market source")
                 .channel(defaultText(savedSnapshot.getSourceKind(), "landing"))
                 .targetAudienceHypothesis("Público buscando " + request.getMarketTheme())
-                .corePromise(defaultText(request.getPainOrOutcomeFocus(), "Melhoria prática percebida"))
+                .corePromise(defaultText(extraction.promiseText(), defaultText(request.getPainOrOutcomeFocus(), "Melhoria prática percebida")))
                 .primaryOfferType("unknown")
-                .mainPrice("não identificado")
-                .confidence(0.4)
-                .deliverablesJson(toJson(List.of("conteúdo a extrair na sprint 4")))
-                .pricePointsJson(toJson(List.of("não identificado")))
-                .proofSummary("Prova pendente de extração")
-                .mechanismClaimSummary("Mecanismo alegado pendente de extração")
-                .positioningSummary("Posicionamento preliminar de fonte real")
-                .funnelPatternSummary("captura por descoberta real")
+                .mainPrice(defaultText(extraction.mainPrice(), "não identificado"))
+                .confidence(extraction.confidence())
+                .deliverablesJson(toJson(List.of(defaultText(extraction.deliveryFormat(), "conteúdo digital"))))
+                .pricePointsJson(toJson(extraction.pricePoints()))
+                .proofSummary(defaultText(extraction.proofText(), "Prova não identificada no recorte coletado"))
+                .mechanismClaimSummary(defaultText(extraction.claimText(), "Mecanismo alegado não identificado no recorte coletado"))
+                .positioningSummary("Oferta observada em " + defaultText(savedSnapshot.getSourceKind(), "canal não identificado"))
+                .funnelPatternSummary(defaultText(extraction.funnelSummary(), "padrão de funil básico"))
                 .build();
     }
 
@@ -390,29 +514,376 @@ public class MoisApiStubService {
                         "v1"
                 ))
                 .toList());
+        refs.addAll(promiseSignalRepository.findByRequest_RequestIdOrderByCreatedAtAsc(requestId)
+                .stream()
+                .map(promise -> new MoisDiscoveryDtos.ArtifactRefResponse(
+                        promise.getArtifactId(),
+                        "mois.marketOfferPromiseSignal.v1",
+                        "v1"
+                ))
+                .toList());
+        refs.addAll(proofSignalRepository.findByRequest_RequestIdOrderByCreatedAtAsc(requestId)
+                .stream()
+                .map(proof -> new MoisDiscoveryDtos.ArtifactRefResponse(
+                        proof.getArtifactId(),
+                        "mois.marketOfferProofSignal.v1",
+                        "v1"
+                ))
+                .toList());
+        refs.addAll(mechanismClaimRepository.findByRequest_RequestIdOrderByCreatedAtAsc(requestId)
+                .stream()
+                .map(mechanism -> new MoisDiscoveryDtos.ArtifactRefResponse(
+                        mechanism.getArtifactId(),
+                        "mois.marketOfferMechanismClaim.v1",
+                        "v1"
+                ))
+                .toList());
+        refs.addAll(funnelPatternRepository.findByRequest_RequestIdOrderByCreatedAtAsc(requestId)
+                .stream()
+                .map(funnel -> new MoisDiscoveryDtos.ArtifactRefResponse(
+                        funnel.getArtifactId(),
+                        "mois.marketOfferFunnelPattern.v1",
+                        "v1"
+                ))
+                .toList());
         return refs;
     }
 
     private List<MoisDiscoveryDtos.ArtifactRefResponse> buildOfferSourceArtifacts(MoisOfferCard offer) {
+        List<MoisDiscoveryDtos.ArtifactRefResponse> refs = new ArrayList<>();
         if (offer.getSourceSnapshot() == null) {
-            return List.of(new MoisDiscoveryDtos.ArtifactRefResponse(
+            refs.add(new MoisDiscoveryDtos.ArtifactRefResponse(
+                    offer.getRequest().getRequestId(),
+                    "mois.marketOfferDiscoveryRequest.v1",
+                    "v1"
+            ));
+        } else {
+            refs.add(new MoisDiscoveryDtos.ArtifactRefResponse(
+                    offer.getSourceSnapshot().getArtifactId(),
+                    "mois.marketOfferSourceSnapshot.v1",
+                    "v1"
+            ));
+            refs.add(new MoisDiscoveryDtos.ArtifactRefResponse(
                     offer.getRequest().getRequestId(),
                     "mois.marketOfferDiscoveryRequest.v1",
                     "v1"
             ));
         }
-        return List.of(
-                new MoisDiscoveryDtos.ArtifactRefResponse(
-                        offer.getSourceSnapshot().getArtifactId(),
-                        "mois.marketOfferSourceSnapshot.v1",
-                        "v1"
-                ),
-                new MoisDiscoveryDtos.ArtifactRefResponse(
-                        offer.getRequest().getRequestId(),
-                        "mois.marketOfferDiscoveryRequest.v1",
-                        "v1"
-                )
+        addFirstArtifactRef(refs, promiseSignalRepository.findByOfferCard_ArtifactIdOrderByCreatedAtAsc(offer.getArtifactId()), "mois.marketOfferPromiseSignal.v1");
+        addFirstArtifactRef(refs, proofSignalRepository.findByOfferCard_ArtifactIdOrderByCreatedAtAsc(offer.getArtifactId()), "mois.marketOfferProofSignal.v1");
+        addFirstArtifactRef(refs, mechanismClaimRepository.findByOfferCard_ArtifactIdOrderByCreatedAtAsc(offer.getArtifactId()), "mois.marketOfferMechanismClaim.v1");
+        addFirstArtifactRef(refs, funnelPatternRepository.findByOfferCard_ArtifactIdOrderByCreatedAtAsc(offer.getArtifactId()), "mois.marketOfferFunnelPattern.v1");
+        return refs;
+    }
+
+    private void addFirstArtifactRef(List<MoisDiscoveryDtos.ArtifactRefResponse> refs, List<? extends Object> items, String artifactType) {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+        String artifactId = null;
+        Object first = items.get(0);
+        if (first instanceof MoisOfferPromiseSignal promise) {
+            artifactId = promise.getArtifactId();
+        } else if (first instanceof MoisOfferProofSignal proof) {
+            artifactId = proof.getArtifactId();
+        } else if (first instanceof MoisOfferMechanismClaim mechanism) {
+            artifactId = mechanism.getArtifactId();
+        } else if (first instanceof MoisOfferFunnelPattern funnel) {
+            artifactId = funnel.getArtifactId();
+        }
+        if (artifactId != null) {
+            refs.add(new MoisDiscoveryDtos.ArtifactRefResponse(artifactId, artifactType, "v1"));
+        }
+    }
+
+    private void persistDerivedArtifacts(
+            MoisDiscoveryRequest request,
+            MoisSourceSnapshot snapshot,
+            MoisOfferCard offer,
+            MoisOfferExtractionResult extraction
+    ) {
+        promiseSignalRepository.save(MoisOfferPromiseSignal.builder()
+                .request(request)
+                .sourceSnapshot(snapshot)
+                .offerCard(offer)
+                .artifactId("mois-promise-" + UUID.randomUUID())
+                .status(MoisArtifactStatus.DRAFT)
+                .promiseText(extraction.promiseText())
+                .promiseType(extraction.promiseType())
+                .intensity(extraction.intensity())
+                .timeframeClaim(extraction.timeframeClaim())
+                .targetOutcome(extraction.targetOutcome())
+                .confidence(extraction.confidence())
+                .build());
+
+        proofSignalRepository.save(MoisOfferProofSignal.builder()
+                .request(request)
+                .sourceSnapshot(snapshot)
+                .offerCard(offer)
+                .artifactId("mois-proof-" + UUID.randomUUID())
+                .status(MoisArtifactStatus.DRAFT)
+                .proofType(extraction.proofType())
+                .proofText(extraction.proofText())
+                .proofStrengthHypothesis(extraction.proofStrength())
+                .proofLocation("headline-or-body")
+                .confidence(extraction.confidence())
+                .build());
+
+        mechanismClaimRepository.save(MoisOfferMechanismClaim.builder()
+                .request(request)
+                .sourceSnapshot(snapshot)
+                .offerCard(offer)
+                .artifactId("mois-mechanism-" + UUID.randomUUID())
+                .status(MoisArtifactStatus.DRAFT)
+                .claimText(extraction.claimText())
+                .claimCategory(extraction.claimCategory())
+                .claimSpecificity(extraction.claimSpecificity())
+                .claimRiskLevel(extraction.claimRiskLevel())
+                .confidence(extraction.confidence())
+                .build());
+
+        funnelPatternRepository.save(MoisOfferFunnelPattern.builder()
+                .request(request)
+                .sourceSnapshot(snapshot)
+                .offerCard(offer)
+                .artifactId("mois-funnel-" + UUID.randomUUID())
+                .status(MoisArtifactStatus.DRAFT)
+                .entryAssetType(extraction.entryAssetType())
+                .leadCaptureFieldsJson(toJson(extraction.leadCaptureFields()))
+                .ctaStyle(extraction.ctaStyle())
+                .nextStepHypothesis(extraction.nextStepHypothesis())
+                .deliveryFormat(extraction.deliveryFormat())
+                .upsellVisible(extraction.upsellVisible())
+                .retentionHint(extraction.retentionHint())
+                .confidence(extraction.confidence())
+                .build());
+    }
+
+    private List<String> buildOfferSignalParentIds(String requestId, String offerArtifactId, MoisSourceSnapshot sourceSnapshot) {
+        List<String> parentIds = new ArrayList<>();
+        parentIds.add(requestId);
+        if (sourceSnapshot != null) {
+            parentIds.add(sourceSnapshot.getArtifactId());
+        }
+        parentIds.add(offerArtifactId);
+        return parentIds;
+    }
+
+    private MoisOfferExtractionResult extractSignalsFromSnapshot(MoisDiscoveryRequest request, MoisSourceSnapshot snapshot) {
+        String sourceText = defaultText(snapshot.getRawExcerpt(), "");
+        List<String> sentences = splitSentences(sourceText);
+
+        String promiseSentence = firstSentenceWithKeywords(
+                sentences,
+                List.of("garanta", "aumente", "alcance", "consiga", "resultado", "sem", "em ")
         );
+        if (promiseSentence.isBlank()) {
+            promiseSentence = firstSentenceWithKeywords(sentences, List.of("transform", "aprenda", "domine"));
+        }
+        if (promiseSentence.isBlank()) {
+            promiseSentence = defaultText(request.getPainOrOutcomeFocus(), "Melhoria prática percebida");
+        }
+
+        String proofSentence = firstSentenceWithKeywords(
+                sentences,
+                List.of("depoimento", "caso real", "antes e depois", "clientes", "alunos", "resultados comprovados", "%", "x")
+        );
+        if (proofSentence.isBlank()) {
+            proofSentence = "Sem prova explícita no recorte";
+        }
+
+        String mechanismSentence = firstSentenceWithKeywords(
+                sentences,
+                List.of("método", "metodo", "framework", "protocolo", "sistema", "passo a passo", "estratégia")
+        );
+        if (mechanismSentence.isBlank()) {
+            mechanismSentence = "Sem mecanismo explícito no recorte";
+        }
+
+        String mainPrice = extractCurrencyValue(sourceText);
+        List<String> pricePoints = mainPrice == null ? List.of("não identificado") : List.of(mainPrice);
+        String timeframe = extractTimeframe(sourceText);
+        String targetOutcome = defaultText(request.getMarketTheme(), request.getNicheName());
+
+        String entryAsset = containsAny(sourceText, List.of("webinar", "aula", "masterclass")) ? "aula"
+                : containsAny(sourceText, List.of("ebook", "guia", "pdf")) ? "isca-digital" : "landing";
+        String ctaStyle = containsAny(sourceText, List.of("whatsapp", "fale agora")) ? "conversacional" : "direta";
+        String nextStep = containsAny(sourceText, List.of("checkout", "comprar", "pagamento")) ? "checkout"
+                : containsAny(sourceText, List.of("whatsapp")) ? "whatsapp" : "lead-follow-up";
+        String delivery = containsAny(sourceText, List.of("mentoria", "acompanhamento")) ? "mentoria" : "curso-digital";
+        boolean upsellVisible = containsAny(sourceText, List.of("bônus", "bonus", "oferta exclusiva"));
+
+        return new MoisOfferExtractionResult(
+                promiseSentence,
+                classifyPromiseType(promiseSentence),
+                classifyIntensity(promiseSentence),
+                timeframe,
+                targetOutcome,
+                classifyProofType(proofSentence),
+                proofSentence,
+                classifyProofStrength(proofSentence),
+                mechanismSentence,
+                classifyClaimCategory(mechanismSentence),
+                classifyClaimSpecificity(mechanismSentence),
+                classifyClaimRisk(mechanismSentence),
+                entryAsset,
+                detectLeadCaptureFields(sourceText),
+                ctaStyle,
+                nextStep,
+                delivery,
+                upsellVisible,
+                "oferta com foco em " + targetOutcome,
+                mainPrice,
+                pricePoints,
+                "entrada=" + entryAsset + ", próximo passo=" + nextStep,
+                calculateExtractionConfidence(promiseSentence, proofSentence, mechanismSentence)
+        );
+    }
+
+    private List<String> splitSentences(String text) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+        return List.of(text.split("(?<=[.!?])\\s+"))
+                .stream()
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList();
+    }
+
+    private String firstSentenceWithKeywords(List<String> sentences, List<String> keywords) {
+        for (String sentence : sentences) {
+            String normalized = sentence.toLowerCase();
+            if (keywords.stream().anyMatch(normalized::contains)) {
+                return limitText(sentence, 500);
+            }
+        }
+        return "";
+    }
+
+    private boolean containsAny(String text, List<String> terms) {
+        String normalized = defaultText(text, "").toLowerCase();
+        return terms.stream().anyMatch(normalized::contains);
+    }
+
+    private String extractCurrencyValue(String text) {
+        Matcher matcher = Pattern.compile("(R\\$\\s?\\d{1,3}(?:\\.\\d{3})*(?:,\\d{2})?)").matcher(defaultText(text, ""));
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    private String extractTimeframe(String text) {
+        Matcher matcher = Pattern.compile("(\\d+\\s*(dias|semanas|meses))", Pattern.CASE_INSENSITIVE)
+                .matcher(defaultText(text, ""));
+        return matcher.find() ? matcher.group(1) : "não declarado";
+    }
+
+    private String classifyPromiseType(String promiseText) {
+        String value = defaultText(promiseText, "").toLowerCase();
+        if (value.contains("sem ")) {
+            return "friction-removal";
+        }
+        if (value.contains("em ")) {
+            return "time-bound";
+        }
+        return "outcome";
+    }
+
+    private String classifyIntensity(String promiseText) {
+        String value = defaultText(promiseText, "").toLowerCase();
+        if (containsAny(value, List.of("garanta", "definitivo", "100%"))) {
+            return "alta";
+        }
+        if (containsAny(value, List.of("melhore", "aumente", "ganhe"))) {
+            return "média";
+        }
+        return "baixa";
+    }
+
+    private String classifyProofType(String proofText) {
+        String value = defaultText(proofText, "").toLowerCase();
+        if (containsAny(value, List.of("depoimento", "caso real", "cliente", "aluno"))) {
+            return "social-proof";
+        }
+        if (containsAny(value, List.of("%", "x", "dados"))) {
+            return "numeric-proof";
+        }
+        return "implicit-proof";
+    }
+
+    private String classifyProofStrength(String proofText) {
+        String value = defaultText(proofText, "").toLowerCase();
+        if (containsAny(value, List.of("comprovado", "caso real", "antes e depois"))) {
+            return "forte";
+        }
+        if (containsAny(value, List.of("cliente", "aluno", "%", "x"))) {
+            return "média";
+        }
+        return "fraca";
+    }
+
+    private String classifyClaimCategory(String claimText) {
+        String value = defaultText(claimText, "").toLowerCase();
+        if (containsAny(value, List.of("método", "metodo", "framework", "protocolo"))) {
+            return "framework";
+        }
+        if (containsAny(value, List.of("sistema", "automatizado", "automação"))) {
+            return "system";
+        }
+        return "generic";
+    }
+
+    private String classifyClaimSpecificity(String claimText) {
+        String value = defaultText(claimText, "").toLowerCase();
+        if (containsAny(value, List.of("3 passos", "4 etapas", "protocolo"))) {
+            return "alta";
+        }
+        if (containsAny(value, List.of("método", "estratégia"))) {
+            return "média";
+        }
+        return "baixa";
+    }
+
+    private String classifyClaimRisk(String claimText) {
+        String value = defaultText(claimText, "").toLowerCase();
+        if (containsAny(value, List.of("garantido", "certeza", "sem risco"))) {
+            return "alto";
+        }
+        if (containsAny(value, List.of("método", "protocolo", "framework"))) {
+            return "médio";
+        }
+        return "baixo";
+    }
+
+    private List<String> detectLeadCaptureFields(String text) {
+        List<String> fields = new ArrayList<>();
+        String normalized = defaultText(text, "").toLowerCase();
+        if (normalized.contains("nome")) {
+            fields.add("name");
+        }
+        if (normalized.contains("email")) {
+            fields.add("email");
+        }
+        if (normalized.contains("whatsapp") || normalized.contains("telefone")) {
+            fields.add("phone");
+        }
+        return fields.isEmpty() ? List.of("name", "email") : fields;
+    }
+
+    private double calculateExtractionConfidence(String promise, String proof, String mechanism) {
+        double score = 0.45;
+        if (!promise.isBlank() && !"Melhoria prática percebida".equals(promise)) {
+            score += 0.2;
+        }
+        if (!proof.contains("Sem prova explícita")) {
+            score += 0.15;
+        }
+        if (!mechanism.contains("Sem mecanismo explícito")) {
+            score += 0.15;
+        }
+        return Math.min(0.95, score);
     }
 
     private MoisDiscoveryDtos.DiscoveryRequestSummaryResponse toSummaryResponse(MoisDiscoveryRequest request) {
@@ -499,5 +970,32 @@ public class MoisApiStubService {
             return value;
         }
         return value.substring(0, maxLength);
+    }
+
+    private record MoisOfferExtractionResult(
+            String promiseText,
+            String promiseType,
+            String intensity,
+            String timeframeClaim,
+            String targetOutcome,
+            String proofType,
+            String proofText,
+            String proofStrength,
+            String claimText,
+            String claimCategory,
+            String claimSpecificity,
+            String claimRiskLevel,
+            String entryAssetType,
+            List<String> leadCaptureFields,
+            String ctaStyle,
+            String nextStepHypothesis,
+            String deliveryFormat,
+            Boolean upsellVisible,
+            String retentionHint,
+            String mainPrice,
+            List<String> pricePoints,
+            String funnelSummary,
+            Double confidence
+    ) {
     }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-22-mois-sprint4-signals.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-22-mois-sprint4-signals.yaml
@@ -1,0 +1,112 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-04-22-mois-sprint4-signals
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: mois_offer_promise_signal
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_offer_promise_signal (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                request_pk BIGINT NOT NULL,
+                source_snapshot_pk BIGINT NULL,
+                offer_card_pk BIGINT NOT NULL,
+                artifact_id VARCHAR(64) NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                promise_text LONGTEXT NOT NULL,
+                promise_type VARCHAR(64) NULL,
+                intensity VARCHAR(32) NULL,
+                timeframe_claim VARCHAR(128) NULL,
+                target_outcome VARCHAR(255) NULL,
+                confidence DECIMAL(5,4) NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_mois_offer_promise_signal_artifact_id (artifact_id),
+                KEY idx_mois_offer_promise_signal_request_created (request_pk, created_at),
+                KEY idx_mois_offer_promise_signal_offer (offer_card_pk),
+                CONSTRAINT fk_mois_offer_promise_signal_request FOREIGN KEY (request_pk) REFERENCES mois_discovery_request (id),
+                CONSTRAINT fk_mois_offer_promise_signal_snapshot FOREIGN KEY (source_snapshot_pk) REFERENCES mois_source_snapshot (id),
+                CONSTRAINT fk_mois_offer_promise_signal_offer FOREIGN KEY (offer_card_pk) REFERENCES mois_offer_card (id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+              CREATE TABLE mois_offer_proof_signal (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                request_pk BIGINT NOT NULL,
+                source_snapshot_pk BIGINT NULL,
+                offer_card_pk BIGINT NOT NULL,
+                artifact_id VARCHAR(64) NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                proof_type VARCHAR(64) NULL,
+                proof_text LONGTEXT NOT NULL,
+                proof_strength_hypothesis VARCHAR(64) NULL,
+                proof_location VARCHAR(128) NULL,
+                confidence DECIMAL(5,4) NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_mois_offer_proof_signal_artifact_id (artifact_id),
+                KEY idx_mois_offer_proof_signal_request_created (request_pk, created_at),
+                KEY idx_mois_offer_proof_signal_offer (offer_card_pk),
+                CONSTRAINT fk_mois_offer_proof_signal_request FOREIGN KEY (request_pk) REFERENCES mois_discovery_request (id),
+                CONSTRAINT fk_mois_offer_proof_signal_snapshot FOREIGN KEY (source_snapshot_pk) REFERENCES mois_source_snapshot (id),
+                CONSTRAINT fk_mois_offer_proof_signal_offer FOREIGN KEY (offer_card_pk) REFERENCES mois_offer_card (id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+              CREATE TABLE mois_offer_mechanism_claim (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                request_pk BIGINT NOT NULL,
+                source_snapshot_pk BIGINT NULL,
+                offer_card_pk BIGINT NOT NULL,
+                artifact_id VARCHAR(64) NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                claim_text LONGTEXT NOT NULL,
+                claim_category VARCHAR(64) NULL,
+                claim_specificity VARCHAR(64) NULL,
+                claim_risk_level VARCHAR(64) NULL,
+                confidence DECIMAL(5,4) NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_mois_offer_mechanism_claim_artifact_id (artifact_id),
+                KEY idx_mois_offer_mechanism_claim_request_created (request_pk, created_at),
+                KEY idx_mois_offer_mechanism_claim_offer (offer_card_pk),
+                CONSTRAINT fk_mois_offer_mechanism_claim_request FOREIGN KEY (request_pk) REFERENCES mois_discovery_request (id),
+                CONSTRAINT fk_mois_offer_mechanism_claim_snapshot FOREIGN KEY (source_snapshot_pk) REFERENCES mois_source_snapshot (id),
+                CONSTRAINT fk_mois_offer_mechanism_claim_offer FOREIGN KEY (offer_card_pk) REFERENCES mois_offer_card (id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+              CREATE TABLE mois_offer_funnel_pattern (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                request_pk BIGINT NOT NULL,
+                source_snapshot_pk BIGINT NULL,
+                offer_card_pk BIGINT NOT NULL,
+                artifact_id VARCHAR(64) NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                entry_asset_type VARCHAR(128) NULL,
+                lead_capture_fields_json LONGTEXT NOT NULL,
+                cta_style VARCHAR(128) NULL,
+                next_step_hypothesis VARCHAR(255) NULL,
+                delivery_format VARCHAR(128) NULL,
+                upsell_visible BOOLEAN NULL,
+                retention_hint VARCHAR(255) NULL,
+                confidence DECIMAL(5,4) NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_mois_offer_funnel_pattern_artifact_id (artifact_id),
+                KEY idx_mois_offer_funnel_pattern_request_created (request_pk, created_at),
+                KEY idx_mois_offer_funnel_pattern_offer (offer_card_pk),
+                CONSTRAINT fk_mois_offer_funnel_pattern_request FOREIGN KEY (request_pk) REFERENCES mois_discovery_request (id),
+                CONSTRAINT fk_mois_offer_funnel_pattern_snapshot FOREIGN KEY (source_snapshot_pk) REFERENCES mois_source_snapshot (id),
+                CONSTRAINT fk_mois_offer_funnel_pattern_offer FOREIGN KEY (offer_card_pk) REFERENCES mois_offer_card (id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-04-22-mois-sprint4-signals.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-04-22-mois-sprint2-persistence.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisApiStubServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisApiStubServiceTest.java
@@ -4,6 +4,10 @@ import com.marketinghub.mois.MoisDiscoveryRequestStatus;
 import com.marketinghub.mois.dto.MoisDiscoveryDtos;
 import com.marketinghub.mois.repository.MoisDiscoveryRequestRepository;
 import com.marketinghub.mois.repository.MoisOfferCardRepository;
+import com.marketinghub.mois.repository.MoisOfferFunnelPatternRepository;
+import com.marketinghub.mois.repository.MoisOfferMechanismClaimRepository;
+import com.marketinghub.mois.repository.MoisOfferProofSignalRepository;
+import com.marketinghub.mois.repository.MoisOfferPromiseSignalRepository;
 import com.marketinghub.mois.repository.MoisSourceSnapshotRepository;
 import com.marketinghub.mois.service.MoisResearchGateway.MoisDiscoveredSource;
 import com.marketinghub.mois.service.MoisResearchGateway.MoisResearchResult;
@@ -35,6 +39,18 @@ class MoisApiStubServiceTest {
 
     @Autowired
     private MoisOfferCardRepository offerCardRepository;
+
+    @Autowired
+    private MoisOfferPromiseSignalRepository promiseSignalRepository;
+
+    @Autowired
+    private MoisOfferProofSignalRepository proofSignalRepository;
+
+    @Autowired
+    private MoisOfferMechanismClaimRepository mechanismClaimRepository;
+
+    @Autowired
+    private MoisOfferFunnelPatternRepository funnelPatternRepository;
 
     @MockBean
     private MoisResearchGateway researchGateway;
@@ -73,6 +89,10 @@ class MoisApiStubServiceTest {
         assertThat(discoveryRequestRepository.findByRequestId(accepted.requestId())).isPresent();
         assertThat(sourceSnapshotRepository.countByRequest_RequestId(accepted.requestId())).isEqualTo(1);
         assertThat(offerCardRepository.countByRequest_RequestId(accepted.requestId())).isEqualTo(1);
+        assertThat(promiseSignalRepository.countByRequest_RequestId(accepted.requestId())).isEqualTo(1);
+        assertThat(proofSignalRepository.countByRequest_RequestId(accepted.requestId())).isEqualTo(1);
+        assertThat(mechanismClaimRepository.countByRequest_RequestId(accepted.requestId())).isEqualTo(1);
+        assertThat(funnelPatternRepository.countByRequest_RequestId(accepted.requestId())).isEqualTo(1);
 
         var persistedRequest = discoveryRequestRepository.findByRequestId(accepted.requestId()).orElseThrow();
         assertThat(persistedRequest.getStatus()).isEqualTo(MoisDiscoveryRequestStatus.COLLECTED);
@@ -80,7 +100,15 @@ class MoisApiStubServiceTest {
         var detail = service.getDiscoveryRequest(accepted.requestId());
         assertThat(detail).isPresent();
         assertThat(detail.get().artifacts()).extracting(MoisDiscoveryDtos.ArtifactRefResponse::artifactType)
-                .contains("mois.marketOfferDiscoveryRequest.v1", "mois.marketOfferSourceSnapshot.v1", "mois.marketOfferCard.v1");
+                .contains(
+                        "mois.marketOfferDiscoveryRequest.v1",
+                        "mois.marketOfferSourceSnapshot.v1",
+                        "mois.marketOfferCard.v1",
+                        "mois.marketOfferPromiseSignal.v1",
+                        "mois.marketOfferProofSignal.v1",
+                        "mois.marketOfferMechanismClaim.v1",
+                        "mois.marketOfferFunnelPattern.v1"
+                );
     }
 
     @Test

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -67,6 +67,25 @@ Regras operacionais associadas:
 - toda criação de request gera ao menos um snapshot e um offer card inicial para cumprir o critério de lineage mínimo da Sprint 2;
 - leitura de artefatos (`/api/v1/mois/artifacts/{artifactId}`) passa a materializar envelope canônico v1 para discovery request, source snapshot e offer card.
 
+## Atualização incremental — MOIS Sprint 4 (extração estruturada de sinais)
+
+Entidades/tabelas adicionadas no backend (`ads-service`) para transformar snapshot bruto em sinais estruturados de oferta:
+
+- `mois_offer_promise_signal`
+  - sinal de promessa central da oferta (`promise_text`, `promise_type`, `intensity`, `timeframe_claim`, `target_outcome`, `confidence`), sempre ligado ao `request`, `offer_card` e opcionalmente ao `source_snapshot`.
+- `mois_offer_proof_signal`
+  - sinal de prova observada (`proof_type`, `proof_text`, `proof_strength_hypothesis`, `proof_location`, `confidence`) com lineage explícito para request/oferta/fonte.
+- `mois_offer_mechanism_claim`
+  - alegação de mecanismo (`claim_text`, `claim_category`, `claim_specificity`, `claim_risk_level`, `confidence`) mantendo distinção entre alegação e mecanismo validado.
+- `mois_offer_funnel_pattern`
+  - padrão de funil inicial (`entry_asset_type`, `lead_capture_fields_json`, `cta_style`, `next_step_hypothesis`, `delivery_format`, `upsell_visible`, `retention_hint`, `confidence`).
+
+Regras operacionais associadas:
+
+- execução de `POST /api/v1/mois/discovery-requests/{requestId}/run` passa a derivar sinais semânticos básicos (heurísticos) a partir do `raw_excerpt` coletado;
+- `marketOfferCard` é enriquecido com os campos extraídos na própria Sprint 4 (promessa/prova/mecanismo/funil) mantendo compatibilidade do contrato de leitura já existente;
+- endpoint de artefato (`/api/v1/mois/artifacts/{artifactId}`) passa a resolver também os novos tipos canônicos `mois.marketOfferPromiseSignal.v1`, `mois.marketOfferProofSignal.v1`, `mois.marketOfferMechanismClaim.v1` e `mois.marketOfferFunnelPattern.v1`.
+
 ## Atualização incremental — MDS Sprint 1 (orquestração e persistência base)
 
 Entidades/tabelas adicionadas no backend (`ads-service`) para suportar o início do Mechanism Discovery Service:

--- a/docs/novos-modulos/MOIS/mois_plano_implementacao_sprints.md
+++ b/docs/novos-modulos/MOIS/mois_plano_implementacao_sprints.md
@@ -382,49 +382,59 @@ A sprint termina quando o sistema conseguir transformar pelo menos parte do cont
 ### Fechamento da Sprint pelo Codex
 
 **Status da sprint:**
-- [ ] Concluída integralmente
+- [x] Concluída integralmente
 - [ ] Concluída parcialmente
 - [ ] Não concluída
 
 **O que foi implementado nesta sprint:**
-- 
-- 
-- 
+- Pipeline inicial de extração heurística a partir do `rawExcerpt` para derivar promessa, prova, mecanismo alegado e padrão de funil sem quebrar o contrato existente do MOIS.
+- Persistência dos artefatos semânticos canônicos (`marketOfferPromiseSignal`, `marketOfferProofSignal`, `marketOfferMechanismClaim`, `marketOfferFunnelPattern`) com lineage para `request`, `sourceSnapshot` e `offerCard`.
+- Enriquecimento do `marketOfferCard` com os sinais extraídos (promessa/prova/mecanismo/funil, confiança e preço detectado) e ampliação do endpoint de artefatos para resolver os novos tipos.
 
 **Arquivos criados ou alterados:**
-- 
-- 
-- 
+- `backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisApiStubService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferPromiseSignal.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferProofSignal.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferMechanismClaim.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/MoisOfferFunnelPattern.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferPromiseSignalRepository.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferProofSignalRepository.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferMechanismClaimRepository.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/repository/MoisOfferFunnelPatternRepository.java`
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-22-mois-sprint4-signals.yaml`
+- `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisApiStubServiceTest.java`
+- `docs/modelo-dados-experimento.md`
 
 **Contratos, endpoints ou artefatos afetados:**
-- 
-- 
-- 
+- Endpoint existente `POST /api/v1/mois/discovery-requests/{requestId}/run` mantido e compatível, agora com derivação e persistência dos sinais estruturados da Sprint 4.
+- Endpoint existente `GET /api/v1/mois/artifacts/{artifactId}` ampliado para suportar os artefatos `mois.marketOfferPromiseSignal.v1`, `mois.marketOfferProofSignal.v1`, `mois.marketOfferMechanismClaim.v1` e `mois.marketOfferFunnelPattern.v1`.
+- `mois.marketOfferCard.v1` permanece o mesmo tipo canônico, porém enriquecido com conteúdo extraído (promessa/prova/mecanismo/funil/preço/confiança).
 
 **Testes executados:**
-- 
-- 
-- 
+- `mvn -Dtest=MoisApiStubServiceTest,MoisControllerContractTest test` (backend/ads-service).
+- Validação de persistência de snapshots + offer cards + quatro sinais semânticos derivados na execução de `run`.
+- Validação de transição para `FAILED` sem criação de offer card/sinais quando não há fonte coletada com sucesso.
 
 **Pendências que ficaram abertas:**
-- 
-- 
-- 
+- Heurísticas de extração ainda são léxicas e não cobrem variações semânticas profundas (multilíngue, ironia, estrutura de copy complexa).
+- Não há deduplicação entre sinais em execuções repetidas da mesma request (`sourceUrl + contentHash + tipo de sinal`).
+- Não há normalizador robusto para preço/parcelamento múltiplo ou moeda diferente de BRL.
 
 **Motivo das pendências:**
-- 
-- 
-- 
+- Sprint 4 priorizou entregar o pipeline estruturado mínimo com persistência canônica e baixo risco incremental sobre o backend já existente.
+- Deduplicação semântica e NLP robusto exigem ciclo próprio de modelagem/validação para evitar regressão de qualidade em dados canônicos.
+- Parsing monetário avançado depende de escopo analítico adicional e possivelmente de enriquecimento por modelo/worker.
 
 **Impacto das pendências no sistema:**
-- 
-- 
-- 
+- Em alguns nichos, os sinais extraídos podem ficar genéricos e exigir revisão humana antes de consumo estratégico.
+- Execuções repetidas podem acumular sinais redundantes para a mesma fonte/oferta.
+- Relatórios consolidados futuros (Sprint 5) precisarão tratar normalização de preço com regras de fallback.
 
 **Orientação obrigatória para a sprint seguinte:**
-- 
-- 
-- 
+- Consolidar os sinais persistidos em agregações de domínio para gerar `marketOfferInsightReport` acionável.
+- Introduzir política de deduplicação e/ou versionamento de sinais por snapshot/oferta antes de expandir volume de coleta.
+- Evoluir regras de confiança e normalização de preço/prova/mecanismo para reduzir ruído nos relatórios estratégicos.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Completar a Sprint 4 do MOIS implementando extração estruturada mínima de sinais (promessa, prova, mecanismo alegado, padrão de funil) a partir dos snapshots coletados para transformar observação bruta em artefatos reutilizáveis.
- Manter compatibilidade com contratos canônicos existentes do Marketing Hub e centralizar toda a persistência no backend (`ads-service`).
- Entregar uma solução incremental, de baixo risco, que permita evoluir para NLP/normalização em sprints posteriores.

### Description
- Adiciona as novas entidades JPA e repositórios para sinais canônicos: `MoisOfferPromiseSignal`, `MoisOfferProofSignal`, `MoisOfferMechanismClaim`, `MoisOfferFunnelPattern` e seus repositórios correspondentes.
- Estende `MoisApiStubService` para executar heurísticas lexicais sobre o `rawExcerpt` durante o `POST /api/v1/mois/discovery-requests/{requestId}/run`, enriquecer o `marketOfferCard`, persistir os sinais derivados e expor os novos artefatos via `GET /api/v1/mois/artifacts/{artifactId}`.
- Inclui changelog Liquibase incremental `changesets/2026-04-22-mois-sprint4-signals.yaml` e registra o include no `db.changelog-master.yaml` para criar as tabelas correspondentes (`mois_offer_*`).
- Atualiza documentação mínima (`docs/modelo-dados-experimento.md` e o fechamento da sprint em `docs/novos-modulos/MOIS/mois_plano_implementacao_sprints.md`) e ajusta testes de integração do serviço para validar persistência dos sinais.

### Testing
- Executado: `mvn -Dtest=MoisApiStubServiceTest,MoisControllerContractTest test` no módulo `backend/ads-service`, ambos os testes passaram com sucesso (build verde).
- Validações automatizadas incluídas: persistência de snapshot + offer card e criação dos quatro sinais derivados em execução simulada, e cobertura do endpoint de contrato do controller (contract test).
- Observação: não foi executada a suíte completa (`mvn test` sem filtro); apenas os testes focados na Sprint 4 foram rodados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93970e8fc8321be9ed23e4b527a34)