### PR TITLE
feat(experiments): mostrar total de custo por nicho no filtro de experimentos

### DIFF
--- a/frontend/src/pages/experiment/ExperimentListPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.tsx
@@ -67,6 +67,16 @@ export default function ExperimentListPage() {
   });
   const experiments = Array.isArray(data) ? data : [];
 
+  const nicheTotalCostMap = useMemo(() => {
+    return experiments.reduce<Record<number, number>>((acc, experiment) => {
+      if (typeof experiment.nicheId !== "number") return acc;
+      const experimentCost = resolveExperimentCost(experiment);
+      if (typeof experimentCost !== "number" || Number.isNaN(experimentCost)) return acc;
+      acc[experiment.nicheId] = (acc[experiment.nicheId] ?? 0) + experimentCost;
+      return acc;
+    }, {});
+  }, [experiments]);
+
   const filtered = useMemo(() => {
     return experiments.filter(
       (e) =>
@@ -135,7 +145,7 @@ export default function ExperimentListPage() {
             {Array.isArray(niches) &&
               niches.map((n) => (
                 <option key={n.id} value={n.id}>
-                  {n.name}
+                  {n.name} ({formatCurrency(nicheTotalCostMap[n.id] ?? 0)})
                 </option>
               ))}
           </select>


### PR DESCRIPTION
### Motivation
- Exibir ao lado do nome do nicho a soma dos custos dos experimentos para facilitar a visão do `Custo total por experimento` agregado por nicho na tela de Testes de Nicho.

### Description
- Adicionei um `useMemo` chamado `nicheTotalCostMap` em `frontend/src/pages/experiment/ExperimentListPage.tsx` que reduz a lista de `experiments` somando os valores retornados por `resolveExperimentCost` por `nicheId`.
- Atualizei o `<select>` de nichos para renderizar cada opção como `Nome do Nicho (R$ X,XX)` usando `formatCurrency(nicheTotalCostMap[n.id] ?? 0)`.
- A alteração é apenas no frontend e não altera contratos de API nem endpoints do backend.

### Testing
- Executei `npm --prefix frontend install`, que finalizou com sucesso.
- Executei `npm --prefix frontend run typecheck` (`tsc --noEmit`), que passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6d7474d8832183004969d44df307)