### PR TITLE
Landing copy v2: stronger copy rules, LHM deterministic behavior, HTML/CSS polish and canonical form injection

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
@@ -1,5 +1,5 @@
 template_id: landing-copy
-template_version: v1
+template_version: v2
 artifact_target: landingPageCopy
 
 SYSTEM_INSTRUCTIONS
@@ -26,24 +26,35 @@ Regras fixas da etapa:
 11. Não invente nicho, persona, hipótese, mecanismo, prova, oferta, camadas ou entregáveis fora dos dados recebidos.
 12. Não retornar campos legados fora do contrato (ex.: `messageMatchSummary`).
 13. Não usar taxonomia interna (`entryAsset`, `coreOffer` etc.) no texto final da copy.
+14. A copy final deve cobrir explicitamente o eixo **Dor → Resultado → Mecanismo → Prova → Oferta** ao longo de `hero`, `bodySections`, `ctaBlocks` e `faq`.
+15. `hero.supportingCopy` não pode ser vazio e deve conectar dor, urgência e próximo passo.
+16. Cada item de `bodySections` deve ter `summary` e `copy` substantivos (não usar placeholders).
+17. Cada item de `bodySections` deve conter no mínimo três bullets concretos e específicos.
+18. `faq` deve conter no mínimo três objeções reais do caso atual (sem perguntas genéricas vazias).
+19. `ctaBlocks` deve conter no mínimo duas variações posicionais de CTA (ex.: hero+final ou mid+final), mantendo coerência com `primaryCTA`.
+20. `ctaUrl` nunca pode conter placeholders (ex.: `{slug}`); sempre retornar URL resolvida para o fluxo atual.
+21. Esta etapa acontece **antes** do wireframe: a copy **não pode depender** de campos, `sectionId` ou estrutura do `landingPageWireframe`.
+22. Estruture a copy com ids e blocos semânticos canônicos próprios, para o wireframe posterior mapear layout sem alterar promessa/argumentação.
+23. Evitar texto raso: proibido output composto apenas por rótulos de seção sem desenvolvimento argumentativo/comercial.
+24. Se faltar dado crítico para cumprir uma regra, registre em `consistencyChecks` com `status: FAIL` e detalhe objetivo do gap.
 
 Diretriz obrigatória para HERO:
-14. `hero.headline`: foco na transformação principal (curta, direta, comercial).
-15. `hero.subheadline`: explicar ativo inicial/prova/primeiro passo quando existir, sem presumir formato fixo.
-16. `hero.supportingCopy`: contextualizar dor + urgência + ponte para a oferta principal atual.
-17. Não presumir formatos universais (kit, PDF, plano fixo, ciclo com duração fixa, regeneração etc.).
+25. `hero.headline`: foco na transformação principal (curta, direta, comercial).
+26. `hero.subheadline`: explicar ativo inicial/prova/primeiro passo quando existir, sem presumir formato fixo.
+27. `hero.supportingCopy`: contextualizar dor + urgência + ponte para a oferta principal atual.
+28. Não presumir formatos universais (kit, PDF, plano fixo, ciclo com duração fixa, regeneração etc.).
 
 Diretriz obrigatória para seção de OFERTA:
-18. Estruture a narrativa para suportar duas camadas quando os dados trouxerem essa distinção:
+29. Estruture a narrativa para suportar duas camadas quando os dados trouxerem essa distinção:
    - Camada A (agora): o que a pessoa recebe/vê/gera de imediato (entryAsset/prova/preview/diagnóstico/primeiro entregável).
    - Camada B (estrutura maior): o que isso representa dentro da entrega principal (coreOffer/sistema/framework/processo/sequência/pacote central).
-19. Se a hipótese trouxer apenas um objeto comercial, não force duas camadas artificiais; mantenha clareza comercial com uma camada única.
-20. Sempre conectar entregáveis ao resultado percebido; evitar listas de exemplos fixos desta hipótese atual.
+30. Se a hipótese trouxer apenas um objeto comercial, não force duas camadas artificiais; mantenha clareza comercial com uma camada única.
+31. Sempre conectar entregáveis ao resultado percebido; evitar listas de exemplos fixos desta hipótese atual.
 
 Diretriz obrigatória para títulos de seção:
-21. Títulos devem ser comerciais e específicos ao caso atual, porém reutilizáveis para hipóteses futuras.
-22. Não usar rótulos internos de taxonomia no output.
-23. Não fixar nomenclaturas da oferta atual como padrão universal.
+32. Títulos devem ser comerciais e específicos ao caso atual, porém reutilizáveis para hipóteses futuras.
+33. Não usar rótulos internos de taxonomia no output.
+34. Não fixar nomenclaturas da oferta atual como padrão universal.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -61,3 +72,10 @@ Campos obrigatórios:
 - ctaBlocks[] com placement, ctaVariant, ctaLabel, ctaUrl, matchAdCta, ctaSupport, messageMatchNotes
 - faq[] com question, answer, objectionTag
 - consistencyChecks[] com check, status (PASS/FAIL/WARNING), details
+
+Critérios mínimos de aceite no próprio output:
+- `bodySections.length >= 4`
+- cada `bodySections[i].bullets.length >= 3`
+- `faq.length >= 3`
+- `ctaBlocks.length >= 2`
+- incluir em `consistencyChecks` os checks: CTA_MATCH, PROMISE_MATCH, GOOGLE_LANDING_BEST_PRACTICES

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -150,6 +150,8 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("ctaBlocks[]");
         assertThat(userPrompt).contains("consistencyChecks[]");
         assertThat(userPrompt).contains("complianceNotes");
+        assertThat(userPrompt).contains("copy **não pode depender** de campos, `sectionId` ou estrutura do `landingPageWireframe`");
+        assertThat(userPrompt).doesNotContain("compatível com os `sectionId` previstos no wireframe recebido em `CASE_DATA`");
     }
 
     @Test
@@ -870,7 +872,7 @@ class ExperimentPipelineOpenAiClientTest {
         Map<String, Object> templateTrace = (Map<String, Object>) trackedRequest.get("templateTrace");
         assertThat(templateTrace)
                 .containsEntry("template_id", "landing-copy")
-                .containsEntry("template_version", "v1")
+                .containsEntry("template_version", "v2")
                 .containsEntry("artifact_target", "landingPageCopy")
                 .containsEntry("model", "gpt-5.2");
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -67,8 +67,7 @@ public class LandingHtmlModule {
                 "Landing");
         String pageSummary = firstNonBlank(
                 asTrimmedString(copy.get("summary")),
-                asTrimmedString(copy.get("lead")),
-                "Landing gerada pelo LHM");
+                asTrimmedString(copy.get("lead")));
 
         List<Map<String, Object>> plannedImages = extractImages(experiment.getLandingPageImagePlanning());
 
@@ -82,20 +81,30 @@ public class LandingHtmlModule {
                 .append("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />")
                 .append("<title>").append(escapeHtml(pageTitle)).append("</title>")
                 .append("<style>")
-                .append("body{font-family:Inter,Arial,sans-serif;margin:0;background:#f7f8fb;color:#141821;line-height:1.5;}")
-                .append("main{max-width:960px;margin:0 auto;padding:24px 16px 48px;display:grid;gap:16px;}")
-                .append(".card{background:#fff;border:1px solid #e6e8ef;border-radius:16px;padding:20px;}")
-                .append("h1,h2{margin:0 0 8px;} p{margin:0 0 10px;} form{display:grid;gap:10px;}")
-                .append("label{font-weight:600;font-size:14px;} input{width:100%;padding:10px;border:1px solid #d2d7e3;border-radius:10px;}")
-                .append("button{padding:12px 16px;border:0;border-radius:999px;background:#1c6dd0;color:#fff;font-weight:700;cursor:pointer;}")
-                .append("img{max-width:100%;height:auto;border-radius:12px;display:block;}")
-                .append("#form-feedback{display:none;margin-top:8px;font-weight:600;}")
+                .append(":root{--bg:#f3f5f9;--card:#ffffff;--border:#e3e8f2;--text:#0f172a;--muted:#475569;--brand:#1d4ed8;--brand-dark:#1e40af;}")
+                .append("*{box-sizing:border-box;}body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;margin:0;background:linear-gradient(180deg,#f8fafc 0%,var(--bg) 100%);color:var(--text);line-height:1.55;}")
+                .append("main{max-width:980px;margin:0 auto;padding:28px 16px 64px;display:grid;gap:14px;}")
+                .append(".card{background:var(--card);border:1px solid var(--border);border-radius:18px;padding:18px;box-shadow:0 10px 30px rgba(15,23,42,.04);}")
+                .append(".card[data-surface-contrast='high']{border-color:#cdd8ee;background:linear-gradient(180deg,#fff 0%,#f8fbff 100%);}")
+                .append("h1{font-size:clamp(1.65rem,4vw,2.1rem);line-height:1.15;margin:0 0 10px;font-weight:800;letter-spacing:-0.02em;}")
+                .append("h2{font-size:clamp(1.25rem,3.2vw,1.55rem);line-height:1.25;margin:0 0 10px;font-weight:750;letter-spacing:-0.01em;}")
+                .append("p{margin:0 0 10px;color:var(--muted);font-size:.98rem;}")
+                .append(".section-objective{font-size:.95rem;color:#334155;background:#f8fafc;border:1px dashed #d6e1f5;border-radius:12px;padding:10px 12px;margin:0 0 12px;}")
+                .append("form{display:grid;gap:12px;background:#fbfdff;border:1px solid #dbe5f5;border-radius:14px;padding:14px;}")
+                .append(".field{display:grid;gap:6px;}.help{color:#64748b;font-size:.88rem;line-height:1.35;}")
+                .append("label{font-weight:700;font-size:.92rem;color:#0f172a;}input{width:100%;padding:11px 12px;border:1px solid #cfd8e6;border-radius:10px;background:#fff;font-size:1rem;outline:none;}")
+                .append("input:focus{border-color:#3b82f6;box-shadow:0 0 0 3px rgba(59,130,246,.15);}button{padding:12px 16px;border:0;border-radius:999px;background:linear-gradient(135deg,var(--brand) 0%,var(--brand-dark) 100%);color:#fff;font-weight:800;cursor:pointer;letter-spacing:.01em;}")
+                .append("button:hover{filter:brightness(1.04);}img{max-width:100%;height:auto;border-radius:12px;display:block;margin-top:8px;}")
+                .append("#form-feedback{display:none;margin-top:2px;font-weight:700;color:#1e3a8a;}")
                 .append("</style></head><body><main>");
 
         for (int sectionIndex = 0; sectionIndex < sections.size(); sectionIndex++) {
             Map<String, Object> section = sections.get(sectionIndex);
             String sectionId = firstNonBlank(asTrimmedString(section.get("sectionId")), "section");
             String sectionName = firstNonBlank(asTrimmedString(section.get("sectionName")), sectionId);
+            String sectionObjective = firstNonBlank(
+                    asTrimmedString(section.get("objective")),
+                    asTrimmedString(section.get("uiNotes")));
             Map<String, Object> surface = section.get("surfaceSpec") instanceof Map<?, ?> rawSurface
                     ? (Map<String, Object>) rawSurface
                     : Map.of();
@@ -114,6 +123,9 @@ public class LandingHtmlModule {
                             : "<h2>" + escapeHtml(sectionName) + "</h2>");
             if (sectionIndex == 0 && StringUtils.hasText(pageSummary)) {
                 html.append("<p>").append(escapeHtml(pageSummary)).append("</p>");
+            }
+            if (sectionIndex > 0 && StringUtils.hasText(sectionObjective)) {
+                html.append("<p class=\"section-objective\">").append(escapeHtml(sectionObjective)).append("</p>");
             }
 
             for (Map<String, Object> image : plannedImages) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1550,6 +1550,7 @@ public class ExperimentPipelineGenerationService {
         Document document = Jsoup.parse(htmlDocument, "", org.jsoup.parser.Parser.htmlParser());
         String expectedFormId = asTrimmedString(wireframeFormSpec.get("formId"));
         String expectedSubmitTarget = asTrimmedString(wireframeFormSpec.get("submitTarget"));
+        String submitLabel = asTrimmedString(wireframeFormSpec.get("submitLabel"));
         Element form = StringUtils.hasText(expectedFormId)
                 ? document.selectFirst("form#" + expectedFormId)
                 : document.selectFirst("form#lead-capture-primary");
@@ -1557,7 +1558,7 @@ public class ExperimentPipelineGenerationService {
             form = document.selectFirst("form");
         }
         if (form == null) {
-            return htmlDocument;
+            form = createCanonicalFormShell(document, expectedFormId, expectedSubmitTarget, submitLabel);
         }
         if (StringUtils.hasText(expectedFormId)) {
             form.attr("id", expectedFormId);
@@ -1573,6 +1574,36 @@ public class ExperimentPipelineGenerationService {
         bindExternalSubmitButtonsToForm(document, form);
         ensureDefaultSubmitRuntime(document, form);
         return document.outerHtml();
+    }
+
+    private Element createCanonicalFormShell(Document document,
+                                             String expectedFormId,
+                                             String expectedSubmitTarget,
+                                             String submitLabel) {
+        Element body = document.body();
+        if (body == null) {
+            body = document.appendElement("body");
+        }
+        Element container = document.selectFirst("main");
+        if (container == null) {
+            container = body;
+        }
+        Element form = container.appendElement("form");
+        form.attr("id", StringUtils.hasText(expectedFormId) ? expectedFormId : "lead-capture-primary");
+        form.attr("method", "post");
+        if (StringUtils.hasText(expectedSubmitTarget)) {
+            form.attr("action", expectedSubmitTarget);
+        }
+        form.appendElement("button")
+                .attr("type", "submit")
+                .text(StringUtils.hasText(submitLabel) ? submitLabel : "Enviar");
+        form.appendElement("p")
+                .attr("id", "form-feedback")
+                .attr("role", "status");
+        container.appendElement("div")
+                .attr("id", "submit-success-state")
+                .attr("style", "display:none");
+        return form;
     }
 
     private void bindExternalSubmitButtonsToForm(Document document, Element form) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -207,6 +207,35 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void generateLandingHtmlWithLhmInjectsCanonicalFormWhenHtmlHasNoForm() {
+        Experiment experiment = new Experiment();
+        experiment.setId(35L);
+        experiment.setLandingPageWireframe("{\"landingPageWireframe\":{\"formSpec\":{\"formId\":\"lead-capture-primary\",\"submitTarget\":\"/api/flows/exp-35/submissions\",\"fields\":[{\"name\":\"nome\",\"type\":\"text\",\"required\":true},{\"name\":\"email\",\"type\":\"email\",\"required\":true}],\"submitLabel\":\"Enviar\"},\"sectionOrder\":[{\"sectionId\":\"hero\",\"sectionName\":\"Hero\",\"contentType\":\"form\",\"surfaceSpec\":{\"surfaceToken\":\"surface-base\",\"style\":\"band\",\"contrastMode\":\"normal\"}}]}}");
+        experiment.setLandingPageCopy("{\"landingPageCopy\":{\"headline\":\"Headline\"}}");
+        experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":{\"images\":[]}}");
+
+        when(experimentRepository.findById(35L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(landingHtmlModule.assembleHtmlDocument(experiment)).thenReturn("""
+                <!doctype html><html><body>
+                <main>
+                  <section data-section-id="hero" data-surface-token="surface-base" data-surface-style="band" data-surface-contrast="normal">
+                    <h1>Hero</h1>
+                  </section>
+                </main>
+                </body></html>
+                """);
+        when(experimentMapper.toDto(experiment)).thenReturn(new ExperimentDto());
+
+        service.generateLandingHtmlWithLhm(35L);
+
+        assertTrue(experiment.getLandingPageHtml().contains("form id=\"lead-capture-primary\""));
+        assertTrue(experiment.getLandingPageHtml().contains("name=\"nome\""));
+        assertTrue(experiment.getLandingPageHtml().contains("name=\"email\""));
+        verify(generationService).recordGeneration(any(AiWorkerGenerationRequest.class));
+    }
+
+    @Test
     void generateLandingHtmlWithLhmTracksFailedAttemptWhenPromptPreparationFails() {
         Experiment experiment = new Experiment();
         experiment.setId(34L);

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -2,6 +2,14 @@
 
 Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 
+> 🔴 **REGRA CANÔNICA EM DESTAQUE — LHM**
+>
+> O **LHM (Landing HTML Module)** é o módulo **determinístico** responsável por gerar o HTML final da landing page.
+>
+> - O LHM **não** é uma etapa de ideação criativa livre da copy.
+> - O LHM deve renderizar de forma previsível a partir dos artefatos canônicos (ex.: `landingPageCopy` e `landingPageWireframe`) e contratos vigentes.
+> - Mudanças no pipeline devem preservar essa responsabilidade para reduzir drift entre especificação, backend e página publicada.
+
 ## Observação importante — independência dos experimentos
 
 - Cada experimento deve ser tratado de forma independente, sem reutilização implícita de artefatos entre experimentos.
@@ -156,6 +164,34 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
   ]
 }
 ```
+
+### Regras canônicas de qualidade para geração da `landingPageCopy`
+
+Para considerar a copy **rica** e **compatível com as especificações**, a etapa de geração deve cumprir os critérios abaixo antes da renderização pelo LHM:
+
+1. **Cobertura completa de narrativa**
+   - A copy deve cobrir explicitamente o eixo: **Dor → Resultado → Mecanismo → Prova → Oferta**.
+   - Essa cobertura deve existir em `hero` + `bodySections` + `ctaBlocks` + `faq`.
+
+2. **Densidade mínima de conteúdo**
+   - `hero.supportingCopy` não pode ser vazio.
+   - Cada item de `bodySections` deve conter `summary` e `copy` não vazios.
+   - Cada item de `bodySections` deve conter ao menos 3 itens em `bullets`.
+   - `faq` deve conter no mínimo 3 perguntas com `question` e `answer` preenchidos.
+   - `ctaBlocks` deve conter no mínimo 2 variações (por exemplo: `mid` e `final` ou `hero` e `final`).
+
+3. **Independência da etapa de wireframe (ordem canônica)**
+   - A geração de `landingPageCopy` acontece **antes** de `landingPageWireframe`; portanto, a copy **não pode depender** de `sectionOrder`, `ctaSlot` ou qualquer campo de wireframe inexistente nessa etapa.
+   - O alinhamento estrutural com layout acontece na etapa posterior (`landingPageWireframe`), preservando a promessa e a argumentação aprovadas na copy.
+   - Toda `ctaUrl` deve ser resolvida (sem placeholders como `{slug}`).
+
+4. **Consistência de promessa e CTA**
+   - `hero.promise`, `primaryCTA` e `ctaBlocks[*].matchAdCta` devem manter coerência semântica.
+   - `consistencyChecks` deve incluir, no mínimo, os checks: `CTA_MATCH`, `PROMISE_MATCH` e `GOOGLE_LANDING_BEST_PRACTICES`.
+
+5. **Critério de bloqueio**
+   - Se qualquer regra acima falhar, o artefato permanece em `DRAFT` e não pode seguir para renderização final.
+   - O LHM só deve processar copy com validação aprovada (`status = VALIDATED` ou `APPROVED`).
 
 ## `landingPageWireframe`
 

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -28,6 +28,7 @@
 4. **Flags derivadas não são verdade primária.** Rótulos de UI, atalhos de leitura, campos calculados e indicadores transitórios são projeções, não a regra original.
 5. **Contratos entre módulos são explícitos e versionados.** Nenhum módulo pode depender de campos implícitos, estados informais ou convenções não registradas.
 6. **Mudanças relevantes exigem teste e documentação correspondente.** Regra operacional sem teste e sem contrato atualizado é candidata imediata a drift.
+7. **LHM é determinístico por definição canônica.** O Landing HTML Module (LHM) é responsável pela renderização previsível do HTML final de landing pages a partir de artefatos/contratos canônicos; não é camada de ideação livre de copy.
 
 ## 3.1 Regra global de exclusividade de artefatos (todo o sistema)
 


### PR DESCRIPTION
### Motivation
- Strengthen the landing page copy contract and ensure the copy stage is independent from the wireframe so the LHM can deterministically render HTML from validated artifacts. 
- Make the Landing HTML Module (LHM) responsible for predictable rendering and improve page visuals and robustness when source HTML lacks a form. 
- Codify canonical rules and prevent drift between workers, backend and front-end by surfacing new quality and governance constraints in docs.

### Description
- Bumped landing copy template to `template_version: v2` and added numerous mandatory copy rules (coverage of Dor→Resultado→Mecanismo→Prova→Oferta, non-empty `hero.supportingCopy`, `bodySections` with `summary`, `copy` and >=3 `bullets`, `faq` >=3, `ctaBlocks` >=2, resolved `ctaUrl`, plus updated `consistencyChecks` requirements). 
- Updated unit test expectations in `ExperimentPipelineOpenAiClientTest` to assert the new prompt content and the template version `v2`. 
- Enhanced `LandingHtmlModule` styling and layout with a refreshed CSS theme and added rendering of section objectives (from `objective` or `uiNotes`) into the HTML. 
- Modified `ExperimentPipelineGenerationService.rebuildFormFromSpec` to inject a canonical form shell when no form is present and added `createCanonicalFormShell` to produce a minimal accessible form markup including submit button and `#form-feedback`. 
- Added a unit test `generateLandingHtmlWithLhmInjectsCanonicalFormWhenHtmlHasNoForm` in `ExperimentPipelineGenerationServiceTest` to cover the new form-injection behavior. 
- Extended docs (`modelo-canonico-artefatos-pipeline-experimento.md` and `system-governance-canon.v2.md`) with LHM determinism and minimum quality rules for `landingPageCopy` generation.

### Testing
- Ran unit tests in `ExperimentPipelineOpenAiClientTest` and `ExperimentPipelineGenerationServiceTest`, which were updated to reflect new prompt content and canonical form injection, and they passed. 
- Executed the backend test suite covering landing HTML generation and the new `generateLandingHtmlWithLhmInjectsCanonicalFormWhenHtmlHasNoForm` test, and it passed. 
- CI run for the modified modules completed successfully with no regressions detected in the changed areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb58933408321a7bddf57b75a89ff)