### PR TITLE
Fix landing page extraction for published flow HTML endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Iterator;
+
 /**
  * Public API used by the portal application to fetch approved lead portal flows by slug.
  */
@@ -130,18 +132,9 @@ public class LeadPortalPublicFlowController {
         }
         try {
             JsonNode root = OBJECT_MAPPER.readTree(payload.trim());
-            if (root.isObject()) {
-                JsonNode landingPageHtmlNode = root.get("landingPageHtml");
-                if (landingPageHtmlNode != null) {
-                    String extracted = extractFromLandingPageNode(landingPageHtmlNode);
-                    if (StringUtils.hasText(extracted)) {
-                        return extracted;
-                    }
-                }
-                JsonNode htmlDocumentNode = root.get("htmlDocument");
-                if (htmlDocumentNode != null && htmlDocumentNode.isTextual()) {
-                    return htmlDocumentNode.asText();
-                }
+            String extracted = extractHtmlDocumentFromNode(root);
+            if (StringUtils.hasText(extracted)) {
+                return extracted;
             }
         } catch (Exception ignored) {
             return null;
@@ -149,16 +142,60 @@ public class LeadPortalPublicFlowController {
         return null;
     }
 
-    private String extractFromLandingPageNode(JsonNode landingPageHtmlNode) throws java.io.IOException {
-        if (landingPageHtmlNode.isTextual()) {
-            JsonNode nested = OBJECT_MAPPER.readTree(landingPageHtmlNode.asText());
-            JsonNode htmlDocumentNode = nested.get("htmlDocument");
-            return htmlDocumentNode != null && htmlDocumentNode.isTextual() ? htmlDocumentNode.asText() : null;
+    private String extractHtmlDocumentFromNode(JsonNode node) throws java.io.IOException {
+        if (node == null || node.isNull()) {
+            return null;
         }
-        if (landingPageHtmlNode.isObject()) {
-            JsonNode htmlDocumentNode = landingPageHtmlNode.get("htmlDocument");
-            return htmlDocumentNode != null && htmlDocumentNode.isTextual() ? htmlDocumentNode.asText() : null;
+        if (node.isObject()) {
+            JsonNode landingPageHtmlNode = node.get("landingPageHtml");
+            if (landingPageHtmlNode != null) {
+                String extracted = extractFromLandingPageNode(landingPageHtmlNode);
+                if (StringUtils.hasText(extracted)) {
+                    return extracted;
+                }
+            }
+            JsonNode htmlDocumentNode = node.get("htmlDocument");
+            if (htmlDocumentNode != null) {
+                String extracted = extractHtmlDocumentFromNode(htmlDocumentNode);
+                if (StringUtils.hasText(extracted)) {
+                    return extracted;
+                }
+            }
+            Iterator<JsonNode> children = node.elements();
+            while (children.hasNext()) {
+                String extracted = extractHtmlDocumentFromNode(children.next());
+                if (StringUtils.hasText(extracted)) {
+                    return extracted;
+                }
+            }
+            return null;
+        }
+        if (node.isTextual()) {
+            String value = node.asText();
+            if (!StringUtils.hasText(value)) {
+                return null;
+            }
+            String trimmedValue = value.trim();
+            if (looksLikeJsonPayload(trimmedValue)) {
+                return tryExtractFromJsonPayload(trimmedValue);
+            }
+            if (trimmedValue.contains("<html") || trimmedValue.contains("<!doctype html")) {
+                return value;
+            }
+            return null;
+        }
+        if (node.isArray()) {
+            for (JsonNode child : node) {
+                String extracted = extractHtmlDocumentFromNode(child);
+                if (StringUtils.hasText(extracted)) {
+                    return extracted;
+                }
+            }
         }
         return null;
+    }
+
+    private String extractFromLandingPageNode(JsonNode landingPageHtmlNode) throws java.io.IOException {
+        return extractHtmlDocumentFromNode(landingPageHtmlNode);
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
@@ -142,4 +142,52 @@ class LeadPortalPublicFlowControllerTest {
                 .andExpect(content().contentType("text/html;charset=UTF-8"))
                 .andExpect(content().string(nestedDocument));
     }
+
+    @Test
+    void getLandingPageBySlugReturnsHtmlWhenLandingPayloadUsesArtifactEnvelope() throws Exception {
+        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Teste").build());
+        String nestedDocument = "<!doctype html><html lang=\"pt-BR\"><body><main><h1>Landing via artifact.content</h1></main></body></html>";
+        ObjectMapper mapper = new ObjectMapper();
+        String payload = mapper.writeValueAsString(Map.of(
+                "artifact", Map.of(
+                        "content", Map.of(
+                                "landingPageHtml", Map.of("htmlDocument", nestedDocument)
+                        )
+                )
+        ));
+        flowRepository.save(LeadPortalFlow.builder()
+                .name("Fluxo Landing")
+                .slug("exp-16-landing")
+                .approved(true)
+                .marketNiche(niche)
+                .customFormHtml(payload)
+                .build());
+
+        mockMvc.perform(get("/api/flows/exp-16-landing/page"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/html;charset=UTF-8"))
+                .andExpect(content().string(nestedDocument));
+    }
+
+    @Test
+    void getLandingPageBySlugReturnsRawHtmlWhenLandingPageHtmlIsPlainText() throws Exception {
+        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Teste").build());
+        String nestedDocument = "<!doctype html><html lang=\"pt-BR\"><body><main><h1>Landing raw html</h1></main></body></html>";
+        ObjectMapper mapper = new ObjectMapper();
+        String payload = mapper.writeValueAsString(Map.of(
+                "landingPageHtml", nestedDocument
+        ));
+        flowRepository.save(LeadPortalFlow.builder()
+                .name("Fluxo Landing")
+                .slug("exp-17-landing")
+                .approved(true)
+                .marketNiche(niche)
+                .customFormHtml(payload)
+                .build());
+
+        mockMvc.perform(get("/api/flows/exp-17-landing/page"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/html;charset=UTF-8"))
+                .andExpect(content().string(nestedDocument));
+    }
 }


### PR DESCRIPTION
### Motivation

- The public endpoint `/api/flows/{slug}/page` could return raw JSON payloads instead of the normalized `htmlDocument`, causing published pages to render as escaped/garbled text.
- The change aims to make the endpoint tolerant to real-world payload shapes produced by the generation/publishing flows (including hybrid wrappers and envelopes like `artifact.content`).

### Description

- Replaced narrow JSON handling with a recursive extractor `extractHtmlDocumentFromNode(JsonNode)` that locates `htmlDocument` in objects, arrays, JSON-strings and plain HTML text.
- Updated `tryExtractFromJsonPayload` to use the recursive extractor and delegated `extractFromLandingPageNode` to it for consistent behavior.
- Added import for `java.util.Iterator` and preserved UTF-8 `text/html` response from `getLandingPageBySlug`.
- Added unit tests `getLandingPageBySlugReturnsHtmlWhenLandingPayloadUsesArtifactEnvelope` and `getLandingPageBySlugReturnsRawHtmlWhenLandingPageHtmlIsPlainText` to cover envelope and plain-text payload cases.

### Testing

- Ran unit tests for the controller with `./mvnw -f ads-service/pom.xml test -Dtest=LeadPortalPublicFlowControllerTest`, which passed: `Tests run: 6, Failures: 0, Errors: 0`.
- An initial test attempt using `./mvnw -pl ads-service test -Dtest=LeadPortalPublicFlowControllerTest` failed due to an incorrect reactor selection, and was resolved by running the command with `-f ads-service/pom.xml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0450f35483219b3b55f2c9f7d84c)