### PR TITLE
Use Lead Portal public domain for generated flow/landing links (configurable via VITE_LEAD_PORTAL_BASE_URL)

### DIFF
--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -18,6 +18,13 @@ type LandingLinks = {
   iframeUrl: string;
 };
 
+const leadPortalBaseUrl = import.meta.env.VITE_LEAD_PORTAL_BASE_URL?.trim() || "https://oportunidadebrasil.shop";
+
+function buildLeadPortalUrl(path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${leadPortalBaseUrl.replace(/\/$/, "")}${normalizedPath}`;
+}
+
 function resolveStandaloneLandingUrl(path: string): string {
   if (/^https?:\/\//i.test(path)) {
     return path;
@@ -46,8 +53,8 @@ function buildLandingLinksFromPublicUrl(publicUrl?: string | null): LandingLinks
       return null;
     }
     return {
-      standaloneUrl: `${parsed.origin}/api/flows/${encodeURIComponent(slug)}/page`,
-      iframeUrl: publicUrl,
+      standaloneUrl: buildLeadPortalUrl(`/api/flows/${encodeURIComponent(slug)}/page`),
+      iframeUrl: buildLeadPortalUrl(`/flows/${encodeURIComponent(slug)}`),
     };
   } catch {
     return null;
@@ -76,13 +83,13 @@ export default function LandingTab({ experiment }: LandingTabProps) {
     if (publishedLinks) {
       return publishedLinks;
     }
-    if (!experiment.leadPortalFlowSlug || typeof window === "undefined" || !window.location?.origin) {
+    if (!experiment.leadPortalFlowSlug) {
       return null;
     }
     const slug = encodeURIComponent(experiment.leadPortalFlowSlug);
     return {
-      standaloneUrl: `${window.location.origin}/api/flows/${slug}/page`,
-      iframeUrl: `${window.location.origin}/flows/${slug}`,
+      standaloneUrl: buildLeadPortalUrl(`/api/flows/${slug}/page`),
+      iframeUrl: buildLeadPortalUrl(`/flows/${slug}`),
     };
   }, [experiment.leadPortalFlowSlug, publishedLinks]);
 

--- a/frontend/src/pages/experiment/LeadPortalFlowTab.tsx
+++ b/frontend/src/pages/experiment/LeadPortalFlowTab.tsx
@@ -551,20 +551,19 @@ function buildStandaloneFlowUrl(flow: LeadPortalFlow): string | null {
     return null;
   }
 
+  const leadPortalBaseUrl = import.meta.env.VITE_LEAD_PORTAL_BASE_URL?.trim() || "https://oportunidadebrasil.shop";
+  const normalizedBaseUrl = leadPortalBaseUrl.replace(/\/$/, "");
+
   if (flow.publicUrl) {
     try {
-      const parsed = new URL(flow.publicUrl);
-      return `${parsed.origin}/api/flows/${encodeURIComponent(slug)}/page`;
+      new URL(flow.publicUrl);
+      return `${normalizedBaseUrl}/api/flows/${encodeURIComponent(slug)}/page`;
     } catch {
       // fallback para ambiente local ou URL parcial
     }
   }
 
-  if (typeof window !== "undefined" && window.location?.origin) {
-    return `${window.location.origin}/api/flows/${encodeURIComponent(slug)}/page`;
-  }
-
-  return null;
+  return `${normalizedBaseUrl}/api/flows/${encodeURIComponent(slug)}/page`;
 }
 
 function formatDate(value?: string | null) {


### PR DESCRIPTION
### Motivation
- Fix incorrect lead portal links that were being generated with the admin host/IP instead of the public Lead Portal domain specified in the docs. 
- Make the public domain configurable so deployments can override the default `https://oportunidadebrasil.shop` when necessary.

### Description
- Added `VITE_LEAD_PORTAL_BASE_URL`-driven `leadPortalBaseUrl` and helper `buildLeadPortalUrl` to `frontend/src/pages/experiment/LandingTab.tsx` and replaced origin-based link assembly with calls to `buildLeadPortalUrl` for both standalone and iframe links. 
- Updated `frontend/src/pages/experiment/LeadPortalFlowTab.tsx` to build the standalone flow URL using the same `VITE_LEAD_PORTAL_BASE_URL` (removed reliance on `window.location.origin` or the parsed `publicUrl`). 
- Normalized base URL handling to strip trailing slashes and always produce `/api/flows/{slug}/page` and `/flows/{slug}` targets consistently across the UI. 

### Testing
- Ran frontend dependency install with `npm -C frontend ci`, which completed successfully. 
- Built the frontend with `npm -C frontend run build`, which produced a production bundle successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9071442c8321b887d49f23fc9c80)