### PR TITLE
Add MOIS playbook and low-fidelity wireframes + backend backlog for MVP

### DIFF
--- a/docs/mois/mois-conjunto-telas-playbook.md
+++ b/docs/mois/mois-conjunto-telas-playbook.md
@@ -1,0 +1,230 @@
+# MOIS — Conjunto de telas para extrair conceitos de produtos digitais de sucesso
+
+## Objetivo
+
+Desenhar um fluxo de telas que permita:
+1. pesquisar referências reais de mercado;
+2. extrair conceitos, layouts, copy e padrões de oferta;
+3. transformar esses aprendizados em ativos aplicáveis às suas próprias ofertas.
+
+Este playbook segue o framework central do Marketing Hub: **Dor → Resultado → Mecanismo → Prova → Oferta**.
+
+## Resultado esperado do módulo
+
+Ao final de cada ciclo no MOIS, o usuário deve sair com:
+- um **mapa de dores e promessas** mais recorrentes no nicho;
+- uma **biblioteca de componentes de copy/layout** reutilizáveis;
+- um **rascunho de oferta aplicada** ao seu produto com hipóteses claras de conversão;
+- um **plano de teste A/B** para validar variações.
+
+---
+
+## Arquitetura de experiência (mapa de telas)
+
+## 1) Tela: Workspace MOIS (visão geral)
+
+**Objetivo:** concentrar o status do ciclo atual e guiar o próximo passo.
+
+**Blocos principais:**
+- indicador do ciclo atual (ex.: “Ciclo 12 — Em extração”);
+- cards de progresso por etapa: Coleta, Extração, Síntese, Aplicação, Teste;
+- atalho para criar nova análise;
+- lista de análises recentes.
+
+**Ações principais:**
+- “Nova análise”;
+- “Retomar análise”;
+- “Aplicar em oferta”.
+
+**Métrica da tela:** tempo até primeira ação útil (< 30s).
+
+---
+
+## 2) Tela: Coleta de referências vencedoras
+
+**Objetivo:** registrar produtos digitais de referência com contexto mínimo obrigatório.
+
+**Campos mínimos (obrigatórios):**
+- nicho/mercado*;
+- URL da oferta/página*;
+- tipo de ativo (landing, VSL, checkout, advertorial)*;
+- promessa principal percebida*;
+- estágio de consciência estimado do público*.
+
+**Campos complementares:**
+- preço/faixa de preço;
+- formato (curso, mentoria, template, comunidade etc.);
+- observações rápidas.
+
+**Regras UX:**
+- botão “Salvar referência” desabilitado enquanto salva;
+- validação instantânea para URLs inválidas;
+- feedback visual de sucesso/erro com mensagem objetiva.
+
+**Saída:** registro consolidado da referência para processamento.
+
+---
+
+## 3) Tela: Extração guiada (conceitos + copy + layout)
+
+**Objetivo:** transformar uma referência bruta em dados estruturados utilizáveis.
+
+**Seções de extração (com score de confiança):**
+- Dor principal (o que a oferta combate);
+- Resultado prometido (transformação percebida);
+- Mecanismo (como afirma gerar o resultado);
+- Prova (evidências, depoimentos, autoridade, números);
+- Oferta (stack, bônus, garantia, urgência, preço).
+
+**Taxonomia de copy para capturar:**
+- headline pattern;
+- abertura de dor;
+- bridge para mecanismo;
+- prova de credibilidade;
+- CTA principal + microcopy;
+- objeções tratadas e como foram tratadas.
+
+**Taxonomia de layout para capturar:**
+- ordem de seções;
+- hierarquia visual do hero;
+- densidade de texto;
+- padrão de CTA (posição/frequência);
+- blocos de prova social.
+
+**Ações principais:**
+- editar extração;
+- aceitar/rejeitar insight;
+- salvar como bloco reutilizável.
+
+---
+
+## 4) Tela: Biblioteca MOIS (blocos reaproveitáveis)
+
+**Objetivo:** permitir reutilização por intenção (dor, promessa, mecanismo, prova, oferta).
+
+**Filtros essenciais:**
+- nicho;
+- avatar;
+- tipo de promessa;
+- estágio de funil;
+- formato de oferta;
+- nível de evidência (baixo/médio/alto).
+
+**Tipos de bloco:**
+- copy block (headline, bullets, CTA, objeção);
+- layout block (estrutura de seção e ordem);
+- oferta block (bundle, bônus, ancoragem, garantia);
+- prova block (social/estatística/autoridade).
+
+**Ações principais:**
+- “duplicar para minha oferta”;
+- “favoritar”; 
+- “comparar com meu histórico”.
+
+---
+
+## 5) Tela: Comparador (referência vs sua oferta)
+
+**Objetivo:** mostrar gap concreto entre o que converte no mercado e sua oferta atual.
+
+**Painéis lado a lado:**
+- promessa de mercado vs promessa atual;
+- mecanismo percebido vs mecanismo comunicado;
+- prova usada no mercado vs prova disponível;
+- estrutura de página atual vs estrutura recomendada.
+
+**Scorecards recomendados (0–100):**
+- clareza de promessa;
+- força de prova;
+- coerência mecanismo-promessa;
+- atrito para ação (CTA/form).
+
+**Saída:** lista priorizada de melhorias com impacto estimado.
+
+---
+
+## 6) Tela: Aplicar na minha oferta (builder)
+
+**Objetivo:** montar uma versão de oferta aplicável baseada nos blocos selecionados.
+
+**Estrutura do builder:**
+- coluna A: blocos recomendados pelo MOIS;
+- coluna B: sua versão atual;
+- coluna C: versão proposta (editável).
+
+**Entregáveis gerados:**
+- copy de hero;
+- sequência de seções;
+- proposta de stack de oferta;
+- CTA principal e variantes;
+- plano de prova mínima necessária.
+
+**Checklist canônico (obrigatório):**
+- Dor explícita;
+- Resultado específico;
+- Mecanismo plausível;
+- Prova verificável;
+- Oferta clara com próximos passos.
+
+---
+
+## 7) Tela: Plano de experimento e validação
+
+**Objetivo:** fechar o ciclo com hipótese testável e rastreável.
+
+**Campos obrigatórios:**
+- hipótese de melhoria*;
+- variação controle vs variação teste*;
+- métrica primária (CTR, CVR, CPA, ROAS)*;
+- janela de teste*;
+- critério de decisão*.
+
+**Saída:** plano A/B pronto para execução e aprendizado futuro.
+
+---
+
+## Fluxo recomendado (fim a fim)
+
+1. **Coletar 5–10 referências** por nicho.
+2. **Extrair padrões** de Dor, Resultado, Mecanismo, Prova, Oferta.
+3. **Salvar blocos de maior evidência** na biblioteca.
+4. **Comparar com sua oferta atual** para identificar lacunas.
+5. **Gerar versão aplicada** no builder.
+6. **Criar teste A/B** com métrica e critério de decisão.
+7. **Registrar aprendizado** e reciclar no próximo ciclo.
+
+---
+
+## Priorização do MVP (ordem sugerida)
+
+### Sprint 1 (alto impacto)
+- Workspace MOIS;
+- Coleta de referências;
+- Extração guiada básica;
+- Aplicar na minha oferta (versão simplificada).
+
+### Sprint 2 (escala de qualidade)
+- Biblioteca MOIS com filtros avançados;
+- Comparador com scorecards;
+- Exportação de blueprint de oferta.
+
+### Sprint 3 (otimização contínua)
+- Plano de experimento integrado;
+- histórico de hipóteses e resultados;
+- recomendações automáticas por nicho.
+
+---
+
+## Critérios de qualidade das telas
+
+- cada tela deve expor **somente ações essenciais** do estágio atual;
+- informações devem ser organizadas por prioridade de decisão;
+- termos usados na interface devem seguir linguagem de negócio (não técnica);
+- toda recomendação de copy/layout deve apontar **origem e justificativa**;
+- toda saída do MOIS deve ser convertível em ação prática (copy, layout, oferta ou teste).
+
+## Próximo passo prático
+
+Implementar primeiro as telas 1, 2, 3 e 6, porque já permitem capturar referência, estruturar aprendizado e aplicar imediatamente na sua oferta.
+
+Wireframes de baixa fidelidade e backlog técnico detalhado: `docs/mois/mois-wireframes-backlog-mvp.md`.

--- a/docs/mois/mois-wireframes-backlog-mvp.md
+++ b/docs/mois/mois-wireframes-backlog-mvp.md
@@ -1,0 +1,327 @@
+# MOIS — Wireframes de baixa fidelidade + backlog técnico (próximo passo)
+
+Este documento transforma o playbook funcional em especificação executável para produto, frontend e backend.
+
+Referência base: `docs/mois/mois-conjunto-telas-playbook.md`.
+
+---
+
+## 1) Wireframes de baixa fidelidade (estrutura + estados)
+
+## Tela 1 — Workspace MOIS
+
+### Estrutura (desktop)
+
+```
+[Header: título + filtro de ciclo + botão "Nova análise"]
+[KPIs: Coletas | Extrações | Aplicações | Testes]
+[Stepper de estágio: Coleta > Extração > Síntese > Aplicação > Teste]
+[Lista "Análises recentes"]
+  - item: nicho | status | updatedAt | ações [Retomar] [Aplicar]
+[Sidebar direita "Ações rápidas"]
+  - Importar referência
+  - Abrir biblioteca
+  - Comparar oferta
+```
+
+### Estrutura (mobile)
+
+```
+[Header compacto]
+[Botão principal "Nova análise"]
+[Stepper horizontal scrollável]
+[Cards de KPI em carrossel]
+[Lista de análises]
+```
+
+### Componentes React sugeridos
+- `MoisWorkspacePage`
+- `MoisKpiCards`
+- `MoisPipelineStepper`
+- `MoisRecentAnalysisList`
+- `MoisQuickActions`
+
+### Estados de UI
+- **loading:** skeleton nos KPIs e na lista.
+- **empty:** CTA "Criar primeira análise".
+- **error:** alerta com ação "Tentar novamente".
+
+---
+
+## Tela 2 — Coleta de referências
+
+### Estrutura
+
+```
+[Header: Coleta de referências]
+[Form principal]
+  nicho* | url* | tipoAtivo* | promessa* | consciencia* 
+  preco | formato | observacoes
+[Preview lateral da URL]
+[Botões: Cancelar | Salvar referência]
+[Tabela de referências já coletadas]
+```
+
+### Componentes React sugeridos
+- `MoisReferenceIntakePage`
+- `MoisReferenceForm`
+- `MoisUrlPreviewCard`
+- `MoisReferenceTable`
+
+### Estados de UI
+- **submitting:** botão `Salvar referência` desabilitado + spinner.
+- **validation error:** mensagem por campo.
+- **save success:** toast "Referência salva".
+- **save error:** toast com motivo técnico amigável.
+
+---
+
+## Tela 3 — Extração guiada
+
+### Estrutura
+
+```
+[Header: Extração guiada]
+[Coluna A: referência (snapshot)]
+[Coluna B: editor estruturado]
+  tabs: Dor | Resultado | Mecanismo | Prova | Oferta
+  cada tab: campos + score de confiança + evidências
+[Painel lateral: taxonomias detectadas]
+  copy patterns
+  layout patterns
+[Rodapé fixo: Salvar rascunho | Aprovar insights]
+```
+
+### Componentes React sugeridos
+- `MoisExtractionPage`
+- `MoisReferenceSnapshotPanel`
+- `MoisExtractionTabs`
+- `MoisTaxonomyPanel`
+- `MoisStickyActions`
+
+### Estados de UI
+- **loading extraction:** skeleton em tabs.
+- **partial data:** badge "extração parcial".
+- **approval success/error:** feedback no rodapé.
+
+---
+
+## Tela 4 — Biblioteca MOIS
+
+### Estrutura
+
+```
+[Header: Biblioteca]
+[Filtros: nicho, avatar, promessa, estágio, formato, evidência]
+[Grid de blocos]
+  card: tipo | resumo | tags | score | origem
+  ações: Favoritar | Duplicar para oferta | Comparar
+[Drawer: detalhes do bloco]
+```
+
+### Componentes React sugeridos
+- `MoisLibraryPage`
+- `MoisLibraryFilters`
+- `MoisBlockGrid`
+- `MoisBlockDetailDrawer`
+
+### Estados de UI
+- **loading grid:** skeleton cards.
+- **empty filtered:** "Nenhum bloco para os filtros atuais".
+- **error:** alerta + retry.
+
+---
+
+## Tela 5 — Comparador (mercado vs sua oferta)
+
+### Estrutura
+
+```
+[Header: Comparador]
+[Seletores: referência base | oferta atual]
+[Quadro 2 colunas]
+  Promessa (mercado vs atual)
+  Mecanismo (mercado vs atual)
+  Prova (mercado vs atual)
+  Layout (mercado vs atual)
+[Scorecards: clareza | prova | coerência | atrito]
+[Lista de melhorias priorizadas]
+```
+
+### Componentes React sugeridos
+- `MoisComparisonPage`
+- `MoisComparisonSelectors`
+- `MoisComparisonMatrix`
+- `MoisScorecards`
+- `MoisImprovementBacklog`
+
+### Estados de UI
+- **no selection:** estado orientativo para escolher pares.
+- **comparison loaded:** diffs com destaques visuais.
+
+---
+
+## Tela 6 — Aplicar na minha oferta (builder)
+
+### Estrutura
+
+```
+[Header: Builder de oferta]
+[3 colunas]
+  A: blocos recomendados
+  B: versão atual
+  C: versão proposta (editável)
+[Checklist obrigatório]
+  Dor | Resultado | Mecanismo | Prova | Oferta
+[Ações: Gerar versão | Salvar versão | Exportar]
+```
+
+### Componentes React sugeridos
+- `MoisOfferBuilderPage`
+- `MoisRecommendedBlocksColumn`
+- `MoisCurrentOfferColumn`
+- `MoisProposedOfferEditor`
+- `MoisCanonicalChecklist`
+
+### Estados de UI
+- **generating:** botões desabilitados + spinner.
+- **missing checklist items:** bloqueio com explicação.
+- **save/export feedback:** toast de confirmação/erro.
+
+---
+
+## Tela 7 — Plano de experimento
+
+### Estrutura
+
+```
+[Header: Plano de experimento]
+[Form]
+  hipótese* | controle* | variação* | métrica* | janela* | critério*
+[Resumo automático de plano]
+[Botões: Salvar plano | Publicar teste]
+```
+
+### Componentes React sugeridos
+- `MoisExperimentPlanPage`
+- `MoisExperimentPlanForm`
+- `MoisPlanSummaryCard`
+
+### Estados de UI
+- **draft saved:** badge "Rascunho salvo".
+- **publish pending:** spinner no botão.
+- **publish failed:** bloco com causa + ação corretiva.
+
+---
+
+## 2) Contratos backend (MVP) para suportar as telas
+
+> Observação: como o front depende do backend, os endpoints abaixo devem ser priorizados antes de UI final.
+
+## 2.1 Workspace
+
+- `GET /api/v1/mois/workspaces/{workspaceId}/dashboard`
+  - retorna KPIs, etapa atual e análises recentes.
+
+## 2.2 Coleta
+
+- `POST /api/v1/mois/references`
+  - cria referência de mercado.
+- `GET /api/v1/mois/references?workspaceId=...`
+  - lista referências coletadas.
+
+Payload mínimo (`POST /references`):
+
+```json
+{
+  "workspaceId": "uuid",
+  "niche": "nutricao-esportiva",
+  "sourceUrl": "https://exemplo.com/oferta",
+  "assetType": "LANDING_PAGE",
+  "primaryPromise": "Secar 5kg em 8 semanas",
+  "awarenessStage": "PROBLEM_AWARE",
+  "priceRange": "97-297",
+  "formatType": "CURSO",
+  "notes": "Oferta com forte prova social"
+}
+```
+
+## 2.3 Extração
+
+- `POST /api/v1/mois/references/{referenceId}/extractions`
+  - inicia/atualiza extração estruturada.
+- `POST /api/v1/mois/extractions/{extractionId}/approve`
+  - aprova insights.
+
+## 2.4 Biblioteca
+
+- `GET /api/v1/mois/library/blocks`
+  - busca com filtros.
+- `POST /api/v1/mois/library/blocks/{blockId}/favorite`
+- `POST /api/v1/mois/library/blocks/{blockId}/duplicate`
+
+## 2.5 Comparador
+
+- `POST /api/v1/mois/comparisons`
+  - gera comparação e scorecards.
+
+## 2.6 Builder
+
+- `POST /api/v1/mois/offers/build`
+  - monta versão proposta com base em blocos selecionados.
+- `POST /api/v1/mois/offers/{offerId}/exports`
+  - exporta blueprint (markdown/json).
+
+## 2.7 Experimentos
+
+- `POST /api/v1/mois/experiment-plans`
+- `POST /api/v1/mois/experiment-plans/{planId}/publish`
+
+---
+
+## 3) Backlog funcional (stories prontas para execução)
+
+## Epic A — Fundamentos do fluxo MOIS
+1. **A1 — Dashboard do workspace**
+   - como usuário, quero ver KPIs e análises recentes para retomar rapidamente.
+   - DoD: loading/empty/error + paginação funcional.
+2. **A2 — Cadastro de referência com validação**
+   - DoD: campos obrigatórios, validação de URL e feedback de submit.
+3. **A3 — Lista de referências coletadas**
+   - DoD: ordenação por data + filtros básicos por tipo/nicho.
+
+## Epic B — Extração e biblioteca
+4. **B1 — Extração em tabs DRMP-O**
+   - DoD: salvar rascunho e aprovar insights.
+5. **B2 — Biblioteca de blocos com filtros**
+   - DoD: favoritar, duplicar e abrir detalhe.
+
+## Epic C — Aplicação e validação
+6. **C1 — Comparador com scorecards**
+   - DoD: cálculo + explicação de score por dimensão.
+7. **C2 — Builder de oferta em 3 colunas**
+   - DoD: checklist obrigatório bloqueando export sem completude.
+8. **C3 — Plano de experimento publicável**
+   - DoD: validação de campos e status de publicação.
+
+---
+
+## 4) Priorização técnica (2 semanas)
+
+### Semana 1
+- Backend: dashboard, references (POST/GET), extraction draft.
+- Frontend: telas 1 e 2 completas + estados.
+
+### Semana 2
+- Backend: library list/favorite/duplicate, comparisons, offer build.
+- Frontend: telas 3, 4, 5 e 6 (MVP), com plano de experimento simplificado.
+
+---
+
+## 5) Critérios de aceite transversais
+
+- Todos os botões assíncronos devem ficar desabilitados durante processamento.
+- Campos obrigatórios devem exibir `*` ao lado do rótulo.
+- Cada tela deve possuir estados: loading, empty (quando aplicável) e error.
+- Toda recomendação gerada deve manter rastreabilidade de origem (referência/bloco).
+- O fluxo completo deve preservar o eixo canônico: Dor → Resultado → Mecanismo → Prova → Oferta.


### PR DESCRIPTION
### Motivation
- Provide a complete product playbook and execution-ready spec for the MOIS flow to extract market-winning digital product concepts and apply them to user offers.
- Align frontend UI, data taxonomy and backend contracts around the Marketing Hub framework `Dor → Resultado → Mecanismo → Prova → Oferta` to enable reproducible extraction, reuse and testing workflows.
- Prioritize an MVP implementation path so teams can deliver value quickly and iterate on library, comparison and experiment features.

### Description
- Add `docs/mois/mois-conjunto-telas-playbook.md` containing objectives, expected outcomes, detailed screen-by-screen flows for seven MOIS screens, recommended UX rules and an end-to-end workflow. 
- Add `docs/mois/mois-wireframes-backlog-mvp.md` with low-fidelity wireframes (desktop/mobile), suggested React components and UI states for each screen, and a practical backlog with DoD and sprint prioritization. 
- Define backend contracts and example payloads required for the MVP, including endpoints such as `POST /api/v1/mois/references`, `GET /api/v1/mois/references`, `POST /api/v1/mois/references/{referenceId}/extractions`, `POST /api/v1/mois/extractions/{extractionId}/approve`, `GET /api/v1/mois/library/blocks`, `POST /api/v1/mois/offers/build`, and experiment plan endpoints. 
- Document acceptance criteria, export options, and next steps recommending implementation of Screens 1, 2, 3 and 6 first, plus checklist rules for production readiness.

### Testing
- No automated tests were added or executed for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec050750ec83218727d9f5b20f15bb)