### PR TITLE
feat(mois): Sprint 3 — actionable analytics, saturation signals and executive summary endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisInsightDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisInsightDtos.java
@@ -14,7 +14,66 @@ public final class MoisInsightDtos {
             String nicheName,
             String marketTheme,
             String status,
-            Instant createdAt
+            Instant createdAt,
+            int offersAnalyzedCount
+    ) {
+    }
+
+    public record InsightReportPatternResponse(
+            String label,
+            long count,
+            double share
+    ) {
+    }
+
+    public record SaturationSignalResponse(
+            String category,
+            String priceBand,
+            long offerCount,
+            double saturationScore
+    ) {
+    }
+
+    public record GapOpportunityResponse(
+            String gapType,
+            String gapDescription,
+            String whyItMatters,
+            List<String> supportingOfferRefs,
+            String priority,
+            double confidence,
+            List<String> scoringCriteria
+    ) {
+    }
+
+    public record FrameworkRecommendationResponse(
+            String dominantPain,
+            String mostPromisedOutcome,
+            String mostExploredMechanism,
+            String mostUsedProof,
+            List<String> subexploredOfferAngles
+    ) {
+    }
+
+    public record InsightExecutiveSummaryResponse(
+            String reportId,
+            String requestId,
+            String nicheName,
+            String marketTheme,
+            FrameworkRecommendationResponse frameworkRecommendation,
+            List<GapOpportunityResponse> topGapOpportunities,
+            List<SaturationSignalResponse> saturationSignals,
+            List<String> decisionReadyActions
+    ) {
+    }
+
+    public record InsightReportRequestSummary(
+            String requestId,
+            String nicheName,
+            String marketTheme,
+            String painOrOutcomeFocus,
+            String status,
+            Instant createdAt,
+            Instant updatedAt
     ) {
     }
 
@@ -25,12 +84,19 @@ public final class MoisInsightDtos {
             String marketTheme,
             String status,
             Instant createdAt,
-            List<String> repeatedPromises,
-            List<String> repeatedProofPatterns,
-            List<String> pricingPatterns,
-            List<String> funnelPatterns,
-            List<String> gapOpportunities,
-            List<String> recommendedNextActions
+            InsightReportRequestSummary requestSummary,
+            List<String> offersAnalyzed,
+            List<InsightReportPatternResponse> repeatedPromises,
+            List<InsightReportPatternResponse> repeatedProofPatterns,
+            List<InsightReportPatternResponse> pricingPatterns,
+            List<InsightReportPatternResponse> funnelPatterns,
+            List<InsightReportPatternResponse> mechanismClaimPatterns,
+            List<SaturationSignalResponse> saturationSignals,
+            List<String> saturationNotes,
+            List<GapOpportunityResponse> gapOpportunities,
+            List<String> differentiationSignals,
+            List<String> recommendedNextActions,
+            FrameworkRecommendationResponse frameworkRecommendation
     ) {
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisModuleGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisModuleGateway.java
@@ -76,6 +76,11 @@ public class MoisModuleGateway {
         return optionalGet("/api/v1/mois/insight-reports/" + reportId, MoisInsightDtos.InsightReportResponse.class);
     }
 
+    public Optional<MoisInsightDtos.InsightExecutiveSummaryResponse> getInsightExecutiveSummary(String reportId) {
+        return optionalGet("/api/v1/mois/insight-reports/" + reportId + "/executive-summary",
+                MoisInsightDtos.InsightExecutiveSummaryResponse.class);
+    }
+
     public Optional<MoisArtifactDtos.ArtifactEnvelopeResponse> getArtifact(String artifactId) {
         return optionalGet("/api/v1/mois/artifacts/" + artifactId, MoisArtifactDtos.ArtifactEnvelopeResponse.class);
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
@@ -85,6 +85,12 @@ public class MoisController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "insight report not found"));
     }
 
+    @GetMapping("/insight-reports/{reportId}/executive-summary")
+    public MoisInsightDtos.InsightExecutiveSummaryResponse getInsightExecutiveSummary(@PathVariable String reportId) {
+        return gateway.getInsightExecutiveSummary(reportId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "insight report not found"));
+    }
+
     @GetMapping("/artifacts/{artifactId}")
     public MoisArtifactDtos.ArtifactEnvelopeResponse getArtifact(@PathVariable String artifactId) {
         return gateway.getArtifact(artifactId)

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
@@ -123,4 +123,27 @@ class MoisControllerContractTest {
                         .param("category", "DIGITAL_PRODUCT"))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    void shouldExposeExecutiveSummaryEndpointContract() throws Exception {
+        when(gateway.getInsightExecutiveSummary("mois-report-001"))
+                .thenReturn(Optional.of(new MoisInsightDtos.InsightExecutiveSummaryResponse(
+                        "mois-report-001",
+                        "mois-req-001",
+                        "nutricao",
+                        "perda de peso",
+                        new MoisInsightDtos.FrameworkRecommendationResponse(
+                                "dor dominante",
+                                "resultado",
+                                "mecanismo",
+                                "prova",
+                                List.of("angulo")),
+                        List.of(),
+                        List.of(),
+                        List.of("acao"))));
+
+        mockMvc.perform(get("/api/v1/mois/insight-reports/mois-report-001/executive-summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reportId").value("mois-report-001"));
+    }
 }

--- a/docs/novos-modulos/MOIS/mois_sprint3_execucao_2026-04-24.md
+++ b/docs/novos-modulos/MOIS/mois_sprint3_execucao_2026-04-24.md
@@ -1,0 +1,32 @@
+# MOIS — Execução da Sprint 3 (24/04/2026)
+
+## Escopo executado
+
+Implementação da Sprint 3 do plano `mois_plano_evolucao_3_sprints_2026-04-24.md` com foco em consolidar acionabilidade do `marketOfferInsightReport`:
+
+1. consolidação analítica com sinal explícito de saturação por combinação `categoria + faixa de preço`;
+2. `gapOpportunities` com critério de pontuação transparente (`scoringCriteria`), prioridade e confiança ordenada;
+3. recomendações orientadas ao framework **Dor → Resultado → Mecanismo → Prova → Oferta** no payload do relatório;
+4. endpoint executivo para consumidores (`GET /api/v1/mois/insight-reports/{reportId}/executive-summary`) no MOIS e na façade do backend;
+5. payload de leitura rápida orientado a decisão para módulos de hipótese/oferta sem transformação manual adicional;
+6. testes de regressão cobrindo ranking de padrões e contrato do endpoint executivo.
+
+## Contratos evoluídos (compatibilidade aditiva)
+
+### `InsightReportResponse`
+- novo campo `saturationSignals` (lista estruturada);
+- novo campo `frameworkRecommendation` (objeto estruturado);
+- `gapOpportunities` agora inclui `scoringCriteria`.
+
+### Novo payload executivo
+- `InsightExecutiveSummaryResponse` contendo:
+  - `frameworkRecommendation`,
+  - `topGapOpportunities`,
+  - `saturationSignals`,
+  - `decisionReadyActions`.
+
+## Critérios de pronto cobertos
+
+- relatório final com recomendações objetivas e justificadas por sinais;
+- backend façade e consumidores com endpoint executivo pronto para consumo direto;
+- suíte de testes ampliada com cenário de regressão de ranking e contrato do resumo executivo.

--- a/mois/src/main/java/com/marketinghub/mois/dto/MoisInsightDtos.java
+++ b/mois/src/main/java/com/marketinghub/mois/dto/MoisInsightDtos.java
@@ -26,13 +26,43 @@ public final class MoisInsightDtos {
     ) {
     }
 
+    public record SaturationSignalResponse(
+            String category,
+            String priceBand,
+            long offerCount,
+            double saturationScore
+    ) {
+    }
+
     public record GapOpportunityResponse(
             String gapType,
             String gapDescription,
             String whyItMatters,
             List<String> supportingOfferRefs,
             String priority,
-            double confidence
+            double confidence,
+            List<String> scoringCriteria
+    ) {
+    }
+
+    public record FrameworkRecommendationResponse(
+            String dominantPain,
+            String mostPromisedOutcome,
+            String mostExploredMechanism,
+            String mostUsedProof,
+            List<String> subexploredOfferAngles
+    ) {
+    }
+
+    public record InsightExecutiveSummaryResponse(
+            String reportId,
+            String requestId,
+            String nicheName,
+            String marketTheme,
+            FrameworkRecommendationResponse frameworkRecommendation,
+            List<GapOpportunityResponse> topGapOpportunities,
+            List<SaturationSignalResponse> saturationSignals,
+            List<String> decisionReadyActions
     ) {
     }
 
@@ -61,10 +91,12 @@ public final class MoisInsightDtos {
             List<InsightReportPatternResponse> pricingPatterns,
             List<InsightReportPatternResponse> funnelPatterns,
             List<InsightReportPatternResponse> mechanismClaimPatterns,
+            List<SaturationSignalResponse> saturationSignals,
             List<String> saturationNotes,
             List<GapOpportunityResponse> gapOpportunities,
             List<String> differentiationSignals,
-            List<String> recommendedNextActions
+            List<String> recommendedNextActions,
+            FrameworkRecommendationResponse frameworkRecommendation
     ) {
     }
 

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -283,6 +284,19 @@ public class MoisDomainService {
         return Optional.of(computed);
     }
 
+    public Optional<MoisInsightDtos.InsightExecutiveSummaryResponse> getInsightExecutiveSummary(String reportId) {
+        return getInsightReport(reportId)
+                .map(report -> new MoisInsightDtos.InsightExecutiveSummaryResponse(
+                        report.reportId(),
+                        report.requestId(),
+                        report.nicheName(),
+                        report.marketTheme(),
+                        report.frameworkRecommendation(),
+                        report.gapOpportunities().stream().limit(3).toList(),
+                        report.saturationSignals().stream().limit(5).toList(),
+                        report.recommendedNextActions()));
+    }
+
     private MoisInsightDtos.InsightReportResponse buildInsightReport(String reportId, DiscoveryRequest request) {
         String requestId = request.requestId();
         List<OfferCard> requestOffers = listOffersByRequest(requestId);
@@ -298,6 +312,9 @@ public class MoisDomainService {
                 buildPatternDistribution(requestOffers, OfferCard::funnelPatternSummary, offerCount);
         List<MoisInsightDtos.InsightReportPatternResponse> mechanismPatterns =
                 buildPatternDistribution(requestOffers, OfferCard::mechanismClaimSummary, offerCount);
+        List<MoisInsightDtos.SaturationSignalResponse> saturationSignals = buildSaturationSignals(requestOffers);
+        MoisInsightDtos.FrameworkRecommendationResponse frameworkRecommendation =
+                buildFrameworkRecommendation(request, repeatedPromises, repeatedProofPatterns, mechanismPatterns, pricingPatterns);
 
         return new MoisInsightDtos.InsightReportResponse(
                 reportId,
@@ -320,10 +337,12 @@ public class MoisDomainService {
                 pricingPatterns,
                 funnelPatterns,
                 mechanismPatterns,
+                saturationSignals,
                 buildSaturationNotes(repeatedPromises, pricingPatterns, offerCount),
-                buildGapOpportunities(requestOffers, repeatedPromises, pricingPatterns),
+                buildGapOpportunities(requestOffers, repeatedPromises, pricingPatterns, mechanismPatterns, repeatedProofPatterns),
                 buildDifferentiationSignals(requestOffers, repeatedPromises, mechanismPatterns),
-                buildRecommendedActions(repeatedPromises, pricingPatterns, mechanismPatterns));
+                buildRecommendedActions(repeatedPromises, pricingPatterns, mechanismPatterns),
+                frameworkRecommendation);
     }
 
     public Optional<MoisArtifactDtos.ArtifactEnvelopeResponse> getArtifact(String artifactId) {
@@ -412,10 +431,12 @@ public class MoisDomainService {
             content.put("pricingPatterns", report.pricingPatterns());
             content.put("funnelPatterns", report.funnelPatterns());
             content.put("mechanismClaimPatterns", report.mechanismClaimPatterns());
+            content.put("saturationSignals", report.saturationSignals());
             content.put("saturationNotes", report.saturationNotes());
             content.put("gapOpportunities", report.gapOpportunities());
             content.put("differentiationSignals", report.differentiationSignals());
             content.put("recommendedNextActions", report.recommendedNextActions());
+            content.put("frameworkRecommendation", report.frameworkRecommendation());
             return Optional.of(new MoisArtifactDtos.ArtifactEnvelopeResponse(
                     report.reportId(),
                     "mois.marketOfferInsightReport.v1",
@@ -457,7 +478,7 @@ public class MoisDomainService {
         return requestOffers.stream()
                 .map(extractor)
                 .filter(value -> value != null && !value.isBlank())
-                .collect(java.util.stream.Collectors.groupingBy(Function.identity(), java.util.stream.Collectors.counting()))
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
                 .entrySet()
                 .stream()
                 .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
@@ -497,7 +518,9 @@ public class MoisDomainService {
     private List<MoisInsightDtos.GapOpportunityResponse> buildGapOpportunities(
             List<OfferCard> requestOffers,
             List<MoisInsightDtos.InsightReportPatternResponse> repeatedPromises,
-            List<MoisInsightDtos.InsightReportPatternResponse> pricingPatterns
+            List<MoisInsightDtos.InsightReportPatternResponse> pricingPatterns,
+            List<MoisInsightDtos.InsightReportPatternResponse> mechanismPatterns,
+            List<MoisInsightDtos.InsightReportPatternResponse> repeatedProofPatterns
     ) {
         if (requestOffers.isEmpty()) {
             return List.of();
@@ -512,7 +535,8 @@ public class MoisDomainService {
                         "Ofertas com promessa alternativa tendem a destacar posicionamento em mercado saturado.",
                         requestOffers.stream().map(OfferCard::artifactId).toList(),
                         "HIGH",
-                        0.72));
+                        0.72,
+                        List.of("promise_share>0.70", "offer_count>3")));
             }
         });
 
@@ -523,9 +547,121 @@ public class MoisDomainService {
                     "Adicionar modelos de ancoragem, parcelamento ou ticket escalonado pode ampliar conversão por perfil.",
                     requestOffers.stream().map(OfferCard::artifactId).toList(),
                     "MEDIUM",
-                    0.66));
+                    0.66,
+                    List.of("unique_price_patterns<=1")));
         }
-        return gaps;
+
+        mechanismPatterns.stream().findFirst().ifPresent(topMechanism -> {
+            if (topMechanism.share() >= 0.65) {
+                gaps.add(new MoisInsightDtos.GapOpportunityResponse(
+                        "MECHANISM_PROOF_GAP",
+                        "Um único mecanismo domina o discurso competitivo.",
+                        "Há espaço para combinar mecanismo alternativo com prova específica e reduzir paridade.",
+                        requestOffers.stream().map(OfferCard::artifactId).toList(),
+                        "HIGH",
+                        0.74,
+                        List.of("mechanism_share>=0.65", "proof_pattern_diversity<3")));
+            }
+        });
+
+        if (repeatedProofPatterns.size() <= 1) {
+            gaps.add(new MoisInsightDtos.GapOpportunityResponse(
+                    "PROOF_ANGLE_UNEXPLORED",
+                    "Pouca variação de prova nas ofertas coletadas.",
+                    "Introduzir prova operacional e estudos de caso aprofundados aumenta credibilidade percebida.",
+                    requestOffers.stream().map(OfferCard::artifactId).toList(),
+                    "MEDIUM",
+                    0.61,
+                    List.of("unique_proof_patterns<=1")));
+        }
+        return gaps.stream()
+                .sorted(Comparator.comparingDouble(MoisInsightDtos.GapOpportunityResponse::confidence).reversed())
+                .toList();
+    }
+
+    private List<MoisInsightDtos.SaturationSignalResponse> buildSaturationSignals(List<OfferCard> requestOffers) {
+        if (requestOffers.isEmpty()) {
+            return List.of();
+        }
+
+        int totalOffers = requestOffers.size();
+        Map<String, Long> grouped = requestOffers.stream()
+                .collect(Collectors.groupingBy(
+                        offer -> offer.primaryOfferType() + "|" + toPriceBand(offer.mainPrice()),
+                        LinkedHashMap::new,
+                        Collectors.counting()));
+
+        return grouped.entrySet().stream()
+                .map(entry -> {
+                    String[] key = entry.getKey().split("\\|", 2);
+                    long count = entry.getValue();
+                    double score = count / (double) totalOffers;
+                    return new MoisInsightDtos.SaturationSignalResponse(key[0], key[1], count, score);
+                })
+                .sorted(Comparator.comparingDouble(MoisInsightDtos.SaturationSignalResponse::saturationScore).reversed())
+                .toList();
+    }
+
+    private MoisInsightDtos.FrameworkRecommendationResponse buildFrameworkRecommendation(
+            DiscoveryRequest request,
+            List<MoisInsightDtos.InsightReportPatternResponse> repeatedPromises,
+            List<MoisInsightDtos.InsightReportPatternResponse> repeatedProofPatterns,
+            List<MoisInsightDtos.InsightReportPatternResponse> mechanismPatterns,
+            List<MoisInsightDtos.InsightReportPatternResponse> pricingPatterns
+    ) {
+        String dominantPain = request.painOrOutcomeFocus() == null || request.painOrOutcomeFocus().isBlank()
+                ? "Dor não especificada na requisição"
+                : request.painOrOutcomeFocus();
+        String mostPromisedOutcome = topLabel(repeatedPromises, "Sem padrão de resultado dominante");
+        String mostExploredMechanism = topLabel(mechanismPatterns, "Mecanismo ainda difuso");
+        String mostUsedProof = topLabel(repeatedProofPatterns, "Prova pouco explicitada");
+        List<String> subexploredAngles = new ArrayList<>();
+        if (mechanismPatterns.size() > 1) {
+            subexploredAngles.add("Explorar mecanismo alternativo: " + mechanismPatterns.get(1).label());
+        }
+        if (pricingPatterns.size() > 1) {
+            subexploredAngles.add("Testar ângulo de oferta na faixa " + pricingPatterns.get(pricingPatterns.size() - 1).label());
+        }
+        if (subexploredAngles.isEmpty()) {
+            subexploredAngles.add("Buscar combinação inédita de mecanismo + prova para romper saturação.");
+        }
+        return new MoisInsightDtos.FrameworkRecommendationResponse(
+                dominantPain,
+                mostPromisedOutcome,
+                mostExploredMechanism,
+                mostUsedProof,
+                subexploredAngles);
+    }
+
+    private String topLabel(List<MoisInsightDtos.InsightReportPatternResponse> patterns, String fallback) {
+        return patterns.stream().findFirst().map(MoisInsightDtos.InsightReportPatternResponse::label).orElse(fallback);
+    }
+
+    private String toPriceBand(String mainPrice) {
+        if (mainPrice == null || mainPrice.isBlank()) {
+            return "UNSPECIFIED";
+        }
+        double numeric = parsePrice(mainPrice);
+        if (numeric <= 0) {
+            return "UNSPECIFIED";
+        }
+        if (numeric < 100) {
+            return "LOW";
+        }
+        if (numeric < 500) {
+            return "MID";
+        }
+        return "HIGH";
+    }
+
+    private double parsePrice(String rawPrice) {
+        String sanitized = rawPrice.replace("R$", "").replace("$", "").trim();
+        sanitized = sanitized.replace(".", "").replace(",", ".");
+        try {
+            return Double.parseDouble(sanitized);
+        } catch (NumberFormatException ignored) {
+            return -1;
+        }
     }
 
     private List<String> buildDifferentiationSignals(

--- a/mois/src/main/java/com/marketinghub/mois/web/MoisDomainController.java
+++ b/mois/src/main/java/com/marketinghub/mois/web/MoisDomainController.java
@@ -87,6 +87,12 @@ public class MoisDomainController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "insight report not found"));
     }
 
+    @GetMapping("/insight-reports/{reportId}/executive-summary")
+    public MoisInsightDtos.InsightExecutiveSummaryResponse getInsightExecutiveSummary(@PathVariable String reportId) {
+        return service.getInsightExecutiveSummary(reportId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "insight report not found"));
+    }
+
     @GetMapping("/artifacts/{artifactId}")
     public MoisArtifactDtos.ArtifactEnvelopeResponse getArtifact(@PathVariable String artifactId) {
         return service.getArtifact(artifactId)

--- a/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
+++ b/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
@@ -86,8 +86,33 @@ class MoisDomainServiceTest {
         assertThat(report.offersAnalyzed()).hasSize(2);
         assertThat(report.repeatedPromises()).isNotEmpty();
         assertThat(report.pricingPatterns()).isNotEmpty();
+        assertThat(report.saturationSignals()).isNotEmpty();
+        assertThat(report.frameworkRecommendation()).isNotNull();
         assertThat(report.saturationNotes()).isNotEmpty();
         assertThat(report.recommendedNextActions()).isNotEmpty();
+    }
+
+    @Test
+    void shouldKeepRankingStableForRepeatedPatterns() {
+        MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse accepted = service.createDiscoveryRequest(
+                new MoisDiscoveryDtos.CreateDiscoveryRequest(
+                        "Fisioterapia",
+                        "Dor lombar",
+                        "Alívio de dor",
+                        List.of("dor lombar oferta"),
+                        List.of(baseUrl + "/oferta-a", baseUrl + "/oferta-duplicada", baseUrl + "/oferta-b"),
+                        List.of("META_ADS"),
+                        "BR",
+                        "pt-BR",
+                        null));
+
+        service.runDiscoveryRequest(accepted.requestId());
+
+        MoisInsightDtos.InsightReportResponse report = service.getInsightReport("mois-report-" + accepted.requestId()).orElseThrow();
+        assertThat(report.repeatedPromises()).isNotEmpty();
+        assertThat(report.repeatedPromises().getFirst().share()).isGreaterThanOrEqualTo(0.5);
+        assertThat(report.gapOpportunities()).isNotEmpty();
+        assertThat(report.gapOpportunities().getFirst().confidence()).isGreaterThan(0.6);
     }
 
     @Test
@@ -195,6 +220,27 @@ class MoisDomainServiceTest {
         assertThat(artifact.artifactType()).isEqualTo("mois.marketOfferInsightReport.v1");
         assertThat(artifact.schemaVersion()).isEqualTo("v1");
         assertThat(artifact.createdBy()).isEqualTo("mois-system");
+    }
+
+    @Test
+    void shouldExposeExecutiveSummaryForConsumers() {
+        MoisDiscoveryDtos.DiscoveryRequestAcceptedResponse accepted = service.createDiscoveryRequest(
+                new MoisDiscoveryDtos.CreateDiscoveryRequest(
+                        "Fisioterapia",
+                        "Dor lombar",
+                        "Alívio de dor",
+                        List.of("dor lombar oferta"),
+                        List.of(baseUrl + "/oferta-a", baseUrl + "/oferta-b"),
+                        List.of("META_ADS"),
+                        "BR",
+                        "pt-BR",
+                        null));
+        service.runDiscoveryRequest(accepted.requestId());
+
+        MoisInsightDtos.InsightExecutiveSummaryResponse summary =
+                service.getInsightExecutiveSummary("mois-report-" + accepted.requestId()).orElseThrow();
+        assertThat(summary.frameworkRecommendation().dominantPain()).isEqualTo("Alívio de dor");
+        assertThat(summary.decisionReadyActions()).isNotEmpty();
     }
 
     private static class HtmlHandler implements HttpHandler {

--- a/mois/src/test/java/com/marketinghub/mois/web/MoisDomainControllerTest.java
+++ b/mois/src/test/java/com/marketinghub/mois/web/MoisDomainControllerTest.java
@@ -100,6 +100,7 @@ class MoisDomainControllerTest {
                         List.of(new com.marketinghub.mois.dto.MoisInsightDtos.InsightReportPatternResponse("R$97", 1, 1.0)),
                         List.of(new com.marketinghub.mois.dto.MoisInsightDtos.InsightReportPatternResponse("Funnel", 1, 1.0)),
                         List.of(new com.marketinghub.mois.dto.MoisInsightDtos.InsightReportPatternResponse("Mecanismo", 1, 1.0)),
+                        List.of(new com.marketinghub.mois.dto.MoisInsightDtos.SaturationSignalResponse("DIGITAL_PRODUCT", "LOW", 1, 1.0)),
                         List.of("Saturação"),
                         List.of(new com.marketinghub.mois.dto.MoisInsightDtos.GapOpportunityResponse(
                                 "PROMISE_DIFFERENTIATION",
@@ -107,11 +108,41 @@ class MoisDomainControllerTest {
                                 "Motivo",
                                 List.of("mois-offer-1"),
                                 "HIGH",
-                                0.7)),
+                                0.7,
+                                List.of("critério"))),
                         List.of("Diferenciação"),
-                        List.of("Next"))));
+                        List.of("Next"),
+                        new com.marketinghub.mois.dto.MoisInsightDtos.FrameworkRecommendationResponse(
+                                "Dor dominante",
+                                "Resultado",
+                                "Mecanismo",
+                                "Prova",
+                                List.of("Ângulo subexplorado")))));
 
         mockMvc.perform(get("/api/v1/mois/insight-reports/mois-report-mois-req-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reportId").value("mois-report-mois-req-1"));
+    }
+
+    @Test
+    void shouldReturnInsightExecutiveSummary() throws Exception {
+        when(service.getInsightExecutiveSummary("mois-report-mois-req-1")).thenReturn(Optional.of(
+                new com.marketinghub.mois.dto.MoisInsightDtos.InsightExecutiveSummaryResponse(
+                        "mois-report-mois-req-1",
+                        "mois-req-1",
+                        "Fisioterapia",
+                        "Dor lombar",
+                        new com.marketinghub.mois.dto.MoisInsightDtos.FrameworkRecommendationResponse(
+                                "Dor dominante",
+                                "Resultado",
+                                "Mecanismo",
+                                "Prova",
+                                List.of("Ângulo subexplorado")),
+                        List.of(),
+                        List.of(),
+                        List.of("Próxima ação"))));
+
+        mockMvc.perform(get("/api/v1/mois/insight-reports/mois-report-mois-req-1/executive-summary"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.reportId").value("mois-report-mois-req-1"));
     }


### PR DESCRIPTION
### Motivation
- Complete Sprint 3 of the MOIS evolution plan to make `marketOfferInsightReport` directly actionable for consumers by adding concise decision-ready signals and recommendations.
- Surface saturation and gap signals with transparent scoring so product/hypothesis modules can act without manual transformation.
- Provide a compact executive-summary payload and endpoint so downstream modules can consume recommendations and top gaps safely through the backend façade.

### Description
- Extended MOIS DTOs with structured outputs: added `SaturationSignalResponse`, `FrameworkRecommendationResponse`, `InsightExecutiveSummaryResponse`, and added `scoringCriteria` to `GapOpportunityResponse`, and included `saturationSignals` and `frameworkRecommendation` in `InsightReportResponse` in `mois/src/main/java/com/marketinghub/mois/dto/MoisInsightDtos.java` and synchronized the backend façade DTO in `backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisInsightDtos.java`.
- Implemented analytical consolidation in the domain service: `buildSaturationSignals`, `buildFrameworkRecommendation`, enhanced `buildGapOpportunities` with scoring criteria and ordering, and exposed `getInsightExecutiveSummary` that composes an `InsightExecutiveSummaryResponse` from the consolidated report in `mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java`.
- Added executive summary endpoint `GET /api/v1/mois/insight-reports/{reportId}/executive-summary` to the MOIS controller and propagated it through the backend façade and gateway (`mois/src/main/java/.../MoisDomainController.java`, `backend/ads-service/src/main/java/.../MoisController.java`, `backend/ads-service/src/main/java/.../MoisModuleGateway.java`).
- Updated artifact envelope output to include the new fields for consumer traceability and added a Sprint 3 execution document `docs/novos-modulos/MOIS/mois_sprint3_execucao_2026-04-24.md`.
- Expanded and updated tests to cover the new DTOs and behavior: added regression checks for pattern ranking stability, executive summary output and contracts in `mois` and the backend façade tests (`mois/src/test/...`, `backend/ads-service/src/test/...`).

### Testing
- Ran unit/integration tests in the module with `mvn -q test` (workdir: `mois`) and they passed.
- Ran the backend contract test with `mvn -q test -Dtest=MoisControllerContractTest` (workdir: `backend/ads-service`) and it passed.
- Note: outbound query-seed HTTP to DuckDuckGo can fail in restricted CI/network environments, but deterministic local fixtures and contract tests used by the test suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf3d386b4832198fc99362784198c)