### PR TITLE
Add MOIS microservice module with Docker setup, health endpoints and tests

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -57,6 +57,23 @@ services:
       retries: 5
       start_period: 40s
 
+  mois:
+    image: ${MOIS_IMAGE:-marketinghub-mois}:${MOIS_IMAGE_TAG:-2026.04.23}
+    container_name: marketinghub-mois
+    restart: unless-stopped
+    environment:
+      MOIS_PORT: ${MOIS_PORT:-8094}
+      MOIS_PUBLIC_BASE_URL: ${MOIS_PUBLIC_BASE_URL:-http://177.153.62.107:8094}
+      TZ: America/Sao_Paulo
+    ports:
+      - "${MOIS_PUBLIC_BIND_IP:-177.153.62.107}:${MOIS_PORT:-8094}:8094"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8094/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
   mcp-server:
     image: ${MCP_SERVER_IMAGE:-marketinghub-mcp-server}:${MCP_SERVER_IMAGE_TAG:-2026.04.15}
     container_name: marketinghub-mcp-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,3 +164,14 @@ services:
       MCP_SERVER_VERSION: ${MCP_SERVER_VERSION:-1.0.0}
     ports:
       - "${MCP_SERVER_PORT:-8096}:8096"
+
+  mois:
+    build:
+      context: ./mois
+      dockerfile: Dockerfile
+    image: marketinghub/mois:latest
+    restart: unless-stopped
+    environment:
+      MOIS_PORT: ${MOIS_PORT:-8094}
+    ports:
+      - "${MOIS_PORT:-8094}:8094"

--- a/docs/novos-modulos/MOIS/mois_sprint_corretiva_a_execucao.md
+++ b/docs/novos-modulos/MOIS/mois_sprint_corretiva_a_execucao.md
@@ -1,0 +1,34 @@
+# MOIS — Sprint corretiva A (execução)
+
+## Objetivo
+
+Executar a fundação arquitetural obrigatória do MOIS como serviço separado, conforme `mois_correcao_arquitetural_pos_sprint4.md`.
+
+## Entregas realizadas
+
+1. Criação do diretório de módulo separado `mois/`.
+2. Criação de projeto próprio em Java 21 + Spring Boot 3.
+3. Criação de `Dockerfile` próprio do módulo.
+4. Configuração mínima em `application.properties`.
+5. Exposição de endpoint de health institucional do módulo em `GET /api/v1/mois/health`.
+6. Exposição de endpoint de health técnico via Actuator em `GET /actuator/health`.
+7. Definição de porta própria: `8094` (env `MOIS_PORT`).
+8. Inclusão do serviço `mois` em:
+   - `docker-compose.yml` (desenvolvimento/local)
+   - `deploy/docker-compose.yml` (deploy)
+
+## Host / Base URL do MOIS
+
+- Base URL local de referência: `http://localhost:8094`
+- Base URL de publicação (deploy atual): `http://177.153.62.107:8094`
+- Endpoint institucional mínimo: `http://localhost:8094/api/v1/mois/health`
+- Endpoint de observabilidade mínima: `http://localhost:8094/actuator/health`
+
+### Bind de rede no deploy
+
+- O serviço `mois` em `deploy/docker-compose.yml` está configurado para publicar no IP `177.153.62.107`.
+- Override opcional via variável: `MOIS_PUBLIC_BIND_IP`.
+
+## Observação de arquitetura
+
+A Sprint corretiva A estabelece a separação física e operacional do módulo. A extração de domínio de `backend/ads-service` permanece para as próximas sprints corretivas (B, C e D), com migração incremental e compatibilidade transitória.

--- a/mois/Dockerfile
+++ b/mois/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q -DskipTests clean package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /opt/mois
+COPY --from=build /app/target/mois-0.1.0-SNAPSHOT.jar app.jar
+EXPOSE 8094
+ENTRYPOINT ["java", "-jar", "/opt/mois/app.jar"]

--- a/mois/README.md
+++ b/mois/README.md
@@ -1,0 +1,20 @@
+# MOIS (Market Offer Intelligence Service)
+
+Serviço separado do MOIS, criado na Sprint corretiva A para estabelecer a fundação arquitetural fora do `backend/ads-service`.
+
+## Execução local
+
+```bash
+mvn spring-boot:run
+```
+
+## Endpoints mínimos da fundação
+
+- Health funcional do módulo: `GET /api/v1/mois/health`
+- Health de infraestrutura (Actuator): `GET /actuator/health`
+
+## Porta e URL base
+
+- Porta padrão: `8094` (configurável por `MOIS_PORT`)
+- Base URL local: `http://localhost:8094`
+- Base URL de deploy atual: `http://177.153.62.107:8094`

--- a/mois/docker-compose.deploy.yml
+++ b/mois/docker-compose.deploy.yml
@@ -1,0 +1,4 @@
+services:
+  mois:
+    image: ${MOIS_IMAGE}
+    build: null

--- a/mois/docker-compose.yml
+++ b/mois/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  mois:
+    build: .
+    container_name: mois-service
+    ports:
+      - "8094:8094"
+    environment:
+      - MOIS_PORT=8094
+      - SPRING_PROFILES_ACTIVE=default

--- a/mois/pom.xml
+++ b/mois/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.marketinghub</groupId>
+    <artifactId>mois</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>mois</name>
+    <description>Market Offer Intelligence Service (MOIS)</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mois/src/main/java/com/marketinghub/mois/MoisApplication.java
+++ b/mois/src/main/java/com/marketinghub/mois/MoisApplication.java
@@ -1,0 +1,12 @@
+package com.marketinghub.mois;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MoisApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MoisApplication.class, args);
+    }
+}

--- a/mois/src/main/java/com/marketinghub/mois/web/MoisHealthController.java
+++ b/mois/src/main/java/com/marketinghub/mois/web/MoisHealthController.java
@@ -1,0 +1,20 @@
+package com.marketinghub.mois.web;
+
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/mois")
+public class MoisHealthController {
+
+    @GetMapping("/health")
+    public Map<String, Object> health() {
+        return Map.of(
+                "status", "ok",
+                "service", "mois",
+                "timestamp", Instant.now().toString());
+    }
+}

--- a/mois/src/main/resources/application.properties
+++ b/mois/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.application.name=mois
+server.port=${MOIS_PORT:8094}
+
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.probes.enabled=true
+management.endpoint.health.show-details=never

--- a/mois/src/test/java/com/marketinghub/mois/web/MoisHealthControllerTest.java
+++ b/mois/src/test/java/com/marketinghub/mois/web/MoisHealthControllerTest.java
@@ -1,0 +1,25 @@
+package com.marketinghub.mois.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MoisHealthController.class)
+class MoisHealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldReturnMoisHealthPayload() throws Exception {
+        mockMvc.perform(get("/api/v1/mois/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ok"))
+                .andExpect(jsonPath("$.service").value("mois"));
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce a standalone MOIS (Market Offer Intelligence Service) module to extract architecture and operational boundaries from the monolith and enable incremental migration.
- Provide a minimal runnable service with observability and deployment artifacts so the module can be run locally and in deploy environments.

### Description

- Add a new `mois/` Spring Boot Java 21 service including `MoisApplication`, a functional health controller at `GET /api/v1/mois/health`, and Actuator health enabled via `application.properties`.
- Add build and containerization artifacts: `mois/Dockerfile`, `mois/pom.xml`, local `mois/docker-compose.yml`, and deploy helper `mois/docker-compose.deploy.yml`, and include `mois` in both top-level `docker-compose.yml` and `deploy/docker-compose.yml` with environment and healthcheck settings and optional `MOIS_PUBLIC_BIND_IP` override.
- Add documentation and runbook files: `mois/README.md` and `docs/novos-modulos/MOIS/mois_sprint_corretiva_a_execucao.md` describing endpoints, ports, and deployment notes.
- Add a unit test `MoisHealthControllerTest` to verify the health endpoint payload.

### Testing

- Added `MoisHealthControllerTest` and executed `mvn test` for the `mois` module; the test suite passed (the health endpoint test succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99b3ebdc0832185be280c79768567)