### PR TITLE
docs(canonical): definir timeout de 20 minutos para OpenAI batch (AI Worker)

### DIFF
--- a/docs/canonical/ai-workers-canon.v1.md
+++ b/docs/canonical/ai-workers-canon.v1.md
@@ -1,0 +1,33 @@
+# AI Workers Canon v1
+
+## 1. Propósito
+
+Definir regras canônicas para integrações dos módulos de AI Worker com modelos OpenAI, incluindo parâmetros operacionais obrigatórios para execução em lote (batch).
+
+## 2. Escopo
+
+Este documento cobre:
+
+- regras operacionais mínimas para chamadas OpenAI em workers de IA;
+- padronização de timeout para processamento batch;
+- referência única para evitar drift entre configurações de ambiente e implementação.
+
+## 3. Regra canônica de timeout para OpenAI Batch
+
+Para toda integração do **Worker AI** com OpenAI em **modo batch**, o timeout de acesso/processamento deve ser **sempre de 20 minutos**.
+
+Regras mandatórias:
+
+1. valor canônico fixo: `20 minutos` (`PT20M`);
+2. não é permitido reduzir esse timeout em código, configuração local ou variável de ambiente;
+3. qualquer exceção futura exige nova versão deste cânone e atualização explícita dos módulos consumidores.
+
+## 4. Conformidade operacional
+
+- Backend e Worker AI devem manter o mesmo valor de referência para evitar divergência de estado entre job e polling.
+- Logs de timeout devem registrar ao menos: `jobId`/`batchId`, `model`, `timeoutConfigured`, `timestamp`.
+
+## 5. Referências normativas
+
+- `docs/canonical/system-governance-canon.v2.md`
+- `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md`


### PR DESCRIPTION
### Motivation

- Padronizar o comportamento operacional do Worker AI para chamadas em modo batch à OpenAI e prevenir drift entre configuração, implementação e operação.

### Description

- Adiciona o documento canônico `docs/canonical/ai-workers-canon.v1.md` que centraliza regras para integrações do Worker AI com OpenAI.
- Define a regra mandatória de timeout fixo de `20 minutos` (`PT20M`) para todas as execuções em modo batch e proíbe reduções locais sem nova versão do cânone.
- Especifica requisitos mínimos de observabilidade para eventos de timeout, incluindo `jobId`/`batchId`, `model`, `timeoutConfigured` e `timestamp`, e referencia documentos normativos relevantes.

### Testing

- Alteração documental — nenhum teste automatizado aplicável a código foi executado.
- Verificação básica de existência do arquivo `docs/canonical/ai-workers-canon.v1.md` foi realizada com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac444fd9c832189ef22d8996f1286)