### PR TITLE
AI Hub: **Resumo**
- Identei, com apoio do `db_query`, que o registro `lead_portal_flow.slug = 'exp-13-landing'` guarda um HTML completo cujo `<body>` contém o JSON de `landingPageHtml`, o que fazia o endpoint `/api/flows/{slug}/page` retornar um document…

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
@@ -47,12 +47,89 @@ public class LeadPortalPublicFlowController {
             return "";
         }
         String trimmedSource = sourceHtml.trim();
-        String lowered = trimmedSource.toLowerCase();
-        if (lowered.startsWith("<html") || lowered.startsWith("<!doctype")) {
-            return sourceHtml;
+        if (looksLikeJsonPayload(trimmedSource)) {
+            String extractedFromJson = tryExtractFromJsonPayload(trimmedSource);
+            if (StringUtils.hasText(extractedFromJson)) {
+                return extractedFromJson;
+            }
+        }
+        String extractedFromHybrid = tryExtractFromHybridHtml(sourceHtml);
+        if (StringUtils.hasText(extractedFromHybrid)) {
+            return extractedFromHybrid;
+        }
+        return sourceHtml;
+    }
+
+    private boolean looksLikeJsonPayload(String value) {
+        if (!StringUtils.hasText(value)) {
+            return false;
+        }
+        char firstChar = value.charAt(0);
+        return firstChar == '{' || firstChar == '[';
+    }
+
+    private String tryExtractFromHybridHtml(String html) {
+        if (!StringUtils.hasText(html)) {
+            return null;
+        }
+        int cursor = html.indexOf('{');
+        while (cursor >= 0) {
+            String candidate = extractJsonCandidate(html, cursor);
+            if (StringUtils.hasText(candidate) && containsLandingPageSignature(candidate)) {
+                String extracted = tryExtractFromJsonPayload(candidate);
+                if (StringUtils.hasText(extracted)) {
+                    return extracted;
+                }
+            }
+            cursor = html.indexOf('{', cursor + 1);
+        }
+        return null;
+    }
+
+    private boolean containsLandingPageSignature(String candidate) {
+        String lowered = candidate.toLowerCase();
+        return lowered.contains("landingpagehtml") || lowered.contains("htmldocument");
+    }
+
+    private String extractJsonCandidate(String source, int startIndex) {
+        if (startIndex < 0 || startIndex >= source.length() || source.charAt(startIndex) != '{') {
+            return null;
+        }
+        int depth = 0;
+        boolean inString = false;
+        boolean escaping = false;
+        for (int i = startIndex; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (inString) {
+                if (escaping) {
+                    escaping = false;
+                } else if (current == '\\') {
+                    escaping = true;
+                } else if (current == '"') {
+                    inString = false;
+                }
+                continue;
+            }
+            if (current == '"') {
+                inString = true;
+            } else if (current == '{') {
+                depth++;
+            } else if (current == '}') {
+                depth--;
+                if (depth == 0) {
+                    return source.substring(startIndex, i + 1);
+                }
+            }
+        }
+        return null;
+    }
+
+    private String tryExtractFromJsonPayload(String payload) {
+        if (!StringUtils.hasText(payload)) {
+            return null;
         }
         try {
-            JsonNode root = OBJECT_MAPPER.readTree(trimmedSource);
+            JsonNode root = OBJECT_MAPPER.readTree(payload.trim());
             if (root.isObject()) {
                 JsonNode landingPageHtmlNode = root.get("landingPageHtml");
                 if (landingPageHtmlNode != null) {
@@ -67,9 +144,9 @@ public class LeadPortalPublicFlowController {
                 }
             }
         } catch (Exception ignored) {
-            return sourceHtml;
+            return null;
         }
-        return sourceHtml;
+        return null;
     }
 
     private String extractFromLandingPageNode(JsonNode landingPageHtmlNode) throws java.io.IOException {

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.leadportal.web;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.ads.AdsServiceApplication;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.LeadPortalFlowQuestion;
@@ -16,6 +17,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -109,5 +111,35 @@ class LeadPortalPublicFlowControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("text/html;charset=UTF-8"))
                 .andExpect(content().string("<!doctype html><html lang='pt-BR'><body><h1>Pare de vender por preço</h1></body></html>"));
+    }
+
+    @Test
+    void getLandingPageBySlugNormalizesJsonInsideHtmlWrapper() throws Exception {
+        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Teste").build());
+        String nestedDocument = "<!doctype html><html lang=\"pt-BR\"><body><main><h1>Landing Normalizada</h1></main></body></html>";
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonPayload = mapper.writeValueAsString(Map.of(
+                "landingPageHtml", Map.of("htmlDocument", nestedDocument)
+        ));
+        String hybridHtml = """
+                <html lang="pt-BR">
+                  <head><title>Wrapper</title></head>
+                  <body>
+                    %s
+                  </body>
+                </html>
+                """.formatted(jsonPayload);
+        flowRepository.save(LeadPortalFlow.builder()
+                .name("Fluxo Landing")
+                .slug("exp-15-landing")
+                .approved(true)
+                .marketNiche(niche)
+                .customFormHtml(hybridHtml)
+                .build());
+
+        mockMvc.perform(get("/api/flows/exp-15-landing/page"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/html;charset=UTF-8"))
+                .andExpect(content().string(nestedDocument));
     }
 }


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
Da uma olhada nessa url de pagina gerada no pipeline por que ela esta assim toda desconfigurada ? https://oportunidadebrasil.shop/api/flows/exp-13-landing/page
Acessa a tool de web_search.

use a tool de banco de dados para pesquisar as informações necessárias
Teste a compilação dos módulos alterados
Sempre que alterar o frontend crie os métodos do backend para suportar. Tanto back quanto o front estão sendo executados no mesmo host.
Faça os testes necessários para garantir que a solicitação está realmente atendida.
Voce pode usar a tool de web search para acessar o log do modulo Lead Portal na url : https://oportunidadebrasil.shop/api/ops-lp-observability-v2/logfile
Sabendo que o dominio oportunidadebrasil.shop está apontando para 191.252.120.96
IMPRTANTE: Use como base de regras canonicas: docs/canonical/system-governance-canon.v2.md
Consulte e se precisar atualize no esquema canônico de artefatos em : docs/modelo-canonico-artefatos-pipeline-experimento.md

**Resumo das alterações:**
**Resumo**
- Identei, com apoio do `db_query`, que o registro `lead_portal_flow.slug = 'exp-13-landing'` guarda um HTML completo cujo `<body>` contém o JSON de `landingPageHtml`, o que fazia o endpoint `/api/flows/{slug}/page` retornar um documento com o JSON visível em vez do HTML final.
- Reescrevi a rotina `extractHtmlDocument` no `LeadPortalPublicFlowController` para localizar e extrair envelopes JSON mesmo quando eles estão embutidos dentro de HTML já renderizado. A lógica agora percorre a string crua, encontra candidatos balanceados (`{ ... }`) que contenham `landingPageHtml`/`htmlDocument` e reutiliza o parser existente para devolver apenas o `htmlDocument`.
- Adicionei um teste de integração (`getLandingPageBySlugNormalizesJsonInsideHtmlWrapper`) que simula exatamente o cenário observado no pipeline e garante que o endpoint devolve o HTML correto.
- Consultei os cânones em `docs/canonical/system-governance-canon.v2.md` e `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md`; nenhuma atualização foi necessária porque o ajuste mantém a API como fonte de verdade única para o artefato de landing.
- Verifiquei os logs em `https://oportunidadebrasil.shop/api/ops-lp-observability-v2/logfile` (via WebSearch) e não há erros adicionais relacionados ao fluxo—apenas avisos de assets legados ausentes.

**Testes**
- `cd backend && ./mvnw -f ads-service/pom.xml test`

Com a extração normalizada, assim que o backend atualizado for implantado no host (191.252.120.96), o endpoint `/api/flows/exp-13-landing/page` voltará a devolver somente o HTML da landing, resolvendo a “desconfiguração” observada no pipeline.