### PR TITLE
Fix Facebook campaign tests to tolerate adset-playbook telemetry ordering

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -41,6 +41,7 @@ alinhada com os identificadores e faixas de audiência retornados pela Meta.
 ## Testes com MockWebServer
 
 A suíte `FacebookCampaignServiceTest` usa `FailFastMockWebServer` com respostas condicionais de fallback para endpoints de telemetria (`/facebook-api-logs`), publicação de instant form (`/instant-forms/{id}/publication`), status de experimento e fallbacks de campanhas/adsets. Isso evita falhas por requisições auxiliares fora da ordem principal, mantendo os cenários focados no fluxo funcional de criação de campanha.
+Com a telemetria de API ativa durante o fluxo principal, os testes que validam `GET /api/experiments/{id}/adset-playbook` devem preferir `takeRequest` com predicado (matching por path+método) em vez de depender de ordem fixa absoluta na fila do backend.
 Como o fluxo agora sempre pré-carrega imagens via `POST /adimages` antes da criação da campanha e publica o anúncio final via `POST /ads`, os testes devem enfileirar respostas para essas duas chamadas para evitar consumo inesperado dos stubs de campanha/adset/criativo.
 
 ## Fila de resolução de targeting

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -141,6 +141,12 @@ class FacebookCampaignServiceTest {
         );
         backend.enqueueConditionalResponse(
             request -> request.getPath() != null
+                && request.getPath().matches("/api/experiments/\\d+/adset-playbook")
+                && "GET".equals(request.getMethod()),
+            () -> new MockResponse().setBody("[]").addHeader("Content-Type", "application/json")
+        );
+        backend.enqueueConditionalResponse(
+            request -> request.getPath() != null
                 && request.getPath().contains("/api/experiments/")
                 && request.getPath().contains("/status?status=")
                 && "PATCH".equals(request.getMethod()),
@@ -214,7 +220,7 @@ class FacebookCampaignServiceTest {
             .addHeader("Content-Type", "application/json"));
         backend.enqueueResponse(new MockResponse().setBody("[]")
             .addHeader("Content-Type", "application/json"));
-        backend.enqueueResponse(new MockResponse().setBody("{}")
+        backend.enqueueResponse(new MockResponse().setBody("[]")
             .addHeader("Content-Type", "application/json"));
         backend.enqueueResponse(new MockResponse().setBody("{}")
             .addHeader("Content-Type", "application/json"));
@@ -233,7 +239,11 @@ class FacebookCampaignServiceTest {
         RecordedRequest creativesGet = takeBackendRequest("backend request");
         assertEquals("/api/experiments/1/creatives", creativesGet.getPath());
 
-        RecordedRequest playbookGet = takeBackendRequest("backend request");
+        RecordedRequest playbookGet = takeBackendRequestMatching(
+            "playbook request",
+            request -> "/api/experiments/1/adset-playbook".equals(request.getPath())
+                && "GET".equals(request.getMethod())
+        );
         assertEquals("/api/experiments/1/adset-playbook", playbookGet.getPath());
 
         RecordedRequest postCampaign = takeFacebookRequest("facebook request");
@@ -398,6 +408,8 @@ class FacebookCampaignServiceTest {
             .addHeader("Content-Type", "application/json"));
         backend.enqueueResponse(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"https://cdn.example/img.jpg\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
             .addHeader("Content-Type", "application/json"));
+        backend.enqueueResponse(new MockResponse().setBody("[]")
+            .addHeader("Content-Type", "application/json"));
         backend.enqueueResponse(new MockResponse().setBody("{}")
             .addHeader("Content-Type", "application/json"));
         backend.enqueueResponse(new MockResponse().setBody("[{\"id\":900,\"experimentId\":1,\"location\":\"Brasil\",\"targetingRequestId\":\"1c9fc7e0-5731-4453-a9f7-a4d404fb80fd\",\"targetingJson\":null,\"prompt\":\"Detalhes\",\"model\":\"gpt-4\"}]")
@@ -419,7 +431,11 @@ class FacebookCampaignServiceTest {
 
         takeBackendRequest("backend request"); // experiments ready
         takeBackendRequest("backend request"); // creatives
-        RecordedRequest playbookRequest = takeBackendRequest("backend request");
+        RecordedRequest playbookRequest = takeBackendRequestMatching(
+            "playbook request",
+            request -> "/api/experiments/1/adset-playbook".equals(request.getPath())
+                && "GET".equals(request.getMethod())
+        );
         assertEquals("/api/experiments/1/adset-playbook", playbookRequest.getPath());
         RecordedRequest adSetsFallbackRequest = takeBackendRequest("backend request");
         assertEquals("/api/adsets?experimentId=1", adSetsFallbackRequest.getPath());
@@ -792,7 +808,11 @@ class FacebookCampaignServiceTest {
 
         takeBackendRequest("backend request"); // experiments-ready
         takeBackendRequest("backend request"); // creatives fetch
-        RecordedRequest playbookRequest = takeBackendRequest("backend request");
+        RecordedRequest playbookRequest = takeBackendRequestMatching(
+            "playbook request",
+            request -> "/api/experiments/1/adset-playbook".equals(request.getPath())
+                && "GET".equals(request.getMethod())
+        );
         assertEquals("/api/experiments/1/adset-playbook", playbookRequest.getPath());
         RecordedRequest backendReport = takeBackendRequestMatching(
             "campaign report",
@@ -933,7 +953,7 @@ class FacebookCampaignServiceTest {
         assertEquals("/api/facebook-campaigns/experiments-ready", secondGet.getPath());
 
         assertEquals(2, facebook.getRequestCount());
-        assertEquals(7, backend.getRequestCount());
+        assertEquals(8, backend.getRequestCount());
     }
 
     @Test
@@ -1009,7 +1029,11 @@ class FacebookCampaignServiceTest {
         assertEquals("/api/facebook-campaigns/experiments-ready", firstExperimentRequest.getPath());
         RecordedRequest firstCreativeRequest = takeBackendRequest("backend request");
         assertEquals("/api/experiments/1/creatives", firstCreativeRequest.getPath());
-        RecordedRequest firstPlaybookRequest = takeBackendRequest("backend request");
+        RecordedRequest firstPlaybookRequest = takeBackendRequestMatching(
+            "first playbook request",
+            request -> "/api/experiments/1/adset-playbook".equals(request.getPath())
+                && "GET".equals(request.getMethod())
+        );
         assertEquals("/api/experiments/1/adset-playbook", firstPlaybookRequest.getPath());
         RecordedRequest expiredCampaignRequest = takeFacebookRequest("facebook request");
         assertEquals("/v23.0/act_1/campaigns", expiredCampaignRequest.getPath());
@@ -1101,7 +1125,11 @@ class FacebookCampaignServiceTest {
         assertEquals("/api/facebook-campaigns/experiments-ready", firstExperiment.getPath());
         RecordedRequest firstCreative = takeBackendRequest("backend request");
         assertEquals("/api/experiments/1/creatives", firstCreative.getPath());
-        RecordedRequest firstPlaybookRequest = takeBackendRequest("backend request");
+        RecordedRequest firstPlaybookRequest = takeBackendRequestMatching(
+            "first playbook request",
+            request -> "/api/experiments/1/adset-playbook".equals(request.getPath())
+                && "GET".equals(request.getMethod())
+        );
         assertEquals("/api/experiments/1/adset-playbook", firstPlaybookRequest.getPath());
         RecordedRequest expiredCampaign = takeFacebookRequest("facebook request");
         assertEquals("/v23.0/act_1/campaigns", expiredCampaign.getPath());
@@ -1119,7 +1147,11 @@ class FacebookCampaignServiceTest {
         assertEquals("/api/facebook-campaigns/experiments-ready", secondExperiment.getPath());
         RecordedRequest secondCreative = takeBackendRequest("backend request");
         assertEquals("/api/experiments/1/creatives", secondCreative.getPath());
-        RecordedRequest secondPlaybookRequest = takeBackendRequest("backend request");
+        RecordedRequest secondPlaybookRequest = takeBackendRequestMatching(
+            "second playbook request",
+            request -> "/api/experiments/1/adset-playbook".equals(request.getPath())
+                && "GET".equals(request.getMethod())
+        );
         assertEquals("/api/experiments/1/adset-playbook", secondPlaybookRequest.getPath());
         RecordedRequest renewedCampaign = takeFacebookRequest("facebook request");
         assertEquals("/v23.0/act_1/campaigns", renewedCampaign.getPath());
@@ -1181,7 +1213,11 @@ class FacebookCampaignServiceTest {
 
         takeBackendRequest("backend request"); // experiments-ready
         takeBackendRequest("backend request"); // creatives fetch
-        RecordedRequest playbookRequest = takeBackendRequest("backend request");
+        RecordedRequest playbookRequest = takeBackendRequestMatching(
+            "playbook request",
+            request -> "/api/experiments/1/adset-playbook".equals(request.getPath())
+                && "GET".equals(request.getMethod())
+        );
         assertEquals("/api/experiments/1/adset-playbook", playbookRequest.getPath());
         takeBackendRequestMatching(
             "campaign report",
@@ -1231,7 +1267,11 @@ class FacebookCampaignServiceTest {
 
         takeBackendRequest("backend request"); // experiments-ready
         takeBackendRequest("backend request"); // creatives fetch
-        RecordedRequest playbookRequest = takeBackendRequest("backend request");
+        RecordedRequest playbookRequest = takeBackendRequestMatching(
+            "playbook request",
+            request -> "/api/experiments/1/adset-playbook".equals(request.getPath())
+                && "GET".equals(request.getMethod())
+        );
         assertEquals("/api/experiments/1/adset-playbook", playbookRequest.getPath());
         takeBackendRequestMatching(
             "campaign report",


### PR DESCRIPTION
### Motivation
- Tests were flaky because telemetry/logging calls (`/api/experiments/{id}/facebook-api-logs`) can interleave with backend stubs and shift the absolute queue order used by several assertions. 
- Make the test suite resilient to request ordering variance so CI is stable and failures like "No mock response enqueued for request: GET /api/experiments/1/adset-playbook" stop occurring.

### Description
- Replace strict queue-based `takeBackendRequest(...)` usages for `GET /api/experiments/{id}/adset-playbook` with predicate-based `takeBackendRequestMatching(...)` that matches by `path` and `method` to tolerate interleaved telemetry requests. 
- Add a conditional fallback stub in the test setup for `GET /api/experiments/{id}/adset-playbook` to avoid unmatched-request failures when tests do not explicitly enqueue that endpoint. 
- Adjust several test fixtures (response bodies enqueued) and one request-count expectation (`backend.getRequestCount()` from `7` to `8`) to align with the updated flow and stubs. 
- Document the new MockWebServer guidance in `facebook-ads-worker/README.md` advising predicate-based request matching for `adset-playbook` when telemetry is active.

### Testing
- Ran targeted tests with `mvn -q -Dtest=FacebookCampaignServiceTest#usesAudiencePipelineTargetingWhenCreatingAdSet,FacebookCampaignServiceTest#marksExperimentAsFailedWhenFacebookReturnsPermissionError,FacebookCampaignServiceTest#resumesProcessingAfterBackendRenewsTokenWithoutAppCredentials test`, which passed. 
- Ran the module test suite with `mvn -q test`, which completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab1dbb88883218933d7f7d594aed3)