### PR TITLE
Add GitHub Actions CI for mds (tests, Docker build/push, and deploy)

### DIFF
--- a/.github/workflows/mds-ci.yml
+++ b/.github/workflows/mds-ci.yml
@@ -1,0 +1,125 @@
+name: CI – MDS
+
+on:
+  push:
+    branches: ["main", "master"]
+    paths:
+      - "mds/**"
+      - ".github/workflows/mds-ci.yml"
+  pull_request:
+    paths:
+      - "mds/**"
+      - ".github/workflows/mds-ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mds
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+      - name: Run tests
+        run: mvn -B test
+
+  docker:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
+      IMAGE_TAG: latest
+      IMAGE_SHA_TAG: ${{ github.sha }}
+    outputs:
+      image-tag: ${{ steps.image_tag.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAMESPACE }}/mds
+          tags: |
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=${{ env.IMAGE_SHA_TAG }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: mds
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/mds:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/mds:buildcache,mode=max
+      - name: Expose image tag
+        id: image_tag
+        run: echo "value=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - test
+      - docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      DEPLOY_HOST: 177.153.62.107
+      DEPLOY_USER: root
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
+      IMAGE_TAG: ${{ needs.docker.outputs['image-tag'] }}
+      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME != '' && secrets.GHCR_USERNAME || github.repository_owner }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+      MDS_CONTAINER_NAME: mds
+      MDS_BACKEND_BASE_URL: ${{ secrets.MDS_BACKEND_BASE_URL }}
+      MDS_WORKER_ID: ${{ secrets.MDS_WORKER_ID != '' && secrets.MDS_WORKER_ID || 'mds-worker-prod' }}
+      MDS_SEARCH_TIMEOUT_MS: ${{ secrets.MDS_SEARCH_TIMEOUT_MS }}
+      MDS_SEARCH_RETRY_MAX_ATTEMPTS: ${{ secrets.MDS_SEARCH_RETRY_MAX_ATTEMPTS }}
+      MDS_SEARCH_RETRY_BACKOFF_MS: ${{ secrets.MDS_SEARCH_RETRY_BACKOFF_MS }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure SSH
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_CHAVE != '' && secrets.VPS_SSH_CHAVE || secrets.VPS_SSH_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "SSH_COMMON_ARGS=-i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -o ConnectTimeout=60" >> "$GITHUB_ENV"
+      - name: Publish MDS service
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "set -euo pipefail \
+            && if [ -n '${GHCR_TOKEN}' ]; then echo '${GHCR_TOKEN}' | docker login ${IMAGE_REGISTRY} -u '${GHCR_USERNAME}' --password-stdin; fi \
+            && IMAGE='${IMAGE_NAMESPACE}/mds:${IMAGE_TAG}' \
+            && docker pull ${IMAGE_NAMESPACE}/mds:${IMAGE_TAG} \
+            && (docker rm -f ${MDS_CONTAINER_NAME} >/dev/null 2>&1 || true) \
+            && docker run -d --name ${MDS_CONTAINER_NAME} \
+              --restart unless-stopped \
+              -p 8091:8091 \
+              -e MDS_BACKEND_BASE_URL='${MDS_BACKEND_BASE_URL}' \
+              -e MDS_WORKER_ID='${MDS_WORKER_ID}' \
+              -e MDS_SEARCH_TIMEOUT_MS='${MDS_SEARCH_TIMEOUT_MS}' \
+              -e MDS_SEARCH_RETRY_MAX_ATTEMPTS='${MDS_SEARCH_RETRY_MAX_ATTEMPTS}' \
+              -e MDS_SEARCH_RETRY_BACKOFF_MS='${MDS_SEARCH_RETRY_BACKOFF_MS}' \
+              ${IMAGE} \
+            && docker image prune -af"


### PR DESCRIPTION
### Motivation

- Provide continuous integration and delivery for the `mds` service by running tests, building and publishing a Docker image, and enabling automated deployment to a production host.

### Description

- Add a new workflow file `.github/workflows/mds-ci.yml` that defines three jobs: `test`, `docker`, and `deploy` with `ubuntu-latest` runners.
- The `test` job sets up Java 21 via `actions/setup-java@v4` and runs `mvn -B test` in the `mds` working directory.
- The `docker` job depends on `test`, configures Docker Buildx, logs into GHCR with `docker/login-action@v3`, generates image metadata with `docker/metadata-action@v5`, and builds/pushes the image using `docker/build-push-action@v5` with registry cache support. 
- The `deploy` job runs only on the `main` branch and uses an SSH key to connect to the target host and run remote commands to `docker pull` the published image and `docker run` the `mds` container with environment variables and port mappings.

### Testing

- The workflow is configured to run unit/integration tests via `mvn -B test` in the `test` job as the gate for subsequent jobs. 
- No automated CI runs were executed as part of this PR, so no test results are reported here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8389e0588321b64769e9bcab3cd9)