### PR TITLE
Use HTTP runtime log endpoints as defaults and add AGENTS.md

### DIFF
--- a/mcp-server/AGENTS.md
+++ b/mcp-server/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md — mcp-server
+
+## Defaults fixos para logs dos módulos Java via MCP
+
+Manter os seguintes endpoints como defaults de origem de logs no módulo `mcp-server`:
+
+- Worker AI: `http://191.252.120.96:4567/worker-observability/logfile`
+- Backend: `http://191.252.120.96:4567/worker-observability/logfile`
+- Email Service: `http://191.252.120.96:8086/ops-email-gateway-7xk9/email-service-audit-log`
+- Facebook Ads Worker: `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`
+- Lead Portal: `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`
+- Portal Pagamentos (Lead Portal): `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`
+
+Sempre que houver alteração desses endpoints, atualizar em conjunto:
+
+1. `src/main/resources/application.yml`
+2. `README.md`
+3. este `AGENTS.md`

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -43,14 +43,14 @@ mvn -s settings.xml spring-boot:run
 
 O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou URL HTTP/HTTPS** configurada em:
 
-- `MCP_LOG_BACKEND_PATH` (default `/var/log/marketinghub/backend.log`);
-- `MCP_LOG_AI_WORKER_PATH` (default `/var/log/marketinghub/ai-worker.log`);
-- `MCP_LOG_LEAD_PORTAL_PATH` (default `/var/log/marketinghub/lead-portal.log`);
-- `MCP_LOG_FACEBOOK_ADS_PATH` (default `/var/log/marketinghub/facebook-ads.log`);
-- `MCP_LOG_EMAIL_SERVICE_PATH` (default `/var/log/marketinghub/email-service.log`);
-- `MCP_LOG_LEAD_PORTAL_PAYMENT_PATH` (default `/var/log/marketinghub/lead-portal-payment.log`);
+- `MCP_LOG_BACKEND_PATH` (default `http://191.252.120.96:4567/worker-observability/logfile`);
+- `MCP_LOG_AI_WORKER_PATH` (default `http://191.252.120.96:4567/worker-observability/logfile`);
+- `MCP_LOG_LEAD_PORTAL_PATH` (default `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`);
+- `MCP_LOG_FACEBOOK_ADS_PATH` (default `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`);
+- `MCP_LOG_EMAIL_SERVICE_PATH` (default `http://191.252.120.96:8086/ops-email-gateway-7xk9/email-service-audit-log`);
+- `MCP_LOG_LEAD_PORTAL_PAYMENT_PATH` (default `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`);
 - `MCP_LOG_MDS_PATH` (default `http://177.153.62.107:8091/actuator/logfile`);
-- `MCP_LOG_MOIS_PATH` (default `http://177.153.62.107:8094/actuator/logfile`).
+- `MCP_LOG_MOIS_PATH` (default `http://177.153.62.107:8094/manage/logfile`).
 
 > Em produção, configure explicitamente os `MCP_LOG_*_PATH` via variáveis de ambiente (arquivo `.env` do host) para apontar para o destino de log aprovado.
 

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -27,14 +27,14 @@ mcp:
   server-version: ${MCP_SERVER_VERSION:1.0.0}
   api-key: ${MCP_API_KEY:}
   logs:
-    backend-path: ${MCP_LOG_BACKEND_PATH:/var/log/marketinghub/backend.log}
-    ai-worker-path: ${MCP_LOG_AI_WORKER_PATH:/var/log/marketinghub/ai-worker.log}
-    lead-portal-path: ${MCP_LOG_LEAD_PORTAL_PATH:/var/log/marketinghub/lead-portal.log}
-    facebook-ads-path: ${MCP_LOG_FACEBOOK_ADS_PATH:/var/log/marketinghub/facebook-ads.log}
-    email-service-path: ${MCP_LOG_EMAIL_SERVICE_PATH:/var/log/marketinghub/email-service.log}
-    lead-portal-payment-path: ${MCP_LOG_LEAD_PORTAL_PAYMENT_PATH:/var/log/marketinghub/lead-portal-payment.log}
+    backend-path: ${MCP_LOG_BACKEND_PATH:http://191.252.120.96:4567/worker-observability/logfile}
+    ai-worker-path: ${MCP_LOG_AI_WORKER_PATH:http://191.252.120.96:4567/worker-observability/logfile}
+    lead-portal-path: ${MCP_LOG_LEAD_PORTAL_PATH:http://191.252.120.96:8082/public/runtime-logs/tail?lines=300}
+    facebook-ads-path: ${MCP_LOG_FACEBOOK_ADS_PATH:http://191.252.120.96:8082/public/runtime-logs/tail?lines=300}
+    email-service-path: ${MCP_LOG_EMAIL_SERVICE_PATH:http://191.252.120.96:8086/ops-email-gateway-7xk9/email-service-audit-log}
+    lead-portal-payment-path: ${MCP_LOG_LEAD_PORTAL_PAYMENT_PATH:http://191.252.102.54:8092/api/v1/logs/runtime?lines=200}
     mds-path: ${MCP_LOG_MDS_PATH:http://177.153.62.107:8091/actuator/logfile}
-    mois-path: ${MCP_LOG_MOIS_PATH:http://177.153.62.107:8094/actuator/logfile}
+    mois-path: ${MCP_LOG_MOIS_PATH:http://177.153.62.107:8094/manage/logfile}
     max-lines: ${MCP_LOG_MAX_LINES:500}
   meta:
     enabled: ${MCP_META_ENABLED:true}


### PR DESCRIPTION
### Motivation

- Replace local-file defaults for Java module logs with HTTP endpoints so the `java_module_logs` tool can read runtime logs from central HTTP log endpoints.
- Document the fixed agent endpoints and the coordination required when they change.
- Fix the MOIS actuator path to use the `/manage/logfile` endpoint.

### Description

- Update `src/main/resources/application.yml` to set `mcp.logs.*` defaults to HTTP URLs for `backend-path`, `ai-worker-path`, `lead-portal-path`, `facebook-ads-path`, `email-service-path`, and `lead-portal-payment-path`, and change `mois-path` default to `/manage/logfile`.
- Update `README.md` to reflect the new default `MCP_LOG_*_PATH` values and the changed `MCP_LOG_MOIS_PATH` default.
- Add `AGENTS.md` documenting the canonical agent log endpoints and instructing to update `application.yml`, `README.md`, and `AGENTS.md` together when endpoints change.

### Testing

- No automated tests were run for this configuration and documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9383d0cc83219b6e388917a2838f)