### PR TITLE
Corrige experimentId nulo no feedback de publicação da landing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -311,8 +311,11 @@ public class ExperimentPipelineGenerationService {
             throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, message, ex);
         }
         String pixelId = saved.getMarketNiche() != null ? saved.getMarketNiche().getFacebookPixelId() : null;
+        Long publicationExperimentId = experimentDto != null && experimentDto.getId() != null
+                ? experimentDto.getId()
+                : experimentId;
         return new LandingPagePublicationResultDto(
-                experimentDto.getId(),
+                publicationExperimentId,
                 saved.getId(),
                 saved.isApproved(),
                 true,


### PR DESCRIPTION
### Motivation
- O teste `ExperimentPipelineGenerationServiceTest.approveAndPublishLandingPageReturnsPublicationFeedback` falhava porque o serviço usava `experimentDto.getId()` diretamente e o mapper pode retornar um DTO sem `id`, resultando em `null` no `LandingPagePublicationResultDto`.

### Description
- Ajusta `ExperimentPipelineGenerationService.approveAndPublishLandingPage` para preencher `publicationExperimentId` com `experimentDto.getId()` quando disponível e fazer fallback para o parâmetro `experimentId` caso contrário, preservando os demais campos; alteração em `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`.

### Testing
- Executei `mvn -Dtest=ExperimentPipelineGenerationServiceTest test` dentro de `backend/ads-service` e os testes específicos passaram com sucesso; executei `mvn test` em `backend/ads-service` e a suíte completa retornou `324 tests, 0 failures`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb49444f04832189e8ecfd34b8ac89)