### PR TITLE
Alinha prompt `landing-design-preset` ao contrato canônico `landingPageDesignPreset`

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
@@ -21,7 +21,9 @@ Regras:
    - `THEME_CONTRAST`
    - `CTA_VISUAL_HIERARCHY`
    - `MOBILE_READABILITY`
-8. Saída obrigatoriamente em JSON válido no envelope do artefato.
+8. `layoutPreset` só pode ser: `hero-focus`, `form-focus`, `proof-grid`, `narrative-stack`, `faq-clean`, `cta-strong`.
+9. `motion.enabled` deve ser booleano (`true` ou `false`).
+10. Saída obrigatoriamente em JSON válido no envelope do artefato, sem markdown, sem bloco de código e sem texto adicional.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -61,7 +63,7 @@ Responda em JSON válido no formato:
         "sectionId": "string",
         "surfaceStyle": "band | solid | gradient-soft | image-tint",
         "contrastMode": "normal | high | soft",
-        "layoutPreset": "string",
+        "layoutPreset": "hero-focus | form-focus | proof-grid | narrative-stack | faq-clean | cta-strong",
         "emphasis": "primary | secondary | support",
         "notes": "string"
       }
@@ -82,7 +84,7 @@ Responda em JSON válido no formato:
       }
     },
     "motion": {
-      "enabled": true,
+      "enabled": "boolean",
       "intensity": "none | subtle | moderate"
     },
     "consistencyChecks": [


### PR DESCRIPTION
### Motivation
- Corrigir gap de aderência entre o prompt de geração de design e o artefato canônico `landingPageDesignPreset` para reduzir outputs fora do schema esperado. 
- Evitar rejeições posteriores no pipeline por variações de formato ou valores inválidos gerados pelo modelo. 

### Description
- Atualiza o template `ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md` para restringir `layoutPreset` aos valores canônicos `hero-focus`, `form-focus`, `proof-grid`, `narrative-stack`, `faq-clean` e `cta-strong`. 
- Torna explícito que `motion.enabled` deve ser um booleano (`true` | `false`) em vez de um valor fixo. 
- Reforça que a resposta deve ser `JSON` puro no envelope do artefato, sem markdown, blocos de código ou texto adicional, e ajusta o `OUTPUT_CONTRACT` de exemplo para refletir essas regras. 

### Testing
- Executado `cd ai-worker && ./mvnw -q -DskipTests compile`, que não pôde ser executado porque `./mvnw` não existe no ambiente (falha de infraestrutura). 
- Executado `cd ai-worker && mvn -q -DskipTests compile`, que falhou por limitação de ambiente (dependência em repositório privado GitHub Packages retornou HTTP 403), portanto build automático não pôde ser concluído aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5adc52ac8320bbe5e4b4ccfce99c)