### PR TITLE
docs: adicionar regra geral de revisão de testes para mudanças no cânone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Toda decisão de arquitetura, dados, prompts, automações, integrações e arte
 - **Qualidade**: sempre que alterar um módulo Java realizar os testes unitários antes de publicar o PR.
 - **Logs**: os logs dos modulos Java Spring Boot podem ser acessados pelo MCP Server.  Chame o endpoint MCP https://mcpserverdigi.shop/mcp via JSON-RPC.
 - **Testes Unitários**: os testes unitários precisam sempre estar em concordancia com as regras dos documentos canonicos.
+- **Regra Geral (cânone x testes)**: sempre que houver alteração de regra em documento canônico, revisar e atualizar os testes unitários relacionados para manter aderência entre documentação, regras de domínio e validações automatizadas.
 - **Telas do Usuario**: as telas de usuario, ou frontend precisam sempre estar dando as informações mais importantes e precisas para  o usuario e ofereçendo so comandos necessários para o direcionamento dos fluxo de processos mantidos pelo sistema. Evite informações contraditórias, em excesso e desorganizadas. Mantenha sempre a conformidade com os documentos canonicos.
 
 ## 3. Orientações Práticas:


### PR DESCRIPTION
### Motivation
- Garantir aderência entre alterações em documentos canônicos e os testes automatizados, reduzindo o risco de divergências entre regras documentadas e as validações do sistema.

### Description
- Adiciona em `AGENTS.md` uma nova regra sob "Convenções de engenharia" que exige revisar e atualizar os testes unitários relacionados sempre que houver alteração de regra em documento canônico.

### Testing
- Executados comandos automatizados de alteração/commit: `apply_patch` (atualização do arquivo), `git diff -- AGENTS.md`, `git status --short` e `git commit -m "docs: adicionar regra geral para revisão de testes após mudanças no cânone"`, todos concluídos com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4ba50ef08321856732478f4f8c23)