### PR TITLE
feat(experiment): replace Instant Forms tab with Landing tab

### DIFF
--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -168,6 +168,24 @@ Quando `BLOCKED`:
 - exibir causa técnica resumida + ação recomendada;
 - disponibilizar apenas comandos necessários para destravar (`retentar`, `corrigir`, `pausar`).
 
+### 8.5 Aba canônica de destino da campanha (Landing)
+
+Para experimentos com tráfego direcionado para página própria, a UI administrativa
+deve centralizar a escolha do destino na aba **Landing** do detalhe do experimento.
+
+Regras mandatórias:
+
+- a navegação principal do experimento deve expor a aba `Landing` (em substituição
+  à aba operacional de `Instant Forms` no fluxo desta tela);
+- a aba `Landing` deve exibir a **URL standalone** do HTML gerado no experimento
+  (publicado em `/landings/...` no mesmo host);
+- a aba deve oferecer ação explícita para **aprovar** a landing como destino do
+  experimento/campanha;
+- ao aprovar, o backend deve persistir a URL escolhida como `followUpActionUrl`
+  do experimento, mantendo o backend como única fonte de verdade do destino;
+- toda ação assíncrona de aprovação deve manter feedback visual (botão desabilitado
+  + spinner + mensagem de sucesso/erro).
+
 ## 9. Observabilidade mínima
 
 Cada transição de estado da fila e de etapa deve gerar log com:

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -14,7 +14,6 @@ import { getExperimentStageLabel } from "./stageLabels";
 import nicheIcon from "../../assets/icons/niche-icon.svg";
 import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import CriativosTab from "./CriativosTab";
-import InstantFormsTab from "./InstantFormsTab";
 import EmailsTab from "./EmailsTab";
 import SampleEmailsTab from "./SampleEmailsTab";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
@@ -38,6 +37,7 @@ import ExperimentFunnelTab from "./ExperimentFunnelTab";
 import ExperimentReportPanel from "./ExperimentReportPanel";
 import ExperimentLearningPanel from "./ExperimentLearningPanel";
 import ExperimentContentGenerationTab from "./ExperimentContentGenerationTab";
+import LandingTab from "./LandingTab";
 import { useExperimentAdSetWorkflow } from "../../api/experiment/useExperimentAdSetWorkflow";
 import { useExperimentFacebookRelease } from "../../api/experiment/useExperimentFacebookRelease";
 
@@ -111,21 +111,18 @@ export default function ExperimentDetailPage() {
     { label: data?.name || "...", icon: experimentIcon },
   ]);
   const templateSteps = template?.steps ?? [];
-  const hasInstantFormSteps = templateSteps.some(
-    (step) => step.stimulusType === "INSTANT_FORM",
-  );
   const hasEmailSteps = templateSteps.some(
     (step) => step.stimulusType === "EMAIL",
   );
 
   useEffect(() => {
-    if (tab === "instant-form" && !hasInstantFormSteps) {
+    if (tab === "instant-form") {
       setTab("overview");
     }
     if (tab === "emails" && !hasEmailSteps) {
       setTab("overview");
     }
-  }, [tab, hasInstantFormSteps, hasEmailSteps]);
+  }, [tab, hasEmailSteps]);
 
   const assignmentsWithSteps = useMemo(() => {
     const assignments = journeyAssignments?.assignments ?? [];
@@ -254,11 +251,6 @@ export default function ExperimentDetailPage() {
   const hasConfiguredFacebookPage = facebookConfig?.hasConfiguredPages ?? false;
   const experimentPage = data.facebookPage;
   const hasExperimentPage = Boolean(experimentPage?.pageId);
-  const experimentInstantForm = data.facebookInstantForm;
-  const instantFormApproved = Boolean(experimentInstantForm?.approved);
-  const instantFormPublished = Boolean(experimentInstantForm?.published);
-  const instantFormReadyForCampaign =
-    Boolean(experimentInstantForm) && instantFormApproved && instantFormPublished;
   const instagramAccount = data.instagramAccount;
   const hasInstagramAccount = Boolean(instagramAccount);
   const facebookWorker = facebookConfig?.worker;
@@ -333,8 +325,8 @@ export default function ExperimentDetailPage() {
     isReadyForFacebook && data.platform === "FACEBOOK";
   const releaseButtonDisabled =
     releaseInProgress || !canReleaseExperiment || isLoadingReadiness;
-  const openInstantFormActions = () => {
-    setTab("instant-form");
+  const openLandingActions = () => {
+    setTab("landing");
     window.requestAnimationFrame(() => {
       tabsSectionRef.current?.scrollIntoView({
         behavior: "smooth",
@@ -412,29 +404,16 @@ export default function ExperimentDetailPage() {
   ];
 
   const operationalChecklist: ChecklistItem[] = [
-    ...(hasInstantFormSteps
-      ? [
-          {
-            id: "instant-form",
-            title: "Instant form aprovado e publicado",
-            isMet: instantFormReadyForCampaign,
-            hint: experimentInstantForm
-              ? instantFormReadyForCampaign
-                ? `O formulário ${experimentInstantForm.name}${experimentInstantForm.facebookFormId ? ` (${experimentInstantForm.facebookFormId})` : ""} está aprovado e publicado para a campanha.`
-                : `O formulário ${experimentInstantForm.name} está vinculado, mas ainda precisa ${instantFormApproved ? "" : "de aprovação"}${!instantFormApproved && !instantFormPublished ? " e " : ""}${instantFormPublished ? "" : "de publicação na Meta"} para liberar a campanha.`
-              : "Associe um instant form compatível na aba Instant Forms para destravar a etapa de captura.",
-            action: experimentInstantForm
-              ? instantFormReadyForCampaign
-                ? undefined
-                : openInstantFormActions
-              : openInstantFormActions,
-            actionLabel:
-              experimentInstantForm && instantFormReadyForCampaign
-                ? undefined
-                : "Ir para Instant Forms",
-          },
-        ]
-      : []),
+    {
+      id: "landing-destination",
+      title: "Landing aprovada como destino da campanha",
+      isMet: Boolean(data.followUpActionUrl),
+      hint: data.followUpActionUrl
+        ? `URL de destino ativa: ${data.followUpActionUrl}.`
+        : "Aprove uma landing na aba Landing para definir a URL de destino da campanha.",
+      action: data.followUpActionUrl ? undefined : openLandingActions,
+      actionLabel: data.followUpActionUrl ? undefined : "Ir para Landing",
+    },
     {
       id: "platform",
       title: "Plataforma configurada para Facebook Ads",
@@ -1253,11 +1232,9 @@ export default function ExperimentDetailPage() {
           <Tabs.Trigger value="creatives" className="nav-link">
             Criativos
           </Tabs.Trigger>
-          {hasInstantFormSteps ? (
-            <Tabs.Trigger value="instant-form" className="nav-link">
-              Instant Forms
-            </Tabs.Trigger>
-          ) : null}
+          <Tabs.Trigger value="landing" className="nav-link">
+            Landing
+          </Tabs.Trigger>
           {hasEmailSteps ? (
             <Tabs.Trigger value="emails" className="nav-link">
               E-mails
@@ -1321,11 +1298,9 @@ export default function ExperimentDetailPage() {
         <Tabs.Content value="creatives" asChild>
           <CriativosTab experimentId={expId} />
         </Tabs.Content>
-        {hasInstantFormSteps ? (
-          <Tabs.Content value="instant-form" asChild>
-            <InstantFormsTab experiment={data} steps={templateSteps} />
-          </Tabs.Content>
-        ) : null}
+        <Tabs.Content value="landing" asChild>
+          <LandingTab experiment={data} />
+        </Tabs.Content>
         {hasEmailSteps ? (
           <Tabs.Content value="emails" asChild>
             <EmailsTab

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -1,0 +1,187 @@
+import { useMemo, useState } from "react";
+import type { Experiment } from "../../api/experiment/useExperiments";
+import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
+import { useLandingPages } from "../../api/landing/useLandingPages";
+
+interface LandingTabProps {
+  experiment: Experiment;
+}
+
+type FeedbackState = {
+  variant: "success" | "error";
+  message: string;
+};
+
+function resolveStandaloneLandingUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return `${window.location.origin}${normalizedPath}`;
+  }
+  return normalizedPath;
+}
+
+function normalizeUrl(url?: string | null) {
+  return (url ?? "").trim().replace(/\/$/, "");
+}
+
+export default function LandingTab({ experiment }: LandingTabProps) {
+  const { data: landingPages, isLoading, isError } = useLandingPages(experiment.id);
+  const updateExperiment = useUpdateExperiment(experiment.id);
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const [pendingLandingId, setPendingLandingId] = useState<number | null>(null);
+
+  const sortedLandingPages = useMemo(() => {
+    if (!Array.isArray(landingPages)) {
+      return [];
+    }
+
+    return [...landingPages].sort((a, b) => b.id - a.id);
+  }, [landingPages]);
+
+  const selectedDestinationUrl = normalizeUrl(experiment.followUpActionUrl);
+
+  const handleApproveLanding = async (landingId: number, landingUrl: string) => {
+    const kpiTargetValue = experiment.kpiTarget ?? experiment.kpiTargetCpl;
+    if (kpiTargetValue == null || experiment.metricPresetId == null) {
+      setFeedback({
+        variant: "error",
+        message:
+          "Defina a meta de KPI e o preset de métricas antes de aprovar a landing como destino da campanha.",
+      });
+      return;
+    }
+
+    const destinationUrl = resolveStandaloneLandingUrl(landingUrl);
+    setPendingLandingId(landingId);
+    setFeedback(null);
+
+    try {
+      await updateExperiment.mutateAsync({
+        name: experiment.name,
+        hypothesis: experiment.hypothesis,
+        kpiTarget: Number(kpiTargetValue),
+        metricPresetId: experiment.metricPresetId ?? undefined,
+        sampleSize: experiment.sampleSize ?? undefined,
+        mde: experiment.mdePercent ?? undefined,
+        startDate: experiment.startDate ?? undefined,
+        endDate: experiment.endDate ?? undefined,
+        creativesToGenerate: experiment.creativesToGenerate ?? undefined,
+        instantFormsToGenerate: experiment.instantFormsToGenerate ?? undefined,
+        emailsToGenerate: experiment.emailsToGenerate ?? undefined,
+        deliverablesToGenerate: experiment.deliverablesToGenerate ?? undefined,
+        leadPortalFlowsToGenerate: experiment.leadPortalFlowsToGenerate ?? undefined,
+        journeyTemplateId: experiment.journeyTemplateId ?? undefined,
+        facebookPageId: experiment.facebookPage?.id ?? null,
+        facebookInstantFormId: experiment.facebookInstantForm?.id ?? null,
+        instagramAccountId: experiment.instagramAccount?.id ?? null,
+        leadPortalFlowId: experiment.leadPortalFlowId ?? null,
+        followUpActionUrl: destinationUrl,
+      });
+
+      setFeedback({
+        variant: "success",
+        message: "Landing aprovada e definida como URL de destino da campanha.",
+      });
+    } catch {
+      setFeedback({
+        variant: "error",
+        message:
+          "Não foi possível aprovar esta landing agora. Tente novamente em instantes.",
+      });
+    } finally {
+      setPendingLandingId(null);
+    }
+  };
+
+  return (
+    <div className="d-flex flex-column gap-3">
+      <div className="card border-0 shadow-sm">
+        <div className="card-body">
+          <h5 className="card-title mb-1">Landing do experimento</h5>
+          <p className="text-muted mb-0">
+            Aprove a landing que deve ser usada como URL de destino da campanha.
+          </p>
+        </div>
+      </div>
+
+      {feedback ? (
+        <div
+          className={`alert ${feedback.variant === "success" ? "alert-success" : "alert-danger"}`}
+          role="alert"
+        >
+          {feedback.message}
+        </div>
+      ) : null}
+
+      {isLoading ? (
+        <p className="text-muted">Carregando landings do experimento...</p>
+      ) : isError ? (
+        <p className="text-danger">Não foi possível carregar as landings deste experimento.</p>
+      ) : sortedLandingPages.length === 0 ? (
+        <p className="text-muted mb-0">
+          Nenhuma landing gerada ainda. Gere o HTML na aba Estrutura de conteúdo para publicar aqui.
+        </p>
+      ) : (
+        <div className="d-flex flex-column gap-3">
+          {sortedLandingPages.map((landing) => {
+            const standaloneUrl = resolveStandaloneLandingUrl(landing.url);
+            const isSelected = normalizeUrl(standaloneUrl) === selectedDestinationUrl;
+            const isApproving =
+              pendingLandingId === landing.id ||
+              (updateExperiment.isPending && pendingLandingId === landing.id);
+
+            return (
+              <div key={landing.id} className="card border-0 shadow-sm">
+                <div className="card-body d-flex flex-column gap-3">
+                  <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
+                    <div>
+                      <h6 className="mb-1 d-flex align-items-center gap-2">
+                        Landing #{landing.id}
+                        {isSelected ? (
+                          <span className="badge text-bg-success">Destino ativo</span>
+                        ) : null}
+                      </h6>
+                      <p className="text-muted small mb-1">Tipo: {landing.type}</p>
+                      <p className="text-muted small mb-0">Status: {landing.status}</p>
+                    </div>
+                    <button
+                      type="button"
+                      className="btn btn-primary btn-sm"
+                      onClick={() => handleApproveLanding(landing.id, landing.url)}
+                      disabled={isApproving || updateExperiment.isPending}
+                    >
+                      {isApproving ? (
+                        <span className="spinner-border spinner-border-sm" role="status" />
+                      ) : null}
+                      {isApproving
+                        ? "Aprovando..."
+                        : isSelected
+                          ? "Landing aprovada"
+                          : "Aprovar landing"}
+                    </button>
+                  </div>
+
+                  <div>
+                    <p className="text-muted small mb-1">URL standalone</p>
+                    <a
+                      href={standaloneUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="small text-break"
+                    >
+                      {standaloneUrl}
+                    </a>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Replace the Instant Forms operational tab with a dedicated Landing tab so the experiment UI can expose the standalone HTML URL and allow approving a landing as the campaign destination persisted in the experiment (`followUpActionUrl`).
- Keep the backend as the single source of truth for the campaign destination and update the canonical process document to reflect the new UI flow.

### Description
- Removed the Instant Forms tab from the experiment detail navigation and added a new `Landing` tab in `ExperimentDetailPage.tsx` that renders a `LandingTab` component.
- Added `LandingTab` (`frontend/src/pages/experiment/LandingTab.tsx`) which lists landings for the experiment, shows the standalone URL, and provides an Approve button that persists the chosen URL to `followUpActionUrl` via `useUpdateExperiment` with proper async feedback (disabled button + spinner + success/error messages).
- Replaced the readiness/checklist item for instant forms with a new operational checklist entry `landing-destination` that checks `followUpActionUrl` and guides users to the new tab.
- Updated canonical documentation `docs/canonical/experiments-automation-flow-canon.v1.md` to add the mandatory UI rule for the Landing tab (display standalone URL, approval action and persistence to `followUpActionUrl`).

### Testing
- Ran TypeScript checks with `npm --prefix frontend run typecheck` which completed successfully. 
- Ran the frontend test suite with `npm --prefix frontend run test -- --run`; the run exercised the test harness but produced pre-existing failures unrelated to this change (Vitest results: 73 tests passed, 3 tests failed, 1 error across the suite). 
- No backend changes were made and no server-side tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac601e1388321a07bb21dbf498432)