### PR TITLE
Add collection-ops summary endpoint, rollout gate and runtime stats for MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisWorkspaceDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisWorkspaceDtos.java
@@ -247,4 +247,33 @@ public final class MoisWorkspaceDtos {
             Instant updatedAt
     ) {
     }
+
+    public record CollectionSourceOpsSummaryResponse(
+            String source,
+            int attempts,
+            int successes,
+            int failures,
+            int retries,
+            int rateLimitedEvents,
+            long averageLatencyMs,
+            String lastError,
+            Instant lastAttemptAt
+    ) {
+    }
+
+    public record CollectionOpsSummaryResponse(
+            String workspaceId,
+            boolean rolloutEnabled,
+            int totalJobs,
+            int queuedJobs,
+            int runningJobs,
+            int completedJobs,
+            int failedJobs,
+            int totalCollectedReferences,
+            long averageJobLatencyMs,
+            int totalRetries,
+            List<CollectionSourceOpsSummaryResponse> sourceBreakdown,
+            Instant generatedAt
+    ) {
+    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisModuleGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisModuleGateway.java
@@ -232,6 +232,13 @@ public class MoisModuleGateway {
         );
     }
 
+    public MoisWorkspaceDtos.CollectionOpsSummaryResponse getCollectionOpsSummary(String workspaceId) {
+        return exchange("/api/v1/mois/workspaces/" + workspaceId + "/collection-ops/summary",
+                HttpMethod.GET,
+                null,
+                MoisWorkspaceDtos.CollectionOpsSummaryResponse.class).getBody();
+    }
+
     public Map<String, String> health() {
         return exchange("/api/v1/mois/health", HttpMethod.GET, null, Map.class).getBody();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
@@ -190,6 +190,11 @@ public class MoisController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "collected reference lineage not found"));
     }
 
+    @GetMapping("/workspaces/{workspaceId}/collection-ops/summary")
+    public MoisWorkspaceDtos.CollectionOpsSummaryResponse getCollectionOpsSummary(@PathVariable String workspaceId) {
+        return gateway.getCollectionOpsSummary(workspaceId);
+    }
+
     @GetMapping("/offers")
     public MoisOfferDtos.OfferCardListResponse listOffers(
             @RequestParam(required = false) String requestId,

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
@@ -56,6 +56,41 @@ class MoisControllerContractTest {
     }
 
     @Test
+    void shouldReturnCollectionOpsSummaryContract() throws Exception {
+        when(gateway.getCollectionOpsSummary("workspace-001"))
+                .thenReturn(new MoisWorkspaceDtos.CollectionOpsSummaryResponse(
+                        "workspace-001",
+                        true,
+                        2,
+                        0,
+                        0,
+                        2,
+                        0,
+                        4,
+                        280,
+                        1,
+                        List.of(new MoisWorkspaceDtos.CollectionSourceOpsSummaryResponse(
+                                "CLICKBANK",
+                                2,
+                                2,
+                                0,
+                                0,
+                                0,
+                                110,
+                                null,
+                                Instant.parse("2026-04-26T12:00:00Z")
+                        )),
+                        Instant.parse("2026-04-26T12:00:30Z")
+                ));
+
+        mockMvc.perform(get("/api/v1/mois/workspaces/workspace-001/collection-ops/summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.workspaceId").value("workspace-001"))
+                .andExpect(jsonPath("$.totalJobs").value(2))
+                .andExpect(jsonPath("$.sourceBreakdown[0].source").value("CLICKBANK"));
+    }
+
+    @Test
     void shouldReturnValidationErrorWhenRequiredFieldsMissing() throws Exception {
         mockMvc.perform(post("/api/v1/mois/discovery-requests")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/docs/mois/mois-plano-coleta-automatica-sprints-e-relatorios.md
+++ b/docs/mois/mois-plano-coleta-automatica-sprints-e-relatorios.md
@@ -296,9 +296,27 @@ Garantir estabilidade, observabilidade e adoção segura em produção.
 - **Próximos passos:** estabilizar operação, observabilidade e rollout gradual na Sprint 5.
 
 ## Relatório — Sprint 5
-- **Status:** Planejado
-- **Período:** a definir
-- **Escopo concluído:** pendente
-- **Evidências (PRs, commits, testes):** pendente
-- **Riscos/pendências:** pendente
-- **Próximos passos:** operação contínua + melhorias incrementais
+- **Status:** Em andamento
+- **Período:** iniciado em 26/04/2026
+- **Confirmação de status (26/04/2026):** Sprint 5 está **iniciada e em execução**, ainda **não concluída**.
+- **Escopo em execução:**
+  - definição de baseline operacional para coleta automática (latência, taxa de falha por fonte e taxa de referências úteis);
+  - desenho de persistência relacional para jobs, referências e lineage de coleta;
+  - plano de rollout gradual por workspace com feature flag;
+  - playbook inicial de incidentes para indisponibilidade de fontes externas.
+- **Entregas implementadas nesta rodada:**
+  - endpoint de resumo operacional por workspace: `GET /api/v1/mois/workspaces/{workspaceId}/collection-ops/summary`;
+  - instrumentação operacional no módulo `mois` para consolidar tentativas, falhas, retries, eventos de rate limit e latência média;
+  - execução da coleta com status de job (`RUNNING` → `COMPLETED`/`FAILED`) e retry controlado por fonte;
+  - gate de rollout para coleta automática por workspace (com bloqueio explícito quando fora da política).
+- **Evidências (PRs, commits, testes):**
+  - documento de status atualizado: `docs/mois/mois-status-implantacao-2026-04-26.md`;
+  - este ajuste de execução da Sprint 5 neste relatório único.
+- **Riscos/pendências atuais:**
+  - coleta ainda depende de persistência volátil em memória no módulo `mois`;
+  - ausência de telemetria consolidada por fonte para operação diária;
+  - necessidade de validar limites/rate limit por conector antes de ampliar rollout.
+- **Próximos passos (curto prazo):**
+  - publicar contrato técnico de observabilidade mínima da Sprint 5;
+  - implementar persistência relacional do ciclo de coleta com migrações;
+  - liberar rollout controlado para workspaces piloto com monitoramento ativo.

--- a/docs/mois/mois-status-implantacao-2026-04-26.md
+++ b/docs/mois/mois-status-implantacao-2026-04-26.md
@@ -1,0 +1,95 @@
+# MOIS — Levantamento atualizado de implantação (26/04/2026)
+
+## Escopo deste levantamento
+
+Este levantamento consolida o estado atual do módulo MOIS com foco em:
+
+1. situação da tela **/mois/research-sources** (Locais de pesquisa MOIS);
+2. status da iniciativa de **pesquisa dos destaques por fonte**;
+3. estágio operacional do fluxo de coleta automática e integração com workspace.
+
+Data de referência: **26/04/2026**.
+
+---
+
+## 1) Situação da tela “Locais de pesquisa MOIS”
+
+### Status: **Implantada no frontend (MVP estático)**
+
+- A rota `/mois/research-sources` está publicada no roteamento principal do frontend.
+- A tela lista fontes recomendadas (Meta Ad Library, TikTok Creative Center, Google Ads Transparency Center, YouTube, Hotmart, Monetizze, Eduzz, Google Trends, ClickBank, Digistore24 e JVZoo).
+- Cada fonte possui descrição, categoria, “quando usar” e link externo com abertura em nova aba (`target="_blank"`).
+
+### Leitura operacional
+
+- A tela atende o objetivo de **guia de pesquisa** para orientar o operador humano antes da extração.
+- Atualmente funciona como **catálogo curado estático** (não há ingestão dinâmica por API para essa página específica).
+
+---
+
+## 2) Situação da “pesquisa dos destaques de cada fonte”
+
+### Status: **Parcialmente implantada (no fluxo de coleta automática, ainda sem consolidação analítica por fonte)**
+
+O que já está implementado:
+
+- O fluxo de coleta automática gera referências com campos de destaque de performance por item coletado:
+  - `successScore`
+  - `successSignal`
+  - `confidenceLevel`
+  - `engagementRelative`
+  - `recurrenceScore`
+  - `evidenceScore`
+- Há filtros por fonte, nicho, score mínimo e confiança.
+- Há ações operacionais por referência (favoritar, descartar, importar, importar e iniciar extração) e lineage.
+
+O que ainda não está implementado (lacuna principal):
+
+- Não existe hoje um endpoint/tela dedicada de **“destaques agregados por fonte”** (ex.: top insights por fonte com consolidação analítica por período).
+- No módulo MOIS, as referências de coleta ainda são seedadas em memória para contrato/smoke (não são conectores reais de produção por fonte).
+
+### Conclusão objetiva sobre os destaques por fonte
+
+- Existe o **destaque por referência coletada** (nível item).
+- Ainda falta o **destaque consolidado por fonte** (nível analítico agregado).
+
+---
+
+## 3) Situação macro da implantação do MOIS
+
+### Estado do módulo
+
+- Arquitetura separada do MOIS em módulo próprio (`/mois`) está em vigor, com backend principal atuando como façade/gateway.
+- Serviço MOIS está previsto em container próprio (`8094`) no `deploy/docker-compose.yml`.
+- Integração do backend com o módulo MOIS está parametrizada via `integrations.mois.module.*`.
+
+### Estado de execução por sprint (coleta automática)
+
+- Sprint 0: concluída.
+- Sprint 1: concluída.
+- Sprint 2: concluída.
+- Sprint 3: concluída (UI de coleta automática).
+- Sprint 4: concluída (importação + extração + lineage).
+- Sprint 5: **em andamento**, já com entrega inicial de observabilidade operacional (`collection-ops/summary`), retry controlado e gate de rollout por workspace.
+
+---
+
+## 4) Diagnóstico final (objetivo)
+
+1. A iniciativa da tela em anexo (**Locais de pesquisa MOIS**) está implantada e navegável.
+2. A iniciativa de “destaques” avançou no nível de score/sinal por referência coletada.
+3. Ainda há gap para entregar o que normalmente se entende por “destaques de cada fonte” no nível executivo (agregado por fonte e período).
+4. O ciclo de produto entrou na Sprint 5 para endurecimento operacional (persistência robusta, observabilidade e rollout com segurança).
+
+---
+
+## 5) Próximo passo recomendado (curto prazo)
+
+Priorizar uma entrega incremental de **Resumo por Fonte** com:
+
+- endpoint de agregação por fonte/tempo (top promessas, top provas, score médio, volume, confiança);
+- card executivo no workspace/coleta automática “Destaques por fonte”;
+- persistência relacional dos resultados de coleta para auditoria histórica;
+- telemetria mínima (latência por fonte, falhas, taxa de coleta útil).
+
+Isso fecha a lacuna entre “listar fontes para pesquisar” e “mostrar, de forma acionável, os destaques extraídos de cada fonte”.

--- a/mois/src/main/java/com/marketinghub/mois/dto/MoisWorkspaceDtos.java
+++ b/mois/src/main/java/com/marketinghub/mois/dto/MoisWorkspaceDtos.java
@@ -247,4 +247,33 @@ public final class MoisWorkspaceDtos {
             Instant updatedAt
     ) {
     }
+
+    public record CollectionSourceOpsSummaryResponse(
+            String source,
+            int attempts,
+            int successes,
+            int failures,
+            int retries,
+            int rateLimitedEvents,
+            long averageLatencyMs,
+            String lastError,
+            Instant lastAttemptAt
+    ) {
+    }
+
+    public record CollectionOpsSummaryResponse(
+            String workspaceId,
+            boolean rolloutEnabled,
+            int totalJobs,
+            int queuedJobs,
+            int runningJobs,
+            int completedJobs,
+            int failedJobs,
+            int totalCollectedReferences,
+            long averageJobLatencyMs,
+            int totalRetries,
+            List<CollectionSourceOpsSummaryResponse> sourceBreakdown,
+            Instant generatedAt
+    ) {
+    }
 }

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -47,6 +48,7 @@ public class MoisDomainService {
     private static final double ENGAGEMENT_WEIGHT = 0.45;
     private static final double RECURRENCE_WEIGHT = 0.35;
     private static final double EVIDENCE_WEIGHT = 0.20;
+    private static final int MAX_COLLECTION_RETRIES = 2;
 
     private final Map<String, DiscoveryRequest> requests = new ConcurrentHashMap<>();
     private final Map<String, SourceSnapshot> snapshots = new ConcurrentHashMap<>();
@@ -56,6 +58,8 @@ public class MoisDomainService {
     private final Map<String, MoisWorkspaceDtos.CollectionJobResponse> collectionJobs = new ConcurrentHashMap<>();
     private final Map<String, List<MoisWorkspaceDtos.CollectedReferenceResponse>> collectedReferencesByJob = new ConcurrentHashMap<>();
     private final Map<String, MoisWorkspaceDtos.CollectedReferenceLineageResponse> collectedReferenceLineage = new ConcurrentHashMap<>();
+    private final Map<String, CollectionJobRuntimeStats> collectionJobRuntimeStats = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, SourceOpsStats>> collectionOpsByWorkspace = new ConcurrentHashMap<>();
     private final Map<String, MoisWorkspaceDtos.ReferenceResponse> referencesById = new ConcurrentHashMap<>();
     private final Map<String, MoisWorkspaceDtos.ExtractionDraftResponse> extractionByReferenceId = new ConcurrentHashMap<>();
     private final Map<String, MoisWorkspaceDtos.LibraryBlockResponse> libraryBlocksById = new ConcurrentHashMap<>();
@@ -66,6 +70,12 @@ public class MoisDomainService {
     private static final String MODULE_NAME = "MOIS";
     private static final String CREATED_BY = "mois-system";
     private static final String DEFAULT_STAGE = "COLETA";
+    private volatile boolean collectionRolloutEnabled = true;
+    private final Set<String> rolloutAllowedWorkspaces = ConcurrentHashMap.newKeySet();
+
+    public MoisDomainService() {
+        loadCollectionRolloutFromEnv();
+    }
 
     public MoisWorkspaceDtos.WorkspaceDashboardResponse getDashboard(String workspaceId) {
         List<MoisWorkspaceDtos.ReferenceResponse> workspaceReferences = listWorkspaceReferences(workspaceId);
@@ -653,11 +663,14 @@ public class MoisDomainService {
     }
 
     public MoisWorkspaceDtos.CollectionJobResponse createCollectionJob(MoisWorkspaceDtos.CreateCollectionJobRequest request) {
+        if (!isCollectionRolloutAllowed(request.workspaceId())) {
+            throw new IllegalStateException("collection rollout is disabled for workspace");
+        }
         String jobId = "mois-collect-" + UUID.randomUUID();
         Instant now = Instant.now();
         int limitPerSource = request.limitPerSource() == null ? DEFAULT_LIMIT_PER_SOURCE : request.limitPerSource();
         int minSuccessScore = request.minSuccessScore() == null ? DEFAULT_MIN_SUCCESS_SCORE : request.minSuccessScore();
-        MoisWorkspaceDtos.CollectionJobResponse job = new MoisWorkspaceDtos.CollectionJobResponse(
+        MoisWorkspaceDtos.CollectionJobResponse queuedJob = new MoisWorkspaceDtos.CollectionJobResponse(
                 jobId,
                 request.workspaceId(),
                 request.niche(),
@@ -669,11 +682,100 @@ public class MoisDomainService {
                 request.sources(),
                 now
         );
-        collectionJobs.put(jobId, job);
-        collectedReferencesByJob.put(jobId, buildSeedCollectedReferences(job, request.niche()));
+        collectionJobs.put(jobId, queuedJob);
+        MoisWorkspaceDtos.CollectionJobResponse runningJob = new MoisWorkspaceDtos.CollectionJobResponse(
+                queuedJob.jobId(),
+                queuedJob.workspaceId(),
+                queuedJob.niche(),
+                queuedJob.marketTheme(),
+                "RUNNING",
+                queuedJob.timeWindow(),
+                queuedJob.limitPerSource(),
+                queuedJob.minSuccessScore(),
+                queuedJob.sources(),
+                queuedJob.createdAt()
+        );
+        collectionJobs.put(jobId, runningJob);
+        CollectionExecutionResult execution = runCollectionWithRetries(runningJob, request.niche());
+        collectedReferencesByJob.put(jobId, reRank(execution.references()));
+        collectionJobRuntimeStats.put(jobId, execution.runtimeStats());
+        MoisWorkspaceDtos.CollectionJobResponse completedJob = new MoisWorkspaceDtos.CollectionJobResponse(
+                runningJob.jobId(),
+                runningJob.workspaceId(),
+                runningJob.niche(),
+                runningJob.marketTheme(),
+                execution.hasFailure() ? "FAILED" : "COMPLETED",
+                runningJob.timeWindow(),
+                runningJob.limitPerSource(),
+                runningJob.minSuccessScore(),
+                runningJob.sources(),
+                runningJob.createdAt()
+        );
+        collectionJobs.put(jobId, completedJob);
         log.info("mois_collection_job_created jobId={} workspaceId={} sources={} window={}",
                 jobId, request.workspaceId(), request.sources(), request.timeWindow());
-        return job;
+        return completedJob;
+    }
+
+    public MoisWorkspaceDtos.CollectionOpsSummaryResponse getCollectionOpsSummary(String workspaceId) {
+        boolean rolloutEnabled = isCollectionRolloutAllowed(workspaceId);
+        List<MoisWorkspaceDtos.CollectionJobResponse> workspaceJobs = collectionJobs.values().stream()
+                .filter(job -> workspaceId == null || workspaceId.isBlank() || workspaceId.equals(job.workspaceId()))
+                .toList();
+        int queued = (int) workspaceJobs.stream().filter(job -> "QUEUED".equalsIgnoreCase(job.status())).count();
+        int running = (int) workspaceJobs.stream().filter(job -> "RUNNING".equalsIgnoreCase(job.status())).count();
+        int completed = (int) workspaceJobs.stream().filter(job -> "COMPLETED".equalsIgnoreCase(job.status())).count();
+        int failed = (int) workspaceJobs.stream().filter(job -> "FAILED".equalsIgnoreCase(job.status())).count();
+        int totalRetries = workspaceJobs.stream()
+                .map(MoisWorkspaceDtos.CollectionJobResponse::jobId)
+                .map(collectionJobRuntimeStats::get)
+                .filter(Objects::nonNull)
+                .mapToInt(CollectionJobRuntimeStats::retries)
+                .sum();
+        long avgLatencyMs = (long) workspaceJobs.stream()
+                .map(MoisWorkspaceDtos.CollectionJobResponse::jobId)
+                .map(collectionJobRuntimeStats::get)
+                .filter(Objects::nonNull)
+                .mapToLong(CollectionJobRuntimeStats::latencyMs)
+                .average()
+                .orElse(0);
+        int totalReferences = workspaceJobs.stream()
+                .map(MoisWorkspaceDtos.CollectionJobResponse::jobId)
+                .map(collectedReferencesByJob::get)
+                .filter(Objects::nonNull)
+                .mapToInt(List::size)
+                .sum();
+        List<MoisWorkspaceDtos.CollectionSourceOpsSummaryResponse> sourceBreakdown = collectionOpsByWorkspace
+                .getOrDefault(workspaceId, Map.of())
+                .values()
+                .stream()
+                .sorted(Comparator.comparing(SourceOpsStats::source))
+                .map(item -> new MoisWorkspaceDtos.CollectionSourceOpsSummaryResponse(
+                        item.source(),
+                        item.attempts(),
+                        item.successes(),
+                        item.failures(),
+                        item.retries(),
+                        item.rateLimitedEvents(),
+                        item.averageLatencyMs(),
+                        item.lastError(),
+                        item.lastAttemptAt()
+                ))
+                .toList();
+        return new MoisWorkspaceDtos.CollectionOpsSummaryResponse(
+                workspaceId,
+                rolloutEnabled,
+                workspaceJobs.size(),
+                queued,
+                running,
+                completed,
+                failed,
+                totalReferences,
+                avgLatencyMs,
+                totalRetries,
+                sourceBreakdown,
+                Instant.now()
+        );
     }
 
     public MoisWorkspaceDtos.CollectionJobListResponse listCollectionJobs(String workspaceId, String status) {
@@ -1140,14 +1242,21 @@ public class MoisDomainService {
                 .toList();
     }
 
-    private List<MoisWorkspaceDtos.CollectedReferenceResponse> buildSeedCollectedReferences(
-            MoisWorkspaceDtos.CollectionJobResponse job,
-            String niche
-    ) {
+    private CollectionExecutionResult runCollectionWithRetries(MoisWorkspaceDtos.CollectionJobResponse job, String niche) {
         List<MoisWorkspaceDtos.CollectedReferenceResponse> items = new ArrayList<>();
         int index = 0;
+        boolean hasFailure = false;
+        int retries = 0;
+        long totalLatencyMs = 0;
         for (String source : job.sources()) {
             index++;
+            SourceExecutionOutcome outcome = executeSourceCollection(job.workspaceId(), source, index);
+            retries += outcome.retries();
+            totalLatencyMs += outcome.latencyMs();
+            if (!outcome.success()) {
+                hasFailure = true;
+                continue;
+            }
             SourceMetricSnapshot metrics = buildSourceMetricSnapshot(job, source, index);
             NormalizedSuccessSignal normalized = normalizeSuccessSignal(metrics, job.minSuccessScore());
             items.add(new MoisWorkspaceDtos.CollectedReferenceResponse(
@@ -1171,6 +1280,9 @@ public class MoisDomainService {
                     Map.of(
                             "status", "ACTIVE",
                             "timeWindow", job.timeWindow(),
+                            "attempts", String.valueOf(outcome.attempts()),
+                            "retries", String.valueOf(outcome.retries()),
+                            "latencyMs", String.valueOf(outcome.latencyMs()),
                             "engagementRaw", String.valueOf(metrics.engagementRaw()),
                             "recurrenceRaw", String.valueOf(metrics.recurrenceRaw()),
                             "evidenceRaw", String.valueOf(metrics.evidenceRaw()),
@@ -1178,7 +1290,28 @@ public class MoisDomainService {
                     )
             ));
         }
-        return reRank(items);
+        return new CollectionExecutionResult(
+                reRank(items),
+                hasFailure,
+                new CollectionJobRuntimeStats(job.jobId(), retries, totalLatencyMs, Instant.now())
+        );
+    }
+
+    private SourceExecutionOutcome executeSourceCollection(String workspaceId, String source, int index) {
+        boolean hasRateLimit = source.toUpperCase().contains("META");
+        boolean unavailable = source.toUpperCase().contains("UNAVAILABLE");
+        int attempts = unavailable ? (MAX_COLLECTION_RETRIES + 1) : (hasRateLimit ? 2 : 1);
+        int retries = Math.max(0, attempts - 1);
+        int failures = unavailable ? attempts : retries;
+        int successes = unavailable ? 0 : 1;
+        int rateLimitedEvents = hasRateLimit ? 1 : 0;
+        long latencyMs = 160L + (Math.abs(source.hashCode()) % 450L) + (retries * 120L) + (index * 15L);
+        String lastError = unavailable ? "source unavailable" : (hasRateLimit ? "rate limited (recovered)" : null);
+        SourceOpsStats stats = collectionOpsByWorkspace
+                .computeIfAbsent(workspaceId, ignored -> new ConcurrentHashMap<>())
+                .computeIfAbsent(source, SourceOpsStats::new);
+        stats.register(attempts, successes, failures, retries, rateLimitedEvents, latencyMs, lastError);
+        return new SourceExecutionOutcome(!unavailable, attempts, retries, latencyMs);
     }
 
     private List<MoisWorkspaceDtos.CollectedReferenceResponse> reRank(List<MoisWorkspaceDtos.CollectedReferenceResponse> items) {
@@ -1590,6 +1723,43 @@ public class MoisDomainService {
         return trimmed.length() <= max ? trimmed : trimmed.substring(0, max);
     }
 
+    private void loadCollectionRolloutFromEnv() {
+        String enabled = System.getenv().getOrDefault("MOIS_COLLECTION_ROLLOUT_ENABLED", "true");
+        this.collectionRolloutEnabled = !"false".equalsIgnoreCase(enabled);
+        String allowed = System.getenv().getOrDefault("MOIS_COLLECTION_ROLLOUT_ALLOWED_WORKSPACES", "");
+        rolloutAllowedWorkspaces.clear();
+        if (!allowed.isBlank()) {
+            for (String workspace : allowed.split(",")) {
+                String normalized = workspace.trim();
+                if (!normalized.isBlank()) {
+                    rolloutAllowedWorkspaces.add(normalized);
+                }
+            }
+        }
+    }
+
+    void configureCollectionRollout(boolean enabled, List<String> allowedWorkspaces) {
+        this.collectionRolloutEnabled = enabled;
+        this.rolloutAllowedWorkspaces.clear();
+        if (allowedWorkspaces != null) {
+            this.rolloutAllowedWorkspaces.addAll(allowedWorkspaces.stream()
+                    .filter(Objects::nonNull)
+                    .map(String::trim)
+                    .filter(value -> !value.isBlank())
+                    .toList());
+        }
+    }
+
+    private boolean isCollectionRolloutAllowed(String workspaceId) {
+        if (!collectionRolloutEnabled) {
+            return false;
+        }
+        if (rolloutAllowedWorkspaces.isEmpty()) {
+            return true;
+        }
+        return workspaceId != null && rolloutAllowedWorkspaces.contains(workspaceId);
+    }
+
     private List<String> defaultList(List<String> values) {
         return values == null ? List.of() : values;
     }
@@ -1635,5 +1805,99 @@ public class MoisDomainService {
             double recurrenceScore,
             double evidenceScore
     ) {
+    }
+
+    private record SourceExecutionOutcome(
+            boolean success,
+            int attempts,
+            int retries,
+            long latencyMs
+    ) {
+    }
+
+    private record CollectionExecutionResult(
+            List<MoisWorkspaceDtos.CollectedReferenceResponse> references,
+            boolean hasFailure,
+            CollectionJobRuntimeStats runtimeStats
+    ) {
+    }
+
+    private record CollectionJobRuntimeStats(
+            String jobId,
+            int retries,
+            long latencyMs,
+            Instant finishedAt
+    ) {
+    }
+
+    private static final class SourceOpsStats {
+        private final String source;
+        private int attempts;
+        private int successes;
+        private int failures;
+        private int retries;
+        private int rateLimitedEvents;
+        private long totalLatencyMs;
+        private String lastError;
+        private Instant lastAttemptAt;
+
+        private SourceOpsStats(String source) {
+            this.source = source;
+        }
+
+        synchronized void register(
+                int attempts,
+                int successes,
+                int failures,
+                int retries,
+                int rateLimitedEvents,
+                long latencyMs,
+                String lastError
+        ) {
+            this.attempts += attempts;
+            this.successes += successes;
+            this.failures += failures;
+            this.retries += retries;
+            this.rateLimitedEvents += rateLimitedEvents;
+            this.totalLatencyMs += latencyMs;
+            this.lastError = lastError;
+            this.lastAttemptAt = Instant.now();
+        }
+
+        String source() {
+            return source;
+        }
+
+        synchronized int attempts() {
+            return attempts;
+        }
+
+        synchronized int successes() {
+            return successes;
+        }
+
+        synchronized int failures() {
+            return failures;
+        }
+
+        synchronized int retries() {
+            return retries;
+        }
+
+        synchronized int rateLimitedEvents() {
+            return rateLimitedEvents;
+        }
+
+        synchronized long averageLatencyMs() {
+            return attempts == 0 ? 0 : totalLatencyMs / attempts;
+        }
+
+        synchronized String lastError() {
+            return lastError;
+        }
+
+        synchronized Instant lastAttemptAt() {
+            return lastAttemptAt;
+        }
     }
 }

--- a/mois/src/main/java/com/marketinghub/mois/web/MoisDomainController.java
+++ b/mois/src/main/java/com/marketinghub/mois/web/MoisDomainController.java
@@ -175,7 +175,11 @@ public class MoisDomainController {
     public MoisWorkspaceDtos.CollectionJobResponse createCollectionJob(
             @Valid @RequestBody MoisWorkspaceDtos.CreateCollectionJobRequest request
     ) {
-        return service.createCollectionJob(request);
+        try {
+            return service.createCollectionJob(request);
+        } catch (IllegalStateException ex) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, ex.getMessage());
+        }
     }
 
     @GetMapping("/collection-jobs")
@@ -241,5 +245,10 @@ public class MoisDomainController {
     ) {
         return service.getCollectedReferenceLineage(jobId, referenceId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "collected reference lineage not found"));
+    }
+
+    @GetMapping("/workspaces/{workspaceId}/collection-ops/summary")
+    public MoisWorkspaceDtos.CollectionOpsSummaryResponse getCollectionOpsSummary(@PathVariable String workspaceId) {
+        return service.getCollectionOpsSummary(workspaceId);
     }
 }

--- a/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
+++ b/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
@@ -260,11 +260,12 @@ class MoisDomainServiceTest {
                 )
         );
 
-        MoisWorkspaceDtos.CollectionJobListResponse jobs = service.listCollectionJobs("workspace-001", "QUEUED");
+        MoisWorkspaceDtos.CollectionJobListResponse jobs = service.listCollectionJobs("workspace-001", "COMPLETED");
 
         assertThat(created.jobId()).startsWith("mois-collect-");
         assertThat(jobs.items()).hasSize(1);
         assertThat(jobs.items().getFirst().workspaceId()).isEqualTo("workspace-001");
+        assertThat(created.status()).isEqualTo("COMPLETED");
     }
 
     @Test
@@ -388,6 +389,50 @@ class MoisDomainServiceTest {
         assertThat(lineage.importedReferenceId()).isEqualTo(action.importedReferenceId());
         assertThat(lineage.extractionId()).isEqualTo(action.extractionId());
         assertThat(lineage.generatedLibraryBlockIds()).hasSize(2);
+    }
+
+    @Test
+    void shouldExposeCollectionOpsSummaryWithRetriesAndLatency() {
+        service.createCollectionJob(
+                new MoisWorkspaceDtos.CreateCollectionJobRequest(
+                        "workspace-ops",
+                        "nutricao",
+                        "perda de gordura",
+                        List.of("META_AD_LIBRARY", "CLICKBANK"),
+                        "LAST_7_DAYS",
+                        10,
+                        "pt-BR",
+                        "BR",
+                        55
+                )
+        );
+
+        MoisWorkspaceDtos.CollectionOpsSummaryResponse summary = service.getCollectionOpsSummary("workspace-ops");
+        assertThat(summary.workspaceId()).isEqualTo("workspace-ops");
+        assertThat(summary.totalJobs()).isEqualTo(1);
+        assertThat(summary.completedJobs()).isEqualTo(1);
+        assertThat(summary.totalRetries()).isGreaterThanOrEqualTo(1);
+        assertThat(summary.averageJobLatencyMs()).isGreaterThan(0);
+        assertThat(summary.sourceBreakdown()).isNotEmpty();
+    }
+
+    @Test
+    void shouldBlockCollectionWhenRolloutDoesNotAllowWorkspace() {
+        service.configureCollectionRollout(true, List.of("workspace-allowed"));
+
+        var request = new MoisWorkspaceDtos.CreateCollectionJobRequest(
+                "workspace-blocked",
+                "nutricao",
+                "tema",
+                List.of("CLICKBANK"),
+                "LAST_7_DAYS",
+                10,
+                "pt-BR",
+                "BR",
+                40
+        );
+
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () -> service.createCollectionJob(request));
     }
 
     private static class HtmlHandler implements HttpHandler {

--- a/mois/src/test/java/com/marketinghub/mois/web/MoisDomainControllerTest.java
+++ b/mois/src/test/java/com/marketinghub/mois/web/MoisDomainControllerTest.java
@@ -2,6 +2,7 @@ package com.marketinghub.mois.web;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -179,6 +180,24 @@ class MoisDomainControllerTest {
     }
 
     @Test
+    void shouldReturnForbiddenWhenCollectionRolloutBlocksWorkspace() throws Exception {
+        doThrow(new IllegalStateException("collection rollout is disabled for workspace"))
+                .when(service).createCollectionJob(any());
+
+        mockMvc.perform(post("/api/v1/mois/collection-jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "workspaceId": "workspace-001",
+                                  "niche": "nutricao",
+                                  "sources": ["CLICKBANK"],
+                                  "timeWindow": "LAST_7_DAYS"
+                                }
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void shouldListCollectedReferencesByJob() throws Exception {
         when(service.listCollectedReferencesByJob("mois-collect-001", "CLICKBANK", "nutricao", 70, "HIGH"))
                 .thenReturn(Optional.of(new MoisWorkspaceDtos.CollectedReferenceListResponse(
@@ -252,5 +271,40 @@ class MoisDomainControllerTest {
         mockMvc.perform(post("/api/v1/mois/collection-jobs/mois-collect-001/references/ref-1/import-and-start-extraction"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.extractionId").value("ext-1"));
+    }
+
+    @Test
+    void shouldReturnCollectionOpsSummary() throws Exception {
+        when(service.getCollectionOpsSummary("workspace-001"))
+                .thenReturn(new MoisWorkspaceDtos.CollectionOpsSummaryResponse(
+                        "workspace-001",
+                        true,
+                        3,
+                        0,
+                        0,
+                        3,
+                        0,
+                        6,
+                        320,
+                        2,
+                        List.of(new MoisWorkspaceDtos.CollectionSourceOpsSummaryResponse(
+                                "CLICKBANK",
+                                3,
+                                3,
+                                0,
+                                0,
+                                0,
+                                120,
+                                null,
+                                Instant.parse("2026-04-26T12:00:00Z")
+                        )),
+                        Instant.parse("2026-04-26T12:01:00Z")
+                ));
+
+        mockMvc.perform(get("/api/v1/mois/workspaces/workspace-001/collection-ops/summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.workspaceId").value("workspace-001"))
+                .andExpect(jsonPath("$.completedJobs").value(3))
+                .andExpect(jsonPath("$.sourceBreakdown[0].source").value("CLICKBANK"));
     }
 }


### PR DESCRIPTION
### Motivation
- Provide operational visibility into automatic collection by exposing per-workspace summary metrics (attempts, successes, failures, retries, rate limits, latency). 
- Enforce controlled rollout of the automatic collection feature per workspace to avoid unintended runs during rollout. 
- Record runtime stats for collection jobs (retries, latency) to enable observability and future analytics.

### Description
- Introduced new DTOs `CollectionSourceOpsSummaryResponse` and `CollectionOpsSummaryResponse` to both `mois` and `ads-service` DTO packages. 
- Added `GET /api/v1/mois/workspaces/{workspaceId}/collection-ops/summary` endpoints in `MoisController` and `MoisDomainController` and exposed the summary via `MoisModuleGateway#getCollectionOpsSummary`. 
- Implemented collection execution with retry simulation, per-source `SourceOpsStats`, and job runtime tracking in `MoisDomainService`, including rollout gating (`configureCollectionRollout`, env-driven `MOIS_COLLECTION_ROLLOUT_*`) and helper records (`SourceExecutionOutcome`, `CollectionExecutionResult`, `CollectionJobRuntimeStats`, `SourceOpsStats`). 
- Updated domain flow to run queued jobs to completion (QUEUED -> RUNNING -> COMPLETED/FAILED) and persist collected references and runtime stats. 
- Documentation updated with Sprint 5 status and a new MOIS deployment/status report (`docs/mois/*`). 
- Updated/added unit tests and controller contract tests to cover the new summary endpoint and rollout behavior.

### Testing
- Ran unit and controller tests including `MoisDomainServiceTest`, `MoisDomainControllerTest` and `MoisControllerContractTest`, which exercise collection job creation, collected references, import/extraction lineage and the new `collection-ops/summary` behavior; all tests passed. 
- Verified HTTP contract behavior for the new `GET /api/v1/mois/workspaces/{workspaceId}/collection-ops/summary` via MockMvc-based controller tests; assertions for workspace id, job counts and source breakdown succeeded. 
- Verified rollout gating by asserting `createCollectionJob` throws `IllegalStateException` when workspace is not allowed and that the controller translates this to `403 FORBIDDEN` in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee63750ca883219399b674e481d876)