### PR TITLE
Escape IMAGE variable in MDS deploy SSH command

### DIFF
--- a/.github/workflows/mds-ci.yml
+++ b/.github/workflows/mds-ci.yml
@@ -121,5 +121,5 @@ jobs:
               -e MDS_SEARCH_TIMEOUT_MS='${MDS_SEARCH_TIMEOUT_MS}' \
               -e MDS_SEARCH_RETRY_MAX_ATTEMPTS='${MDS_SEARCH_RETRY_MAX_ATTEMPTS}' \
               -e MDS_SEARCH_RETRY_BACKOFF_MS='${MDS_SEARCH_RETRY_BACKOFF_MS}' \
-              ${IMAGE} \
+              \${IMAGE} \
             && docker image prune -af"


### PR DESCRIPTION
### Motivation
- Ensure `docker run` receives the intended image by forcing expansion of `\${IMAGE}` on the remote host instead of being expanded (and empty) on the GitHub Actions runner.

### Description
- Replace `${IMAGE}` with `\${IMAGE}` in `.github/workflows/mds-ci.yml` inside the `Publish MDS service` SSH command so `IMAGE='${IMAGE_NAMESPACE}/mds:${IMAGE_TAG}'` is defined and expanded on the remote shell before `docker run`.

### Testing
- Parsed the updated workflow with Ruby YAML parser using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mds-ci.yml')"`, which succeeded, and an attempted Python `yaml.safe_load` check failed due to missing `PyYAML` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee87b80de88321b45ecb9733a7448c)