### PR TITLE
fix(db): widen experiment_pipeline_generation_job.section to prevent truncation

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/V2037_04_26__widen_experiment_pipeline_job_section_mysql5.sql
+++ b/backend/ads-service/src/main/resources/db/changelog/V2037_04_26__widen_experiment_pipeline_job_section_mysql5.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset repo:2037-04-26-widen-experiment-pipeline-job-section-mysql5 dbms:mysql
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'experiment_pipeline_generation_job';
+--precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'experiment_pipeline_generation_job' AND column_name = 'section' AND data_type = 'varchar' AND character_maximum_length >= 255;
+ALTER TABLE experiment_pipeline_generation_job
+    MODIFY COLUMN section VARCHAR(255) NOT NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: V2037_04_26__widen_experiment_pipeline_job_section_mysql5.sql
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-04-22-mois-sprint4-signals.yaml
       relativeToChangelogFile: true
   - include:


### PR DESCRIPTION
### Motivation
- Prevent insert failures like `Data truncated for column 'section' at row 1` when triggering the design-preset AI job, caused by environments where the `section` column is narrower than current enum values.

### Description
- Add `V2037_04_26__widen_experiment_pipeline_job_section_mysql5.sql` to modify `experiment_pipeline_generation_job.section` to `VARCHAR(255)` with idempotent `--precondition-sql-check` guards (dbms:mysql) and include the new changelog in `db.changelog-master.yaml`.

### Testing
- Attempted to compile the `ads-service` module with `./mvnw -pl ads-service -DskipTests compile` but the build could not proceed due to a network failure downloading Maven (`Failed to fetch ... apache-maven-3.9.7-bin.zip`), so no automated tests or migrations were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5ca56a9483209bbaa554f674c955)