### PR TITLE
Normalize HTML image-binding attributes before slugification and add test for escaped-quote artifacts

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -2677,11 +2677,11 @@ public class ExperimentPipelineGenerationService {
     }
 
     private String resolveBindingKeyFromHtmlAttrs(Map<String, String> attrs) {
-        String bindingKey = slugifyBindingKey(attrs.get("data-image-binding-key"));
+        String bindingKey = slugifyBindingKey(normalizeHtmlAttr(attrs.get("data-image-binding-key")));
         if (StringUtils.hasText(bindingKey)) {
             return bindingKey;
         }
-        return slugifyBindingKey(attrs.get("data-image-role"));
+        return slugifyBindingKey(normalizeHtmlAttr(attrs.get("data-image-role")));
     }
 
     private String summarizeImageBindingPairs(List<ImagePlanBindingContract> bindings) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -551,6 +551,30 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void completeJobSucceedsWhenBindingKeyContainsEscapedQuoteArtifacts() {
+        Experiment experiment = buildLandingHtmlValidationExperiment(205L);
+        ExperimentPipelineGenerationJob job = createLandingHtmlJob(experiment);
+
+        service.completeJob(job.getId(), landingHtmlCompletionRequest("""
+                <!doctype html><html><body>
+                <section data-section-id='hero' data-surface-token='surface-base' data-surface-style='band' data-surface-contrast='normal'>
+                  <img src='https://cdn.example.com/hero.jpg' alt='Hero'
+                       data-image-section-id='hero'
+                       data-image-binding-key='\\&quot;hero_pain_anchor\\&quot;\\n'
+                       data-image-role='Hero Pain Anchor'
+                       data-conversion-role='grab-attention'
+                       data-attention-priority='high'
+                       data-visual-weight='primary'
+                       data-distance-to-cta='near'
+                       data-supports-form-conversion='true' />
+                  <form id='lead-capture-primary'><input type='text' name='nome' required /><input type='email' name='email' required /><input type='tel' name='whatsapp' /></form>
+                </section></body></html>
+                """));
+
+        assertNotNull(experiment.getLandingPageHtml());
+    }
+
+    @Test
     void completeJobAutomaticallyEnqueuesSuccessorSection() {
         Experiment experiment = new Experiment();
         experiment.setId(301L);


### PR DESCRIPTION
### Motivation

- HTML attribute values extracted from tags can contain escaped quotes, entities, or trailing whitespace/newlines that break binding-key slugification and prevent correct binding key detection.
- The change ensures binding keys are normalized before producing slugified keys so artifacts like `&quot;` or stray newlines are handled robustly.

### Description

- Normalize HTML attribute values via `normalizeHtmlAttr(...)` before calling `slugifyBindingKey(...)` in `resolveBindingKeyFromHtmlAttrs(...)` for both `data-image-binding-key` and `data-image-role`.
- Added a unit test `completeJobSucceedsWhenBindingKeyContainsEscapedQuoteArtifacts` that supplies a binding key containing escaped quote entities and a newline to verify normalization and successful processing.
- Kept existing attribute parsing behavior and unique-key registration logic unchanged while improving resilience to malformed/escaped inputs.

### Testing

- Ran unit tests with `mvn test` and the test suite passed successfully. 
- The new test `completeJobSucceedsWhenBindingKeyContainsEscapedQuoteArtifacts` passed and verifies the normalization fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9359f80d88321905804ec1d790501)