### PR TITLE
Require full wireframe section coverage in landing image planning prompt

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md
@@ -14,21 +14,23 @@ Modelo conceitual interno obrigatório (não expor no output final):
 
 Regras fixas da etapa:
 1. Entregue `images[]` com no mínimo quatro itens ligados a `sectionId/sectionName` existentes do wireframe.
-2. Cada item de imagem deve incluir vínculo de seção, objetivo visual e função de conversão.
-3. `imagePrompt` deve ser específico para a seção e coerente com o ângulo/copy aprovados.
-4. Defina `dimensions.desktop` e `dimensions.mobile`.
-5. Inclua `safeMargins` e `textOverlayGuidance` quando houver texto sobre imagem.
-6. Não incluir `altText` no output: este campo não faz parte do artefato canônico atual de `landingPageImagePlanning`.
-7. Inclua `layoutBinding` completo com `preferredDesktopPlacement` e `preferredMobilePlacement`.
-8. Inclua `attentionPriority`, `visualWeight`, `distanceToCTA`, `supportsFormConversion` e `formRelationNotes`.
-9. Inclua `complianceNotes` e `negativePrompt` para evitar ruído visual e promessas indevidas.
-10. `consistencyChecks` deve incluir IMAGE_MESSAGE_MATCH, VISUAL_HIERARCHY e CTA_CONTINUITY.
-11. Priorize prova visível e continuidade anúncio→landing na direção visual quando disponíveis nos resumos estruturados.
-12. Hero image deve reforçar transformação/prova/contexto sem assumir formato visual fixo de entregável.
-13. Offer image deve tangibilizar o tipo de entrega desta hipótese atual com base nos insumos (ex.: diagnóstico, sequência, framework, kit, app, área de membros, documento etc.), sem hardcode.
-14. Não hardcode mockup específico (ex.: “kit”, “PDF”) quando os insumos não indicarem isso.
-15. Reagir ao tipo concreto de oferta atual sem inventar objetos não presentes nos artefatos.
-16. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
+2. `images[]` deve cobrir **100%** dos `sectionId` de `landingPageWireframe.sectionOrder` recebidos em `CASE_DATA` (incluindo seções de formulário, como `form-*`, quando existirem).
+3. É proibido omitir seção do wireframe em `images[]` e também é proibido inventar `sectionId` fora do wireframe.
+4. Cada item de imagem deve incluir vínculo de seção, objetivo visual e função de conversão.
+5. `imagePrompt` deve ser específico para a seção e coerente com o ângulo/copy aprovados.
+6. Defina `dimensions.desktop` e `dimensions.mobile`.
+7. Inclua `safeMargins` e `textOverlayGuidance` quando houver texto sobre imagem.
+8. Não incluir `altText` no output: este campo não faz parte do artefato canônico atual de `landingPageImagePlanning`.
+9. Inclua `layoutBinding` completo com `preferredDesktopPlacement` e `preferredMobilePlacement`.
+10. Inclua `attentionPriority`, `visualWeight`, `distanceToCTA`, `supportsFormConversion` e `formRelationNotes`.
+11. Inclua `complianceNotes` e `negativePrompt` para evitar ruído visual e promessas indevidas.
+12. `consistencyChecks` deve incluir IMAGE_MESSAGE_MATCH, VISUAL_HIERARCHY e CTA_CONTINUITY.
+13. Priorize prova visível e continuidade anúncio→landing na direção visual quando disponíveis nos resumos estruturados.
+14. Hero image deve reforçar transformação/prova/contexto sem assumir formato visual fixo de entregável.
+15. Offer image deve tangibilizar o tipo de entrega desta hipótese atual com base nos insumos (ex.: diagnóstico, sequência, framework, kit, app, área de membros, documento etc.), sem hardcode.
+16. Não hardcode mockup específico (ex.: “kit”, “PDF”) quando os insumos não indicarem isso.
+17. Reagir ao tipo concreto de oferta atual sem inventar objetos não presentes nos artefatos.
+18. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -203,6 +203,42 @@ class ExperimentPipelineOpenAiClientTest {
     }
 
     @Test
+    void prependsLandingImagePlanningGuidanceRequiringFullWireframeCoverage() {
+        AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(payloadRef)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        ExperimentPipelineJobDto job = new ExperimentPipelineJobDto(
+                UUID.randomUUID(),
+                13L,
+                "landing-page-image-planning",
+                "gpt-5.2",
+                "prompt",
+                """
+                        {
+                          "model": "gpt-5.2",
+                          "input": [
+                            {"role": "user", "content": "Prompt de imagens"}
+                          ]
+                        }
+                        """,
+                Instant.now());
+
+        client.generate(job);
+
+        Map<String, Object> payload = payloadRef.get();
+        @SuppressWarnings("unchecked")
+        var input = (java.util.List<Map<String, Object>>) payload.get("input");
+        String userPrompt = String.valueOf(input.get(0).get("content"));
+        assertThat(userPrompt).contains("`images[]` deve cobrir **100%** dos `sectionId` de `landingPageWireframe.sectionOrder`");
+        assertThat(userPrompt).contains("incluindo seções de formulário");
+        assertThat(userPrompt).contains("é proibido inventar `sectionId` fora do wireframe");
+    }
+
+    @Test
     void injectsStructuredCaseDataBlockIntoSectionTemplate() {
         AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
         ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(


### PR DESCRIPTION
### Motivation
- The pipeline failed with a `422` because `landingPageImagePlanning.images[]` did not include all `sectionId` from the wireframe (missing `form-lead-capture-primary`), so the AI output must match backend validation. 
- The prompt for the AI Worker previously allowed omission or invention of `sectionId`, creating mismatch with backend checks that require exact coverage.

### Description
- Updated the landing image planning prompt `ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md` to require `images[]` to cover **100%** of `landingPageWireframe.sectionOrder` `sectionId`s and to forbid inventing `sectionId`s outside the wireframe. 
- Clarified the prompt to explicitly include form sections (e.g. `form-*`) in the required coverage and added the prohibition against omissions and extras. 
- Added a regression unit test `prependsLandingImagePlanningGuidanceRequiringFullWireframeCoverage` in `ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java` that asserts the generated user prompt contains the new mandatory coverage instructions. 

### Testing
- Attempted to run the test with `./gradlew :ai-worker:test --tests com.marketinghub.worker.experimentpipeline.ExperimentPipelineOpenAiClientTest`, but `gradlew` is not present in this environment so the command could not run. 
- Ran `mvn -f ai-worker/pom.xml test -Dtest=ExperimentPipelineOpenAiClientTest`, which started but the build failed due to resolving a private snapshot dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT` from GitHub Packages returning `401 Unauthorized`, blocking test execution (build failure). 
- The change is limited to prompt text and a unit test; once the private dependency resolution is available the included test should validate the prompt injection behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee48156ba083218d98f47fe370b7ac)