### PR TITLE
Approve and publish landing page as IA + LHM variants and return variant links

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/dto/LandingPagePublicationResultDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/dto/LandingPagePublicationResultDto.java
@@ -1,11 +1,14 @@
 package com.marketinghub.experiment.pipeline.dto;
 
+import java.util.List;
+
 public record LandingPagePublicationResultDto(
         Long experimentId,
         Long flowId,
         boolean approved,
         boolean published,
         String publicUrl,
+        List<LandingPageVariantLinksDto> variantLinks,
         String facebookPixelId,
         boolean pixelAppliedAutomatically,
         String message) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/dto/LandingPageVariantLinksDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/dto/LandingPageVariantLinksDto.java
@@ -1,0 +1,8 @@
+package com.marketinghub.experiment.pipeline.dto;
+
+public record LandingPageVariantLinksDto(
+        String variant,
+        Long flowId,
+        String iframeUrl,
+        String standaloneUrl) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/repository/ExperimentPipelineGenerationJobRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/repository/ExperimentPipelineGenerationJobRepository.java
@@ -7,6 +7,7 @@ import com.marketinghub.experiment.ExperimentStatus;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +24,12 @@ public interface ExperimentPipelineGenerationJobRepository extends JpaRepository
     List<ExperimentPipelineGenerationJob> findByExperimentIdAndStatusInOrderByCreatedAtDesc(
             Long experimentId,
             Collection<ExperimentPipelineGenerationJobStatus> statuses);
+
+    Optional<ExperimentPipelineGenerationJob> findTopByExperimentIdAndSectionAndStatusAndModelOrderByCreatedAtDesc(
+            Long experimentId,
+            ExperimentPipelineSection section,
+            ExperimentPipelineGenerationJobStatus status,
+            String model);
 
     List<ExperimentPipelineGenerationJob> findByStatusOrderByCreatedAtAsc(ExperimentPipelineGenerationJobStatus status,
                                                                           Pageable pageable);

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -17,6 +17,7 @@ import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationJobD
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationJobSummaryDto;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationRequest;
 import com.marketinghub.experiment.pipeline.dto.LandingPagePublicationResultDto;
+import com.marketinghub.experiment.pipeline.dto.LandingPageVariantLinksDto;
 import com.marketinghub.experiment.pipeline.dto.internal.ExperimentPipelineGenerationJobCompletionRequest;
 import com.marketinghub.experiment.pipeline.dto.internal.ExperimentPipelineGenerationJobDto;
 import com.marketinghub.experiment.frameworkimage.service.FrameworkImageGenerationService;
@@ -33,6 +34,7 @@ import com.marketinghub.openai.OpenAiResponse;
 import com.marketinghub.openai.service.OpenAiPricingService;
 import java.math.BigDecimal;
 import java.text.Normalizer;
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -62,6 +64,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.core.NestedExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -368,43 +371,127 @@ public class ExperimentPipelineGenerationService {
 
     @Transactional
     public LandingPagePublicationResultDto approveAndPublishLandingPage(Long experimentId) {
-        ExperimentDto experimentDto = applyLandingHtmlToLeadPortalForm(experimentId);
         Experiment experiment = experimentRepository.findById(experimentId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Experimento não encontrado"));
-        LeadPortalFlow flowRef = experiment.getLeadPortalFlow();
-        if (flowRef == null || flowRef.getId() == null) {
+        if (!StringUtils.hasText(experiment.getLandingPageHtml())) {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "Fluxo de landing não foi criado para este experimento");
+                    "Landing HTML ainda não foi gerado para este experimento");
         }
-        LeadPortalFlow flow = leadPortalFlowRepository.findById(flowRef.getId())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Fluxo do Lead Portal não encontrado"));
-        flow.setApproved(true);
-        if (flow.getApprovedAt() == null) {
-            flow.setApprovedAt(Instant.now());
+        ExperimentPipelineGenerationJob latestLhmJob = jobRepository
+                .findTopByExperimentIdAndSectionAndStatusAndModelOrderByCreatedAtDesc(
+                        experimentId,
+                        ExperimentPipelineSection.LANDING_PAGE_HTML,
+                        ExperimentPipelineGenerationJobStatus.COMPLETED,
+                        LHM_MODEL)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        "HTML determinístico (LHM) não encontrado. Gere novamente em 'LHM + IA' antes de publicar."));
+        String lhmHtml = firstNonBlank(latestLhmJob.getResponseContent(), latestLhmJob.getRawResponse());
+        if (!StringUtils.hasText(lhmHtml)) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "HTML determinístico (LHM) está vazio. Gere novamente em 'LHM + IA' antes de publicar.");
         }
-        LeadPortalFlow saved = leadPortalFlowRepository.save(flow);
-        try {
-            leadPortalFlowPublisher.publish(saved);
-        } catch (LeadPortalPublicationException ex) {
-            String rootCauseMessage = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
-            String message = StringUtils.hasText(rootCauseMessage)
-                    ? "Falha ao aprovar/publicar landing automaticamente: " + rootCauseMessage
-                    : "Falha ao aprovar/publicar landing automaticamente";
-            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, message, ex);
+        LeadPortalFlow iaFlow = upsertLandingVariantFlow(experiment, "ia", "WORKER_IA", experiment.getLandingPageHtml());
+        LeadPortalFlow lhmFlow = upsertLandingVariantFlow(experiment, "lhm", LHM_MODEL, lhmHtml);
+
+        for (LeadPortalFlow flow : List.of(iaFlow, lhmFlow)) {
+            flow.setApproved(true);
+            if (flow.getApprovedAt() == null) {
+                flow.setApprovedAt(Instant.now());
+            }
+            leadPortalFlowRepository.save(flow);
+            try {
+                leadPortalFlowPublisher.publish(flow);
+            } catch (LeadPortalPublicationException ex) {
+                String rootCauseMessage = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
+                String message = StringUtils.hasText(rootCauseMessage)
+                        ? "Falha ao aprovar/publicar landing automaticamente: " + rootCauseMessage
+                        : "Falha ao aprovar/publicar landing automaticamente";
+                throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, message, ex);
+            }
         }
-        String pixelId = saved.getMarketNiche() != null ? saved.getMarketNiche().getFacebookPixelId() : null;
-        Long publicationExperimentId = experimentDto != null && experimentDto.getId() != null
-                ? experimentDto.getId()
-                : experimentId;
+        experiment.setLeadPortalFlow(iaFlow);
+        experiment.setSchemaFirstLeadPortalEnabled(true);
+        experimentRepository.save(experiment);
+
+        List<LandingPageVariantLinksDto> variantLinks = List.of(
+                toVariantLinks("IA", iaFlow),
+                toVariantLinks("LHM", lhmFlow));
+
+        String pixelId = iaFlow.getMarketNiche() != null ? iaFlow.getMarketNiche().getFacebookPixelId() : null;
         return new LandingPagePublicationResultDto(
-                publicationExperimentId,
-                saved.getId(),
-                saved.isApproved(),
+                experimentId,
+                iaFlow.getId(),
+                iaFlow.isApproved() && lhmFlow.isApproved(),
                 true,
-                leadPortalPublicUrlResolver.resolve(saved),
+                leadPortalPublicUrlResolver.resolve(iaFlow),
+                variantLinks,
                 pixelId,
                 StringUtils.hasText(pixelId),
                 "Landing aprovada e publicação iniciada automaticamente após a aprovação.");
+    }
+
+    private LeadPortalFlow upsertLandingVariantFlow(Experiment experiment,
+                                                    String variantKey,
+                                                    String model,
+                                                    String landingHtml) {
+        Long experimentId = experiment.getId();
+        String variantSuffix = normalizeSlug(variantKey);
+        String slug = "exp-" + experimentId + "-landing-" + variantSuffix;
+        LeadPortalFlow flow = leadPortalFlowRepository.findBySlug(slug).orElseGet(() -> LeadPortalFlow.builder()
+                .name("Landing " + variantKey.toUpperCase(Locale.ROOT) + " - Experimento " + experimentId)
+                .slug(slug)
+                .description("Fluxo criado automaticamente para a variação " + variantKey.toUpperCase(Locale.ROOT)
+                        + " da landing page do experimento " + experimentId)
+                .prompt("Pipeline: landing-page-html/approve-and-publish")
+                .schemaFirst(true)
+                .experiment(experiment)
+                .marketNiche(experiment.getNiche())
+                .build());
+        String htmlWithImages = landingPageImageInjector.injectImages(experimentId, landingHtml);
+        flow.setCustomFormHtml(htmlWithImages != null ? htmlWithImages.trim() : null);
+        flow.setSchemaFirst(true);
+        flow.setModel(model);
+        flow.setExperiment(experiment);
+        flow.setMarketNiche(experiment.getNiche());
+        return leadPortalFlowRepository.save(flow);
+    }
+
+    private LandingPageVariantLinksDto toVariantLinks(String variant, LeadPortalFlow flow) {
+        String iframeUrl = leadPortalPublicUrlResolver.resolve(flow);
+        return new LandingPageVariantLinksDto(
+                variant,
+                flow.getId(),
+                iframeUrl,
+                resolveStandaloneLandingUrl(iframeUrl));
+    }
+
+    private String resolveStandaloneLandingUrl(String iframeUrl) {
+        if (!StringUtils.hasText(iframeUrl)) {
+            return null;
+        }
+        try {
+            URI parsed = URI.create(iframeUrl);
+            String path = parsed.getPath();
+            if (!StringUtils.hasText(path)) {
+                return null;
+            }
+            String[] segments = path.split("/");
+            String slug = segments.length == 0 ? "" : segments[segments.length - 1];
+            if (!StringUtils.hasText(slug)) {
+                return null;
+            }
+            return UriComponentsBuilder.newInstance()
+                    .scheme(parsed.getScheme())
+                    .host(parsed.getHost())
+                    .port(parsed.getPort())
+                    .path("/api/flows/{slug}/page")
+                    .buildAndExpand(slug)
+                    .toUriString();
+        } catch (RuntimeException ex) {
+            return null;
+        }
     }
 
     private LeadPortalFlow createLeadPortalFlowFromLandingHtml(Experiment experiment) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -368,27 +368,42 @@ class ExperimentPipelineGenerationServiceTest {
 
     @Test
     void approveAndPublishLandingPageReturnsPublicationFeedback() {
-        LeadPortalFlow linkedFlow = new LeadPortalFlow();
-        linkedFlow.setId(902L);
-        linkedFlow.setSlug("exp-22-landing");
-        linkedFlow.setApproved(false);
+        LeadPortalFlow iaFlow = new LeadPortalFlow();
+        iaFlow.setId(902L);
+        iaFlow.setSlug("exp-22-landing-ia");
+        iaFlow.setApproved(false);
+
+        LeadPortalFlow lhmFlow = new LeadPortalFlow();
+        lhmFlow.setId(903L);
+        lhmFlow.setSlug("exp-22-landing-lhm");
+        lhmFlow.setApproved(false);
 
         MarketNiche niche = new MarketNiche();
         niche.setFacebookPixelId("pixel-abc");
-        linkedFlow.setMarketNiche(niche);
+        iaFlow.setMarketNiche(niche);
+        lhmFlow.setMarketNiche(niche);
 
         Experiment experiment = new Experiment();
         experiment.setId(22L);
-        experiment.setLandingPageHtml("<section>ok</section>");
-        experiment.setLeadPortalFlow(linkedFlow);
+        experiment.setNiche(niche);
+        experiment.setLandingPageHtml("<section>ia</section>");
 
+        ExperimentPipelineGenerationJob lhmJob = new ExperimentPipelineGenerationJob();
+        lhmJob.setResponseContent("<section>lhm</section>");
         when(experimentRepository.findById(22L)).thenReturn(Optional.of(experiment));
-        when(leadPortalFlowRepository.findById(902L)).thenReturn(Optional.of(linkedFlow));
+        when(jobRepository.findTopByExperimentIdAndSectionAndStatusAndModelOrderByCreatedAtDesc(
+                22L,
+                ExperimentPipelineSection.LANDING_PAGE_HTML,
+                ExperimentPipelineGenerationJobStatus.COMPLETED,
+                "LHM")).thenReturn(Optional.of(lhmJob));
+        when(leadPortalFlowRepository.findBySlug("exp-22-landing-ia")).thenReturn(Optional.of(iaFlow));
+        when(leadPortalFlowRepository.findBySlug("exp-22-landing-lhm")).thenReturn(Optional.of(lhmFlow));
         when(leadPortalFlowRepository.save(any(LeadPortalFlow.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        when(experimentMapper.toDto(experiment)).thenReturn(new ExperimentDto());
-        when(landingPageImageInjector.injectImages(22L, "<section>ok</section>")).thenReturn("<section>ok</section>");
-        when(leadPortalPublicUrlResolver.resolve(any(LeadPortalFlow.class)))
-                .thenReturn("https://lead.portal/flows/exp-22-landing");
+        when(experimentRepository.save(any(Experiment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(landingPageImageInjector.injectImages(22L, "<section>ia</section>")).thenReturn("<section>ia</section>");
+        when(landingPageImageInjector.injectImages(22L, "<section>lhm</section>")).thenReturn("<section>lhm</section>");
+        when(leadPortalPublicUrlResolver.resolve(iaFlow)).thenReturn("https://lead.portal/flows/exp-22-landing-ia");
+        when(leadPortalPublicUrlResolver.resolve(lhmFlow)).thenReturn("https://lead.portal/flows/exp-22-landing-lhm");
 
         LandingPagePublicationResultDto result = service.approveAndPublishLandingPage(22L);
 
@@ -397,8 +412,13 @@ class ExperimentPipelineGenerationServiceTest {
         assertTrue(result.published());
         assertTrue(result.pixelAppliedAutomatically());
         assertEquals("pixel-abc", result.facebookPixelId());
-        assertEquals("https://lead.portal/flows/exp-22-landing", result.publicUrl());
-        verify(leadPortalFlowPublisher, times(1)).publish(any(LeadPortalFlow.class));
+        assertEquals("https://lead.portal/flows/exp-22-landing-ia", result.publicUrl());
+        assertEquals(2, result.variantLinks().size());
+        assertEquals("IA", result.variantLinks().get(0).variant());
+        assertEquals("https://lead.portal/api/flows/exp-22-landing-ia/page", result.variantLinks().get(0).standaloneUrl());
+        assertEquals("LHM", result.variantLinks().get(1).variant());
+        assertEquals("https://lead.portal/api/flows/exp-22-landing-lhm/page", result.variantLinks().get(1).standaloneUrl());
+        verify(leadPortalFlowPublisher, times(2)).publish(any(LeadPortalFlow.class));
     }
 
     @Test

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -18,6 +18,13 @@ type LandingLinks = {
   iframeUrl: string;
 };
 
+type VariantLandingLinks = {
+  variant: string;
+  flowId?: number;
+  standaloneUrl?: string | null;
+  iframeUrl?: string | null;
+};
+
 const leadPortalBaseUrl = import.meta.env.VITE_LEAD_PORTAL_BASE_URL?.trim() || "https://oportunidadebrasil.shop";
 
 function buildLeadPortalUrl(path: string): string {
@@ -61,6 +68,17 @@ function buildLandingLinksFromPublicUrl(publicUrl?: string | null): LandingLinks
   }
 }
 
+function normalizeVariantLabel(variant: string): string {
+  const upper = variant.trim().toUpperCase();
+  if (upper === "LHM") {
+    return "LHM (determinística)";
+  }
+  if (upper === "IA" || upper === "WORKER_IA") {
+    return "IA";
+  }
+  return variant;
+}
+
 export default function LandingTab({ experiment }: LandingTabProps) {
   const { data: landingPages, isLoading, isError } = useLandingPages(experiment.id);
   const updateExperiment = useUpdateExperiment(experiment.id);
@@ -68,6 +86,7 @@ export default function LandingTab({ experiment }: LandingTabProps) {
   const [pendingLandingId, setPendingLandingId] = useState<number | null>(null);
   const [isPublishing, setIsPublishing] = useState(false);
   const [publishedLinks, setPublishedLinks] = useState<LandingLinks | null>(null);
+  const [publishedVariantLinks, setPublishedVariantLinks] = useState<VariantLandingLinks[]>([]);
 
   const sortedLandingPages = useMemo(() => {
     if (!Array.isArray(landingPages)) {
@@ -109,8 +128,14 @@ export default function LandingTab({ experiment }: LandingTabProps) {
         publicUrl?: string | null;
         facebookPixelId?: string | null;
         pixelAppliedAutomatically?: boolean;
+        variantLinks?: VariantLandingLinks[] | null;
       }>(`/api/experiments/${experiment.id}/pipeline/landing-page-html/approve-and-publish`);
       setPublishedLinks(buildLandingLinksFromPublicUrl(data?.publicUrl));
+      setPublishedVariantLinks(
+        Array.isArray(data?.variantLinks)
+          ? data.variantLinks.filter((item) => item?.standaloneUrl || item?.iframeUrl)
+          : [],
+      );
 
       const pixelFeedback =
         data?.pixelAppliedAutomatically && data.facebookPixelId
@@ -235,6 +260,36 @@ export default function LandingTab({ experiment }: LandingTabProps) {
               >
                 {experimentApprovedLinks.iframeUrl}
               </a>
+            </div>
+          ) : null}
+          {publishedVariantLinks.length > 0 ? (
+            <div className="mt-3">
+              <p className="text-muted small mb-1">Variantes públicas (LHM + IA)</p>
+              {publishedVariantLinks.map((variantLink) => (
+                <div key={`${variantLink.variant}-${variantLink.flowId ?? "flow"}`} className="mb-2">
+                  <p className="small fw-semibold mb-1">{normalizeVariantLabel(variantLink.variant)}</p>
+                  {variantLink.standaloneUrl ? (
+                    <a
+                      href={variantLink.standaloneUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="small text-break d-block"
+                    >
+                      Standalone: {variantLink.standaloneUrl}
+                    </a>
+                  ) : null}
+                  {variantLink.iframeUrl ? (
+                    <a
+                      href={variantLink.iframeUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="small text-break d-block"
+                    >
+                      Iframe: {variantLink.iframeUrl}
+                    </a>
+                  ) : null}
+                </div>
+              ))}
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
### Motivation
- Provide deterministic (LHM) and IA landing variants when approving/publishing a landing and expose direct links for each variant to the UI.
- Surface variant-specific standalone and iframe URLs so users can open or embed each published variation.

### Description
- Added `LandingPageVariantLinksDto` and extended `LandingPagePublicationResultDto` with `variantLinks` to return variant metadata.
- Added repository method `findTopByExperimentIdAndSectionAndStatusAndModelOrderByCreatedAtDesc` to fetch latest completed LHM job for an experiment. 
- Updated `approveAndPublishLandingPage` to locate the latest LHM job, upsert two LeadPortal flows (IA and LHM), approve and publish both flows, persist experiment flags, and return a `LandingPagePublicationResultDto` containing variant links. 
- Implemented helper methods `upsertLandingVariantFlow`, `toVariantLinks`, and `resolveStandaloneLandingUrl` to create/update flows, build variant DTOs and compute standalone page URLs, and updated the frontend `LandingTab` to display published variant links with normalized labels.

### Testing
- Ran backend unit tests including the updated `ExperimentPipelineGenerationServiceTest`, which covers the new publish flow and variant link generation, and the tests passed.
- Verified that the modified test asserts publication of both variants and the returned variant links (including standalone URL resolution) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef900363f08321a613c58c93f9a348)