### PR TITLE
Integrate backend with MOIS module via HTTP gateway (Sprint corretiva C)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisModuleGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisModuleGateway.java
@@ -1,0 +1,121 @@
+package com.marketinghub.mois.service;
+
+import com.marketinghub.mois.dto.MoisArtifactDtos;
+import com.marketinghub.mois.dto.MoisDiscoveryDtos;
+import com.marketinghub.mois.dto.MoisInsightDtos;
+import com.marketinghub.mois.dto.MoisOfferDtos;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class MoisModuleGateway {
+
+    private final MoisModuleProperties properties;
+    private final RestTemplateBuilder restTemplateBuilder;
+
+    public MoisModuleGateway(MoisModuleProperties properties, RestTemplateBuilder restTemplateBuilder) {
+        this.properties = properties;
+        this.restTemplateBuilder = restTemplateBuilder;
+    }
+
+    public MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse createDiscoveryRequest(MoisDiscoveryDtos.CreateDiscoveryRequest request) {
+        return exchange("/api/v1/mois/discovery-requests", HttpMethod.POST, request,
+                MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse.class).getBody();
+    }
+
+    public MoisDiscoveryDtos.DiscoveryRequestListResponse listDiscoveryRequests(String status, String nicheName, String marketTheme) {
+        UriComponentsBuilder uri = UriComponentsBuilder.fromPath("/api/v1/mois/discovery-requests");
+        maybeAddQuery(uri, "status", status);
+        maybeAddQuery(uri, "nicheName", nicheName);
+        maybeAddQuery(uri, "marketTheme", marketTheme);
+        return exchange(uri.toUriString(), HttpMethod.GET, null, MoisDiscoveryDtos.DiscoveryRequestListResponse.class)
+                .getBody();
+    }
+
+    public Optional<MoisDiscoveryDtos.DiscoveryRequestDetailResponse> getDiscoveryRequest(String requestId) {
+        return optionalGet("/api/v1/mois/discovery-requests/" + requestId, MoisDiscoveryDtos.DiscoveryRequestDetailResponse.class);
+    }
+
+    public MoisDiscoveryDtos.AsyncAcceptedResponse runDiscoveryRequest(String requestId) {
+        return exchange("/api/v1/mois/discovery-requests/" + requestId + "/run", HttpMethod.POST, null,
+                MoisDiscoveryDtos.AsyncAcceptedResponse.class).getBody();
+    }
+
+    public MoisOfferDtos.OfferCardListResponse listOffers(String requestId, String nicheName, String sellerOrBrand) {
+        UriComponentsBuilder uri = UriComponentsBuilder.fromPath("/api/v1/mois/offers");
+        maybeAddQuery(uri, "requestId", requestId);
+        maybeAddQuery(uri, "nicheName", nicheName);
+        maybeAddQuery(uri, "sellerOrBrand", sellerOrBrand);
+        return exchange(uri.toUriString(), HttpMethod.GET, null, MoisOfferDtos.OfferCardListResponse.class).getBody();
+    }
+
+    public Optional<MoisOfferDtos.OfferCardResponse> getOffer(String offerId) {
+        return optionalGet("/api/v1/mois/offers/" + offerId, MoisOfferDtos.OfferCardResponse.class);
+    }
+
+    public MoisInsightDtos.InsightReportListResponse listInsightReports(String requestId, String nicheName) {
+        UriComponentsBuilder uri = UriComponentsBuilder.fromPath("/api/v1/mois/insight-reports");
+        maybeAddQuery(uri, "requestId", requestId);
+        maybeAddQuery(uri, "nicheName", nicheName);
+        return exchange(uri.toUriString(), HttpMethod.GET, null, MoisInsightDtos.InsightReportListResponse.class).getBody();
+    }
+
+    public Optional<MoisInsightDtos.InsightReportResponse> getInsightReport(String reportId) {
+        return optionalGet("/api/v1/mois/insight-reports/" + reportId, MoisInsightDtos.InsightReportResponse.class);
+    }
+
+    public Optional<MoisArtifactDtos.ArtifactEnvelopeResponse> getArtifact(String artifactId) {
+        return optionalGet("/api/v1/mois/artifacts/" + artifactId, MoisArtifactDtos.ArtifactEnvelopeResponse.class);
+    }
+
+    public Map<String, String> health() {
+        return exchange("/api/v1/mois/health", HttpMethod.GET, null, Map.class).getBody();
+    }
+
+    private <T> Optional<T> optionalGet(String path, Class<T> responseType) {
+        try {
+            return Optional.ofNullable(exchange(path, HttpMethod.GET, null, responseType).getBody());
+        } catch (HttpClientErrorException.NotFound notFound) {
+            return Optional.empty();
+        }
+    }
+
+    private <T> ResponseEntity<T> exchange(String path, HttpMethod method, Object body, Class<T> responseType) {
+        try {
+            return buildRestTemplate().exchange(path, method, new HttpEntity<>(body), responseType);
+        } catch (HttpClientErrorException ex) {
+            throw ex;
+        } catch (RestClientException ex) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    HttpStatus.BAD_GATEWAY,
+                    "mois module unavailable",
+                    ex
+            );
+        }
+    }
+
+    private RestTemplate buildRestTemplate() {
+        return restTemplateBuilder
+                .rootUri(properties.getBaseUrl())
+                .setConnectTimeout(properties.getConnectTimeout())
+                .setReadTimeout(properties.getReadTimeout())
+                .build();
+    }
+
+    private void maybeAddQuery(UriComponentsBuilder uri, String key, String value) {
+        if (StringUtils.hasText(value)) {
+            uri.queryParam(key, value);
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisModuleProperties.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisModuleProperties.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.service;
+
+import java.time.Duration;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "integrations.mois.module")
+public class MoisModuleProperties {
+
+    private String baseUrl = "http://localhost:8094";
+    private Duration connectTimeout = Duration.ofSeconds(2);
+    private Duration readTimeout = Duration.ofSeconds(10);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
@@ -4,7 +4,7 @@ import com.marketinghub.mois.dto.MoisArtifactDtos;
 import com.marketinghub.mois.dto.MoisDiscoveryDtos;
 import com.marketinghub.mois.dto.MoisInsightDtos;
 import com.marketinghub.mois.dto.MoisOfferDtos;
-import com.marketinghub.mois.service.MoisApiStubService;
+import com.marketinghub.mois.service.MoisModuleGateway;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -24,14 +24,14 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class MoisController {
 
-    private final MoisApiStubService service;
+    private final MoisModuleGateway gateway;
 
     @PostMapping("/discovery-requests")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse createDiscoveryRequest(
             @Valid @RequestBody MoisDiscoveryDtos.CreateDiscoveryRequest request
     ) {
-        return service.createDiscoveryRequest(request);
+        return gateway.createDiscoveryRequest(request);
     }
 
     @GetMapping("/discovery-requests")
@@ -40,19 +40,19 @@ public class MoisController {
             @RequestParam(required = false) String nicheName,
             @RequestParam(required = false) String marketTheme
     ) {
-        return service.listDiscoveryRequests(status, nicheName, marketTheme);
+        return gateway.listDiscoveryRequests(status, nicheName, marketTheme);
     }
 
     @GetMapping("/discovery-requests/{requestId}")
     public MoisDiscoveryDtos.DiscoveryRequestDetailResponse getDiscoveryRequest(@PathVariable String requestId) {
-        return service.getDiscoveryRequest(requestId)
+        return gateway.getDiscoveryRequest(requestId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "discovery request not found"));
     }
 
     @PostMapping("/discovery-requests/{requestId}/run")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public MoisDiscoveryDtos.AsyncAcceptedResponse runDiscoveryRequest(@PathVariable String requestId) {
-        return service.runDiscoveryRequest(requestId);
+        return gateway.runDiscoveryRequest(requestId);
     }
 
     @GetMapping("/offers")
@@ -61,12 +61,12 @@ public class MoisController {
             @RequestParam(required = false) String nicheName,
             @RequestParam(required = false) String sellerOrBrand
     ) {
-        return service.listOffers(requestId, nicheName, sellerOrBrand);
+        return gateway.listOffers(requestId, nicheName, sellerOrBrand);
     }
 
     @GetMapping("/offers/{offerId}")
     public MoisOfferDtos.OfferCardResponse getOffer(@PathVariable String offerId) {
-        return service.getOffer(offerId)
+        return gateway.getOffer(offerId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "offer not found"));
     }
 
@@ -75,23 +75,23 @@ public class MoisController {
             @RequestParam(required = false) String requestId,
             @RequestParam(required = false) String nicheName
     ) {
-        return service.listInsightReports(requestId, nicheName);
+        return gateway.listInsightReports(requestId, nicheName);
     }
 
     @GetMapping("/insight-reports/{reportId}")
     public MoisInsightDtos.InsightReportResponse getInsightReport(@PathVariable String reportId) {
-        return service.getInsightReport(reportId)
+        return gateway.getInsightReport(reportId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "insight report not found"));
     }
 
     @GetMapping("/artifacts/{artifactId}")
     public MoisArtifactDtos.ArtifactEnvelopeResponse getArtifact(@PathVariable String artifactId) {
-        return service.getArtifact(artifactId)
+        return gateway.getArtifact(artifactId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "artifact not found"));
     }
 
     @GetMapping("/health")
     public Map<String, String> health() {
-        return Map.of("status", "ok", "module", "mois-backend");
+        return gateway.health();
     }
 }

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -169,3 +169,8 @@ integrations.mois.market-research.base-url=${MOIS_MARKET_RESEARCH_BASE_URL:http:
 integrations.mois.market-research.connect-timeout=${MOIS_MARKET_RESEARCH_CONNECT_TIMEOUT:PT2S}
 integrations.mois.market-research.read-timeout=${MOIS_MARKET_RESEARCH_READ_TIMEOUT:PT8S}
 integrations.mois.market-research.max-sources=${MOIS_MARKET_RESEARCH_MAX_SOURCES:10}
+
+# MOIS module integration (Sprint corretiva C)
+integrations.mois.module.base-url=${MOIS_MODULE_BASE_URL:http://localhost:8094}
+integrations.mois.module.connect-timeout=${MOIS_MODULE_CONNECT_TIMEOUT:PT2S}
+integrations.mois.module.read-timeout=${MOIS_MODULE_READ_TIMEOUT:PT10S}

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
@@ -2,7 +2,7 @@ package com.marketinghub.mois.web;
 
 import com.marketinghub.mois.dto.MoisDiscoveryDtos;
 import com.marketinghub.mois.dto.MoisOfferDtos;
-import com.marketinghub.mois.service.MoisApiStubService;
+import com.marketinghub.mois.service.MoisModuleGateway;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -33,11 +33,11 @@ class MoisControllerContractTest {
     private MockMvc mockMvc;
 
     @MockBean
-    private MoisApiStubService service;
+    private MoisModuleGateway gateway;
 
     @Test
     void shouldAcceptDiscoveryRequest() throws Exception {
-        when(service.createDiscoveryRequest(any(MoisDiscoveryDtos.CreateDiscoveryRequest.class)))
+        when(gateway.createDiscoveryRequest(any(MoisDiscoveryDtos.CreateDiscoveryRequest.class)))
                 .thenReturn(new MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse("mois-req-123", "ACCEPTED"));
 
         mockMvc.perform(post("/api/v1/mois/discovery-requests")
@@ -63,7 +63,7 @@ class MoisControllerContractTest {
 
     @Test
     void shouldReturnDiscoveryRequestDetail() throws Exception {
-        when(service.getDiscoveryRequest(eq("mois-req-001")))
+        when(gateway.getDiscoveryRequest(eq("mois-req-001")))
                 .thenReturn(Optional.of(new MoisDiscoveryDtos.DiscoveryRequestDetailResponse(
                         "mois-req-001",
                         "personal trainer",
@@ -82,7 +82,7 @@ class MoisControllerContractTest {
 
     @Test
     void shouldReturn404WhenOfferDoesNotExist() throws Exception {
-        when(service.getOffer(eq("unknown-offer"))).thenReturn(Optional.empty());
+        when(gateway.getOffer(eq("unknown-offer"))).thenReturn(Optional.empty());
 
         mockMvc.perform(get("/api/v1/mois/offers/unknown-offer"))
                 .andExpect(status().isNotFound());
@@ -90,7 +90,7 @@ class MoisControllerContractTest {
 
     @Test
     void shouldReturnOfferListContract() throws Exception {
-        when(service.listOffers(any(), any(), any()))
+        when(gateway.listOffers(any(), any(), any()))
                 .thenReturn(new MoisOfferDtos.OfferCardListResponse(List.of(
                         new MoisOfferDtos.OfferCardSummaryResponse(
                                 "mois-offer-001",

--- a/docs/novos-modulos/MOIS/mois_sprint_corretiva_c_execucao.md
+++ b/docs/novos-modulos/MOIS/mois_sprint_corretiva_c_execucao.md
@@ -1,0 +1,22 @@
+# MOIS — Sprint corretiva C (execução)
+
+## Objetivo
+
+Executar a integração backend ↔ MOIS com contrato explícito via HTTP, removendo o comportamento de implementação local do domínio MOIS dentro do backend.
+
+## Entregas realizadas
+
+1. Criação do gateway de integração do backend com o serviço separado MOIS:
+   - `MoisModuleGateway`
+   - `MoisModuleProperties`
+2. Atualização do controller institucional do backend (`/api/v1/mois/*`) para atuar como façade de integração:
+   - chamadas HTTP para o módulo `mois` em vez de execução local do domínio.
+3. Configuração de integração adicionada no backend:
+   - `integrations.mois.module.base-url`
+   - `integrations.mois.module.connect-timeout`
+   - `integrations.mois.module.read-timeout`
+4. Atualização de teste de contrato web do backend para mockar o gateway HTTP, validando a borda de integração.
+
+## Observação de compatibilidade transitória
+
+Nesta sprint corretiva, o backend mantém a URL institucional `/api/v1/mois/*` para clientes já integrados, mas a execução de domínio passa a ser delegada ao serviço separado `mois`.


### PR DESCRIPTION
### Motivation
- Implement the Sprint corretiva C from `docs/novos-modulos/MOIS/mois_correcao_arquitetural_pos_sprint4.md` to stop executing MOIS domain logic inside `backend/ads-service` and instead call the separate `mois` service by contract. 
- Ensure the backend acts as an institutional façade while the MOIS service becomes an independent module with its own host/container and API. 

### Description
- Added an HTTP gateway `MoisModuleGateway` that proxies calls to the external MOIS service for discovery, runs, offers, insight-reports, artifacts and health, and maps downstream unavailability to `502 Bad Gateway`.
- Introduced `MoisModuleProperties` and new configuration keys `integrations.mois.module.*` and added them to `backend/ads-service/src/main/resources/application.properties` for base URL and timeouts.
- Updated `MoisController` to delegate all `/api/v1/mois/*` endpoints to the gateway (keeps the institutional endpoints for compatibility) and updated the web contract test to mock the gateway instead of the local service.
- Added documentation `docs/novos-modulos/MOIS/mois_sprint_corretiva_c_execucao.md` describing the sprint execution and compatibility notes.

### Testing
- Ran `mvn -Dtest=MoisControllerContractTest test` in `backend/ads-service`; the test suite passed (build and all assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a20888588321b417f91eab20b355)