### PR TITLE
Include nested exception message when failing to generate experiment section

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -286,7 +286,11 @@ public class ExperimentPipelineOpenAiClient {
                     outputTokens,
                     OpenAiCostEstimator.estimateUsd(effectiveModel, response.usage()));
         } catch (Exception ex) {
-            throw new IllegalStateException("Falha ao gerar seção " + job.section() + " do experimento " + job.experimentId(), ex);
+            String message = "Falha ao gerar seção " + job.section() + " do experimento " + job.experimentId();
+            if (StringUtils.hasText(ex.getMessage())) {
+                message = message + ". " + ex.getMessage();
+            }
+            throw new IllegalStateException(message, ex);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Improve diagnostics by including the nested exception message when throwing `IllegalStateException` after a failure to generate an experiment section. 

### Description
- Update the catch block to build a `message` string and append `ex.getMessage()` when present before rethrowing the `IllegalStateException` so the root cause is surfaced. 

### Testing
- Ran the existing automated test suite and build checks and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebec5fae4c8321a77ba50720a37305)