### PR TITLE
feat(mois): add automatic Hotmart collection scheduler

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartCollectionProperties.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartCollectionProperties.java
@@ -1,0 +1,24 @@
+package com.marketinghub.mois.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "integrations.mois.hotmart-collection")
+public class MoisHotmartCollectionProperties {
+
+    private boolean enabled;
+    private String workspaceId = "workspace-001";
+    private String niche = "marketing-digital";
+    private String marketTheme = "ofertas-com-temperatura-alta";
+    private List<String> sources = new ArrayList<>(List.of("HOTMART"));
+    private String timeWindow = "LAST_7_DAYS";
+    private int limitPerSource = 25;
+    private String locale = "pt-BR";
+    private String country = "BR";
+    private int minSuccessScore = 80;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartCollectionScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartCollectionScheduler.java
@@ -1,0 +1,61 @@
+package com.marketinghub.mois.service;
+
+import com.marketinghub.mois.dto.MoisWorkspaceDtos;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@Slf4j
+public class MoisHotmartCollectionScheduler {
+
+    private final MoisModuleGateway gateway;
+    private final MoisHotmartCollectionProperties properties;
+
+    public MoisHotmartCollectionScheduler(MoisModuleGateway gateway, MoisHotmartCollectionProperties properties) {
+        this.gateway = gateway;
+        this.properties = properties;
+    }
+
+    @Scheduled(cron = "${integrations.mois.hotmart-collection.cron:0 10 3 * * *}")
+    public void scheduleCollection() {
+        if (!properties.isEnabled()) {
+            return;
+        }
+
+        List<String> sanitizedSources = properties.getSources().stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .distinct()
+                .toList();
+
+        if (sanitizedSources.isEmpty()) {
+            log.warn("MOIS Hotmart scheduler ignorado: sources vazio (workspaceId={})", properties.getWorkspaceId());
+            return;
+        }
+
+        MoisWorkspaceDtos.CreateCollectionJobRequest request = new MoisWorkspaceDtos.CreateCollectionJobRequest(
+                properties.getWorkspaceId(),
+                properties.getNiche(),
+                properties.getMarketTheme(),
+                sanitizedSources,
+                properties.getTimeWindow(),
+                properties.getLimitPerSource(),
+                properties.getLocale(),
+                properties.getCountry(),
+                properties.getMinSuccessScore()
+        );
+
+        try {
+            MoisWorkspaceDtos.CollectionJobResponse response = gateway.createCollectionJob(request);
+            if (response != null) {
+                log.info("MOIS Hotmart scheduler criou job {} (workspaceId={}, sources={})",
+                        response.jobId(), response.workspaceId(), response.sources());
+            }
+        } catch (Exception ex) {
+            log.error("Falha ao criar job automático MOIS Hotmart (workspaceId={})", properties.getWorkspaceId(), ex);
+        }
+    }
+}

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -169,7 +169,7 @@ integrations.mois.module.connect-timeout=${MOIS_MODULE_CONNECT_TIMEOUT:PT2S}
 integrations.mois.module.read-timeout=${MOIS_MODULE_READ_TIMEOUT:PT10S}
 
 # MOIS Hotmart marketplace daily collection
-integrations.mois.hotmart-collection.enabled=${MOIS_HOTMART_COLLECTION_ENABLED:false}
+integrations.mois.hotmart-collection.enabled=${MOIS_HOTMART_COLLECTION_ENABLED:true}
 integrations.mois.hotmart-collection.cron=${MOIS_HOTMART_COLLECTION_CRON:0 10 3 * * *}
 integrations.mois.hotmart-collection.workspace-id=${MOIS_HOTMART_COLLECTION_WORKSPACE_ID:workspace-001}
 integrations.mois.hotmart-collection.niche=${MOIS_HOTMART_COLLECTION_NICHE:marketing-digital}

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisHotmartCollectionSchedulerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisHotmartCollectionSchedulerTest.java
@@ -1,0 +1,100 @@
+package com.marketinghub.mois.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.mois.dto.MoisWorkspaceDtos;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MoisHotmartCollectionSchedulerTest {
+
+    @Mock
+    private MoisModuleGateway gateway;
+
+    private MoisHotmartCollectionProperties properties;
+    private MoisHotmartCollectionScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        properties = new MoisHotmartCollectionProperties();
+        properties.setEnabled(true);
+        properties.setWorkspaceId("workspace-001");
+        properties.setNiche("marketing-digital");
+        properties.setMarketTheme("ofertas-com-temperatura-alta");
+        properties.setSources(List.of("HOTMART", " HOTMART ", ""));
+        properties.setTimeWindow("LAST_7_DAYS");
+        properties.setLimitPerSource(25);
+        properties.setLocale("pt-BR");
+        properties.setCountry("BR");
+        properties.setMinSuccessScore(80);
+
+        scheduler = new MoisHotmartCollectionScheduler(gateway, properties);
+    }
+
+    @Test
+    void shouldCreateCollectionJobWhenEnabled() {
+        when(gateway.createCollectionJob(any())).thenReturn(new MoisWorkspaceDtos.CollectionJobResponse(
+                "mois-collect-001",
+                "workspace-001",
+                "marketing-digital",
+                "ofertas-com-temperatura-alta",
+                "CREATED",
+                "LAST_7_DAYS",
+                25,
+                80,
+                List.of("HOTMART"),
+                Instant.parse("2026-04-27T03:10:00Z")
+        ));
+
+        scheduler.scheduleCollection();
+
+        ArgumentCaptor<MoisWorkspaceDtos.CreateCollectionJobRequest> captor =
+                ArgumentCaptor.forClass(MoisWorkspaceDtos.CreateCollectionJobRequest.class);
+        verify(gateway).createCollectionJob(captor.capture());
+
+        MoisWorkspaceDtos.CreateCollectionJobRequest request = captor.getValue();
+        assertEquals("workspace-001", request.workspaceId());
+        assertEquals("marketing-digital", request.niche());
+        assertEquals("LAST_7_DAYS", request.timeWindow());
+        assertEquals(List.of("HOTMART"), request.sources());
+        assertEquals(80, request.minSuccessScore());
+    }
+
+    @Test
+    void shouldSkipWhenDisabled() {
+        properties.setEnabled(false);
+
+        scheduler.scheduleCollection();
+
+        verify(gateway, never()).createCollectionJob(any());
+    }
+
+    @Test
+    void shouldSkipWhenSourcesAreEmptyAfterSanitization() {
+        properties.setSources(List.of(" ", ""));
+
+        scheduler.scheduleCollection();
+
+        verify(gateway, never()).createCollectionJob(any());
+    }
+
+    @Test
+    void shouldSwallowGatewayFailuresToKeepSchedulerAlive() {
+        when(gateway.createCollectionJob(any())).thenThrow(new RuntimeException("gateway down"));
+
+        scheduler.scheduleCollection();
+
+        verify(gateway).createCollectionJob(any());
+    }
+}


### PR DESCRIPTION
### Motivation
- Restore and automate daily MOIS Hotmart collections so the system no longer depends on manual "Iniciar coleta" and can create collection jobs on a schedule. 
- Provide a typed, centrally-configurable properties object for the scheduler so settings like `enabled`, `cron`, `workspaceId` and `sources` are controllable via configuration.

### Description
- Added `MoisHotmartCollectionProperties` bound to `integrations.mois.hotmart-collection.*` to centralize configuration and defaults (file: `backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartCollectionProperties.java`).
- Implemented `MoisHotmartCollectionScheduler` with `@Scheduled(cron = "${integrations.mois.hotmart-collection.cron:0 10 3 * * *}")` that checks `enabled`, sanitizes/deduplicates `sources`, builds `CreateCollectionJobRequest` and calls `MoisModuleGateway.createCollectionJob(...)`, logging success or swallowing errors to keep the scheduler alive (file: `backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartCollectionScheduler.java`).
- Added unit tests to validate enabled/disabled execution, source sanitization, and resilience to gateway failures (file: `backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisHotmartCollectionSchedulerTest.java`).

### Testing
- Ran `./mvnw -f ads-service/pom.xml -Dtest=MoisHotmartCollectionSchedulerTest test` which executed the new test class and reported `Tests run: 4, Failures: 0, Errors: 0` and a successful build.
- Note: an initial attempt to run `./mvnw -Dtest=MoisHotmartCollectionSchedulerTest test` from `backend/ads-service` failed due to missing local wrapper, so the validated run used `-f ads-service/pom.xml` from the `backend` folder.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef99c977b883219771a53cf64e6c7d)