### PR TITLE
Fix MCP server build by using supported RestTemplateBuilder timeout methods

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpConfiguration.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpConfiguration.java
@@ -16,8 +16,8 @@ public class McpConfiguration {
     public RestTemplate mcpRestTemplate(RestTemplateBuilder builder, McpProperties properties) {
         Duration timeout = Duration.ofMillis(properties.meta().requestTimeoutMillis());
         return builder
-                .connectTimeout(timeout)
-                .readTimeout(timeout)
+                .setConnectTimeout(timeout)
+                .setReadTimeout(timeout)
                 .build();
     }
 }


### PR DESCRIPTION
### Motivation
- Fix a compilation failure caused by calling unsupported `RestTemplateBuilder.connectTimeout/readTimeout` methods that are not available for the Spring Boot version used by `mcp-server`.

### Description
- Replace `connectTimeout(timeout)` and `readTimeout(timeout)` with the Spring Boot 3.2-compatible `setConnectTimeout(timeout)` and `setReadTimeout(timeout)` in `mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpConfiguration.java` to restore build compatibility while preserving timeout behavior.

### Testing
- Ran `mvn -f mcp-server/pom.xml test` which completed with `BUILD SUCCESS` (20 tests run, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea21c9ff2c8321b316e57990801a83)