### PR TITLE
Stop automatic LANDING_PAGE_HTML enqueue and require manual HTML choice

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -738,6 +738,12 @@ public class ExperimentPipelineGenerationService {
             }
             return;
         }
+        if (section == ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET) {
+            log.info("Fila automática finalizada após LANDING_PAGE_DESIGN_PRESET para experimento {}. "
+                            + "A geração do HTML deve ser iniciada manualmente (LHM ou IA).",
+                    experimentId);
+            return;
+        }
 
         ExperimentPipelineSection successor = section.successor();
         if (successor == null) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -1066,6 +1066,75 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void completeJobDoesNotAutomaticallyEnqueueLandingHtmlAfterDesignPreset() {
+        Experiment experiment = new Experiment();
+        experiment.setId(314L);
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {
+                        "sectionId": "hero",
+                        "surfaceSpec": {"surfaceToken": "surface-base", "notes": "hero"}
+                      }
+                    ]
+                  }
+                }
+                """);
+        ExperimentPipelineGenerationJob job = createJobForSection(experiment, ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET);
+        String designPresetPayload = """
+                {
+                  "landingPageDesignPreset": {
+                    "presetId": "preset-manual-html",
+                    "theme": {
+                      "palette": {
+                        "background":"#ffffff",
+                        "surface":"#ffffff",
+                        "textPrimary":"#111827",
+                        "textMuted":"#6b7280",
+                        "brandPrimary":"#2563eb",
+                        "brandSecondary":"#1d4ed8",
+                        "border":"#e5e7eb"
+                      }
+                    },
+                    "sectionPresets": [
+                      {
+                        "sectionId":"hero",
+                        "surfaceStyle":"band",
+                        "contrastMode":"normal",
+                        "layoutPreset":"hero-focus",
+                        "emphasis":"primary",
+                        "notes":"hero"
+                      }
+                    ],
+                    "componentPresets": {},
+                    "motion": {"enabled": false, "intensity": "none"},
+                    "consistencyChecks": [{"check":"THEME_CONTRAST","status":"PASS"}]
+                  },
+                  "experimentMetadata": {
+                    "primary_variable":"pv",
+                    "variant_id":"v1",
+                    "stage":"AD",
+                    "control_or_treatment":"treatment",
+                    "asset_role":"landing-page-design-preset"
+                  }
+                }
+                """;
+
+        service.completeJob(job.getId(), new ExperimentPipelineGenerationJobCompletionRequest(
+                designPresetPayload,
+                "{\"id\":\"resp_design\"}",
+                "{\"model\":\"gpt-5.2\"}",
+                50,
+                30,
+                null));
+
+        verify(jobRepository, never()).save(argThat(saved ->
+                saved.getSection() == ExperimentPipelineSection.LANDING_PAGE_HTML
+                        && saved.getStatus() == ExperimentPipelineGenerationJobStatus.PENDING));
+    }
+
+    @Test
     void generateLandingDesignPresetFailsWhenPlannedImagesAreNotFullyGenerated() {
         Experiment experiment = new Experiment();
         experiment.setId(302L);

--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -68,6 +68,9 @@ Regras mandatórias:
   recomendada antes de permitir retomada.
 - após `landingPageDesignPreset`, a continuidade para `landingPageHtml` exige
   comando manual explícito do usuário (LHM ou IA).
+- a etapa `landingPageImagePlanning` só é considerada **efetivamente concluída**
+  após a conclusão da geração das imagens planejadas (não apenas após salvar o
+  artefato de planejamento).
 
 ## 4. Estados da fila automática
 
@@ -104,6 +107,12 @@ A etapa atual só pode transicionar para `COMPLETED` quando:
 1. o artefato obrigatório da etapa foi persistido;
 2. o artefato passou nas validações canônicas mínimas;
 3. o vínculo com `experimentId` está consistente.
+
+Regra complementar obrigatória para `landingPageImagePlanning`:
+
+4. todos os itens de geração de imagem vinculados ao planejamento do mesmo
+   `experimentId` já concluíram seu ciclo (sem itens em `PLANNED`, `PENDING`
+   ou `PROCESSING`).
 
 Se algum critério falhar:
 
@@ -151,6 +160,9 @@ A UI deve exibir, no mínimo:
 - quando houver desvio controlado para geração de imagens, explicitar que o
   fluxo saiu temporariamente de `landingPageImagePlanning`, está gerando imagens
   e retornará automaticamente para `landingPageHtml`.
+- mesmo fora da aba específica de planejamento de imagens, exibir status
+  simplificado do fluxo de imagens da landing com os estados:
+  `Iniciado` → `Processando` → `Concluído`.
 
 ### 8.2 Bloqueios obrigatórios de ação
 

--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -31,16 +31,22 @@ Quando a fila automática estiver ativa, o pipeline deve respeitar a sequência 
 4. `landingPageCopy` (Texto da Landing)
 5. `landingPageWireframe` (Layout da Landing)
 6. `landingPageImagePlanning` (Planejamento de Imagens da Landing)
-7. `landingPageHtml` (HTML da Landing)
+7. `landingPageDesignPreset` (Preset visual da Landing)
+
+Após `landingPageDesignPreset`, a etapa `landingPageHtml` **não** deve ser enfileirada automaticamente.
+Ela passa a ser uma escolha manual do usuário na UI, com duas opções válidas:
+
+- `Gerar com LHM` (determinístico);
+- `Gerar com IA` (não determinístico, sujeito ao contrato de validação do backend).
 
 Regra canônica:
 
 - uma etapa só pode iniciar quando a etapa anterior estiver em `COMPLETED`.
 - avanço fora de ordem é drift e deve ser bloqueado no backend.
 
-### 3.1 Desvio controlado obrigatório entre planejamento e HTML
+### 3.1 Desvio controlado obrigatório entre planejamento e preset visual
 
-Entre as etapas `landingPageImagePlanning` e `landingPageHtml`, existe um
+Entre as etapas `landingPageImagePlanning` e `landingPageDesignPreset`, existe um
 **desvio controlado obrigatório** para geração das imagens finais da landing.
 
 Fluxo canônico:
@@ -50,16 +56,18 @@ Fluxo canônico:
 3. fila entra em `WAITING_DEPENDENCY` enquanto houver item em `PLANNED`,
    `PENDING` ou `PROCESSING`;
 4. após concluir (ou consolidar erro tratável) os itens de imagem, a fila
-   retorna ao trilho principal e só então libera `landingPageHtml`.
+   retorna ao trilho principal e só então libera `landingPageDesignPreset`.
 
 Regras mandatórias:
 
-- `landingPageHtml` não pode iniciar enquanto a geração de imagens estiver em
+- `landingPageDesignPreset` não pode iniciar enquanto a geração de imagens estiver em
   andamento.
-- o retorno ao trilho principal deve ser automático (sem exigir ação manual
-  quando não houver bloqueio).
+- o retorno ao trilho principal deve ser automático até `landingPageDesignPreset`
+  (sem exigir ação manual quando não houver bloqueio).
 - se houver falha na geração de imagens, a UI deve apresentar causa e ação
   recomendada antes de permitir retomada.
+- após `landingPageDesignPreset`, a continuidade para `landingPageHtml` exige
+  comando manual explícito do usuário (LHM ou IA).
 
 ## 4. Estados da fila automática
 
@@ -69,7 +77,8 @@ Estados permitidos para execução da fila:
 - `RUNNING`: fila automática ativa com etapa em processamento;
 - `WAITING_DEPENDENCY`: aguardando pré-condição externa (worker, artefato obrigatório ou sincronização);
 - `BLOCKED`: execução interrompida por erro de regra, contrato ou validação;
-- `COMPLETED`: todas as etapas automáticas concluídas para o experimento.
+- `COMPLETED`: todas as etapas automáticas concluídas para o experimento
+  (termina em `landingPageDesignPreset`).
 
 Regra canônica:
 

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -176,6 +176,8 @@ interface AutoQueueState {
   pending: ContentGenerationSectionKey[];
 }
 
+type LandingImageFlowStatus = "NOT_STARTED" | "STARTED" | "PROCESSING" | "COMPLETED";
+
 const SECTION_REQUEST_INITIAL_STATE: Record<
   ContentGenerationSectionKey,
   SectionRequestState
@@ -234,6 +236,20 @@ const EXECUTION_SOURCE_LABELS: Record<"WORKER_IA" | "LHM", string> = {
 const EXECUTION_SOURCE_BADGES: Record<"WORKER_IA" | "LHM", string> = {
   WORKER_IA: "primary",
   LHM: "info",
+};
+
+const LANDING_IMAGE_FLOW_LABELS: Record<LandingImageFlowStatus, string> = {
+  NOT_STARTED: "Não iniciado",
+  STARTED: "Iniciado",
+  PROCESSING: "Processando",
+  COMPLETED: "Concluído",
+};
+
+const LANDING_IMAGE_FLOW_BADGES: Record<LandingImageFlowStatus, string> = {
+  NOT_STARTED: "secondary",
+  STARTED: "info",
+  PROCESSING: "warning",
+  COMPLETED: "success",
 };
 
 const COMMON_PIPELINE_PROMPT = `Você cria ativos de campanha para o Marketing Hub.
@@ -1382,6 +1398,46 @@ export default function ExperimentContentGenerationTab({
     [requestsFromBackend, requestsBySection],
   );
 
+  const landingImagePlanningRequest =
+    mergedRequestsBySection["landing-image-planning"];
+
+  const landingImageFlowStatus = useMemo<LandingImageFlowStatus>(() => {
+    if (!landingImagePlanningRequest.requestedAt) {
+      return "NOT_STARTED";
+    }
+    if (!landingImagePlanningRequest.completedAt) {
+      return "STARTED";
+    }
+    if (!hasFrameworkImages) {
+      return "STARTED";
+    }
+    if (hasFrameworkImagesInFlight) {
+      return "PROCESSING";
+    }
+    return "COMPLETED";
+  }, [
+    hasFrameworkImages,
+    hasFrameworkImagesInFlight,
+    landingImagePlanningRequest.completedAt,
+    landingImagePlanningRequest.requestedAt,
+  ]);
+
+  const landingImageFlowMessage = useMemo(() => {
+    if (landingImageFlowStatus === "NOT_STARTED") {
+      return "Aguardando solicitação do planejamento de imagens.";
+    }
+    if (landingImageFlowStatus === "STARTED") {
+      return "Planejamento finalizado. Disparo da geração das imagens iniciado.";
+    }
+    if (landingImageFlowStatus === "PROCESSING") {
+      return "Geração das imagens em andamento.";
+    }
+    if (hasFrameworkImageFailure) {
+      return "Geração finalizada com falhas em alguns itens.";
+    }
+    return "Geração das imagens concluída.";
+  }, [hasFrameworkImageFailure, landingImageFlowStatus]);
+
   const lhmHistory = useMemo(
     () =>
       (jobsQuery.data ?? [])
@@ -2211,6 +2267,18 @@ export default function ExperimentContentGenerationTab({
         </div>
       ) : null}
 
+      <div className="alert alert-light border py-2 px-3 mb-3" role="status">
+        <div className="d-flex flex-wrap align-items-center gap-2">
+          <strong>Fluxo das imagens da landing:</strong>
+          <span
+            className={`badge text-bg-${LANDING_IMAGE_FLOW_BADGES[landingImageFlowStatus]}`}
+          >
+            {LANDING_IMAGE_FLOW_LABELS[landingImageFlowStatus]}
+          </span>
+          <span className="small text-body-secondary">{landingImageFlowMessage}</span>
+        </div>
+      </div>
+
       <Tabs.Root
         value={activeSection}
         onValueChange={(value) =>
@@ -2434,12 +2502,21 @@ export default function ExperimentContentGenerationTab({
             {CONTENT_GENERATION_SECTIONS.map((section) => {
               const request = mergedRequestsBySection[section.key];
               const invalidation = invalidationBySection[section.key];
+              const isLandingImagePlanningSection =
+                section.key === "landing-image-planning";
+              const effectiveRequestStatus: RequestUiStatus =
+                isLandingImagePlanningSection &&
+                request.status === "COMPLETED" &&
+                landingImageFlowStatus !== "COMPLETED"
+                  ? "PROCESSING"
+                  : request.status;
               const displayStatus: RequestUiStatus =
-                request.status === "PROCESSING" || request.status === "PENDING"
+                effectiveRequestStatus === "PROCESSING" ||
+                effectiveRequestStatus === "PENDING"
                   ? "PROCESSING"
                   : invalidation
                     ? "INVALIDATED"
-                    : request.status;
+                    : effectiveRequestStatus;
               const workerStatus = getWorkerStatus(request);
               const executionSource = request.executionSource ?? "WORKER_IA";
               const backendError = parseBackendError(request.errorMessage);
@@ -2494,14 +2571,21 @@ export default function ExperimentContentGenerationTab({
                     </div>
                     <div>
                       <strong>3. Conclusão:</strong>{" "}
-                      {request.completedAt
+                      {isLandingImagePlanningSection &&
+                      landingImageFlowStatus !== "COMPLETED"
+                        ? "aguardando conclusão da geração das imagens planejadas."
+                        : request.completedAt
                         ? `finalizada em ${formatDateTime(request.completedAt)}.`
                         : request.status === "FAILED"
                           ? "fluxo encerrado com erro."
                           : "aguardando finalização."}
                     </div>
                   </div>
-                  {request.stageLabel ? (
+                  {isLandingImagePlanningSection ? (
+                    <small className="text-body-secondary">
+                      Etapa atual: {landingImageFlowMessage}
+                    </small>
+                  ) : request.stageLabel ? (
                     <small className="text-body-secondary">
                       Etapa atual: {request.stageLabel}
                     </small>


### PR DESCRIPTION
### Motivation

- The pipeline should stop auto-generating the final HTML so the user can explicitly choose between deterministic LHM rendering or an AI-generated HTML preview. 
- This preserves the canonical responsibility of the `LHM` as a deterministic renderer and avoids surprising non-deterministic HTML being published automatically. 

### Description

- Stop automatic continuation of the experiment pipeline after `LANDING_PAGE_DESIGN_PRESET` by returning early in `enqueueNextAutomaticStep` and emitting a log message that HTML generation must be started manually (`LHM` or `IA`).
- Add a unit test `completeJobDoesNotAutomaticallyEnqueueLandingHtmlAfterDesignPreset` to assert the service does not enqueue `LANDING_PAGE_HTML` after a design preset job completes.
- Update canonical documentation `docs/canonical/experiments-automation-flow-canon.v1.md` to document that `landingPageHtml` must be initiated manually and the automatic pipeline ends at `landingPageDesignPreset`.

### Testing

- Attempted `mvn -pl backend/ads-service -Dtest=ExperimentPipelineGenerationServiceTest test` failed due to an incorrect project selection in the reactor (command error), not test failures. 
- Ran `mvn -f backend/ads-service/pom.xml -Dtest=ExperimentPipelineGenerationServiceTest test` which executed the `ExperimentPipelineGenerationServiceTest` suite (36 tests) and completed with all tests passing and a successful build. 
- No other automated tests were modified; the new unit test passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee49ae48a88321b893efcc76d8129c)