### PR TITLE
Support reading Java module logs over HTTP and update MDS/MOIS defaults

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -41,7 +41,7 @@ mvn -s settings.xml spring-boot:run
 
 ## Logs de Spring Boot dos módulos Java
 
-O tool `java_module_logs` lê os arquivos de log do Spring Boot configurados em:
+O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou URL HTTP/HTTPS** configurada em:
 
 - `MCP_LOG_BACKEND_PATH` (default `/var/log/marketinghub/backend.log`);
 - `MCP_LOG_AI_WORKER_PATH` (default `/var/log/marketinghub/ai-worker.log`);
@@ -49,8 +49,8 @@ O tool `java_module_logs` lê os arquivos de log do Spring Boot configurados em:
 - `MCP_LOG_FACEBOOK_ADS_PATH` (default `/var/log/marketinghub/facebook-ads.log`);
 - `MCP_LOG_EMAIL_SERVICE_PATH` (default `/var/log/marketinghub/email-service.log`);
 - `MCP_LOG_LEAD_PORTAL_PAYMENT_PATH` (default `/var/log/marketinghub/lead-portal-payment.log`);
-- `MCP_LOG_MDS_PATH` (default `/var/log/marketinghub/mds.log`);
-- `MCP_LOG_MOIS_PATH` (default `/var/log/marketinghub/mois.log`).
+- `MCP_LOG_MDS_PATH` (default `http://177.153.62.107:8091/actuator/logfile`);
+- `MCP_LOG_MOIS_PATH` (default `http://177.153.62.107:8094/actuator/logfile`).
 
 > Em produção, configure explicitamente os `MCP_LOG_*_PATH` via variáveis de ambiente (arquivo `.env` do host) para apontar para o destino de log aprovado.
 

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -33,8 +33,8 @@ mcp:
     facebook-ads-path: ${MCP_LOG_FACEBOOK_ADS_PATH:/var/log/marketinghub/facebook-ads.log}
     email-service-path: ${MCP_LOG_EMAIL_SERVICE_PATH:/var/log/marketinghub/email-service.log}
     lead-portal-payment-path: ${MCP_LOG_LEAD_PORTAL_PAYMENT_PATH:/var/log/marketinghub/lead-portal-payment.log}
-    mds-path: ${MCP_LOG_MDS_PATH:/var/log/marketinghub/mds.log}
-    mois-path: ${MCP_LOG_MOIS_PATH:/var/log/marketinghub/mois.log}
+    mds-path: ${MCP_LOG_MDS_PATH:http://177.153.62.107:8091/actuator/logfile}
+    mois-path: ${MCP_LOG_MOIS_PATH:http://177.153.62.107:8094/actuator/logfile}
     max-lines: ${MCP_LOG_MAX_LINES:500}
   meta:
     enabled: ${MCP_META_ENABLED:true}


### PR DESCRIPTION
### Motivation
- Allow the `java_module_logs` tool to fetch Spring Boot logs from either local files or HTTP/HTTPS actuator endpoints to support remote log exposure. 
- Provide sensible defaults for MDS and MOIS services so the MCP can reach their actuator log endpoints out of the box.

### Description
- Update `README.md` to indicate that `java_module_logs` can read logs from a local file or an `http/https` URL and document the configuration variables. 
- Change defaults in `application.yml` for `mcp.logs.mds-path` and `mcp.logs.mois-path` to `http://177.153.62.107:8091/actuator/logfile` and `http://177.153.62.107:8094/actuator/logfile` respectively, while keeping other log and meta settings unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef669918bc83218c03f3efee448198)