### PR TITLE
docs: adicionar seção de troubleshooting rápido para build do frontend no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,17 @@ deploy/                      arquivos de deploy em containers
 docs/                        documentação e cânones
 AGENTS.md                    contrato operacional principal
 docker-compose.yml           compose raiz para serviços auxiliares
+
+## Troubleshooting rápido (Frontend / Sandbox)
+
+Se o comando de build do frontend falhar com mensagens como `vite: command not found` ou erro equivalente, normalmente as dependências ainda não foram instaladas no diretório `frontend`.
+
+Fluxo recomendado:
+
+1. `npm -C frontend ci`
+2. `npm -C frontend run build`
+
+Observações:
+
+- O script de build do frontend usa `vite build`, então o pacote `vite` precisa existir em `node_modules` antes de executar o build.
+- Em ambientes de sandbox/CI podem aparecer avisos de configuração global do npm (por exemplo, proxy). Esses avisos podem ser específicos do ambiente e não necessariamente indicam erro de código do projeto.


### PR DESCRIPTION
### Motivation
- Esclarecer passos rápidos para resolver falhas de build do frontend em ambientes sandbox/CI, como erro `vite: command not found`.

### Description
- Adiciona seção `Troubleshooting rápido (Frontend / Sandbox)` ao `README.md` com o fluxo recomendado `npm -C frontend ci` seguido de `npm -C frontend run build` e observações sobre a necessidade do `vite` em `node_modules` e avisos de configuração do npm em CI.

### Testing
- Nenhum teste automatizado foi executado, pois a alteração consiste apenas em documentação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb91751ccc8321ac9f8e3007a9fcab)