### PR TITLE
Fix LHM landing HTML to preserve wireframe surface contract

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -92,12 +92,8 @@ public class LandingHtmlModule {
                 .append("#form-feedback{display:none;margin-top:8px;font-weight:600;}")
                 .append("</style></head><body><main>");
 
-        html.append("<section class=\"card\" data-section-id=\"hero\" data-surface-token=\"surface-hero\" data-surface-style=\"band\" data-surface-contrast=\"normal\">")
-                .append("<h1>").append(escapeHtml(pageTitle)).append("</h1>")
-                .append("<p>").append(escapeHtml(pageSummary)).append("</p>")
-                .append("</section>");
-
-        for (Map<String, Object> section : sections) {
+        for (int sectionIndex = 0; sectionIndex < sections.size(); sectionIndex++) {
+            Map<String, Object> section = sections.get(sectionIndex);
             String sectionId = firstNonBlank(asTrimmedString(section.get("sectionId")), "section");
             String sectionName = firstNonBlank(asTrimmedString(section.get("sectionName")), sectionId);
             Map<String, Object> surface = section.get("surfaceSpec") instanceof Map<?, ?> rawSurface
@@ -113,7 +109,12 @@ public class LandingHtmlModule {
                     .append("\" data-surface-style=\"").append(escapeAttr(surfaceStyle))
                     .append("\" data-surface-contrast=\"").append(escapeAttr(surfaceContrast))
                     .append("\">")
-                    .append("<h2>").append(escapeHtml(sectionName)).append("</h2>");
+                    .append(sectionIndex == 0
+                            ? "<h1>" + escapeHtml(pageTitle) + "</h1>"
+                            : "<h2>" + escapeHtml(sectionName) + "</h2>");
+            if (sectionIndex == 0 && StringUtils.hasText(pageSummary)) {
+                html.append("<p>").append(escapeHtml(pageSummary)).append("</p>");
+            }
 
             for (Map<String, Object> image : plannedImages) {
                 String imageSectionId = asTrimmedString(image.get("sectionId"));
@@ -127,12 +128,6 @@ public class LandingHtmlModule {
                 html.append(buildFormMarkup(formId, submitTarget, submitLabel, formSpec));
             }
             html.append("</section>");
-        }
-
-        if (!html.toString().contains("<form ")) {
-            html.append("<section class=\"card\" data-section-id=\"form\" data-surface-token=\"surface-form\" data-surface-style=\"band\" data-surface-contrast=\"normal\">")
-                    .append(buildFormMarkup(formId, submitTarget, submitLabel, formSpec))
-                    .append("</section>");
         }
 
         html.append("</main>").append(buildSubmissionScript(formId)).append("</body></html>");

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.Experiment;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LandingHtmlModuleTest {
@@ -61,5 +62,46 @@ class LandingHtmlModuleTest {
         assertTrue(html.toLowerCase().contains("checkvalidity"));
         assertTrue(html.toLowerCase().contains("reportvalidity"));
         assertTrue(html.toLowerCase().contains("success"));
+    }
+
+    @Test
+    void assembleHtmlDocumentKeepsExactSurfaceContractFromWireframe() {
+        Experiment experiment = new Experiment();
+        experiment.setName("Teste LHM Surface");
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {
+                        "sectionId": "benefits",
+                        "sectionName": "Benefícios",
+                        "contentType": "split",
+                        "surfaceSpec": {
+                          "surfaceToken": "surface-benefits",
+                          "style": "solid",
+                          "contrastMode": "high"
+                        }
+                      }
+                    ],
+                    "formSpec": {
+                      "formId": "lead-capture-primary",
+                      "submitTarget": "/api/flows/submissions",
+                      "submitLabel": "Enviar",
+                      "fields": [
+                        {"name": "nome", "type": "text", "required": true}
+                      ]
+                    }
+                  }
+                }
+                """);
+
+        String html = module.assembleHtmlDocument(experiment);
+
+        assertTrue(html.contains("data-section-id=\"benefits\""));
+        assertTrue(html.contains("data-surface-token=\"surface-benefits\""));
+        assertTrue(html.contains("data-surface-style=\"solid\""));
+        assertTrue(html.contains("data-surface-contrast=\"high\""));
+        assertFalse(html.contains("data-section-id=\"hero\""));
+        assertFalse(html.contains("data-section-id=\"form\""));
     }
 }


### PR DESCRIPTION
### Motivation
- The LHM-generated HTML injected synthetic `hero` and fallback `form` sections which caused the error `Divergência de superfície: landing-page-html deve reproduzir exatamente landing-page-wireframe.sectionOrder.surfaceSpec` by diverging from the canonical `sectionOrder.surfaceSpec` binding. 
- The intent is to ensure the produced HTML reproduces exactly the surfaces declared in the wireframe while still rendering page title/summary in a usable way.

### Description
- Changed `LandingHtmlModule.assembleHtmlDocument` to iterate only the sections declared in `landingPageWireframe.sectionOrder` and removed injection of a synthetic `hero` and fallback `form` block so the output contains only explicit wireframe sections. 
- Promoted the first declared section to render the page `title` as an `<h1>` (and its `summary` when present) and render subsequent sections with `<h2>` to keep visual semantics without creating synthetic sections. 
- Preserved exact per-section surface attributes (`data-section-id`, `data-surface-token`, `data-surface-style`, `data-surface-contrast`) and retained image and form binding logic; added a regression test in `LandingHtmlModuleTest` that asserts presence of the exact `data-surface-*` attributes and absence of injected `hero`/`form` sections.

### Testing
- Ran the unit test suite for the module with `mvn -Dtest=LandingHtmlModuleTest test`, which executed 2 tests and completed with `BUILD SUCCESS` (all tests passed). 
- The new regression test `assembleHtmlDocumentKeepsExactSurfaceContractFromWireframe` verifies the HTML contains the expected `data-section-id` and `data-surface-*` attributes and does not include synthetic `hero` or `form` sections.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec41c9790083219ebf8d8aa8e383c5)