### PR TITLE
Fix MOIS discovery seed precedence to avoid unstable offer sets

### DIFF
--- a/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
@@ -1645,6 +1645,9 @@ public class MoisDomainService {
 
     private List<String> buildCollectionSeeds(DiscoveryRequest request) {
         List<String> seeds = new ArrayList<>(request.seedUrls());
+        if (!seeds.isEmpty()) {
+            return seeds;
+        }
         for (String query : request.seedQueries()) {
             if (query == null || query.isBlank()) {
                 continue;


### PR DESCRIPTION
### Motivation
- Discovery requests that include explicit `seedUrls` were still appending DuckDuckGo search seeds generated from `seedQueries`, which produced nondeterministic external crawling and caused flaky test failures (extra offers/ranking changes). 

### Description
- Update `MoisDomainService#buildCollectionSeeds` (`mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java`) to return the provided `seedUrls` immediately when non-empty and skip generating `https://duckduckgo.com/?q=` seeds from `seedQueries`.

### Testing
- Ran module tests with `cd mois && mvn test` and all automated tests passed (27/27), including the previously failing `MoisDomainServiceTest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee85f3fad88321adbdaf679d3f2632)