### PR TITLE
Fix mcp-server compile errors caused by outdated Meta property accessors

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpConfiguration.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpConfiguration.java
@@ -12,12 +12,13 @@ import java.time.Duration;
 @EnableConfigurationProperties(McpProperties.class)
 public class McpConfiguration {
 
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(15);
+
     @Bean
     public RestTemplate mcpRestTemplate(RestTemplateBuilder builder, McpProperties properties) {
-        Duration timeout = Duration.ofMillis(properties.meta().requestTimeoutMillis());
         return builder
-                .setConnectTimeout(timeout)
-                .setReadTimeout(timeout)
+                .setConnectTimeout(DEFAULT_TIMEOUT)
+                .setReadTimeout(DEFAULT_TIMEOUT)
                 .build();
     }
 }

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/MetaToolsService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/MetaToolsService.java
@@ -20,6 +20,7 @@ public class MetaToolsService {
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
     };
+    private static final int DEFAULT_MAX_RESPONSE_CHARS = 12_000;
 
     private final McpProperties properties;
     private final RestTemplate restTemplate;
@@ -40,7 +41,7 @@ public class MetaToolsService {
         String body = Objects.requireNonNullElse(response.getBody(), "");
         String excerpt = toPlainText(body);
 
-        int maxChars = properties.meta().maxResponseChars();
+        int maxChars = DEFAULT_MAX_RESPONSE_CHARS;
         boolean truncated = excerpt.length() > maxChars;
         String content = truncated ? excerpt.substring(0, maxChars) : excerpt;
 
@@ -58,8 +59,8 @@ public class MetaToolsService {
         String normalizedPath = normalizePath(path);
 
         UriComponentsBuilder builder = UriComponentsBuilder
-                .fromHttpUrl(properties.meta().graphApiBaseUrl())
-                .pathSegment(properties.meta().graphApiVersion())
+                .fromHttpUrl(properties.meta().graphBaseUrl())
+                .pathSegment(properties.meta().graphVersion())
                 .pathSegment(normalizedPath.split("/"));
 
         if (queryParams != null) {
@@ -85,14 +86,16 @@ public class MetaToolsService {
 
     public Map<String, Object> debugToken(String inputToken) {
         ensureMetaEnabled();
-        String appId = requiredText(properties.meta().appId(), "mcp.meta.app-id");
-        String appSecret = requiredText(properties.meta().appSecret(), "mcp.meta.app-secret");
+        String debugAccessToken = requiredText(
+                properties.meta().debugAccessToken(),
+                "mcp.meta.debug-access-token"
+        );
 
         URI uri = UriComponentsBuilder
-                .fromHttpUrl(properties.meta().graphApiBaseUrl())
-                .pathSegment(properties.meta().graphApiVersion(), "debug_token")
+                .fromHttpUrl(properties.meta().graphBaseUrl())
+                .pathSegment(properties.meta().graphVersion(), "debug_token")
                 .queryParam("input_token", requiredText(inputToken, "input_token"))
-                .queryParam("access_token", appId + "|" + appSecret)
+                .queryParam("access_token", debugAccessToken)
                 .build(true)
                 .toUri();
 
@@ -114,7 +117,7 @@ public class MetaToolsService {
 
     private void validateAllowedHost(URI uri) {
         String host = Objects.requireNonNullElse(uri.getHost(), "").toLowerCase(Locale.ROOT);
-        boolean allowed = properties.meta().docsAllowlistHosts().stream()
+        boolean allowed = properties.meta().docsAllowedHosts().stream()
                 .map(value -> value.toLowerCase(Locale.ROOT))
                 .anyMatch(allowedHost -> host.equals(allowedHost) || host.endsWith("." + allowedHost));
         if (!allowed) {

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -35,14 +35,11 @@ class MetaToolsServiceTest {
                 new McpProperties.Logs("a", "b", "c", "d", "e", "f", 500),
                 new McpProperties.Meta(
                         true,
-                        List.of("developers.facebook.com"),
                         "https://graph.facebook.com",
                         "v22.0",
                         "system-token",
-                        "app-id",
-                        "app-secret",
-                        10000,
-                        2000
+                        "system-token",
+                        List.of("developers.facebook.com")
                 )
         );
         service = new MetaToolsService(properties, restTemplate, new ObjectMapper());


### PR DESCRIPTION
### Motivation
- The `mcp-server` build was failing with `cannot find symbol` errors because code referenced removed/renamed accessors on `McpProperties.Meta` (timeout, response size and several `meta.*` getters).
- The goal is to update the configuration, service and tests to the current `McpProperties.Meta` record shape so the module compiles and unit tests run.

### Description
- Replaced the removed `requestTimeoutMillis()` usage in `McpConfiguration` with an internal default `Duration` constant and applied it to the `RestTemplate` timeouts (`mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpConfiguration.java`).
- In `MetaToolsService` replaced usages of deleted accessors with the current `Meta` record accessors and safe defaults: switched `graphApiBaseUrl`/`graphApiVersion` → `graphBaseUrl`/`graphVersion`, `docsAllowlistHosts` → `docsAllowedHosts`, replaced `maxResponseChars()` with an internal `DEFAULT_MAX_RESPONSE_CHARS`, and used `debugAccessToken` for `debugToken` requests (`mcp-server/src/main/java/com/marketinghub/mcpserver/service/MetaToolsService.java`).
- Updated the unit test fixture construction to match the current `McpProperties.Meta` constructor signature so tests compile (`mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java`).

### Testing
- Ran the module unit tests with `mvn test` from the `mcp-server` directory, and all tests passed (`Tests run: 20, Failures: 0, Errors: 0`).
- Confirmed the updated `MetaToolsService` tests exercise docs fetching, allowlist rejection and graph URL masking and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2af0eb908321903f061cb559c611)