### PR TITLE
Increase MDS search retry backoff to 180000ms (3 minutes) and document env var

### DIFF
--- a/mds/README.md
+++ b/mds/README.md
@@ -27,6 +27,7 @@ Variáveis úteis:
 
 - `MDS_BACKEND_BASE_URL` (default `http://localhost:8080`)
 - `MDS_WORKER_ID` (default `mds-worker-local`)
+- `MDS_SEARCH_RETRY_BACKOFF_MS` (default `180000`, ou 3 minutos)
 
 ## Build de artefato executável
 

--- a/mds/src/main/java/com/marketinghub/mds/config/MdsProperties.java
+++ b/mds/src/main/java/com/marketinghub/mds/config/MdsProperties.java
@@ -65,7 +65,7 @@ public class MdsProperties {
     public static class Search {
         private int timeoutMs = 5000;
         private int retryMaxAttempts = 2;
-        private int retryBackoffMs = 250;
+        private int retryBackoffMs = 180000;
 
         public int getTimeoutMs() {
             return timeoutMs;

--- a/mds/src/main/resources/application.yml
+++ b/mds/src/main/resources/application.yml
@@ -23,7 +23,7 @@ mds:
   search:
     timeout-ms: ${MDS_SEARCH_TIMEOUT_MS:5000}
     retry-max-attempts: ${MDS_SEARCH_RETRY_MAX_ATTEMPTS:2}
-    retry-backoff-ms: ${MDS_SEARCH_RETRY_BACKOFF_MS:250}
+    retry-backoff-ms: ${MDS_SEARCH_RETRY_BACKOFF_MS:180000}
   backend:
     base-url: ${MDS_BACKEND_BASE_URL:http://localhost:8080}
     worker-id: ${MDS_WORKER_ID:mds-worker-local}


### PR DESCRIPTION
### Motivation

- Reduce aggressive polling of the search endpoint by increasing the default retry backoff to avoid excessive requests and allow longer propagation windows.

### Description

- Change default search retry backoff from `250` ms to `180000` ms in `MdsProperties.java`.
- Update `application.yml` to use `MDS_SEARCH_RETRY_BACKOFF_MS` with a default of `180000` ms for the `mds.search.retry-backoff-ms` property.
- Add `MDS_SEARCH_RETRY_BACKOFF_MS` to `mds/README.md` with the default value and a brief note that it equals 3 minutes.

### Testing

- Ran the module test suite with `cd mds && mvn test`; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9336260c8321b519d56f017d7da1)