### PR TITLE
Fix exp landing public page HTML rendering

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
@@ -1,8 +1,13 @@
 package com.marketinghub.leadportal.web;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.integration.LeadPortalFlowPublicationRequest;
 import com.marketinghub.leadportal.service.LeadPortalFlowService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/flows")
 public class LeadPortalPublicFlowController {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final LeadPortalFlowService flowService;
 
     public LeadPortalPublicFlowController(LeadPortalFlowService flowService) {
@@ -25,5 +31,57 @@ public class LeadPortalPublicFlowController {
     public LeadPortalFlowPublicationRequest getBySlug(@PathVariable String slug) {
         LeadPortalFlow flow = flowService.getApprovedBySlug(slug);
         return LeadPortalFlowPublicationRequest.from(flow);
+    }
+
+    @GetMapping(value = "/{slug}/page", produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<String> getLandingPageBySlug(@PathVariable String slug) {
+        LeadPortalFlow flow = flowService.getApprovedBySlug(slug);
+        String htmlDocument = extractHtmlDocument(flow.getCustomFormHtml());
+        return ResponseEntity.ok()
+                .contentType(new MediaType("text", "html", java.nio.charset.StandardCharsets.UTF_8))
+                .body(htmlDocument);
+    }
+
+    private String extractHtmlDocument(String sourceHtml) {
+        if (!StringUtils.hasText(sourceHtml)) {
+            return "";
+        }
+        String trimmedSource = sourceHtml.trim();
+        String lowered = trimmedSource.toLowerCase();
+        if (lowered.startsWith("<html") || lowered.startsWith("<!doctype")) {
+            return sourceHtml;
+        }
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(trimmedSource);
+            if (root.isObject()) {
+                JsonNode landingPageHtmlNode = root.get("landingPageHtml");
+                if (landingPageHtmlNode != null) {
+                    String extracted = extractFromLandingPageNode(landingPageHtmlNode);
+                    if (StringUtils.hasText(extracted)) {
+                        return extracted;
+                    }
+                }
+                JsonNode htmlDocumentNode = root.get("htmlDocument");
+                if (htmlDocumentNode != null && htmlDocumentNode.isTextual()) {
+                    return htmlDocumentNode.asText();
+                }
+            }
+        } catch (Exception ignored) {
+            return sourceHtml;
+        }
+        return sourceHtml;
+    }
+
+    private String extractFromLandingPageNode(JsonNode landingPageHtmlNode) throws java.io.IOException {
+        if (landingPageHtmlNode.isTextual()) {
+            JsonNode nested = OBJECT_MAPPER.readTree(landingPageHtmlNode.asText());
+            JsonNode htmlDocumentNode = nested.get("htmlDocument");
+            return htmlDocumentNode != null && htmlDocumentNode.isTextual() ? htmlDocumentNode.asText() : null;
+        }
+        if (landingPageHtmlNode.isObject()) {
+            JsonNode htmlDocumentNode = landingPageHtmlNode.get("htmlDocument");
+            return htmlDocumentNode != null && htmlDocumentNode.isTextual() ? htmlDocumentNode.asText() : null;
+        }
+        return null;
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -89,5 +90,24 @@ class LeadPortalPublicFlowControllerTest {
 
         mockMvc.perform(get("/api/flows/exp-10-landing"))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getLandingPageBySlugReturnsHtmlDocumentFromStructuredJsonPayload() throws Exception {
+        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Teste").build());
+        flowRepository.save(LeadPortalFlow.builder()
+                .name("Fluxo Landing")
+                .slug("exp-13-landing")
+                .approved(true)
+                .marketNiche(niche)
+                .customFormHtml("""
+                        {"landingPageHtml":"{\\"htmlDocument\\":\\"<!doctype html><html lang='pt-BR'><body><h1>Pare de vender por preço</h1></body></html>\\"}"}
+                        """)
+                .build());
+
+        mockMvc.perform(get("/api/flows/exp-13-landing/page"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/html;charset=UTF-8"))
+                .andExpect(content().string("<!doctype html><html lang='pt-BR'><body><h1>Pare de vender por preço</h1></body></html>"));
     }
 }


### PR DESCRIPTION
### Motivation
- The public landing URL for experiment flows was returning structured JSON payloads (e.g. `landingPageHtml` / `htmlDocument`) as escaped/plain text, so browsers displayed the JSON instead of rendering the HTML.
- Provide a simple public endpoint that returns the actual landing HTML so experiment landing pages display correctly in the portal and in browsers.

### Description
- Added a new endpoint `GET /api/flows/{slug}/page` that responds with `text/html; charset=UTF-8` and serves the landing HTML for an approved flow.
- Implemented robust extraction logic in `extractHtmlDocument` to handle raw HTML, top-level `htmlDocument`, and nested `landingPageHtml` formats (both object and serialized string), with safe fallbacks to avoid breaking existing content.
- Introduced a shared `ObjectMapper` instance and helper `extractFromLandingPageNode` to parse nested JSON safely.
- Added an integration test `getLandingPageBySlugReturnsHtmlDocumentFromStructuredJsonPayload` in `LeadPortalPublicFlowControllerTest` to validate HTML extraction and response content-type.

### Testing
- Ran the controller integration tests with `../mvnw -Dtest=LeadPortalPublicFlowControllerTest test` from the `backend/ads-service` directory and all tests passed (`Tests run: 3, Failures: 0`).
- An earlier attempt with `./mvnw -pl ads-service -Dtest=LeadPortalPublicFlowControllerTest test` at repository root failed because that invocation did not resolve the module in the reactor. The verified command above was executed in the module and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea727ef7108321ba6e444c0895f0e8)