### PR TITLE
Fix landing HTML pipeline model-enforcement test fixture

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -803,7 +803,16 @@ class ExperimentPipelineOpenAiClientTest {
     void enforcesGpt51CodexModelForLandingHtmlPipelineCall() {
         AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
         ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
-                WebClient.builder().exchangeFunction(capturePayloadExchange(payloadRef)),
+                WebClient.builder().exchangeFunction(capturePayloadExchange(
+                        payloadRef,
+                        """
+                                <!doctype html>
+                                <html lang="pt-BR">
+                                  <body>
+                                    <form id="lead-capture-primary"></form>
+                                  </body>
+                                </html>
+                                """)),
                 MAPPER,
                 "test-key",
                 "http://openai");


### PR DESCRIPTION
### Motivation
- The `landing-page-html` pipeline test used a mocked OpenAI response that did not satisfy the landing HTML contract, causing a contract validation `IllegalStateException` before the test could assert the model override behavior.

### Description
- Updated `ExperimentPipelineOpenAiClientTest.enforcesGpt51CodexModelForLandingHtmlPipelineCall` to mock a valid HTML response (raw `<!doctype html>...<form id="lead-capture-primary">...`) via `capturePayloadExchange` so the `landing-page-html` response contract is met and the `gpt-5.1-codex` model enforcement assertion can run; no production code changes were made.

### Testing
- Attempted to run `mvn -Dtest=ExperimentPipelineOpenAiClientTest#enforcesGpt51CodexModelForLandingHtmlPipelineCall test`, but the build failed due to private dependency resolution (`com.marketinghub:ads-service:0.0.1-SNAPSHOT` from GitHub Packages returned `401 Unauthorized`), so the test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd92ab76c8321a8b50a25e74655f7)