### PR TITLE
Docs: Simplify canonical landing publication flow and update artifacts doc

### DIFF
--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -168,23 +168,31 @@ Quando `BLOCKED`:
 - exibir causa técnica resumida + ação recomendada;
 - disponibilizar apenas comandos necessários para destravar (`retentar`, `corrigir`, `pausar`).
 
-### 8.5 Aba canônica de destino da campanha (Landing)
+### 8.5 Fluxo canônico simplificado de publicação da landing (obrigatório)
 
-Para experimentos com tráfego direcionado para página própria, a UI administrativa
-deve centralizar a escolha do destino na aba **Landing** do detalhe do experimento.
+Para experimentos com tráfego direcionado para landing própria, o processo oficial
+de publicação deve ser simplificado em **3 passos**:
+
+1. **Geração da landing pela IA**
+   O pipeline gera o HTML final da landing para o experimento.
+2. **Aprovação única do usuário**
+   O usuário aprova a landing uma única vez na interface administrativa.
+3. **Publicação automática pelo sistema**
+   Após a aprovação, o backend/sistema:
+   - cria/publica a URL final da landing;
+   - aplica automaticamente o pixel do nicho na landing publicada.
 
 Regras mandatórias:
 
-- a navegação principal do experimento deve expor a aba `Landing` (em substituição
-  à aba operacional de `Instant Forms` no fluxo desta tela);
-- a aba `Landing` deve exibir a **URL standalone** do HTML gerado no experimento
-  (publicado em `/landings/...` no mesmo host);
-- a aba deve oferecer ação explícita para **aprovar** a landing como destino do
-  experimento/campanha;
-- ao aprovar, o backend deve persistir a URL escolhida como `followUpActionUrl`
-  do experimento, mantendo o backend como única fonte de verdade do destino;
-- toda ação assíncrona de aprovação deve manter feedback visual (botão desabilitado
-  + spinner + mensagem de sucesso/erro).
+- não exigir etapa manual adicional entre aprovação e publicação da URL final;
+- não exigir etapa manual adicional para inserção do pixel do nicho;
+- manter o backend como fonte única de verdade para URL publicada e vínculo de pixel;
+- exibir feedback claro de sucesso/erro da aprovação e do resultado da publicação.
+
+### 8.6 Aba canônica de destino da campanha (Landing)
+
+A navegação principal do experimento deve expor a aba `Landing` para suportar o
+fluxo simplificado definido na seção 8.5.
 
 ## 9. Observabilidade mínima
 

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -428,6 +428,21 @@ Regra prática:
 - este arquivo responde a "qual artefato e qual estrutura";
 - o cânone de automação responde a "em qual ordem, com quais estados e com quais gatilhos".
 
+### Regra canônica de publicação da landing (resumo executivo obrigatório)
+
+Independentemente dos detalhes internos de orquestração, a experiência oficial
+de publicação da landing para o usuário deve seguir exatamente:
+
+1. geração da landing pela IA;
+2. aprovação do usuário;
+3. sistema cria/publica a URL final e aplica o pixel do nicho automaticamente.
+
+Regras mandatórias:
+
+- é proibido exigir do usuário uma segunda aprovação para concluir publicação;
+- é proibido exigir inserção manual do pixel após a aprovação;
+- URL publicada e pixel aplicado devem ficar auditáveis no backend.
+
 
 ---
 


### PR DESCRIPTION
### Motivation

- Unify and simplify the official publication experience for experiment landings so the UI/backend follow a single, auditable 3-step flow and avoid manual post-approval steps.

### Description

- Add a new mandatory, simplified 3-step publication flow to `docs/canonical/experiments-automation-flow-canon.v1.md` that requires IA generation, a single user approval, and automatic system publication with pixel application.
- Move and clarify the landing-tab guidance into a new section (`8.6`) and require clear UI feedback and backend-as-source-of-truth behavior for the landing URL and pixel linkage.
- Add an executive summary rule to `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` that reiterates the 3-step constraint and forbids additional manual approvals or manual pixel insertion while requiring backend auditability.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacb2fe8608321b75812d036a9daeb)