### PR TITLE
Add Meta (Facebook) Graph/docs tools to MCP server

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -18,6 +18,25 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `db_read_table`: lê dados de uma tabela com paginação (`table`, `limit`, `offset`).
 - `db_query`: executa SQL de leitura (`SELECT`/`WITH`) com limite de linhas.
 - `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`).
+- `meta_docs_get`: baixa uma URL de documentação da Meta (hosts em allowlist) e retorna um trecho textual simplificado.
+- `meta_graph_get`: executa chamada GET na Graph API usando token configurado no MCP.
+- `meta_graph_debug_token`: valida um token via endpoint `debug_token` da Graph API.
+
+### Configuração dos tools da Meta (MVP)
+
+Defina as variáveis abaixo para habilitar os tools:
+
+- `MCP_META_ENABLED=true`
+- `MCP_META_ACCESS_TOKEN=<token-sistema-ou-usuario-com-permissoes>`
+- `MCP_META_APP_ID=<app-id-meta>` e `MCP_META_APP_SECRET=<app-secret-meta>` (necessários para `meta_graph_debug_token`)
+
+Opcional:
+
+- `MCP_META_DOCS_ALLOWLIST_HOSTS=developers.facebook.com,www.facebook.com`
+- `MCP_META_GRAPH_API_BASE_URL=https://graph.facebook.com`
+- `MCP_META_GRAPH_API_VERSION=v22.0`
+- `MCP_META_TIMEOUT_MS=10000`
+- `MCP_META_MAX_RESPONSE_CHARS=6000`
 
 ## Executar localmente
 

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpConfiguration.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpConfiguration.java
@@ -1,9 +1,23 @@
 package com.marketinghub.mcpserver.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
 
 @Configuration
 @EnableConfigurationProperties(McpProperties.class)
 public class McpConfiguration {
+
+    @Bean
+    public RestTemplate mcpRestTemplate(RestTemplateBuilder builder, McpProperties properties) {
+        Duration timeout = Duration.ofMillis(properties.meta().requestTimeoutMillis());
+        return builder
+                .connectTimeout(timeout)
+                .readTimeout(timeout)
+                .build();
+    }
 }

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -7,13 +7,16 @@ import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.List;
+
 @Validated
 @ConfigurationProperties(prefix = "mcp")
 public record McpProperties(
         @NotBlank String serverName,
         @NotBlank String serverVersion,
         String apiKey,
-        @NotNull @Valid Logs logs
+        @NotNull @Valid Logs logs,
+        @NotNull @Valid Meta meta
 ) {
     public record Logs(
             @NotBlank String backendPath,
@@ -23,6 +26,19 @@ public record McpProperties(
             @NotBlank String emailServicePath,
             @NotBlank String leadPortalPaymentPath,
             @Positive int maxLines
+    ) {
+    }
+
+    public record Meta(
+            boolean enabled,
+            @NotNull List<@NotBlank String> docsAllowlistHosts,
+            @NotBlank String graphApiBaseUrl,
+            @NotBlank String graphApiVersion,
+            String accessToken,
+            String appId,
+            String appSecret,
+            @Positive int requestTimeoutMillis,
+            @Positive int maxResponseChars
     ) {
     }
 }

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -2,6 +2,7 @@ package com.marketinghub.mcpserver.controller;
 
 import com.marketinghub.mcpserver.config.McpProperties;
 import com.marketinghub.mcpserver.service.DatabaseDiagnosticsService;
+import com.marketinghub.mcpserver.service.MetaToolsService;
 import com.marketinghub.mcpserver.service.ModuleLogService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.MediaType;
@@ -30,13 +31,16 @@ public class McpController {
     private final McpProperties properties;
     private final DatabaseDiagnosticsService databaseDiagnosticsService;
     private final ModuleLogService moduleLogService;
+    private final MetaToolsService metaToolsService;
 
     public McpController(McpProperties properties,
                          DatabaseDiagnosticsService databaseDiagnosticsService,
-                         ModuleLogService moduleLogService) {
+                         ModuleLogService moduleLogService,
+                         MetaToolsService metaToolsService) {
         this.properties = properties;
         this.databaseDiagnosticsService = databaseDiagnosticsService;
         this.moduleLogService = moduleLogService;
+        this.metaToolsService = metaToolsService;
     }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
@@ -127,6 +131,41 @@ public class McpController {
                                                     "description", "Quantidade de linhas do final do arquivo de log. Padrão: 200.")),
                                     "required", List.of("module"),
                                     "additionalProperties", false)
+                    ),
+                    Map.of(
+                            "name", "meta_docs_get",
+                            "description", "Busca uma página de documentação da Meta em hosts aprovados e retorna texto simplificado.",
+                            "inputSchema", Map.of(
+                                    "type", "object",
+                                    "properties", Map.of(
+                                            "url", Map.of("type", "string",
+                                                    "description", "URL HTTPS da documentação da Meta.")),
+                                    "required", List.of("url"),
+                                    "additionalProperties", false)
+                    ),
+                    Map.of(
+                            "name", "meta_graph_get",
+                            "description", "Executa GET na Graph API da Meta usando token configurado no MCP.",
+                            "inputSchema", Map.of(
+                                    "type", "object",
+                                    "properties", Map.of(
+                                            "path", Map.of("type", "string",
+                                                    "description", "Path da Graph API, sem versão (ex.: me/adaccounts)."),
+                                            "query", Map.of("type", "object",
+                                                    "description", "Query string adicional enviada na chamada.")),
+                                    "required", List.of("path"),
+                                    "additionalProperties", false)
+                    ),
+                    Map.of(
+                            "name", "meta_graph_debug_token",
+                            "description", "Executa debug_token na Graph API para validar um token de usuário/sistema.",
+                            "inputSchema", Map.of(
+                                    "type", "object",
+                                    "properties", Map.of(
+                                            "input_token", Map.of("type", "string",
+                                                    "description", "Token a ser validado.")),
+                                    "required", List.of("input_token"),
+                                    "additionalProperties", false)
                     )))));
             case "tools/call" -> ResponseEntity.ok(callTool(id, request));
             default -> ResponseEntity.ok(error(id, -32601, "Method not found: " + method));
@@ -163,6 +202,9 @@ public class McpController {
                 case "db_read_table" -> callReadTable(id, arguments);
                 case "db_query" -> callQueryTool(id, arguments);
                 case "java_module_logs" -> callJavaModuleLogsTool(id, arguments);
+                case "meta_docs_get" -> callMetaDocsTool(id, arguments);
+                case "meta_graph_get" -> callMetaGraphGetTool(id, arguments);
+                case "meta_graph_debug_token" -> callMetaGraphDebugTokenTool(id, arguments);
                 default -> error(id, -32602, "Unknown tool: " + toolName);
             };
         } catch (IllegalArgumentException ex) {
@@ -231,6 +273,43 @@ public class McpController {
         }
     }
 
+    private Map<String, Object> callMetaDocsTool(Object id, Map<String, Object> arguments) {
+        String url = stringArgument(arguments, "url");
+        try {
+            Map<String, Object> result = metaToolsService.getDocumentationPage(url);
+            return successToolResult(id, result, "Fetched meta docs page from " + result.get("host"));
+        } catch (IllegalArgumentException ex) {
+            return error(id, -32602, ex.getMessage());
+        } catch (Exception ex) {
+            return error(id, -32603, "Failed to fetch meta docs page: " + ex.getMessage());
+        }
+    }
+
+    private Map<String, Object> callMetaGraphGetTool(Object id, Map<String, Object> arguments) {
+        String path = stringArgument(arguments, "path");
+        Map<String, Object> query = mapArgument(arguments, "query");
+        try {
+            Map<String, Object> result = metaToolsService.graphGet(path, query);
+            return successToolResult(id, result, "Graph API GET executed");
+        } catch (IllegalArgumentException ex) {
+            return error(id, -32602, ex.getMessage());
+        } catch (Exception ex) {
+            return error(id, -32603, "Failed to execute Graph API GET: " + ex.getMessage());
+        }
+    }
+
+    private Map<String, Object> callMetaGraphDebugTokenTool(Object id, Map<String, Object> arguments) {
+        String inputToken = stringArgument(arguments, "input_token");
+        try {
+            Map<String, Object> result = metaToolsService.debugToken(inputToken);
+            return successToolResult(id, result, "Graph debug_token executed");
+        } catch (IllegalArgumentException ex) {
+            return error(id, -32602, ex.getMessage());
+        } catch (Exception ex) {
+            return error(id, -32603, "Failed to execute Graph debug_token: " + ex.getMessage());
+        }
+    }
+
     private Map<String, Object> extractArguments(Map<?, ?> params) {
         Object argumentsObject = params.get("arguments");
         if (argumentsObject == null) {
@@ -267,6 +346,18 @@ public class McpController {
         } catch (NumberFormatException ex) {
             throw new IllegalArgumentException(name + " must be an integer");
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> mapArgument(Map<String, Object> arguments, String name) {
+        Object value = arguments.get(name);
+        if (value == null) {
+            return Map.of();
+        }
+        if (value instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        throw new IllegalArgumentException(name + " must be an object");
     }
 
     private Map<String, Object> successToolResult(Object id, Map<String, Object> data, String text) {

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/MetaToolsService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/MetaToolsService.java
@@ -1,0 +1,154 @@
+package com.marketinghub.mcpserver.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.mcpserver.config.McpProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+public class MetaToolsService {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
+    };
+
+    private final McpProperties properties;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public MetaToolsService(McpProperties properties, RestTemplate restTemplate, ObjectMapper objectMapper) {
+        this.properties = properties;
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public Map<String, Object> getDocumentationPage(String url) {
+        ensureMetaEnabled();
+        URI uri = URI.create(requiredText(url, "url"));
+        validateAllowedHost(uri);
+
+        ResponseEntity<String> response = restTemplate.getForEntity(uri, String.class);
+        String body = Objects.requireNonNullElse(response.getBody(), "");
+        String excerpt = toPlainText(body);
+
+        int maxChars = properties.meta().maxResponseChars();
+        boolean truncated = excerpt.length() > maxChars;
+        String content = truncated ? excerpt.substring(0, maxChars) : excerpt;
+
+        return Map.of(
+                "url", uri.toString(),
+                "host", Objects.requireNonNullElse(uri.getHost(), ""),
+                "excerpt", content,
+                "truncated", truncated,
+                "excerptLength", content.length()
+        );
+    }
+
+    public Map<String, Object> graphGet(String path, Map<String, Object> queryParams) {
+        ensureMetaEnabled();
+        String normalizedPath = normalizePath(path);
+
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromHttpUrl(properties.meta().graphApiBaseUrl())
+                .pathSegment(properties.meta().graphApiVersion())
+                .pathSegment(normalizedPath.split("/"));
+
+        if (queryParams != null) {
+            queryParams.forEach((key, value) -> {
+                if (value != null && !"access_token".equalsIgnoreCase(key)) {
+                    builder.queryParam(key, value);
+                }
+            });
+        }
+
+        builder.queryParam("access_token", requiredText(properties.meta().accessToken(), "mcp.meta.access-token"));
+        URI uri = builder.build(true).toUri();
+
+        ResponseEntity<Object> response = restTemplate.getForEntity(uri, Object.class);
+        Map<String, Object> payload = objectMapper.convertValue(response.getBody(), MAP_TYPE);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("graphUrl", sanitizeAccessToken(uri.toString()));
+        result.put("statusCode", response.getStatusCode().value());
+        result.put("payload", payload);
+        return result;
+    }
+
+    public Map<String, Object> debugToken(String inputToken) {
+        ensureMetaEnabled();
+        String appId = requiredText(properties.meta().appId(), "mcp.meta.app-id");
+        String appSecret = requiredText(properties.meta().appSecret(), "mcp.meta.app-secret");
+
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl(properties.meta().graphApiBaseUrl())
+                .pathSegment(properties.meta().graphApiVersion(), "debug_token")
+                .queryParam("input_token", requiredText(inputToken, "input_token"))
+                .queryParam("access_token", appId + "|" + appSecret)
+                .build(true)
+                .toUri();
+
+        ResponseEntity<Object> response = restTemplate.getForEntity(uri, Object.class);
+        Map<String, Object> payload = objectMapper.convertValue(response.getBody(), MAP_TYPE);
+
+        return Map.of(
+                "graphUrl", sanitizeAccessToken(uri.toString()),
+                "statusCode", response.getStatusCode().value(),
+                "payload", payload
+        );
+    }
+
+    private void ensureMetaEnabled() {
+        if (!properties.meta().enabled()) {
+            throw new IllegalArgumentException("meta tools are disabled (set mcp.meta.enabled=true)");
+        }
+    }
+
+    private void validateAllowedHost(URI uri) {
+        String host = Objects.requireNonNullElse(uri.getHost(), "").toLowerCase(Locale.ROOT);
+        boolean allowed = properties.meta().docsAllowlistHosts().stream()
+                .map(value -> value.toLowerCase(Locale.ROOT))
+                .anyMatch(allowedHost -> host.equals(allowedHost) || host.endsWith("." + allowedHost));
+        if (!allowed) {
+            throw new IllegalArgumentException("host not allowed for meta_docs_get: " + host);
+        }
+    }
+
+    private String normalizePath(String path) {
+        String raw = requiredText(path, "path");
+        String normalized = raw.startsWith("/") ? raw.substring(1) : raw;
+        if (!StringUtils.hasText(normalized)) {
+            throw new IllegalArgumentException("path must not be blank");
+        }
+        if (normalized.contains("?")) {
+            throw new IllegalArgumentException("path must not contain query string");
+        }
+        return normalized;
+    }
+
+    private String requiredText(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    private String sanitizeAccessToken(String url) {
+        return url.replaceAll("access_token=[^&]+", "access_token=***");
+    }
+
+    private String toPlainText(String html) {
+        String noScript = html.replaceAll("(?is)<script.*?>.*?</script>", " ")
+                .replaceAll("(?is)<style.*?>.*?</style>", " ");
+        String withoutTags = noScript.replaceAll("(?is)<[^>]+>", " ");
+        return withoutTags.replaceAll("\\s+", " ").trim();
+    }
+}

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -34,3 +34,13 @@ mcp:
     email-service-path: ${MCP_LOG_EMAIL_SERVICE_PATH:http://191.252.120.96:8086/ops-email-gateway-7xk9/email-service-audit-log}
     lead-portal-payment-path: ${MCP_LOG_LEAD_PORTAL_PAYMENT_PATH:http://191.252.102.54:8092/api/v1/logs/runtime?lines=200}
     max-lines: ${MCP_LOG_MAX_LINES:500}
+  meta:
+    enabled: ${MCP_META_ENABLED:false}
+    docs-allowlist-hosts: ${MCP_META_DOCS_ALLOWLIST_HOSTS:developers.facebook.com,www.facebook.com}
+    graph-api-base-url: ${MCP_META_GRAPH_API_BASE_URL:https://graph.facebook.com}
+    graph-api-version: ${MCP_META_GRAPH_API_VERSION:v22.0}
+    access-token: ${MCP_META_ACCESS_TOKEN:}
+    app-id: ${MCP_META_APP_ID:}
+    app-secret: ${MCP_META_APP_SECRET:}
+    request-timeout-millis: ${MCP_META_TIMEOUT_MS:10000}
+    max-response-chars: ${MCP_META_MAX_RESPONSE_CHARS:6000}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -46,6 +46,12 @@ class McpControllerTest {
         registry.add("mcp.logs.lead-portal-payment-path",
                 () -> TEST_LOG_DIR.resolve("lead-portal-payment.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
+        registry.add("mcp.meta.enabled", () -> "false");
+        registry.add("mcp.meta.docs-allowlist-hosts", () -> "developers.facebook.com,www.facebook.com");
+        registry.add("mcp.meta.graph-api-base-url", () -> "https://graph.facebook.com");
+        registry.add("mcp.meta.graph-api-version", () -> "v22.0");
+        registry.add("mcp.meta.request-timeout-millis", () -> "10000");
+        registry.add("mcp.meta.max-response-chars", () -> "2000");
     }
 
     @BeforeEach
@@ -191,6 +197,31 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.id").doesNotExist())
                 .andExpect(jsonPath("$.error.code").value(-32601));
     }
+
+    @Test
+    void shouldListMetaTools() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","id":12,"method":"tools/list","params":{}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.tools[?(@.name == 'meta_docs_get')]").exists())
+                .andExpect(jsonPath("$.result.tools[?(@.name == 'meta_graph_get')]").exists())
+                .andExpect(jsonPath("$.result.tools[?(@.name == 'meta_graph_debug_token')]").exists());
+    }
+
+    @Test
+    void shouldRejectMetaToolWhenFeatureIsDisabled() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"meta_graph_get","arguments":{"path":"me"}}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.error.code").value(-32602))
+                .andExpect(jsonPath("$.error.message").value("meta tools are disabled (set mcp.meta.enabled=true)"));
+    }
 }
 
 @SpringBootTest(properties = "mcp.api-key=super-secret")
@@ -216,6 +247,12 @@ class McpControllerApiKeyEnabledTest {
         registry.add("mcp.logs.lead-portal-payment-path",
                 () -> TEST_LOG_DIR.resolve("lead-portal-payment.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
+        registry.add("mcp.meta.enabled", () -> "false");
+        registry.add("mcp.meta.docs-allowlist-hosts", () -> "developers.facebook.com,www.facebook.com");
+        registry.add("mcp.meta.graph-api-base-url", () -> "https://graph.facebook.com");
+        registry.add("mcp.meta.graph-api-version", () -> "v22.0");
+        registry.add("mcp.meta.request-timeout-millis", () -> "10000");
+        registry.add("mcp.meta.max-response-chars", () -> "2000");
     }
 
     @Test

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -1,0 +1,84 @@
+package com.marketinghub.mcpserver.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.mcpserver.config.McpProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.http.HttpMethod.GET;
+
+class MetaToolsServiceTest {
+
+    private MetaToolsService service;
+    private MockRestServiceServer server;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+
+        McpProperties properties = new McpProperties(
+                "marketing-hub-mcp",
+                "1.0.0",
+                null,
+                new McpProperties.Logs("a", "b", "c", "d", "e", "f", 500),
+                new McpProperties.Meta(
+                        true,
+                        List.of("developers.facebook.com"),
+                        "https://graph.facebook.com",
+                        "v22.0",
+                        "system-token",
+                        "app-id",
+                        "app-secret",
+                        10000,
+                        2000
+                )
+        );
+        service = new MetaToolsService(properties, restTemplate, new ObjectMapper());
+    }
+
+    @Test
+    void shouldFetchMetaDocumentationFromAllowedHost() {
+        server.expect(requestTo("https://developers.facebook.com/docs/marketing-apis/"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess("<html><body><h1>Meta Docs</h1><p>Marketing API</p></body></html>",
+                        MediaType.TEXT_HTML));
+
+        Map<String, Object> result = service.getDocumentationPage("https://developers.facebook.com/docs/marketing-apis/");
+
+        assertThat(result.get("host")).isEqualTo("developers.facebook.com");
+        assertThat(result.get("excerpt")).isEqualTo("Meta Docs Marketing API");
+        server.verify();
+    }
+
+    @Test
+    void shouldRejectDocumentationHostOutsideAllowlist() {
+        assertThatThrownBy(() -> service.getDocumentationPage("https://example.org/meta-docs"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("host not allowed for meta_docs_get: example.org");
+    }
+
+    @Test
+    void shouldMaskAccessTokenOnGraphResponseMetadata() {
+        server.expect(requestTo("https://graph.facebook.com/v22.0/me?fields=id,name&access_token=system-token"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess("{\"id\":\"123\"}", MediaType.APPLICATION_JSON));
+
+        Map<String, Object> result = service.graphGet("me", Map.of("fields", "id,name"));
+
+        assertThat(result.get("graphUrl")).isEqualTo("https://graph.facebook.com/v22.0/me?fields=id,name&access_token=***");
+        assertThat(((Map<?, ?>) result.get("payload")).get("id")).isEqualTo("123");
+        server.verify();
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide basic Meta (Facebook) integrations in the MCP server to fetch documentation pages and call the Graph API for diagnostic and automation tools.
- Allow secure, configurable use of system/user access tokens and protect which documentation hosts can be fetched.

### Description

- Added a new `Meta` configuration record to `McpProperties` and wired corresponding properties in `application.yml` to control enablement, allowlist, timeouts and tokens, and added environment variable names to `README.md` and docs listing for the new tools. 
- Implemented `MetaToolsService` with `getDocumentationPage`, `graphGet`, and `debugToken` methods including host allowlist validation, token masking in returned URLs, HTML->plain text excerpting, parameter validation, and feature-gate checking via `mcp.meta.enabled`. 
- Exposed three new MCP tools in `McpController`: `meta_docs_get`, `meta_graph_get`, and `meta_graph_debug_token`, added request handlers (`callMetaDocsTool`, `callMetaGraphGetTool`, `callMetaGraphDebugTokenTool`) and a `mapArgument` helper, and injected `MetaToolsService`. 
- Registered a `RestTemplate` bean in `McpConfiguration` using `RestTemplateBuilder` with request/read timeouts driven by `mcp.meta.request-timeout-millis`.

### Testing

- Added `MetaToolsServiceTest` unit tests using `MockRestServiceServer` that verify allowed-host fetch, allowlist rejection, and access token masking, and these tests passed. 
- Updated `McpControllerTest` to include meta config properties and added tests to ensure the meta tools are listed and that calling meta tools while disabled returns the expected error, and these controller tests passed. 
- Existing integration tests for other tools continued to run and passed locally as part of the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1ec4afe48321a4421c2c4d7df8a7)