### PR TITLE
facebook-ads-worker: fallback to adimages hash after image download failures

### DIFF
--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -23,6 +23,7 @@
 - Na criação de ad sets de campanha, manter placements exclusivos de Instagram (`publisher_platforms=["instagram"]` e `instagram_positions=["stream","story","reels","explore"]`), removendo placements de Facebook, Audience Network e Messenger.
 - Quando não houver `instagramAccount` no experimento, utilize o `defaultInstagramActorId` configurado ou o identificador vindo do criativo, seguindo sem `instagram_user_id` se nenhum valor estiver disponível.
 - Na criação de criativos (`POST /adcreatives`), se a Graph API retornar erro transitório de download da imagem (`error_subcode = 3858258`, ex.: “A imagem não foi baixada”), tente novamente até 3 vezes antes de falhar o experimento.
+- Na criação de criativos (`POST /adcreatives`), ao receber `error_subcode = 3858258`, tente fazer upload prévio da imagem em `/adimages` para obter `image_hash` e reenviar o criativo com `image_hash` (sem `picture`) antes de esgotar as tentativas.
 - Identificadores de instant form no formato `ai_form_*` devem ser normalizados para `form_*` antes de chamar a Graph API.
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.
 - Endpoints do backend devem ser acessados com o prefixo configurado em `backend.api-prefix` (default `/api`).

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -129,13 +129,12 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    `dailyBudget` do experimento (em reais), convertido para centavos antes do
    POST; somente na ausência desse valor o worker recorre ao
    `adSetDailyBudget` configurado na conta da Meta.
-4. **Imagem do criativo**: em vez de enviar `POST /adimages`, o worker
-   referencia diretamente a URL pública retornada pelo backend no campo
-   `object_story_spec.link_data.picture`. Quando o caminho é relativo (por
+4. **Imagem do criativo**: o worker referencia a URL pública retornada pelo
+   backend no campo `object_story_spec.link_data.picture`. Quando o caminho é relativo (por
    exemplo, `/uploads/arquivo.jpg`), o worker o normaliza para o domínio
    configurado em `backend.base-url` antes de encaminhá-lo ao Facebook. Essa
-   abordagem evita depender da biblioteca de imagens da conta e é suportada pela
-   Graph API desde que a URL seja acessível pelo crawler da Meta.
+   abordagem é suportada pela Graph API desde que a URL seja acessível pelo
+   crawler da Meta.
 5. **Criativo** (`POST /adcreatives`) baseado em um `object_story_spec`
    contendo o `page_id` definido na conta selecionada no backend. Quando a conta
    não possui `defaultPageId`, o worker utiliza a página vinculada ao
@@ -152,12 +151,13 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    `instagram_positions=["stream","story","reels","explore"]`), removendo
    placements de Facebook, Audience Network e Messenger.
    Opcionalmente o fluxo inclui mensagem e call-to-action vindos do próprio
-   criativo. A imagem é sempre veiculada via `link_data.picture` — não há hash
-   salvo na biblioteca —, garantindo que o anúncio utilize exatamente o ativo
-   hospedado pelo backend. Se a Meta devolver erro transitório de download da
-   imagem (`error_subcode = 3858258`, por exemplo “A imagem não foi baixada”),
-   o worker tenta novamente a criação do criativo até 3 vezes antes de marcar a
-   publicação como falha definitiva.
+   criativo. Por padrão a imagem segue via `link_data.picture` com a URL pública
+   do ativo; se a Meta devolver erro transitório de download da imagem
+   (`error_subcode = 3858258`, por exemplo “A imagem não foi baixada”), o worker
+   tenta subir a imagem em `/adimages` para obter `image_hash` e reenviar o
+   criativo com hash (sem `picture`). Em caso de nova falha, o worker mantém as
+   retentativas até 3 tentativas totais antes de marcar a publicação como falha
+   definitiva.
 6. **Anúncio** (`POST /ads`) que referencia o conjunto e o criativo recém
    criados, mantido pausado até que o time operacional revise os detalhes no
    Gerenciador de Anúncios.

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -1340,16 +1340,44 @@ public class FacebookCampaignService {
         FacebookAdsService.AdCreativeRequest request
     ) {
         int attempt = 1;
+        boolean triedImageLibraryFallback = false;
+        FacebookAdsService.AdCreativeRequest requestInUse = request;
         while (true) {
             try {
+                FacebookAdsService.AdCreativeRequest requestSnapshot = requestInUse;
                 return executeFacebookCallWithLogging(
                     experimentId,
                     ExperimentFacebookApiLogContext.CAMPAIGN_AD_CREATIVE,
-                    () -> facebookAdsService.createAdCreative(adAccountId, request)
+                    () -> facebookAdsService.createAdCreative(adAccountId, requestSnapshot)
                 );
             } catch (WebClientResponseException ex) {
                 if (!isCreativeImageDownloadError(ex) || attempt >= AD_CREATIVE_IMAGE_DOWNLOAD_RETRY_MAX_ATTEMPTS) {
                     throw ex;
+                }
+                if (!triedImageLibraryFallback
+                    && StringUtils.hasText(requestInUse.imageUrl())
+                    && !StringUtils.hasText(requestInUse.imageHash())) {
+                    String imageUrlSnapshot = requestInUse.imageUrl();
+                    try {
+                        String uploadedImageHash = executeFacebookCallWithLogging(
+                            experimentId,
+                            ExperimentFacebookApiLogContext.CAMPAIGN_AD_CREATIVE,
+                            () -> facebookAdsService.uploadAdImage(adAccountId, imageUrlSnapshot)
+                        );
+                        requestInUse = withImageHashOnly(requestInUse, uploadedImageHash);
+                        triedImageLibraryFallback = true;
+                        LOGGER.info(
+                            "Uploaded creative image to Facebook ad library after download error and switched request to image_hash: experimentId={}, hash={}",
+                            experimentId,
+                            uploadedImageHash
+                        );
+                    } catch (Exception uploadEx) {
+                        LOGGER.warn(
+                            "Could not upload image to Facebook ad library after download error; keeping URL fallback: experimentId={}, message={}",
+                            experimentId,
+                            uploadEx.getMessage()
+                        );
+                    }
                 }
                 LOGGER.warn(
                     "Retrying ad creative creation after transient image download error: experimentId={}, attempt={}/{}, status={}, message={}",
@@ -1362,6 +1390,25 @@ public class FacebookCampaignService {
                 attempt++;
             }
         }
+    }
+
+    private FacebookAdsService.AdCreativeRequest withImageHashOnly(
+        FacebookAdsService.AdCreativeRequest request,
+        String imageHash
+    ) {
+        return new FacebookAdsService.AdCreativeRequest(
+            request.name(),
+            request.pageId(),
+            request.instagramActorId(),
+            request.websiteUrl(),
+            request.leadGenFormId(),
+            request.message(),
+            imageHash,
+            null,
+            request.callToActionType(),
+            request.headline(),
+            request.description()
+        );
     }
 
     private boolean isCreativeImageDownloadError(WebClientResponseException ex) {

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -281,8 +281,7 @@ class FacebookCampaignServiceTest {
             .setBody("{\"error\":{\"message\":\"Invalid parameter\",\"code\":100,\"error_subcode\":3858258,\"error_user_msg\":\"Não foi possível baixar sua imagem\"}}")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueueResponse(new MockResponse()
-            .setResponseCode(400)
-            .setBody("{\"error\":{\"message\":\"Invalid parameter\",\"code\":100,\"error_subcode\":3858258,\"error_user_msg\":\"Não foi possível baixar sua imagem\"}}")
+            .setBody("{\"images\":{\"https://cdn.example/img.jpg\":{\"hash\":\"hash123\"}}}")
             .addHeader("Content-Type", "application/json"));
         facebook.enqueueResponse(new MockResponse().setBody("{\"id\":\"30\"}")
             .addHeader("Content-Type", "application/json"));
@@ -307,10 +306,10 @@ class FacebookCampaignServiceTest {
 
         RecordedRequest creativeAttempt1 = takeFacebookRequest("facebook creative attempt 1");
         assertEquals("/v23.0/act_1/adcreatives", creativeAttempt1.getPath());
+        RecordedRequest uploadImage = takeFacebookRequest("facebook ad image upload");
+        assertEquals("/v23.0/act_1/adimages", uploadImage.getPath());
         RecordedRequest creativeAttempt2 = takeFacebookRequest("facebook creative attempt 2");
         assertEquals("/v23.0/act_1/adcreatives", creativeAttempt2.getPath());
-        RecordedRequest creativeAttempt3 = takeFacebookRequest("facebook creative attempt 3");
-        assertEquals("/v23.0/act_1/adcreatives", creativeAttempt3.getPath());
 
         RecordedRequest postAd = takeFacebookRequest("facebook ad creation");
         assertEquals("/v23.0/act_1/ads", postAd.getPath());


### PR DESCRIPTION
### Motivation
- O experimento 13 estava falhando no `POST /adcreatives` com `error_subcode=3858258` (Meta: “A imagem não foi baixada”), enquanto experimentos anteriores (ex.: 10) publicaram normalmente, indicando problema no download da imagem pelo crawler da Meta.
- Queremos reduzir a dependência do fetch direto da URL pública no momento da criação do criativo e tentar um caminho alternativo que a Graph API aceita quando o download falha.

### Description
- Adicionado fallback em `createAdCreativeWithImageDownloadRetry` para, após detectar erro de download (`error_subcode=3858258`), tentar `facebookAdsService.uploadAdImage(adAccountId, imageUrl)` e reemitir o criativo usando `image_hash` (removendo `picture`).
- Implementada a função auxiliar `withImageHashOnly` que transforma uma `AdCreativeRequest` para usar o `image_hash` e zerar a URL, e controle `triedImageLibraryFallback` para evitar múltiplos uploads redundantes.
- Atualizados testes em `FacebookCampaignServiceTest` para refletir a sequência `POST /adcreatives` (erro) → `POST /adimages` (upload/hash) → `POST /adcreatives` (novo envio) e ajustadas asserções correspondentes.
- Documentação operacional atualizada em `facebook-ads-worker/README.md` e `facebook-ads-worker/AGENTS.md` explicando o novo comportamento de fallback para `image_hash`.

### Testing
- Executei os diagnósticos via MCP com `tools/call` (`db_query` e `java_module_logs`) para confirmar o histórico do experimento 13 e identificar entradas de `experiment_facebook_api_log` mostrando os `400` com `error_subcode=3858258` (sucesso).
- Rodei os testes unitários do módulo com `mvn -f facebook-ads-worker/pom.xml test -DskipITs` e todos os testes passaram (`Tests run: 76, Failures: 0, Errors: 0`).
- Os ajustes de `FacebookCampaignServiceTest` validam agora explicitamente o upload em `/adimages` e a nova tentativa de criação do criativo com `image_hash`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea529058b88321b6d1f2cb1e1be20f)