### PR TITLE
Apply AI generation cost to experiment hierarchy and show waiting-dependency state in UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.ai.generation.dto.AiWorkerGenerationRequest;
 import com.marketinghub.ai.generation.service.AiWorkerGenerationService;
+import com.marketinghub.cost.CostAttributionService;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.dto.ExperimentDto;
@@ -122,6 +123,7 @@ public class ExperimentPipelineGenerationService {
     private final FrameworkImageGenerationService frameworkImageGenerationService;
     private final OpenAiPricingService openAiPricingService;
     private final LeadPortalPublicUrlResolver leadPortalPublicUrlResolver;
+    private final CostAttributionService costAttributionService;
 
     public ExperimentPipelineGenerationService(ExperimentRepository experimentRepository,
                                                ExperimentPipelineGenerationJobRepository jobRepository,
@@ -134,7 +136,8 @@ public class ExperimentPipelineGenerationService {
                                                LandingHtmlModule landingHtmlModule,
                                                FrameworkImageGenerationService frameworkImageGenerationService,
                                                OpenAiPricingService openAiPricingService,
-                                               LeadPortalPublicUrlResolver leadPortalPublicUrlResolver) {
+                                               LeadPortalPublicUrlResolver leadPortalPublicUrlResolver,
+                                               CostAttributionService costAttributionService) {
         this.experimentRepository = experimentRepository;
         this.jobRepository = jobRepository;
         this.experimentMapper = experimentMapper;
@@ -147,6 +150,7 @@ public class ExperimentPipelineGenerationService {
         this.frameworkImageGenerationService = frameworkImageGenerationService;
         this.openAiPricingService = openAiPricingService;
         this.leadPortalPublicUrlResolver = leadPortalPublicUrlResolver;
+        this.costAttributionService = costAttributionService;
     }
 
     @Transactional
@@ -569,6 +573,7 @@ public class ExperimentPipelineGenerationService {
         job.setCostUsd(estimatedCost);
         job.setErrorMessage(null);
         job.setFinishedAt(Instant.now());
+        applyCostToExperimentHierarchy(experiment, estimatedCost);
 
         enqueueNextAutomaticStep(job, request);
     }
@@ -657,6 +662,7 @@ public class ExperimentPipelineGenerationService {
         job.setCostUsd(costUsd != null ? costUsd : BigDecimal.ZERO);
         job.setErrorMessage(null);
         job.setFinishedAt(Instant.now());
+        applyCostToExperimentHierarchy(job.getExperiment(), costUsd);
     }
 
     private void failInlineGenerationJob(ExperimentPipelineGenerationJob job, String errorMessage) {
@@ -667,6 +673,16 @@ public class ExperimentPipelineGenerationService {
         job.setStage(ExperimentPipelineGenerationJobStage.FAILED);
         job.setErrorMessage(StringUtils.hasText(errorMessage) ? errorMessage.trim() : "Falha desconhecida no LHM");
         job.setFinishedAt(Instant.now());
+    }
+
+    private void applyCostToExperimentHierarchy(Experiment experiment, BigDecimal costUsd) {
+        if (experiment == null || experiment.getId() == null) {
+            return;
+        }
+        if (costUsd == null || costUsd.compareTo(BigDecimal.ZERO) <= 0) {
+            return;
+        }
+        costAttributionService.addUsdCostToExperimentHierarchy(experiment, costUsd);
     }
 
     private String writeJsonSilently(Object payload) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -25,6 +25,7 @@ import com.marketinghub.leadportal.support.LeadPortalPublicUrlResolver;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.openai.service.OpenAiPricingService;
 import com.marketinghub.ai.generation.service.AiWorkerGenerationService;
+import com.marketinghub.cost.CostAttributionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +82,8 @@ class ExperimentPipelineGenerationServiceTest {
     private OpenAiPricingService openAiPricingService;
     @Mock
     private LeadPortalPublicUrlResolver leadPortalPublicUrlResolver;
+    @Mock
+    private CostAttributionService costAttributionService;
 
     private ExperimentPipelineGenerationService service;
 
@@ -98,7 +101,8 @@ class ExperimentPipelineGenerationServiceTest {
                 landingHtmlModule,
                 frameworkImageGenerationService,
                 openAiPricingService,
-                leadPortalPublicUrlResolver);
+                leadPortalPublicUrlResolver,
+                costAttributionService);
         lenient().when(landingHtmlModule.buildPromptV2Inputs(any())).thenReturn("");
         lenient().when(landingHtmlModule.assembleHtmlDocument(any())).thenReturn("<!doctype html><html><body></body></html>");
         lenient().when(openAiPricingService.estimateStandardCost(any(), any())).thenReturn(BigDecimal.ZERO);
@@ -634,8 +638,10 @@ class ExperimentPipelineGenerationServiceTest {
                 100,
                 50,
                 null);
+        when(openAiPricingService.estimateStandardCost(any(), any())).thenReturn(new BigDecimal("0.0750"));
 
         service.completeJob(jobId, request);
+        verify(costAttributionService).addUsdCostToExperimentHierarchy(experiment, new BigDecimal("0.0750"));
 
         ObjectMapper mapper = new ObjectMapper();
         @SuppressWarnings("unchecked")

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -2510,16 +2510,25 @@ export default function ExperimentContentGenerationTab({
                 landingImageFlowStatus !== "COMPLETED"
                   ? "PROCESSING"
                   : request.status;
+              const waitingDependency = invalidation?.requiresRefresh === true;
               const displayStatus: RequestUiStatus =
-                effectiveRequestStatus === "PROCESSING" ||
-                effectiveRequestStatus === "PENDING"
+                waitingDependency
                   ? "PROCESSING"
-                  : invalidation
-                    ? "INVALIDATED"
-                    : effectiveRequestStatus;
+                  : effectiveRequestStatus === "PROCESSING" ||
+                      effectiveRequestStatus === "PENDING"
+                    ? "PROCESSING"
+                    : invalidation
+                      ? "INVALIDATED"
+                      : effectiveRequestStatus;
               const workerStatus = getWorkerStatus(request);
               const executionSource = request.executionSource ?? "WORKER_IA";
               const backendError = parseBackendError(request.errorMessage);
+              const displayWorkerStatus = waitingDependency
+                ? {
+                    label: "Aguardando atualização após dependência",
+                    badge: "info",
+                  }
+                : workerStatus;
 
               return (
                 <div
@@ -2560,18 +2569,28 @@ export default function ExperimentContentGenerationTab({
                         2. Atendimento do{" "}
                         {EXECUTION_SOURCE_LABELS[executionSource]}:
                       </strong>
-                      <span className={`badge text-bg-${workerStatus.badge}`}>
-                        {workerStatus.label}
+                      <span
+                        className={`badge text-bg-${displayWorkerStatus.badge}`}
+                      >
+                        {displayWorkerStatus.label}
                       </span>
                       <span>
-                        {request.startedAt
+                        {waitingDependency
+                          ? request.completedAt
+                            ? `última execução finalizada em ${formatDateTime(request.completedAt)}`
+                            : "aguardando nova execução"
+                          : request.startedAt
                           ? `iniciado em ${formatDateTime(request.startedAt)}`
-                          : "sem início registrado"}
+                          : request.status === "PENDING"
+                            ? "aguardando início"
+                            : "sem início registrado"}
                       </span>
                     </div>
                     <div>
                       <strong>3. Conclusão:</strong>{" "}
-                      {isLandingImagePlanningSection &&
+                      {waitingDependency
+                        ? `aguardando conclusão de ${invalidation?.sourceSection} para atualizar esta etapa.`
+                        : isLandingImagePlanningSection &&
                       landingImageFlowStatus !== "COMPLETED"
                         ? "aguardando conclusão da geração das imagens planejadas."
                         : request.completedAt
@@ -2584,6 +2603,11 @@ export default function ExperimentContentGenerationTab({
                   {isLandingImagePlanningSection ? (
                     <small className="text-body-secondary">
                       Etapa atual: {landingImageFlowMessage}
+                    </small>
+                  ) : waitingDependency && invalidation ? (
+                    <small className="text-body-secondary">
+                      Etapa atual: aguardando conclusão de{" "}
+                      {invalidation.sourceSection} para atualização automática.
                     </small>
                   ) : request.stageLabel ? (
                     <small className="text-body-secondary">
@@ -2602,15 +2626,11 @@ export default function ExperimentContentGenerationTab({
                       landing para retomar automaticamente esta etapa ao final.
                     </small>
                   ) : null}
-                  {invalidation ? (
+                  {invalidation && !invalidation.requiresRefresh ? (
                     <small className="text-warning-emphasis">
-                      {invalidation.requiresRefresh
-                        ? `Execução em andamento em ${invalidation.sourceSection} (${formatDateTime(
-                            invalidation.sourceAt,
-                          )}). Esta etapa será atualizada após a conclusão da dependência anterior.`
-                        : `Dependência atualizada em ${invalidation.sourceSection} (${formatDateTime(
-                            invalidation.sourceAt,
-                          )}). Gere esta etapa novamente.`}
+                      {`Dependência atualizada em ${invalidation.sourceSection} (${formatDateTime(
+                        invalidation.sourceAt,
+                      )}). Gere esta etapa novamente.`}
                     </small>
                   ) : null}
                   {request.errorMessage ? (


### PR DESCRIPTION
### Motivation
- Record and attribute AI generation costs to experiments so costs are tracked across experiment hierarchies when pipeline jobs complete.
- Improve UX for pipeline steps that are invalidated by dependent sections by showing an explicit "waiting for dependency" state in the content generation UI.

### Description
- Backend: Inject `CostAttributionService` into `ExperimentPipelineGenerationService` and call `addUsdCostToExperimentHierarchy` when jobs (both regular and inline) complete via the new private helper `applyCostToExperimentHierarchy` which validates cost and experiment before delegating.
- Backend: Persist job `costUsd` as before and additionally invoke cost attribution after setting job completion fields.
- Tests: Add a mock `CostAttributionService` to `ExperimentPipelineGenerationServiceTest`, update setup to pass the mock, stub `openAiPricingService` to return a non-zero cost, and verify the cost attribution is invoked when `completeJob` runs.
- Frontend: Update `ExperimentContentGenerationTab.tsx` to propagate `invalidation.requiresRefresh` as a `waitingDependency` flag, show a distinct badge/label/state when waiting for a dependency, adjust the timing/status messages shown to the user, and conditionally display an explanatory line about the dependency when appropriate.

### Testing
- Updated unit test `ExperimentPipelineGenerationServiceTest` was executed and verifies `CostAttributionService.addUsdCostToExperimentHierarchy` is called on job completion; the test passed.
- Existing backend unit tests related to pipeline generation were executed after the change and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5131b75483218a0b43d15511a938)