### PR TITLE
Align MOIS CI image tag with deploy and remove compose version key

### DIFF
--- a/.github/workflows/mois-ci.yml
+++ b/.github/workflows/mois-ci.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha
+            type=raw,value=sha-${{ github.sha }}
             type=raw,value=latest
 
       - name: Build and push

--- a/mois/docker-compose.yml
+++ b/mois/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   mois:
     build: .


### PR DESCRIPTION
### Motivation
- Prevent GHCR image pull failures during deploy by ensuring the CI publishes the exact tag the deploy expects. 
- Remove the obsolete `version` key from the MOIS `docker-compose.yml` to eliminate the compose warning during deploy.

### Description
- Updated `.github/workflows/mois-ci.yml` metadata tagging to emit an explicit full-SHA tag `sha-${{ github.sha }}` so pushed images match the `MOIS_IMAGE` used by the deploy step. 
- Removed the top-level `version` attribute from `mois/docker-compose.yml` to avoid the `the attribute 'version' is obsolete` warning from `docker compose`.
- Changes touch only the MOIS workflow and compose descriptor and do not modify application source code or runtime behavior.

### Testing
- Attempted to validate the composed files with `docker compose -f mois/docker-compose.yml -f mois/docker-compose.deploy.yml config`, which failed in this environment with `docker: command not found`. 
- The repository's CI defines a `test` job that runs `mvn -B test` for MOIS and will run on GitHub Actions; that CI job is expected to validate unit tests when the workflow executes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef74eea9508321a5953a740195089e)