### PR TITLE
Add canonical rule: LHM must be deterministic and render from canonical artifacts

### DIFF
--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -2,6 +2,14 @@
 
 Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 
+> 🔴 **REGRA CANÔNICA EM DESTAQUE — LHM**
+>
+> O **LHM (Landing HTML Module)** é o módulo **determinístico** responsável por gerar o HTML final da landing page.
+>
+> - O LHM **não** é uma etapa de ideação criativa livre da copy.
+> - O LHM deve renderizar de forma previsível a partir dos artefatos canônicos (ex.: `landingPageCopy` e `landingPageWireframe`) e contratos vigentes.
+> - Mudanças no pipeline devem preservar essa responsabilidade para reduzir drift entre especificação, backend e página publicada.
+
 ## Observação importante — independência dos experimentos
 
 - Cada experimento deve ser tratado de forma independente, sem reutilização implícita de artefatos entre experimentos.

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -28,6 +28,7 @@
 4. **Flags derivadas não são verdade primária.** Rótulos de UI, atalhos de leitura, campos calculados e indicadores transitórios são projeções, não a regra original.
 5. **Contratos entre módulos são explícitos e versionados.** Nenhum módulo pode depender de campos implícitos, estados informais ou convenções não registradas.
 6. **Mudanças relevantes exigem teste e documentação correspondente.** Regra operacional sem teste e sem contrato atualizado é candidata imediata a drift.
+7. **LHM é determinístico por definição canônica.** O Landing HTML Module (LHM) é responsável pela renderização previsível do HTML final de landing pages a partir de artefatos/contratos canônicos; não é camada de ideação livre de copy.
 
 ## 3.1 Regra global de exclusividade de artefatos (todo o sistema)
 


### PR DESCRIPTION
### Motivation
- Introduce an explicit governance rule that the Landing HTML Module (LHM) is a deterministic renderer of landing pages from canonical artifacts to reduce drift between specifications, backend and published pages. 

### Description
- Add a highlighted canonical rule block `REGRA CANÔNICA EM DESTAQUE — LHM` to `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` that defines LHM responsibilities and constraints. 
- Add rule 7 `LHM é determinístico por definição canônica` to `docs/canonical/system-governance-canon.v2.md` under global principles to capture the LHM requirement in the system governance document. 

### Testing
- Ran documentation linting (`markdownlint`) and the docs site build (`mkdocs build`) in CI, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb58933408321a7bddf57b75a89ff)