### PR TITLE
Aprovar e publicar landing automaticamente (implementa fluxo canônico 8.5)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/dto/LandingPagePublicationResultDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/dto/LandingPagePublicationResultDto.java
@@ -1,0 +1,12 @@
+package com.marketinghub.experiment.pipeline.dto;
+
+public record LandingPagePublicationResultDto(
+        Long experimentId,
+        Long flowId,
+        boolean approved,
+        boolean published,
+        String publicUrl,
+        String facebookPixelId,
+        boolean pixelAppliedAutomatically,
+        String message) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -15,6 +15,7 @@ import com.marketinghub.experiment.pipeline.ExperimentPipelineSection;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationJobDetailDto;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationJobSummaryDto;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationRequest;
+import com.marketinghub.experiment.pipeline.dto.LandingPagePublicationResultDto;
 import com.marketinghub.experiment.pipeline.dto.internal.ExperimentPipelineGenerationJobCompletionRequest;
 import com.marketinghub.experiment.pipeline.dto.internal.ExperimentPipelineGenerationJobDto;
 import com.marketinghub.experiment.frameworkimage.service.FrameworkImageGenerationService;
@@ -25,6 +26,7 @@ import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;
 import com.marketinghub.leadportal.integration.LeadPortalPublicationException;
 import com.marketinghub.leadportal.repository.LeadPortalFlowRepository;
+import com.marketinghub.leadportal.support.LeadPortalPublicUrlResolver;
 import com.marketinghub.openai.OpenAiResponse;
 import com.marketinghub.openai.service.OpenAiPricingService;
 import java.math.BigDecimal;
@@ -114,6 +116,7 @@ public class ExperimentPipelineGenerationService {
     private final LandingPageImageInjector landingPageImageInjector;
     private final FrameworkImageGenerationService frameworkImageGenerationService;
     private final OpenAiPricingService openAiPricingService;
+    private final LeadPortalPublicUrlResolver leadPortalPublicUrlResolver;
 
     public ExperimentPipelineGenerationService(ExperimentRepository experimentRepository,
                                                ExperimentPipelineGenerationJobRepository jobRepository,
@@ -124,7 +127,8 @@ public class ExperimentPipelineGenerationService {
                                                ObjectMapper objectMapper,
                                                LandingPageImageInjector landingPageImageInjector,
                                                FrameworkImageGenerationService frameworkImageGenerationService,
-                                               OpenAiPricingService openAiPricingService) {
+                                               OpenAiPricingService openAiPricingService,
+                                               LeadPortalPublicUrlResolver leadPortalPublicUrlResolver) {
         this.experimentRepository = experimentRepository;
         this.jobRepository = jobRepository;
         this.experimentMapper = experimentMapper;
@@ -135,6 +139,7 @@ public class ExperimentPipelineGenerationService {
         this.landingPageImageInjector = landingPageImageInjector;
         this.frameworkImageGenerationService = frameworkImageGenerationService;
         this.openAiPricingService = openAiPricingService;
+        this.leadPortalPublicUrlResolver = leadPortalPublicUrlResolver;
     }
 
     @Transactional
@@ -277,6 +282,44 @@ public class ExperimentPipelineGenerationService {
             }
         }
         return experimentMapper.toDto(experiment);
+    }
+
+    @Transactional
+    public LandingPagePublicationResultDto approveAndPublishLandingPage(Long experimentId) {
+        ExperimentDto experimentDto = applyLandingHtmlToLeadPortalForm(experimentId);
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Experimento não encontrado"));
+        LeadPortalFlow flowRef = experiment.getLeadPortalFlow();
+        if (flowRef == null || flowRef.getId() == null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Fluxo de landing não foi criado para este experimento");
+        }
+        LeadPortalFlow flow = leadPortalFlowRepository.findById(flowRef.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Fluxo do Lead Portal não encontrado"));
+        flow.setApproved(true);
+        if (flow.getApprovedAt() == null) {
+            flow.setApprovedAt(Instant.now());
+        }
+        LeadPortalFlow saved = leadPortalFlowRepository.save(flow);
+        try {
+            leadPortalFlowPublisher.publish(saved);
+        } catch (LeadPortalPublicationException ex) {
+            String rootCauseMessage = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
+            String message = StringUtils.hasText(rootCauseMessage)
+                    ? "Falha ao aprovar/publicar landing automaticamente: " + rootCauseMessage
+                    : "Falha ao aprovar/publicar landing automaticamente";
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, message, ex);
+        }
+        String pixelId = saved.getMarketNiche() != null ? saved.getMarketNiche().getFacebookPixelId() : null;
+        return new LandingPagePublicationResultDto(
+                experimentDto.getId(),
+                saved.getId(),
+                saved.isApproved(),
+                true,
+                leadPortalPublicUrlResolver.resolve(saved),
+                pixelId,
+                StringUtils.hasText(pixelId),
+                "Landing aprovada e publicação iniciada automaticamente após a aprovação.");
     }
 
     private LeadPortalFlow createLeadPortalFlowFromLandingHtml(Experiment experiment) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/web/ExperimentPipelineController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/web/ExperimentPipelineController.java
@@ -5,6 +5,7 @@ import com.marketinghub.experiment.pipeline.ExperimentPipelineSection;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationJobDetailDto;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationJobSummaryDto;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationRequest;
+import com.marketinghub.experiment.pipeline.dto.LandingPagePublicationResultDto;
 import com.marketinghub.experiment.pipeline.dto.internal.ExperimentPipelineGenerationJobDto;
 import com.marketinghub.experiment.pipeline.service.ExperimentPipelineGenerationService;
 import java.math.BigDecimal;
@@ -47,6 +48,11 @@ public class ExperimentPipelineController {
     @PostMapping("/landing-page-html/apply-to-form")
     public ExperimentDto applyLandingHtmlToForm(@PathVariable Long id) {
         return generationService.applyLandingHtmlToLeadPortalForm(id);
+    }
+
+    @PostMapping("/landing-page-html/approve-and-publish")
+    public LandingPagePublicationResultDto approveAndPublishLanding(@PathVariable Long id) {
+        return generationService.approveAndPublishLandingPage(id);
     }
 
     @GetMapping("/jobs")

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -10,6 +10,7 @@ import com.marketinghub.experiment.pipeline.ExperimentPipelineGenerationJobStage
 import com.marketinghub.experiment.pipeline.ExperimentPipelineGenerationJobStatus;
 import com.marketinghub.experiment.pipeline.ExperimentPipelineSection;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationRequest;
+import com.marketinghub.experiment.pipeline.dto.LandingPagePublicationResultDto;
 import com.marketinghub.experiment.pipeline.dto.internal.ExperimentPipelineGenerationJobCompletionRequest;
 import com.marketinghub.experiment.pipeline.repository.ExperimentPipelineGenerationJobRepository;
 import com.marketinghub.experiment.frameworkimage.service.FrameworkImageGenerationService;
@@ -18,6 +19,7 @@ import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;
 import com.marketinghub.leadportal.integration.LeadPortalPublicationException;
 import com.marketinghub.leadportal.repository.LeadPortalFlowRepository;
+import com.marketinghub.leadportal.support.LeadPortalPublicUrlResolver;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.openai.service.OpenAiPricingService;
 import com.marketinghub.ai.generation.service.AiWorkerGenerationService;
@@ -72,6 +74,8 @@ class ExperimentPipelineGenerationServiceTest {
     private FrameworkImageGenerationService frameworkImageGenerationService;
     @Mock
     private OpenAiPricingService openAiPricingService;
+    @Mock
+    private LeadPortalPublicUrlResolver leadPortalPublicUrlResolver;
 
     private ExperimentPipelineGenerationService service;
 
@@ -87,7 +91,8 @@ class ExperimentPipelineGenerationServiceTest {
                 new ObjectMapper(),
                 landingPageImageInjector,
                 frameworkImageGenerationService,
-                openAiPricingService);
+                openAiPricingService,
+                leadPortalPublicUrlResolver);
         lenient().when(openAiPricingService.estimateStandardCost(any(), any())).thenReturn(BigDecimal.ZERO);
     }
 
@@ -183,6 +188,41 @@ class ExperimentPipelineGenerationServiceTest {
 
         assertEquals(502, error.getStatusCode().value());
         assertTrue(error.getReason().contains("Connection refused"));
+    }
+
+    @Test
+    void approveAndPublishLandingPageReturnsPublicationFeedback() {
+        LeadPortalFlow linkedFlow = new LeadPortalFlow();
+        linkedFlow.setId(902L);
+        linkedFlow.setSlug("exp-22-landing");
+        linkedFlow.setApproved(false);
+
+        MarketNiche niche = new MarketNiche();
+        niche.setFacebookPixelId("pixel-abc");
+        linkedFlow.setMarketNiche(niche);
+
+        Experiment experiment = new Experiment();
+        experiment.setId(22L);
+        experiment.setLandingPageHtml("<section>ok</section>");
+        experiment.setLeadPortalFlow(linkedFlow);
+
+        when(experimentRepository.findById(22L)).thenReturn(Optional.of(experiment));
+        when(leadPortalFlowRepository.findById(902L)).thenReturn(Optional.of(linkedFlow));
+        when(leadPortalFlowRepository.save(any(LeadPortalFlow.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(experimentMapper.toDto(experiment)).thenReturn(new ExperimentDto());
+        when(landingPageImageInjector.injectImages(22L, "<section>ok</section>")).thenReturn("<section>ok</section>");
+        when(leadPortalPublicUrlResolver.resolve(any(LeadPortalFlow.class)))
+                .thenReturn("https://lead.portal/flows/exp-22-landing");
+
+        LandingPagePublicationResultDto result = service.approveAndPublishLandingPage(22L);
+
+        assertEquals(22L, result.experimentId());
+        assertTrue(result.approved());
+        assertTrue(result.published());
+        assertTrue(result.pixelAppliedAutomatically());
+        assertEquals("pixel-abc", result.facebookPixelId());
+        assertEquals("https://lead.portal/flows/exp-22-landing", result.publicUrl());
+        verify(leadPortalFlowPublisher, times(1)).publish(any(LeadPortalFlow.class));
     }
 
     @Test

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -3415,10 +3415,23 @@ function LandingHtmlPreview({
     if (!experimentId) return;
     try {
       setIsApplying(true);
-      await axios.post(
-        `/api/experiments/${experimentId}/pipeline/landing-page-html/apply-to-form`,
+      const { data } = await axios.post<{
+        publicUrl?: string | null;
+        facebookPixelId?: string | null;
+        pixelAppliedAutomatically?: boolean;
+      }>(
+        `/api/experiments/${experimentId}/pipeline/landing-page-html/approve-and-publish`,
       );
-      toast.success("HTML da landing aplicado no formulário do experimento.");
+      const publicationUrl = data?.publicUrl;
+      const pixelFeedback =
+        data?.pixelAppliedAutomatically && data.facebookPixelId
+          ? ` Pixel do nicho aplicado automaticamente (${data.facebookPixelId}).`
+          : " Pixel do nicho será aplicado automaticamente ao ficar disponível.";
+      toast.success(
+        publicationUrl
+          ? `Landing aprovada e publicada automaticamente em ${publicationUrl}.${pixelFeedback}`
+          : `Landing aprovada e publicação automática iniciada.${pixelFeedback}`,
+      );
     } catch (error) {
       toast.error(getErrorMessage(error));
     } finally {
@@ -3450,7 +3463,7 @@ function LandingHtmlPreview({
               Aplicando...
             </span>
           ) : (
-            "Usar como formulário do experimento"
+            "Aprovar e publicar landing"
           )}
         </button>
       </div>


### PR DESCRIPTION
### Motivation
- Tornar o pipeline aderente ao item 8.5 do cânone `docs/canonical/experiments-automation-flow-canon.v1.md` exigindo aprovação única do usuário seguida de publicação automática da landing. 
- Evitar passos manuais entre a aprovação do HTML da landing e a publicação da URL/pixel, mantendo o backend como fonte única de verdade para publicação e vínculo do pixel.

### Description
- Adiciona endpoint `POST /api/experiments/{id}/pipeline/landing-page-html/approve-and-publish` no controller do pipeline que expõe a operação canônica de aprovação + publicação (`ExperimentPipelineController`).
- Implementa `approveAndPublishLandingPage` em `ExperimentPipelineGenerationService` que reaplica o HTML como formulário, marca o `LeadPortalFlow` como aprovado, aciona `LeadPortalFlowPublisher.publish(...)` e retorna feedback operacional via novo DTO `LandingPagePublicationResultDto`.
- Cria `LandingPagePublicationResultDto` para comunicar `experimentId`, `flowId`, `publicUrl`, `facebookPixelId` e flags de sucesso (pixel aplicado automaticamente etc.).
- Atualiza a UI (`ExperimentContentGenerationTab.tsx`) trocando o botão para "Aprovar e publicar landing" e consumindo o novo endpoint para exibir feedback sobre URL publicada e status do pixel.
- Adiciona teste unitário `approveAndPublishLandingPageReturnsPublicationFeedback` em `ExperimentPipelineGenerationServiceTest` cobrindo o caminho feliz de aprovação/publicação e retorno de URL/pixel.

### Testing
- Executei `mvn -f backend/ads-service/pom.xml -Dtest=ExperimentPipelineGenerationServiceTest test`, porém a execução falhou por erro de resolução de dependência remoto (Maven Central retornou HTTP 502), impedindo conclusão dos testes unitários nesta máquina de rollout.
- O novo teste unitário foi adicionado e está preparado para execução; por conta do problema externo de repositório os resultados não puderam ser verificados here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead09885d483218be3c9daea354bc1)