### PR TITLE
Expor detalhes da falha do Facebook/worker no diagnóstico de experimento FAILED

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDiagnosticsDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDiagnosticsDto.java
@@ -8,5 +8,6 @@ public record ExperimentDiagnosticsDto(
         String headline,
         String description,
         String resolution,
-        List<ExperimentPublishingArtifactDto> artifacts
+        List<ExperimentPublishingArtifactDto> artifacts,
+        ExperimentFailureDetailsDto failureDetails
 ) { }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentFailureDetailsDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentFailureDetailsDto.java
@@ -1,0 +1,12 @@
+package com.marketinghub.experiment.dto;
+
+import java.time.Instant;
+
+public record ExperimentFailureDetailsDto(
+        String message,
+        String endpoint,
+        Integer statusCode,
+        Instant occurredAt,
+        String source
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentDiagnosticsService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentDiagnosticsService.java
@@ -4,7 +4,10 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.dto.ExperimentDiagnosticsDto;
 import com.marketinghub.experiment.dto.ExperimentDiagnosticsSeverity;
+import com.marketinghub.experiment.dto.ExperimentFailureDetailsDto;
 import com.marketinghub.experiment.dto.ExperimentPublishingArtifactDto;
+import com.marketinghub.facebookads.playbook.dto.ExperimentFacebookApiLogDto;
+import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
 import com.marketinghub.facebookads.FacebookAdsAd;
 import com.marketinghub.facebookads.FacebookAdsAdRepository;
 import com.marketinghub.facebookads.FacebookAdsAdSet;
@@ -15,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,15 +30,18 @@ public class ExperimentDiagnosticsService {
     private final FacebookAdsCampaignRepository campaignRepository;
     private final FacebookAdsAdSetRepository adSetRepository;
     private final FacebookAdsAdRepository adRepository;
+    private final ExperimentFacebookApiLogService facebookApiLogService;
 
     public ExperimentDiagnosticsService(ExperimentService experimentService,
                                         FacebookAdsCampaignRepository campaignRepository,
                                         FacebookAdsAdSetRepository adSetRepository,
-                                        FacebookAdsAdRepository adRepository) {
+                                        FacebookAdsAdRepository adRepository,
+                                        ExperimentFacebookApiLogService facebookApiLogService) {
         this.experimentService = experimentService;
         this.campaignRepository = campaignRepository;
         this.adSetRepository = adSetRepository;
         this.adRepository = adRepository;
+        this.facebookApiLogService = facebookApiLogService;
     }
 
     @Transactional(readOnly = true)
@@ -57,6 +64,7 @@ public class ExperimentDiagnosticsService {
 
         boolean hasPendingArtifacts = !artifacts.isEmpty();
         boolean statusFailed = experiment.getStatus() == ExperimentStatus.FAILED;
+        ExperimentFailureDetailsDto failureDetails = resolveFailureDetails(experimentId, statusFailed);
 
         ExperimentDiagnosticsSeverity severity;
         String headline;
@@ -87,7 +95,54 @@ public class ExperimentDiagnosticsService {
                     : "Altere o status para Planejado quando quiser liberar uma nova tentativa.";
         }
 
-        return new ExperimentDiagnosticsDto(severity, headline, description, resolution, artifacts);
+        return new ExperimentDiagnosticsDto(severity, headline, description, resolution, artifacts, failureDetails);
+    }
+
+    private ExperimentFailureDetailsDto resolveFailureDetails(Long experimentId, boolean statusFailed) {
+        if (!statusFailed) {
+            return null;
+        }
+        return facebookApiLogService.findLogs(experimentId, 200).stream()
+                .filter(this::isFailureLog)
+                .findFirst()
+                .map(log -> new ExperimentFailureDetailsDto(
+                        log.errorMessage(),
+                        log.endpoint(),
+                        log.statusCode(),
+                        resolveOccurrence(log),
+                        resolveFailureSource(log)
+                ))
+                .orElse(null);
+    }
+
+    private boolean isFailureLog(ExperimentFacebookApiLogDto log) {
+        if (log == null) {
+            return false;
+        }
+        if (StringUtils.hasText(log.errorMessage())) {
+            return true;
+        }
+        return log.statusCode() != null && log.statusCode() >= 400;
+    }
+
+    private Instant resolveOccurrence(ExperimentFacebookApiLogDto log) {
+        if (log.respondedAt() != null) {
+            return log.respondedAt();
+        }
+        if (log.requestedAt() != null) {
+            return log.requestedAt();
+        }
+        return log.createdAt();
+    }
+
+    private String resolveFailureSource(ExperimentFacebookApiLogDto log) {
+        if (log.jobWorker() != null) {
+            return log.jobWorker().name();
+        }
+        if (StringUtils.hasText(log.provider())) {
+            return log.provider();
+        }
+        return "FACEBOOK_API_LOG";
     }
 
     private static boolean hasMetaId(String externalId, String internalId) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentDiagnosticsServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentDiagnosticsServiceTest.java
@@ -7,6 +7,7 @@ import com.marketinghub.facebookads.FacebookAdsAdRepository;
 import com.marketinghub.facebookads.FacebookAdsAdSetRepository;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.FacebookAdsCampaignRepository;
+import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,6 +30,8 @@ class ExperimentDiagnosticsServiceTest {
     private FacebookAdsAdSetRepository adSetRepository;
     @Mock
     private FacebookAdsAdRepository adRepository;
+    @Mock
+    private ExperimentFacebookApiLogService facebookApiLogService;
 
     @InjectMocks
     private ExperimentDiagnosticsService service;
@@ -49,6 +52,7 @@ class ExperimentDiagnosticsServiceTest {
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(campaignRepository.findByExperimentId(experimentId)).thenReturn(List.of(campaign));
         when(adSetRepository.findByCampaignIdIn(List.of(campaign.getId()))).thenReturn(List.of());
+        when(facebookApiLogService.findLogs(experimentId, 200)).thenReturn(List.of());
 
         ExperimentDiagnosticsDto diagnostics = service.diagnose(experimentId);
 

--- a/frontend/src/api/experiment/useExperimentDiagnostics.ts
+++ b/frontend/src/api/experiment/useExperimentDiagnostics.ts
@@ -17,6 +17,13 @@ export interface ExperimentDiagnostics {
   description: string;
   resolution: string | null;
   artifacts: ExperimentPublishingArtifact[];
+  failureDetails: {
+    message: string | null;
+    endpoint: string | null;
+    statusCode: number | null;
+    occurredAt: string | null;
+    source: string | null;
+  } | null;
 }
 
 export function useExperimentDiagnostics(id?: string) {

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -753,6 +753,44 @@ export default function ExperimentDetailPage() {
                 </p>
               ) : null}
               <p className="mb-2">{diagnostics.description}</p>
+              {diagnostics.failureDetails ? (
+                <div className="alert alert-light border small mb-2" role="alert">
+                  <div className="fw-semibold mb-1">
+                    Último erro retornado pelo worker / Meta Ads
+                  </div>
+                  <ul className="mb-0 ps-3">
+                    <li>
+                      <strong>Mensagem:</strong>{" "}
+                      {diagnostics.failureDetails.message ??
+                        "Sem mensagem detalhada no log."}
+                    </li>
+                    <li>
+                      <strong>Endpoint:</strong>{" "}
+                      <code>{diagnostics.failureDetails.endpoint ?? "—"}</code>
+                    </li>
+                    <li>
+                      <strong>Status HTTP:</strong>{" "}
+                      {diagnostics.failureDetails.statusCode ?? "—"}
+                    </li>
+                    <li>
+                      <strong>Origem:</strong>{" "}
+                      {diagnostics.failureDetails.source ?? "—"}
+                    </li>
+                    <li>
+                      <strong>Horário do erro:</strong>{" "}
+                      {diagnostics.failureDetails.occurredAt
+                        ? formatDateTimeValue(diagnostics.failureDetails.occurredAt)
+                        : "—"}
+                    </li>
+                  </ul>
+                  <Link
+                    to="facebook-api-logs"
+                    className="btn btn-sm btn-outline-danger mt-2"
+                  >
+                    Abrir Chamadas Meta com payload completo
+                  </Link>
+                </div>
+              ) : null}
               {diagnostics.resolution ? (
                 <p className="mb-2">
                   <strong>O que deve ser corrigido:</strong>{" "}


### PR DESCRIPTION
### Motivation
- Melhorar a visibilidade de erros quando um experimento aparece como `FAILED`, exibindo a mensagem completa e contexto de onde a falha ocorreu para acelerar o troubleshooting.
- Recuperar a informação relevante dos logs das chamadas à Graph API / worker para trazer o texto de erro, endpoint, status e horário diretamente no diagnóstico do experimento.

### Description
- Adiciona o DTO `ExperimentFailureDetailsDto` e estende `ExperimentDiagnosticsDto` com o campo `failureDetails` para transportar `message`, `endpoint`, `statusCode`, `occurredAt` e `source`.
- Atualiza `ExperimentDiagnosticsService` para injetar `ExperimentFacebookApiLogService` e, quando o experimento está em `FAILED`, buscar os logs recentes (`findLogs`) e preencher `failureDetails` com o primeiro log de erro relevante.
- Ajusta o teste `ExperimentDiagnosticsServiceTest` para mockar `ExperimentFacebookApiLogService` e validar o comportamento legacy sem regressão.
- Atualiza o frontend: o tipo retornado por `useExperimentDiagnostics` inclui `failureDetails` e `ExperimentDetailPage` passa a renderizar um bloco com mensagem, endpoint, status, origem, horário e um CTA para abrir `facebook-api-logs` com payload completo.

### Testing
- Backend: executei testes focados com `./mvnw -Dtest=ExperimentDiagnosticsServiceTest,ExperimentFacebookApiLogServiceTest test` dentro de `backend/ads-service`, e os testes passaram ✅.
- Backend: uma execução anterior da suíte revelou um `NullPointer` em `ExperimentDiagnosticsServiceTest` por falta do mock; corrigi o teste para mockar `ExperimentFacebookApiLogService` e os testes relevantes foram validados com sucesso (regressão corrigida). 
- Frontend: rodei `npm run typecheck` em `frontend`, que falhou no ambiente de execução por ausência local de definições de tipos (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`), portanto a validação de tipo não pôde ser concluída aqui ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea850cbb1c8321af762a366d51da41)