### PR TITLE
Adicionar ação 'Aprovar e publicar landing' na aba Landing e alinhar documentação canônica

### DIFF
--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -194,6 +194,13 @@ Regras mandatórias:
 A navegação principal do experimento deve expor a aba `Landing` para suportar o
 fluxo simplificado definido na seção 8.5.
 
+Regra mandatória de posicionamento da ação de aprovação:
+
+- o comando primário de aprovação/publicação da landing deve estar na aba `Landing`;
+- o rótulo recomendado é `Aprovar e publicar landing` (ou equivalente semântico direto);
+- é proibido deslocar a ação principal de aprovação para outra aba como único ponto de execução;
+- controles auxiliares (pré-visualização, diagnóstico e reprocessamento) podem existir em outras abas, desde que a aprovação oficial permaneça acessível na aba `Landing`.
+
 ## 9. Observabilidade mínima
 
 Cada transição de estado da fila e de etapa deve gerar log com:

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -442,6 +442,7 @@ Regras mandatórias:
 - é proibido exigir do usuário uma segunda aprovação para concluir publicação;
 - é proibido exigir inserção manual do pixel após a aprovação;
 - URL publicada e pixel aplicado devem ficar auditáveis no backend.
+- a ação oficial de aprovação/publicação deve estar disponível na aba `Landing` do experimento (não apenas em abas auxiliares).
 
 
 ---

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import axios from "axios";
 import type { Experiment } from "../../api/experiment/useExperiments";
 import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
 import { useLandingPages } from "../../api/landing/useLandingPages";
@@ -33,6 +34,7 @@ export default function LandingTab({ experiment }: LandingTabProps) {
   const updateExperiment = useUpdateExperiment(experiment.id);
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const [pendingLandingId, setPendingLandingId] = useState<number | null>(null);
+  const [isPublishing, setIsPublishing] = useState(false);
 
   const sortedLandingPages = useMemo(() => {
     if (!Array.isArray(landingPages)) {
@@ -43,6 +45,45 @@ export default function LandingTab({ experiment }: LandingTabProps) {
   }, [landingPages]);
 
   const selectedDestinationUrl = normalizeUrl(experiment.followUpActionUrl);
+  const hasGeneratedLandingHtml = Boolean(experiment.landingPageHtml?.trim());
+
+  const handleApproveAndPublish = async () => {
+    if (!hasGeneratedLandingHtml) {
+      setFeedback({
+        variant: "error",
+        message: "Gere o HTML da landing na aba Estrutura de conteúdo antes de aprovar e publicar.",
+      });
+      return;
+    }
+
+    setFeedback(null);
+    setIsPublishing(true);
+    try {
+      const { data } = await axios.post<{
+        publicUrl?: string | null;
+        facebookPixelId?: string | null;
+        pixelAppliedAutomatically?: boolean;
+      }>(`/api/experiments/${experiment.id}/pipeline/landing-page-html/approve-and-publish`);
+
+      const pixelFeedback =
+        data?.pixelAppliedAutomatically && data.facebookPixelId
+          ? ` Pixel do nicho aplicado automaticamente (${data.facebookPixelId}).`
+          : " Pixel do nicho será aplicado automaticamente ao ficar disponível.";
+      setFeedback({
+        variant: "success",
+        message: data?.publicUrl
+          ? `Landing aprovada e publicada automaticamente em ${data.publicUrl}.${pixelFeedback}`
+          : `Landing aprovada e publicação automática iniciada.${pixelFeedback}`,
+      });
+    } catch {
+      setFeedback({
+        variant: "error",
+        message: "Não foi possível aprovar/publicar a landing agora. Tente novamente em instantes.",
+      });
+    } finally {
+      setIsPublishing(false);
+    }
+  };
 
   const handleApproveLanding = async (landingId: number, landingUrl: string) => {
     const kpiTargetValue = experiment.kpiTarget ?? experiment.kpiTargetCpl;
@@ -105,6 +146,28 @@ export default function LandingTab({ experiment }: LandingTabProps) {
           <p className="text-muted mb-0">
             Aprove a landing que deve ser usada como URL de destino da campanha.
           </p>
+          <div className="mt-3">
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={handleApproveAndPublish}
+              disabled={isPublishing || !hasGeneratedLandingHtml}
+            >
+              {isPublishing ? (
+                <span className="d-inline-flex align-items-center gap-2">
+                  <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true" />
+                  Publicando...
+                </span>
+              ) : (
+                "Aprovar e publicar landing"
+              )}
+            </button>
+          </div>
+          {!hasGeneratedLandingHtml ? (
+            <p className="text-muted small mt-2 mb-0">
+              Gere o HTML na aba Estrutura de conteúdo para habilitar a aprovação nesta aba.
+            </p>
+          ) : null}
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation

- Padronizar o fluxo de publicação de landings garantindo que a ação oficial de aprovação/publicação esteja acessível na aba `Landing` conforme o cânone de automação. 
- Facilitar publicação automática da URL final e aplicação do pixel do nicho sem passos manuais adicionais na interface.

### Description

- Adiciona botão `Aprovar e publicar landing` na componente `LandingTab.tsx` que envia requisição `POST` para `/api/experiments/:id/pipeline/landing-page-html/approve-and-publish` e exibe feedback ao usuário. 
- Implementa estado de publicação com spinner e desabilita a ação quando não houver HTML de landing gerado, usando `experiment.landingPageHtml` para validação. 
- Introduz mensagens de sucesso/erro detalhadas incluindo informação sobre aplicação automática do pixel e URL pública quando retornadas pelo endpoint. 
- Atualiza documentação canônica em `experiments-automation-flow-canon.v1.md` e `modelo-canonico-artefatos-pipeline-experimento.md` para exigir que a ação oficial de aprovação/publicação esteja disponível na aba `Landing`.

### Testing

- Executado `yarn build` no frontend para verificação de build e TypeScript, que concluiu com sucesso. 
- Executado `yarn test` (suites de unit tests do frontend), que passou sem falhas. 
- Executado `tsc --noEmit` para checagem de tipos, que retornou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb72ee61908321b84134a2aa591d48)