### PR TITLE
Bump landing-copy template to v2 and add copy-quality + LHM governance rules

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
@@ -1,5 +1,5 @@
 template_id: landing-copy
-template_version: v1
+template_version: v2
 artifact_target: landingPageCopy
 
 SYSTEM_INSTRUCTIONS
@@ -26,24 +26,35 @@ Regras fixas da etapa:
 11. Não invente nicho, persona, hipótese, mecanismo, prova, oferta, camadas ou entregáveis fora dos dados recebidos.
 12. Não retornar campos legados fora do contrato (ex.: `messageMatchSummary`).
 13. Não usar taxonomia interna (`entryAsset`, `coreOffer` etc.) no texto final da copy.
+14. A copy final deve cobrir explicitamente o eixo **Dor → Resultado → Mecanismo → Prova → Oferta** ao longo de `hero`, `bodySections`, `ctaBlocks` e `faq`.
+15. `hero.supportingCopy` não pode ser vazio e deve conectar dor, urgência e próximo passo.
+16. Cada item de `bodySections` deve ter `summary` e `copy` substantivos (não usar placeholders).
+17. Cada item de `bodySections` deve conter no mínimo três bullets concretos e específicos.
+18. `faq` deve conter no mínimo três objeções reais do caso atual (sem perguntas genéricas vazias).
+19. `ctaBlocks` deve conter no mínimo duas variações posicionais de CTA (ex.: hero+final ou mid+final), mantendo coerência com `primaryCTA`.
+20. `ctaUrl` nunca pode conter placeholders (ex.: `{slug}`); sempre retornar URL resolvida para o fluxo atual.
+21. Esta etapa acontece **antes** do wireframe: a copy **não pode depender** de campos, `sectionId` ou estrutura do `landingPageWireframe`.
+22. Estruture a copy com ids e blocos semânticos canônicos próprios, para o wireframe posterior mapear layout sem alterar promessa/argumentação.
+23. Evitar texto raso: proibido output composto apenas por rótulos de seção sem desenvolvimento argumentativo/comercial.
+24. Se faltar dado crítico para cumprir uma regra, registre em `consistencyChecks` com `status: FAIL` e detalhe objetivo do gap.
 
 Diretriz obrigatória para HERO:
-14. `hero.headline`: foco na transformação principal (curta, direta, comercial).
-15. `hero.subheadline`: explicar ativo inicial/prova/primeiro passo quando existir, sem presumir formato fixo.
-16. `hero.supportingCopy`: contextualizar dor + urgência + ponte para a oferta principal atual.
-17. Não presumir formatos universais (kit, PDF, plano fixo, ciclo com duração fixa, regeneração etc.).
+25. `hero.headline`: foco na transformação principal (curta, direta, comercial).
+26. `hero.subheadline`: explicar ativo inicial/prova/primeiro passo quando existir, sem presumir formato fixo.
+27. `hero.supportingCopy`: contextualizar dor + urgência + ponte para a oferta principal atual.
+28. Não presumir formatos universais (kit, PDF, plano fixo, ciclo com duração fixa, regeneração etc.).
 
 Diretriz obrigatória para seção de OFERTA:
-18. Estruture a narrativa para suportar duas camadas quando os dados trouxerem essa distinção:
+29. Estruture a narrativa para suportar duas camadas quando os dados trouxerem essa distinção:
    - Camada A (agora): o que a pessoa recebe/vê/gera de imediato (entryAsset/prova/preview/diagnóstico/primeiro entregável).
    - Camada B (estrutura maior): o que isso representa dentro da entrega principal (coreOffer/sistema/framework/processo/sequência/pacote central).
-19. Se a hipótese trouxer apenas um objeto comercial, não force duas camadas artificiais; mantenha clareza comercial com uma camada única.
-20. Sempre conectar entregáveis ao resultado percebido; evitar listas de exemplos fixos desta hipótese atual.
+30. Se a hipótese trouxer apenas um objeto comercial, não force duas camadas artificiais; mantenha clareza comercial com uma camada única.
+31. Sempre conectar entregáveis ao resultado percebido; evitar listas de exemplos fixos desta hipótese atual.
 
 Diretriz obrigatória para títulos de seção:
-21. Títulos devem ser comerciais e específicos ao caso atual, porém reutilizáveis para hipóteses futuras.
-22. Não usar rótulos internos de taxonomia no output.
-23. Não fixar nomenclaturas da oferta atual como padrão universal.
+32. Títulos devem ser comerciais e específicos ao caso atual, porém reutilizáveis para hipóteses futuras.
+33. Não usar rótulos internos de taxonomia no output.
+34. Não fixar nomenclaturas da oferta atual como padrão universal.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -61,3 +72,10 @@ Campos obrigatórios:
 - ctaBlocks[] com placement, ctaVariant, ctaLabel, ctaUrl, matchAdCta, ctaSupport, messageMatchNotes
 - faq[] com question, answer, objectionTag
 - consistencyChecks[] com check, status (PASS/FAIL/WARNING), details
+
+Critérios mínimos de aceite no próprio output:
+- `bodySections.length >= 4`
+- cada `bodySections[i].bullets.length >= 3`
+- `faq.length >= 3`
+- `ctaBlocks.length >= 2`
+- incluir em `consistencyChecks` os checks: CTA_MATCH, PROMISE_MATCH, GOOGLE_LANDING_BEST_PRACTICES

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -150,6 +150,8 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("ctaBlocks[]");
         assertThat(userPrompt).contains("consistencyChecks[]");
         assertThat(userPrompt).contains("complianceNotes");
+        assertThat(userPrompt).contains("copy **não pode depender** de campos, `sectionId` ou estrutura do `landingPageWireframe`");
+        assertThat(userPrompt).doesNotContain("compatível com os `sectionId` previstos no wireframe recebido em `CASE_DATA`");
     }
 
     @Test
@@ -870,7 +872,7 @@ class ExperimentPipelineOpenAiClientTest {
         Map<String, Object> templateTrace = (Map<String, Object>) trackedRequest.get("templateTrace");
         assertThat(templateTrace)
                 .containsEntry("template_id", "landing-copy")
-                .containsEntry("template_version", "v1")
+                .containsEntry("template_version", "v2")
                 .containsEntry("artifact_target", "landingPageCopy")
                 .containsEntry("model", "gpt-5.2");
     }

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -2,6 +2,14 @@
 
 Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 
+> 🔴 **REGRA CANÔNICA EM DESTAQUE — LHM**
+>
+> O **LHM (Landing HTML Module)** é o módulo **determinístico** responsável por gerar o HTML final da landing page.
+>
+> - O LHM **não** é uma etapa de ideação criativa livre da copy.
+> - O LHM deve renderizar de forma previsível a partir dos artefatos canônicos (ex.: `landingPageCopy` e `landingPageWireframe`) e contratos vigentes.
+> - Mudanças no pipeline devem preservar essa responsabilidade para reduzir drift entre especificação, backend e página publicada.
+
 ## Observação importante — independência dos experimentos
 
 - Cada experimento deve ser tratado de forma independente, sem reutilização implícita de artefatos entre experimentos.
@@ -156,6 +164,34 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
   ]
 }
 ```
+
+### Regras canônicas de qualidade para geração da `landingPageCopy`
+
+Para considerar a copy **rica** e **compatível com as especificações**, a etapa de geração deve cumprir os critérios abaixo antes da renderização pelo LHM:
+
+1. **Cobertura completa de narrativa**
+   - A copy deve cobrir explicitamente o eixo: **Dor → Resultado → Mecanismo → Prova → Oferta**.
+   - Essa cobertura deve existir em `hero` + `bodySections` + `ctaBlocks` + `faq`.
+
+2. **Densidade mínima de conteúdo**
+   - `hero.supportingCopy` não pode ser vazio.
+   - Cada item de `bodySections` deve conter `summary` e `copy` não vazios.
+   - Cada item de `bodySections` deve conter ao menos 3 itens em `bullets`.
+   - `faq` deve conter no mínimo 3 perguntas com `question` e `answer` preenchidos.
+   - `ctaBlocks` deve conter no mínimo 2 variações (por exemplo: `mid` e `final` ou `hero` e `final`).
+
+3. **Independência da etapa de wireframe (ordem canônica)**
+   - A geração de `landingPageCopy` acontece **antes** de `landingPageWireframe`; portanto, a copy **não pode depender** de `sectionOrder`, `ctaSlot` ou qualquer campo de wireframe inexistente nessa etapa.
+   - O alinhamento estrutural com layout acontece na etapa posterior (`landingPageWireframe`), preservando a promessa e a argumentação aprovadas na copy.
+   - Toda `ctaUrl` deve ser resolvida (sem placeholders como `{slug}`).
+
+4. **Consistência de promessa e CTA**
+   - `hero.promise`, `primaryCTA` e `ctaBlocks[*].matchAdCta` devem manter coerência semântica.
+   - `consistencyChecks` deve incluir, no mínimo, os checks: `CTA_MATCH`, `PROMISE_MATCH` e `GOOGLE_LANDING_BEST_PRACTICES`.
+
+5. **Critério de bloqueio**
+   - Se qualquer regra acima falhar, o artefato permanece em `DRAFT` e não pode seguir para renderização final.
+   - O LHM só deve processar copy com validação aprovada (`status = VALIDATED` ou `APPROVED`).
 
 ## `landingPageWireframe`
 

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -28,6 +28,7 @@
 4. **Flags derivadas não são verdade primária.** Rótulos de UI, atalhos de leitura, campos calculados e indicadores transitórios são projeções, não a regra original.
 5. **Contratos entre módulos são explícitos e versionados.** Nenhum módulo pode depender de campos implícitos, estados informais ou convenções não registradas.
 6. **Mudanças relevantes exigem teste e documentação correspondente.** Regra operacional sem teste e sem contrato atualizado é candidata imediata a drift.
+7. **LHM é determinístico por definição canônica.** O Landing HTML Module (LHM) é responsável pela renderização previsível do HTML final de landing pages a partir de artefatos/contratos canônicos; não é camada de ideação livre de copy.
 
 ## 3.1 Regra global de exclusividade de artefatos (todo o sistema)
 


### PR DESCRIPTION
### Motivation
- Strengthen and make explicit the quality, structural and independence requirements for generating `landingPageCopy`, and ensure the copy step cannot depend on wireframe fields. 
- Make the Landing HTML Module (LHM) deterministic by documenting that rendering must come from validated canonical artifacts and not perform copy ideation. 
- Bump the prompt template version to reflect the new rules and acceptance criteria so workers and tests stay in sync.

### Description
- Updated `ai-worker/src/main/resources/prompts/experiment/landing-copy.md` to `template_version: v2` and added numerous constraints and acceptance criteria (coverage Dor→Resultado→Mecanismo→Prova→Oferta, `hero.supportingCopy` required, `bodySections` summaries/copies and >=3 bullets, `faq` >=3, `ctaBlocks` >=2, resolved `ctaUrl`, independence from wireframe, explicit `consistencyChecks` requirements, and more). 
- Extended canonical docs: added copy-quality rules to `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` and added LHM determinism guidance to `docs/canonical/system-governance-canon.v2.md`. 
- Updated unit tests in `ExperimentPipelineOpenAiClientTest` to expect `template_version: v2` and to assert the prompt includes the new wireframe-independence guidance while removing an obsolete compatibility assertion.

### Testing
- Ran the unit test `ExperimentPipelineOpenAiClientTest` which was updated to match the new template and content checks, and the test suite passed. 
- Ran the project's automated unit tests via the normal test task (`./gradlew test` / `mvn test`) and there were no test failures related to these changes. 
- No integration or end-to-end tests were modified or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb58933408321a7bddf57b75a89ff)