### PR TITLE
Introduce OpenAiPricingService and switch cost estimation to model-catalog pricing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -25,8 +25,8 @@ import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;
 import com.marketinghub.leadportal.integration.LeadPortalPublicationException;
 import com.marketinghub.leadportal.repository.LeadPortalFlowRepository;
-import com.marketinghub.openai.OpenAiCostEstimator;
 import com.marketinghub.openai.OpenAiResponse;
+import com.marketinghub.openai.service.OpenAiPricingService;
 import java.math.BigDecimal;
 import java.text.Normalizer;
 import java.time.Duration;
@@ -113,6 +113,7 @@ public class ExperimentPipelineGenerationService {
     private final ObjectMapper objectMapper;
     private final LandingPageImageInjector landingPageImageInjector;
     private final FrameworkImageGenerationService frameworkImageGenerationService;
+    private final OpenAiPricingService openAiPricingService;
 
     public ExperimentPipelineGenerationService(ExperimentRepository experimentRepository,
                                                ExperimentPipelineGenerationJobRepository jobRepository,
@@ -122,7 +123,8 @@ public class ExperimentPipelineGenerationService {
                                                LeadPortalFlowPublisher leadPortalFlowPublisher,
                                                ObjectMapper objectMapper,
                                                LandingPageImageInjector landingPageImageInjector,
-                                               FrameworkImageGenerationService frameworkImageGenerationService) {
+                                               FrameworkImageGenerationService frameworkImageGenerationService,
+                                               OpenAiPricingService openAiPricingService) {
         this.experimentRepository = experimentRepository;
         this.jobRepository = jobRepository;
         this.experimentMapper = experimentMapper;
@@ -132,6 +134,7 @@ public class ExperimentPipelineGenerationService {
         this.objectMapper = objectMapper;
         this.landingPageImageInjector = landingPageImageInjector;
         this.frameworkImageGenerationService = frameworkImageGenerationService;
+        this.openAiPricingService = openAiPricingService;
     }
 
     @Transactional
@@ -398,7 +401,7 @@ public class ExperimentPipelineGenerationService {
                 totalTokens(request.inputTokens(), request.outputTokens()));
         BigDecimal estimatedCost = request.costUsd() != null
                 ? request.costUsd()
-                : OpenAiCostEstimator.estimateUsd(job.getModel(), usage);
+                : openAiPricingService.estimateStandardCost(job.getModel(), usage);
 
         generationService.recordGeneration(AiWorkerGenerationRequest.builder()
                 .domain("experiment.pipeline." + job.getSection().path())

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisFrameworkGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisFrameworkGenerationService.java
@@ -19,8 +19,8 @@ import com.marketinghub.hypothesis.framework.HypothesisFrameworkSection;
 import com.marketinghub.hypothesis.mapper.HypothesisMapper;
 import com.marketinghub.hypothesis.repository.HypothesisFrameworkGenerationJobRepository;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
-import com.marketinghub.openai.OpenAiCostEstimator;
 import com.marketinghub.openai.OpenAiResponse;
+import com.marketinghub.openai.service.OpenAiPricingService;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -59,19 +59,22 @@ public class HypothesisFrameworkGenerationService {
     private final HypothesisFrameworkMapperSupport frameworkSupport;
     private final AiWorkerGenerationService generationService;
     private final ObjectMapper objectMapper;
+    private final OpenAiPricingService openAiPricingService;
 
     public HypothesisFrameworkGenerationService(HypothesisRepository repository,
                                                 HypothesisFrameworkGenerationJobRepository jobRepository,
                                                 HypothesisMapper mapper,
                                                 HypothesisFrameworkMapperSupport frameworkSupport,
                                                 AiWorkerGenerationService generationService,
-                                                ObjectMapper objectMapper) {
+                                                ObjectMapper objectMapper,
+                                                OpenAiPricingService openAiPricingService) {
         this.repository = repository;
         this.jobRepository = jobRepository;
         this.mapper = mapper;
         this.frameworkSupport = frameworkSupport;
         this.generationService = generationService;
         this.objectMapper = objectMapper;
+        this.openAiPricingService = openAiPricingService;
     }
 
     @Transactional
@@ -189,7 +192,7 @@ public class HypothesisFrameworkGenerationService {
                 totalTokens(request.inputTokens(), request.outputTokens()));
         BigDecimal estimatedCost = request.costUsd() != null
                 ? request.costUsd()
-                : OpenAiCostEstimator.estimateUsd(job.getModel(), usage);
+                : openAiPricingService.estimateStandardCost(job.getModel(), usage);
 
         generationService.recordGeneration(AiWorkerGenerationRequest.builder()
                 .domain("hypothesis.framework." + job.getSection().path() + (summaryOnly ? ".summary" : ""))

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiPricingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiPricingService.java
@@ -1,17 +1,17 @@
 package com.marketinghub.openai.service;
 
-import com.marketinghub.openai.OpenAiCostEstimator;
 import com.marketinghub.openai.OpenAiModel;
 import com.marketinghub.openai.OpenAiResponse;
 import com.marketinghub.openai.repository.OpenAiModelRepository;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Locale;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OpenAiPricingService {
 
-    private static final BigDecimal ONE_THOUSAND = BigDecimal.valueOf(1000);
+    private static final BigDecimal ONE_MILLION = BigDecimal.valueOf(1_000_000);
 
     private final OpenAiModelRepository modelRepository;
 
@@ -19,28 +19,56 @@ public class OpenAiPricingService {
         this.modelRepository = modelRepository;
     }
 
+    public BigDecimal estimateStandardCost(String modelCode, OpenAiResponse.OpenAiUsage usage) {
+        return estimateCost(modelCode, usage, PricingMode.STANDARD);
+    }
+
     public BigDecimal estimateBatchCost(String modelCode, OpenAiResponse.OpenAiUsage usage) {
+        return estimateCost(modelCode, usage, PricingMode.BATCH);
+    }
+
+    private BigDecimal estimateCost(String modelCode, OpenAiResponse.OpenAiUsage usage, PricingMode mode) {
         if (usage == null) {
             return BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP);
         }
-        return modelRepository.findByCode(modelCode)
-                .map(model -> calculateCost(model, usage))
-                .orElse(OpenAiCostEstimator.estimateUsd(modelCode, usage));
+        OpenAiModel model = modelRepository.findByCode(normalizeModelCode(modelCode))
+                .or(() -> modelRepository.findByCode(modelCode))
+                .orElseThrow(() -> new IllegalStateException(
+                        "Modelo OpenAI não encontrado no catálogo para cálculo de custo: " + modelCode));
+        return calculateCost(model, usage, mode);
     }
 
-    private BigDecimal calculateCost(OpenAiModel model, OpenAiResponse.OpenAiUsage usage) {
+    private BigDecimal calculateCost(OpenAiModel model, OpenAiResponse.OpenAiUsage usage, PricingMode mode) {
         int inputTokens = usage.effectiveInputTokens() != null ? usage.effectiveInputTokens() : 0;
         int outputTokens = usage.effectiveOutputTokens() != null ? usage.effectiveOutputTokens() : 0;
-        BigDecimal inputCost = multiplyTokens(model.getPriceInputBatch(), inputTokens);
-        BigDecimal outputCost = multiplyTokens(model.getPriceOutputBatch(), outputTokens);
+        BigDecimal inputPrice = mode == PricingMode.BATCH
+                ? model.getPriceInputBatch()
+                : model.getPriceInputStandard();
+        BigDecimal outputPrice = mode == PricingMode.BATCH
+                ? model.getPriceOutputBatch()
+                : model.getPriceOutputStandard();
+        BigDecimal inputCost = multiplyTokens(inputPrice, inputTokens);
+        BigDecimal outputCost = multiplyTokens(outputPrice, outputTokens);
         return inputCost.add(outputCost).setScale(4, RoundingMode.HALF_UP);
     }
 
-    private BigDecimal multiplyTokens(BigDecimal pricePerThousand, int tokens) {
-        if (pricePerThousand == null || tokens <= 0) {
+    private BigDecimal multiplyTokens(BigDecimal pricePerMillion, int tokens) {
+        if (pricePerMillion == null || tokens <= 0) {
             return BigDecimal.ZERO;
         }
-        return pricePerThousand.multiply(BigDecimal.valueOf(tokens))
-                .divide(ONE_THOUSAND, 6, RoundingMode.HALF_UP);
+        return pricePerMillion.multiply(BigDecimal.valueOf(tokens))
+                .divide(ONE_MILLION, 6, RoundingMode.HALF_UP);
+    }
+
+    private String normalizeModelCode(String modelCode) {
+        if (modelCode == null) {
+            return null;
+        }
+        return modelCode.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private enum PricingMode {
+        STANDARD,
+        BATCH
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -19,6 +19,7 @@ import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;
 import com.marketinghub.leadportal.integration.LeadPortalPublicationException;
 import com.marketinghub.leadportal.repository.LeadPortalFlowRepository;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.openai.service.OpenAiPricingService;
 import com.marketinghub.ai.generation.service.AiWorkerGenerationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ import java.util.UUID;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -46,6 +48,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,6 +70,8 @@ class ExperimentPipelineGenerationServiceTest {
     private LandingPageImageInjector landingPageImageInjector;
     @Mock
     private FrameworkImageGenerationService frameworkImageGenerationService;
+    @Mock
+    private OpenAiPricingService openAiPricingService;
 
     private ExperimentPipelineGenerationService service;
 
@@ -81,7 +86,9 @@ class ExperimentPipelineGenerationServiceTest {
                 leadPortalFlowPublisher,
                 new ObjectMapper(),
                 landingPageImageInjector,
-                frameworkImageGenerationService);
+                frameworkImageGenerationService,
+                openAiPricingService);
+        lenient().when(openAiPricingService.estimateStandardCost(any(), any())).thenReturn(BigDecimal.ZERO);
     }
 
     @Test

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/HypothesisFrameworkGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/HypothesisFrameworkGenerationServiceTest.java
@@ -22,6 +22,8 @@ import com.marketinghub.hypothesis.framework.HypothesisFrameworkSection;
 import com.marketinghub.hypothesis.mapper.HypothesisMapper;
 import com.marketinghub.hypothesis.repository.HypothesisFrameworkGenerationJobRepository;
 import com.marketinghub.hypothesis.repository.HypothesisRepository;
+import com.marketinghub.openai.service.OpenAiPricingService;
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -51,6 +53,8 @@ class HypothesisFrameworkGenerationServiceTest {
 
     @Mock
     private AiWorkerGenerationService generationService;
+    @Mock
+    private OpenAiPricingService openAiPricingService;
 
     @Captor
     private ArgumentCaptor<HypothesisFrameworkGenerationJob> jobCaptor;
@@ -67,8 +71,10 @@ class HypothesisFrameworkGenerationServiceTest {
                 mapper,
                 frameworkSupport,
                 generationService,
-                objectMapper
+                objectMapper,
+                openAiPricingService
         );
+        lenient().when(openAiPricingService.estimateStandardCost(any(), any())).thenReturn(BigDecimal.ZERO);
 
         lenient().when(frameworkSupport.merge(any(HypothesisFrameworkDto.class), any(HypothesisFrameworkDto.class)))
                 .thenAnswer(invocation -> {

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiPricingServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiPricingServiceTest.java
@@ -1,0 +1,73 @@
+package com.marketinghub.openai.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.openai.OpenAiModel;
+import com.marketinghub.openai.OpenAiResponse;
+import com.marketinghub.openai.repository.OpenAiModelRepository;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAiPricingServiceTest {
+
+    @Mock
+    private OpenAiModelRepository modelRepository;
+
+    private OpenAiPricingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new OpenAiPricingService(modelRepository);
+    }
+
+    @Test
+    void estimateStandardCostUsesPricesPerMillionTokens() {
+        OpenAiModel model = OpenAiModel.builder()
+                .code("gpt-5.3-codex")
+                .priceInputStandard(new BigDecimal("2.00000"))
+                .priceOutputStandard(new BigDecimal("10.00000"))
+                .build();
+        when(modelRepository.findByCode("gpt-5.3-codex")).thenReturn(Optional.of(model));
+
+        OpenAiResponse.OpenAiUsage usage = new OpenAiResponse.OpenAiUsage(250_000, 125_000, null, null, 375_000);
+        BigDecimal cost = service.estimateStandardCost("gpt-5.3-codex", usage);
+
+        assertThat(cost).isEqualByComparingTo("1.7500");
+    }
+
+    @Test
+    void estimateBatchCostUsesBatchColumnsPerMillionTokens() {
+        OpenAiModel model = OpenAiModel.builder()
+                .code("gpt-5.3-codex")
+                .priceInputBatch(new BigDecimal("1.00000"))
+                .priceOutputBatch(new BigDecimal("4.00000"))
+                .build();
+        when(modelRepository.findByCode("gpt-5.3-codex")).thenReturn(Optional.of(model));
+
+        OpenAiResponse.OpenAiUsage usage = new OpenAiResponse.OpenAiUsage(300_000, 50_000, null, null, 350_000);
+        BigDecimal cost = service.estimateBatchCost("gpt-5.3-codex", usage);
+
+        assertThat(cost).isEqualByComparingTo("0.5000");
+    }
+
+    @Test
+    void estimateCostFailsWhenModelIsMissingFromCatalog() {
+        when(modelRepository.findByCode("missing-model")).thenReturn(Optional.empty());
+
+        OpenAiResponse.OpenAiUsage usage = new OpenAiResponse.OpenAiUsage(1000, 1000, null, null, 2000);
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> service.estimateStandardCost("missing-model", usage));
+
+        assertThat(error.getMessage()).contains("Modelo OpenAI não encontrado no catálogo");
+    }
+}

--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -92,10 +92,12 @@ O cartão também lista itens operacionais que não travam o worker, mas devem s
    - `custo_texto_usd = (tokens_totais / 1_000_000) * preco_usd_por_milhao_tokens`;
    - `custo_producao_textos_brl = custo_texto_usd * 5`;
    - taxa fixa vigente neste cânone: **`1 USD = 5 BRL`**.
-5. **Regra de consistência de moeda** – `custo_total_experimento_brl` deve ser persistido/exibido em BRL. Campos operacionais em USD podem existir para auditoria, porém não substituem o total consolidado em BRL.
-6. **Zerar contagens** – o botão atualiza `experiment.funnel_reset_at`, e somente eventos com `occurred_at >= funnel_reset_at` permanecem visíveis. Use quando testes internos poluírem o funil sem necessidade de liberar novamente o worker.
-7. **Execução registrada por anúncio** – cada criativo listado traz sua referência de rastreio e a tabela de conversões para as etapas 3 a 9, permitindo diagnosticar rapidamente qual anúncio sustentou o restante do funil.
-8. **Diagnóstico estatístico por etapa** – o backend expõe `GET /api/experiments/{experimentId}/funnel/diagnostics` com status por transição prioritária, separando explicitamente risco estatístico (`INSUFFICIENT_DATA`, `WEAK_SIGNAL`, `STATISTICALLY_FAILED`) de suspeita técnica (`TECHNICAL_ISSUE_SUSPECTED`). A UI consome o diagnóstico e não replica regras críticas.
+5. **Fonte canônica de preço por modelo** – `preco_usd_por_milhao_tokens` deve vir do catálogo interno `openai_model` (backend, chave por `code` do modelo), respeitando o modo da execução (standard/batch). É proibido usar tabela hardcoded de preços como fonte primária para custo de experimento.
+6. **Regra de consistência de unidade** – os preços de `openai_model` são expressos em **USD por 1 milhão de tokens**; qualquer cálculo operacional deve manter esta unidade (divisor `1_000_000`) para evitar drift financeiro.
+7. **Regra de consistência de moeda** – `custo_total_experimento_brl` deve ser persistido/exibido em BRL. Campos operacionais em USD podem existir para auditoria, porém não substituem o total consolidado em BRL.
+8. **Zerar contagens** – o botão atualiza `experiment.funnel_reset_at`, e somente eventos com `occurred_at >= funnel_reset_at` permanecem visíveis. Use quando testes internos poluírem o funil sem necessidade de liberar novamente o worker.
+9. **Execução registrada por anúncio** – cada criativo listado traz sua referência de rastreio e a tabela de conversões para as etapas 3 a 9, permitindo diagnosticar rapidamente qual anúncio sustentou o restante do funil.
+10. **Diagnóstico estatístico por etapa** – o backend expõe `GET /api/experiments/{experimentId}/funnel/diagnostics` com status por transição prioritária, separando explicitamente risco estatístico (`INSUFFICIENT_DATA`, `WEAK_SIGNAL`, `STATISTICALLY_FAILED`) de suspeita técnica (`TECHNICAL_ISSUE_SUSPECTED`). A UI consome o diagnóstico e não replica regras críticas.
 
 ## 9. Dependências externas e domínio publicado
 


### PR DESCRIPTION
### Motivation
- Replace the old ad-hoc cost estimator with a centralized pricing service that reads model prices from the internal `openai_model` catalog and supports different pricing modes.
- Ensure consistent unit handling by using USD prices expressed per 1,000,000 tokens and make pricing behavior explicit in the canonical documentation.

### Description
- Add `OpenAiPricingService` with `estimateStandardCost` and `estimateBatchCost` methods, model code normalization, and pricing mode handling using USD-per-1,000,000-tokens arithmetic.
- Replace direct calls to the removed `OpenAiCostEstimator` with `openAiPricingService.estimateStandardCost(...)` in `ExperimentPipelineGenerationService` and `HypothesisFrameworkGenerationService`, and wire the new dependency through constructors and fields.
- Update unit tests to inject a mocked `OpenAiPricingService` and add `OpenAiPricingServiceTest` covering standard pricing, batch pricing, and missing-model failure cases.
- Update canonical doc `facebook-campaign-publication-canon.v1.md` to mandate the `openai_model` catalog as the canonical price source and to require prices to be interpreted as USD per 1,000,000 tokens.

### Testing
- Ran `OpenAiPricingServiceTest` which includes `estimateStandardCostUsesPricesPerMillionTokens`, `estimateBatchCostUsesBatchColumnsPerMillionTokens`, and `estimateCostFailsWhenModelIsMissingFromCatalog`, and all tests passed.
- Ran updated unit tests `HypothesisFrameworkGenerationServiceTest` and `ExperimentPipelineGenerationServiceTest` with the mocked `OpenAiPricingService`, and they passed.
- Full unit test suite was executed locally for changed modules and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1f0bc3c48321aaf86927a1577870)