### PR TITLE
Retry ad creative creation on transient image download error (3 attempts)

### DIFF
--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -22,6 +22,7 @@
 - Na criação de ad sets de campanha, manter `targeting_automation.advantage_audience = 0` para garantir o público Advantage+ desabilitado por padrão.
 - Na criação de ad sets de campanha, manter placements exclusivos de Instagram (`publisher_platforms=["instagram"]` e `instagram_positions=["stream","story","reels","explore"]`), removendo placements de Facebook, Audience Network e Messenger.
 - Quando não houver `instagramAccount` no experimento, utilize o `defaultInstagramActorId` configurado ou o identificador vindo do criativo, seguindo sem `instagram_user_id` se nenhum valor estiver disponível.
+- Na criação de criativos (`POST /adcreatives`), se a Graph API retornar erro transitório de download da imagem (`error_subcode = 3858258`, ex.: “A imagem não foi baixada”), tente novamente até 3 vezes antes de falhar o experimento.
 - Identificadores de instant form no formato `ai_form_*` devem ser normalizados para `form_*` antes de chamar a Graph API.
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.
 - Endpoints do backend devem ser acessados com o prefixo configurado em `backend.api-prefix` (default `/api`).

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -154,7 +154,10 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    Opcionalmente o fluxo inclui mensagem e call-to-action vindos do próprio
    criativo. A imagem é sempre veiculada via `link_data.picture` — não há hash
    salvo na biblioteca —, garantindo que o anúncio utilize exatamente o ativo
-   hospedado pelo backend.
+   hospedado pelo backend. Se a Meta devolver erro transitório de download da
+   imagem (`error_subcode = 3858258`, por exemplo “A imagem não foi baixada”),
+   o worker tenta novamente a criação do criativo até 3 vezes antes de marcar a
+   publicação como falha definitiva.
 6. **Anúncio** (`POST /ads`) que referencia o conjunto e o criativo recém
    criados, mantido pausado até que o time operacional revise os detalhes no
    Gerenciador de Anúncios.

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -57,6 +58,8 @@ import java.util.function.Supplier;
 @Service
 public class FacebookCampaignService {
     private static final Logger LOGGER = LoggerFactory.getLogger(FacebookCampaignService.class);
+    private static final int AD_CREATIVE_IMAGE_DOWNLOAD_RETRY_MAX_ATTEMPTS = 3;
+    private static final int AD_CREATIVE_IMAGE_DOWNLOAD_ERROR_SUBCODE = 3858258;
 
     private final FacebookAdsService facebookAdsService;
     private final WebClient backendClient;
@@ -1292,11 +1295,7 @@ public class FacebookCampaignService {
         );
 
         try {
-            String creativeId = executeFacebookCallWithLogging(
-                experiment.id(),
-                ExperimentFacebookApiLogContext.CAMPAIGN_AD_CREATIVE,
-                () -> facebookAdsService.createAdCreative(adAccountId, primaryRequest)
-            );
+            String creativeId = createAdCreativeWithImageDownloadRetry(adAccountId, experiment.id(), primaryRequest);
             return new AdCreativeCreation(creativeId, primaryRequest);
         } catch (FacebookPermissionException ex) {
             if (!StringUtils.hasText(instagramActorId) || !isInstagramPermissionError(ex)) {
@@ -1325,11 +1324,7 @@ public class FacebookCampaignService {
                 description
             );
 
-            String creativeId = executeFacebookCallWithLogging(
-                experiment.id(),
-                ExperimentFacebookApiLogContext.CAMPAIGN_AD_CREATIVE,
-                () -> facebookAdsService.createAdCreative(adAccountId, fallbackRequest)
-            );
+            String creativeId = createAdCreativeWithImageDownloadRetry(adAccountId, experiment.id(), fallbackRequest);
             LOGGER.info(
                 "Created Facebook ad creative without Instagram user ID after permission error: experimentId={}, creativeId={}",
                 experiment.id(),
@@ -1337,6 +1332,61 @@ public class FacebookCampaignService {
             );
             return new AdCreativeCreation(creativeId, fallbackRequest);
         }
+    }
+
+    private String createAdCreativeWithImageDownloadRetry(
+        String adAccountId,
+        long experimentId,
+        FacebookAdsService.AdCreativeRequest request
+    ) {
+        int attempt = 1;
+        while (true) {
+            try {
+                return executeFacebookCallWithLogging(
+                    experimentId,
+                    ExperimentFacebookApiLogContext.CAMPAIGN_AD_CREATIVE,
+                    () -> facebookAdsService.createAdCreative(adAccountId, request)
+                );
+            } catch (WebClientResponseException ex) {
+                if (!isCreativeImageDownloadError(ex) || attempt >= AD_CREATIVE_IMAGE_DOWNLOAD_RETRY_MAX_ATTEMPTS) {
+                    throw ex;
+                }
+                LOGGER.warn(
+                    "Retrying ad creative creation after transient image download error: experimentId={}, attempt={}/{}, status={}, message={}",
+                    experimentId,
+                    attempt,
+                    AD_CREATIVE_IMAGE_DOWNLOAD_RETRY_MAX_ATTEMPTS,
+                    ex.getRawStatusCode(),
+                    ex.getMessage()
+                );
+                attempt++;
+            }
+        }
+    }
+
+    private boolean isCreativeImageDownloadError(WebClientResponseException ex) {
+        if (ex == null || ex.getRawStatusCode() != 400) {
+            return false;
+        }
+        JsonNode errorNode = parseJson(ex.getResponseBodyAsString());
+        if (errorNode == null) {
+            return false;
+        }
+        JsonNode details = errorNode.path("error");
+        if (details.path("error_subcode").asInt() == AD_CREATIVE_IMAGE_DOWNLOAD_ERROR_SUBCODE) {
+            return true;
+        }
+        String combinedMessage = (
+            details.path("message").asText("")
+                + " "
+                + details.path("error_user_title").asText("")
+                + " "
+                + details.path("error_user_msg").asText("")
+        ).toLowerCase();
+        return combinedMessage.contains("imagem não foi baixada")
+            || combinedMessage.contains("image was not downloaded")
+            || combinedMessage.contains("unable to download")
+            || combinedMessage.contains("não foi possível baixar sua imagem");
     }
 
     private boolean isInstagramPermissionError(FacebookPermissionException ex) {

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -268,6 +268,54 @@ class FacebookCampaignServiceTest {
         assertTrue(backend.getRequestCount() >= 4);
     }
 
+    @Test
+    void retriesAdCreativeCreationWhenFacebookCannotDownloadImageTemporarily() throws Exception {
+        backend.enqueueResponse(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"dailyBudget\":25.0,\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueueResponse(new MockResponse().setBody("{\"id\":\"10\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueueResponse(new MockResponse().setBody("{\"id\":\"20\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueueResponse(new MockResponse()
+            .setResponseCode(400)
+            .setBody("{\"error\":{\"message\":\"Invalid parameter\",\"code\":100,\"error_subcode\":3858258,\"error_user_msg\":\"Não foi possível baixar sua imagem\"}}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueueResponse(new MockResponse()
+            .setResponseCode(400)
+            .setBody("{\"error\":{\"message\":\"Invalid parameter\",\"code\":100,\"error_subcode\":3858258,\"error_user_msg\":\"Não foi possível baixar sua imagem\"}}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueueResponse(new MockResponse().setBody("{\"id\":\"30\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueueResponse(new MockResponse().setBody("{\"id\":\"40\"}")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueueResponse(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueueResponse(new MockResponse().setBody("[]")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueueResponse(new MockResponse().setBody("{}")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueueResponse(new MockResponse().setBody("{}")
+            .addHeader("Content-Type", "application/json"));
+
+        service.createCampaignsFromExperiments();
+
+        RecordedRequest postCampaign = takeFacebookRequest("facebook campaign creation");
+        assertEquals("/v23.0/act_1/campaigns", postCampaign.getPath());
+
+        RecordedRequest postAdSet = takeFacebookRequest("facebook adset creation");
+        assertEquals("/v23.0/act_1/adsets", postAdSet.getPath());
+
+        RecordedRequest creativeAttempt1 = takeFacebookRequest("facebook creative attempt 1");
+        assertEquals("/v23.0/act_1/adcreatives", creativeAttempt1.getPath());
+        RecordedRequest creativeAttempt2 = takeFacebookRequest("facebook creative attempt 2");
+        assertEquals("/v23.0/act_1/adcreatives", creativeAttempt2.getPath());
+        RecordedRequest creativeAttempt3 = takeFacebookRequest("facebook creative attempt 3");
+        assertEquals("/v23.0/act_1/adcreatives", creativeAttempt3.getPath());
+
+        RecordedRequest postAd = takeFacebookRequest("facebook ad creation");
+        assertEquals("/v23.0/act_1/ads", postAd.getPath());
+    }
+
     
     @Test
     void deletesFacebookCampaignWhenAdSetCreationFails() throws Exception {


### PR DESCRIPTION
### Motivation

- Handle transient Graph API failures when the Facebook crawler cannot download a creative image to avoid marking experiments as failed for recoverable errors.

### Description

- Add retry logic in `FacebookCampaignService` by introducing `createAdCreativeWithImageDownloadRetry` which retries `facebookAdsService.createAdCreative` up to 3 times on transient image-download errors.
- Detect image-download failures by inspecting `WebClientResponseException` payloads and `error_subcode = 3858258` or common localized error messages via `isCreativeImageDownloadError` and the `AD_CREATIVE_IMAGE_DOWNLOAD_ERROR_SUBCODE` constant.
- Preserve existing fallback behavior for Instagram permission errors while delegating creative creation to the new retry wrapper.
- Document the new retry behavior in `AGENTS.md` and `README.md` to reflect the 3-attempt retry on transient image download errors.

### Testing

- Added unit test `retriesAdCreativeCreationWhenFacebookCannotDownloadImageTemporarily` that simulates two transient 400 responses with `error_subcode=3858258` followed by a successful create, and the test passed.
- Ran the module unit test suite containing the new test and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99ceef4208321b8373a60faeb3cfd)