### PR TITLE
Implementa deduplicação canônica de imagens na publicação de campanhas Meta

### DIFF
--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -151,13 +151,20 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    `instagram_positions=["stream","story","reels","explore"]`), removendo
    placements de Facebook, Audience Network e Messenger.
    Opcionalmente o fluxo inclui mensagem e call-to-action vindos do próprio
-   criativo. O caminho principal de publicação da imagem agora é
-   `POST /adimages` para obter `image_hash` e enviar o criativo com
-   `link_data.image_hash` (sem `picture`). Se o upload da imagem não retornar
-   hash válido, o worker registra aviso e usa fallback com
-   `link_data.picture` (URL pública). Em caso de erro transitório de download da
-   imagem (`error_subcode = 3858258`), o fluxo mantém retentativas de criação
-   até 3 tentativas totais antes de marcar a publicação como falha definitiva.
+   criativo. O caminho principal de publicação da imagem agora segue o cânone
+   de deduplicação por conteúdo: o worker baixa o asset, calcula `sha256`
+   local, consulta o backend em
+   `GET /api/internal/facebook-campaigns/image-hash-mappings/resolve` e, se já
+   existir vínculo para a mesma conta (`local_hash -> meta_image_hash`),
+   reutiliza diretamente o hash sem novo upload para a Meta. Quando não existe
+   mapeamento, o worker envia o binário em `POST /adimages`, recebe o
+   `image_hash` e persiste o vínculo em
+   `POST /api/internal/facebook-campaigns/image-hash-mappings` para reuso nas
+   próximas publicações. Se o upload da imagem não retornar hash válido, o
+   worker registra aviso e usa fallback com `link_data.picture` (URL pública).
+   Em caso de erro transitório de download da imagem (`error_subcode = 3858258`),
+   o fluxo mantém retentativas de criação até 3 tentativas totais antes de
+   marcar a publicação como falha definitiva.
 6. **Anúncio** (`POST /ads`) que referencia o conjunto e o criativo recém
    criados, mantido pausado até que o time operacional revise os detalhes no
    Gerenciador de Anúncios.

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -42,6 +42,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.security.MessageDigest;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -66,6 +67,7 @@ public class FacebookCampaignService {
     private static final Logger LOGGER = LoggerFactory.getLogger(FacebookCampaignService.class);
     private static final int AD_CREATIVE_IMAGE_DOWNLOAD_RETRY_MAX_ATTEMPTS = 3;
     private static final int AD_CREATIVE_IMAGE_DOWNLOAD_ERROR_SUBCODE = 3858258;
+    private static final String IMAGE_HASH_PLATFORM = "FACEBOOK";
 
     private static final Duration CREATIVE_IMAGE_DOWNLOAD_TIMEOUT = Duration.ofSeconds(20);
     private static final long CREATIVE_IMAGE_MAX_BYTES = 10 * 1024 * 1024L;
@@ -1353,6 +1355,15 @@ public class FacebookCampaignService {
     }
 
     private record DownloadedImage(byte[] bytes, String contentType) {}
+    private record CanonicalImageHashUpsertRequest(
+        String platform,
+        String adAccountId,
+        String localHash,
+        String metaImageHash
+    ) {}
+    private record CanonicalImageHashResponse(
+        @JsonAlias({"metaImageHash", "meta_image_hash", "imageHash", "image_hash"}) String metaImageHash
+    ) {}
 
     private JsonNode parseJson(String raw) {
         if (!StringUtils.hasText(raw)) {
@@ -1470,6 +1481,7 @@ public class FacebookCampaignService {
         List<CreativePublicationPayload> creativePayloads
     ) {
         List<CreativePublicationPayload> resolvedPayloads = new ArrayList<>(creativePayloads.size());
+        Map<String, String> localHashCache = new java.util.HashMap<>();
         for (CreativePublicationPayload payload : creativePayloads) {
             if (!StringUtils.hasText(payload.imageUrl())) {
                 LOGGER.warn(
@@ -1480,17 +1492,13 @@ public class FacebookCampaignService {
                 resolvedPayloads.add(payload.withImageHash(null));
                 continue;
             }
-            LOGGER.info(
-                "Preloading creative image in Facebook ad library before campaign creation: experimentId={}, creativeId={}, imageUrl={}",
-                experimentId,
-                payload.creative().id(),
-                payload.imageUrl()
-            );
             try {
-                String uploadedImageHash = executeFacebookCallWithLogging(
+                String uploadedImageHash = resolveOrUploadCanonicalImageHash(
                     experimentId,
-                    ExperimentFacebookApiLogContext.CAMPAIGN_AD_CREATIVE,
-                    () -> uploadAdImageWithFallback(adAccountId, experimentId, payload.imageUrl())
+                    adAccountId,
+                    payload.creative().id(),
+                    payload.imageUrl(),
+                    localHashCache
                 );
                 LOGGER.info(
                     "Creative image preload succeeded and will use image_hash as primary path: experimentId={}, creativeId={}, hash={}",
@@ -1511,6 +1519,169 @@ public class FacebookCampaignService {
             }
         }
         return resolvedPayloads;
+    }
+
+    private String resolveOrUploadCanonicalImageHash(
+        long experimentId,
+        String adAccountId,
+        Long creativeId,
+        String imageUrl,
+        Map<String, String> localHashCache
+    ) {
+        LOGGER.info(
+            "Preloading creative image using canonical hash deduplication: experimentId={}, creativeId={}, imageUrl={}",
+            experimentId,
+            creativeId,
+            imageUrl
+        );
+        DownloadedImage downloadedImage;
+        try {
+            downloadedImage = downloadCreativeImage(imageUrl);
+        } catch (Exception ex) {
+            LOGGER.warn(
+                "Could not download creative image for canonical hash deduplication; falling back to legacy upload flow: experimentId={}, creativeId={}, imageUrl={}, message={}",
+                experimentId,
+                creativeId,
+                imageUrl,
+                ex.getMessage()
+            );
+            return executeFacebookCallWithLogging(
+                experimentId,
+                ExperimentFacebookApiLogContext.CAMPAIGN_AD_CREATIVE,
+                () -> uploadAdImageWithFallback(adAccountId, experimentId, imageUrl)
+            );
+        }
+        String localHash = computeSha256(downloadedImage.bytes());
+        if (localHashCache.containsKey(localHash)) {
+            String cachedHash = localHashCache.get(localHash);
+            LOGGER.info(
+                "Reusing image_hash from in-memory deduplication cache: experimentId={}, creativeId={}, localHash={}, hash={}",
+                experimentId,
+                creativeId,
+                localHash,
+                cachedHash
+            );
+            return cachedHash;
+        }
+
+        Optional<String> canonicalHash = lookupCanonicalImageHash(adAccountId, localHash);
+        if (canonicalHash.isPresent()) {
+            String existingHash = canonicalHash.get();
+            localHashCache.put(localHash, existingHash);
+            LOGGER.info(
+                "Reusing canonical image_hash returned by backend repository: experimentId={}, creativeId={}, localHash={}, hash={}",
+                experimentId,
+                creativeId,
+                localHash,
+                existingHash
+            );
+            return existingHash;
+        }
+
+        String uploadedImageHash = executeFacebookCallWithLogging(
+            experimentId,
+            ExperimentFacebookApiLogContext.CAMPAIGN_AD_CREATIVE,
+            () -> facebookAdsService.uploadAdImageFromBytes(
+                adAccountId,
+                downloadedImage.bytes(),
+                resolveImageFileName(imageUrl),
+                downloadedImage.contentType()
+            )
+        );
+        localHashCache.put(localHash, uploadedImageHash);
+        LOGGER.info(
+            "Creative image uploaded to Meta and image_hash captured for canonical persistence: experimentId={}, creativeId={}, localHash={}, hash={}",
+            experimentId,
+            creativeId,
+            localHash,
+            uploadedImageHash
+        );
+        persistCanonicalImageHash(adAccountId, localHash, uploadedImageHash);
+        return uploadedImageHash;
+    }
+
+    private Optional<String> lookupCanonicalImageHash(String adAccountId, String localHash) {
+        String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/facebook-campaigns/image-hash-mappings/resolve");
+        URI uri = UriComponentsBuilder.fromUriString(baseUrl)
+            .queryParam("platform", IMAGE_HASH_PLATFORM)
+            .queryParam("adAccountId", adAccountId)
+            .queryParam("localHash", localHash)
+            .build(true)
+            .toUri();
+        LOGGER.info(
+            "Requesting canonical image hash mapping from backend: url==>{}, params={}",
+            uri,
+            JsonLogFormatter.wrap(objectMapper, Map.of("platform", IMAGE_HASH_PLATFORM, "adAccountId", adAccountId, "localHash", localHash))
+        );
+        try {
+            CanonicalImageHashResponse response = backendClient.get()
+                .uri(uri)
+                .exchangeToMono(clientResponse -> {
+                    if (clientResponse.statusCode().value() == HttpStatus.NOT_FOUND.value()) {
+                        return Mono.empty();
+                    }
+                    if (clientResponse.statusCode().isError()) {
+                        return clientResponse.createException().flatMap(Mono::error);
+                    }
+                    return clientResponse.bodyToMono(CanonicalImageHashResponse.class);
+                })
+                .block();
+            LOGGER.info(
+                "Received canonical image hash mapping from backend: url<=={}, response={}",
+                uri,
+                JsonLogFormatter.wrap(objectMapper, response)
+            );
+            return Optional.ofNullable(response)
+                .map(CanonicalImageHashResponse::metaImageHash)
+                .filter(StringUtils::hasText);
+        } catch (Exception ex) {
+            LOGGER.warn("Failed to resolve canonical image hash mapping from backend: url==>{}, message={}", uri, ex.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private void persistCanonicalImageHash(String adAccountId, String localHash, String metaImageHash) {
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/facebook-campaigns/image-hash-mappings");
+        CanonicalImageHashUpsertRequest payload = new CanonicalImageHashUpsertRequest(
+            IMAGE_HASH_PLATFORM,
+            adAccountId,
+            localHash,
+            metaImageHash
+        );
+        LOGGER.info(
+            "Persisting canonical image hash mapping in backend: url==>{}, payload={}",
+            url,
+            JsonLogFormatter.wrap(objectMapper, payload)
+        );
+        try {
+            CanonicalImageHashResponse response = backendClient.post()
+                .uri(url)
+                .bodyValue(payload)
+                .retrieve()
+                .bodyToMono(CanonicalImageHashResponse.class)
+                .block();
+            LOGGER.info(
+                "Canonical image hash mapping persisted in backend: url<=={}, response={}",
+                url,
+                JsonLogFormatter.wrap(objectMapper, response)
+            );
+        } catch (Exception ex) {
+            LOGGER.warn("Failed to persist canonical image hash mapping in backend: url==>{}, message={}", url, ex.getMessage());
+        }
+    }
+
+    private String computeSha256(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(bytes);
+            StringBuilder builder = new StringBuilder(hash.length * 2);
+            for (byte value : hash) {
+                builder.append(String.format("%02x", value));
+            }
+            return builder.toString();
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to compute SHA-256 hash for creative image", ex);
+        }
     }
 
     private String createAdCreativeWithImageDownloadRetry(

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -147,6 +147,19 @@ class FacebookCampaignServiceTest {
         );
         backend.enqueueConditionalResponse(
             request -> request.getPath() != null
+                && request.getPath().startsWith("/api/internal/facebook-campaigns/image-hash-mappings/resolve")
+                && "GET".equals(request.getMethod()),
+            () -> new MockResponse().setResponseCode(404)
+        );
+        backend.enqueueConditionalResponse(
+            request -> "/api/internal/facebook-campaigns/image-hash-mappings".equals(request.getPath())
+                && "POST".equals(request.getMethod()),
+            () -> new MockResponse()
+                .setBody("{\"metaImageHash\":\"hash-preloaded\"}")
+                .addHeader("Content-Type", "application/json")
+        );
+        backend.enqueueConditionalResponse(
+            request -> request.getPath() != null
                 && request.getPath().contains("/api/experiments/")
                 && request.getPath().contains("/status?status=")
                 && "PATCH".equals(request.getMethod()),


### PR DESCRIPTION
### Motivation
- Aplicar o novo esquema canônico de tratamento de imagens descrito no cânone de publicação de campanhas para reduzir uploads duplicados, custo e latência ao publicar criativos na Meta.
- Garantir reuso de `image_hash` já existentes por conta/plataforma em vez de fazer upload cego do mesmo asset em múltiplas execuções.

### Description
- Adiciona fluxo de deduplicação: baixa o asset, calcula `sha256` local e consulta o backend por `local_hash -> meta_image_hash` usando `GET /api/internal/facebook-campaigns/image-hash-mappings/resolve` antes de publicar o criativo.
- Quando houver mapeamento, reutiliza o `meta_image_hash`; quando não houver, faz upload binário ao endpoint da Meta (`POST /act_<adAccountId>/adimages`) via `facebookAdsService.uploadAdImageFromBytes` e persiste o vínculo no backend com `POST /api/internal/facebook-campaigns/image-hash-mappings`.
- Mantém fallback para o fluxo legado quando o download local da imagem falhar (usa `uploadAdImage` por URL), evitando regressão operacional.
- Inclui utilitários e payloads auxiliares: `computeSha256`, `resolveOrUploadCanonicalImageHash`, `lookupCanonicalImageHash`, `persistCanonicalImageHash` e records de request/response para o mapeamento; atualiza `facebook-ads-worker` README para documentar os novos endpoints e o comportamento.

### Testing
- Executado `mvn -f facebook-ads-worker/pom.xml -Dtest=FacebookCampaignServiceTest test` que executou a suíte `FacebookCampaignServiceTest` completa e finalizou com sucesso (todos os testes passaram).
- Testes direcionados de criação de campanha/ad set/criativo também foram executados com `mvn -f facebook-ads-worker/pom.xml -Dtest=FacebookCampaignServiceTest#createsCampaignHierarchyForEachExperiment,...` e passaram conforme logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4f81789083219506d29058121f63)