### PR TITLE
Preserve wireframe surfaceSpec in LHM (prevent design preset override)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -100,7 +100,6 @@ public class LandingHtmlModule {
         Map<String, Object> designRoot = safeReadObject(experiment.getLandingPageDesignPreset());
         Map<String, Object> designPreset = unwrapSectionPayload(designRoot, "landingPageDesignPreset");
         Map<String, Object> palette = extractPalette(designPreset);
-        Map<String, Map<String, Object>> sectionDesignPresets = indexSectionDesignPresets(designPreset);
 
         String formId = firstNonBlank(asTrimmedString(formSpec.get("formId")), "lead-capture-primary");
         String submitTarget = firstNonBlank(asTrimmedString(formSpec.get("submitTarget")), "/api/flows/submissions");
@@ -159,9 +158,6 @@ public class LandingHtmlModule {
             String surfaceToken = firstNonBlank(asTrimmedString(surface.get("surfaceToken")), "surface-base");
             String surfaceStyle = firstNonBlank(asTrimmedString(surface.get("style")), "band");
             String surfaceContrast = firstNonBlank(asTrimmedString(surface.get("contrastMode")), "normal");
-            Map<String, Object> sectionPreset = sectionDesignPresets.getOrDefault(sectionId.toLowerCase(), Map.of());
-            surfaceStyle = firstNonBlank(asTrimmedString(sectionPreset.get("surfaceStyle")), surfaceStyle);
-            surfaceContrast = firstNonBlank(asTrimmedString(sectionPreset.get("contrastMode")), surfaceContrast);
             String surfaceStyleClass = "surface-" + normalizeCssToken(surfaceStyle);
             String surfaceContrastClass = "contrast-" + normalizeCssToken(surfaceContrast);
 
@@ -326,29 +322,6 @@ public class LandingHtmlModule {
             return Map.of();
         }
         return (Map<String, Object>) rawPalette;
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Map<String, Object>> indexSectionDesignPresets(Map<String, Object> designPreset) {
-        if (designPreset == null || designPreset.isEmpty()) {
-            return Map.of();
-        }
-        if (!(designPreset.get("sectionPresets") instanceof List<?> rawSectionPresets)) {
-            return Map.of();
-        }
-        java.util.LinkedHashMap<String, Map<String, Object>> indexed = new java.util.LinkedHashMap<>();
-        for (Object rawPreset : rawSectionPresets) {
-            if (!(rawPreset instanceof Map<?, ?> rawPresetMap)) {
-                continue;
-            }
-            Map<String, Object> preset = (Map<String, Object>) rawPresetMap;
-            String sectionId = asTrimmedString(preset.get("sectionId"));
-            if (!StringUtils.hasText(sectionId)) {
-                continue;
-            }
-            indexed.put(sectionId.toLowerCase(), preset);
-        }
-        return indexed;
     }
 
     @SuppressWarnings("unchecked")

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
@@ -164,4 +164,56 @@ class LandingHtmlModuleTest {
         assertTrue(html.contains("<details><summary>Dúvida 1"));
         assertTrue(html.contains("Final CTA"));
     }
+
+    @Test
+    void assembleHtmlDocumentDoesNotOverrideSurfaceSpecFromWireframeUsingDesignPreset() {
+        Experiment experiment = new Experiment();
+        experiment.setName("Teste LHM Surface Preset");
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {
+                        "sectionId": "proof",
+                        "sectionName": "Prova",
+                        "contentType": "proof",
+                        "surfaceSpec": {
+                          "surfaceToken": "surface-proof",
+                          "style": "band",
+                          "contrastMode": "soft"
+                        }
+                      }
+                    ],
+                    "formSpec": {
+                      "formId": "lead-capture-primary",
+                      "submitTarget": "/api/flows/submissions",
+                      "submitLabel": "Enviar",
+                      "fields": [{"name": "nome", "type": "text", "required": true}]
+                    }
+                  }
+                }
+                """);
+        experiment.setLandingPageDesignPreset("""
+                {
+                  "landingPageDesignPreset": {
+                    "sectionPresets": [
+                      {
+                        "sectionId": "proof",
+                        "surfaceStyle": "solid",
+                        "contrastMode": "high"
+                      }
+                    ]
+                  }
+                }
+                """);
+
+        String html = module.assembleHtmlDocument(experiment);
+
+        assertTrue(html.contains("data-section-id=\"proof\""));
+        assertTrue(html.contains("class=\"card surface-band contrast-soft\""));
+        assertTrue(html.contains("data-surface-style=\"band\""));
+        assertTrue(html.contains("data-surface-contrast=\"soft\""));
+        assertFalse(html.contains("data-surface-style=\"solid\""));
+        assertFalse(html.contains("data-surface-contrast=\"high\""));
+    }
 }


### PR DESCRIPTION
### Motivation
- Corrigir causa raiz do erro `Divergência de superfície: landing-page-html deve reproduzir exatamente landing-page-wireframe.sectionOrder.surfaceSpec` onde o LHM estava sobrescrevendo `surfaceSpec` do wireframe com valores vindos de `landingPageDesignPreset.sectionPresets`.
- Alinhar o comportamento do `LandingHtmlModule` ao contrato canônico que exige reprodução estrita dos atributos de superfície no HTML (`data-surface-token`, `data-surface-style`, `data-surface-contrast`).

### Description
- Removida a lógica que aplicava valores de `landingPageDesignPreset.sectionPresets` para sobrescrever `surfaceSpec` extraído do `landingPageWireframe` em `LandingHtmlModule.java` (agora os `data-surface-*` vêm estritamente do wireframe).
- Eliminada a indexação/uso de `sectionDesignPresets` no ponto onde ocorria o override, preservando apenas o uso do `designPreset` para paleta/global, não para binding de superfície.
- Adicionado teste de regressão `assembleHtmlDocumentDoesNotOverrideSurfaceSpecFromWireframeUsingDesignPreset` em `LandingHtmlModuleTest.java` para garantir que valores conflitantes no `landingPageDesignPreset` não alterem o `data-surface-style`/`data-surface-contrast` emitidos.
- Arquivos modificados: `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java` e `backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java`.

### Testing
- Executado comando de build/test unitário `./mvnw -pl ads-service -Dtest=LandingHtmlModuleTest test`, que falhou no ambiente por limitação externa do wrapper (erro: `wget: Failed to fetch https://repo.maven.apache.org/...`), impedindo execução local dos novos testes.
- Foram inspecionados e grepados os pontos relevantes do código e dos documentos canônicos para validar a regra (`ExperimentPipelineGenerationService` validação de surfaceSpec e `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md`).
- O novo teste de regressão foi adicionado ao repositório e o commit foi criado; validação automatizada em CI deverá passar quando o runner puder baixar dependências e executar `LandingHtmlModuleTest` com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed60a8ba44832095e3cfaa2a839ed0)