### PR TITLE
Add landingPageDesignPreset artifact and integrate design-preset step across pipeline

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -60,12 +60,14 @@ public class ExperimentPipelineOpenAiClient {
     private static final String LANDING_COPY_TEMPLATE_PATH = "prompts/experiment/landing-copy.md";
     private static final String LANDING_WIREFRAME_TEMPLATE_PATH = "prompts/experiment/landing-wireframe.md";
     private static final String LANDING_IMAGE_PLANNING_TEMPLATE_PATH = "prompts/experiment/landing-image-planning.md";
+    private static final String LANDING_DESIGN_PRESET_TEMPLATE_PATH = "prompts/experiment/landing-design-preset.md";
     private static final String LANDING_HTML_TEMPLATE_PATH = "prompts/experiment/landing-html.md";
 
     private static final String CAMPAIGN_ANGLE_MARKER = "- visualAngle";
     private static final String LANDING_COPY_MARKER = "- messageMatchSource";
     private static final String LANDING_WIREFRAME_MARKER = "variantLayoutId";
     private static final String LANDING_IMAGE_PLANNING_MARKER = "visualDirectionSummary";
+    private static final String LANDING_DESIGN_PRESET_MARKER = "sectionPresets";
     private static final String LANDING_HTML_MARKER = "htmlDocument";
 
     private static final List<String> TEMPLATE_VARIABLE_KEYS = List.of(
@@ -1285,6 +1287,9 @@ public class ExperimentPipelineOpenAiClient {
         if (isLandingImagePlanningSection(job) && !base.contains(LANDING_IMAGE_PLANNING_MARKER)) {
             return appendSectionTemplate(base, LANDING_IMAGE_PLANNING_TEMPLATE_PATH, job);
         }
+        if (isLandingDesignPresetSection(job) && !base.contains(LANDING_DESIGN_PRESET_MARKER)) {
+            return appendSectionTemplate(base, LANDING_DESIGN_PRESET_TEMPLATE_PATH, job);
+        }
         if (isLandingHtmlSection(job) && !base.contains(LANDING_HTML_MARKER)) {
             return appendSectionTemplate(base, LANDING_HTML_TEMPLATE_PATH, job);
         }
@@ -1352,6 +1357,7 @@ public class ExperimentPipelineOpenAiClient {
                 LANDING_COPY_TEMPLATE_PATH,
                 LANDING_WIREFRAME_TEMPLATE_PATH,
                 LANDING_IMAGE_PLANNING_TEMPLATE_PATH,
+                LANDING_DESIGN_PRESET_TEMPLATE_PATH,
                 LANDING_HTML_TEMPLATE_PATH);
         for (String path : paths) {
             templates.put(path, readPromptTemplate(path));
@@ -1448,6 +1454,9 @@ public class ExperimentPipelineOpenAiClient {
         if (isLandingImagePlanningSection(job)) {
             return LANDING_IMAGE_PLANNING_TEMPLATE_PATH;
         }
+        if (isLandingDesignPresetSection(job)) {
+            return LANDING_DESIGN_PRESET_TEMPLATE_PATH;
+        }
         if (isLandingHtmlSection(job)) {
             return LANDING_HTML_TEMPLATE_PATH;
         }
@@ -1470,6 +1479,7 @@ public class ExperimentPipelineOpenAiClient {
             case LANDING_COPY_TEMPLATE_PATH -> "landingPageCopy";
             case LANDING_WIREFRAME_TEMPLATE_PATH -> "landingPageWireframe";
             case LANDING_IMAGE_PLANNING_TEMPLATE_PATH -> "landingPageImagePlanning";
+            case LANDING_DESIGN_PRESET_TEMPLATE_PATH -> "landingPageDesignPreset";
             case LANDING_HTML_TEMPLATE_PATH -> "landingPageHtml";
             default -> "unknown";
         };
@@ -1643,6 +1653,10 @@ public class ExperimentPipelineOpenAiClient {
 
     private boolean isLandingImagePlanningSection(ExperimentPipelineJobDto job) {
         return isSection(job, "landing-page-image-planning", "landing-page_image_planning", "landing-image-planning", "landing_image_planning");
+    }
+
+    private boolean isLandingDesignPresetSection(ExperimentPipelineJobDto job) {
+        return isSection(job, "landing-page-design-preset", "landing-page_design_preset", "landing-design-preset", "landing_design_preset");
     }
 
     private boolean isSection(ExperimentPipelineJobDto job, String... aliases) {

--- a/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
@@ -1,5 +1,5 @@
 template_id: landing-copy
-template_version: v1
+template_version: v2
 artifact_target: landingPageCopy
 
 SYSTEM_INSTRUCTIONS
@@ -26,24 +26,35 @@ Regras fixas da etapa:
 11. Não invente nicho, persona, hipótese, mecanismo, prova, oferta, camadas ou entregáveis fora dos dados recebidos.
 12. Não retornar campos legados fora do contrato (ex.: `messageMatchSummary`).
 13. Não usar taxonomia interna (`entryAsset`, `coreOffer` etc.) no texto final da copy.
+14. A copy final deve cobrir explicitamente o eixo **Dor → Resultado → Mecanismo → Prova → Oferta** ao longo de `hero`, `bodySections`, `ctaBlocks` e `faq`.
+15. `hero.supportingCopy` não pode ser vazio e deve conectar dor, urgência e próximo passo.
+16. Cada item de `bodySections` deve ter `summary` e `copy` substantivos (não usar placeholders).
+17. Cada item de `bodySections` deve conter no mínimo três bullets concretos e específicos.
+18. `faq` deve conter no mínimo três objeções reais do caso atual (sem perguntas genéricas vazias).
+19. `ctaBlocks` deve conter no mínimo duas variações posicionais de CTA (ex.: hero+final ou mid+final), mantendo coerência com `primaryCTA`.
+20. `ctaUrl` nunca pode conter placeholders (ex.: `{slug}`); sempre retornar URL resolvida para o fluxo atual.
+21. Esta etapa acontece **antes** do wireframe: a copy **não pode depender** de campos, `sectionId` ou estrutura do `landingPageWireframe`.
+22. Estruture a copy com ids e blocos semânticos canônicos próprios, para o wireframe posterior mapear layout sem alterar promessa/argumentação.
+23. Evitar texto raso: proibido output composto apenas por rótulos de seção sem desenvolvimento argumentativo/comercial.
+24. Se faltar dado crítico para cumprir uma regra, registre em `consistencyChecks` com `status: FAIL` e detalhe objetivo do gap.
 
 Diretriz obrigatória para HERO:
-14. `hero.headline`: foco na transformação principal (curta, direta, comercial).
-15. `hero.subheadline`: explicar ativo inicial/prova/primeiro passo quando existir, sem presumir formato fixo.
-16. `hero.supportingCopy`: contextualizar dor + urgência + ponte para a oferta principal atual.
-17. Não presumir formatos universais (kit, PDF, plano fixo, ciclo com duração fixa, regeneração etc.).
+25. `hero.headline`: foco na transformação principal (curta, direta, comercial).
+26. `hero.subheadline`: explicar ativo inicial/prova/primeiro passo quando existir, sem presumir formato fixo.
+27. `hero.supportingCopy`: contextualizar dor + urgência + ponte para a oferta principal atual.
+28. Não presumir formatos universais (kit, PDF, plano fixo, ciclo com duração fixa, regeneração etc.).
 
 Diretriz obrigatória para seção de OFERTA:
-18. Estruture a narrativa para suportar duas camadas quando os dados trouxerem essa distinção:
+29. Estruture a narrativa para suportar duas camadas quando os dados trouxerem essa distinção:
    - Camada A (agora): o que a pessoa recebe/vê/gera de imediato (entryAsset/prova/preview/diagnóstico/primeiro entregável).
    - Camada B (estrutura maior): o que isso representa dentro da entrega principal (coreOffer/sistema/framework/processo/sequência/pacote central).
-19. Se a hipótese trouxer apenas um objeto comercial, não force duas camadas artificiais; mantenha clareza comercial com uma camada única.
-20. Sempre conectar entregáveis ao resultado percebido; evitar listas de exemplos fixos desta hipótese atual.
+30. Se a hipótese trouxer apenas um objeto comercial, não force duas camadas artificiais; mantenha clareza comercial com uma camada única.
+31. Sempre conectar entregáveis ao resultado percebido; evitar listas de exemplos fixos desta hipótese atual.
 
 Diretriz obrigatória para títulos de seção:
-21. Títulos devem ser comerciais e específicos ao caso atual, porém reutilizáveis para hipóteses futuras.
-22. Não usar rótulos internos de taxonomia no output.
-23. Não fixar nomenclaturas da oferta atual como padrão universal.
+32. Títulos devem ser comerciais e específicos ao caso atual, porém reutilizáveis para hipóteses futuras.
+33. Não usar rótulos internos de taxonomia no output.
+34. Não fixar nomenclaturas da oferta atual como padrão universal.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -61,3 +72,10 @@ Campos obrigatórios:
 - ctaBlocks[] com placement, ctaVariant, ctaLabel, ctaUrl, matchAdCta, ctaSupport, messageMatchNotes
 - faq[] com question, answer, objectionTag
 - consistencyChecks[] com check, status (PASS/FAIL/WARNING), details
+
+Critérios mínimos de aceite no próprio output:
+- `bodySections.length >= 4`
+- cada `bodySections[i].bullets.length >= 3`
+- `faq.length >= 3`
+- `ctaBlocks.length >= 2`
+- incluir em `consistencyChecks` os checks: CTA_MATCH, PROMISE_MATCH, GOOGLE_LANDING_BEST_PRACTICES

--- a/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
@@ -1,0 +1,96 @@
+template_id: landing-design-preset
+template_version: v1
+artifact_target: landingPageDesignPreset
+
+SYSTEM_INSTRUCTIONS
+Você está gerando o artefato canônico `landingPageDesignPreset` para a landing page.
+
+Objetivo:
+- Definir tema visual e presets por seção de forma estruturada e determinística.
+- Não gerar HTML final nesta etapa.
+- Não inventar sectionId que não exista no wireframe.
+
+Regras:
+1. Preencher `presetId`, `theme`, `sectionPresets`, `componentPresets`, `motion` e `consistencyChecks`.
+2. `sectionPresets[]` deve cobrir todas as seções relevantes do wireframe.
+3. `surfaceStyle` só pode ser: `band`, `solid`, `gradient-soft`, `image-tint`.
+4. `contrastMode` só pode ser: `normal`, `high`, `soft`.
+5. `emphasis` só pode ser: `primary`, `secondary`, `support`.
+6. `motion.intensity` só pode ser: `none`, `subtle`, `moderate`.
+7. `consistencyChecks` deve incluir pelo menos:
+   - `THEME_CONTRAST`
+   - `CTA_VISUAL_HIERARCHY`
+   - `MOBILE_READABILITY`
+8. Saída obrigatoriamente em JSON válido no envelope do artefato.
+
+CASE_DATA
+{{CASE_DATA_BLOCK}}
+
+OUTPUT_CONTRACT
+Responda em JSON válido no formato:
+{
+  "landingPageDesignPreset": {
+    "presetId": "string",
+    "theme": {
+      "palette": {
+        "background": "string",
+        "surface": "string",
+        "textPrimary": "string",
+        "textMuted": "string",
+        "brandPrimary": "string",
+        "brandSecondary": "string",
+        "border": "string"
+      },
+      "typography": {
+        "fontFamily": "string",
+        "baseSize": "string",
+        "headingScale": "string"
+      },
+      "radius": {
+        "card": "string",
+        "field": "string",
+        "button": "string"
+      },
+      "shadow": {
+        "card": "string",
+        "focusRing": "string"
+      }
+    },
+    "sectionPresets": [
+      {
+        "sectionId": "string",
+        "surfaceStyle": "band | solid | gradient-soft | image-tint",
+        "contrastMode": "normal | high | soft",
+        "layoutPreset": "string",
+        "emphasis": "primary | secondary | support",
+        "notes": "string"
+      }
+    ],
+    "componentPresets": {
+      "hero": {
+        "titleMaxWidth": "string",
+        "summaryMaxWidth": "string",
+        "ctaVariant": "primary | ghost"
+      },
+      "form": {
+        "fieldSpacing": "string",
+        "labelWeight": "string",
+        "submitStyle": "pill | block"
+      },
+      "faq": {
+        "variant": "accordion | stacked-cards"
+      }
+    },
+    "motion": {
+      "enabled": true,
+      "intensity": "none | subtle | moderate"
+    },
+    "consistencyChecks": [
+      {
+        "check": "THEME_CONTRAST | CTA_VISUAL_HIERARCHY | MOBILE_READABILITY",
+        "status": "PASS | FAIL | WARNING",
+        "details": "string"
+      }
+    ]
+  }
+}

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -150,6 +150,8 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("ctaBlocks[]");
         assertThat(userPrompt).contains("consistencyChecks[]");
         assertThat(userPrompt).contains("complianceNotes");
+        assertThat(userPrompt).contains("copy **não pode depender** de campos, `sectionId` ou estrutura do `landingPageWireframe`");
+        assertThat(userPrompt).doesNotContain("compatível com os `sectionId` previstos no wireframe recebido em `CASE_DATA`");
     }
 
     @Test
@@ -870,7 +872,7 @@ class ExperimentPipelineOpenAiClientTest {
         Map<String, Object> templateTrace = (Map<String, Object>) trackedRequest.get("templateTrace");
         assertThat(templateTrace)
                 .containsEntry("template_id", "landing-copy")
-                .containsEntry("template_version", "v1")
+                .containsEntry("template_version", "v2")
                 .containsEntry("artifact_target", "landingPageCopy")
                 .containsEntry("model", "gpt-5.2");
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -187,6 +187,9 @@ public class Experiment {
     @Column(name = "landing_page_image_planning", columnDefinition = "LONGTEXT")
     private String landingPageImagePlanning;
 
+    @Column(name = "landing_page_design_preset", columnDefinition = "LONGTEXT")
+    private String landingPageDesignPreset;
+
     @Column(name = "landing_page_html", columnDefinition = "LONGTEXT")
     private String landingPageHtml;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -34,6 +34,7 @@ public class ExperimentDto {
     private String landingPageCopy;
     private String landingPageWireframe;
     private String landingPageImagePlanning;
+    private String landingPageDesignPreset;
     private String landingPageHtml;
     private InstagramAccountDto instagramAccount;
     private String facebookPixelId;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/ExperimentPipelineSection.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/ExperimentPipelineSection.java
@@ -9,7 +9,8 @@ public enum ExperimentPipelineSection {
     LANDING_PAGE_COPY("landing-page-copy", AD_IMAGE_BRIEFING),
     LANDING_PAGE_WIREFRAME("landing-page-wireframe", LANDING_PAGE_COPY),
     LANDING_PAGE_IMAGE_PLANNING("landing-page-image-planning", LANDING_PAGE_WIREFRAME),
-    LANDING_PAGE_HTML("landing-page-html", LANDING_PAGE_IMAGE_PLANNING);
+    LANDING_PAGE_DESIGN_PRESET("landing-page-design-preset", LANDING_PAGE_IMAGE_PLANNING),
+    LANDING_PAGE_HTML("landing-page-html", LANDING_PAGE_DESIGN_PRESET);
 
     private final String path;
     private final ExperimentPipelineSection predecessor;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -27,14 +27,15 @@ public class LandingHtmlModule {
         }
         StringBuilder sb = new StringBuilder();
         sb.append("\nPrompt v2 (inputs mínimos para LANDING_PAGE_HTML):\n");
-        sb.append("Use apenas os 3 insumos abaixo como fonte de verdade para montar o HTML final.\n");
+        sb.append("Use apenas os 4 insumos abaixo como fonte de verdade para montar o HTML final.\n");
         appendIfPresent(sb, "1) Wireframe aprovado (JSON)", experiment.getLandingPageWireframe());
         appendIfPresent(sb, "2) Texto da landing aprovado (JSON)", experiment.getLandingPageCopy());
+        appendIfPresent(sb, "3) Preset de design aprovado (JSON)", experiment.getLandingPageDesignPreset());
         String imageUrls = summarizeImageUrlsFromPlanning(experiment.getLandingPageImagePlanning());
         if (StringUtils.hasText(imageUrls)) {
-            sb.append("3) URLs de imagens aprovadas por seção:\n").append(imageUrls);
+            sb.append("4) URLs de imagens aprovadas por seção:\n").append(imageUrls);
         } else {
-            appendIfPresent(sb, "3) Planejamento de imagens (JSON)", experiment.getLandingPageImagePlanning());
+            appendIfPresent(sb, "4) Planejamento de imagens (JSON)", experiment.getLandingPageImagePlanning());
         }
         return sb.toString();
     }
@@ -59,8 +60,33 @@ public class LandingHtmlModule {
 
         Map<String, Object> copyRoot = safeReadObject(experiment.getLandingPageCopy());
         Map<String, Object> copy = unwrapSectionPayload(copyRoot, "landingPageCopy");
+        Map<String, Object> heroCopy = copy.get("hero") instanceof Map<?, ?> rawHero
+                ? (Map<String, Object>) rawHero
+                : Map.of();
+        List<Map<String, Object>> bodySectionsCopy = copy.get("bodySections") instanceof List<?> rawBodySections
+                ? rawBodySections.stream()
+                .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .map(item -> (Map<String, Object>) item)
+                .toList()
+                : List.of();
+        List<Map<String, Object>> ctaBlocksCopy = copy.get("ctaBlocks") instanceof List<?> rawCtaBlocks
+                ? rawCtaBlocks.stream()
+                .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .map(item -> (Map<String, Object>) item)
+                .toList()
+                : List.of();
+        List<Map<String, Object>> faqCopy = copy.get("faq") instanceof List<?> rawFaq
+                ? rawFaq.stream()
+                .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .map(item -> (Map<String, Object>) item)
+                .toList()
+                : List.of();
         String pageTitle = firstNonBlank(
                 asTrimmedString(copy.get("headline")),
+                asTrimmedString(heroCopy.get("headline")),
                 asTrimmedString(copy.get("title")),
                 asTrimmedString(formSpec.get("title")),
                 experiment.getName(),
@@ -68,9 +94,13 @@ public class LandingHtmlModule {
         String pageSummary = firstNonBlank(
                 asTrimmedString(copy.get("summary")),
                 asTrimmedString(copy.get("lead")),
-                "Landing gerada pelo LHM");
+                asTrimmedString(heroCopy.get("supportingCopy")));
 
         List<Map<String, Object>> plannedImages = extractImages(experiment.getLandingPageImagePlanning());
+        Map<String, Object> designRoot = safeReadObject(experiment.getLandingPageDesignPreset());
+        Map<String, Object> designPreset = unwrapSectionPayload(designRoot, "landingPageDesignPreset");
+        Map<String, Object> palette = extractPalette(designPreset);
+        Map<String, Map<String, Object>> sectionDesignPresets = indexSectionDesignPresets(designPreset);
 
         String formId = firstNonBlank(asTrimmedString(formSpec.get("formId")), "lead-capture-primary");
         String submitTarget = firstNonBlank(asTrimmedString(formSpec.get("submitTarget")), "/api/flows/submissions");
@@ -82,28 +112,64 @@ public class LandingHtmlModule {
                 .append("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />")
                 .append("<title>").append(escapeHtml(pageTitle)).append("</title>")
                 .append("<style>")
-                .append("body{font-family:Inter,Arial,sans-serif;margin:0;background:#f7f8fb;color:#141821;line-height:1.5;}")
-                .append("main{max-width:960px;margin:0 auto;padding:24px 16px 48px;display:grid;gap:16px;}")
-                .append(".card{background:#fff;border:1px solid #e6e8ef;border-radius:16px;padding:20px;}")
-                .append("h1,h2{margin:0 0 8px;} p{margin:0 0 10px;} form{display:grid;gap:10px;}")
-                .append("label{font-weight:600;font-size:14px;} input{width:100%;padding:10px;border:1px solid #d2d7e3;border-radius:10px;}")
-                .append("button{padding:12px 16px;border:0;border-radius:999px;background:#1c6dd0;color:#fff;font-weight:700;cursor:pointer;}")
-                .append("img{max-width:100%;height:auto;border-radius:12px;display:block;}")
-                .append("#form-feedback{display:none;margin-top:8px;font-weight:600;}")
+                .append(":root{--bg:").append(escapeCss(firstNonBlank(asTrimmedString(palette.get("background")), "#f3f5f9")))
+                .append(";--card:").append(escapeCss(firstNonBlank(asTrimmedString(palette.get("surface")), "#ffffff")))
+                .append(";--border:").append(escapeCss(firstNonBlank(asTrimmedString(palette.get("border")), "#e3e8f2")))
+                .append(";--text:").append(escapeCss(firstNonBlank(asTrimmedString(palette.get("textPrimary")), "#0f172a")))
+                .append(";--muted:").append(escapeCss(firstNonBlank(asTrimmedString(palette.get("textMuted")), "#475569")))
+                .append(";--brand:").append(escapeCss(firstNonBlank(asTrimmedString(palette.get("brandPrimary")), "#1d4ed8")))
+                .append(";--brand-dark:").append(escapeCss(firstNonBlank(asTrimmedString(palette.get("brandSecondary")), "#1e40af")))
+                .append(";}")
+                .append("*{box-sizing:border-box;}body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;margin:0;background:linear-gradient(180deg,#f8fafc 0%,var(--bg) 100%);color:var(--text);line-height:1.55;}")
+                .append("main{max-width:980px;margin:0 auto;padding:28px 16px 64px;display:grid;gap:14px;}")
+                .append(".card{background:var(--card);border:1px solid var(--border);border-radius:18px;padding:18px;box-shadow:0 10px 30px rgba(15,23,42,.04);}")
+                .append(".card[data-surface-contrast='high']{border-color:#cdd8ee;background:linear-gradient(180deg,#fff 0%,#f8fbff 100%);}")
+                .append(".surface-band{background:linear-gradient(180deg,#ffffff 0%,#f8fbff 100%);}")
+                .append(".surface-solid{background:#ffffff;}")
+                .append(".surface-gradient-soft{background:linear-gradient(135deg,#f8fbff 0%,#eef4ff 100%);}")
+                .append(".surface-image-tint{background:linear-gradient(135deg,#f8fafc 0%,#eef2ff 100%);}")
+                .append(".contrast-high{border-color:#bfd0ee;box-shadow:0 12px 32px rgba(29,78,216,.08);}")
+                .append(".contrast-soft{border-color:#e8edf6;background:#fbfdff;}")
+                .append("h1{font-size:clamp(1.65rem,4vw,2.1rem);line-height:1.15;margin:0 0 10px;font-weight:800;letter-spacing:-0.02em;}")
+                .append("h2{font-size:clamp(1.25rem,3.2vw,1.55rem);line-height:1.25;margin:0 0 10px;font-weight:750;letter-spacing:-0.01em;}")
+                .append("p{margin:0 0 10px;color:var(--muted);font-size:.98rem;}")
+                .append(".section-objective{font-size:.95rem;color:#334155;background:#f8fafc;border:1px dashed #d6e1f5;border-radius:12px;padding:10px 12px;margin:0 0 12px;}")
+                .append("form{display:grid;gap:12px;background:#fbfdff;border:1px solid #dbe5f5;border-radius:14px;padding:14px;}")
+                .append(".field{display:grid;gap:6px;}.help{color:#64748b;font-size:.88rem;line-height:1.35;}")
+                .append("label{font-weight:700;font-size:.92rem;color:#0f172a;}input{width:100%;padding:11px 12px;border:1px solid #cfd8e6;border-radius:10px;background:#fff;font-size:1rem;outline:none;}")
+                .append("input:focus{border-color:#3b82f6;box-shadow:0 0 0 3px rgba(59,130,246,.15);}button{padding:12px 16px;border:0;border-radius:999px;background:linear-gradient(135deg,var(--brand) 0%,var(--brand-dark) 100%);color:#fff;font-weight:800;cursor:pointer;letter-spacing:.01em;}")
+                .append(".hero-cta-link{display:inline-block;padding:10px 14px;border-radius:999px;background:linear-gradient(135deg,var(--brand) 0%,var(--brand-dark) 100%);color:#fff;text-decoration:none;font-weight:800;}")
+                .append("ul{margin:0 0 12px 18px;padding:0;}li{margin-bottom:6px;color:#1e293b;}")
+                .append(".faq-list details{border:1px solid #dbe5f5;border-radius:12px;background:#fff;padding:10px 12px;margin:0 0 10px;}")
+                .append(".faq-list summary{cursor:pointer;font-weight:700;color:#0f172a;}")
+                .append("button:hover{filter:brightness(1.04);}img{max-width:100%;height:auto;border-radius:12px;display:block;margin-top:8px;}")
+                .append("#form-feedback{display:none;margin-top:2px;font-weight:700;color:#1e3a8a;}")
                 .append("</style></head><body><main>");
 
         for (int sectionIndex = 0; sectionIndex < sections.size(); sectionIndex++) {
             Map<String, Object> section = sections.get(sectionIndex);
             String sectionId = firstNonBlank(asTrimmedString(section.get("sectionId")), "section");
             String sectionName = firstNonBlank(asTrimmedString(section.get("sectionName")), sectionId);
+            String sectionObjective = firstNonBlank(
+                    asTrimmedString(section.get("objective")),
+                    asTrimmedString(section.get("uiNotes")));
             Map<String, Object> surface = section.get("surfaceSpec") instanceof Map<?, ?> rawSurface
                     ? (Map<String, Object>) rawSurface
                     : Map.of();
             String surfaceToken = firstNonBlank(asTrimmedString(surface.get("surfaceToken")), "surface-base");
             String surfaceStyle = firstNonBlank(asTrimmedString(surface.get("style")), "band");
             String surfaceContrast = firstNonBlank(asTrimmedString(surface.get("contrastMode")), "normal");
+            Map<String, Object> sectionPreset = sectionDesignPresets.getOrDefault(sectionId.toLowerCase(), Map.of());
+            surfaceStyle = firstNonBlank(asTrimmedString(sectionPreset.get("surfaceStyle")), surfaceStyle);
+            surfaceContrast = firstNonBlank(asTrimmedString(sectionPreset.get("contrastMode")), surfaceContrast);
+            String surfaceStyleClass = "surface-" + normalizeCssToken(surfaceStyle);
+            String surfaceContrastClass = "contrast-" + normalizeCssToken(surfaceContrast);
 
-            html.append("<section class=\"card\" data-section-id=\"")
+            html.append("<section class=\"card ")
+                    .append(escapeAttr(surfaceStyleClass))
+                    .append(" ")
+                    .append(escapeAttr(surfaceContrastClass))
+                    .append("\" data-section-id=\"")
                     .append(escapeAttr(sectionId))
                     .append("\" data-surface-token=\"").append(escapeAttr(surfaceToken))
                     .append("\" data-surface-style=\"").append(escapeAttr(surfaceStyle))
@@ -115,6 +181,15 @@ public class LandingHtmlModule {
             if (sectionIndex == 0 && StringUtils.hasText(pageSummary)) {
                 html.append("<p>").append(escapeHtml(pageSummary)).append("</p>");
             }
+            if (sectionIndex == 0) {
+                html.append(buildHeroCopyMarkup(heroCopy, submitLabel, submitTarget));
+            }
+            if (sectionIndex > 0 && StringUtils.hasText(sectionObjective)) {
+                html.append("<p class=\"section-objective\">").append(escapeHtml(sectionObjective)).append("</p>");
+            }
+            html.append(buildBodySectionCopyMarkup(sectionId, bodySectionsCopy));
+            html.append(buildFaqMarkup(sectionId, faqCopy));
+            html.append(buildCtaBlocksMarkup(sectionId, ctaBlocksCopy));
 
             for (Map<String, Object> image : plannedImages) {
                 String imageSectionId = asTrimmedString(image.get("sectionId"));
@@ -239,6 +314,44 @@ public class LandingHtmlModule {
     }
 
     @SuppressWarnings("unchecked")
+    private Map<String, Object> extractPalette(Map<String, Object> designPreset) {
+        if (designPreset == null || designPreset.isEmpty()) {
+            return Map.of();
+        }
+        if (!(designPreset.get("theme") instanceof Map<?, ?> rawTheme)) {
+            return Map.of();
+        }
+        Map<String, Object> theme = (Map<String, Object>) rawTheme;
+        if (!(theme.get("palette") instanceof Map<?, ?> rawPalette)) {
+            return Map.of();
+        }
+        return (Map<String, Object>) rawPalette;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Map<String, Object>> indexSectionDesignPresets(Map<String, Object> designPreset) {
+        if (designPreset == null || designPreset.isEmpty()) {
+            return Map.of();
+        }
+        if (!(designPreset.get("sectionPresets") instanceof List<?> rawSectionPresets)) {
+            return Map.of();
+        }
+        java.util.LinkedHashMap<String, Map<String, Object>> indexed = new java.util.LinkedHashMap<>();
+        for (Object rawPreset : rawSectionPresets) {
+            if (!(rawPreset instanceof Map<?, ?> rawPresetMap)) {
+                continue;
+            }
+            Map<String, Object> preset = (Map<String, Object>) rawPresetMap;
+            String sectionId = asTrimmedString(preset.get("sectionId"));
+            if (!StringUtils.hasText(sectionId)) {
+                continue;
+            }
+            indexed.put(sectionId.toLowerCase(), preset);
+        }
+        return indexed;
+    }
+
+    @SuppressWarnings("unchecked")
     private String buildFormMarkup(String formId,
                                    String submitTarget,
                                    String submitLabel,
@@ -301,6 +414,135 @@ public class LandingHtmlModule {
                 + "\" data-visual-weight=\"" + escapeAttr(visualWeight)
                 + "\" data-distance-to-cta=\"" + escapeAttr(distanceToCta)
                 + "\" data-supports-form-conversion=\"" + supportsFormConversion + "\" />";
+    }
+
+    private String buildHeroCopyMarkup(Map<String, Object> heroCopy, String fallbackSubmitLabel, String fallbackSubmitTarget) {
+        if (heroCopy == null || heroCopy.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        String promise = asTrimmedString(heroCopy.get("promise"));
+        String supportingCopy = asTrimmedString(heroCopy.get("supportingCopy"));
+        String proofBadge = asTrimmedString(heroCopy.get("proofBadge"));
+        String microcopy = asTrimmedString(heroCopy.get("microcopy"));
+        String ctaLabel = firstNonBlank(asTrimmedString(heroCopy.get("ctaLabel")), fallbackSubmitLabel);
+        String ctaUrl = firstNonBlank(asTrimmedString(heroCopy.get("ctaUrl")), fallbackSubmitTarget);
+        if (StringUtils.hasText(promise)) {
+            sb.append("<p class=\"section-objective\">").append(escapeHtml(promise)).append("</p>");
+        }
+        if (StringUtils.hasText(supportingCopy)) {
+            sb.append("<p>").append(escapeHtml(supportingCopy)).append("</p>");
+        }
+        if (StringUtils.hasText(proofBadge)) {
+            sb.append("<p><strong>").append(escapeHtml(proofBadge)).append("</strong></p>");
+        }
+        if (StringUtils.hasText(microcopy)) {
+            sb.append("<p>").append(escapeHtml(microcopy)).append("</p>");
+        }
+        if (StringUtils.hasText(ctaLabel) && StringUtils.hasText(ctaUrl)) {
+            sb.append("<p><a class=\"hero-cta-link\" href=\"")
+                    .append(escapeAttr(ctaUrl))
+                    .append("\" target=\"_blank\" rel=\"noopener noreferrer\">")
+                    .append(escapeHtml(ctaLabel))
+                    .append("</a></p>");
+        }
+        return sb.toString();
+    }
+
+    private String buildBodySectionCopyMarkup(String sectionId, List<Map<String, Object>> bodySectionsCopy) {
+        if (!StringUtils.hasText(sectionId) || bodySectionsCopy == null || bodySectionsCopy.isEmpty()) {
+            return "";
+        }
+        for (Map<String, Object> bodySection : bodySectionsCopy) {
+            String bodySectionId = asTrimmedString(bodySection.get("sectionId"));
+            if (!StringUtils.hasText(bodySectionId) || !sectionId.equalsIgnoreCase(bodySectionId)) {
+                continue;
+            }
+            StringBuilder sb = new StringBuilder();
+            appendParagraph(sb, asTrimmedString(bodySection.get("summary")));
+            appendParagraph(sb, asTrimmedString(bodySection.get("copy")));
+            if (bodySection.get("bullets") instanceof List<?> rawBullets) {
+                StringBuilder bulletsMarkup = new StringBuilder();
+                for (Object rawBullet : rawBullets) {
+                    String bullet = asTrimmedString(rawBullet);
+                    if (!StringUtils.hasText(bullet)) {
+                        continue;
+                    }
+                    bulletsMarkup.append("<li>").append(escapeHtml(bullet)).append("</li>");
+                }
+                if (bulletsMarkup.length() > 0) {
+                    sb.append("<ul>").append(bulletsMarkup).append("</ul>");
+                }
+            }
+            appendParagraph(sb, asTrimmedString(bodySection.get("ctaSupport")));
+            return sb.toString();
+        }
+        return "";
+    }
+
+    private String buildFaqMarkup(String sectionId, List<Map<String, Object>> faqCopy) {
+        if (!StringUtils.hasText(sectionId) || faqCopy == null || faqCopy.isEmpty()) {
+            return "";
+        }
+        if (!sectionId.toLowerCase().contains("faq")) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder("<div class=\"faq-list\">");
+        for (Map<String, Object> faqItem : faqCopy) {
+            String question = asTrimmedString(faqItem.get("question"));
+            String answer = asTrimmedString(faqItem.get("answer"));
+            if (!StringUtils.hasText(question) || !StringUtils.hasText(answer)) {
+                continue;
+            }
+            sb.append("<details><summary>")
+                    .append(escapeHtml(question))
+                    .append("</summary><p>")
+                    .append(escapeHtml(answer))
+                    .append("</p></details>");
+        }
+        sb.append("</div>");
+        return sb.toString();
+    }
+
+    private String buildCtaBlocksMarkup(String sectionId, List<Map<String, Object>> ctaBlocksCopy) {
+        if (!StringUtils.hasText(sectionId) || ctaBlocksCopy == null || ctaBlocksCopy.isEmpty()) {
+            return "";
+        }
+        String lowerSectionId = sectionId.toLowerCase();
+        String placementHint = lowerSectionId.contains("sticky") ? "sticky"
+                : lowerSectionId.contains("final") || lowerSectionId.contains("cta") ? "final"
+                : lowerSectionId.contains("hero") ? "hero"
+                : "mid";
+        StringBuilder sb = new StringBuilder();
+        for (Map<String, Object> ctaBlock : ctaBlocksCopy) {
+            String placement = asTrimmedString(ctaBlock.get("placement"));
+            String ctaVariant = asTrimmedString(ctaBlock.get("ctaVariant"));
+            if (StringUtils.hasText(placement) && !placementHint.equalsIgnoreCase(placement)) {
+                continue;
+            }
+            if (StringUtils.hasText(ctaVariant) && !placementHint.equalsIgnoreCase(ctaVariant) && !lowerSectionId.contains("cta")) {
+                continue;
+            }
+            String ctaLabel = asTrimmedString(ctaBlock.get("ctaLabel"));
+            String ctaUrl = asTrimmedString(ctaBlock.get("ctaUrl"));
+            String ctaSupport = asTrimmedString(ctaBlock.get("ctaSupport"));
+            if (StringUtils.hasText(ctaLabel) && StringUtils.hasText(ctaUrl)) {
+                sb.append("<p><a class=\"hero-cta-link\" href=\"")
+                        .append(escapeAttr(ctaUrl))
+                        .append("\" target=\"_blank\" rel=\"noopener noreferrer\">")
+                        .append(escapeHtml(ctaLabel))
+                        .append("</a></p>");
+            }
+            appendParagraph(sb, ctaSupport);
+        }
+        return sb.toString();
+    }
+
+    private void appendParagraph(StringBuilder sb, String text) {
+        if (!StringUtils.hasText(text)) {
+            return;
+        }
+        sb.append("<p>").append(escapeHtml(text)).append("</p>");
     }
 
     private String buildSubmissionScript(String formId) {
@@ -366,5 +608,23 @@ public class LandingHtmlModule {
     private String escapeAttr(String value) {
         if (value == null) return "";
         return escapeHtml(value).replace("\"", "&quot;");
+    }
+
+    private String escapeCss(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace(";", "").replace("{", "").replace("}", "");
+    }
+
+    private String normalizeCssToken(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "normal";
+        }
+        String normalized = value.trim().toLowerCase()
+                .replace('_', '-')
+                .replace(' ', '-')
+                .replaceAll("[^a-z0-9-]", "");
+        return StringUtils.hasText(normalized) ? normalized : "normal";
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -669,16 +669,18 @@ public class ExperimentPipelineGenerationService {
             case LANDING_PAGE_COPY -> experiment.getLandingPageCopy();
             case LANDING_PAGE_WIREFRAME -> experiment.getLandingPageWireframe();
             case LANDING_PAGE_IMAGE_PLANNING -> experiment.getLandingPageImagePlanning();
+            case LANDING_PAGE_DESIGN_PRESET -> experiment.getLandingPageDesignPreset();
             case LANDING_PAGE_HTML -> experiment.getLandingPageHtml();
         };
         if (!StringUtils.hasText(predecessorContent)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "A seção " + section.path() + " depende da seção " + predecessor.path() + " já concluída");
         }
-        if (section == ExperimentPipelineSection.LANDING_PAGE_HTML
+        if ((section == ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET
+                || section == ExperimentPipelineSection.LANDING_PAGE_HTML)
                 && !frameworkImageGenerationService.allPlanningImagesCompleted(experiment.getId())) {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "A seção landing-page-html depende da geração completa das imagens planejadas da landing");
+                    "A seção " + section.path() + " depende da geração completa das imagens planejadas da landing");
         }
     }
 
@@ -693,7 +695,7 @@ public class ExperimentPipelineGenerationService {
         if (section == ExperimentPipelineSection.LANDING_PAGE_IMAGE_PLANNING) {
             frameworkImageGenerationService.enqueueJobsForExperiment(experimentId);
             if (frameworkImageGenerationService.allPlanningImagesCompleted(experimentId)) {
-                enqueueJob(job.getExperiment(), ExperimentPipelineSection.LANDING_PAGE_HTML, deriveFollowUpRequest(request));
+                enqueueJob(job.getExperiment(), ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET, deriveFollowUpRequest(request));
             }
             return;
         }
@@ -1153,6 +1155,25 @@ public class ExperimentPipelineGenerationService {
             return;
         }
 
+        if (section == ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET) {
+            sb.append("\nDiretriz específica para Preset de Design da Landing:\n");
+            sb.append("Contexto do nicho: ").append(niche).append("\n");
+            sb.append("Ângulo da campanha: ").append(campaignAngle).append("\n");
+            sb.append("Promessa principal: ").append(primaryPromise).append("\n");
+            sb.append("CTA obrigatório: ").append(landingCtaForInstructions).append("\n");
+            sb.append("\nObjetivo:\n");
+            sb.append("Definir um preset visual estruturado para a landing (tema + presets por seção) sem gerar HTML final nesta etapa.\n\n");
+            sb.append("Regras:\n");
+            sb.append("1. Gerar objeto `landingPageDesignPreset` com presetId, theme, sectionPresets, componentPresets, motion e consistencyChecks.\n");
+            sb.append("2. Em sectionPresets, cobrir todas as sectionId existentes no wireframe atual.\n");
+            sb.append("3. surfaceStyle deve usar apenas: band, solid, gradient-soft, image-tint.\n");
+            sb.append("4. contrastMode deve usar apenas: normal, high, soft.\n");
+            sb.append("5. Não inventar novas seções; somente mapear sectionId do wireframe.\n");
+            sb.append("6. consistencyChecks deve incluir THEME_CONTRAST e MOBILE_READABILITY.\n");
+            sb.append("7. Não gerar HTML, CSS bruto ou JS nesta etapa; apenas preset estruturado.\n");
+            return;
+        }
+
         if (section == ExperimentPipelineSection.LANDING_PAGE_HTML) {
             sb.append("\nDiretriz específica para implementação final da landing (HTML/CSS/JS):\n");
             sb.append(COMMON_CAMPAIGN_ASSET_RULES).append("\n");
@@ -1246,6 +1267,7 @@ public class ExperimentPipelineGenerationService {
         appendSectionOutputIfEligible(sb, section, ExperimentPipelineSection.LANDING_PAGE_COPY, "Textos da landing", completedOutputs);
         appendSectionOutputIfEligible(sb, section, ExperimentPipelineSection.LANDING_PAGE_WIREFRAME, "Wireframe da landing", completedOutputs);
         appendSectionOutputIfEligible(sb, section, ExperimentPipelineSection.LANDING_PAGE_IMAGE_PLANNING, "Planejamento de imagens da landing", completedOutputs);
+        appendSectionOutputIfEligible(sb, section, ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET, "Preset de design da landing", completedOutputs);
     }
 
     private boolean shouldIncludeSectionOutput(ExperimentPipelineSection targetSection,
@@ -1318,6 +1340,7 @@ public class ExperimentPipelineGenerationService {
             case LANDING_PAGE_COPY -> experiment.setLandingPageCopy(normalized);
             case LANDING_PAGE_WIREFRAME -> experiment.setLandingPageWireframe(normalized);
             case LANDING_PAGE_IMAGE_PLANNING -> experiment.setLandingPageImagePlanning(normalized);
+            case LANDING_PAGE_DESIGN_PRESET -> experiment.setLandingPageDesignPreset(normalized);
             case LANDING_PAGE_HTML -> {
                 validateLandingHtmlFormConsistency(experiment, normalized);
                 validateLandingHtmlSubmissionRuntime(experiment, normalized);
@@ -1550,6 +1573,7 @@ public class ExperimentPipelineGenerationService {
         Document document = Jsoup.parse(htmlDocument, "", org.jsoup.parser.Parser.htmlParser());
         String expectedFormId = asTrimmedString(wireframeFormSpec.get("formId"));
         String expectedSubmitTarget = asTrimmedString(wireframeFormSpec.get("submitTarget"));
+        String submitLabel = asTrimmedString(wireframeFormSpec.get("submitLabel"));
         Element form = StringUtils.hasText(expectedFormId)
                 ? document.selectFirst("form#" + expectedFormId)
                 : document.selectFirst("form#lead-capture-primary");
@@ -1557,7 +1581,7 @@ public class ExperimentPipelineGenerationService {
             form = document.selectFirst("form");
         }
         if (form == null) {
-            return htmlDocument;
+            form = createCanonicalFormShell(document, expectedFormId, expectedSubmitTarget, submitLabel);
         }
         if (StringUtils.hasText(expectedFormId)) {
             form.attr("id", expectedFormId);
@@ -1573,6 +1597,36 @@ public class ExperimentPipelineGenerationService {
         bindExternalSubmitButtonsToForm(document, form);
         ensureDefaultSubmitRuntime(document, form);
         return document.outerHtml();
+    }
+
+    private Element createCanonicalFormShell(Document document,
+                                             String expectedFormId,
+                                             String expectedSubmitTarget,
+                                             String submitLabel) {
+        Element body = document.body();
+        if (body == null) {
+            body = document.appendElement("body");
+        }
+        Element container = document.selectFirst("main");
+        if (container == null) {
+            container = body;
+        }
+        Element form = container.appendElement("form");
+        form.attr("id", StringUtils.hasText(expectedFormId) ? expectedFormId : "lead-capture-primary");
+        form.attr("method", "post");
+        if (StringUtils.hasText(expectedSubmitTarget)) {
+            form.attr("action", expectedSubmitTarget);
+        }
+        form.appendElement("button")
+                .attr("type", "submit")
+                .text(StringUtils.hasText(submitLabel) ? submitLabel : "Enviar");
+        form.appendElement("p")
+                .attr("id", "form-feedback")
+                .attr("role", "status");
+        container.appendElement("div")
+                .attr("id", "submit-success-state")
+                .attr("style", "display:none");
+        return form;
     }
 
     private void bindExternalSubmitButtonsToForm(Document document, Element form) {
@@ -2163,6 +2217,10 @@ public class ExperimentPipelineGenerationService {
                     "landingPageImagePlanning",
                     landingPageImagePlanningFieldSchema(),
                     metadataSchema);
+            case LANDING_PAGE_DESIGN_PRESET -> schemaWithMetadata(
+                    "landingPageDesignPreset",
+                    landingPageDesignPresetFieldSchema(),
+                    metadataSchema);
             case LANDING_PAGE_HTML -> schemaWithMetadata("landingPageHtml", landingPageHtmlFieldSchema(), metadataSchema);
         };
     }
@@ -2291,6 +2349,57 @@ public class ExperimentPipelineGenerationService {
                 ),
                 "required", List.of("pageGoal", "images", "consistencyChecks")
         );
+    }
+
+    private Map<String, Object> landingPageDesignPresetFieldSchema() {
+        Map<String, Object> paletteSchema = Map.of(
+                "type", "object",
+                "additionalProperties", false,
+                "properties", Map.of(
+                        "background", stringSchema(),
+                        "surface", stringSchema(),
+                        "textPrimary", stringSchema(),
+                        "textMuted", stringSchema(),
+                        "brandPrimary", stringSchema(),
+                        "brandSecondary", stringSchema(),
+                        "border", stringSchema()),
+                "required", List.of("background", "surface", "textPrimary", "textMuted", "brandPrimary", "brandSecondary", "border"));
+        Map<String, Object> sectionPresetSchema = Map.of(
+                "type", "object",
+                "additionalProperties", false,
+                "properties", Map.of(
+                        "sectionId", stringSchema(),
+                        "surfaceStyle", Map.of("type", "string", "enum", List.of("band", "solid", "gradient-soft", "image-tint")),
+                        "contrastMode", Map.of("type", "string", "enum", List.of("normal", "high", "soft")),
+                        "layoutPreset", stringSchema(),
+                        "emphasis", Map.of("type", "string", "enum", List.of("primary", "secondary", "support")),
+                        "notes", stringSchema()),
+                "required", List.of("sectionId", "surfaceStyle", "contrastMode", "layoutPreset", "emphasis", "notes"));
+        return Map.of(
+                "type", "object",
+                "additionalProperties", false,
+                "properties", Map.of(
+                        "presetId", stringSchema(),
+                        "theme", Map.of(
+                                "type", "object",
+                                "additionalProperties", false,
+                                "properties", Map.of(
+                                        "palette", paletteSchema,
+                                        "typography", Map.of("type", "object", "additionalProperties", true),
+                                        "radius", Map.of("type", "object", "additionalProperties", true),
+                                        "shadow", Map.of("type", "object", "additionalProperties", true)),
+                                "required", List.of("palette")),
+                        "sectionPresets", Map.of("type", "array", "minItems", 1, "items", sectionPresetSchema),
+                        "componentPresets", Map.of("type", "object", "additionalProperties", true),
+                        "motion", Map.of(
+                                "type", "object",
+                                "additionalProperties", false,
+                                "properties", Map.of(
+                                        "enabled", Map.of("type", "boolean"),
+                                        "intensity", Map.of("type", "string", "enum", List.of("none", "subtle", "moderate"))),
+                                "required", List.of("enabled", "intensity")),
+                        "consistencyChecks", Map.of("type", "array", "minItems", 1, "items", consistencyCheckSchema())),
+                "required", List.of("presetId", "theme", "sectionPresets", "componentPresets", "motion", "consistencyChecks"));
     }
 
     private Map<String, Object> landingPageHtmlFieldSchema() {

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-25-experiment-landing-design-preset.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-25-experiment-landing-design-preset.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-04-25-experiment-landing-design-preset
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        and:
+          - dbms:
+              type: mysql
+          - sqlCheck:
+              expectedResult: "0"
+              sql: |
+                SELECT COUNT(*)
+                FROM information_schema.COLUMNS
+                WHERE TABLE_SCHEMA = DATABASE()
+                  AND TABLE_NAME = 'experiment'
+                  AND COLUMN_NAME = 'landing_page_design_preset'
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment
+                ADD COLUMN landing_page_design_preset LONGTEXT NULL
+                AFTER landing_page_image_planning;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -656,3 +656,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-04-17-mds-sprint1-base.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-04-25-experiment-landing-design-preset.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
@@ -98,10 +98,70 @@ class LandingHtmlModuleTest {
         String html = module.assembleHtmlDocument(experiment);
 
         assertTrue(html.contains("data-section-id=\"benefits\""));
+        assertTrue(html.contains("class=\"card surface-solid contrast-high\""));
         assertTrue(html.contains("data-surface-token=\"surface-benefits\""));
         assertTrue(html.contains("data-surface-style=\"solid\""));
         assertTrue(html.contains("data-surface-contrast=\"high\""));
         assertFalse(html.contains("data-section-id=\"hero\""));
         assertFalse(html.contains("data-section-id=\"form\""));
+    }
+
+    @Test
+    void assembleHtmlDocumentRendersBodyFaqAndCtaFromLandingCopy() {
+        Experiment experiment = new Experiment();
+        experiment.setName("Teste LHM Copy Completa");
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {"sectionId": "hero", "sectionName": "Hero", "contentType": "split", "surfaceSpec": {"surfaceToken": "surface-hero", "style": "band", "contrastMode": "high"}},
+                      {"sectionId": "mechanism_01", "sectionName": "Mecanismo", "contentType": "split", "surfaceSpec": {"surfaceToken": "surface-mech", "style": "solid", "contrastMode": "normal"}},
+                      {"sectionId": "faq_01", "sectionName": "FAQ", "contentType": "faq", "surfaceSpec": {"surfaceToken": "surface-faq", "style": "band", "contrastMode": "soft"}},
+                      {"sectionId": "cta_01_final", "sectionName": "CTA Final", "contentType": "cta", "surfaceSpec": {"surfaceToken": "surface-cta", "style": "solid", "contrastMode": "high"}}
+                    ],
+                    "formSpec": {
+                      "formId": "lead-capture-primary",
+                      "submitTarget": "/api/flows/submissions",
+                      "submitLabel": "Enviar",
+                      "fields": [{"name": "nome", "type": "text", "required": true}]
+                    }
+                  }
+                }
+                """);
+        experiment.setLandingPageCopy("""
+                {
+                  "landingPageCopy": {
+                    "hero": {
+                      "promise": "Promessa principal",
+                      "supportingCopy": "Resumo do valor",
+                      "ctaLabel": "Quero agora",
+                      "ctaUrl": "https://example.com/cta"
+                    },
+                    "bodySections": [
+                      {
+                        "sectionId": "mechanism_01",
+                        "summary": "Resumo mecanismo",
+                        "copy": "Copy mecanismo",
+                        "bullets": ["Passo 1", "Passo 2", "Passo 3"],
+                        "ctaSupport": "Apoio do CTA"
+                      }
+                    ],
+                    "faq": [
+                      {"question": "Dúvida 1", "answer": "Resposta 1"}
+                    ],
+                    "ctaBlocks": [
+                      {"placement": "final", "ctaVariant": "final", "ctaLabel": "Final CTA", "ctaUrl": "https://example.com/final", "ctaSupport": "Suporte final"}
+                    ]
+                  }
+                }
+                """);
+
+        String html = module.assembleHtmlDocument(experiment);
+
+        assertTrue(html.contains("Promessa principal"));
+        assertTrue(html.contains("Resumo mecanismo"));
+        assertTrue(html.contains("Passo 1"));
+        assertTrue(html.contains("<details><summary>Dúvida 1"));
+        assertTrue(html.contains("Final CTA"));
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -207,6 +207,35 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void generateLandingHtmlWithLhmInjectsCanonicalFormWhenHtmlHasNoForm() {
+        Experiment experiment = new Experiment();
+        experiment.setId(35L);
+        experiment.setLandingPageWireframe("{\"landingPageWireframe\":{\"formSpec\":{\"formId\":\"lead-capture-primary\",\"submitTarget\":\"/api/flows/exp-35/submissions\",\"fields\":[{\"name\":\"nome\",\"type\":\"text\",\"required\":true},{\"name\":\"email\",\"type\":\"email\",\"required\":true}],\"submitLabel\":\"Enviar\"},\"sectionOrder\":[{\"sectionId\":\"hero\",\"sectionName\":\"Hero\",\"contentType\":\"form\",\"surfaceSpec\":{\"surfaceToken\":\"surface-base\",\"style\":\"band\",\"contrastMode\":\"normal\"}}]}}");
+        experiment.setLandingPageCopy("{\"landingPageCopy\":{\"headline\":\"Headline\"}}");
+        experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":{\"images\":[]}}");
+
+        when(experimentRepository.findById(35L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(landingHtmlModule.assembleHtmlDocument(experiment)).thenReturn("""
+                <!doctype html><html><body>
+                <main>
+                  <section data-section-id="hero" data-surface-token="surface-base" data-surface-style="band" data-surface-contrast="normal">
+                    <h1>Hero</h1>
+                  </section>
+                </main>
+                </body></html>
+                """);
+        when(experimentMapper.toDto(experiment)).thenReturn(new ExperimentDto());
+
+        service.generateLandingHtmlWithLhm(35L);
+
+        assertTrue(experiment.getLandingPageHtml().contains("form id=\"lead-capture-primary\""));
+        assertTrue(experiment.getLandingPageHtml().contains("name=\"nome\""));
+        assertTrue(experiment.getLandingPageHtml().contains("name=\"email\""));
+        verify(generationService).recordGeneration(any(AiWorkerGenerationRequest.class));
+    }
+
+    @Test
     void generateLandingHtmlWithLhmTracksFailedAttemptWhenPromptPreparationFails() {
         Experiment experiment = new Experiment();
         experiment.setId(34L);
@@ -776,7 +805,7 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
-    void generateLandingHtmlFailsWhenPlannedImagesAreNotFullyGenerated() {
+    void generateLandingDesignPresetFailsWhenPlannedImagesAreNotFullyGenerated() {
         Experiment experiment = new Experiment();
         experiment.setId(302L);
         experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":{\"images\":[{\"sectionId\":\"hero\",\"imagePrompt\":\"x\"}]}}");
@@ -785,7 +814,7 @@ class ExperimentPipelineGenerationServiceTest {
         when(frameworkImageGenerationService.allPlanningImagesCompleted(302L)).thenReturn(false);
 
         ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-                () -> service.generate(302L, ExperimentPipelineSection.LANDING_PAGE_HTML, new com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationRequest()));
+                () -> service.generate(302L, ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET, new com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationRequest()));
 
         assertTrue(ex.getReason().contains("geração completa das imagens"));
     }

--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -176,8 +176,8 @@ de publicação deve ser simplificado em **3 passos**:
 1. **Geração da landing pela IA**
    O pipeline gera o HTML final da landing para o experimento.
    A composição final deve ser executada pelo **LHM (Landing HTML Module)**,
-   responsável por consolidar wireframe aprovado, copy aprovada e URLs de
-   imagens aprovadas em um único `htmlDocument`.
+   responsável por consolidar wireframe aprovado, copy aprovada, design preset
+   aprovado e URLs de imagens aprovadas em um único `htmlDocument`.
 2. **Aprovação única do usuário**
    O usuário aprova a landing uma única vez na interface administrativa.
 3. **Publicação automática pelo sistema**
@@ -202,7 +202,7 @@ oficialmente como:
 
 Definição operacional do LHM:
 
-- recebe como entradas canônicas: `wireframe`, `copy` e `imagens (URLs)`;
+- recebe como entradas canônicas: `wireframe`, `copy`, `designPreset` e `imagens (URLs)`;
 - entrega como saída canônica: `htmlDocument` final da landing;
 - roda no backend como fonte única de verdade para aplicação de contratos e
   validações de publicação.

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -2,6 +2,14 @@
 
 Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 
+> 🔴 **REGRA CANÔNICA EM DESTAQUE — LHM**
+>
+> O **LHM (Landing HTML Module)** é o módulo **determinístico** responsável por gerar o HTML final da landing page.
+>
+> - O LHM **não** é uma etapa de ideação criativa livre da copy.
+> - O LHM deve renderizar de forma previsível a partir dos artefatos canônicos (ex.: `landingPageCopy` e `landingPageWireframe`) e contratos vigentes.
+> - Mudanças no pipeline devem preservar essa responsabilidade para reduzir drift entre especificação, backend e página publicada.
+
 ## Observação importante — independência dos experimentos
 
 - Cada experimento deve ser tratado de forma independente, sem reutilização implícita de artefatos entre experimentos.
@@ -157,6 +165,34 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 }
 ```
 
+### Regras canônicas de qualidade para geração da `landingPageCopy`
+
+Para considerar a copy **rica** e **compatível com as especificações**, a etapa de geração deve cumprir os critérios abaixo antes da renderização pelo LHM:
+
+1. **Cobertura completa de narrativa**
+   - A copy deve cobrir explicitamente o eixo: **Dor → Resultado → Mecanismo → Prova → Oferta**.
+   - Essa cobertura deve existir em `hero` + `bodySections` + `ctaBlocks` + `faq`.
+
+2. **Densidade mínima de conteúdo**
+   - `hero.supportingCopy` não pode ser vazio.
+   - Cada item de `bodySections` deve conter `summary` e `copy` não vazios.
+   - Cada item de `bodySections` deve conter ao menos 3 itens em `bullets`.
+   - `faq` deve conter no mínimo 3 perguntas com `question` e `answer` preenchidos.
+   - `ctaBlocks` deve conter no mínimo 2 variações (por exemplo: `mid` e `final` ou `hero` e `final`).
+
+3. **Independência da etapa de wireframe (ordem canônica)**
+   - A geração de `landingPageCopy` acontece **antes** de `landingPageWireframe`; portanto, a copy **não pode depender** de `sectionOrder`, `ctaSlot` ou qualquer campo de wireframe inexistente nessa etapa.
+   - O alinhamento estrutural com layout acontece na etapa posterior (`landingPageWireframe`), preservando a promessa e a argumentação aprovadas na copy.
+   - Toda `ctaUrl` deve ser resolvida (sem placeholders como `{slug}`).
+
+4. **Consistência de promessa e CTA**
+   - `hero.promise`, `primaryCTA` e `ctaBlocks[*].matchAdCta` devem manter coerência semântica.
+   - `consistencyChecks` deve incluir, no mínimo, os checks: `CTA_MATCH`, `PROMISE_MATCH` e `GOOGLE_LANDING_BEST_PRACTICES`.
+
+5. **Critério de bloqueio**
+   - Se qualquer regra acima falhar, o artefato permanece em `DRAFT` e não pode seguir para renderização final.
+   - O LHM só deve processar copy com validação aprovada (`status = VALIDATED` ou `APPROVED`).
+
 ## `landingPageWireframe`
 
 ```json
@@ -294,11 +330,83 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 }
 ```
 
+## `landingPageDesignPreset`
+
+> Artefato canônico para separar decisão de estética/tema da etapa final de composição HTML.
+> O objetivo é permitir evolução visual com previsibilidade, sem transformar o LHM em camada de ideação livre.
+
+```json
+{
+  "presetId": "string",
+  "theme": {
+    "palette": {
+      "background": "string",
+      "surface": "string",
+      "textPrimary": "string",
+      "textMuted": "string",
+      "brandPrimary": "string",
+      "brandSecondary": "string",
+      "border": "string"
+    },
+    "typography": {
+      "fontFamily": "string",
+      "baseSize": "string",
+      "headingScale": "string"
+    },
+    "radius": {
+      "card": "string",
+      "field": "string",
+      "button": "string"
+    },
+    "shadow": {
+      "card": "string",
+      "focusRing": "string"
+    }
+  },
+  "sectionPresets": [
+    {
+      "sectionId": "string",
+      "surfaceStyle": "band | solid | gradient-soft | image-tint",
+      "contrastMode": "normal | high | soft",
+      "layoutPreset": "hero-focus | form-focus | proof-grid | narrative-stack | faq-clean | cta-strong",
+      "emphasis": "primary | secondary | support",
+      "notes": "string"
+    }
+  ],
+  "componentPresets": {
+    "hero": {
+      "titleMaxWidth": "string",
+      "summaryMaxWidth": "string",
+      "ctaVariant": "primary | ghost"
+    },
+    "form": {
+      "fieldSpacing": "string",
+      "labelWeight": "string",
+      "submitStyle": "pill | block"
+    },
+    "faq": {
+      "variant": "accordion | stacked-cards"
+    }
+  },
+  "motion": {
+    "enabled": "boolean",
+    "intensity": "none | subtle | moderate"
+  },
+  "consistencyChecks": [
+    {
+      "check": "THEME_CONTRAST | CTA_VISUAL_HIERARCHY | MOBILE_READABILITY",
+      "status": "PASS | FAIL | WARNING",
+      "details": "string"
+    }
+  ]
+}
+```
+
 ## `landingPageHtml`
 
 > **Owner canônico de composição:** **LHM (Landing HTML Module)**.
 > O LHM é o módulo de backend responsável por receber os insumos aprovados
-> (`wireframe`, `copy` e `imagens com URL`) e consolidá-los no
+> (`wireframe`, `copy`, `designPreset` e `imagens com URL`) e consolidá-los no
 > `htmlDocument` final da landing.
 >
 > **Leitura operacional obrigatória para evolução do LHM:** `docs/canonical/lhm-evolution-guide.v1.md`.

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -28,6 +28,8 @@
 4. **Flags derivadas não são verdade primária.** Rótulos de UI, atalhos de leitura, campos calculados e indicadores transitórios são projeções, não a regra original.
 5. **Contratos entre módulos são explícitos e versionados.** Nenhum módulo pode depender de campos implícitos, estados informais ou convenções não registradas.
 6. **Mudanças relevantes exigem teste e documentação correspondente.** Regra operacional sem teste e sem contrato atualizado é candidata imediata a drift.
+7. **LHM é determinístico por definição canônica.** O Landing HTML Module (LHM) é responsável pela renderização previsível do HTML final de landing pages a partir de artefatos/contratos canônicos; não é camada de ideação livre de copy.
+8. **Evolução visual via artefato canônico.** Ajustes de estética/tema para landing pages devem ser modelados em artefato canônico estruturado (ex.: `landingPageDesignPreset`) consumido pelo LHM; evitar etapa de geração livre de HTML/JS fora do contrato.
 
 ## 3.1 Regra global de exclusividade de artefatos (todo o sistema)
 

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -14,6 +14,14 @@ criativos, campanha e objetos de ativação/medição.
 - Coleta de leads no fluxo vinculado ao experimento.
 - Governança mínima de compliance para o módulo Avatar Sales Video (consentimento e revisão humana antes de render/publicação produtiva).
 
+## Atualização incremental — Pipeline de Landing (Design Preset)
+
+Campo adicionado na entidade/tabela `experiment` para suportar o novo passo canônico de design da landing:
+
+- `landing_page_design_preset` (`LONGTEXT`)
+  - armazena o artefato estruturado `landingPageDesignPreset` produzido no pipeline entre `landingPageImagePlanning` e `landingPageHtml`;
+  - objetivo: separar decisão visual (tema/presets) da composição final do HTML pelo LHM, preservando determinismo e auditabilidade.
+
 ## Atualização incremental — Avatar Sales Video (Sprint V4)
 
 Campos adicionados no backend (`sales_video_profile` / `sales_video_job`) para suportar compliance e auditoria:

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -62,6 +62,7 @@ type ContentGenerationSectionKey =
   | "landing-copy"
   | "landing-layout"
   | "landing-image-planning"
+  | "landing-design-preset"
   | "landing-html";
 
 interface ContentGenerationSection {
@@ -112,6 +113,13 @@ const CONTENT_GENERATION_SECTIONS: ContentGenerationSection[] = [
     label: "Planejamento de Imagens da Landing",
     description:
       "Planeje prompts, posicionamento e direção visual das imagens antes da geração final do HTML.",
+    defaultQuantity: 1,
+  },
+  {
+    key: "landing-design-preset",
+    label: "Preset de Design da Landing",
+    description:
+      "Defina tema visual, paleta e presets por seção antes da composição final do HTML.",
     defaultQuantity: 1,
   },
   {
@@ -186,6 +194,7 @@ const JOB_SECTION_ALIASES: Record<string, ContentGenerationSectionKey> = {
   LANDING_PAGE_COPY: "landing-copy",
   LANDING_PAGE_WIREFRAME: "landing-layout",
   LANDING_PAGE_IMAGE_PLANNING: "landing-image-planning",
+  LANDING_PAGE_DESIGN_PRESET: "landing-design-preset",
   LANDING_PAGE_HTML: "landing-html",
 };
 
@@ -586,6 +595,39 @@ artifact {
   }
 }`;
 
+const LANDING_DESIGN_PRESET_PROMPT_TEMPLATE = `${COMMON_PIPELINE_PROMPT}
+
+Criar o Preset de Design da Landing após o planejamento de imagens e antes do HTML final.
+
+Objetivo:
+Estruturar tema visual reutilizável (paleta, estilos e presets por seção) mantendo coerência com copy, wireframe e planejamento de imagens.
+
+Regras:
+1. Entregar objeto landingPageDesignPreset com:
+   - presetId
+   - theme.palette
+   - sectionPresets[]
+   - componentPresets
+   - motion
+   - consistencyChecks[]
+2. sectionPresets deve cobrir as sectionId existentes no wireframe atual.
+3. surfaceStyle permitido: band | solid | gradient-soft | image-tint.
+4. contrastMode permitido: normal | high | soft.
+5. Não gerar HTML/CSS/JS nesta etapa.
+
+Formato esperado:
+JSON com envelope canônico:
+{
+  landingPageDesignPreset: {
+    presetId,
+    theme,
+    sectionPresets,
+    componentPresets,
+    motion,
+    consistencyChecks
+  }
+}`;
+
 const SECTION_PROMPT_DEFAULTS: Partial<
   Record<ContentGenerationSectionKey, string>
 > = {
@@ -593,6 +635,7 @@ const SECTION_PROMPT_DEFAULTS: Partial<
   "landing-copy": LANDING_COPY_PROMPT_TEMPLATE,
   "landing-layout": LANDING_LAYOUT_PROMPT_TEMPLATE,
   "landing-image-planning": LANDING_IMAGE_PLANNING_PROMPT_TEMPLATE,
+  "landing-design-preset": LANDING_DESIGN_PRESET_PROMPT_TEMPLATE,
   "landing-html": LANDING_HTML_PROMPT_TEMPLATE,
 };
 
@@ -603,6 +646,7 @@ const SECTION_API_PATHS: Record<ContentGenerationSectionKey, string> = {
   "landing-copy": "landing-page-copy",
   "landing-layout": "landing-page-wireframe",
   "landing-image-planning": "landing-page-image-planning",
+  "landing-design-preset": "landing-page-design-preset",
   "landing-html": "landing-page-html",
 };
 
@@ -655,6 +699,7 @@ type HistorySectionKey =
   | "landing-copy"
   | "landing-layout"
   | "landing-image-planning"
+  | "landing-design-preset"
   | "landing-html";
 
 const REPORT_SECTION_ORDER: ContentGenerationSectionKey[] = [
@@ -664,6 +709,7 @@ const REPORT_SECTION_ORDER: ContentGenerationSectionKey[] = [
   "landing-copy",
   "landing-layout",
   "landing-image-planning",
+  "landing-design-preset",
   "landing-html",
 ];
 
@@ -678,6 +724,8 @@ const REPORT_DOMAIN_ALIASES: Record<string, ContentGenerationSectionKey> = {
   "landing-layout": "landing-layout",
   "landing-page-image-planning": "landing-image-planning",
   "landing-image-planning": "landing-image-planning",
+  "landing-page-design-preset": "landing-design-preset",
+  "landing-design-preset": "landing-design-preset",
   "landing-page-html": "landing-html",
   "landing-html": "landing-html",
 };
@@ -1198,6 +1246,7 @@ export default function ExperimentContentGenerationTab({
     "landing-copy": [],
     "landing-layout": [],
     "landing-image-planning": [],
+    "landing-design-preset": [],
     "landing-html": [],
   });
   const [isLoadingSectionGenerations, setIsLoadingSectionGenerations] =
@@ -1206,6 +1255,7 @@ export default function ExperimentContentGenerationTab({
       "landing-copy": false,
       "landing-layout": false,
       "landing-image-planning": false,
+      "landing-design-preset": false,
       "landing-html": false,
     });
   const [requestsBySection, setRequestsBySection] = useState<
@@ -1236,10 +1286,11 @@ export default function ExperimentContentGenerationTab({
   const hasFrameworkImageReady = frameworkImageStatuses.some(
     (item) => item.status?.toUpperCase() === "COMPLETED",
   );
-  const shouldWaitLandingHtmlForImages =
+  const shouldWaitLandingFlowForImages =
     autoQueue.isActive &&
     autoQueue.waitingFor === "landing-image-planning" &&
-    autoQueue.pending[0] === "landing-html" &&
+    (autoQueue.pending[0] === "landing-design-preset" ||
+      autoQueue.pending[0] === "landing-html") &&
     (frameworkImageStatusQuery.isLoading ||
       !hasFrameworkImages ||
       hasFrameworkImagesInFlight);
@@ -1461,6 +1512,11 @@ export default function ExperimentContentGenerationTab({
         items: sectionGenerations["landing-image-planning"],
       },
       {
+        key: "landing-design-preset",
+        label: getSectionLabel("landing-design-preset"),
+        items: sectionGenerations["landing-design-preset"],
+      },
+      {
         key: "landing-html",
         label: getSectionLabel("landing-html"),
         items: sectionGenerations["landing-html"],
@@ -1666,6 +1722,7 @@ export default function ExperimentContentGenerationTab({
       "landing-copy",
       "landing-layout",
       "landing-image-planning",
+      "landing-design-preset",
       "landing-html",
     ];
 
@@ -1750,7 +1807,8 @@ export default function ExperimentContentGenerationTab({
     const [nextSectionKey, ...remaining] = autoQueue.pending;
     if (
       autoQueue.waitingFor === "landing-image-planning" &&
-      nextSectionKey === "landing-html"
+      (nextSectionKey === "landing-design-preset" ||
+        nextSectionKey === "landing-html")
     ) {
       const stillLoadingImageStatuses =
         frameworkImageStatusQuery.isLoading || frameworkImageStatusQuery.isFetching;
@@ -1762,7 +1820,7 @@ export default function ExperimentContentGenerationTab({
       if (mustWaitForImages) {
         if (!imageGenerationWaitToastRef.current) {
           imageGenerationWaitToastRef.current = toast.info(
-            "Planejamento concluído. Aguardando geração das imagens para continuar com o HTML da landing.",
+            "Planejamento concluído. Aguardando geração das imagens para continuar com as próximas etapas da landing.",
             { autoClose: 6000 },
           ) as unknown as string;
         }
@@ -2105,10 +2163,10 @@ export default function ExperimentContentGenerationTab({
               aguardando conclusão de{" "}
               <strong>{getSectionLabel(autoQueue.waitingFor)}</strong>.
             </span>
-            {shouldWaitLandingHtmlForImages ? (
+            {shouldWaitLandingFlowForImages ? (
               <span className="text-warning-emphasis">
-                Desvio controlado: gerando imagens da landing antes do HTML
-                final.
+                Desvio controlado: gerando imagens da landing antes das etapas
+                finais.
               </span>
             ) : null}
             <span className="badge text-bg-light">
@@ -2143,8 +2201,9 @@ export default function ExperimentContentGenerationTab({
         {CONTENT_GENERATION_SECTIONS.map((section) => (
           <Tabs.Content key={section.key} value={section.key} className="mt-3">
             {(() => {
-              const isLandingHtmlBlockedByImageGeneration =
-                section.key === "landing-html" &&
+              const isLandingFlowBlockedByImageGeneration =
+                (section.key === "landing-design-preset" ||
+                  section.key === "landing-html") &&
                 (frameworkImageStatusQuery.isLoading ||
                   hasFrameworkImagesInFlight);
               return (
@@ -2164,7 +2223,7 @@ export default function ExperimentContentGenerationTab({
                         isGeneratingSection ||
                         isGeneratingWithLhm ||
                         autoQueue.isActive ||
-                        isLandingHtmlBlockedByImageGeneration
+                        isLandingFlowBlockedByImageGeneration
                       }
                       title={`Solicita ao Worker IA a geração da etapa "${section.label}" com prompt canônico do pipeline.`}
                     >
@@ -2187,7 +2246,7 @@ export default function ExperimentContentGenerationTab({
                           />
                           Fila em execução...
                         </span>
-                      ) : isLandingHtmlBlockedByImageGeneration ? (
+                      ) : isLandingFlowBlockedByImageGeneration ? (
                         <span className="d-inline-flex align-items-center gap-1">
                           <span
                             className="spinner-border spinner-border-sm"
@@ -2209,7 +2268,7 @@ export default function ExperimentContentGenerationTab({
                           isGeneratingWithLhm ||
                           isGeneratingSection ||
                           autoQueue.isActive ||
-                          isLandingHtmlBlockedByImageGeneration
+                          isLandingFlowBlockedByImageGeneration
                         }
                         title="Gera o HTML final usando o LHM (Landing HTML Module), sem acionar o Worker IA."
                       >
@@ -2418,7 +2477,7 @@ export default function ExperimentContentGenerationTab({
                     </small>
                   ) : null}
                   {section.key === "landing-html" &&
-                  shouldWaitLandingHtmlForImages ? (
+                  shouldWaitLandingFlowForImages ? (
                     <small className="text-warning-emphasis">
                       Fluxo em desvio controlado: estamos gerando as imagens da
                       landing para retomar automaticamente esta etapa ao final.
@@ -2758,6 +2817,8 @@ function parseSectionContent(
       return parseLandingLayoutPayload(raw);
     case "landing-image-planning":
       return parseLandingImagePlanningPayload(raw);
+    case "landing-design-preset":
+      return undefined;
     case "landing-html":
       return parseLandingHtmlPayload(raw);
     default:
@@ -2846,6 +2907,8 @@ function resolveStructuredPreview(
       }
       return { hasStructuredData: false };
     }
+    case "landing-design-preset":
+      return { hasStructuredData: false };
     case "landing-html": {
       const content = parsed as LandingHtmlContent | undefined;
       if (hasLandingHtmlContent(content)) {
@@ -2915,6 +2978,8 @@ function describeGenerationSummary(
       }
       return "Planejamento de imagens registrado para a landing.";
     }
+    case "landing-design-preset":
+      return "Preset de design registrado para a landing.";
     case "landing-html": {
       const typed = content as LandingHtmlContent | undefined;
       if (hasLandingHtmlContent(typed)) {

--- a/frontend/src/pages/experiment/ExperimentPipelineJobsPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentPipelineJobsPage.tsx
@@ -20,6 +20,7 @@ const SECTION_OPTIONS = [
   { value: "landing-page-copy", label: "Texto da landing" },
   { value: "landing-page-wireframe", label: "Layout da landing" },
   { value: "landing-page-image-planning", label: "Planejamento de imagens da landing" },
+  { value: "landing-page-design-preset", label: "Preset de design da landing" },
   { value: "landing-page-html", label: "HTML da landing" },
 ];
 


### PR DESCRIPTION
### Motivation
- Introduce a canonical, structured design preset artifact (`landingPageDesignPreset`) to separate visual theme/presets from copy/wireframe and make LHM composition deterministic.
- Ensure the pipeline supports a new generation step between image planning and final HTML so design decisions are auditable and reusable.

### Description
- Added a new prompt template `prompts/experiment/landing-design-preset.md` and wired it into the AI worker (`ExperimentPipelineOpenAiClient`) including markers, template loading and selection logic. 
- Introduced the `landing_page_design_preset` column on `experiment` with DTO, entity field and a Liquibase changeset to add the DB column. 
- Extended pipeline enums and flow: added `LANDING_PAGE_DESIGN_PRESET` to `ExperimentPipelineSection`, updated predecessor/successor handling, enqueue logic and predecessor validation to require images before design preset/html when appropriate. 
- Enhanced `LandingHtmlModule` to consume `landingPageDesignPreset`, extract palette and section presets, apply surface/contrast presets in generated HTML (CSS variables, surface classes) and render copy-driven blocks (hero, body sections, faq, cta blocks) with helper methods. 
- Added JSON schema support for the new artifact in `ExperimentPipelineGenerationService`, validation logic and prompt text for the design preset step, plus deterministic HTML form injection/normalization improvements. 
- Updated AI prompt for landing copy (`landing-copy.md`) to `template_version: v2` with additional copy quality rules and acceptance criteria. 
- Frontend updates to expose the new section in generation UI, prompts, mappings and auto-queue logic to treat design preset as part of the landing flow. 
- Updated docs (canonical models, governance and flow) to describe the new artifact and LHM responsibilities. 
- Tests updated/added to cover prompt composition, HTML assembly with design presets and pipeline generation behavior.

### Testing
- Ran unit tests in the backend worker and ads-service modules including `ExperimentPipelineOpenAiClientTest`, `LandingHtmlModuleTest` and `ExperimentPipelineGenerationServiceTest`, and all updated tests passed. 
- Verified new Liquibase changeset file is included in `db.changelog-master.yaml` to apply the DB column migration (no runtime DB execution errors in CI dry-run). 
- Performed frontend build and unit/logic checks for generation tab changes and mapping additions, and the frontend test/compile step succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb58933408321a7bddf57b75a89ff)