### PR TITLE
docs(facebook-ads-worker): instruct upload via adimages and use image_hash for creatives

### DIFF
--- a/docs/facebook-ads-worker/endpoint-flow.md
+++ b/docs/facebook-ads-worker/endpoint-flow.md
@@ -59,6 +59,8 @@ sequenceDiagram
         GraphAPI-->>Worker: campaignId
         Worker->>GraphAPI: POST /{v}/act_<adAccountId>/adsets
         GraphAPI-->>Worker: adSetId
+        Worker->>GraphAPI: POST /{v}/act_<adAccountId>/adimages
+        GraphAPI-->>Worker: imageHash
         Worker->>GraphAPI: POST /{v}/act_<adAccountId>/adcreatives
         GraphAPI-->>Worker: adCreativeId
         Worker->>GraphAPI: POST /{v}/act_<adAccountId>/ads
@@ -92,8 +94,10 @@ sequenceDiagram
    worker calcula página do Facebook, Instagram user ID, URL/lead form e CTA,
    combinando valores vindos do experimento com os defaults da conta.
 6. **Criar a hierarquia na Graph API** – A sequência de chamadas `POST` cria a
-   campanha (`/campaigns`), conjunto (`/adsets`), criativo (`/adcreatives`) e
-   anúncio (`/ads`) usando `facebook.graph-api.version` (padrão `v23.0`). Todas
+   campanha (`/campaigns`), conjunto (`/adsets`), faz upload da imagem em
+   `/adimages` para obter `image_hash`, cria o criativo (`/adcreatives`)
+   referenciando esse hash e finaliza com anúncio (`/ads`) usando
+   `facebook.graph-api.version` (padrão `v23.0`). Todas
    são enviadas com `status=PAUSED` e token mascarado nos logs. A composição dos
    payloads inclui segmentação geográfica, promoted object com `page_id`, CTA e
    mensagem do criativo.
@@ -128,7 +132,8 @@ sequenceDiagram
 | --- | --- | --- | --- | --- |
 | POST | `/v23.0/act_<adAccountId>/campaigns` | `FacebookAdsService.createCampaign` | Nome, objetivo dinâmico (`OUTCOME_TRAFFIC` ou `OUTCOME_LEADS`), `special_ad_categories=[]`, `status=PAUSED` | Usado tanto para campanhas Facebook quanto Instagram |
 | POST | `/v23.0/act_<adAccountId>/adsets` | `FacebookAdsService.createAdSet` | Daily budget, billing event, optimization goal, destination type, targeting por país, promoted page | Inclui `bid_strategy` e `bid_amount` quando configurados |
-| POST | `/v23.0/act_<adAccountId>/adcreatives` | `FacebookAdsService.createAdCreative` | `object_story_spec` com `page_id`, `instagram_user_id`, mensagem, CTA, link ou lead form | CTA só envia `value` quando há URL ou formulário |
+| POST | `/v23.0/act_<adAccountId>/adimages` | `FacebookAdsService.uploadAdImage` | upload binário/URL da imagem do criativo + `access_token` | Upload é independente do anúncio/criativo e retorna `image_hash` reutilizável na biblioteca da conta |
+| POST | `/v23.0/act_<adAccountId>/adcreatives` | `FacebookAdsService.createAdCreative` | `object_story_spec` com `page_id`, `instagram_user_id`, mensagem, CTA, link ou lead form + `image_hash` | Evitar `image_url` direto no criativo; usar hash retornado por `/adimages` |
 | POST | `/v23.0/act_<adAccountId>/ads` | `FacebookAdsService.createAd` | Nome, `adset_id`, `creative_id`, `status=PAUSED` | Mantido pausado para revisão manual |
 | POST | `/v23.0/{campaignId}` | `FacebookAdsService.pauseCampaign` | `status=PAUSED`, `access_token` | Conforme [referência oficial da Marketing API](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/#Updating) |
 | GET | `/v23.0/{campaignId}/insights` | `FacebookAdsService.getCampaignMetrics` | Retorna métricas agregadas da campanha | Trata `(#190)` como token expirado |
@@ -199,6 +204,12 @@ sequenceDiagram
    o mesmo fluxo acima. Se a renovação automática não estiver configurada ou
    continuar falhando, o worker pausa o processamento até receber um token
    válido, registrando mensagens de orientação nos logs.
+
+## Diretriz de tratamento de imagens em publicação de campanha
+
+- Para publicação de campanhas, **não enviar `image_url` diretamente no payload do criativo** quando a imagem precisar ser materializada na conta de anúncio.
+- O fluxo recomendado é: fazer upload da imagem em `POST /act_<adAccountId>/adimages`, capturar o `image_hash` retornado e então enviar esse `image_hash` no `POST /adcreatives`.
+- A Meta documenta que o envio e gerenciamento de imagens pode ocorrer de forma independente do anúncio/criativo, por isso o worker deve priorizar esse fluxo baseado em biblioteca de imagens da conta.
 
 ## Referências adicionais
 

--- a/docs/facebook-ads-worker/input-output-mapping.md
+++ b/docs/facebook-ads-worker/input-output-mapping.md
@@ -40,7 +40,8 @@ flowchart TD
     experiments --> service
     service --> createCampaign["POST /v20.0/act_<adAccountId>/campaigns"]
     createCampaign --> createAdSet["POST /v20.0/act_<adAccountId>/adsets"]
-    createAdSet --> createCreative["POST /v20.0/act_<adAccountId>/adcreatives"]
+    createAdSet --> uploadImage["POST /v20.0/act_<adAccountId>/adimages"]
+    uploadImage --> createCreative["POST /v20.0/act_<adAccountId>/adcreatives (com image_hash)"]
     createCreative --> createAd["POST /v20.0/act_<adAccountId>/ads"]
     createAd --> persist["POST /facebook-campaigns"]
     persist --> db["Tabelas facebook_ads_*"]
@@ -93,7 +94,13 @@ flowchart TD
 
 * **Resposta tratada:** o `id` do ad set é utilizado na criação do anúncio.
 
-## 4. Criação do criativo
+## 4. Upload da imagem para a biblioteca da conta
+
+* **Endpoint da Graph API:** `POST https://graph.facebook.com/v20.0/act_<adAccountId>/adimages`
+* **Objetivo:** enviar a imagem do anúncio para a biblioteca da conta de anúncio e recuperar o `image_hash` oficial.
+* **Observação:** a Meta permite enviar e gerenciar imagens de forma independente de anúncios/criativos; por isso o worker deve priorizar esse fluxo em vez de depender de `image_url` no criativo.
+
+## 5. Criação do criativo
 
 * **Endpoint da Graph API:** `POST https://graph.facebook.com/v20.0/act_<adAccountId>/adcreatives`
 * **Payload enviado:**
@@ -108,11 +115,12 @@ flowchart TD
 | `object_story_spec.link_data.call_to_action.type` | Conta configurada (`worker-config.defaultCallToActionType`) ou `Creative.cta` | Lista completa documentada em [call-to-action-types.md](call-to-action-types.md) |
 | `object_story_spec.link_data.call_to_action.value.link` | Mesmo valor de `link` | Omitido quando a campanha utiliza formulário de leads |
 | `object_story_spec.link_data.call_to_action.value.lead_gen_form_id` | `Creative.leadGenFormId` ou `worker-config.defaultLeadGenFormId` | Permite direcionar o CTA para formulários do Facebook ou Instagram |
+| `object_story_spec.link_data.image_hash` | Retorno de `POST /adimages` | Referencia a imagem já enviada à biblioteca da conta; preferível a `image_url` no criativo |
 | `access_token` | Conta configurada (`worker-config.accessToken`) | Token com permissão para o Ad Account |
 
 * **Resposta tratada:** o `id` do criativo abastece a criação do anúncio.
 
-## 5. Criação do anúncio
+## 6. Criação do anúncio
 
 * **Endpoint da Graph API:** `POST https://graph.facebook.com/v20.0/act_<adAccountId>/ads`
 * **Payload enviado:**
@@ -128,7 +136,7 @@ flowchart TD
 * **Resposta tratada:** o identificador alimenta o payload enviado ao backend,
   mantendo o vínculo entre anúncio, conjunto e criativo na base própria.
 
-## 6. Persistência da campanha no backend
+## 7. Persistência da campanha no backend
 
 Após criar a hierarquia na Graph API, o worker envia um `CreateCampaignRequest`
 para o backend.

--- a/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
+++ b/docs/facebook-ads-worker/transformacao-experimentos-campanhas.md
@@ -21,7 +21,8 @@ flowchart TD
     backendFetch --> service
     service --> campaign["POST /v20.0/act_{adAccountId}/campaigns"]
     campaign --> adset["POST /v20.0/act_{adAccountId}/adsets"]
-    adset --> creative["POST /v20.0/act_{adAccountId}/adcreatives"]
+    adset --> adimages["POST /v20.0/act_{adAccountId}/adimages"]
+    adimages --> creative["POST /v20.0/act_{adAccountId}/adcreatives (image_hash)"]
     creative --> ad["POST /v20.0/act_{adAccountId}/ads"]
     ad --> persist["POST /facebook-campaigns"]
     persist --> db["Tabela facebook_ads_campaign"]
@@ -59,13 +60,18 @@ montar a hierarquia completa:
    `leadGenFormId`, o worker troca `destination_type` para `ON_AD` e força o `optimization_goal` para `LEAD_GENERATION`.
    A segmentação inicial utiliza apenas o país padrão enquanto o backend não
    envia dados mais ricos. O `id` retornado é usado na criação do anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L196-L208)).
-3. **Criativo**: `POST /adcreatives` baseado em um `object_story_spec` que inclui
+3. **Imagem do anúncio**: antes do criativo, o worker faz `POST /adimages` para
+   enviar a imagem à biblioteca da conta de anúncios e obter o `image_hash`,
+   conforme prática recomendada pela Meta para gerenciamento independente de
+   assets visuais.
+4. **Criativo**: `POST /adcreatives` baseado em um `object_story_spec` que inclui
    `page_id`, `instagram_user_id` opcional, template de mensagem com o nome do
-   experimento e call-to-action vindos da mesma configuração. Quando o criativo
-   ou a conta informam `leadGenFormId`, o worker adiciona `call_to_action.value.lead_gen_form_id`
-   e torna o campo `link` opcional, habilitando formulários instantâneos no
-   Facebook/Instagram. O `id` retornado alimenta o anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L209-L219)).
-4. **Anúncio**: `POST /ads` referenciando o ad set e o criativo recém-criados, em
+   experimento, call-to-action e `image_hash` retornado no upload anterior.
+   Quando o criativo ou a conta informam `leadGenFormId`, o worker adiciona
+   `call_to_action.value.lead_gen_form_id` e torna o campo `link` opcional,
+   habilitando formulários instantâneos no Facebook/Instagram. O `id` retornado
+   alimenta o anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L209-L219)).
+5. **Anúncio**: `POST /ads` referenciando o ad set e o criativo recém-criados, em
    status `PAUSED` para permitir revisão manual antes da ativação
    ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L220-L225)).
 
@@ -94,12 +100,13 @@ utilizados (`targetCountry`, `pageId`) e os metadados do criativo (`websiteUrl`,
 | `Experiment.name` | `Graph API - name` | Nome base para campanha, ad set, criativo e anúncio ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L169-L224)) |
 | `Experiment.name` | `CreateCampaignRequest.name` | Mantém rastreabilidade entre backend e Facebook ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L226-L263)) |
 | `worker-config.adAccountId` | `Graph API - URLs` | Define o Ad Account usado em todas as chamadas `POST` ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L38-L67)) |
-| `worker-config.accessToken` | `Graph API - access_token` | Token reutilizado em campanha, ad set, criativo e anúncio ([FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L18-L208)) |
+| `worker-config.accessToken` | `Graph API - access_token` | Token reutilizado em campanha, ad set, upload de imagem (`/adimages`), criativo e anúncio ([FacebookAdsService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java#L18-L208)) |
 | `worker-config.adSet*` | `Graph API - adsets` e `CreateCampaignRequest.adSet` | Define orçamento, otimização e país padrão, replicados no backend ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L196-L245)) |
 | `worker-config.defaultPageId` | `Graph API - promoted_object` / `object_story_spec.page_id` / `CreateCampaignRequest.adSet.pageId` | Necessário para ad sets e criativos; caso ausente, o worker usa a página associada ao experimento e ignora o experimento quando nenhuma estiver configurada ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L177-L245)) |
 | `worker-config.defaultInstagramActorId` | `Graph API - object_story_spec.instagram_user_id` / `CreateCampaignRequest.adCreative.instagramActorId` | Opcional, incluído apenas quando configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L209-L255)) |
 | `worker-config.defaultCreativeMessageTemplate` | `Graph API - object_story_spec.link_data.message` | Template com suporte a `%s` para o nome do experimento ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L189-L193)) |
 | `worker-config.defaultWebsiteUrl` | `Graph API - link_data.link`/`call_to_action.value.link` e `CreateCampaignRequest.adCreative.websiteUrl` | URL padrão de destino persistida no backend; opcional quando há formulário configurado ([FacebookCampaignService.java](../../facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java#L209-L255)) |
+| Imagem do criativo (asset aprovado) | `POST /adimages` -> `image_hash` -> `Graph API - object_story_spec.link_data.image_hash` | Substitui o envio direto de `image_url` no criativo e reutiliza a biblioteca de imagens da conta |
 | `worker-config.defaultLeadGenFormId` | `Graph API - call_to_action.value.lead_gen_form_id` e `CreateCampaignRequest.adCreative.leadGenFormId` | Fallback para formulários Instant/Lead Ads quando o criativo não define `leadGenFormId` |
 | Resposta da Graph API (`id`) | `CreateCampaignRequest.id`/`adSet.id`/`adCreative.id`/`ad.id` | Identificadores de campanha, ad set, criativo e anúncio persistidos nas respectivas tabelas |
 | Valor dinâmico (`OUTCOME_TRAFFIC`/`OUTCOME_LEADS`) | `Graph API - objective` e `CreateCampaignRequest.objective` | Escolha automática conforme o destino resolvido |
@@ -127,3 +134,10 @@ para completar a configuração avançada da campanha:
 Com a hierarquia básica persistida, as próximas evoluções se concentram em
 enriquecer os registros com segmentações detalhadas, UTMs e métricas periódicas
 ([pendencias.md](./pendencias.md)).
+
+## Diretriz de imagens para publicação de campanha
+
+- Em campanhas publicadas via worker, o tratamento de imagem deve priorizar upload prévio no endpoint `adimages` da conta (`act_<adAccountId>`).
+- Após upload, o `image_hash` retornado deve ser usado no payload de `adcreatives`.
+- Evite depender de `image_url` direto no criativo quando houver asset próprio aprovado no experimento.
+- Essa diretriz segue a documentação da Meta de que imagens de anúncios podem ser enviadas e gerenciadas independentemente do anúncio/criativo.


### PR DESCRIPTION
### Motivation
- Alinhar a documentação do fluxo de publicação de campanhas com a recomendação da Meta de que imagens podem ser enviadas e gerenciadas independentemente do criativo, reduzindo falhas de publicação causadas por download/URL. 

### Description
- Atualiza `docs/facebook-ads-worker/endpoint-flow.md` para inserir o passo de upload em `POST /{v}/act_<adAccountId>/adimages` na sequência de criação de campanha e incluir diretriz de tratamento de imagens. 
- Atualiza `docs/facebook-ads-worker/input-output-mapping.md` para trocar o fluxo `adsets -> adcreatives` por `adsets -> adimages -> adcreatives` e documentar `object_story_spec.link_data.image_hash` como campo preferencial. 
- Atualiza `docs/facebook-ads-worker/transformacao-experimentos-campanhas.md` para explicitar o upload prévio de imagens, mapear `image_hash` no pipeline e adicionar a diretriz final de uso de `image_hash` em vez de `image_url`. 

### Testing
- Executed repository scans with `rg` to locate impacted docs and references and the searches completed successfully. 
- Verified working tree and changes with `git status --short`, `git diff -- <files>` and `git log -1 --oneline`, and these commands returned expected outputs. 
- Committed the changes with `git add` + `git commit` and created the PR via the internal `make_pr` helper; the commit and PR creation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4b24a8788321bd3a9c77d54f9767)