### PR TITLE
feat(mois): implementar Sprint 1 — workspace, referências (API + frontend) e documentação

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisWorkspaceDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisWorkspaceDtos.java
@@ -1,0 +1,83 @@
+package com.marketinghub.mois.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.List;
+
+public final class MoisWorkspaceDtos {
+
+    private MoisWorkspaceDtos() {
+    }
+
+    public record WorkspaceDashboardResponse(
+            String workspaceId,
+            WorkspaceKpisResponse kpis,
+            String currentStage,
+            List<RecentAnalysisResponse> recentAnalyses
+    ) {
+    }
+
+    public record WorkspaceKpisResponse(int collections, int extractions, int applications, int tests) {
+    }
+
+    public record RecentAnalysisResponse(
+            String analysisId,
+            String niche,
+            String status,
+            Instant updatedAt
+    ) {
+    }
+
+    public record CreateReferenceRequest(
+            @NotBlank String workspaceId,
+            @NotBlank String niche,
+            @NotBlank
+            @Pattern(regexp = "https?://.+", message = "sourceUrl must start with http:// or https://")
+            String sourceUrl,
+            @NotBlank String assetType,
+            @NotBlank String primaryPromise,
+            @NotBlank String awarenessStage,
+            @Size(max = 120) String priceRange,
+            @Size(max = 80) String formatType,
+            @Size(max = 1000) String notes
+    ) {
+    }
+
+    public record ReferenceResponse(
+            String referenceId,
+            String workspaceId,
+            String niche,
+            String sourceUrl,
+            String assetType,
+            String primaryPromise,
+            String awarenessStage,
+            String priceRange,
+            String formatType,
+            String notes,
+            Instant createdAt
+    ) {
+    }
+
+    public record ReferenceListResponse(List<ReferenceResponse> items) {
+    }
+
+    public record UpsertExtractionDraftRequest(
+            String pain,
+            String result,
+            String mechanism,
+            String proof,
+            String offer,
+            List<String> evidenceItems
+    ) {
+    }
+
+    public record ExtractionDraftResponse(
+            String extractionId,
+            String referenceId,
+            String status,
+            Instant updatedAt
+    ) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisSprintOneService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisSprintOneService.java
@@ -1,0 +1,113 @@
+package com.marketinghub.mois.service;
+
+import com.marketinghub.mois.dto.MoisWorkspaceDtos;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MoisSprintOneService {
+
+    private static final String DEFAULT_STAGE = "COLETA";
+
+    private final ConcurrentMap<String, MoisWorkspaceDtos.ReferenceResponse> referencesById = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, MoisWorkspaceDtos.ExtractionDraftResponse> extractionByReferenceId =
+            new ConcurrentHashMap<>();
+
+    public MoisWorkspaceDtos.WorkspaceDashboardResponse getDashboard(String workspaceId) {
+        List<MoisWorkspaceDtos.ReferenceResponse> workspaceReferences = listWorkspaceReferences(workspaceId);
+        int extractions = (int) workspaceReferences.stream()
+                .filter(reference -> extractionByReferenceId.containsKey(reference.referenceId()))
+                .count();
+
+        List<MoisWorkspaceDtos.RecentAnalysisResponse> recentAnalyses = workspaceReferences.stream()
+                .sorted(Comparator.comparing(MoisWorkspaceDtos.ReferenceResponse::createdAt).reversed())
+                .limit(10)
+                .map(reference -> new MoisWorkspaceDtos.RecentAnalysisResponse(
+                        reference.referenceId(),
+                        reference.niche(),
+                        extractionByReferenceId.containsKey(reference.referenceId()) ? "EXTRACTION_DRAFT" : "COLETA_CONCLUIDA",
+                        reference.createdAt()))
+                .toList();
+
+        return new MoisWorkspaceDtos.WorkspaceDashboardResponse(
+                workspaceId,
+                new MoisWorkspaceDtos.WorkspaceKpisResponse(workspaceReferences.size(), extractions, 0, 0),
+                DEFAULT_STAGE,
+                recentAnalyses
+        );
+    }
+
+    public MoisWorkspaceDtos.ReferenceResponse createReference(MoisWorkspaceDtos.CreateReferenceRequest request) {
+        Instant now = Instant.now();
+        MoisWorkspaceDtos.ReferenceResponse created = new MoisWorkspaceDtos.ReferenceResponse(
+                UUID.randomUUID().toString(),
+                request.workspaceId(),
+                request.niche(),
+                request.sourceUrl(),
+                request.assetType(),
+                request.primaryPromise(),
+                request.awarenessStage(),
+                request.priceRange(),
+                request.formatType(),
+                request.notes(),
+                now
+        );
+        referencesById.put(created.referenceId(), created);
+        return created;
+    }
+
+    public MoisWorkspaceDtos.ReferenceListResponse listReferences(String workspaceId) {
+        List<MoisWorkspaceDtos.ReferenceResponse> references = listWorkspaceReferences(workspaceId).stream()
+                .sorted(Comparator.comparing(MoisWorkspaceDtos.ReferenceResponse::createdAt).reversed())
+                .toList();
+        return new MoisWorkspaceDtos.ReferenceListResponse(references);
+    }
+
+    public MoisWorkspaceDtos.ExtractionDraftResponse upsertExtractionDraft(
+            String referenceId,
+            MoisWorkspaceDtos.UpsertExtractionDraftRequest request
+    ) {
+        MoisWorkspaceDtos.ReferenceResponse reference = referencesById.get(referenceId);
+        if (reference == null) {
+            throw new IllegalArgumentException("reference not found");
+        }
+
+        MoisWorkspaceDtos.ExtractionDraftResponse draft = new MoisWorkspaceDtos.ExtractionDraftResponse(
+                UUID.randomUUID().toString(),
+                referenceId,
+                hasAnyDraftContent(request) ? "DRAFT" : "EMPTY_DRAFT",
+                Instant.now()
+        );
+        extractionByReferenceId.put(referenceId, draft);
+        return draft;
+    }
+
+    private List<MoisWorkspaceDtos.ReferenceResponse> listWorkspaceReferences(String workspaceId) {
+        List<MoisWorkspaceDtos.ReferenceResponse> references = new ArrayList<>();
+        for (MoisWorkspaceDtos.ReferenceResponse reference : referencesById.values()) {
+            if (reference.workspaceId().equals(workspaceId)) {
+                references.add(reference);
+            }
+        }
+        return references;
+    }
+
+    private boolean hasAnyDraftContent(MoisWorkspaceDtos.UpsertExtractionDraftRequest request) {
+        return isNotBlank(request.pain())
+                || isNotBlank(request.result())
+                || isNotBlank(request.mechanism())
+                || isNotBlank(request.proof())
+                || isNotBlank(request.offer())
+                || (request.evidenceItems() != null && !request.evidenceItems().isEmpty());
+    }
+
+    private boolean isNotBlank(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
@@ -4,7 +4,9 @@ import com.marketinghub.mois.dto.MoisArtifactDtos;
 import com.marketinghub.mois.dto.MoisDiscoveryDtos;
 import com.marketinghub.mois.dto.MoisInsightDtos;
 import com.marketinghub.mois.dto.MoisOfferDtos;
+import com.marketinghub.mois.dto.MoisWorkspaceDtos;
 import com.marketinghub.mois.service.MoisModuleGateway;
+import com.marketinghub.mois.service.MoisSprintOneService;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class MoisController {
 
     private final MoisModuleGateway gateway;
+    private final MoisSprintOneService sprintOneService;
 
     @PostMapping("/discovery-requests")
     @ResponseStatus(HttpStatus.ACCEPTED)
@@ -53,6 +56,37 @@ public class MoisController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public MoisDiscoveryDtos.AsyncAcceptedResponse runDiscoveryRequest(@PathVariable String requestId) {
         return gateway.runDiscoveryRequest(requestId);
+    }
+
+
+    @GetMapping("/workspaces/{workspaceId}/dashboard")
+    public MoisWorkspaceDtos.WorkspaceDashboardResponse getWorkspaceDashboard(@PathVariable String workspaceId) {
+        return sprintOneService.getDashboard(workspaceId);
+    }
+
+    @PostMapping("/references")
+    @ResponseStatus(HttpStatus.CREATED)
+    public MoisWorkspaceDtos.ReferenceResponse createReference(
+            @Valid @RequestBody MoisWorkspaceDtos.CreateReferenceRequest request
+    ) {
+        return sprintOneService.createReference(request);
+    }
+
+    @GetMapping("/references")
+    public MoisWorkspaceDtos.ReferenceListResponse listReferences(@RequestParam String workspaceId) {
+        return sprintOneService.listReferences(workspaceId);
+    }
+
+    @PostMapping("/references/{referenceId}/extractions")
+    public MoisWorkspaceDtos.ExtractionDraftResponse upsertExtractionDraft(
+            @PathVariable String referenceId,
+            @RequestBody MoisWorkspaceDtos.UpsertExtractionDraftRequest request
+    ) {
+        try {
+            return sprintOneService.upsertExtractionDraft(referenceId, request);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        }
     }
 
     @GetMapping("/offers")

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
@@ -3,7 +3,9 @@ package com.marketinghub.mois.web;
 import com.marketinghub.mois.dto.MoisDiscoveryDtos;
 import com.marketinghub.mois.dto.MoisInsightDtos;
 import com.marketinghub.mois.dto.MoisOfferDtos;
+import com.marketinghub.mois.dto.MoisWorkspaceDtos;
 import com.marketinghub.mois.service.MoisModuleGateway;
+import com.marketinghub.mois.service.MoisSprintOneService;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +37,9 @@ class MoisControllerContractTest {
 
     @MockBean
     private MoisModuleGateway gateway;
+
+    @MockBean
+    private MoisSprintOneService sprintOneService;
 
     @Test
     void shouldAcceptDiscoveryRequest() throws Exception {
@@ -146,4 +151,119 @@ class MoisControllerContractTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.reportId").value("mois-report-001"));
     }
+
+    @Test
+    void shouldReturnWorkspaceDashboardContract() throws Exception {
+        when(sprintOneService.getDashboard(eq("workspace-001")))
+                .thenReturn(new MoisWorkspaceDtos.WorkspaceDashboardResponse(
+                        "workspace-001",
+                        new MoisWorkspaceDtos.WorkspaceKpisResponse(12, 4, 2, 1),
+                        "COLETA",
+                        List.of(new MoisWorkspaceDtos.RecentAnalysisResponse(
+                                "ref-1",
+                                "nutricao",
+                                "COLETA_CONCLUIDA",
+                                Instant.parse("2026-04-25T12:00:00Z")) )
+                ));
+
+        mockMvc.perform(get("/api/v1/mois/workspaces/workspace-001/dashboard"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.kpis.collections").value(12))
+                .andExpect(jsonPath("$.recentAnalyses[0].analysisId").value("ref-1"));
+    }
+
+    @Test
+    void shouldCreateReferenceForSprintOneContract() throws Exception {
+        when(sprintOneService.createReference(any(MoisWorkspaceDtos.CreateReferenceRequest.class)))
+                .thenReturn(new MoisWorkspaceDtos.ReferenceResponse(
+                        "ref-123",
+                        "workspace-001",
+                        "nutricao-esportiva",
+                        "https://exemplo.com/oferta",
+                        "LANDING_PAGE",
+                        "Secar 5kg em 8 semanas",
+                        "PROBLEM_AWARE",
+                        "97-297",
+                        "CURSO",
+                        "Oferta com prova social",
+                        Instant.parse("2026-04-25T12:00:00Z")
+                ));
+
+        mockMvc.perform(post("/api/v1/mois/references")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "workspaceId": "workspace-001",
+                                  "niche": "nutricao-esportiva",
+                                  "sourceUrl": "https://exemplo.com/oferta",
+                                  "assetType": "LANDING_PAGE",
+                                  "primaryPromise": "Secar 5kg em 8 semanas",
+                                  "awarenessStage": "PROBLEM_AWARE",
+                                  "priceRange": "97-297",
+                                  "formatType": "CURSO",
+                                  "notes": "Oferta com prova social"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.referenceId").value("ref-123"))
+                .andExpect(jsonPath("$.workspaceId").value("workspace-001"));
+    }
+
+    @Test
+    void shouldValidateReferencePayload() throws Exception {
+        mockMvc.perform(post("/api/v1/mois/references")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldListReferencesByWorkspace() throws Exception {
+        when(sprintOneService.listReferences(eq("workspace-001")))
+                .thenReturn(new MoisWorkspaceDtos.ReferenceListResponse(List.of(
+                        new MoisWorkspaceDtos.ReferenceResponse(
+                                "ref-123",
+                                "workspace-001",
+                                "nutricao-esportiva",
+                                "https://exemplo.com/oferta",
+                                "LANDING_PAGE",
+                                "Secar 5kg em 8 semanas",
+                                "PROBLEM_AWARE",
+                                "97-297",
+                                "CURSO",
+                                null,
+                                Instant.parse("2026-04-25T12:00:00Z")
+                        )
+                )));
+
+        mockMvc.perform(get("/api/v1/mois/references").param("workspaceId", "workspace-001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].referenceId").value("ref-123"));
+    }
+
+
+    @Test
+    void shouldUpsertExtractionDraft() throws Exception {
+        when(sprintOneService.upsertExtractionDraft(eq("ref-123"), any(MoisWorkspaceDtos.UpsertExtractionDraftRequest.class)))
+                .thenReturn(new MoisWorkspaceDtos.ExtractionDraftResponse(
+                        "ext-123",
+                        "ref-123",
+                        "DRAFT",
+                        Instant.parse("2026-04-25T12:00:00Z")
+                ));
+
+        mockMvc.perform(post("/api/v1/mois/references/ref-123/extractions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "pain": "Falta de tempo",
+                                  "result": "Emagrecer com rotina curta",
+                                  "mechanism": "Treino de 15 minutos"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.extractionId").value("ext-123"))
+                .andExpect(jsonPath("$.status").value("DRAFT"));
+    }
+
 }

--- a/docs/mois/mois-wireframes-backlog-mvp.md
+++ b/docs/mois/mois-wireframes-backlog-mvp.md
@@ -336,3 +336,24 @@ Ao final de **toda sprint**, registrar no próprio documento (ou em log vinculad
 - Cada tela deve possuir estados: loading, empty (quando aplicável) e error.
 - Toda recomendação gerada deve manter rastreabilidade de origem (referência/bloco).
 - O fluxo completo deve preservar o eixo canônico: Dor → Resultado → Mecanismo → Prova → Oferta.
+
+---
+
+## 6) Registro de execução de sprint
+
+### Sprint 1 — fechamento
+- **Data de fechamento:** `2026-04-25`
+- **O que foi feito:**
+  - Backend entregue com contratos MVP da Sprint 1:
+    - `GET /api/v1/mois/workspaces/{workspaceId}/dashboard`
+    - `POST /api/v1/mois/references`
+    - `GET /api/v1/mois/references?workspaceId=...`
+    - `POST /api/v1/mois/references/{referenceId}/extractions`
+  - Frontend entregue para as telas 1 e 2:
+    - Workspace MOIS com KPIs, stepper, lista de análises recentes e estados `loading/empty/error`.
+    - Coleta de referências com formulário validado, submit assíncrono com botão desabilitado + spinner, preview de URL, tabela de referências coletadas e feedback de sucesso/erro via toast.
+  - Navegação principal atualizada para incluir entrada de acesso ao módulo MOIS.
+- **Pendências:**
+  - Trocar armazenamento transitório em memória por persistência em banco para referências e extrações.
+  - Implementar ações `Retomar` e `Aplicar` do workspace conectadas aos próximos endpoints do backlog.
+  - Evoluir Sprint 2 (biblioteca, comparador e builder) conforme seção de planejamento deste documento.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -115,6 +115,8 @@ import OprmEvidencePage from "./pages/oprm/OprmEvidencePage";
 import OprmFeedbackPage from "./pages/oprm/OprmFeedbackPage";
 import OprmOperationsPage from "./pages/oprm/OprmOperationsPage";
 import OprmOccupationCatalogPage from "./pages/oprm/OprmOccupationCatalogPage";
+import MoisWorkspacePage from "./pages/mois/MoisWorkspacePage";
+import MoisReferenceIntakePage from "./pages/mois/MoisReferenceIntakePage";
 
 export default function App() {
   return (
@@ -260,6 +262,8 @@ export default function App() {
                 element={<TargetingRecentQueriesPage />}
               />
               <Route path="/oprm" element={<OprmWorkspacePage />} />
+              <Route path="/mois" element={<MoisWorkspacePage />} />
+              <Route path="/mois/references/new" element={<MoisReferenceIntakePage />} />
               <Route
                 path="/oprm/routine/:occupationSeedRef"
                 element={<OprmRoutinePage />}

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -1,0 +1,50 @@
+export interface MoisWorkspaceKpis {
+  collections: number;
+  extractions: number;
+  applications: number;
+  tests: number;
+}
+
+export interface MoisRecentAnalysis {
+  analysisId: string;
+  niche: string;
+  status: string;
+  updatedAt: string;
+}
+
+export interface MoisWorkspaceDashboard {
+  workspaceId: string;
+  kpis: MoisWorkspaceKpis;
+  currentStage: string;
+  recentAnalyses: MoisRecentAnalysis[];
+}
+
+export interface MoisCreateReferencePayload {
+  workspaceId: string;
+  niche: string;
+  sourceUrl: string;
+  assetType: string;
+  primaryPromise: string;
+  awarenessStage: string;
+  priceRange?: string;
+  formatType?: string;
+  notes?: string;
+}
+
+export interface MoisReference {
+  referenceId: string;
+  workspaceId: string;
+  niche: string;
+  sourceUrl: string;
+  assetType: string;
+  primaryPromise: string;
+  awarenessStage: string;
+  priceRange?: string;
+  formatType?: string;
+  notes?: string;
+  createdAt: string;
+}
+
+export interface MoisReferenceListResponse {
+  items: MoisReference[];
+}

--- a/frontend/src/api/mois/useMoisDashboard.ts
+++ b/frontend/src/api/mois/useMoisDashboard.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { MoisWorkspaceDashboard } from "./types";
+
+export function useMoisDashboard(workspaceId: string) {
+  return useQuery({
+    queryKey: ["mois", "dashboard", workspaceId],
+    queryFn: async () => {
+      const { data } = await axios.get<MoisWorkspaceDashboard>(`/api/v1/mois/workspaces/${workspaceId}/dashboard`);
+      return data;
+    },
+    enabled: workspaceId.trim().length > 0,
+  });
+}

--- a/frontend/src/api/mois/useMoisReferences.ts
+++ b/frontend/src/api/mois/useMoisReferences.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import type {
+  MoisCreateReferencePayload,
+  MoisReference,
+  MoisReferenceListResponse,
+} from "./types";
+
+export function useMoisReferences(workspaceId: string) {
+  return useQuery({
+    queryKey: ["mois", "references", workspaceId],
+    queryFn: async () => {
+      const { data } = await axios.get<MoisReferenceListResponse>("/api/v1/mois/references", {
+        params: { workspaceId },
+      });
+      return data.items;
+    },
+    enabled: workspaceId.trim().length > 0,
+  });
+}
+
+export function useCreateMoisReference() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: MoisCreateReferencePayload) => {
+      const { data } = await axios.post<MoisReference>("/api/v1/mois/references", payload);
+      return data;
+    },
+    onSuccess: async (data) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["mois", "references", data.workspaceId] }),
+        queryClient.invalidateQueries({ queryKey: ["mois", "dashboard", data.workspaceId] }),
+      ]);
+    },
+  });
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -104,6 +104,7 @@ const NAV_SECTIONS: NavSection[] = [
             ],
           },
       { to: "/hypotheses", label: "Hipóteses", icon: hypothesisIcon },
+      { to: "/mois", label: "MOIS", icon: Workflow },
       { to: "/oprm", label: "OPRM", icon: Workflow },
     ],
   },

--- a/frontend/src/pages/mois/MoisReferenceIntakePage.tsx
+++ b/frontend/src/pages/mois/MoisReferenceIntakePage.tsx
@@ -1,0 +1,216 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "react-toastify";
+import PageTitle from "../../components/PageTitle";
+import { useCreateMoisReference, useMoisReferences } from "../../api/mois/useMoisReferences";
+import type { MoisCreateReferencePayload } from "../../api/mois/types";
+
+const WORKSPACE_ID = "workspace-default";
+
+const INITIAL_FORM: MoisCreateReferencePayload = {
+  workspaceId: WORKSPACE_ID,
+  niche: "",
+  sourceUrl: "",
+  assetType: "LANDING_PAGE",
+  primaryPromise: "",
+  awarenessStage: "PROBLEM_AWARE",
+  priceRange: "",
+  formatType: "",
+  notes: "",
+};
+
+export default function MoisReferenceIntakePage() {
+  const [form, setForm] = useState<MoisCreateReferencePayload>(INITIAL_FORM);
+  const createReference = useCreateMoisReference();
+  const referencesQuery = useMoisReferences(WORKSPACE_ID);
+
+  const sourcePreview = useMemo(() => form.sourceUrl.trim(), [form.sourceUrl]);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    try {
+      await createReference.mutateAsync(form);
+      toast.success("Referência salva");
+      setForm(INITIAL_FORM);
+    } catch {
+      toast.error("Falha ao salvar referência. Revise os dados e tente novamente.");
+    }
+  }
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-wrap justify-content-between gap-3">
+        <div>
+          <PageTitle>Coleta de referências MOIS</PageTitle>
+          <p className="text-secondary mb-0">Sprint 1: cadastro e listagem de referências do workspace.</p>
+        </div>
+        <Link className="btn btn-outline-secondary" to="/mois">
+          Voltar ao workspace
+        </Link>
+      </header>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <form className="row g-3" onSubmit={handleSubmit}>
+            <div className="col-12 col-lg-6">
+              <label className="form-label" htmlFor="mois-niche">Nicho *</label>
+              <input
+                id="mois-niche"
+                className="form-control"
+                value={form.niche}
+                onChange={(event) => setForm((prev) => ({ ...prev, niche: event.target.value }))}
+                required
+              />
+            </div>
+
+            <div className="col-12 col-lg-6">
+              <label className="form-label" htmlFor="mois-url">URL *</label>
+              <input
+                id="mois-url"
+                className="form-control"
+                type="url"
+                value={form.sourceUrl}
+                onChange={(event) => setForm((prev) => ({ ...prev, sourceUrl: event.target.value }))}
+                placeholder="https://"
+                required
+              />
+            </div>
+
+            <div className="col-12 col-lg-4">
+              <label className="form-label" htmlFor="mois-asset-type">Tipo de ativo *</label>
+              <select
+                id="mois-asset-type"
+                className="form-select"
+                value={form.assetType}
+                onChange={(event) => setForm((prev) => ({ ...prev, assetType: event.target.value }))}
+                required
+              >
+                <option value="LANDING_PAGE">Landing page</option>
+                <option value="VSL">VSL</option>
+                <option value="CHECKOUT">Checkout</option>
+              </select>
+            </div>
+
+            <div className="col-12 col-lg-4">
+              <label className="form-label" htmlFor="mois-promise">Promessa principal *</label>
+              <input
+                id="mois-promise"
+                className="form-control"
+                value={form.primaryPromise}
+                onChange={(event) => setForm((prev) => ({ ...prev, primaryPromise: event.target.value }))}
+                required
+              />
+            </div>
+
+            <div className="col-12 col-lg-4">
+              <label className="form-label" htmlFor="mois-awareness">Consciência *</label>
+              <select
+                id="mois-awareness"
+                className="form-select"
+                value={form.awarenessStage}
+                onChange={(event) => setForm((prev) => ({ ...prev, awarenessStage: event.target.value }))}
+                required
+              >
+                <option value="PROBLEM_AWARE">Problem aware</option>
+                <option value="SOLUTION_AWARE">Solution aware</option>
+                <option value="PRODUCT_AWARE">Product aware</option>
+              </select>
+            </div>
+
+            <div className="col-12 col-lg-6">
+              <label className="form-label" htmlFor="mois-price">Faixa de preço</label>
+              <input
+                id="mois-price"
+                className="form-control"
+                value={form.priceRange}
+                onChange={(event) => setForm((prev) => ({ ...prev, priceRange: event.target.value }))}
+              />
+            </div>
+
+            <div className="col-12 col-lg-6">
+              <label className="form-label" htmlFor="mois-format">Formato</label>
+              <input
+                id="mois-format"
+                className="form-control"
+                value={form.formatType}
+                onChange={(event) => setForm((prev) => ({ ...prev, formatType: event.target.value }))}
+              />
+            </div>
+
+            <div className="col-12">
+              <label className="form-label" htmlFor="mois-notes">Observações</label>
+              <textarea
+                id="mois-notes"
+                className="form-control"
+                rows={3}
+                value={form.notes}
+                onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+              />
+            </div>
+
+            <div className="col-12 d-flex flex-wrap justify-content-between align-items-center gap-3">
+              <span className="text-secondary small">Workspace: {WORKSPACE_ID}</span>
+              <button
+                type="submit"
+                className="btn btn-primary d-inline-flex align-items-center gap-2"
+                disabled={createReference.isPending}
+              >
+                {createReference.isPending ? <span className="spinner-border spinner-border-sm" aria-hidden="true" /> : null}
+                Salvar referência
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-2">
+          <h2 className="h6 mb-0">Preview da URL</h2>
+          {sourcePreview ? (
+            <a href={sourcePreview} target="_blank" rel="noreferrer" className="text-break">
+              {sourcePreview}
+            </a>
+          ) : (
+            <p className="text-secondary mb-0">Informe uma URL para habilitar o preview.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <h2 className="h5">Referências coletadas</h2>
+          {referencesQuery.isLoading ? <p className="text-secondary mb-0">Carregando referências...</p> : null}
+          {referencesQuery.isError ? <div className="alert alert-danger mb-0">Não foi possível carregar referências.</div> : null}
+          {!referencesQuery.isLoading && !referencesQuery.isError ? (
+            referencesQuery.data && referencesQuery.data.length > 0 ? (
+              <div className="table-responsive">
+                <table className="table align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th>Nicho</th>
+                      <th>Tipo</th>
+                      <th>Promessa</th>
+                      <th>Data</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {referencesQuery.data.map((reference) => (
+                      <tr key={reference.referenceId}>
+                        <td>{reference.niche}</td>
+                        <td>{reference.assetType}</td>
+                        <td>{reference.primaryPromise}</td>
+                        <td>{new Date(reference.createdAt).toLocaleString("pt-BR")}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="text-secondary mb-0">Nenhuma referência cadastrada até o momento.</p>
+            )
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/mois/MoisWorkspacePage.tsx
+++ b/frontend/src/pages/mois/MoisWorkspacePage.tsx
@@ -1,0 +1,147 @@
+import { Link } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useMoisDashboard } from "../../api/mois/useMoisDashboard";
+import "./mois.css";
+
+const WORKSPACE_ID = "workspace-default";
+const STAGES = ["Coleta", "Extração", "Síntese", "Aplicação", "Teste"];
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "-"
+    : date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
+}
+
+export default function MoisWorkspacePage() {
+  const dashboardQuery = useMoisDashboard(WORKSPACE_ID);
+  const dashboard = dashboardQuery.data;
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-wrap align-items-center justify-content-between gap-3">
+        <div>
+          <PageTitle>MOIS Workspace</PageTitle>
+          <p className="text-secondary mb-0">Visão Sprint 1 com KPIs e análises recentes.</p>
+        </div>
+        <Link className="btn btn-primary" to="/mois/references/new">
+          Nova análise
+        </Link>
+      </header>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <h2 className="h6 mb-0">Pipeline MOIS</h2>
+          <ol className="mois-stepper mb-0">
+            {STAGES.map((stage) => (
+              <li key={stage} className="mois-stepper__item">
+                <span>{stage}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      {dashboardQuery.isLoading ? (
+        <section className="card border-0 shadow-sm">
+          <div className="card-body">
+            <div className="placeholder-glow">
+              <span className="placeholder col-12 mb-2" />
+              <span className="placeholder col-8" />
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {dashboardQuery.isError ? (
+        <div className="alert alert-danger mb-0" role="alert">
+          Não foi possível carregar o workspace MOIS. Tente novamente.
+        </div>
+      ) : null}
+
+      {!dashboardQuery.isLoading && !dashboardQuery.isError && dashboard ? (
+        <>
+          <section className="row g-3">
+            <div className="col-12 col-md-6 col-xl-3">
+              <article className="card border-0 shadow-sm h-100">
+                <div className="card-body">
+                  <p className="text-secondary mb-1">Coletas</p>
+                  <strong className="h4 mb-0">{dashboard.kpis.collections}</strong>
+                </div>
+              </article>
+            </div>
+            <div className="col-12 col-md-6 col-xl-3">
+              <article className="card border-0 shadow-sm h-100">
+                <div className="card-body">
+                  <p className="text-secondary mb-1">Extrações</p>
+                  <strong className="h4 mb-0">{dashboard.kpis.extractions}</strong>
+                </div>
+              </article>
+            </div>
+            <div className="col-12 col-md-6 col-xl-3">
+              <article className="card border-0 shadow-sm h-100">
+                <div className="card-body">
+                  <p className="text-secondary mb-1">Aplicações</p>
+                  <strong className="h4 mb-0">{dashboard.kpis.applications}</strong>
+                </div>
+              </article>
+            </div>
+            <div className="col-12 col-md-6 col-xl-3">
+              <article className="card border-0 shadow-sm h-100">
+                <div className="card-body">
+                  <p className="text-secondary mb-1">Testes</p>
+                  <strong className="h4 mb-0">{dashboard.kpis.tests}</strong>
+                </div>
+              </article>
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body d-flex flex-column gap-3">
+              <div className="d-flex align-items-center justify-content-between">
+                <h2 className="h5 mb-0">Análises recentes</h2>
+                <span className="badge text-bg-light">Etapa atual: {dashboard.currentStage}</span>
+              </div>
+
+              {dashboard.recentAnalyses.length === 0 ? (
+                <div className="alert alert-secondary mb-0">Nenhuma análise disponível. Crie a primeira referência.</div>
+              ) : (
+                <div className="table-responsive">
+                  <table className="table align-middle mb-0">
+                    <thead>
+                      <tr>
+                        <th>Nicho</th>
+                        <th>Status</th>
+                        <th>Atualizado em</th>
+                        <th>Ações</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {dashboard.recentAnalyses.map((analysis) => (
+                        <tr key={analysis.analysisId}>
+                          <td>{analysis.niche}</td>
+                          <td>{analysis.status}</td>
+                          <td>{formatDate(analysis.updatedAt)}</td>
+                          <td>
+                            <div className="d-flex gap-2">
+                              <button type="button" className="btn btn-outline-secondary btn-sm" disabled>
+                                Retomar
+                              </button>
+                              <button type="button" className="btn btn-outline-primary btn-sm" disabled>
+                                Aplicar
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/mois/mois.css
+++ b/frontend/src/pages/mois/mois.css
@@ -1,0 +1,17 @@
+.mois-stepper {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.mois-stepper__item {
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  text-align: center;
+  font-size: 0.9rem;
+  background: var(--bs-light-bg-subtle);
+}


### PR DESCRIPTION
### Motivation
- Entregar o escopo da Sprint 1 definido no backlog MOIS, fornecendo os contratos backend mínimos e as telas iniciais para iniciar o fluxo Coleta → Extração.
- Fornecer um serviço de suporte rápido (em memória) para permitir integração do frontend nas telas `Workspace` e `Coleta de referências` sem dependência imediata de persistência.
- Registrar o fechamento da sprint no documento canônico de MOIS para manter rastreabilidade das entregas e pendências.

### Description
- Adicionadas as DTOs e contratos para Sprint 1 em `MoisWorkspaceDtos` e um serviço inicial `MoisSprintOneService` com armazenamento em memória para referências e rascunhos de extração.
- Estendendo o controller MOIS com os novos endpoints: `GET /api/v1/mois/workspaces/{workspaceId}/dashboard`, `POST /api/v1/mois/references`, `GET /api/v1/mois/references?workspaceId=...` e `POST /api/v1/mois/references/{referenceId}/extractions`.
- Atualizados os testes de contrato do controller em `MoisControllerContractTest` para cobrir validações e os novos endpoints da Sprint 1.
- Adicionados artefatos de frontend: tipos e hooks (`frontend/src/api/mois/*`), páginas e estilos (`frontend/src/pages/mois/*`, `mois.css`), rotas em `App.tsx` e entrada no menu em `MainNavigation.tsx`, além do fluxo de criação/listagem de referências com estados e feedbacks UI padrão.
- Atualizada a documentação `docs/mois/mois-wireframes-backlog-mvp.md` com o registro de fechamento da Sprint 1 e pendências (persistência, ações Retomar/Aplicar, planejamento Sprint 2).

### Testing
- Executado o teste de contrato do backend com `../mvnw -Dtest=MoisControllerContractTest test` dentro de `backend/ads-service`, que passou com `12` testes executados e `0` falhas (BUILD SUCCESS).
- Executado `npm run build` para validar o frontend build no ambiente, que falhou por limitação do ambiente (`vite: not found`), portanto o build frontend não foi gerado aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec307e3e848321bd180bae42c0cc8e)