### PR TITLE
Add inline LHM job monitoring and recording for landing HTML generation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -79,6 +79,8 @@ public class ExperimentPipelineGenerationService {
     private static final Pattern OPENING_TAG_PATTERN = Pattern.compile("(?is)<([a-z0-9:-]+)\\b[^>]*>");
     private static final Pattern IMG_TAG_PATTERN = Pattern.compile("(?is)<img\\b[^>]*>");
     private static final String DEFAULT_MODEL = "gpt-5.2";
+    private static final String LHM_MODEL = "LHM";
+    private static final String LHM_WORKER_ID = "lhm-inline";
     private static final Duration STALE_PENDING_TIMEOUT = Duration.ofMinutes(10);
     private static final Duration STALE_PROCESSING_TIMEOUT = Duration.ofMinutes(20);
     private static final Set<ExperimentPipelineGenerationJobStatus> ACTIVE_JOB_STATUSES = Set.of(
@@ -300,13 +302,36 @@ public class ExperimentPipelineGenerationService {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "Copy da landing ainda não foi gerada para este experimento");
         }
-        String assembledHtml = landingHtmlModule.assembleHtmlDocument(experiment);
-        if (!StringUtils.hasText(assembledHtml)) {
-            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
-                    "LHM não conseguiu montar HTML válido para este experimento");
+        String promptInputs = landingHtmlModule.buildPromptV2Inputs(experiment);
+        Map<String, Object> monitoringPayload = Map.of(
+                "mode", "INLINE",
+                "source", "LHM",
+                "section", ExperimentPipelineSection.LANDING_PAGE_HTML.path(),
+                "experimentId", experimentId);
+        ExperimentPipelineGenerationJob monitoringJob = createInlineGenerationJob(
+                experiment,
+                ExperimentPipelineSection.LANDING_PAGE_HTML,
+                LHM_MODEL,
+                LHM_WORKER_ID,
+                promptInputs,
+                monitoringPayload);
+
+        try {
+            String assembledHtml = landingHtmlModule.assembleHtmlDocument(experiment);
+            if (!StringUtils.hasText(assembledHtml)) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "LHM não conseguiu montar HTML válido para este experimento");
+            }
+            applySectionContent(experiment, ExperimentPipelineSection.LANDING_PAGE_HTML, assembledHtml);
+            completeInlineGenerationJob(monitoringJob, assembledHtml, assembledHtml, BigDecimal.ZERO);
+            return experimentMapper.toDto(experiment);
+        } catch (ResponseStatusException ex) {
+            failInlineGenerationJob(monitoringJob, ex.getReason());
+            throw ex;
+        } catch (RuntimeException ex) {
+            failInlineGenerationJob(monitoringJob, ex.getMessage());
+            throw ex;
         }
-        applySectionContent(experiment, ExperimentPipelineSection.LANDING_PAGE_HTML, assembledHtml);
-        return experimentMapper.toDto(experiment);
     }
 
     @Transactional
@@ -558,6 +583,74 @@ public class ExperimentPipelineGenerationService {
                 .requestBodyJson(requestBodyJson)
                 .build();
         jobRepository.save(job);
+    }
+
+    private ExperimentPipelineGenerationJob createInlineGenerationJob(Experiment experiment,
+                                                                      ExperimentPipelineSection section,
+                                                                      String model,
+                                                                      String workerId,
+                                                                      String prompt,
+                                                                      Map<String, Object> payload) {
+        ExperimentPipelineGenerationJob job = ExperimentPipelineGenerationJob.builder()
+                .experiment(experiment)
+                .section(section)
+                .status(ExperimentPipelineGenerationJobStatus.PROCESSING)
+                .stage(ExperimentPipelineGenerationJobStage.WAITING_OPENAI)
+                .model(model)
+                .workerId(workerId)
+                .prompt(prompt)
+                .requestBodyJson(writeJsonSilently(payload))
+                .startedAt(Instant.now())
+                .build();
+        return jobRepository.save(job);
+    }
+
+    private void completeInlineGenerationJob(ExperimentPipelineGenerationJob job,
+                                             String responseContent,
+                                             String rawResponse,
+                                             BigDecimal costUsd) {
+        generationService.recordGeneration(AiWorkerGenerationRequest.builder()
+                .domain("experiment.pipeline." + job.getSection().path())
+                .referenceId(job.getExperiment().getId().toString())
+                .prompt(job.getPrompt())
+                .rawResponse(rawResponse)
+                .model(job.getModel())
+                .inputTokens(0)
+                .outputTokens(0)
+                .costUsd(costUsd != null ? costUsd : BigDecimal.ZERO)
+                .build());
+
+        job.setStatus(ExperimentPipelineGenerationJobStatus.COMPLETED);
+        job.setStage(ExperimentPipelineGenerationJobStage.COMPLETED);
+        job.setResponseContent(responseContent);
+        job.setRawResponse(rawResponse);
+        job.setInputTokens(0);
+        job.setOutputTokens(0);
+        job.setCostUsd(costUsd != null ? costUsd : BigDecimal.ZERO);
+        job.setErrorMessage(null);
+        job.setFinishedAt(Instant.now());
+    }
+
+    private void failInlineGenerationJob(ExperimentPipelineGenerationJob job, String errorMessage) {
+        if (job == null) {
+            return;
+        }
+        job.setStatus(ExperimentPipelineGenerationJobStatus.FAILED);
+        job.setStage(ExperimentPipelineGenerationJobStage.FAILED);
+        job.setErrorMessage(StringUtils.hasText(errorMessage) ? errorMessage.trim() : "Falha desconhecida no LHM");
+        job.setFinishedAt(Instant.now());
+    }
+
+    private String writeJsonSilently(Object payload) {
+        if (payload == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException ex) {
+            log.warn("Falha ao serializar payload de monitoramento inline do pipeline", ex);
+            return null;
+        }
     }
 
     private void validatePredecessor(Experiment experiment, ExperimentPipelineSection section) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment.pipeline.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.ai.generation.dto.AiWorkerGenerationRequest;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.dto.ExperimentDto;
@@ -154,6 +155,7 @@ class ExperimentPipelineGenerationServiceTest {
         experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":{\"images\":[]}}");
 
         when(experimentRepository.findById(31L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(landingHtmlModule.assembleHtmlDocument(experiment)).thenReturn("""
                 <!doctype html><html><body>
                 <section data-section-id="hero" data-surface-token="surface-base" data-surface-style="band" data-surface-contrast="normal">
@@ -174,6 +176,19 @@ class ExperimentPipelineGenerationServiceTest {
 
         verify(landingHtmlModule).assembleHtmlDocument(experiment);
         assertTrue(experiment.getLandingPageHtml().contains("<!doctype html>"));
+        verify(jobRepository).save(any(ExperimentPipelineGenerationJob.class));
+        verify(generationService).recordGeneration(any(AiWorkerGenerationRequest.class));
+
+        ArgumentCaptor<ExperimentPipelineGenerationJob> jobCaptor = ArgumentCaptor.forClass(ExperimentPipelineGenerationJob.class);
+        verify(jobRepository).save(jobCaptor.capture());
+        ExperimentPipelineGenerationJob job = jobCaptor.getValue();
+        assertEquals(ExperimentPipelineGenerationJobStatus.COMPLETED, job.getStatus());
+        assertEquals(ExperimentPipelineGenerationJobStage.COMPLETED, job.getStage());
+        assertEquals("LHM", job.getModel());
+        assertEquals("lhm-inline", job.getWorkerId());
+        assertNotNull(job.getRequestBodyJson());
+        assertNotNull(job.getResponseContent());
+        assertNotNull(job.getFinishedAt());
     }
 
     @Test
@@ -188,6 +203,33 @@ class ExperimentPipelineGenerationServiceTest {
 
         assertEquals(409, error.getStatusCode().value());
         assertTrue(error.getReason().contains("Wireframe"));
+    }
+
+    @Test
+    void generateLandingHtmlWithLhmTracksFailedAttemptWhenValidationFails() {
+        Experiment experiment = new Experiment();
+        experiment.setId(33L);
+        experiment.setLandingPageWireframe("{\"landingPageWireframe\":{\"formSpec\":{\"formId\":\"lead-capture-primary\",\"submitTarget\":\"/api/flows/exp-33/submissions\",\"fields\":[{\"name\":\"nome\",\"type\":\"text\",\"required\":true}],\"submitLabel\":\"Enviar\"},\"sectionOrder\":[{\"sectionId\":\"hero\",\"sectionName\":\"Hero\",\"contentType\":\"form\",\"surfaceSpec\":{\"surfaceToken\":\"surface-base\",\"style\":\"band\",\"contrastMode\":\"normal\"}}]}}");
+        experiment.setLandingPageCopy("{\"landingPageCopy\":{\"headline\":\"Headline\"}}");
+        when(experimentRepository.findById(33L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(landingHtmlModule.assembleHtmlDocument(experiment))
+                .thenReturn("<!doctype html><html><body><form id=\"lead-capture-primary\" method=\"post\" action=\"/api/flows/exp-33/submissions\"></form></body></html>");
+
+        ResponseStatusException error = assertThrows(ResponseStatusException.class,
+                () -> service.generateLandingHtmlWithLhm(33L));
+
+        assertEquals(422, error.getStatusCode().value());
+        verify(jobRepository).save(any(ExperimentPipelineGenerationJob.class));
+        verify(generationService, never()).recordGeneration(any(AiWorkerGenerationRequest.class));
+
+        ArgumentCaptor<ExperimentPipelineGenerationJob> jobCaptor = ArgumentCaptor.forClass(ExperimentPipelineGenerationJob.class);
+        verify(jobRepository).save(jobCaptor.capture());
+        ExperimentPipelineGenerationJob job = jobCaptor.getValue();
+        assertEquals(ExperimentPipelineGenerationJobStatus.FAILED, job.getStatus());
+        assertEquals(ExperimentPipelineGenerationJobStage.FAILED, job.getStage());
+        assertTrue(job.getErrorMessage().contains("Divergência"));
+        assertNotNull(job.getFinishedAt());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Instrument inline LHM (local monitoring) executions when generating landing HTML to improve observability and capture successes and failures. 
- Ensure generation events are recorded via the existing generation service so calls made inline are accounted for in billing/monitoring.

### Description
- Introduces `LHM_MODEL` and `LHM_WORKER_ID` constants and creates helper methods `createInlineGenerationJob`, `completeInlineGenerationJob`, `failInlineGenerationJob`, and `writeJsonSilently` to manage inline job lifecycle and payload serialization. 
- Updates `generateLandingHtmlWithLhm` to build prompt inputs, create a monitoring job before assembly, wrap the assembly and apply flow in try/catch, and mark the job as completed or failed accordingly. 
- Calls `generationService.recordGeneration` on successful completion to persist generation metadata, and persists job state changes via `jobRepository`. 
- Adds and adjusts test expectations in `ExperimentPipelineGenerationServiceTest` to verify job creation, completion/failure states, and that `generationService.recordGeneration` is invoked or not as appropriate.

### Testing
- Updated unit tests in `ExperimentPipelineGenerationServiceTest` were executed and assert new behaviors for successful and failed inline runs, and they passed. 
- Verified that `jobRepository.save` is invoked and jobs are marked `COMPLETED` or `FAILED` with timestamps in the tests. 
- Verified that `generationService.recordGeneration` is called for successful inline generation and not called when validation fails, and the assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2fa42d8c8321931451e03cb0f4ef)