### PR TITLE
fix(liquibase): remove broken include for missing Hotmart changelog

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,8 +1,5 @@
 databaseChangeLog:
   - include:
-      file: changesets/2026-04-27-mois-hotmart-daily-collection.yaml
-      relativeToChangelogFile: true
-  - include:
       file: V2037_04_26__widen_experiment_pipeline_job_section_mysql5.sql
       relativeToChangelogFile: true
   - include:


### PR DESCRIPTION
### Motivation
- Remove a broken Liquibase include that caused changelog parsing to fail because `changesets/2026-04-27-mois-hotmart-daily-collection.yaml` was not present in the repository.

### Description
- Removed the `include` entry referencing `changesets/2026-04-27-mois-hotmart-daily-collection.yaml` from `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`.

### Testing
- Executed `mvn -q liquibase:validate -Dliquibase.changeLogFile=src/main/resources/db/changelog/db.changelog-master.yaml -Dliquibase.url=jdbc:h2:mem:lbtest -Dliquibase.username=sa -Dliquibase.password= -Dliquibase.driver=org.h2.Driver` which completed successfully and ran `mvn test -DskipITs` in `backend/ads-service` where all tests passed (365 tests, build success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6e1ffd108321bd50e4501438c318)