### PR TITLE
MOIS: add implementation plan doc and Research Sources page (frontend integration)

### DIFF
--- a/docs/mois/mois-plano-coleta-automatica-sprints-e-relatorios.md
+++ b/docs/mois/mois-plano-coleta-automatica-sprints-e-relatorios.md
@@ -1,0 +1,203 @@
+# MOIS — Plano de implementação da coleta automática + documento único de relatórios de conclusão
+
+## Contexto
+
+Objetivo: evoluir o MOIS para coletar referências de sucesso de mercado com janela temporal (semana/mês), consolidar sinais de sucesso e alimentar o fluxo de **Coleta → Extração → Síntese → Aplicação → Teste** com dados mais acionáveis.
+
+Este plano mantém aderência ao eixo central do Marketing Hub: **Dor → Resultado → Mecanismo → Prova → Oferta**.
+
+---
+
+## Escopo funcional (visão macro)
+
+1. Seleção de fontes de pesquisa (internacionais e locais).
+2. Coleta assistida/automática por janela temporal:
+   - últimos 7 dias (semana);
+   - últimos 30 dias (mês).
+3. Definição de critérios objetivos de “sinais de sucesso”.
+4. Persistência e rastreabilidade (lineage) por referência.
+5. Consolidação dos resultados no workspace MOIS.
+6. Relatórios de conclusão por sprint neste mesmo documento.
+
+---
+
+## SPRINT 0 — Descoberta técnica e contratos (1 semana)
+
+### Objetivo
+Definir contratos, critérios e limites técnicos antes da implementação.
+
+### Entregas
+- catálogo inicial de fontes suportadas (com tipo de acesso/API/política);
+- contrato de coleta (request/response) com filtros de tempo (7/30 dias);
+- contrato de “sinal de sucesso” (campos mínimos obrigatórios);
+- matriz de risco legal/compliance por fonte (termos de uso/rate limits).
+
+### Critérios de pronto
+- contratos versionados e revisados;
+- definição explícita de fallback quando a fonte não fornecer métrica direta.
+
+---
+
+## SPRINT 1 — Backend base da coleta automática (1 semana)
+
+### Objetivo
+Disponibilizar pipeline backend para iniciar coletas por fonte/período.
+
+### Entregas
+- endpoint para criar job de coleta automática;
+- endpoint para listar jobs e status (queued/running/completed/failed);
+- endpoint para listar referências coletadas por job;
+- persistência mínima de job, referência bruta e metadados de origem;
+- logs estruturados por execução.
+
+### Critérios de pronto
+- criação e acompanhamento de jobs funcionando em ambiente local;
+- validações de payload e mensagens de erro claras.
+
+---
+
+## SPRINT 2 — Normalização de sucesso e ranking (1 semana)
+
+### Objetivo
+Transformar dados heterogêneos em score comparável entre fontes.
+
+### Entregas
+- módulo de normalização de métricas (ex.: engajamento relativo, recorrência, evidência);
+- score composto de “sinal de sucesso” (0–100);
+- ordenação e filtros por período, fonte, nicho e score mínimo;
+- marcação de confiança da evidência (baixo/médio/alto).
+
+### Critérios de pronto
+- score reproduzível e documentado;
+- testes cobrindo cenários de dados ausentes/incompletos.
+
+---
+
+## SPRINT 3 — Frontend MOIS (coleta automática) (1 semana)
+
+### Objetivo
+Expor a funcionalidade na UI do MOIS com fluxo simples e objetivo.
+
+### Entregas
+- página de “Coleta automática” com:
+  - seleção de fontes;
+  - janela temporal (7/30 dias);
+  - nicho/tema;
+  - botão de iniciar coleta;
+- tabela de resultados com status, score, origem e data;
+- ações: importar para Coleta MOIS, descartar, favoritar.
+
+### Critérios de pronto
+- UX sem ruído, com estados loading/empty/error;
+- botões assíncronos desabilitados com indicador de carregamento;
+- links externos abrindo em nova aba.
+
+---
+
+## SPRINT 4 — Integração com Extração e Biblioteca (1 semana)
+
+### Objetivo
+Fechar o ciclo operacional: da coleta automática para uso real no MOIS.
+
+### Entregas
+- importação de resultados automáticos para referências do workspace;
+- ponte para Extração guiada com pré-preenchimento dos campos base;
+- geração inicial de blocos de biblioteca a partir das melhores referências;
+- rastreabilidade (fonte original → referência MOIS → extração/bloco).
+
+### Critérios de pronto
+- clique único para “importar e iniciar extração”;
+- lineage visível para auditoria.
+
+---
+
+## SPRINT 5 — Operação, qualidade e rollout (1 semana)
+
+### Objetivo
+Garantir estabilidade, observabilidade e adoção segura em produção.
+
+### Entregas
+- monitoração de jobs (latência, falhas por fonte, taxa de sucesso);
+- retries com backoff e controle de rate limit;
+- flags de rollout gradual por workspace;
+- documentação de operação e playbook de incidentes.
+
+### Critérios de pronto
+- métricas mínimas em produção;
+- fallback definido para indisponibilidade de fonte.
+
+---
+
+## Backlog transversal (todas as sprints)
+
+- segurança e secrets (sem credenciais em código);
+- conformidade de contratos frontend/backend;
+- cobertura de testes unitários e de contrato;
+- revisão de aderência aos documentos canônicos;
+- revisão de performance e custo operacional.
+
+---
+
+## Cronograma sugerido
+
+- Sprint 0: Semana 1
+- Sprint 1: Semana 2
+- Sprint 2: Semana 3
+- Sprint 3: Semana 4
+- Sprint 4: Semana 5
+- Sprint 5: Semana 6
+
+---
+
+# Relatórios de conclusão (documento único)
+
+> Regra: ao finalizar cada sprint, registrar o relatório nesta seção (sem criar documento separado).
+
+## Relatório — Sprint 0
+- **Status:** Planejado
+- **Período:** a definir
+- **Escopo concluído:** pendente
+- **Evidências (PRs, commits, testes):** pendente
+- **Riscos/pendências:** pendente
+- **Próximos passos:** iniciar contratos e matriz de risco por fonte
+
+## Relatório — Sprint 1
+- **Status:** Planejado
+- **Período:** a definir
+- **Escopo concluído:** pendente
+- **Evidências (PRs, commits, testes):** pendente
+- **Riscos/pendências:** pendente
+- **Próximos passos:** implementar normalização e score na Sprint 2
+
+## Relatório — Sprint 2
+- **Status:** Planejado
+- **Período:** a definir
+- **Escopo concluído:** pendente
+- **Evidências (PRs, commits, testes):** pendente
+- **Riscos/pendências:** pendente
+- **Próximos passos:** entregar interface de coleta automática na Sprint 3
+
+## Relatório — Sprint 3
+- **Status:** Planejado
+- **Período:** a definir
+- **Escopo concluído:** pendente
+- **Evidências (PRs, commits, testes):** pendente
+- **Riscos/pendências:** pendente
+- **Próximos passos:** integrar com extração/biblioteca na Sprint 4
+
+## Relatório — Sprint 4
+- **Status:** Planejado
+- **Período:** a definir
+- **Escopo concluído:** pendente
+- **Evidências (PRs, commits, testes):** pendente
+- **Riscos/pendências:** pendente
+- **Próximos passos:** fechar operação e rollout na Sprint 5
+
+## Relatório — Sprint 5
+- **Status:** Planejado
+- **Período:** a definir
+- **Escopo concluído:** pendente
+- **Evidências (PRs, commits, testes):** pendente
+- **Riscos/pendências:** pendente
+- **Próximos passos:** operação contínua + melhorias incrementais
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -121,6 +121,7 @@ import MoisExtractionPage from "./pages/mois/MoisExtractionPage";
 import MoisLibraryPage from "./pages/mois/MoisLibraryPage";
 import MoisComparisonPage from "./pages/mois/MoisComparisonPage";
 import MoisOfferBuilderPage from "./pages/mois/MoisOfferBuilderPage";
+import MoisResearchSourcesPage from "./pages/mois/MoisResearchSourcesPage";
 
 export default function App() {
   return (
@@ -268,6 +269,7 @@ export default function App() {
               <Route path="/oprm" element={<OprmWorkspacePage />} />
               <Route path="/mois" element={<MoisWorkspacePage />} />
               <Route path="/mois/references/new" element={<MoisReferenceIntakePage />} />
+              <Route path="/mois/research-sources" element={<MoisResearchSourcesPage />} />
               <Route path="/mois/extraction" element={<MoisExtractionPage />} />
               <Route path="/mois/library" element={<MoisLibraryPage />} />
               <Route path="/mois/comparison" element={<MoisComparisonPage />} />

--- a/frontend/src/pages/mois/MoisResearchSourcesPage.tsx
+++ b/frontend/src/pages/mois/MoisResearchSourcesPage.tsx
@@ -1,0 +1,146 @@
+import { Link } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+
+type ResearchSource = {
+  name: string;
+  category: string;
+  description: string;
+  url: string;
+  useCase: string;
+};
+
+const RESEARCH_SOURCES: ResearchSource[] = [
+  {
+    name: "Meta Ad Library",
+    category: "Anúncios",
+    description: "Biblioteca pública de anúncios ativos em Facebook e Instagram.",
+    url: "https://www.facebook.com/ads/library/",
+    useCase: "Mapear ângulos de copy, criativos e ofertas por nicho.",
+  },
+  {
+    name: "TikTok Creative Center",
+    category: "Anúncios",
+    description: "Repositório de tendências e anúncios com filtros por região e segmento.",
+    url: "https://ads.tiktok.com/business/creativecenter/inspiration/topads",
+    useCase: "Encontrar padrões de gancho, ritmo e CTA em vídeos curtos.",
+  },
+  {
+    name: "Google Ads Transparency Center",
+    category: "Anúncios",
+    description: "Consulta de anúncios exibidos no ecossistema Google.",
+    url: "https://adstransparency.google.com/",
+    useCase: "Validar recorrência de mensagens e posicionamento por marca.",
+  },
+  {
+    name: "YouTube",
+    category: "VSL / Conteúdo",
+    description: "Plataforma para localizar VSLs, webinars e conteúdos de venda longos.",
+    url: "https://www.youtube.com/",
+    useCase: "Analisar narrativa de dor, mecanismo, prova e oferta em vídeo.",
+  },
+  {
+    name: "Hotmart Marketplace",
+    category: "Produtos digitais",
+    description: "Marketplace com ofertas, descrições e formatos de infoprodutos.",
+    url: "https://www.hotmart.com/pt-br/marketplace",
+    useCase: "Comparar promessa, ticket e estrutura de produto por categoria.",
+  },
+  {
+    name: "Monetizze",
+    category: "Produtos digitais",
+    description: "Plataforma com campanhas e produtos em múltiplos nichos.",
+    url: "https://www.monetizze.com.br/",
+    useCase: "Buscar referências de oferta e modelo comercial.",
+  },
+  {
+    name: "Eduzz",
+    category: "Produtos digitais",
+    description: "Ecossistema de produtos digitais e páginas de venda.",
+    url: "https://www.eduzz.com/",
+    useCase: "Identificar variações de proposta de valor e diferenciais.",
+  },
+  {
+    name: "Google Trends",
+    category: "Demanda",
+    description: "Tendência de interesse por termos ao longo do tempo.",
+    url: "https://trends.google.com/",
+    useCase: "Priorizar temas com demanda crescente para novas coletas.",
+  },
+  {
+    name: "ClickBank Marketplace",
+    category: "Produtos digitais internacionais",
+    description: "Marketplace global com ofertas de afiliados em diversos nichos.",
+    url: "https://www.clickbank.com/marketplace/",
+    useCase: "Mapear promessas e estruturas de ofertas internacionais validadas.",
+  },
+  {
+    name: "Digistore24 Marketplace",
+    category: "Produtos digitais internacionais",
+    description: "Plataforma internacional com produtos digitais e físicos por categoria.",
+    url: "https://www.digistore24.com/en/home",
+    useCase: "Comparar copy e posicionamento de ofertas em mercados externos.",
+  },
+  {
+    name: "JVZoo",
+    category: "Produtos digitais internacionais",
+    description: "Ecossistema focado em lançamentos e ofertas digitais internacionais.",
+    url: "https://www.jvzoo.com/",
+    useCase: "Identificar padrões de lançamento e ângulos de conversão globais.",
+  },
+];
+
+export default function MoisResearchSourcesPage() {
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-wrap justify-content-between gap-3">
+        <div>
+          <PageTitle>Locais de pesquisa MOIS</PageTitle>
+          <p className="text-secondary mb-0">
+            Lista de fontes para coletar referências de mercado antes da extração guiada.
+          </p>
+        </div>
+        <Link className="btn btn-outline-secondary" to="/mois">
+          Voltar ao workspace
+        </Link>
+      </header>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <h2 className="h5">Fontes recomendadas</h2>
+          <p className="text-secondary mb-3">
+            Use estas fontes para identificar ofertas que já estão sendo veiculadas e validar padrões recorrentes.
+          </p>
+          <div className="table-responsive">
+            <table className="table align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>Fonte</th>
+                  <th>Categoria</th>
+                  <th>Quando usar</th>
+                  <th>Link</th>
+                </tr>
+              </thead>
+              <tbody>
+                {RESEARCH_SOURCES.map((source) => (
+                  <tr key={source.name}>
+                    <td>
+                      <strong>{source.name}</strong>
+                      <p className="mb-0 text-secondary small">{source.description}</p>
+                    </td>
+                    <td>{source.category}</td>
+                    <td>{source.useCase}</td>
+                    <td>
+                      <a href={source.url} target="_blank" rel="noreferrer">
+                        Abrir fonte
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/mois/MoisWorkspacePage.tsx
+++ b/frontend/src/pages/mois/MoisWorkspacePage.tsx
@@ -56,6 +56,9 @@ export default function MoisWorkspacePage() {
           <Link className="btn btn-outline-secondary btn-sm" to="/mois/builder">
             Builder
           </Link>
+          <Link className="btn btn-outline-secondary btn-sm" to="/mois/research-sources">
+            Locais de pesquisa
+          </Link>
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Registrar o plano de implantação da coleta automática do MOIS com sprints e critérios de aceitação para guiar desenvolvimento e rollout. 
- Fornecer uma página no frontend com fontes de pesquisa recomendadas para apoiar coletas manuais e orientar a priorização de extrações.

### Description
- Adiciona documento de planejamento em `docs/mois/mois-plano-coleta-automatica-sprints-e-relatorios.md` com escopo, sprints, backlog e template de relatórios de conclusão. 
- Implementa a nova tela `MoisResearchSourcesPage` em `frontend/src/pages/mois/MoisResearchSourcesPage.tsx` com uma tabela de fontes recomendadas e links externos. 
- Integra a página ao aplicativo ao importar `MoisResearchSourcesPage` em `frontend/src/App.tsx` e registrar a rota `"/mois/research-sources"`, e adiciona um botão no workspace em `frontend/src/pages/mois/MoisWorkspacePage.tsx` apontando para a nova rota.

### Testing
- Nenhum teste automatizado novo foi adicionado ou modificado para esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd58b02108321a2bc66ee4dfda25c)