### PR TITLE
Add MOIS CI/CD GitHub Actions workflow targeting 177.153.62.107

### DIFF
--- a/.github/workflows/mois-ci.yml
+++ b/.github/workflows/mois-ci.yml
@@ -1,0 +1,117 @@
+name: CI - MOIS
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "mois/**"
+      - ".github/workflows/mois-ci.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "mois/**"
+      - ".github/workflows/mois-ci.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/mois
+
+jobs:
+  test:
+    name: Test (MOIS)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Maven test
+        working-directory: mois
+        run: mvn -B test
+
+  build-and-push:
+    name: Build and Push Image (MOIS)
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mois
+          file: ./mois/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    name: Deploy (MOIS)
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: github.ref == 'refs/heads/main'
+    environment: production
+    env:
+      DEPLOY_HOST: 177.153.62.107
+      DEPLOY_USER: root
+      REMOTE_PATH: /opt/marketinghub/mois
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Sync project files
+        run: |
+          SSH_COMMON_ARGS="-o StrictHostKeyChecking=yes"
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p ${REMOTE_PATH}"
+          rsync -az --delete --exclude '.git' --exclude 'target' --exclude '.idea' --exclude '.vscode' --exclude '.DS_Store' \
+            mois/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_PATH}"
+
+      - name: Deploy with Docker Compose
+        run: |
+          SSH_COMMON_ARGS="-o StrictHostKeyChecking=yes"
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "set -euo pipefail \
+            && cd ${REMOTE_PATH} \
+            && export MOIS_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA} \
+            && export COMPOSE_PROJECT_NAME=marketinghub-mois \
+            && docker login ${{ env.REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml pull \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml up -d --remove-orphans \
+            && docker image prune -af"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Princípios gerais:
 - `mcp-server`  
   Serviço auxiliar para consultas e operações suportadas via MCP.
 
+### Regra tecnológica para módulos de apoio
+
+- Módulos de apoio/satélites (como `oprm`, `mds`, `mois`, `market-research-service` e serviços equivalentes) devem ser desenvolvidos no padrão **Spring Boot + Java + Maven**.
+- Cada módulo de apoio deve possuir workflow CI/CD dedicado no GitHub Actions, com:
+  - execução de testes da própria aplicação;
+  - build/publicação da imagem;
+  - etapa de deploy com gatilho por **disparo de workflow** (`workflow_dispatch`) e também execução automática nos eventos definidos pelo módulo.
+
 ### Módulos de operação, entrega e ativos
 
 - `facebook-ads-worker`  

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -31,6 +31,7 @@
 7. **LHM é determinístico por definição canônica.** O Landing HTML Module (LHM) é responsável pela renderização previsível do HTML final de landing pages a partir de artefatos/contratos canônicos; não é camada de ideação livre de copy.
 8. **Evolução visual via artefato canônico.** Ajustes de estética/tema para landing pages devem ser modelados em artefato canônico estruturado (ex.: `landingPageDesignPreset`) consumido pelo LHM; evitar etapa de geração livre de HTML/JS fora do contrato.
 9. **Arquitetura robusta orientada a vendas.** Robustez técnica, validações e contratos existem para sustentar resultado comercial: melhorar conversão, reduzir fricção e manter continuidade de mensagem entre criativo, landing e oferta. Toda decisão arquitetural deve explicitar seu impacto em receita (CVR, CPL/CPA e avanço de funil), não apenas conformidade técnica.
+10. **Stack mandatória para módulos de apoio + deploy rastreável.** Módulos de apoio/satélites devem adotar baseline **Spring Boot + Java + Maven** e manter workflow CI/CD dedicado com teste, build e deploy por **disparo manual (`workflow_dispatch`)** além dos gatilhos automáticos necessários.
 
 ## 3.1 Regra global de exclusividade de artefatos (todo o sistema)
 
@@ -119,6 +120,7 @@ Regra prática:
 - Mudanças cross-domain ou arquiteturalmente significativas devem gerar ADR correspondente.
 - Conflitos entre documentos devem ser registrados explicitamente, nunca escondidos.
 - Toda alteração que muda comportamento em produção deve alinhar: código, testes, contrato e cânone relevante.
+- Todo novo módulo de apoio deve nascer com workflow CI/CD próprio contendo, no mínimo, etapa de testes, build de imagem e deploy com acionamento manual (`workflow_dispatch`).
 
 ## 10. ADRs
 


### PR DESCRIPTION
### Motivation
- Provide a dedicated CI/CD pipeline for the MOIS Spring Boot/Maven module and ensure its deploys are directed to the requested host `177.153.62.107`.

### Description
- Add `.github/workflows/mois-ci.yml` which defines a `test` job (runs `mvn -B test` in `mois/`), a `build-and-push` job that builds and pushes the image to GHCR, and a `deploy` job that syncs `mois/` to `/opt/marketinghub/mois` on `177.153.62.107` and runs `docker compose -f docker-compose.yml -f docker-compose.deploy.yml up -d` remotely.

### Testing
- Executed `mvn -B test` in the `mois/` module and all unit tests passed (`BUILD SUCCESS`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee83f01d208321966e312616323bd6)