### PR TITLE
Rescue legacy wrapped HTML payloads in Lead Portal flow pages

### DIFF
--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/CustomFormHtmlResolver.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/CustomFormHtmlResolver.java
@@ -1,5 +1,9 @@
 package com.marketinghub.leadportal.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -11,6 +15,10 @@ import org.springframework.util.StringUtils;
 public class CustomFormHtmlResolver {
 
     private static final Pattern HTML_HINT = Pattern.compile("(?is)^\\s*(?:<!doctype|<html|<body|<main|<section|<div|<header|<footer)");
+    private static final Pattern WRAPPED_JSON_IN_BODY = Pattern.compile("(?is)<body[^>]*>\\s*(\\{[\\s\\S]*?})\\s*</body>");
+    private static final Pattern HTML_DOCUMENT_FIELD = Pattern.compile("(?is)\"htmlDocument\"\\s*:\\s*\"((?:\\\\.|[^\"\\\\])*)\"");
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * Accepts only pure HTML payloads (no mixed JSON wrappers).
@@ -21,7 +29,7 @@ public class CustomFormHtmlResolver {
         }
         String trimmed = rawValue.trim();
         if (looksLikeHtml(trimmed)) {
-            return trimmed;
+            return rescueLegacyWrappedPayload(trimmed).orElse(trimmed);
         }
         throw new IllegalArgumentException(
                 "customFormHtml deve ser HTML puro. Payload JSON/misto não é mais aceito.");
@@ -29,6 +37,99 @@ public class CustomFormHtmlResolver {
 
     private boolean looksLikeHtml(String value) {
         return HTML_HINT.matcher(value).find();
+    }
+
+    private Optional<String> rescueLegacyWrappedPayload(String htmlDocument) {
+        String lowered = htmlDocument.toLowerCase();
+        if (!lowered.contains("landingpagehtml") || !lowered.contains("htmldocument")) {
+            return Optional.empty();
+        }
+
+        String jsonCandidate = extractJsonCandidate(htmlDocument);
+        if (!StringUtils.hasText(jsonCandidate)) {
+            return Optional.empty();
+        }
+
+        try {
+            var rawHtmlDocumentMatcher = HTML_DOCUMENT_FIELD.matcher(jsonCandidate);
+            if (rawHtmlDocumentMatcher.find()) {
+                String decodedRaw = rawHtmlDocumentMatcher.group(1)
+                        .replace("\\\\", "\\")
+                        .replace("\\n", "\n")
+                        .replace("\\t", "\t")
+                        .replace("\\r", "\r")
+                        .replace("\\/", "/");
+                String normalizedFromField = unescapeLegacyArtifacts(decodedRaw).trim();
+                if (looksLikeHtml(normalizedFromField)) {
+                    return Optional.of(normalizedFromField);
+                }
+            }
+
+            JsonNode root = objectMapper.readTree(unescapeLegacyArtifacts(jsonCandidate));
+            JsonNode htmlNode = root.path("landingPageHtml").path("htmlDocument");
+            String normalized = unescapeLegacyArtifacts(htmlNode.asText()).trim();
+            if (!looksLikeHtml(normalized)) {
+                return Optional.empty();
+            }
+            return Optional.of(normalized);
+        } catch (IOException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private String extractJsonCandidate(String htmlDocument) {
+        var matcher = WRAPPED_JSON_IN_BODY.matcher(htmlDocument);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        int marker = htmlDocument.indexOf("\"landingPageHtml\"");
+        if (marker < 0) {
+            marker = htmlDocument.indexOf("landingPageHtml");
+        }
+        if (marker < 0) {
+            return htmlDocument;
+        }
+        int firstBrace = htmlDocument.lastIndexOf('{', marker);
+        if (firstBrace < 0) {
+            return htmlDocument;
+        }
+        int depth = 0;
+        for (int i = firstBrace; i < htmlDocument.length(); i++) {
+            char ch = htmlDocument.charAt(i);
+            if (ch == '{') {
+                depth++;
+            } else if (ch == '}') {
+                depth--;
+                if (depth == 0) {
+                    return htmlDocument.substring(firstBrace, i + 1);
+                }
+            }
+        }
+        return htmlDocument;
+    }
+
+    private String unescapeLegacyArtifacts(String value) {
+        return value
+                .replace("\\&quot;", "\"")
+                .replace("&quot;", "\"")
+                .replace("\\&apos;", "'")
+                .replace("&apos;", "'")
+                .replace("\\&#39;", "'")
+                .replace("&#39;", "'")
+                .replace("\\&amp;", "&")
+                .replace("&amp;", "&")
+                .replace("\\>", ">")
+                .replace("\\<", "<")
+                .replace("\\/", "/")
+                .replace("\\n", "\n")
+                .replace("\\t", "\t")
+                .replace("\\r", "\r")
+                .replace("\u00a0", " ")
+                .replace("\u201c", "\"")
+                .replace("\u201d", "\"")
+                .replace("\u2018", "'")
+                .replace("\u2019", "'")
+                .trim();
     }
 
 }

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/CustomFormHtmlResolverTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/CustomFormHtmlResolverTest.java
@@ -30,4 +30,19 @@ class CustomFormHtmlResolverTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("HTML puro");
     }
+
+    @Test
+    void normalizeRescuesLegacyWrappedJsonInsideHtmlBody() {
+        String payload = """
+                <html lang="\\&quot;pt-BR\\&quot;">
+                  <head></head>
+                  <body>
+                    {"landingPageHtml":{"htmlDocument":"<html><body><h1>Exp 14</h1><p class=\\&quot;lead\\&quot;>ok</p></body></html>"}}
+                  </body>
+                </html>
+                """;
+
+        assertThat(resolver.normalize(payload))
+                .isEqualTo("<html><body><h1>Exp 14</h1><p class=\"lead\">ok</p></body></html>");
+    }
 }


### PR DESCRIPTION
### Motivation
- Some legacy `customFormHtml` values were stored as an HTML shell that embeds a JSON payload (e.g. `landingPageHtml.htmlDocument`) inside the `<body>`, with broken escapes like `\&quot;`, causing `/api/flows/{slug}/page` to return malformed HTML (observed for `exp-14-landing`).
- The system must keep rejecting pure/mixed JSON, but for common legacy corruption patterns we should attempt to recover the real HTML to avoid broken public pages.

### Description
- Update `lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/CustomFormHtmlResolver.java` to detect HTML wrappers that contain a JSON object and attempt to rescue `landingPageHtml.htmlDocument` by extracting and decoding it, including unescaping legacy artifacts (escaped quotes, entities, newlines, slashes, etc.).
- Add robust JSON extraction heuristics: a `WRAPPED_JSON_IN_BODY` regex to locate JSON inside `<body>`, an `HTML_DOCUMENT_FIELD` regex to decode serialized `htmlDocument`, and a fallback that parses the candidate with Jackson to obtain `landingPageHtml.htmlDocument`.
- Preserve existing behavior of rejecting payloads that are pure JSON or cannot be safely normalized to standalone HTML.
- Add unit test `normalizeRescuesLegacyWrappedJsonInsideHtmlBody` in `lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/CustomFormHtmlResolverTest.java` that reproduces the `exp-14` corruption pattern and asserts recovery of the embedded HTML.

### Testing
- Ran unit tests for the resolver with `mvn -Dtest=CustomFormHtmlResolverTest test` and they passed (all tests in that class succeeded).
- Ran `FlowController` tests with `mvn -Dtest=FlowControllerTest test` and they passed to verify no regressions in flow endpoints.
- Verified the problematic page response locally with `curl` during investigation to reproduce the corruption pattern before implementing the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb938d86288321b1c8f09cddf5f22e)