### PR TITLE
feat(mois): Sprint 1 — add artifact `createdBy`, idempotent run and propagate `category` filter

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisArtifactDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisArtifactDtos.java
@@ -14,6 +14,7 @@ public final class MoisArtifactDtos {
             String schemaVersion,
             String status,
             String module,
+            String createdBy,
             Instant createdAt,
             Instant updatedAt,
             Map<String, Object> lineage,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisModuleGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisModuleGateway.java
@@ -64,10 +64,11 @@ public class MoisModuleGateway {
         return optionalGet("/api/v1/mois/offers/" + offerId, MoisOfferDtos.OfferCardResponse.class);
     }
 
-    public MoisInsightDtos.InsightReportListResponse listInsightReports(String requestId, String nicheName) {
+    public MoisInsightDtos.InsightReportListResponse listInsightReports(String requestId, String nicheName, String category) {
         UriComponentsBuilder uri = UriComponentsBuilder.fromPath("/api/v1/mois/insight-reports");
         maybeAddQuery(uri, "requestId", requestId);
         maybeAddQuery(uri, "nicheName", nicheName);
+        maybeAddQuery(uri, "category", category);
         return exchange(uri.toUriString(), HttpMethod.GET, null, MoisInsightDtos.InsightReportListResponse.class).getBody();
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
@@ -73,9 +73,10 @@ public class MoisController {
     @GetMapping("/insight-reports")
     public MoisInsightDtos.InsightReportListResponse listInsightReports(
             @RequestParam(required = false) String requestId,
-            @RequestParam(required = false) String nicheName
+            @RequestParam(required = false) String nicheName,
+            @RequestParam(required = false) String category
     ) {
-        return gateway.listInsightReports(requestId, nicheName);
+        return gateway.listInsightReports(requestId, nicheName, category);
     }
 
     @GetMapping("/insight-reports/{reportId}")

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.mois.web;
 
 import com.marketinghub.mois.dto.MoisDiscoveryDtos;
+import com.marketinghub.mois.dto.MoisInsightDtos;
 import com.marketinghub.mois.dto.MoisOfferDtos;
 import com.marketinghub.mois.service.MoisModuleGateway;
 import java.time.Instant;
@@ -109,5 +110,17 @@ class MoisControllerContractTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.items[0].offerId").value("mois-offer-001"))
                 .andExpect(jsonPath("$.items[0].confidence").value(0.79));
+    }
+
+    @Test
+    void shouldPropagateCategoryFilterToInsightReportsEndpoint() throws Exception {
+        when(gateway.listInsightReports(eq("mois-req-001"), eq("nutricao"), eq("DIGITAL_PRODUCT")))
+                .thenReturn(new MoisInsightDtos.InsightReportListResponse(List.of()));
+
+        mockMvc.perform(get("/api/v1/mois/insight-reports")
+                        .param("requestId", "mois-req-001")
+                        .param("nicheName", "nutricao")
+                        .param("category", "DIGITAL_PRODUCT"))
+                .andExpect(status().isOk());
     }
 }

--- a/mois/src/main/java/com/marketinghub/mois/dto/MoisArtifactDtos.java
+++ b/mois/src/main/java/com/marketinghub/mois/dto/MoisArtifactDtos.java
@@ -14,6 +14,7 @@ public final class MoisArtifactDtos {
             String schemaVersion,
             String status,
             String module,
+            String createdBy,
             Instant createdAt,
             Instant updatedAt,
             Map<String, Object> lineage,

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
@@ -28,6 +28,10 @@ public class MoisDomainService {
     private final Map<String, DiscoveryRequest> requests = new ConcurrentHashMap<>();
     private final Map<String, SourceSnapshot> snapshots = new ConcurrentHashMap<>();
     private final Map<String, OfferCard> offers = new ConcurrentHashMap<>();
+    private final Map<String, MoisInsightDtos.InsightReportResponse> reports = new ConcurrentHashMap<>();
+    private final Map<String, String> runOperations = new ConcurrentHashMap<>();
+    private static final String MODULE_NAME = "MOIS";
+    private static final String CREATED_BY = "mois-system";
 
     public MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse createDiscoveryRequest(
             MoisDiscoveryDtos.CreateDiscoveryRequest payload
@@ -87,6 +91,9 @@ public class MoisDomainService {
         if (request == null) {
             return Optional.empty();
         }
+        if (runOperations.containsKey(requestId)) {
+            return Optional.of(new MoisDiscoveryDtos.AsyncAcceptedResponse("ACCEPTED", runOperations.get(requestId)));
+        }
 
         List<String> seedUrls = request.seedUrls().isEmpty() ? List.of("https://example.com/oferta") : request.seedUrls();
         for (String seedUrl : seedUrls) {
@@ -136,7 +143,10 @@ public class MoisDomainService {
                 request.createdAt(),
                 Instant.now()));
 
-        return Optional.of(new MoisDiscoveryDtos.AsyncAcceptedResponse("ACCEPTED", "mois-run-" + requestId));
+        String operationId = "mois-run-" + requestId;
+        runOperations.put(requestId, operationId);
+        reports.put("mois-report-" + requestId, buildInsightReport("mois-report-" + requestId, requests.get(requestId)));
+        return Optional.of(new MoisDiscoveryDtos.AsyncAcceptedResponse("ACCEPTED", operationId));
     }
 
     public MoisOfferDtos.OfferCardListResponse listOffers(String requestId, String nicheName, String sellerOrBrand) {
@@ -201,6 +211,10 @@ public class MoisDomainService {
     }
 
     public Optional<MoisInsightDtos.InsightReportResponse> getInsightReport(String reportId) {
+        MoisInsightDtos.InsightReportResponse persisted = reports.get(reportId);
+        if (persisted != null) {
+            return Optional.of(persisted);
+        }
         String prefix = "mois-report-";
         if (!reportId.startsWith(prefix)) {
             return Optional.empty();
@@ -210,7 +224,13 @@ public class MoisDomainService {
         if (request == null || request.status() != DiscoveryStatus.COLLECTED) {
             return Optional.empty();
         }
+        MoisInsightDtos.InsightReportResponse computed = buildInsightReport(reportId, request);
+        reports.put(reportId, computed);
+        return Optional.of(computed);
+    }
 
+    private MoisInsightDtos.InsightReportResponse buildInsightReport(String reportId, DiscoveryRequest request) {
+        String requestId = request.requestId();
         List<OfferCard> requestOffers = listOffersByRequest(requestId);
         int offerCount = requestOffers.size();
 
@@ -225,7 +245,7 @@ public class MoisDomainService {
         List<MoisInsightDtos.InsightReportPatternResponse> mechanismPatterns =
                 buildPatternDistribution(requestOffers, OfferCard::mechanismClaimSummary, offerCount);
 
-        return Optional.of(new MoisInsightDtos.InsightReportResponse(
+        return new MoisInsightDtos.InsightReportResponse(
                 reportId,
                 requestId,
                 request.nicheName(),
@@ -249,7 +269,7 @@ public class MoisDomainService {
                 buildSaturationNotes(repeatedPromises, pricingPatterns, offerCount),
                 buildGapOpportunities(requestOffers, repeatedPromises, pricingPatterns),
                 buildDifferentiationSignals(requestOffers, repeatedPromises, mechanismPatterns),
-                buildRecommendedActions(repeatedPromises, pricingPatterns, mechanismPatterns)));
+                buildRecommendedActions(repeatedPromises, pricingPatterns, mechanismPatterns));
     }
 
     public Optional<MoisArtifactDtos.ArtifactEnvelopeResponse> getArtifact(String artifactId) {
@@ -260,7 +280,8 @@ public class MoisDomainService {
                     "mois.marketOfferDiscoveryRequest.v1",
                     "v1",
                     request.status().name(),
-                    "MOIS",
+                    MODULE_NAME,
+                    CREATED_BY,
                     request.createdAt(),
                     request.updatedAt(),
                     Map.of("requestId", request.requestId(), "parentArtifactIds", List.of()),
@@ -284,7 +305,8 @@ public class MoisDomainService {
                     "mois.marketOfferSourceSnapshot.v1",
                     "v1",
                     "COLLECTED",
-                    "MOIS",
+                    MODULE_NAME,
+                    CREATED_BY,
                     snapshot.capturedAt(),
                     snapshot.capturedAt(),
                     Map.of("requestId", snapshot.requestId(), "parentArtifactIds", List.of(snapshot.requestId())),
@@ -304,7 +326,8 @@ public class MoisDomainService {
                     "mois.marketOfferCard.v1",
                     "v1",
                     "COLLECTED",
-                    "MOIS",
+                    MODULE_NAME,
+                    CREATED_BY,
                     offer.createdAt(),
                     offer.createdAt(),
                     Map.of("requestId", offer.requestId(), "parentArtifactIds", collectParentArtifactsForOffer(offer.requestId())),
@@ -318,6 +341,33 @@ public class MoisDomainService {
                             "proofSummary", offer.proofSummary(),
                             "mechanismClaimSummary", offer.mechanismClaimSummary(),
                             "funnelPatternSummary", offer.funnelPatternSummary())));
+        }
+        MoisInsightDtos.InsightReportResponse report = reports.get(artifactId);
+        if (report != null) {
+            Map<String, Object> content = new HashMap<>();
+            content.put("requestSummary", report.requestSummary());
+            content.put("offersAnalyzed", report.offersAnalyzed());
+            content.put("repeatedPromises", report.repeatedPromises());
+            content.put("repeatedProofPatterns", report.repeatedProofPatterns());
+            content.put("pricingPatterns", report.pricingPatterns());
+            content.put("funnelPatterns", report.funnelPatterns());
+            content.put("mechanismClaimPatterns", report.mechanismClaimPatterns());
+            content.put("saturationNotes", report.saturationNotes());
+            content.put("gapOpportunities", report.gapOpportunities());
+            content.put("differentiationSignals", report.differentiationSignals());
+            content.put("recommendedNextActions", report.recommendedNextActions());
+            return Optional.of(new MoisArtifactDtos.ArtifactEnvelopeResponse(
+                    report.reportId(),
+                    "mois.marketOfferInsightReport.v1",
+                    "v1",
+                    report.status(),
+                    MODULE_NAME,
+                    CREATED_BY,
+                    report.createdAt(),
+                    report.createdAt(),
+                    Map.of("requestId", report.requestId(), "parentArtifactIds", report.offersAnalyzed()),
+                    Map.of("nicheName", report.nicheName(), "marketTheme", report.marketTheme()),
+                    content));
         }
         return Optional.empty();
     }

--- a/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
+++ b/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.marketinghub.mois.dto.MoisDiscoveryDtos;
 import com.marketinghub.mois.dto.MoisInsightDtos;
+import com.marketinghub.mois.dto.MoisArtifactDtos;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,5 +65,47 @@ class MoisDomainServiceTest {
 
         assertThat(matching.items()).hasSize(1);
         assertThat(noMatch.items()).isEmpty();
+    }
+
+    @Test
+    void shouldBeIdempotentWhenRunningSameRequestTwice() {
+        MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse accepted = service.createDiscoveryRequest(
+                new MoisDiscoveryDtos.CreateDiscoveryRequest(
+                        "Nutrição",
+                        "Perda de peso",
+                        "Resultado rápido",
+                        List.of(),
+                        List.of("https://example.com/oferta-c"),
+                        List.of("SEARCH"),
+                        "BR",
+                        "pt-BR",
+                        null));
+
+        MoisDiscoveryDtos.AsyncAcceptedResponse firstRun = service.runDiscoveryRequest(accepted.requestId()).orElseThrow();
+        MoisDiscoveryDtos.AsyncAcceptedResponse secondRun = service.runDiscoveryRequest(accepted.requestId()).orElseThrow();
+
+        assertThat(firstRun.correlationId()).isEqualTo(secondRun.correlationId());
+        assertThat(service.listOffers(accepted.requestId(), null, null).items()).hasSize(1);
+    }
+
+    @Test
+    void shouldExposeInsightReportArtifactWithCanonicalEnvelope() {
+        MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse accepted = service.createDiscoveryRequest(
+                new MoisDiscoveryDtos.CreateDiscoveryRequest(
+                        "Fisioterapia",
+                        "Dor lombar",
+                        "Alívio de dor",
+                        List.of("dor lombar oferta"),
+                        List.of("https://example.com/oferta-a"),
+                        List.of("META_ADS"),
+                        "BR",
+                        "pt-BR",
+                        null));
+        service.runDiscoveryRequest(accepted.requestId());
+
+        MoisArtifactDtos.ArtifactEnvelopeResponse artifact = service.getArtifact("mois-report-" + accepted.requestId()).orElseThrow();
+        assertThat(artifact.artifactType()).isEqualTo("mois.marketOfferInsightReport.v1");
+        assertThat(artifact.schemaVersion()).isEqualTo("v1");
+        assertThat(artifact.createdBy()).isEqualTo("mois-system");
     }
 }


### PR DESCRIPTION
### Motivation
- Implement core items from the MOIS Sprint 1 plan to harden contracts and remove state volatility (canonical artifact envelope, idempotent `run`, and façade filter propagation). 
- Ensure downstream consumers can filter insight reports by `category` and retrieve stable, fully-enveloped artifacts for lineage and audit.

### Description
- Backend façade: `GET /api/v1/mois/insight-reports` now accepts `category` and forwards it to the MOIS module via the gateway by adding the query param in `MoisController` and `MoisModuleGateway` and adding a contract test in `MoisControllerContractTest`.
- Canonical envelope: added mandatory `createdBy` to `ArtifactEnvelopeResponse` DTO in both backend (`backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisArtifactDtos.java`) and MOIS (`mois/src/main/java/com/marketinghub/mois/dto/MoisArtifactDtos.java`).
- MOIS module: implemented basic idempotence for `run` using `runOperations` (reusing the same `correlationId` for repeated runs), persisted in-memory `reports` for `reportId` lookup, computed/stored insight reports with `buildInsightReport`, and extended `GET /artifacts/{artifactId}` to return `mois.marketOfferInsightReport.v1` with full envelope including `createdBy` (changes in `MoisDomainService`).
- Tests: added/updated contract and unit tests covering the `category` propagation, idempotent `run` behavior, and canonical artifact envelope for insight reports.

### Testing
- Ran backend contract test: `mvn -f backend/ads-service/pom.xml -Dtest=MoisControllerContractTest test`, which completed successfully (tests passed).
- Ran MOIS module tests: `mvn -f mois/pom.xml test`, which completed successfully (all module tests passed).
- All modified tests (`MoisControllerContractTest` and `MoisDomainServiceTest`) passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebed5d55308321bf82c3b0090171ad)