### PR TITLE
docs(mois): align with canons, enforce backend contracts and add sprint closure rules

### DIFF
--- a/docs/mois/mois-wireframes-backlog-mvp.md
+++ b/docs/mois/mois-wireframes-backlog-mvp.md
@@ -4,6 +4,11 @@ Este documento transforma o playbook funcional em especificação executável pa
 
 Referência base: `docs/mois/mois-conjunto-telas-playbook.md`.
 
+Documentos canônicos obrigatórios para este módulo e para o projeto:
+- `docs/canonical/system-governance-canon.v2.md` (cânone de governança do projeto).
+- `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` (cânone de artefatos e regras de pipeline).
+- `docs/mois/mois-conjunto-telas-playbook.md` (cânone funcional de telas/fluxo do módulo MOIS).
+
 ---
 
 ## 1) Wireframes de baixa fidelidade (estrutura + estados)
@@ -216,7 +221,7 @@ Referência base: `docs/mois/mois-conjunto-telas-playbook.md`.
 
 ## 2) Contratos backend (MVP) para suportar as telas
 
-> Observação: como o front depende do backend, os endpoints abaixo devem ser priorizados antes de UI final.
+> Observação obrigatória: como o frontend depende do backend, os métodos/endpoints abaixo devem ser construídos e mantidos de forma contínua para sustentar as telas. Não evoluir frontend sem contrato/método correspondente no backend.
 
 ## 2.1 Workspace
 
@@ -306,15 +311,21 @@ Payload mínimo (`POST /references`):
 
 ---
 
-## 4) Priorização técnica (2 semanas)
+## 4) Divisão em sprints (MVP)
 
-### Semana 1
+### Sprint 1 (Semana 1)
 - Backend: dashboard, references (POST/GET), extraction draft.
 - Frontend: telas 1 e 2 completas + estados.
 
-### Semana 2
+### Sprint 2 (Semana 2)
 - Backend: library list/favorite/duplicate, comparisons, offer build.
 - Frontend: telas 3, 4, 5 e 6 (MVP), com plano de experimento simplificado.
+
+### Encerramento obrigatório de cada sprint
+Ao final de **toda sprint**, registrar no próprio documento (ou em log vinculado):
+- **Data de fechamento** (formato ISO: `YYYY-MM-DD`);
+- **O que foi feito** (entregas concluídas e evidências objetivas);
+- **Pendências** (itens não concluídos, bloqueios e plano de ação para próxima sprint).
 
 ---
 


### PR DESCRIPTION
### Motivation
- Garantir governança e alinhamento entre frontend, backend e documentos canônicos do projeto no backlog MOIS.
- Assegurar que o desenvolvimento de UI seja apoiado continuamente por métodos/endpoints no backend para evitar divergências de contrato.
- Introduzir disciplina de execução por sprints para melhorar rastreabilidade das entregas do MVP.

### Description
- Adiciona seção com os `Documentos canônicos obrigatórios` para o módulo/projeto em `docs/mois/mois-wireframes-backlog-mvp.md` apontando para os cânones relevantes. 
- Torna explícita a regra de que o frontend só deve evoluir com métodos/endpoints correspondentes no backend, reforçando a prioridade de implementação dos contratos. 
- Substitui a seção de priorização por uma `Divisão em sprints (MVP)` com `Sprint 1` e `Sprint 2` e detalhes do escopo de cada sprint. 
- Inclui `Encerramento obrigatório de cada sprint` exigindo registro de `Data de fechamento`, `O que foi feito` e `Pendências` no documento ou log vinculado.

### Testing
- Validado o conteúdo e posicionamento das alterações usando `nl -ba docs/mois/mois-wireframes-backlog-mvp.md | sed -n '1,420p'`, que exibiu o novo texto corretamente. (sucesso)
- Aplicação do patch confirmada pela ferramenta de aplicação de patch (`apply_patch`) que retornou sucesso ao atualizar o arquivo. (sucesso)
- Verificação do estado do repositório com `git status --short` após a operação, resultando em repositório limpo. (sucesso)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec07d7a82883219b77247c897020cd)