### PR TITLE
LHM: use design preset for visual style/contrast; add pre-validation and artifact validators for landing pipeline

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-html.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-html.md
@@ -19,7 +19,7 @@ Regras fixas da etapa:
 4. Inclua validação de campos obrigatórios no JavaScript.
 5. Inclua compliance reforçando entrega digital via IA e sem consultoria.
 6. Consuma explicitamente os artefatos aprovados de copy, wireframe e planejamento de imagens.
-7. Cada seção renderizada deve incluir `data-section-id` e aplicar `wireframe.sectionOrder[i].surfaceSpec`.
+7. Cada seção renderizada deve incluir `data-section-id` e aplicar superfícies com origem canônica dividida: `data-surface-token` do `wireframe.sectionOrder[i].surfaceSpec.surfaceToken`; `data-surface-style` e `data-surface-contrast` do `landingPageDesignPreset.sectionPresets` por `sectionId`.
 8. Não invente estrutura visual fora de wireframe/plano de imagens sem justificar em `consistencyChecks`.
 9. Não use bibliotecas externas.
 10. Renderize imagens apenas para itens listados em `landingPageImagePlanning.images[]`.

--- a/ai-worker/src/main/resources/prompts/experiment/landing-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-wireframe.md
@@ -15,7 +15,7 @@ Modelo conceitual interno obrigatório (não expor no output final):
 Regras fixas da etapa:
 1. `pageGoal` deve explicitar a ação principal esperada da página.
 2. `variantLayoutId` deve ser um entre: form-first, proof-first, story-first.
-3. `sectionOrder` deve mapear ordem, objetivo, dependências de message match e variação intencional de seção via `surfaceSpec` + `uiNotes`.
+3. `sectionOrder` deve mapear ordem, objetivo, dependências de message match e variação intencional de seção via `surfaceSpec` (âncora estrutural) + `uiNotes`.
 4. Cada seção deve incluir todos os campos canônicos de `sectionOrder`, incluindo `surfaceSpec` e `ctaSlot`.
 5. Se houver CTA na seção, preencher `ctaSlot` com `hasCta`, `ctaLabel`, `ctaVariant`, `matchAdCta` e `notes`.
 6. `formPlacementNotes` deve informar momento de exposição do formulário e estratégia sticky quando aplicável.
@@ -44,3 +44,7 @@ Campos obrigatórios:
 - formPlacementNotes
 - consistencyChecks[]
 - formSpec
+
+Observação canônica:
+- Em `surfaceSpec` do wireframe, trate `surfaceToken` + `notes` como núcleo obrigatório estrutural.
+- `style` e `contrastMode` são responsabilidade da etapa `landingPageDesignPreset.sectionPresets`.

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Landing HTML Module (LHM): consolidates canonical inputs for the LANDING_PAGE_HTML prompt.
@@ -100,6 +102,7 @@ public class LandingHtmlModule {
         Map<String, Object> designRoot = safeReadObject(experiment.getLandingPageDesignPreset());
         Map<String, Object> designPreset = unwrapSectionPayload(designRoot, "landingPageDesignPreset");
         Map<String, Object> palette = extractPalette(designPreset);
+        Map<String, SectionVisualPreset> sectionVisualPresets = extractSectionVisualPresets(designPreset);
 
         String formId = firstNonBlank(asTrimmedString(formSpec.get("formId")), "lead-capture-primary");
         String submitTarget = firstNonBlank(asTrimmedString(formSpec.get("submitTarget")), "/api/flows/submissions");
@@ -155,9 +158,16 @@ public class LandingHtmlModule {
             Map<String, Object> surface = section.get("surfaceSpec") instanceof Map<?, ?> rawSurface
                     ? (Map<String, Object>) rawSurface
                     : Map.of();
+            SectionVisualPreset visualPreset = sectionVisualPresets.get(normalizeLookupKey(sectionId));
             String surfaceToken = firstNonBlank(asTrimmedString(surface.get("surfaceToken")), "surface-base");
-            String surfaceStyle = firstNonBlank(asTrimmedString(surface.get("style")), "band");
-            String surfaceContrast = firstNonBlank(asTrimmedString(surface.get("contrastMode")), "normal");
+            String surfaceStyle = firstNonBlank(
+                    visualPreset != null ? visualPreset.surfaceStyle() : null,
+                    asTrimmedString(surface.get("style")),
+                    "band");
+            String surfaceContrast = firstNonBlank(
+                    visualPreset != null ? visualPreset.contrastMode() : null,
+                    asTrimmedString(surface.get("contrastMode")),
+                    "normal");
             String surfaceStyleClass = "surface-" + normalizeCssToken(surfaceStyle);
             String surfaceContrastClass = "contrast-" + normalizeCssToken(surfaceContrast);
 
@@ -322,6 +332,41 @@ public class LandingHtmlModule {
             return Map.of();
         }
         return (Map<String, Object>) rawPalette;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, SectionVisualPreset> extractSectionVisualPresets(Map<String, Object> designPreset) {
+        if (designPreset == null || !(designPreset.get("sectionPresets") instanceof List<?> rawSectionPresets)) {
+            return Map.of();
+        }
+        return rawSectionPresets.stream()
+                .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .map(item -> (Map<String, Object>) item)
+                .map(this::toSectionVisualPreset)
+                .filter(preset -> preset != null && StringUtils.hasText(preset.sectionId()))
+                .collect(Collectors.toMap(
+                        preset -> normalizeLookupKey(preset.sectionId()),
+                        preset -> preset,
+                        (first, second) -> second));
+    }
+
+    private SectionVisualPreset toSectionVisualPreset(Map<String, Object> sectionPreset) {
+        if (sectionPreset == null) {
+            return null;
+        }
+        String sectionId = asTrimmedString(sectionPreset.get("sectionId"));
+        if (!StringUtils.hasText(sectionId)) {
+            return null;
+        }
+        return new SectionVisualPreset(
+                sectionId,
+                asTrimmedString(sectionPreset.get("surfaceStyle")),
+                asTrimmedString(sectionPreset.get("contrastMode")));
+    }
+
+    private String normalizeLookupKey(String value) {
+        return firstNonBlank(value, "").trim().toLowerCase(Locale.ROOT);
     }
 
     @SuppressWarnings("unchecked")
@@ -594,10 +639,13 @@ public class LandingHtmlModule {
         if (!StringUtils.hasText(value)) {
             return "normal";
         }
-        String normalized = value.trim().toLowerCase()
+        String normalized = value.trim().toLowerCase(Locale.ROOT)
                 .replace('_', '-')
                 .replace(' ', '-')
                 .replaceAll("[^a-z0-9-]", "");
         return StringUtils.hasText(normalized) ? normalized : "normal";
+    }
+
+    private record SectionVisualPreset(String sectionId, String surfaceStyle, String contrastMode) {
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -39,6 +39,7 @@ import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -705,6 +706,21 @@ public class ExperimentPipelineGenerationService {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "A seção " + section.path() + " depende da geração completa das imagens planejadas da landing");
         }
+        if (section == ExperimentPipelineSection.LANDING_PAGE_HTML) {
+            validateLandingArtifactsReadinessForHtml(experiment);
+        }
+    }
+
+    private void validateLandingArtifactsReadinessForHtml(Experiment experiment) {
+        try {
+            validateLandingWireframeArtifacts(experiment.getLandingPageWireframe());
+            validateLandingDesignPresetArtifacts(experiment, experiment.getLandingPageDesignPreset());
+        } catch (ResponseStatusException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Pré-validação antes de LANDING_PAGE_HTML falhou: " + ex.getReason(),
+                    ex);
+        }
     }
 
     private void enqueueNextAutomaticStep(ExperimentPipelineGenerationJob job,
@@ -1117,8 +1133,8 @@ public class ExperimentPipelineGenerationService {
             sb.append("10. mobilePriorityNotes deve destacar o que precisa aparecer antes da rolagem.\n");
             sb.append("11. Cada sectionOrder[i] deve preencher mediaSlot com: none, image, illustration, chart, icon-set ou video-thumb.\n");
             sb.append("12. Cada sectionOrder[i] deve preencher compositionNotes explicando hierarquia visual, densidade de conteúdo e leitura mobile-first.\n");
-            sb.append("13. Cada sectionOrder[i] deve preencher surfaceSpec com surfaceToken, style, contrastMode e notes para formalizar a superfície visual da seção.\n");
-            sb.append("14. Use surfaceToken alternando entre surface-base e surface-alt-* para reforçar escaneabilidade entre seções consecutivas.\n");
+            sb.append("13. Cada sectionOrder[i] deve preencher surfaceSpec com surfaceToken e notes para ancorar identidade estrutural da seção.\n");
+            sb.append("14. style e contrastMode são responsabilidade da etapa landing-page-design-preset (sectionPresets), não do wireframe.\n");
             sb.append("15. Não transformar o layout em HTML final; esta etapa deve decidir ordem, hierarquia e slots de mídia.\n");
             sb.append("16. Não usar linguagem de consultoria e não criar estrutura que pareça página genérica para qualquer mercado.\n");
             sb.append("17. Se a estrutura puder servir para qualquer nicho, reescreva até ficar específica para ").append(niche).append(".\n");
@@ -1133,7 +1149,7 @@ public class ExperimentPipelineGenerationService {
             sb.append("   - successState: title e message preenchidos.\n\n");
             sb.append("Formato obrigatório:\n");
             sb.append("- Preencher sectionOrder respeitando a ordem real da landing e referenciando sectionId de bodySections quando existir.\n");
-            sb.append("- Preencher mediaSlot, compositionNotes e surfaceSpec em todas as seções.\n");
+            sb.append("- Preencher mediaSlot, compositionNotes e surfaceSpec (somente surfaceToken + notes) em todas as seções.\n");
             sb.append("- Preencher formSpec completo como fonte única da verdade para campos e obrigatoriedade do formulário.\n");
             sb.append("- Preencher ctaSlot dentro das seções com CTA.\n");
             sb.append("- Preencher consistencyChecks e observações finais (mobilePriorityNotes, ctaPlacementNotes, formPlacementNotes).\n");
@@ -1225,7 +1241,7 @@ public class ExperimentPipelineGenerationService {
             sb.append("   - wireframe para ordem/hierarquia e mediaSlot;\n");
             sb.append("   - planejamento de imagens para imageRole, conversionRole, layoutBinding, prioridade e altText;\n");
             sb.append("   - wireframe.formSpec para renderização exata dos campos do formulário.\n");
-            sb.append("9. Renderizar cada seção com data-section-id e aplicar exatamente wireframe.sectionOrder[i].surfaceSpec via data-surface-token, data-surface-style e data-surface-contrast.\n");
+            sb.append("9. Renderizar cada seção com data-section-id e aplicar: data-surface-token vindo do wireframe.sectionOrder[i].surfaceSpec.surfaceToken; data-surface-style e data-surface-contrast vindos de landing-page-design-preset.sectionPresets por sectionId.\n");
             sb.append("10. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.\n");
             sb.append("11. O código deve ser limpo, legível e pronto para ser renderizado em iframe.\n");
             sb.append("12. Toda tag <img> deve usar src absoluto válido (https://... ou data:image/...) e reaproveitar altText do planejamento de imagens.\n\n");
@@ -1360,10 +1376,22 @@ public class ExperimentPipelineGenerationService {
             case CAMPAIGN_ANGLE -> experiment.setCampaignAngle(normalized);
             case AD_COPY -> experiment.setAdCopy(normalized);
             case AD_IMAGE_BRIEFING -> experiment.setAdImageBriefing(normalized);
-            case LANDING_PAGE_COPY -> experiment.setLandingPageCopy(normalized);
-            case LANDING_PAGE_WIREFRAME -> experiment.setLandingPageWireframe(normalized);
-            case LANDING_PAGE_IMAGE_PLANNING -> experiment.setLandingPageImagePlanning(normalized);
-            case LANDING_PAGE_DESIGN_PRESET -> experiment.setLandingPageDesignPreset(normalized);
+            case LANDING_PAGE_COPY -> {
+                validateLandingCopyArtifacts(normalized);
+                experiment.setLandingPageCopy(normalized);
+            }
+            case LANDING_PAGE_WIREFRAME -> {
+                validateLandingWireframeArtifacts(normalized);
+                experiment.setLandingPageWireframe(normalized);
+            }
+            case LANDING_PAGE_IMAGE_PLANNING -> {
+                validateLandingImagePlanningArtifacts(experiment, normalized);
+                experiment.setLandingPageImagePlanning(normalized);
+            }
+            case LANDING_PAGE_DESIGN_PRESET -> {
+                validateLandingDesignPresetArtifacts(experiment, normalized);
+                experiment.setLandingPageDesignPreset(normalized);
+            }
             case LANDING_PAGE_HTML -> {
                 validateLandingHtmlFormConsistency(experiment, normalized);
                 validateLandingHtmlSubmissionRuntime(experiment, normalized);
@@ -1371,6 +1399,224 @@ public class ExperimentPipelineGenerationService {
                 validateLandingHtmlImagePlanConsistency(experiment, normalized);
                 experiment.setLandingPageHtml(normalized);
             }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateLandingCopyArtifacts(String landingCopyContent) {
+        if (!StringUtils.hasText(landingCopyContent)) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Copy da landing vazia");
+        }
+        Map<String, Object> copyRoot = readObject(landingCopyContent, "Copy da landing inválida");
+        Map<String, Object> copyPayload = unwrapSectionPayload(copyRoot, "landingPageCopy");
+        boolean hasCanonicalHero = false;
+        if (copyPayload.get("hero") instanceof Map<?, ?> rawHero) {
+            Map<String, Object> hero = (Map<String, Object>) rawHero;
+            hasCanonicalHero = StringUtils.hasText(asTrimmedString(hero.get("headline")))
+                    && StringUtils.hasText(asTrimmedString(hero.get("promise")))
+                    && StringUtils.hasText(asTrimmedString(hero.get("ctaLabel")));
+        }
+        boolean hasLegacyMinimal = StringUtils.hasText(asTrimmedString(copyPayload.get("pageGoal")))
+                && StringUtils.hasText(asTrimmedString(copyPayload.get("primaryCTA")));
+
+        if (!hasCanonicalHero && !hasLegacyMinimal) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Copy da landing incompleta: esperado hero estruturado (headline/promise/ctaLabel) ou legado mínimo (pageGoal/primaryCTA)");
+        }
+
+        if (hasCanonicalHero) {
+            if (!(copyPayload.get("bodySections") instanceof List<?> rawBodySections) || rawBodySections.isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Copy da landing sem bodySections estruturado");
+            }
+            for (Object rawBodySection : rawBodySections) {
+                if (!(rawBodySection instanceof Map<?, ?> rawBodySectionMap)) {
+                    continue;
+                }
+                Map<String, Object> bodySection = (Map<String, Object>) rawBodySectionMap;
+                String sectionId = asTrimmedString(bodySection.get("sectionId"));
+                String summary = asTrimmedString(bodySection.get("summary"));
+                String copy = asTrimmedString(bodySection.get("copy"));
+                if (!StringUtils.hasText(sectionId) || (!StringUtils.hasText(summary) && !StringUtils.hasText(copy))) {
+                    throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                            "Copy da landing inválida em bodySections: cada item exige sectionId e summary/copy");
+                }
+            }
+            if (!(copyPayload.get("consistencyChecks") instanceof List<?> rawChecks) || rawChecks.isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Copy da landing sem consistencyChecks");
+            }
+            Set<String> checkNames = extractCheckNames(rawChecks);
+            if (!checkNames.contains("CTA_MATCH") || !checkNames.contains("PROMISE_MATCH")) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Copy da landing sem consistencyChecks obrigatórios: CTA_MATCH e PROMISE_MATCH");
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateLandingImagePlanningArtifacts(Experiment experiment, String imagePlanningContent) {
+        if (!StringUtils.hasText(imagePlanningContent)) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Planejamento de imagens vazio");
+        }
+        Map<String, Object> planningRoot = readObject(imagePlanningContent, "Planejamento de imagens inválido");
+        Map<String, Object> planningPayload = unwrapSectionPayload(planningRoot, "landingPageImagePlanning");
+        if (!(planningPayload.get("images") instanceof List<?> rawImages) || rawImages.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Planejamento de imagens sem images[] estruturado");
+        }
+        if (!(planningPayload.get("consistencyChecks") instanceof List<?> rawChecks) || rawChecks.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Planejamento de imagens sem consistencyChecks");
+        }
+        Set<String> checkNames = extractCheckNames(rawChecks);
+        if (!checkNames.contains("IMAGE_MESSAGE_MATCH") || !checkNames.contains("CTA_CONTINUITY")) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Planejamento de imagens sem consistencyChecks obrigatórios: IMAGE_MESSAGE_MATCH e CTA_CONTINUITY");
+        }
+        Set<String> plannedSectionIds = new LinkedHashSet<>();
+        Set<String> bindingKeys = new LinkedHashSet<>();
+        for (Object rawImage : rawImages) {
+            if (!(rawImage instanceof Map<?, ?> rawImageMap)) {
+                continue;
+            }
+            Map<String, Object> image = (Map<String, Object>) rawImageMap;
+            String sectionId = asTrimmedString(image.get("sectionId"));
+            String bindingKey = asTrimmedString(image.get("imageBindingKey"));
+            if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(bindingKey)) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Planejamento de imagens incompleto: cada item exige sectionId e imageBindingKey");
+            }
+            if (!bindingKeys.add(normalizeLookupKey(bindingKey))) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Planejamento de imagens inválido: imageBindingKey duplicado em images[]");
+            }
+            plannedSectionIds.add(normalizeLookupKey(sectionId));
+        }
+
+        if (experiment == null || !StringUtils.hasText(experiment.getLandingPageWireframe())) {
+            return;
+        }
+        Map<String, Object> wireframeRoot = readObject(experiment.getLandingPageWireframe(), "Wireframe da landing inválido");
+        Map<String, Object> wireframePayload = unwrapSectionPayload(wireframeRoot, "landingPageWireframe");
+        if (!(wireframePayload.get("sectionOrder") instanceof List<?> rawSections) || rawSections.isEmpty()) {
+            return;
+        }
+        Set<String> expectedSectionIds = new LinkedHashSet<>();
+        for (Object rawSection : rawSections) {
+            if (!(rawSection instanceof Map<?, ?> rawSectionMap)) {
+                continue;
+            }
+            String sectionId = asTrimmedString(((Map<String, Object>) rawSectionMap).get("sectionId"));
+            if (StringUtils.hasText(sectionId)) {
+                expectedSectionIds.add(normalizeLookupKey(sectionId));
+            }
+        }
+        Set<String> missing = new LinkedHashSet<>(expectedSectionIds);
+        missing.removeAll(plannedSectionIds);
+        if (!missing.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Planejamento de imagens incompleto: faltam sectionId do wireframe em images[]. Faltando: " + missing);
+        }
+        Set<String> extras = new LinkedHashSet<>(plannedSectionIds);
+        extras.removeAll(expectedSectionIds);
+        if (!extras.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Planejamento de imagens inválido: sectionId fora do wireframe em images[]. Excedente: " + extras);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> extractCheckNames(List<?> rawChecks) {
+        Set<String> checkNames = new LinkedHashSet<>();
+        if (rawChecks == null) {
+            return checkNames;
+        }
+        for (Object rawCheck : rawChecks) {
+            if (!(rawCheck instanceof Map<?, ?> rawCheckMap)) {
+                continue;
+            }
+            String check = asTrimmedString(((Map<String, Object>) rawCheckMap).get("check"));
+            if (StringUtils.hasText(check)) {
+                checkNames.add(check.toUpperCase(Locale.ROOT));
+            }
+        }
+        return checkNames;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateLandingWireframeArtifacts(String wireframeContent) {
+        if (!StringUtils.hasText(wireframeContent)) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Wireframe da landing vazio");
+        }
+        Map<String, Object> wireframeRoot = readObject(wireframeContent, "Wireframe da landing inválido");
+        Map<String, Object> wireframePayload = unwrapSectionPayload(wireframeRoot, "landingPageWireframe");
+        if (!(wireframePayload.get("sectionOrder") instanceof List<?> rawSections) || rawSections.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Wireframe da landing sem sectionOrder estruturado");
+        }
+        for (Object rawSection : rawSections) {
+            if (!(rawSection instanceof Map<?, ?> rawSectionMap)) {
+                continue;
+            }
+            Map<String, Object> section = (Map<String, Object>) rawSectionMap;
+            String sectionId = asTrimmedString(section.get("sectionId"));
+            if (!StringUtils.hasText(sectionId)) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Wireframe da landing com section sem sectionId");
+            }
+            if (!(section.get("surfaceSpec") instanceof Map<?, ?> rawSurfaceMap)) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Wireframe da landing com section sem surfaceSpec");
+            }
+            Map<String, Object> surfaceSpec = (Map<String, Object>) rawSurfaceMap;
+            if (!StringUtils.hasText(asTrimmedString(surfaceSpec.get("surfaceToken")))) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Wireframe da landing com section sem surfaceSpec.surfaceToken");
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateLandingDesignPresetArtifacts(Experiment experiment, String designPresetContent) {
+        if (!StringUtils.hasText(designPresetContent)) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Preset de design da landing vazio");
+        }
+        Map<String, Object> designRoot = readObject(designPresetContent, "Preset de design da landing inválido");
+        Map<String, Object> designPayload = unwrapSectionPayload(designRoot, "landingPageDesignPreset");
+        if (!(designPayload.get("sectionPresets") instanceof List<?> rawSectionPresets) || rawSectionPresets.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Preset de design da landing sem sectionPresets estruturado");
+        }
+
+        if (experiment == null || !StringUtils.hasText(experiment.getLandingPageWireframe())) {
+            return;
+        }
+        Map<String, Object> wireframeRoot = readObject(experiment.getLandingPageWireframe(), "Wireframe da landing inválido");
+        Map<String, Object> wireframePayload = unwrapSectionPayload(wireframeRoot, "landingPageWireframe");
+        if (!(wireframePayload.get("sectionOrder") instanceof List<?> rawSections) || rawSections.isEmpty()) {
+            return;
+        }
+        Set<String> expectedSectionIds = new LinkedHashSet<>();
+        for (Object rawSection : rawSections) {
+            if (!(rawSection instanceof Map<?, ?> rawSectionMap)) {
+                continue;
+            }
+            String sectionId = asTrimmedString(((Map<String, Object>) rawSectionMap).get("sectionId"));
+            if (StringUtils.hasText(sectionId)) {
+                expectedSectionIds.add(normalizeLookupKey(sectionId));
+            }
+        }
+        Set<String> presetSectionIds = new LinkedHashSet<>();
+        for (Object rawPreset : rawSectionPresets) {
+            if (!(rawPreset instanceof Map<?, ?> rawPresetMap)) {
+                continue;
+            }
+            String sectionId = asTrimmedString(((Map<String, Object>) rawPresetMap).get("sectionId"));
+            if (StringUtils.hasText(sectionId)) {
+                presetSectionIds.add(normalizeLookupKey(sectionId));
+            }
+        }
+        Set<String> missing = new LinkedHashSet<>(expectedSectionIds);
+        missing.removeAll(presetSectionIds);
+        if (!missing.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Preset de design incompleto: sectionPresets não cobre todas as sectionId do wireframe. Faltando: " + missing);
         }
     }
 
@@ -1751,7 +1997,7 @@ public class ExperimentPipelineGenerationService {
                 Map.of("check", "CTA_MATCH", "status", "PASS", "details", "CTA principal mantido conforme artefatos anteriores."),
                 Map.of("check", "PROMISE_MATCH", "status", "PASS", "details", "Narrativa permanece consistente com os artefatos predecessores."),
                 Map.of("check", "IMAGE_PLAN_BINDING", "status", "PASS", "details", "Bindings de imagem preservados na saída final."),
-                Map.of("check", "SURFACE_SPEC_BINDING", "status", "PASS", "details", "surfaceSpec aplicado conforme wireframe.")
+                Map.of("check", "SURFACE_SPEC_BINDING", "status", "PASS", "details", "surfaceToken aplicado conforme wireframe e style/contrast conforme design preset.")
         );
     }
 
@@ -2678,7 +2924,7 @@ public class ExperimentPipelineGenerationService {
                         Map.entry("contrastMode", Map.of("type", "string", "enum", List.of("normal", "high", "soft"))),
                         Map.entry("notes", stringSchema())
                 ),
-                "required", List.of("surfaceToken", "style", "contrastMode", "notes")
+                "required", List.of("surfaceToken", "notes")
         );
         Map<String, Object> ctaSlotSchema = Map.of(
                 "type", "object",
@@ -2844,7 +3090,8 @@ public class ExperimentPipelineGenerationService {
 
         Map<String, Object> wireframeRoot = readObject(experiment.getLandingPageWireframe(), "Wireframe da landing inválido");
         Map<String, Object> wireframePayload = unwrapSectionPayload(wireframeRoot, "landingPageWireframe");
-        List<SectionSurfaceContract> expectedSurfaces = extractExpectedSectionSurfaces(wireframePayload);
+        Map<String, SectionVisualPresetContract> visualPresetBySection = extractSectionVisualPresetBySection(experiment);
+        List<SectionSurfaceContract> expectedSurfaces = extractExpectedSectionSurfaces(wireframePayload, visualPresetBySection);
         if (expectedSurfaces.isEmpty()) {
             log.warn("Validação landing HTML (experimentId={}): wireframe sem sectionOrder.surfaceSpec", experiment.getId());
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Wireframe da landing sem sectionOrder.surfaceSpec estruturado");
@@ -2876,7 +3123,9 @@ public class ExperimentPipelineGenerationService {
     }
 
     @SuppressWarnings("unchecked")
-    private List<SectionSurfaceContract> extractExpectedSectionSurfaces(Map<String, Object> wireframePayload) {
+    private List<SectionSurfaceContract> extractExpectedSectionSurfaces(
+            Map<String, Object> wireframePayload,
+            Map<String, SectionVisualPresetContract> visualPresetBySection) {
         if (!(wireframePayload.get("sectionOrder") instanceof List<?> rawSections)) {
             return List.of();
         }
@@ -2892,8 +3141,13 @@ public class ExperimentPipelineGenerationService {
             }
             Map<String, Object> surfaceSpec = (Map<String, Object>) rawSurfaceMap;
             String surfaceToken = normalizeHtmlAttr(asTrimmedString(surfaceSpec.get("surfaceToken")));
-            String style = normalizeHtmlAttr(asTrimmedString(surfaceSpec.get("style")));
-            String contrastMode = normalizeHtmlAttr(asTrimmedString(surfaceSpec.get("contrastMode")));
+            SectionVisualPresetContract visualPreset = visualPresetBySection.get(normalizeLookupKey(sectionId));
+            String style = normalizeHtmlAttr(firstNonBlank(
+                    visualPreset != null ? visualPreset.surfaceStyle() : null,
+                    asTrimmedString(surfaceSpec.get("style"))));
+            String contrastMode = normalizeHtmlAttr(firstNonBlank(
+                    visualPreset != null ? visualPreset.contrastMode() : null,
+                    asTrimmedString(surfaceSpec.get("contrastMode"))));
             if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(surfaceToken)
                     || !StringUtils.hasText(style) || !StringUtils.hasText(contrastMode)) {
                 continue;
@@ -2901,6 +3155,33 @@ public class ExperimentPipelineGenerationService {
             surfaces.add(new SectionSurfaceContract(sectionId, surfaceToken, style, contrastMode));
         }
         return surfaces;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, SectionVisualPresetContract> extractSectionVisualPresetBySection(Experiment experiment) {
+        if (experiment == null || !StringUtils.hasText(experiment.getLandingPageDesignPreset())) {
+            return Map.of();
+        }
+        Map<String, Object> designRoot = readObject(experiment.getLandingPageDesignPreset(), "Preset de design da landing inválido");
+        Map<String, Object> designPayload = unwrapSectionPayload(designRoot, "landingPageDesignPreset");
+        if (!(designPayload.get("sectionPresets") instanceof List<?> rawPresets)) {
+            return Map.of();
+        }
+        Map<String, SectionVisualPresetContract> presets = new LinkedHashMap<>();
+        for (Object rawPreset : rawPresets) {
+            if (!(rawPreset instanceof Map<?, ?> rawPresetMap)) {
+                continue;
+            }
+            Map<String, Object> preset = (Map<String, Object>) rawPresetMap;
+            String sectionId = normalizeHtmlAttr(asTrimmedString(preset.get("sectionId")));
+            String surfaceStyle = normalizeHtmlAttr(asTrimmedString(preset.get("surfaceStyle")));
+            String contrastMode = normalizeHtmlAttr(asTrimmedString(preset.get("contrastMode")));
+            if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(surfaceStyle) || !StringUtils.hasText(contrastMode)) {
+                continue;
+            }
+            presets.put(normalizeLookupKey(sectionId), new SectionVisualPresetContract(sectionId, surfaceStyle, contrastMode));
+        }
+        return presets;
     }
 
     private List<SectionSurfaceContract> extractSectionSurfacesFromHtmlDocument(Long experimentId, String htmlDocument) {
@@ -3232,6 +3513,10 @@ public class ExperimentPipelineGenerationService {
                 || lower.contains("\\\"");
     }
 
+    private String normalizeLookupKey(String value) {
+        return StringUtils.hasText(value) ? value.trim().toLowerCase(Locale.ROOT) : "";
+    }
+
     private record FormFieldContract(String name, String type, boolean required) {
         @Override
         public boolean equals(Object obj) {
@@ -3250,6 +3535,9 @@ public class ExperimentPipelineGenerationService {
     }
 
     private record SectionSurfaceContract(String sectionId, String surfaceToken, String style, String contrastMode) {
+    }
+
+    private record SectionVisualPresetContract(String sectionId, String surfaceStyle, String contrastMode) {
     }
 
     private record ImagePlanBindingContract(String sectionId,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
@@ -166,7 +166,7 @@ class LandingHtmlModuleTest {
     }
 
     @Test
-    void assembleHtmlDocumentDoesNotOverrideSurfaceSpecFromWireframeUsingDesignPreset() {
+    void assembleHtmlDocumentUsesDesignPresetForStyleAndContrastMode() {
         Experiment experiment = new Experiment();
         experiment.setName("Teste LHM Surface Preset");
         experiment.setLandingPageWireframe("""
@@ -210,10 +210,11 @@ class LandingHtmlModuleTest {
         String html = module.assembleHtmlDocument(experiment);
 
         assertTrue(html.contains("data-section-id=\"proof\""));
-        assertTrue(html.contains("class=\"card surface-band contrast-soft\""));
-        assertTrue(html.contains("data-surface-style=\"band\""));
-        assertTrue(html.contains("data-surface-contrast=\"soft\""));
-        assertFalse(html.contains("data-surface-style=\"solid\""));
-        assertFalse(html.contains("data-surface-contrast=\"high\""));
+        assertTrue(html.contains("class=\"card surface-solid contrast-high\""));
+        assertTrue(html.contains("data-surface-token=\"surface-proof\""));
+        assertTrue(html.contains("data-surface-style=\"solid\""));
+        assertTrue(html.contains("data-surface-contrast=\"high\""));
+        assertFalse(html.contains("data-surface-style=\"band\""));
+        assertFalse(html.contains("data-surface-contrast=\"soft\""));
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -492,6 +492,42 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void generateLandingHtmlFailsEarlyWhenWireframeAndDesignPresetAreInconsistent() {
+        Experiment experiment = new Experiment();
+        experiment.setId(88L);
+        experiment.setLandingPageDesignPreset("""
+                {
+                  "landingPageDesignPreset": {
+                    "sectionPresets": [
+                      {"sectionId":"hero","surfaceStyle":"solid","contrastMode":"high","layoutPreset":"hero-focus","emphasis":"primary","notes":"hero"}
+                    ]
+                  }
+                }
+                """);
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {"sectionId":"hero","surfaceSpec":{"surfaceToken":"surface-base","notes":"hero"}},
+                      {"sectionId":"proof","surfaceSpec":{"surfaceToken":"surface-alt-1","notes":"proof"}}
+                    ]
+                  }
+                }
+                """);
+
+        when(experimentRepository.findById(88L)).thenReturn(Optional.of(experiment));
+        when(frameworkImageGenerationService.allPlanningImagesCompleted(88L)).thenReturn(true);
+
+        ResponseStatusException error = assertThrows(ResponseStatusException.class,
+                () -> service.generate(88L, ExperimentPipelineSection.LANDING_PAGE_HTML, new ExperimentPipelineGenerationRequest()));
+
+        assertEquals(409, error.getStatusCode().value());
+        assertTrue(error.getReason().contains("Pré-validação antes de LANDING_PAGE_HTML falhou"));
+        assertTrue(error.getReason().contains("Preset de design incompleto"));
+        verify(jobRepository, never()).save(any(ExperimentPipelineGenerationJob.class));
+    }
+
+    @Test
     void listPendingJobsReturnsOnlyEligibleExperimentStatuses() {
         Experiment plannedExperiment = new Experiment();
         plannedExperiment.setId(31L);
@@ -770,6 +806,211 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void completeJobUsesDesignPresetAsCanonicalSourceForSurfaceStyleAndContrast() {
+        Experiment experiment = buildLandingHtmlValidationExperiment(240L);
+        experiment.setLandingPageDesignPreset("""
+                {
+                  "landingPageDesignPreset": {
+                    "sectionPresets": [
+                      {
+                        "sectionId": "hero",
+                        "surfaceStyle": "solid",
+                        "contrastMode": "high"
+                      }
+                    ]
+                  }
+                }
+                """);
+        ExperimentPipelineGenerationJob job = createLandingHtmlJob(experiment);
+
+        service.completeJob(job.getId(), landingHtmlCompletionRequest("""
+                <!doctype html><html><body>
+                <section data-section-id='hero' data-surface-token='surface-base' data-surface-style='solid' data-surface-contrast='high'>
+                  <img src='https://cdn.example.com/hero.jpg' alt='Hero'
+                       data-image-section-id='hero'
+                       data-image-binding-key='hero_pain_anchor'
+                       data-image-role='Hero Pain Anchor'
+                       data-conversion-role='grab-attention'
+                       data-attention-priority='high'
+                       data-visual-weight='primary'
+                       data-distance-to-cta='near'
+                       data-supports-form-conversion='true' />
+                  <form id='lead-capture-primary'><input type='text' name='nome' required /><input type='email' name='email' required /><input type='tel' name='whatsapp' /></form>
+                </section></body></html>
+                """));
+
+        assertNotNull(experiment.getLandingPageHtml());
+    }
+
+    @Test
+    void completeJobRejectsWireframeWhenSurfaceTokenIsMissing() {
+        Experiment experiment = new Experiment();
+        experiment.setId(410L);
+        ExperimentPipelineGenerationJob job = createJobForSection(experiment, ExperimentPipelineSection.LANDING_PAGE_WIREFRAME);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> service.completeJob(job.getId(), new ExperimentPipelineGenerationJobCompletionRequest(
+                        """
+                                {
+                                  "landingPageWireframe": {
+                                    "pageGoal": "goal",
+                                    "variantLayoutId": "form-first",
+                                    "sectionOrder": [
+                                      {
+                                        "sectionId": "hero",
+                                        "sectionName": "Hero",
+                                        "objective": "obj",
+                                        "contentType": "hero",
+                                        "mobilePriorityScore": 10,
+                                        "dropOffRisk": "baixo",
+                                        "surfaceSpec": {"notes": "sem token"}
+                                      }
+                                    ],
+                                    "consistencyChecks": [{"check":"CTA_MATCH","status":"PASS"}],
+                                    "formSpec": {
+                                      "formId": "lead-capture-primary",
+                                      "title": "Receber a prévia",
+                                      "submitLabel": "Enviar",
+                                      "submitTarget": "/api/flows/submissions",
+                                      "fields": [{"name":"nome","type":"text","label":"Nome","required":true,"placeholder":"Seu nome"}],
+                                      "consent": {"enabled": true, "required": false, "label": "ok"},
+                                      "successState": {"title":"ok","message":"ok"}
+                                    }
+                                  },
+                                  "experimentMetadata": {
+                                    "primary_variable":"pv","variant_id":"v1","stage":"AD","control_or_treatment":"treatment","asset_role":"landing-page-wireframe"
+                                  }
+                                }
+                                """,
+                        null, null, null, null, null)));
+
+        assertTrue(exception.getReason().contains("surfaceSpec.surfaceToken"));
+    }
+
+    @Test
+    void completeJobRejectsDesignPresetWhenSectionPresetsDoesNotCoverWireframeSections() {
+        Experiment experiment = new Experiment();
+        experiment.setId(411L);
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {
+                        "sectionId": "hero",
+                        "surfaceSpec": {"surfaceToken": "surface-base", "notes": "hero"}
+                      },
+                      {
+                        "sectionId": "proof",
+                        "surfaceSpec": {"surfaceToken": "surface-alt-1", "notes": "proof"}
+                      }
+                    ]
+                  }
+                }
+                """);
+        ExperimentPipelineGenerationJob job = createJobForSection(experiment, ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> service.completeJob(job.getId(), new ExperimentPipelineGenerationJobCompletionRequest(
+                        """
+                                {
+                                  "landingPageDesignPreset": {
+                                    "presetId": "preset-1",
+                                    "theme": {
+                                      "palette": {
+                                        "background":"#fff","surface":"#fff","textPrimary":"#111","textMuted":"#666","brandPrimary":"#1d4ed8","brandSecondary":"#1e40af","border":"#e2e8f0"
+                                      }
+                                    },
+                                    "sectionPresets": [
+                                      {"sectionId":"hero","surfaceStyle":"solid","contrastMode":"high","layoutPreset":"hero-focus","emphasis":"primary","notes":"hero"}
+                                    ],
+                                    "componentPresets": {},
+                                    "motion": {"enabled": false, "intensity": "none"},
+                                    "consistencyChecks": [{"check":"THEME_CONTRAST","status":"PASS"}]
+                                  },
+                                  "experimentMetadata": {
+                                    "primary_variable":"pv","variant_id":"v1","stage":"AD","control_or_treatment":"treatment","asset_role":"landing-page-design-preset"
+                                  }
+                                }
+                                """,
+                        null, null, null, null, null)));
+
+        assertTrue(exception.getReason().contains("Preset de design incompleto"));
+        assertTrue(exception.getReason().contains("proof"));
+    }
+
+    @Test
+    void completeJobRejectsLandingCopyWhenCanonicalChecksAreMissing() {
+        Experiment experiment = new Experiment();
+        experiment.setId(412L);
+        ExperimentPipelineGenerationJob job = createJobForSection(experiment, ExperimentPipelineSection.LANDING_PAGE_COPY);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> service.completeJob(job.getId(), new ExperimentPipelineGenerationJobCompletionRequest(
+                        """
+                                {
+                                  "landingPageCopy": {
+                                    "hero": {
+                                      "headline": "Headline",
+                                      "promise": "Promise",
+                                      "ctaLabel": "CTA"
+                                    },
+                                    "bodySections": [
+                                      {"sectionId": "hero", "summary": "Resumo"}
+                                    ],
+                                    "consistencyChecks": [
+                                      {"check":"GOOGLE_LANDING_BEST_PRACTICES","status":"PASS"}
+                                    ]
+                                  },
+                                  "experimentMetadata": {
+                                    "primary_variable":"pv","variant_id":"v1","stage":"AD","control_or_treatment":"treatment","asset_role":"landing-page-copy"
+                                  }
+                                }
+                                """,
+                        null, null, null, null, null)));
+
+        assertTrue(exception.getReason().contains("CTA_MATCH"));
+        assertTrue(exception.getReason().contains("PROMISE_MATCH"));
+    }
+
+    @Test
+    void completeJobRejectsImagePlanningWhenRequiredChecksAreMissing() {
+        Experiment experiment = new Experiment();
+        experiment.setId(413L);
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {"sectionId": "hero", "surfaceSpec": {"surfaceToken": "surface-base", "notes": "hero"}}
+                    ]
+                  }
+                }
+                """);
+        ExperimentPipelineGenerationJob job = createJobForSection(experiment, ExperimentPipelineSection.LANDING_PAGE_IMAGE_PLANNING);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> service.completeJob(job.getId(), new ExperimentPipelineGenerationJobCompletionRequest(
+                        """
+                                {
+                                  "landingPageImagePlanning": {
+                                    "images": [
+                                      {"sectionId":"hero","imageBindingKey":"hero-anchor"}
+                                    ],
+                                    "consistencyChecks": [
+                                      {"check":"VISUAL_HIERARCHY","status":"PASS"}
+                                    ]
+                                  },
+                                  "experimentMetadata": {
+                                    "primary_variable":"pv","variant_id":"v1","stage":"AD","control_or_treatment":"treatment","asset_role":"landing-page-image-planning"
+                                  }
+                                }
+                                """,
+                        null, null, null, null, null)));
+
+        assertTrue(exception.getReason().contains("IMAGE_MESSAGE_MATCH"));
+        assertTrue(exception.getReason().contains("CTA_CONTINUITY"));
+    }
+
+    @Test
     void completeJobSucceedsWhenBindingKeyContainsEscapedQuoteArtifacts() {
         Experiment experiment = buildLandingHtmlValidationExperiment(205L);
         ExperimentPipelineGenerationJob job = createLandingHtmlJob(experiment);
@@ -923,6 +1164,10 @@ class ExperimentPipelineGenerationServiceTest {
         experiment.setLandingPageImagePlanning("""
                 {
                   "landingPageImagePlanning": {
+                    "consistencyChecks": [
+                      {"check": "IMAGE_MESSAGE_MATCH", "status": "PASS"},
+                      {"check": "CTA_CONTINUITY", "status": "PASS"}
+                    ],
                     "images": [
                       {
                         "sectionId": "hero",
@@ -966,6 +1211,10 @@ class ExperimentPipelineGenerationServiceTest {
         String payload = """
                 {
                   "landingPageImagePlanning": {
+                    "consistencyChecks": [
+                      {"check": "IMAGE_MESSAGE_MATCH", "status": "PASS"},
+                      {"check": "CTA_CONTINUITY", "status": "PASS"}
+                    ],
                     "images": [
                       {
                         "sectionId": "s0-hero-variant",
@@ -1081,11 +1330,15 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     private ExperimentPipelineGenerationJob createLandingHtmlJob(Experiment experiment) {
+        return createJobForSection(experiment, ExperimentPipelineSection.LANDING_PAGE_HTML);
+    }
+
+    private ExperimentPipelineGenerationJob createJobForSection(Experiment experiment, ExperimentPipelineSection section) {
         UUID jobId = UUID.randomUUID();
         ExperimentPipelineGenerationJob job = ExperimentPipelineGenerationJob.builder()
                 .id(jobId)
                 .experiment(experiment)
-                .section(ExperimentPipelineSection.LANDING_PAGE_HTML)
+                .section(section)
                 .status(ExperimentPipelineGenerationJobStatus.PROCESSING)
                 .stage(ExperimentPipelineGenerationJobStage.SENT_TO_OPENAI)
                 .model("gpt-5.2")

--- a/docs/canonical/matriz-responsabilidades-pipeline-landing.md
+++ b/docs/canonical/matriz-responsabilidades-pipeline-landing.md
@@ -1,0 +1,28 @@
+# Matriz de responsabilidades — pipeline de landing
+
+## Objetivo
+Documento operacional para leitura rápida, separando **quem é responsável por cada item** no pipeline e quais validações de fechamento existem em cada etapa.
+
+## Mapa por etapa
+
+| Etapa | Responsabilidade principal | Itens canônicos sob responsabilidade | Validação pesada no fechamento (`complete`) |
+|---|---|---|---|
+| `landingPageCopy` | Narrativa comercial e continuidade de mensagem | `hero` (headline/promise/ctaLabel), `bodySections`, `consistencyChecks` (`CTA_MATCH`, `PROMISE_MATCH`) | Rejeita payload sem `hero` estruturado (ou fallback legado mínimo), sem `bodySections` válidos e sem checks obrigatórios `CTA_MATCH` + `PROMISE_MATCH`. |
+| `landingPageWireframe` | Estrutura da página (ordem/hierarquia) | `sectionOrder`, `sectionId`, `surfaceSpec.surfaceToken`, `formSpec` | Rejeita sem `sectionOrder`, sem `sectionId` ou sem `surfaceSpec.surfaceToken` por seção. |
+| `landingPageImagePlanning` | Cobertura de imagem por seção | `images[]` com `sectionId` + `imageBindingKey`, `consistencyChecks` (`IMAGE_MESSAGE_MATCH`, `CTA_CONTINUITY`) | Rejeita ausência dos checks obrigatórios `IMAGE_MESSAGE_MATCH` + `CTA_CONTINUITY`, item sem `sectionId`/`imageBindingKey`, `imageBindingKey` duplicado, sectionId fora do wireframe e falta de cobertura das `sectionId` do wireframe. |
+| `landingPageDesignPreset` | Detalhe visual por seção | `sectionPresets` com `surfaceStyle`/`contrastMode` | Rejeita sem `sectionPresets` e rejeita se `sectionPresets` não cobre todas as `sectionId` do wireframe. |
+| `landingPageHtml` | Implementação final e aderência total de contrato | `htmlDocument` + binding de formulário, superfície e imagens | Valida runtime de form, binding de superfície e binding canônico de imagem antes de aceitar publicação. |
+
+## Regra de ownership visual x estrutural
+
+- **Estrutural (`wireframe`)**: `surfaceToken` + organização da página.
+- **Visual (`designPreset`)**: `surfaceStyle` + `contrastMode` por `sectionId`.
+- **HTML final (`LHM`)**: combina os dois contratos e publica os `data-*` aderentes.
+
+## Gate antecipado antes de HTML
+
+Além do fechamento de cada etapa, o backend executa pré-validação antes de gerar `landingPageHtml` para bloquear inconsistências de artefatos cedo (sem esperar o erro final de publicação).
+
+## Score comercial (vendas)
+
+Além das validações de contrato, a qualidade comercial da landing deve ser avaliada pelo **Scorecard de Vendas — Landing Page (v2)** em `docs/canonical/scorecard-vendas-landing.md`, incluindo gate automático de regressão para ajuste quando o score ficar abaixo do limiar.

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -9,6 +9,7 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
 > - O LHM **não** é uma etapa de ideação criativa livre da copy.
 > - O LHM deve renderizar de forma previsível a partir dos artefatos canônicos (ex.: `landingPageCopy` e `landingPageWireframe`) e contratos vigentes.
 > - Mudanças no pipeline devem preservar essa responsabilidade para reduzir drift entre especificação, backend e página publicada.
+> - **Regra de negócio mandatória**: a robustez arquitetural dos artefatos deve sempre servir ao objetivo de vendas (conversão, consistência de promessa, redução de fricção e avanço de funil).
 
 ## Observação importante — independência dos experimentos
 
@@ -189,7 +190,16 @@ Para considerar a copy **rica** e **compatível com as especificações**, a eta
    - `hero.promise`, `primaryCTA` e `ctaBlocks[*].matchAdCta` devem manter coerência semântica.
    - `consistencyChecks` deve incluir, no mínimo, os checks: `CTA_MATCH`, `PROMISE_MATCH` e `GOOGLE_LANDING_BEST_PRACTICES`.
 
-5. **Critério de bloqueio**
+5. **Mínimos comerciais de oferta (mandatórios)**
+   - A copy deve explicitar risco reverso (garantia, teste ou política equivalente).
+   - A copy deve apresentar escassez/urgência legítima (sem alegação artificial).
+   - A copy deve apresentar ancoragem de valor (comparação clara entre custo e valor percebido).
+   - A copy deve incluir prova específica e contextualizada (evitar prova genérica).
+
+6. **Biblioteca de mecanismos de prova por nicho**
+   - Priorizar combinação de pelo menos 2 tipos de prova entre: antes/depois, benchmark comparativo, micro-caso com número e evidência técnica simplificada.
+
+7. **Critério de bloqueio**
    - Se qualquer regra acima falhar, o artefato permanece em `DRAFT` e não pode seguir para renderização final.
    - O LHM só deve processar copy com validação aprovada (`status = VALIDATED` ou `APPROVED`).
 
@@ -213,8 +223,6 @@ Para considerar a copy **rica** e **compatível com as especificações**, a eta
       "dropOffRisk": "baixo | medio | alto",
       "surfaceSpec": {
         "surfaceToken": "string",
-        "style": "band | solid | gradient-soft | image-tint",
-        "contrastMode": "normal | high | soft",
         "notes": "string"
       },
       "ctaSlot": {
@@ -263,6 +271,12 @@ Para considerar a copy **rica** e **compatível com as especificações**, a eta
   }
 }
 ```
+
+> **Responsabilidade canônica (vigente):**
+> - `landingPageWireframe` define **estrutura** (ordem, hierarquia, intenção de seção) e mantém em `surfaceSpec` apenas a âncora estrutural (`surfaceToken` + `notes`).
+> - `style` e `contrastMode` são responsabilidade da etapa `landingPageDesignPreset.sectionPresets` (detalhe visual por `sectionId`).
+> - Após `complete` da etapa de wireframe, o backend valida presença de `sectionOrder` estruturado e `surfaceSpec.surfaceToken` por seção antes de aceitar o artefato.
+> - Antes de iniciar `landingPageHtml`, o backend executa pré-validação de consistência entre wireframe e design preset para antecipar falhas que antes apareciam apenas no fim do pipeline.
 
 ## `landingPageImagePlanning`
 
@@ -401,6 +415,9 @@ Para considerar a copy **rica** e **compatível com as especificações**, a eta
   ]
 }
 ```
+
+> `landingPageDesignPreset.sectionPresets` é a fonte canônica de `surfaceStyle` e `contrastMode` por `sectionId` para renderização final do HTML.
+> Após `complete` da etapa de design preset, o backend valida se `sectionPresets` cobre todas as `sectionId` do wireframe atual.
 
 ## `landingPageHtml`
 

--- a/docs/canonical/scorecard-vendas-landing.md
+++ b/docs/canonical/scorecard-vendas-landing.md
@@ -1,0 +1,135 @@
+# Scorecard de Vendas — Landing Page (v2)
+
+## Objetivo
+Padronizar a avaliação comercial de cada landing antes de publicação, mantendo coerência com o eixo canônico **Dor → Resultado → Mecanismo → Prova → Oferta** e garantindo que a arquitetura robusta sirva a vendas reais (não só conformidade técnica).
+
+---
+
+## Como pontuar
+
+- Escala por dimensão: **0 a 5**
+- Peso por dimensão: conforme tabela abaixo
+- Fórmula:
+
+```text
+score_final (0-100) = Σ( nota_dimensão/5 * peso_dimensão )
+```
+
+---
+
+## Dimensões, pesos e critérios (gate comercial)
+
+| Dimensão | Peso | O que mede | Critério de nota 5 |
+|---|---:|---|---|
+| 1) Clareza da Promessa | 25 | Clareza da dor, do resultado e do próximo passo | Headline + promessa + CTA estão cristalinos para o ICP, sem ambiguidade e com alta continuidade de mensagem. |
+| 2) Força da Prova | 25 | Evidência que sustenta a promessa | Prova concreta, específica e contextualizada (não genérica), com risco percebido baixo de “promessa vazia”. |
+| 3) Fricção do Formulário | 15 | Esforço para conversão | Formulário com mínimo atrito, microcopy anti-ansiedade e clareza de próximos passos. |
+| 4) Urgência e Oferta | 20 | Intensidade de decisão | Oferta com escassez/urgência legítima, ancoragem de valor e risco reverso explícito. |
+| 5) Objeções Cobertas | 15 | Capacidade de remover travas de compra | FAQ e seções de prova neutralizam objeções principais do nicho com respostas específicas. |
+
+---
+
+## Rubrica prática (0 a 5) por dimensão
+
+- **0**: ausente ou contraditório
+- **1**: muito fraco; confuso; sem evidência
+- **2**: básico; parcialmente claro; ainda gera objeções críticas
+- **3**: aceitável; converte em cenário favorável
+- **4**: forte; consistente; reduz objeções principais
+- **5**: excelente; específico; convincente para tráfego frio
+
+---
+
+## Gate automático pré-publicação
+
+### Gate mínimo global
+- **Aprova para publicação controlada**: `score_final >= 75`
+- **Aprova para escala**: `score_final >= 85`
+
+### Gates mínimos por dimensão (hard-fail)
+Se qualquer condição abaixo falhar, a landing não escala mesmo com score global alto:
+
+- Clareza da Promessa **>= 3.5**
+- Força da Prova **>= 3.0**
+- Fricção do Formulário **>= 3.0**
+- Urgência e Oferta **>= 3.0**
+- Objeções Cobertas **>= 3.0**
+
+### Regra de regressão para ajuste automático
+- Se `score_final < 75` **ou** qualquer hard-fail ocorrer, a variante deve voltar para ajuste de `landingPageCopy`/`landingPageWireframe`/`landingPageDesignPreset` antes de nova tentativa de publicação.
+
+---
+
+## Critérios mínimos de oferta (mandatórios)
+
+Toda landing aprovada deve explicitar:
+
+1. **Risco reverso**: garantia, teste, política clara ou mecanismo equivalente.
+2. **Escassez/urgência legítima**: justificativa real, sem manipulação artificial.
+3. **Ancoragem de valor**: contraste explícito entre custo e valor percebido.
+4. **Prova específica**: dados/casos contextuais, evitando afirmações genéricas.
+
+---
+
+## Biblioteca canônica de mecanismos de prova por nicho
+
+As variantes devem priorizar combinações de prova de alto impacto:
+
+- **Antes/depois** com contexto de aplicação.
+- **Benchmark comparativo** com alternativa comum do mercado.
+- **Micro-caso com número** (resultado mensurável + janela temporal).
+- **Evidência técnica simplificada** (como o mecanismo funciona em linguagem acessível).
+
+> Regra prática: pelo menos **2 tipos de prova** por landing, sendo ao menos 1 prova numérica ou comparativa.
+
+---
+
+## Checklist operacional por dimensão
+
+### 1) Clareza da Promessa (25)
+- A dor principal aparece em até 5 segundos de leitura.
+- O resultado prometido é específico (o quê, para quem e em qual contexto).
+- CTA principal está semanticamente alinhado à promessa do anúncio.
+
+### 2) Força da Prova (25)
+- Existe ao menos 1 prova principal com contexto (quem, quando, cenário).
+- Há mecanismo explicando **como** o resultado ocorre.
+- Limitações/condições estão explícitas para reduzir risco jurídico e de confiança.
+
+### 3) Fricção do Formulário (15)
+- Campos estritamente necessários para a etapa do funil.
+- Microcopy reduz ansiedade (privacidade, tempo de resposta, próximos passos).
+- CTA é claro, visível e consistente em pontos críticos da página.
+
+### 4) Urgência e Oferta (20)
+- Entregáveis e formato estão claros.
+- Risco reverso está explícito.
+- Escassez/urgência é legítima e verificável.
+- Ancoragem de valor foi comunicada.
+
+### 5) Objeções Cobertas (15)
+- FAQ cobre objeções principais do público-alvo.
+- Respostas usam prova e não só opinião.
+- Objeções de preço, tempo, confiança e aplicabilidade possuem tratamento claro.
+
+---
+
+## Loop de aprendizado pós-publicação (obrigatório)
+
+Após publicar, reavaliar semanalmente com dados reais para retroalimentar copy/wireframe/preset:
+
+- CTR anúncio → landing
+- Scroll por seção
+- Submit rate da landing
+- Abandono por campo de formulário
+- CPL / CPA
+
+Regra: variações com piora estatisticamente relevante devem regressar para ajuste automático e nova rodada de scorecard.
+
+---
+
+## Governança
+
+- Este scorecard é canônico para avaliação comercial de landing pages no pipeline de experimento.
+- O scorecard valida não apenas “está correto”, mas “está vendendo”.
+- Alterações de pesos, gates ou rubrica exigem atualização versionada deste documento.

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -30,6 +30,7 @@
 6. **Mudanças relevantes exigem teste e documentação correspondente.** Regra operacional sem teste e sem contrato atualizado é candidata imediata a drift.
 7. **LHM é determinístico por definição canônica.** O Landing HTML Module (LHM) é responsável pela renderização previsível do HTML final de landing pages a partir de artefatos/contratos canônicos; não é camada de ideação livre de copy.
 8. **Evolução visual via artefato canônico.** Ajustes de estética/tema para landing pages devem ser modelados em artefato canônico estruturado (ex.: `landingPageDesignPreset`) consumido pelo LHM; evitar etapa de geração livre de HTML/JS fora do contrato.
+9. **Arquitetura robusta orientada a vendas.** Robustez técnica, validações e contratos existem para sustentar resultado comercial: melhorar conversão, reduzir fricção e manter continuidade de mensagem entre criativo, landing e oferta. Toda decisão arquitetural deve explicitar seu impacto em receita (CVR, CPL/CPA e avanço de funil), não apenas conformidade técnica.
 
 ## 3.1 Regra global de exclusividade de artefatos (todo o sistema)
 

--- a/relatorios/analise-erro-divergencia-superficie-2026-04-26.md
+++ b/relatorios/analise-erro-divergencia-superficie-2026-04-26.md
@@ -1,0 +1,93 @@
+# Análise — erro `Divergência de superfície` na geração de landing com LHM
+
+Data da análise: 2026-04-26 (UTC)
+
+## 1) Evidência encontrada no banco (MCP)
+
+Foi identificado um job `LANDING_PAGE_HTML` com falha `422` contendo exatamente a mensagem reportada:
+
+- `created_at`: `2026-04-24T21:42:22` (UTC)
+- erro retornado pelo backend (`/complete`):
+  - `timestamp`: `2026-04-24T18:44:29.527029916-03:00`
+  - `status`: `422`
+  - `message`: `Divergência de superfície: landing-page-html deve reproduzir exatamente landing-page-wireframe.sectionOrder.surfaceSpec`
+
+Também há execuções posteriores do mesmo experimento (`experiment_id = 15`) com `LANDING_PAGE_HTML` em `COMPLETED`, indicando falha pontual de aderência do output nessa tentativa específica.
+
+## 2) Regra canônica aplicável (artefatos)
+
+No cânone de artefatos, o `landingPageHtml` deve respeitar o contrato de superfície por seção com os atributos:
+
+- `data-section-id`
+- `data-surface-token`
+- `data-surface-style`
+- `data-surface-contrast`
+
+A etapa de HTML precisa manter binding estrito com o `landingPageWireframe.sectionOrder[*].surfaceSpec`.
+
+## 3) Validação ativa no backend que rejeitou
+
+A rejeição ocorre no método:
+
+- `validateLandingHtmlSurfaceConsistency(...)`
+
+Fluxo de validação:
+
+1. Lê `landingPageWireframe.sectionOrder[*].surfaceSpec` e monta a lista esperada (`extractExpectedSectionSurfaces`).
+2. Extrai do HTML os atributos `data-section-id`, `data-surface-token`, `data-surface-style`, `data-surface-contrast` (`extractSectionSurfacesFromHtmlDocument`).
+3. Ordena por `sectionId` e compara igualdade exata (`expectedSorted.equals(actualSorted)`).
+4. Se diferente, lança `422` com a mensagem de divergência de superfície.
+
+## 4) Diagnóstico no formato SOP (422)
+
+### O que o modelo entregou (literal)
+
+Na tentativa analisada, o backend recebeu um `landing-page-html` cuja superfície extraída do HTML **não bateu exatamente** com o wireframe ao finalizar o job (conforme mensagem de erro 422 acima).
+
+> Observação operacional: o log persistido em banco contém a mensagem do erro, mas não persistiu o diff `expected vs actual` do WARN interno. Esse diff aparece no log de aplicação quando disponível em retenção.
+
+### O que a especificação esperava (literal)
+
+Para cada seção do `wireframe.sectionOrder`, o HTML precisa reproduzir exatamente:
+
+- mesmo `sectionId` em `data-section-id`
+- mesmo `surfaceToken` em `data-surface-token`
+- mesmo `style` em `data-surface-style`
+- mesmo `contrastMode` em `data-surface-contrast`
+
+### Diferença entre a entrega e o esperado
+
+A validação de igualdade estrita detectou divergência entre a lista esperada (wireframe) e a lista extraída do HTML final. Portanto, pelo menos um item teve:
+
+- `sectionId` ausente/trocado, **ou**
+- `surfaceToken` divergente, **ou**
+- `style` divergente, **ou**
+- `contrastMode` divergente.
+
+### Ação corretiva recomendada
+
+1. Reforçar no prompt de `landing-page-html` a obrigatoriedade de copiar `surfaceSpec` sem reinterpretar por seção.
+2. No worker, adicionar checagem pré-envio para `/complete` (falhar antes) comparando superfícies esperadas x extraídas, com log explícito por `sectionId`.
+3. Persistir no job (campo técnico) o diff objetivo `expected vs actual` para diagnóstico rápido sem depender de retenção de logs.
+4. Manter retry automático, pois há evidência de sucesso em tentativas posteriores do mesmo experimento.
+
+## 5) Conclusão objetiva
+
+O que aconteceu foi uma rejeição contratual do backend (422) por não conformidade estrita entre superfícies do HTML gerado e o `surfaceSpec` canônico do wireframe naquela tentativa. Não foi erro de indisponibilidade; foi bloqueio de consistência de artefato.
+
+
+## 6) Relação com a investigação de override por `landingPageDesignPreset.sectionPresets`
+
+Sim, **há relação técnica direta** com a investigação que apontou override indevido no LHM.
+
+- O erro observado (`Divergência de superfície`) nasce exatamente quando os atributos `data-surface-*` do HTML divergem do `wireframe.sectionOrder[].surfaceSpec`.
+- Se o LHM aplicar `surfaceStyle/contrastMode` vindos de `sectionPresets` (preset visual) sobre o que veio do wireframe, a validação estrita de superfície pode reprovar com 422.
+- Portanto, a correção de manter `surfaceSpec` do wireframe como fonte única para `data-surface-token`, `data-surface-style` e `data-surface-contrast` é compatível com a causa raiz descrita na outra investigação.
+
+### Observação de data/horário
+
+Nesta coleta específica via MCP, não apareceu registro com falha em `2026-04-25 21:46` (UTC-3). O registro mais próximo com essa mensagem foi:
+
+- `2026-04-24T18:44:29.527-03:00` (erro 422 no `/complete`, experimento 15).
+
+Ou seja: o sintoma é o mesmo; a diferença pode ser tentativa distinta, fuso/percepção de horário na UI, ou novo ciclo de geração já não presente na janela de retenção.


### PR DESCRIPTION
### Motivation
- Separate structural intent (wireframe.surfaceToken) from visual details (style/contrast) by making `landingPageDesignPreset.sectionPresets` the canonical source for per-section visual presets. 
- Prevent repeated runtime failures at final HTML publication by validating inter-artifact consistency earlier in the pipeline.
- Make LHM deterministic and aligned with updated prompt rules so generated HTML embeds canonical `data-*` bindings reliably.
- Document ownership, gates and commercial scorecard to reduce drift between workers, backend and creatives.

### Description
- LandingHtmlModule now extracts `sectionPresets` from `landingPageDesignPreset` and prefers those values for `data-surface-style` and `data-surface-contrast` while keeping `data-surface-token` from the wireframe, adding `SectionVisualPreset` and lookup normalization. 
- Experiment pipeline service gained pre-validation and per-artifact validators: `validateLandingCopyArtifacts`, `validateLandingWireframeArtifacts`, `validateLandingImagePlanningArtifacts`, `validateLandingDesignPresetArtifacts`, and a `validateLandingArtifactsReadinessForHtml` gate invoked before `LANDING_PAGE_HTML`. 
- Surface-consistency check changed to accept `surfaceToken` from wireframe and style/contrast from design preset by building expected surfaces with visuals merged from `landingPageDesignPreset.sectionPresets`. 
- Wireframe and prompt text updated to treat `surfaceSpec` as structural anchor (`surfaceToken` + `notes`) and move `style`/`contrastMode` responsibility to design preset; ai-worker prompt templates updated accordingly. 
- Added docs and operational artifacts: `matriz-responsabilidades-pipeline-landing.md`, updated canonical model, `scorecard-vendas-landing.md`, governance doc and an analysis report for surface divergence. 
- Tests updated/added to reflect behavior: `LandingHtmlModuleTest` renamed/updated test asserting design-preset-driven style/contrast and many new `ExperimentPipelineGenerationServiceTest` cases covering early rejection and normalization rules.

### Testing
- Ran unit tests touching the landing pipeline: `LandingHtmlModuleTest` and `ExperimentPipelineGenerationServiceTest`, including the new cases for pre-validation and surface merging, and all new/updated tests passed. 
- Existing landing HTML validation tests (image binding, escaped quote normalization, legacy fallbacks) were executed and remain passing after the changes. 
- No integration or manual validation was included in this PR; changes are covered by automated unit tests described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee25249f3883219e638157d3b7787e)