### PR TITLE
Bump landing-copy to v2, add strict copy quality rules and LHM governance, update tests

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
@@ -1,5 +1,5 @@
 template_id: landing-copy
-template_version: v1
+template_version: v2
 artifact_target: landingPageCopy
 
 SYSTEM_INSTRUCTIONS
@@ -26,24 +26,34 @@ Regras fixas da etapa:
 11. Não invente nicho, persona, hipótese, mecanismo, prova, oferta, camadas ou entregáveis fora dos dados recebidos.
 12. Não retornar campos legados fora do contrato (ex.: `messageMatchSummary`).
 13. Não usar taxonomia interna (`entryAsset`, `coreOffer` etc.) no texto final da copy.
+14. A copy final deve cobrir explicitamente o eixo **Dor → Resultado → Mecanismo → Prova → Oferta** ao longo de `hero`, `bodySections`, `ctaBlocks` e `faq`.
+15. `hero.supportingCopy` não pode ser vazio e deve conectar dor, urgência e próximo passo.
+16. Cada item de `bodySections` deve ter `summary` e `copy` substantivos (não usar placeholders).
+17. Cada item de `bodySections` deve conter no mínimo três bullets concretos e específicos.
+18. `faq` deve conter no mínimo três objeções reais do caso atual (sem perguntas genéricas vazias).
+19. `ctaBlocks` deve conter no mínimo duas variações posicionais de CTA (ex.: hero+final ou mid+final), mantendo coerência com `primaryCTA`.
+20. `ctaUrl` nunca pode conter placeholders (ex.: `{slug}`); sempre retornar URL resolvida para o fluxo atual.
+21. Todo conteúdo de seção deve ser compatível com os `sectionId` previstos no wireframe recebido em `CASE_DATA`.
+22. Evitar texto raso: proibido output composto apenas por rótulos de seção sem desenvolvimento argumentativo/comercial.
+23. Se faltar dado crítico para cumprir uma regra, registre em `consistencyChecks` com `status: FAIL` e detalhe objetivo do gap.
 
 Diretriz obrigatória para HERO:
-14. `hero.headline`: foco na transformação principal (curta, direta, comercial).
-15. `hero.subheadline`: explicar ativo inicial/prova/primeiro passo quando existir, sem presumir formato fixo.
-16. `hero.supportingCopy`: contextualizar dor + urgência + ponte para a oferta principal atual.
-17. Não presumir formatos universais (kit, PDF, plano fixo, ciclo com duração fixa, regeneração etc.).
+24. `hero.headline`: foco na transformação principal (curta, direta, comercial).
+25. `hero.subheadline`: explicar ativo inicial/prova/primeiro passo quando existir, sem presumir formato fixo.
+26. `hero.supportingCopy`: contextualizar dor + urgência + ponte para a oferta principal atual.
+27. Não presumir formatos universais (kit, PDF, plano fixo, ciclo com duração fixa, regeneração etc.).
 
 Diretriz obrigatória para seção de OFERTA:
-18. Estruture a narrativa para suportar duas camadas quando os dados trouxerem essa distinção:
+28. Estruture a narrativa para suportar duas camadas quando os dados trouxerem essa distinção:
    - Camada A (agora): o que a pessoa recebe/vê/gera de imediato (entryAsset/prova/preview/diagnóstico/primeiro entregável).
    - Camada B (estrutura maior): o que isso representa dentro da entrega principal (coreOffer/sistema/framework/processo/sequência/pacote central).
-19. Se a hipótese trouxer apenas um objeto comercial, não force duas camadas artificiais; mantenha clareza comercial com uma camada única.
-20. Sempre conectar entregáveis ao resultado percebido; evitar listas de exemplos fixos desta hipótese atual.
+29. Se a hipótese trouxer apenas um objeto comercial, não force duas camadas artificiais; mantenha clareza comercial com uma camada única.
+30. Sempre conectar entregáveis ao resultado percebido; evitar listas de exemplos fixos desta hipótese atual.
 
 Diretriz obrigatória para títulos de seção:
-21. Títulos devem ser comerciais e específicos ao caso atual, porém reutilizáveis para hipóteses futuras.
-22. Não usar rótulos internos de taxonomia no output.
-23. Não fixar nomenclaturas da oferta atual como padrão universal.
+31. Títulos devem ser comerciais e específicos ao caso atual, porém reutilizáveis para hipóteses futuras.
+32. Não usar rótulos internos de taxonomia no output.
+33. Não fixar nomenclaturas da oferta atual como padrão universal.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -61,3 +71,10 @@ Campos obrigatórios:
 - ctaBlocks[] com placement, ctaVariant, ctaLabel, ctaUrl, matchAdCta, ctaSupport, messageMatchNotes
 - faq[] com question, answer, objectionTag
 - consistencyChecks[] com check, status (PASS/FAIL/WARNING), details
+
+Critérios mínimos de aceite no próprio output:
+- `bodySections.length >= 4`
+- cada `bodySections[i].bullets.length >= 3`
+- `faq.length >= 3`
+- `ctaBlocks.length >= 2`
+- incluir em `consistencyChecks` os checks: CTA_MATCH, PROMISE_MATCH, GOOGLE_LANDING_BEST_PRACTICES

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -870,7 +870,7 @@ class ExperimentPipelineOpenAiClientTest {
         Map<String, Object> templateTrace = (Map<String, Object>) trackedRequest.get("templateTrace");
         assertThat(templateTrace)
                 .containsEntry("template_id", "landing-copy")
-                .containsEntry("template_version", "v1")
+                .containsEntry("template_version", "v2")
                 .containsEntry("artifact_target", "landingPageCopy")
                 .containsEntry("model", "gpt-5.2");
     }

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -2,6 +2,14 @@
 
 Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 
+> 🔴 **REGRA CANÔNICA EM DESTAQUE — LHM**
+>
+> O **LHM (Landing HTML Module)** é o módulo **determinístico** responsável por gerar o HTML final da landing page.
+>
+> - O LHM **não** é uma etapa de ideação criativa livre da copy.
+> - O LHM deve renderizar de forma previsível a partir dos artefatos canônicos (ex.: `landingPageCopy` e `landingPageWireframe`) e contratos vigentes.
+> - Mudanças no pipeline devem preservar essa responsabilidade para reduzir drift entre especificação, backend e página publicada.
+
 ## Observação importante — independência dos experimentos
 
 - Cada experimento deve ser tratado de forma independente, sem reutilização implícita de artefatos entre experimentos.
@@ -156,6 +164,34 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
   ]
 }
 ```
+
+### Regras canônicas de qualidade para geração da `landingPageCopy`
+
+Para considerar a copy **rica** e **compatível com as especificações**, a etapa de geração deve cumprir os critérios abaixo antes da renderização pelo LHM:
+
+1. **Cobertura completa de narrativa**
+   - A copy deve cobrir explicitamente o eixo: **Dor → Resultado → Mecanismo → Prova → Oferta**.
+   - Essa cobertura deve existir em `hero` + `bodySections` + `ctaBlocks` + `faq`.
+
+2. **Densidade mínima de conteúdo**
+   - `hero.supportingCopy` não pode ser vazio.
+   - Cada item de `bodySections` deve conter `summary` e `copy` não vazios.
+   - Cada item de `bodySections` deve conter ao menos 3 itens em `bullets`.
+   - `faq` deve conter no mínimo 3 perguntas com `question` e `answer` preenchidos.
+   - `ctaBlocks` deve conter no mínimo 2 variações (por exemplo: `mid` e `final` ou `hero` e `final`).
+
+3. **Compatibilidade com wireframe**
+   - Todo `sectionId` de `bodySections` deve existir em `landingPageWireframe.sectionOrder.sectionId`.
+   - Todo `ctaBlocks.placement` deve corresponder a um `ctaSlot` previsto no wireframe.
+   - Toda `ctaUrl` deve ser resolvida (sem placeholders como `{slug}`).
+
+4. **Consistência de promessa e CTA**
+   - `hero.promise`, `primaryCTA` e `ctaBlocks[*].matchAdCta` devem manter coerência semântica.
+   - `consistencyChecks` deve incluir, no mínimo, os checks: `CTA_MATCH`, `PROMISE_MATCH` e `GOOGLE_LANDING_BEST_PRACTICES`.
+
+5. **Critério de bloqueio**
+   - Se qualquer regra acima falhar, o artefato permanece em `DRAFT` e não pode seguir para renderização final.
+   - O LHM só deve processar copy com validação aprovada (`status = VALIDATED` ou `APPROVED`).
 
 ## `landingPageWireframe`
 

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -28,6 +28,7 @@
 4. **Flags derivadas não são verdade primária.** Rótulos de UI, atalhos de leitura, campos calculados e indicadores transitórios são projeções, não a regra original.
 5. **Contratos entre módulos são explícitos e versionados.** Nenhum módulo pode depender de campos implícitos, estados informais ou convenções não registradas.
 6. **Mudanças relevantes exigem teste e documentação correspondente.** Regra operacional sem teste e sem contrato atualizado é candidata imediata a drift.
+7. **LHM é determinístico por definição canônica.** O Landing HTML Module (LHM) é responsável pela renderização previsível do HTML final de landing pages a partir de artefatos/contratos canônicos; não é camada de ideação livre de copy.
 
 ## 3.1 Regra global de exclusividade de artefatos (todo o sistema)
 


### PR DESCRIPTION
### Motivation

- Increase rigor of generated landing page copy by adding explicit narrative and structural rules so outputs are complete and renderable. 
- Ensure the pipeline and rendering module remain deterministic and prevent copy drift between artifacts and final HTML. 
- Align tests and documentation with the new template contract/version to keep contract checks consistent.

### Description

- Bumped the landing copy prompt template version from `v1` to `v2` and expanded the prompt at `ai-worker/src/main/resources/prompts/experiment/landing-copy.md` with 23+ new mandatory rules and explicit acceptance criteria for `landingPageCopy`. 
- Added minimal-acceptance constraints such as coverage of the narrative axis `Dor → Resultado → Mecanismo → Prova → Oferta`, non-empty `hero.supportingCopy`, `bodySections.length >= 4`, `bodySections[*].bullets.length >= 3`, `faq.length >= 3`, `ctaBlocks.length >= 2`, and resolved `ctaUrl` requirements. 
- Updated `ExperimentPipelineOpenAiClientTest` to expect `template_version: v2` when asserting the generated prompt trace. 
- Extended canonical docs (`docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` and `docs/canonical/system-governance-canon.v2.md`) to add the LHM (Landing HTML Module) determinism rule and a new section of canonic quality rules for `landingPageCopy` generation and blocking criteria for rendering.

### Testing

- Ran unit tests including `ExperimentPipelineOpenAiClientTest` which now asserts `template_version` equals `v2`, and the test suite passed. 
- Executed the project's unit test suite (`mvn test`), and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb58933408321a7bddf57b75a89ff)