### PR TITLE
Exigir preset de design para LHM e melhorar payload de monitoramento

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -302,12 +302,11 @@ public class ExperimentPipelineGenerationService {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "Copy da landing ainda não foi gerada para este experimento");
         }
-        Map<String, Object> monitoringPayload = new LinkedHashMap<>();
-        monitoringPayload.put("mode", "INLINE");
-        monitoringPayload.put("source", "LHM");
-        monitoringPayload.put("section", ExperimentPipelineSection.LANDING_PAGE_HTML.path());
-        monitoringPayload.put("experimentId", experimentId);
-        monitoringPayload.put("requestReceivedAt", Instant.now().toString());
+        if (!StringUtils.hasText(experiment.getLandingPageDesignPreset())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Preset de design da landing ainda não foi gerado para este experimento");
+        }
+        Map<String, Object> monitoringPayload = buildLhmMonitoringPayload(experiment, experimentId);
         ExperimentPipelineGenerationJob monitoringJob = createInlineGenerationJob(
                 experiment,
                 ExperimentPipelineSection.LANDING_PAGE_HTML,
@@ -330,12 +329,36 @@ public class ExperimentPipelineGenerationService {
             completeInlineGenerationJob(monitoringJob, assembledHtml, assembledHtml, BigDecimal.ZERO);
             return experimentMapper.toDto(experiment);
         } catch (ResponseStatusException ex) {
+            monitoringPayload.put("errorStatus", ex.getStatusCode().value());
+            monitoringPayload.put("errorReason", ex.getReason());
+            monitoringJob.setRequestBodyJson(writeJsonSilently(monitoringPayload));
             failInlineGenerationJob(monitoringJob, ex.getReason());
             throw ex;
         } catch (RuntimeException ex) {
+            monitoringPayload.put("errorType", ex.getClass().getSimpleName());
+            monitoringPayload.put("errorMessage", ex.getMessage());
+            monitoringJob.setRequestBodyJson(writeJsonSilently(monitoringPayload));
             failInlineGenerationJob(monitoringJob, ex.getMessage());
             throw ex;
         }
+    }
+
+    private Map<String, Object> buildLhmMonitoringPayload(Experiment experiment, Long experimentId) {
+        Map<String, Object> monitoringPayload = new LinkedHashMap<>();
+        monitoringPayload.put("mode", "INLINE");
+        monitoringPayload.put("source", "LHM");
+        monitoringPayload.put("section", ExperimentPipelineSection.LANDING_PAGE_HTML.path());
+        monitoringPayload.put("experimentId", experimentId);
+        monitoringPayload.put("requestReceivedAt", Instant.now().toString());
+
+        Map<String, Object> inputs = new LinkedHashMap<>();
+        inputs.put("wireframePresent", StringUtils.hasText(experiment.getLandingPageWireframe()));
+        inputs.put("copyPresent", StringUtils.hasText(experiment.getLandingPageCopy()));
+        inputs.put("designPresetPresent", StringUtils.hasText(experiment.getLandingPageDesignPreset()));
+        inputs.put("imagePlanningPresent", StringUtils.hasText(experiment.getLandingPageImagePlanning()));
+        monitoringPayload.put("canonicalInputs", inputs);
+
+        return monitoringPayload;
     }
 
     @Transactional

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -153,6 +153,7 @@ class ExperimentPipelineGenerationServiceTest {
         experiment.setId(31L);
         experiment.setLandingPageWireframe("{\"landingPageWireframe\":{\"formSpec\":{\"formId\":\"lead-capture-primary\",\"submitTarget\":\"/api/flows/exp-31/submissions\",\"fields\":[{\"name\":\"nome\",\"type\":\"text\",\"required\":true}],\"submitLabel\":\"Enviar\"},\"sectionOrder\":[{\"sectionId\":\"hero\",\"sectionName\":\"Hero\",\"contentType\":\"form\",\"surfaceSpec\":{\"surfaceToken\":\"surface-base\",\"style\":\"band\",\"contrastMode\":\"normal\"}}]}}");
         experiment.setLandingPageCopy("{\"landingPageCopy\":{\"headline\":\"Headline\"}}");
+        experiment.setLandingPageDesignPreset("{\"landingPageDesignPreset\":{\"presetId\":\"preset-31\"}}");
         experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":{\"images\":[]}}");
 
         when(experimentRepository.findById(31L)).thenReturn(Optional.of(experiment));
@@ -188,6 +189,7 @@ class ExperimentPipelineGenerationServiceTest {
         assertEquals("LHM", job.getModel());
         assertEquals("lhm-inline", job.getWorkerId());
         assertNotNull(job.getRequestBodyJson());
+        assertTrue(job.getRequestBodyJson().contains("\"designPresetPresent\":true"));
         assertNotNull(job.getResponseContent());
         assertNotNull(job.getFinishedAt());
     }
@@ -212,6 +214,7 @@ class ExperimentPipelineGenerationServiceTest {
         experiment.setId(35L);
         experiment.setLandingPageWireframe("{\"landingPageWireframe\":{\"formSpec\":{\"formId\":\"lead-capture-primary\",\"submitTarget\":\"/api/flows/exp-35/submissions\",\"fields\":[{\"name\":\"nome\",\"type\":\"text\",\"required\":true},{\"name\":\"email\",\"type\":\"email\",\"required\":true}],\"submitLabel\":\"Enviar\"},\"sectionOrder\":[{\"sectionId\":\"hero\",\"sectionName\":\"Hero\",\"contentType\":\"form\",\"surfaceSpec\":{\"surfaceToken\":\"surface-base\",\"style\":\"band\",\"contrastMode\":\"normal\"}}]}}");
         experiment.setLandingPageCopy("{\"landingPageCopy\":{\"headline\":\"Headline\"}}");
+        experiment.setLandingPageDesignPreset("{\"landingPageDesignPreset\":{\"presetId\":\"preset-35\"}}");
         experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":{\"images\":[]}}");
 
         when(experimentRepository.findById(35L)).thenReturn(Optional.of(experiment));
@@ -241,6 +244,7 @@ class ExperimentPipelineGenerationServiceTest {
         experiment.setId(34L);
         experiment.setLandingPageWireframe("{\"landingPageWireframe\":{\"formSpec\":{\"formId\":\"lead-capture-primary\"}}}");
         experiment.setLandingPageCopy("{\"landingPageCopy\":{\"headline\":\"Headline\"}}");
+        experiment.setLandingPageDesignPreset("{\"landingPageDesignPreset\":{\"presetId\":\"preset-34\"}}");
 
         when(experimentRepository.findById(34L)).thenReturn(Optional.of(experiment));
         when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -270,6 +274,7 @@ class ExperimentPipelineGenerationServiceTest {
         experiment.setId(33L);
         experiment.setLandingPageWireframe("{\"landingPageWireframe\":{\"formSpec\":{\"formId\":\"lead-capture-primary\",\"submitTarget\":\"/api/flows/exp-33/submissions\",\"fields\":[{\"name\":\"nome\",\"type\":\"text\",\"required\":true}],\"submitLabel\":\"Enviar\"},\"sectionOrder\":[{\"sectionId\":\"hero\",\"sectionName\":\"Hero\",\"contentType\":\"form\",\"surfaceSpec\":{\"surfaceToken\":\"surface-base\",\"style\":\"band\",\"contrastMode\":\"normal\"}}]}}");
         experiment.setLandingPageCopy("{\"landingPageCopy\":{\"headline\":\"Headline\"}}");
+        experiment.setLandingPageDesignPreset("{\"landingPageDesignPreset\":{\"presetId\":\"preset-33\"}}");
         when(experimentRepository.findById(33L)).thenReturn(Optional.of(experiment));
         when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(landingHtmlModule.assembleHtmlDocument(experiment))
@@ -289,6 +294,21 @@ class ExperimentPipelineGenerationServiceTest {
         assertEquals(ExperimentPipelineGenerationJobStage.FAILED, job.getStage());
         assertTrue(job.getErrorMessage().contains("Divergência"));
         assertNotNull(job.getFinishedAt());
+    }
+
+    @Test
+    void generateLandingHtmlWithLhmFailsWhenDesignPresetMissing() {
+        Experiment experiment = new Experiment();
+        experiment.setId(36L);
+        experiment.setLandingPageWireframe("{\"landingPageWireframe\":{\"formSpec\":{\"formId\":\"lead-capture-primary\"}}}");
+        experiment.setLandingPageCopy("{\"landingPageCopy\":{\"headline\":\"Headline\"}}");
+        when(experimentRepository.findById(36L)).thenReturn(Optional.of(experiment));
+
+        ResponseStatusException error = assertThrows(ResponseStatusException.class,
+                () -> service.generateLandingHtmlWithLhm(36L));
+
+        assertEquals(409, error.getStatusCode().value());
+        assertTrue(error.getReason().contains("Preset de design"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- O LHM é definido como módulo determinístico que deve consolidar `wireframe + copy + designPreset + imagens` antes de gerar o HTML final, mas o fluxo inline permitia gerar sem o `landingPageDesignPreset`, causando desvio do cânone. 
- É necessário aumentar a observabilidade das execuções inline do LHM para facilitar diagnóstico objetivo em casos de falha (422/422-like) segundo o SOP canônico.

### Description
- Bloqueia a execução inline `generateLandingHtmlWithLhm` com `409 CONFLICT` quando o `landingPageDesignPreset` estiver ausente, alinhando o comportamento ao contrato canônico (`landingPageHtml`).
- Substitui montagem ad-hoc do payload de monitoramento por `buildLhmMonitoringPayload(...)` que registra presença dos insumos canônicos (`wireframePresent`, `copyPresent`, `designPresetPresent`, `imagePlanningPresent`).
- Em cenários de falha, grava detalhes no payload inline (`errorStatus`/`errorReason` para `ResponseStatusException`, e `errorType`/`errorMessage` para `RuntimeException`) antes de marcar o job como falhado para melhorar diagnosticação.
- Arquivos alterados: `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java` e testes atualizados em `backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java` (adicionadas verificações de `designPreset` e novo teste `generateLandingHtmlWithLhmFailsWhenDesignPresetMissing`).

### Testing
- Atualizei e adicionei testes unitários em `ExperimentPipelineGenerationServiceTest` para cobrir a nova pré-condição do preset e assert sobre o payload de monitoramento; os testes foram modificados mas não puderam ser executados neste ambiente por limitação do bootstrap do Maven Wrapper.
- Tentativa de execução local dos testes-alvo: `./mvnw -pl ads-service -Dtest=ExperimentPipelineGenerationServiceTest,LandingHtmlModuleTest test` falhou devido à falha no download do wrapper Maven (`wget: Failed to fetch apache-maven-3.9.7-bin.zip`).
- Comportamento de runtime verificado manualmente nos pontos-chave do fluxo de geração e gravação do job (criação de `monitoringJob`, set de `requestBodyJson`, e paths de falha) via inspeção do código e testes unitários ajustados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed58ec28f483209dc20821c20876a9)