### PR TITLE
Add MDS administrative API, service, frontend UI and contract tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminArtifactItemResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminArtifactItemResponse.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mds.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record MdsAdminArtifactItemResponse(
+        Long artifactId,
+        String artifactType,
+        String schemaVersion,
+        String version,
+        String status,
+        List<Long> parentArtifactIds,
+        List<Long> childArtifactIds,
+        Map<String, Object> content
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminArtifactLineageEdgeResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminArtifactLineageEdgeResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.mds.dto;
+
+public record MdsAdminArtifactLineageEdgeResponse(
+        Long id,
+        Long parentArtifactId,
+        Long childArtifactId,
+        String relationType
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminArtifactsResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminArtifactsResponse.java
@@ -1,0 +1,10 @@
+package com.marketinghub.mds.dto;
+
+import java.util.List;
+
+public record MdsAdminArtifactsResponse(
+        Long requestId,
+        List<MdsAdminArtifactItemResponse> artifacts,
+        List<MdsAdminArtifactLineageEdgeResponse> lineage
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminProcessingEventResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminProcessingEventResponse.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mds.dto;
+
+import com.marketinghub.mds.MdsEventType;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record MdsAdminProcessingEventResponse(
+        Long eventId,
+        String stageName,
+        MdsEventType eventType,
+        String message,
+        Map<String, Object> payload,
+        Instant createdAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminRequestDetailResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminRequestDetailResponse.java
@@ -1,0 +1,30 @@
+package com.marketinghub.mds.dto;
+
+import com.marketinghub.mds.MdsRequestStatus;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record MdsAdminRequestDetailResponse(
+        Long requestId,
+        MdsRequestStatus status,
+        String market,
+        String problem,
+        String desiredOutcome,
+        String deliveryConstraint,
+        String evidencePreference,
+        String correlationId,
+        String failureReason,
+        Instant createdAt,
+        Instant startedAt,
+        Instant finishedAt,
+        Map<String, Object> context,
+        List<MdsAdminProcessingEventResponse> timeline,
+        String failureClassification,
+        String artifactsUrl,
+        String reportUrl,
+        boolean retryEligible,
+        String retryReason
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminRequestListItemResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminRequestListItemResponse.java
@@ -1,0 +1,20 @@
+package com.marketinghub.mds.dto;
+
+import com.marketinghub.mds.MdsRequestStatus;
+
+import java.time.Instant;
+
+public record MdsAdminRequestListItemResponse(
+        Long requestId,
+        String market,
+        String problem,
+        String desiredOutcome,
+        MdsRequestStatus status,
+        String currentStage,
+        int attempt,
+        Instant lastHeartbeatAt,
+        Instant updatedAt,
+        boolean retryEligible,
+        String retryReason
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminRequestListResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminRequestListResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.mds.dto;
+
+import java.util.List;
+
+public record MdsAdminRequestListResponse(
+        List<MdsAdminRequestListItemResponse> items,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminRetryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/dto/MdsAdminRetryResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.mds.dto;
+
+import com.marketinghub.mds.MdsRequestStatus;
+
+public record MdsAdminRetryResponse(
+        Long requestId,
+        MdsRequestStatus previousStatus,
+        MdsRequestStatus currentStatus,
+        String message
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactLineageEdgeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsArtifactLineageEdgeRepository.java
@@ -3,5 +3,9 @@ package com.marketinghub.mds.repository;
 import com.marketinghub.mds.MdsArtifactLineageEdge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MdsArtifactLineageEdgeRepository extends JpaRepository<MdsArtifactLineageEdge, Long> {
+    List<MdsArtifactLineageEdge> findByParentArtifact_Request_IdOrChildArtifact_Request_IdOrderByIdAsc(Long parentRequestId,
+                                                                                                        Long childRequestId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsProcessingEventRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsProcessingEventRepository.java
@@ -1,7 +1,19 @@
 package com.marketinghub.mds.repository;
 
+import com.marketinghub.mds.MdsEventType;
 import com.marketinghub.mds.MdsProcessingEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface MdsProcessingEventRepository extends JpaRepository<MdsProcessingEvent, Long> {
+    List<MdsProcessingEvent> findByRequestIdOrderByCreatedAtAscIdAsc(Long requestId);
+
+    Optional<MdsProcessingEvent> findTopByRequestIdOrderByCreatedAtDescIdDesc(Long requestId);
+
+    Optional<MdsProcessingEvent> findTopByRequestIdAndEventTypeOrderByCreatedAtDescIdDesc(Long requestId,
+                                                                                          MdsEventType eventType);
+
+    long countByRequestIdAndEventType(Long requestId, MdsEventType eventType);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsRequestRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/repository/MdsRequestRepository.java
@@ -3,9 +3,10 @@ package com.marketinghub.mds.repository;
 import com.marketinghub.mds.MdsRequest;
 import com.marketinghub.mds.MdsRequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 
-public interface MdsRequestRepository extends JpaRepository<MdsRequest, Long> {
+public interface MdsRequestRepository extends JpaRepository<MdsRequest, Long>, JpaSpecificationExecutor<MdsRequest> {
     List<MdsRequest> findTop50ByStatusOrderByCreatedAtAsc(MdsRequestStatus status);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsAdminAuthorizationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsAdminAuthorizationService.java
@@ -1,0 +1,22 @@
+package com.marketinghub.mds.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Set;
+
+@Service
+public class MdsAdminAuthorizationService {
+    private static final Set<String> ALLOWED_ROLES = Set.of("ADMIN", "MDS_OPERATOR", "OPS");
+
+    public void assertAllowed(String roleHeader) {
+        if (roleHeader == null || roleHeader.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "missing X-User-Role");
+        }
+        String normalized = roleHeader.trim().toUpperCase();
+        if (!ALLOWED_ROLES.contains(normalized)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "role not allowed for MDS admin APIs");
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsAdminService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/service/MdsAdminService.java
@@ -1,0 +1,272 @@
+package com.marketinghub.mds.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.mds.*;
+import com.marketinghub.mds.dto.*;
+import com.marketinghub.mds.repository.MdsArtifactLineageEdgeRepository;
+import com.marketinghub.mds.repository.MdsArtifactRecordRepository;
+import com.marketinghub.mds.repository.MdsProcessingEventRepository;
+import com.marketinghub.mds.repository.MdsRequestRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class MdsAdminService {
+    private final MdsRequestRepository requestRepository;
+    private final MdsProcessingEventRepository processingEventRepository;
+    private final MdsArtifactRecordRepository artifactRecordRepository;
+    private final MdsArtifactLineageEdgeRepository lineageEdgeRepository;
+    private final ObjectMapper objectMapper;
+
+    public MdsAdminService(MdsRequestRepository requestRepository,
+                           MdsProcessingEventRepository processingEventRepository,
+                           MdsArtifactRecordRepository artifactRecordRepository,
+                           MdsArtifactLineageEdgeRepository lineageEdgeRepository,
+                           ObjectMapper objectMapper) {
+        this.requestRepository = requestRepository;
+        this.processingEventRepository = processingEventRepository;
+        this.artifactRecordRepository = artifactRecordRepository;
+        this.lineageEdgeRepository = lineageEdgeRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public MdsAdminRequestListResponse listRequests(String status,
+                                                    Instant from,
+                                                    Instant to,
+                                                    String tenantOrProduct,
+                                                    int page,
+                                                    int size) {
+        Pageable pageable = PageRequest.of(Math.max(page, 0), Math.max(1, Math.min(size, 100)));
+
+        Specification<MdsRequest> spec = Specification.where(null);
+        if (status != null && !status.isBlank()) {
+            MdsRequestStatus parsedStatus = parseStatus(status);
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), parsedStatus));
+        }
+        if (from != null) {
+            spec = spec.and((root, query, cb) -> cb.greaterThanOrEqualTo(root.get("createdAt"), from));
+        }
+        if (to != null) {
+            spec = spec.and((root, query, cb) -> cb.lessThanOrEqualTo(root.get("createdAt"), to));
+        }
+        if (tenantOrProduct != null && !tenantOrProduct.isBlank()) {
+            String searchTerm = "%" + tenantOrProduct.trim().toLowerCase() + "%";
+            spec = spec.and((root, query, cb) -> cb.like(cb.lower(root.get("correlationId")), searchTerm));
+        }
+
+        Page<MdsRequest> result = requestRepository.findAll(spec, pageable);
+        List<MdsAdminRequestListItemResponse> items = result.getContent().stream()
+                .map(this::toListItem)
+                .toList();
+
+        return new MdsAdminRequestListResponse(
+                items,
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public MdsAdminRequestDetailResponse getRequestDetail(Long id) {
+        MdsRequest request = requestRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "mds request not found"));
+
+        List<MdsAdminProcessingEventResponse> timeline = processingEventRepository
+                .findByRequestIdOrderByCreatedAtAscIdAsc(id)
+                .stream()
+                .map(this::toTimelineItem)
+                .toList();
+
+        return new MdsAdminRequestDetailResponse(
+                request.getId(),
+                request.getStatus(),
+                request.getMarket(),
+                request.getProblem(),
+                request.getDesiredOutcome(),
+                request.getDeliveryConstraint(),
+                request.getEvidencePreference(),
+                request.getCorrelationId(),
+                request.getFailureReason(),
+                request.getCreatedAt(),
+                request.getStartedAt(),
+                request.getFinishedAt(),
+                parseJson(request.getContextJson()),
+                timeline,
+                classifyFailure(request.getFailureReason()),
+                "/api/mds/requests/" + request.getId() + "/artifacts",
+                "/api/mds/reports/" + request.getId(),
+                isRetryEligible(request.getStatus()),
+                buildRetryReason(request.getStatus())
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public MdsAdminArtifactsResponse listArtifactsWithLineage(Long requestId) {
+        if (!requestRepository.existsById(requestId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "mds request not found");
+        }
+
+        List<MdsArtifactLineageEdge> edges = lineageEdgeRepository
+                .findByParentArtifact_Request_IdOrChildArtifact_Request_IdOrderByIdAsc(requestId, requestId);
+
+        Map<Long, List<Long>> parentByChild = edges.stream()
+                .collect(java.util.stream.Collectors.groupingBy(
+                        edge -> edge.getChildArtifact().getId(),
+                        java.util.stream.Collectors.mapping(edge -> edge.getParentArtifact().getId(), java.util.stream.Collectors.toList())
+                ));
+        Map<Long, List<Long>> childrenByParent = edges.stream()
+                .collect(java.util.stream.Collectors.groupingBy(
+                        edge -> edge.getParentArtifact().getId(),
+                        java.util.stream.Collectors.mapping(edge -> edge.getChildArtifact().getId(), java.util.stream.Collectors.toList())
+                ));
+
+        List<MdsAdminArtifactItemResponse> artifacts = artifactRecordRepository
+                .findByRequestIdOrderByCreatedAtAscIdAsc(requestId)
+                .stream()
+                .map(record -> new MdsAdminArtifactItemResponse(
+                        record.getId(),
+                        record.getArtifactType(),
+                        record.getSchemaVersion(),
+                        record.getVersion(),
+                        record.getStatus().name(),
+                        parentByChild.getOrDefault(record.getId(), List.of()),
+                        childrenByParent.getOrDefault(record.getId(), List.of()),
+                        parseJson(record.getContentJson())
+                ))
+                .toList();
+
+        List<MdsAdminArtifactLineageEdgeResponse> lineage = edges.stream()
+                .map(edge -> new MdsAdminArtifactLineageEdgeResponse(
+                        edge.getId(),
+                        edge.getParentArtifact().getId(),
+                        edge.getChildArtifact().getId(),
+                        edge.getRelationType()
+                ))
+                .toList();
+
+        return new MdsAdminArtifactsResponse(requestId, artifacts, lineage);
+    }
+
+    @Transactional
+    public MdsAdminRetryResponse retryRequest(Long id) {
+        MdsRequest request = requestRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "mds request not found"));
+
+        MdsRequestStatus previous = request.getStatus();
+        if (!isRetryEligible(previous)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, buildRetryReason(previous));
+        }
+
+        request.setStatus(MdsRequestStatus.PENDING);
+        request.setStartedAt(null);
+        request.setFinishedAt(null);
+        request.setFailureReason(null);
+
+        MdsProcessingEvent retryEvent = MdsProcessingEvent.builder()
+                .request(request)
+                .stageName("orchestration")
+                .eventType(MdsEventType.INFO)
+                .message("request moved back to pending by admin retry")
+                .payloadJson("{}")
+                .build();
+        processingEventRepository.save(retryEvent);
+
+        return new MdsAdminRetryResponse(id, previous, request.getStatus(), "retry accepted");
+    }
+
+    private MdsAdminRequestListItemResponse toListItem(MdsRequest request) {
+        MdsProcessingEvent latestEvent = processingEventRepository
+                .findTopByRequestIdOrderByCreatedAtDescIdDesc(request.getId())
+                .orElse(null);
+        MdsProcessingEvent heartbeatEvent = processingEventRepository
+                .findTopByRequestIdAndEventTypeOrderByCreatedAtDescIdDesc(request.getId(), MdsEventType.HEARTBEAT)
+                .orElse(null);
+
+        long attempts = processingEventRepository.countByRequestIdAndEventType(request.getId(), MdsEventType.INFO);
+        int normalizedAttempts = (int) Math.max(attempts, request.getStatus() == MdsRequestStatus.PENDING ? 0 : 1);
+
+        return new MdsAdminRequestListItemResponse(
+                request.getId(),
+                request.getMarket(),
+                request.getProblem(),
+                request.getDesiredOutcome(),
+                request.getStatus(),
+                latestEvent == null ? "pending" : latestEvent.getStageName(),
+                normalizedAttempts,
+                heartbeatEvent == null ? null : heartbeatEvent.getCreatedAt(),
+                request.getUpdatedAt(),
+                isRetryEligible(request.getStatus()),
+                buildRetryReason(request.getStatus())
+        );
+    }
+
+    private MdsAdminProcessingEventResponse toTimelineItem(MdsProcessingEvent event) {
+        return new MdsAdminProcessingEventResponse(
+                event.getId(),
+                event.getStageName(),
+                event.getEventType(),
+                event.getMessage(),
+                parseJson(event.getPayloadJson()),
+                event.getCreatedAt()
+        );
+    }
+
+    private String classifyFailure(String failureReason) {
+        if (failureReason == null || failureReason.isBlank()) {
+            return "NONE";
+        }
+        String normalized = failureReason.toLowerCase();
+        if (normalized.contains("timeout") || normalized.contains("429") || normalized.contains("network")) {
+            return "RECOVERABLE";
+        }
+        return "NON_RECOVERABLE";
+    }
+
+    private boolean isRetryEligible(MdsRequestStatus status) {
+        return status == MdsRequestStatus.FAILED;
+    }
+
+    private String buildRetryReason(MdsRequestStatus status) {
+        if (isRetryEligible(status)) {
+            return "READY";
+        }
+        return switch (status) {
+            case PENDING -> "request is still pending execution";
+            case IN_PROGRESS -> "request is in progress and cannot be retried";
+            case COMPLETED -> "request is completed; retry requires manual replay flow";
+            case FAILED -> "READY";
+        };
+    }
+
+    private MdsRequestStatus parseStatus(String value) {
+        try {
+            return MdsRequestStatus.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "status must be one of PENDING, IN_PROGRESS, COMPLETED, FAILED");
+        }
+    }
+
+    private Map<String, Object> parseJson(String value) {
+        try {
+            return objectMapper.readValue(value == null ? "{}" : value, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "invalid json payload");
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsAdminController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mds/web/MdsAdminController.java
@@ -1,0 +1,84 @@
+package com.marketinghub.mds.web;
+
+import com.marketinghub.mds.dto.*;
+import com.marketinghub.mds.service.MdsAdminAuthorizationService;
+import com.marketinghub.mds.service.MdsAdminService;
+import com.marketinghub.mds.service.MdsArtifactService;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/mds")
+public class MdsAdminController {
+    private final MdsAdminService adminService;
+    private final MdsArtifactService artifactService;
+    private final MdsAdminAuthorizationService authorizationService;
+
+    public MdsAdminController(MdsAdminService adminService,
+                              MdsArtifactService artifactService,
+                              MdsAdminAuthorizationService authorizationService) {
+        this.adminService = adminService;
+        this.artifactService = artifactService;
+        this.authorizationService = authorizationService;
+    }
+
+    @GetMapping("/requests")
+    public MdsAdminRequestListResponse listRequests(
+            @RequestHeader(value = "X-User-Role", required = false) String role,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) Instant from,
+            @RequestParam(required = false) Instant to,
+            @RequestParam(required = false, name = "tenantOrProduct") String tenantOrProduct,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        authorizationService.assertAllowed(role);
+        return adminService.listRequests(status, from, to, tenantOrProduct, page, size);
+    }
+
+    @GetMapping("/requests/{id}")
+    public MdsAdminRequestDetailResponse getRequest(
+            @RequestHeader(value = "X-User-Role", required = false) String role,
+            @PathVariable Long id
+    ) {
+        authorizationService.assertAllowed(role);
+        return adminService.getRequestDetail(id);
+    }
+
+    @GetMapping("/requests/{id}/artifacts")
+    public MdsAdminArtifactsResponse listArtifacts(
+            @RequestHeader(value = "X-User-Role", required = false) String role,
+            @PathVariable Long id
+    ) {
+        authorizationService.assertAllowed(role);
+        return adminService.listArtifactsWithLineage(id);
+    }
+
+    @GetMapping("/reports/{requestId}")
+    public MdsReportResponse getReport(
+            @RequestHeader(value = "X-User-Role", required = false) String role,
+            @PathVariable Long requestId
+    ) {
+        authorizationService.assertAllowed(role);
+        return artifactService.getReportByRequest(requestId);
+    }
+
+    @PostMapping("/requests/{id}/retry")
+    public MdsAdminRetryResponse retry(
+            @RequestHeader(value = "X-User-Role", required = false) String role,
+            @PathVariable Long id
+    ) {
+        authorizationService.assertAllowed(role);
+        return adminService.retryRequest(id);
+    }
+
+    @GetMapping("/health")
+    public Map<String, String> health(
+            @RequestHeader(value = "X-User-Role", required = false) String role
+    ) {
+        authorizationService.assertAllowed(role);
+        return Map.of("status", "ok", "module", "mds-admin-api");
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsAdminControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mds/web/MdsAdminControllerContractTest.java
@@ -1,0 +1,177 @@
+package com.marketinghub.mds.web;
+
+import com.marketinghub.mds.MdsRequestStatus;
+import com.marketinghub.mds.dto.*;
+import com.marketinghub.mds.service.MdsAdminAuthorizationService;
+import com.marketinghub.mds.service.MdsAdminService;
+import com.marketinghub.mds.service.MdsArtifactService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MdsAdminController.class)
+class MdsAdminControllerContractTest {
+
+    @SpringBootApplication
+    static class TestConfig {}
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MdsAdminService adminService;
+
+    @MockBean
+    private MdsArtifactService artifactService;
+
+    @MockBean
+    private MdsAdminAuthorizationService authorizationService;
+
+    @Test
+    void shouldListRequestsWithExpectedContract() throws Exception {
+        doNothing().when(authorizationService).assertAllowed("ADMIN");
+        when(adminService.listRequests(any(), any(), any(), any(), eq(0), eq(20)))
+                .thenReturn(new MdsAdminRequestListResponse(
+                        List.of(new MdsAdminRequestListItemResponse(
+                                12L,
+                                "fitness",
+                                "plateau",
+                                "perder gordura",
+                                MdsRequestStatus.IN_PROGRESS,
+                                "pipeline",
+                                1,
+                                Instant.parse("2026-04-27T10:00:00Z"),
+                                Instant.parse("2026-04-27T10:01:00Z"),
+                                false,
+                                "request is in progress and cannot be retried"
+                        )),
+                        0,
+                        20,
+                        1,
+                        1
+                ));
+
+        mockMvc.perform(get("/api/mds/requests")
+                        .header("X-User-Role", "ADMIN"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].requestId").value(12))
+                .andExpect(jsonPath("$.items[0].status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.items[0].retryEligible").value(false));
+    }
+
+    @Test
+    void shouldGetRequestDetail() throws Exception {
+        doNothing().when(authorizationService).assertAllowed("ADMIN");
+        when(adminService.getRequestDetail(9L)).thenReturn(new MdsAdminRequestDetailResponse(
+                9L,
+                MdsRequestStatus.FAILED,
+                "fitness",
+                "dor",
+                "resultado",
+                "ate 30 dias",
+                "peer-reviewed",
+                "tenant-a",
+                "timeout upstream",
+                Instant.parse("2026-04-27T10:00:00Z"),
+                Instant.parse("2026-04-27T10:01:00Z"),
+                Instant.parse("2026-04-27T10:02:00Z"),
+                Map.of("language", "pt-BR"),
+                List.of(new MdsAdminProcessingEventResponse(
+                        71L,
+                        "pipeline",
+                        com.marketinghub.mds.MdsEventType.ERROR,
+                        "falha",
+                        Map.of("step", "search"),
+                        Instant.parse("2026-04-27T10:02:00Z")
+                )),
+                "RECOVERABLE",
+                "/api/mds/requests/9/artifacts",
+                "/api/mds/reports/9",
+                true,
+                "READY"
+        ));
+
+        mockMvc.perform(get("/api/mds/requests/9")
+                        .header("X-User-Role", "ADMIN"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.failureClassification").value("RECOVERABLE"))
+                .andExpect(jsonPath("$.timeline[0].eventId").value(71))
+                .andExpect(jsonPath("$.retryEligible").value(true));
+    }
+
+    @Test
+    void shouldRetryRequest() throws Exception {
+        doNothing().when(authorizationService).assertAllowed("ADMIN");
+        when(adminService.retryRequest(22L)).thenReturn(new MdsAdminRetryResponse(
+                22L,
+                MdsRequestStatus.FAILED,
+                MdsRequestStatus.PENDING,
+                "retry accepted"
+        ));
+
+        mockMvc.perform(post("/api/mds/requests/22/retry")
+                        .header("X-User-Role", "ADMIN")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.previousStatus").value("FAILED"))
+                .andExpect(jsonPath("$.currentStatus").value("PENDING"));
+    }
+
+
+    @Test
+    void shouldListArtifactsWithCanonicalEnvelopeAndLineage() throws Exception {
+        doNothing().when(authorizationService).assertAllowed("ADMIN");
+        when(adminService.listArtifactsWithLineage(12L)).thenReturn(new MdsAdminArtifactsResponse(
+                12L,
+                List.of(
+                        new MdsAdminArtifactItemResponse(
+                                401L,
+                                "mechanismSpec",
+                                "v1",
+                                "v1",
+                                "VALIDATED",
+                                List.of(301L),
+                                List.of(501L),
+                                Map.of("problem", "plateau", "intervention", "micro-ciclo")
+                        )
+                ),
+                List.of(new MdsAdminArtifactLineageEdgeResponse(9001L, 301L, 401L, "DERIVED_FROM"))
+        ));
+
+        mockMvc.perform(get("/api/mds/requests/12/artifacts").header("X-User-Role", "ADMIN"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value(12))
+                .andExpect(jsonPath("$.artifacts[0].artifactId").value(401))
+                .andExpect(jsonPath("$.artifacts[0].parentArtifactIds[0]").value(301))
+                .andExpect(jsonPath("$.artifacts[0].content.intervention").value("micro-ciclo"))
+                .andExpect(jsonPath("$.lineage[0].relationType").value("DERIVED_FROM"));
+    }
+
+    @Test
+    void shouldGetReport() throws Exception {
+        doNothing().when(authorizationService).assertAllowed("ADMIN");
+        when(artifactService.getReportByRequest(12L))
+                .thenReturn(new MdsReportResponse(12L, 501L, "mechanismDiscoveryReport", "v1", "v1", "VALIDATED", Map.of("status", "SUCCESS")));
+
+        mockMvc.perform(get("/api/mds/reports/12").header("X-User-Role", "ADMIN"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.artifactType").value("mechanismDiscoveryReport"));
+    }
+}

--- a/docs/novos-modulos/MDS/contrato_backend_mds.md
+++ b/docs/novos-modulos/MDS/contrato_backend_mds.md
@@ -35,3 +35,41 @@ Tabelas adicionadas nesta sprint:
 - Claim só aceita request em `PENDING`.
 - Batch de artefatos valida status no envelope (`DRAFT`, `VALIDATED`, `APPROVED`).
 - Lineage pode ser criado no batch (via `parentArtifactIds`) ou endpoint dedicado.
+
+## Endpoints administrativos da UI (Sprint 0)
+Base path: `/api/mds`
+
+### Requests
+- `GET /requests` (paginação + filtros: `status`, `from`, `to`, `tenantOrProduct`)
+- `GET /requests/{id}`
+- `POST /requests/{id}/retry`
+
+### Artefatos e relatório
+- `GET /requests/{id}/artifacts`
+- `GET /reports/{requestId}`
+
+### Operação
+- `GET /health`
+
+## Controle de acesso da camada administrativa
+- Endpoints da UI administrativa exigem header `X-User-Role`.
+- Perfis aceitos no MVP: `ADMIN`, `MDS_OPERATOR`, `OPS`.
+
+
+## Atualização Sprint 2 (artefatos + lineage)
+- `GET /api/mds/requests/{id}/artifacts` retorna cada artefato com:
+  - metadados (`artifactId`, `artifactType`, `schemaVersion`, `version`, `status`)
+  - `parentArtifactIds` e `childArtifactIds` resolvidos
+  - `content` para visualização do envelope canônico na UI administrativa
+
+## Atualização Sprint 3 (retry operacional)
+- `GET /api/mds/requests` e `GET /api/mds/requests/{id}` incluem:
+  - `retryEligible` (boolean)
+  - `retryReason` (string)
+- `POST /api/mds/requests/{id}/retry` aceita apenas requests `FAILED` na operação padrão da UI administrativa.
+
+## Atualização Sprint 4 (observabilidade da UI)
+- `GET /api/mds/health` passa a ser consultado periodicamente pela UI administrativa para monitoramento operacional.
+- Estratégia de consumo no frontend:
+  - polling configurável na lista de requests (`auto-refresh`);
+  - cache com `staleTime` e `keepPreviousData` para reduzir recarga visual e chamadas redundantes.

--- a/docs/novos-modulos/MDS/plano_ui_mds_desenvolvimento.md
+++ b/docs/novos-modulos/MDS/plano_ui_mds_desenvolvimento.md
@@ -154,93 +154,139 @@ Para a UI, o backend principal deve expor endpoints administrativos (autenticado
 
 ### Sprint 0 — Registro
 
-- **Status:** `PLANEJADO`
-- **Período:** `<AAAA-MM-DD até AAAA-MM-DD>`
-- **Responsáveis:** `<nomes/time>`
+- **Status:** `CONCLUÍDO`
+- **Período:** `2026-04-27 até 2026-04-27`
+- **Responsáveis:** `Codex (implementação assistida)`
 - **Escopo realizado:**
-  - `<item>`
+  - definição de DTOs administrativos de listagem, detalhe, timeline, artefatos/lineage e retry no backend principal
+  - criação dos endpoints administrativos autenticáveis por papel em `/api/mds/*`
+  - criação das rotas frontend para lista, detalhe, artefatos e relatório
 - **Endpoints criados/alterados:**
-  - `<endpoint>`
+  - `GET /api/mds/requests`
+  - `GET /api/mds/requests/{id}`
+  - `GET /api/mds/requests/{id}/artifacts`
+  - `GET /api/mds/reports/{requestId}`
+  - `POST /api/mds/requests/{id}/retry`
+  - `GET /api/mds/health`
 - **Telas criadas/alteradas:**
-  - `<arquivo frontend>`
+  - `frontend/src/pages/mds/MdsWorkspacePage.tsx`
+  - `frontend/src/pages/mds/MdsRequestDetailPage.tsx`
+  - `frontend/src/pages/mds/MdsArtifactsPage.tsx`
+  - `frontend/src/pages/mds/MdsReportPage.tsx`
 - **Testes executados:**
-  - `<comando e resultado>`
+  - `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest,MdsInternalControllerContractTest test`
+  - `cd frontend && npm run build`
 - **Riscos pendentes:**
-  - `<item>`
+  - validação final de RBAC com fonte oficial de identidade ainda depende da camada global de autenticação
 - **Decisões tomadas:**
-  - `<item>`
+  - filtro de tenant/produto foi mapeado no MVP para `correlationId`
+  - classificação de falha recuperável x não recuperável foi inicialmente heurística para suportar diagnóstico operacional
 
 ### Sprint 1 — Registro
 
-- **Status:** `PLANEJADO`
-- **Período:** `<AAAA-MM-DD até AAAA-MM-DD>`
-- **Responsáveis:** `<nomes/time>`
+- **Status:** `CONCLUÍDO`
+- **Período:** `2026-04-27 até 2026-04-27`
+- **Responsáveis:** `Codex (implementação assistida)`
 - **Escopo realizado:**
-  - `<item>`
+  - implementação da Tela 1 (lista de requests) com filtros por status/período/tenant-produto, badges de status e ações para detalhe/artefatos/relatório/retry
+  - implementação da Tela 2 (detalhe da request) com diagnóstico, classificação de falha e timeline de estágios
+  - finalização dos estados de loading/erro/vazio nas telas principais da sprint
+  - inclusão de testes unitários para hooks e páginas principais do fluxo da Sprint 1
 - **Endpoints criados/alterados:**
-  - `<endpoint>`
+  - `GET /api/mds/requests`
+  - `GET /api/mds/requests/{id}`
+  - `POST /api/mds/requests/{id}/retry`
 - **Telas criadas/alteradas:**
-  - `<arquivo frontend>`
+  - `frontend/src/pages/mds/MdsWorkspacePage.tsx`
+  - `frontend/src/pages/mds/MdsRequestDetailPage.tsx`
 - **Testes executados:**
-  - `<comando e resultado>`
+  - `cd frontend && npm run test -- --run src/api/mds/useMdsAdmin.test.tsx src/pages/mds/MdsWorkspacePage.test.tsx src/pages/mds/MdsRequestDetailPage.test.tsx`
+  - `cd frontend && npm run build`
+  - `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest test`
 - **Riscos pendentes:**
-  - `<item>`
+  - dependência de disponibilidade do Maven Central ainda pode bloquear execução de testes Java na infraestrutura
 - **Decisões tomadas:**
-  - `<item>`
+  - os filtros de período da UI foram padronizados em UTC (`T00:00:00Z` e `T23:59:59Z`) para consistência de consulta
+  - os testes de sprint foram concentrados em hooks e componentes principais de lista e detalhe
 
 ### Sprint 2 — Registro
 
-- **Status:** `PLANEJADO`
-- **Período:** `<AAAA-MM-DD até AAAA-MM-DD>`
-- **Responsáveis:** `<nomes/time>`
+- **Status:** `CONCLUÍDO`
+- **Período:** `2026-04-27 até 2026-04-27`
+- **Responsáveis:** `Codex (implementação assistida)`
 - **Escopo realizado:**
-  - `<item>`
+  - evolução da tela de artefatos por request com agrupamento por tipo, seleção de item e leitura operacional
+  - implementação da visualização de envelope canônico (`artifact`) com `artifactType`, `artifactVersion`, `status`, `parentArtifactIds` e `content`
+  - implementação de navegação de lineage básico por pais/filhos com botões de salto entre artefatos
+  - ampliação dos contratos backend↔frontend para retorno de conteúdo do artefato no endpoint administrativo de artifacts
+  - inclusão de testes de contrato/frontend para artefatos e lineage
 - **Endpoints criados/alterados:**
-  - `<endpoint>`
+  - `GET /api/mds/requests/{id}/artifacts` (payload enriquecido com `content` + `parentArtifactIds` + `childArtifactIds`)
 - **Telas criadas/alteradas:**
-  - `<arquivo frontend>`
+  - `frontend/src/pages/mds/MdsArtifactsPage.tsx`
 - **Testes executados:**
-  - `<comando e resultado>`
+  - `cd frontend && npm run test -- --run src/api/mds/useMdsAdmin.test.tsx src/pages/mds/MdsArtifactsPage.test.tsx src/pages/mds/MdsWorkspacePage.test.tsx src/pages/mds/MdsRequestDetailPage.test.tsx`
+  - `cd frontend && npm run build`
+  - `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest test`
 - **Riscos pendentes:**
-  - `<item>`
+  - revisão de performance para requests com alto volume de artefatos e lineage denso
 - **Decisões tomadas:**
-  - `<item>`
+  - manter endpoint único de artifacts para reduzir round-trips na auditoria da Sprint 2
+  - expor `parentArtifactIds` e `childArtifactIds` já resolvidos no backend para simplificar navegação no frontend
 
 ### Sprint 3 — Registro
 
-- **Status:** `PLANEJADO`
-- **Período:** `<AAAA-MM-DD até AAAA-MM-DD>`
-- **Responsáveis:** `<nomes/time>`
+- **Status:** `CONCLUÍDO`
+- **Período:** `2026-04-27 até 2026-04-27`
+- **Responsáveis:** `Codex (implementação assistida)`
 - **Escopo realizado:**
-  - `<item>`
+  - evolução da Tela de relatório com leitura executiva (mecanismo, evidências, confiança, limitações, justificativa)
+  - refinamento da UX operacional na lista com mensagens explícitas de retry elegível/não elegível e feedback de sucesso/erro da ação
+  - ajuste do contrato backend para expor `retryEligible` e `retryReason` em listagem e detalhe
+  - inclusão de teste E2E do fluxo principal (lista → detalhe → artefatos → relatório)
 - **Endpoints criados/alterados:**
-  - `<endpoint>`
+  - `GET /api/mds/requests` (campos novos: `retryEligible`, `retryReason`)
+  - `GET /api/mds/requests/{id}` (campos novos: `retryEligible`, `retryReason`)
+  - `POST /api/mds/requests/{id}/retry` (elegibilidade explícita por status)
 - **Telas criadas/alteradas:**
-  - `<arquivo frontend>`
+  - `frontend/src/pages/mds/MdsWorkspacePage.tsx`
+  - `frontend/src/pages/mds/MdsReportPage.tsx`
 - **Testes executados:**
-  - `<comando e resultado>`
+  - `cd frontend && npm run test -- --run src/api/mds/useMdsAdmin.test.tsx src/pages/mds/MdsWorkspacePage.test.tsx src/pages/mds/MdsRequestDetailPage.test.tsx src/pages/mds/MdsArtifactsPage.test.tsx src/pages/mds/MdsReportPage.test.tsx src/pages/mds/MdsMainFlow.e2e.test.tsx`
+  - `cd frontend && npm run build`
+  - `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest test`
 - **Riscos pendentes:**
-  - `<item>`
+  - fluxo de retry para requests `COMPLETED` permanece bloqueado por decisão operacional atual e pode exigir trilha dedicada
 - **Decisões tomadas:**
-  - `<item>`
+  - retry operacional da Sprint 3 ficou restrito a status `FAILED` para evitar replay indevido de requests concluídas
+  - feedback operacional do frontend foi padronizado em alerts persistentes com fechamento manual
 
 ### Sprint 4 — Registro
 
-- **Status:** `PLANEJADO`
-- **Período:** `<AAAA-MM-DD até AAAA-MM-DD>`
-- **Responsáveis:** `<nomes/time>`
+- **Status:** `CONCLUÍDO`
+- **Período:** `2026-04-27 até 2026-04-27`
+- **Responsáveis:** `Codex (implementação assistida)`
 - **Escopo realizado:**
-  - `<item>`
+  - implementação de observabilidade da UI com painel de saúde do módulo (`/api/mds/health`) e contadores por status
+  - melhoria de performance com polling controlável (auto-refresh on/off), `staleTime` e cache com `keepPreviousData`
+  - revisão de acessibilidade/consistência visual (seções com rótulos, `aria-live`, feedbacks operacionais com fechamento manual)
+  - validação final de aderência canônica na visualização de artifacts/report e fluxo principal MDS
 - **Endpoints criados/alterados:**
-  - `<endpoint>`
+  - `GET /api/mds/health` (consumo ativo na UI)
+  - ajustes de contrato de requests para governar ação operacional de retry (`retryEligible`, `retryReason`)
 - **Telas criadas/alteradas:**
-  - `<arquivo frontend>`
+  - `frontend/src/pages/mds/MdsWorkspacePage.tsx`
+  - `frontend/src/pages/mds/MdsReportPage.tsx`
+  - `frontend/src/pages/mds/MdsArtifactsPage.tsx`
 - **Testes executados:**
-  - `<comando e resultado>`
+  - `cd frontend && npm run test -- --run src/api/mds/useMdsAdmin.test.tsx src/pages/mds/MdsWorkspacePage.test.tsx src/pages/mds/MdsRequestDetailPage.test.tsx src/pages/mds/MdsArtifactsPage.test.tsx src/pages/mds/MdsReportPage.test.tsx src/pages/mds/MdsMainFlow.e2e.test.tsx`
+  - `cd frontend && npm run build`
+  - `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest test`
 - **Riscos pendentes:**
-  - `<item>`
+  - em cenários de alto volume pode ser necessário paginação adicional no painel administrativo e otimização de bundle frontend
 - **Decisões tomadas:**
-  - `<item>`
+  - auto-refresh da fila foi mantido habilitado por padrão com opção explícita de desligamento
+  - observabilidade mínima na UI passou a ser obrigatória para operação contínua da fila MDS
 
 ---
 

--- a/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
+++ b/docs/novos-modulos/MDS/protocolo_historico_implantacao_mds.md
@@ -918,3 +918,162 @@ O pipeline do MDS passou a reagir de forma previsível a falhas transitórias de
 **Próximo passo sugerido:**
 
 Abrir a próxima fase fora da Sprint 7 para evolução de dashboards, política adaptativa de retry por tipo de erro e testes end-to-end com cenários reais de indisponibilidade externa.
+
+## [2026-04-27] — Etapa: sprint 0 da UI administrativa MDS
+
+### Resumo objetivo
+
+Foi implementada a base contratual da Sprint 0 da UI MDS, incluindo endpoints administrativos no backend principal, DTOs dedicados para listagem/detalhe/artefatos/relatório e criação das rotas iniciais no frontend para as quatro telas previstas no plano de UI.
+
+### Escopo realizado
+
+- Backend: criação do controlador `/api/mds` com rotas para requests, detalhe, artefatos, relatório, retry e health.
+- Backend: definição de DTOs administrativos da UI e serviço de agregação para timeline, classificação de falha e lineage básico.
+- Backend: validação inicial de papéis por header `X-User-Role` (`ADMIN`, `MDS_OPERATOR`, `OPS`).
+- Frontend: criação das páginas `MdsWorkspacePage`, `MdsRequestDetailPage`, `MdsArtifactsPage` e `MdsReportPage`.
+- Frontend: inclusão das rotas e entrada de navegação para o módulo MDS.
+- Documentação: atualização do plano de UI (registro da Sprint 0) e do contrato backend↔MDS para refletir endpoints administrativos.
+
+### Endpoints criados/alterados
+
+- `GET /api/mds/requests`
+- `GET /api/mds/requests/{id}`
+- `GET /api/mds/requests/{id}/artifacts`
+- `GET /api/mds/reports/{requestId}`
+- `POST /api/mds/requests/{id}/retry`
+- `GET /api/mds/health`
+
+### Testes executados
+
+- `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest,MdsInternalControllerContractTest test`
+- `cd frontend && npm run build`
+
+### Pendências
+
+- Integrar validação de papéis ao provedor oficial de identidade/SSO da plataforma.
+- Evoluir classificação de falha para critério orientado por código/causa estruturada.
+
+## [2026-04-27] — Etapa: sprint 1 da UI administrativa MDS (lista + detalhe)
+
+### Resumo objetivo
+
+Implementada a Sprint 1 da UI MDS com foco em operação mínima: tela de lista de requests com filtros e ações operacionais, tela de detalhe com timeline e classificação de falha, estados de loading/erro/vazio e testes unitários dos hooks/componentes principais.
+
+### Escopo realizado
+
+- Frontend: evolução da `MdsWorkspacePage` com filtros mínimos da sprint (`status`, `período`, `tenant/produto`) e ações de navegação.
+- Frontend: evolução da `MdsRequestDetailPage` para diagnóstico operacional e timeline de estágios.
+- Frontend: cobertura de testes unitários para hooks de API e páginas principais de Sprint 1.
+- Documentação: atualização do registro da Sprint 1 no plano de UI.
+
+### Endpoints utilizados
+
+- `GET /api/mds/requests`
+- `GET /api/mds/requests/{id}`
+- `POST /api/mds/requests/{id}/retry`
+
+### Testes executados
+
+- `cd frontend && npm run test -- --run src/api/mds/useMdsAdmin.test.tsx src/pages/mds/MdsWorkspacePage.test.tsx src/pages/mds/MdsRequestDetailPage.test.tsx`
+- `cd frontend && npm run build`
+- `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest test`
+
+### Pendências
+
+- Refinar UX e feedbacks operacionais para as próximas sprints (artefatos/lineage e relatório avançado).
+- Integrar observabilidade de frontend (telemetria de interação) na fase de hardening.
+
+## [2026-04-27] — Etapa: sprint 2 da UI administrativa MDS (artefatos + lineage)
+
+### Resumo objetivo
+
+Implementada a Sprint 2 da UI MDS com rastreabilidade operacional: tela de artefatos por request, visualização do envelope canônico e navegação básica de lineage (pais/filhos), com testes de contrato frontend↔backend para artifacts.
+
+### Escopo realizado
+
+- Backend: enriquecimento do endpoint `GET /api/mds/requests/{id}/artifacts` para retornar conteúdo canônico de cada artefato e relações derivadas (`parentArtifactIds`/`childArtifactIds`).
+- Backend: ampliação do teste de contrato do controller administrativo para validar estrutura de artifacts + lineage + content.
+- Frontend: evolução da `MdsArtifactsPage` com:
+  - agrupamento por tipo de artefato;
+  - seleção de item para leitura;
+  - envelope canônico renderizado em JSON;
+  - navegação básica de lineage por botões de pais e filhos.
+- Frontend: testes unitários para fluxo da tela de artifacts e contratos do hook `useMdsArtifacts`.
+- Documentação: atualização do plano de UI (registro Sprint 2 concluído).
+
+### Endpoints criados/alterados
+
+- `GET /api/mds/requests/{id}/artifacts` (enriquecido)
+
+### Testes executados
+
+- `cd frontend && npm run test -- --run src/api/mds/useMdsAdmin.test.tsx src/pages/mds/MdsArtifactsPage.test.tsx src/pages/mds/MdsWorkspacePage.test.tsx src/pages/mds/MdsRequestDetailPage.test.tsx`
+- `cd frontend && npm run build`
+- `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest test`
+
+### Pendências
+
+- observar volume de payload de artifacts para requests muito grandes;
+- considerar paginação/virtualização de lineage em sprint de hardening se necessário.
+
+## [2026-04-27] — Etapa: sprint 3 da UI administrativa MDS (relatório + ações operacionais)
+
+### Resumo objetivo
+
+Implementada a Sprint 3 da UI MDS para fechar o ciclo de diagnóstico e ação operacional: refinamento da tela de relatório, regras explícitas de elegibilidade para retry e mensagens operacionais de sucesso/erro no fluxo administrativo.
+
+### Escopo realizado
+
+- Backend: evolução dos DTOs de listagem e detalhe com campos `retryEligible` e `retryReason`.
+- Backend: ajuste da regra de retry para aceitar somente status `FAILED`, com motivo explícito quando bloqueado.
+- Backend: atualização de teste de contrato administrativo para validar os novos campos de elegibilidade.
+- Frontend: evolução da `MdsWorkspacePage` com feedback operacional (sucesso/erro) e explicação de bloqueio de retry por request.
+- Frontend: evolução da `MdsReportPage` com resumo executivo (mecanismo recomendado, evidências selecionadas, confiança, limitações e justificativa).
+- Frontend: criação de teste E2E do fluxo principal `lista → detalhe → artefatos → relatório`.
+
+### Endpoints criados/alterados
+
+- `GET /api/mds/requests` (campos novos de elegibilidade de retry)
+- `GET /api/mds/requests/{id}` (campos novos de elegibilidade de retry)
+- `POST /api/mds/requests/{id}/retry` (bloqueio explícito para status não elegíveis)
+
+### Testes executados
+
+- `cd frontend && npm run test -- --run src/api/mds/useMdsAdmin.test.tsx src/pages/mds/MdsWorkspacePage.test.tsx src/pages/mds/MdsRequestDetailPage.test.tsx src/pages/mds/MdsArtifactsPage.test.tsx src/pages/mds/MdsReportPage.test.tsx src/pages/mds/MdsMainFlow.e2e.test.tsx`
+- `cd frontend && npm run build`
+- `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest test`
+
+### Pendências
+
+- avaliar trilha dedicada para replay seguro de requests `COMPLETED` sem conflitar com retry operacional rápido;
+- avaliar telemetria de UX dos alerts operacionais na sprint de hardening.
+
+## [2026-04-27] — Etapa: sprint 4 da UI administrativa MDS (hardening + governança)
+
+### Resumo objetivo
+
+Implementada a Sprint 4 com foco em robustez operacional contínua: observabilidade da UI, ajustes de performance (polling/caching), revisão de acessibilidade e fechamento de aderência canônica das telas administrativas MDS.
+
+### Escopo realizado
+
+- Frontend: painel de observabilidade na `MdsWorkspacePage` com saúde do backend MDS (`/api/mds/health`) e contadores por status.
+- Frontend: melhoria de performance com `staleTime`, `keepPreviousData`, polling controlável por toggle de auto-refresh e refetch periódico para detalhe/health.
+- Frontend: revisão de acessibilidade e consistência visual (labels de seção, `aria-live`, feedbacks operacionais com fechamento manual).
+- Frontend: manutenção da aderência canônica na leitura de envelope e relatório executivo/técnico.
+- Testes: ampliação da suíte de hooks para health e manutenção do teste E2E do fluxo principal.
+
+### Endpoints criados/alterados
+
+- `GET /api/mds/health` (consumido no dashboard operacional da UI)
+- `GET /api/mds/requests` e `GET /api/mds/requests/{id}` (campos de governança operacional de retry)
+
+### Testes executados
+
+- `cd frontend && npm run test -- --run src/api/mds/useMdsAdmin.test.tsx src/pages/mds/MdsWorkspacePage.test.tsx src/pages/mds/MdsRequestDetailPage.test.tsx src/pages/mds/MdsArtifactsPage.test.tsx src/pages/mds/MdsReportPage.test.tsx src/pages/mds/MdsMainFlow.e2e.test.tsx`
+- `cd frontend && npm run build`
+- `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest test`
+
+### Pendências
+
+- evolução futura para paginação/virtualização adicional quando o volume operacional crescer;
+- avaliação de divisão de bundle para reduzir warning de chunks grandes no build de frontend.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -123,6 +123,10 @@ import MoisComparisonPage from "./pages/mois/MoisComparisonPage";
 import MoisOfferBuilderPage from "./pages/mois/MoisOfferBuilderPage";
 import MoisResearchSourcesPage from "./pages/mois/MoisResearchSourcesPage";
 import MoisAutoCollectionPage from "./pages/mois/MoisAutoCollectionPage";
+import MdsWorkspacePage from "./pages/mds/MdsWorkspacePage";
+import MdsRequestDetailPage from "./pages/mds/MdsRequestDetailPage";
+import MdsArtifactsPage from "./pages/mds/MdsArtifactsPage";
+import MdsReportPage from "./pages/mds/MdsReportPage";
 
 export default function App() {
   return (
@@ -276,6 +280,10 @@ export default function App() {
               <Route path="/mois/library" element={<MoisLibraryPage />} />
               <Route path="/mois/comparison" element={<MoisComparisonPage />} />
               <Route path="/mois/builder" element={<MoisOfferBuilderPage />} />
+              <Route path="/mds" element={<MdsWorkspacePage />} />
+              <Route path="/mds/requests/:requestId" element={<MdsRequestDetailPage />} />
+              <Route path="/mds/requests/:requestId/artifacts" element={<MdsArtifactsPage />} />
+              <Route path="/mds/reports/:requestId" element={<MdsReportPage />} />
               <Route
                 path="/oprm/routine/:occupationSeedRef"
                 element={<OprmRoutinePage />}

--- a/frontend/src/api/mds/types.ts
+++ b/frontend/src/api/mds/types.ts
@@ -1,0 +1,101 @@
+export type MdsRequestStatus = "PENDING" | "IN_PROGRESS" | "COMPLETED" | "FAILED";
+
+export interface MdsAdminRequestListItem {
+  requestId: number;
+  market: string;
+  problem: string;
+  desiredOutcome: string;
+  status: MdsRequestStatus;
+  currentStage: string;
+  attempt: number;
+  lastHeartbeatAt: string | null;
+  updatedAt: string;
+  retryEligible: boolean;
+  retryReason: string;
+}
+
+export interface MdsAdminRequestListResponse {
+  items: MdsAdminRequestListItem[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface MdsAdminProcessingEvent {
+  eventId: number;
+  stageName: string;
+  eventType: "INFO" | "HEARTBEAT" | "WARNING" | "ERROR";
+  message: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface MdsAdminRequestDetail {
+  requestId: number;
+  status: MdsRequestStatus;
+  market: string;
+  problem: string;
+  desiredOutcome: string;
+  deliveryConstraint: string | null;
+  evidencePreference: string | null;
+  correlationId: string;
+  failureReason: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  context: Record<string, unknown>;
+  timeline: MdsAdminProcessingEvent[];
+  failureClassification: string;
+  artifactsUrl: string;
+  reportUrl: string;
+  retryEligible: boolean;
+  retryReason: string;
+}
+
+export interface MdsArtifactItem {
+  artifactId: number;
+  artifactType: string;
+  schemaVersion: string;
+  version: string;
+  status: "DRAFT" | "VALIDATED" | "APPROVED";
+  parentArtifactIds: number[];
+  childArtifactIds: number[];
+  content: Record<string, unknown>;
+}
+
+export interface MdsArtifactLineageEdge {
+  id: number;
+  parentArtifactId: number;
+  childArtifactId: number;
+  relationType: string;
+}
+
+export interface MdsAdminArtifactsResponse {
+  requestId: number;
+  artifacts: MdsArtifactItem[];
+  lineage: MdsArtifactLineageEdge[];
+}
+
+export interface MdsReportResponse {
+  requestId: number;
+  artifactId: number;
+  artifactType: string;
+  schemaVersion: string;
+  version: string;
+  status: "DRAFT" | "VALIDATED" | "APPROVED";
+  content: Record<string, unknown>;
+}
+
+export interface MdsRetryResponse {
+  requestId: number;
+  previousStatus: MdsRequestStatus;
+  currentStatus: MdsRequestStatus;
+  message: string;
+}
+
+
+export interface MdsHealthResponse {
+  status: string;
+  module: string;
+}

--- a/frontend/src/api/mds/useMdsAdmin.test.tsx
+++ b/frontend/src/api/mds/useMdsAdmin.test.tsx
@@ -1,0 +1,134 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import axios from "axios";
+import { useMdsArtifacts, useMdsHealth, useMdsRequests, useRetryMdsRequest } from "./useMdsAdmin";
+
+vi.mock("axios");
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useMdsAdmin hooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("envia filtros na listagem de requests", async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: { items: [], page: 0, size: 20, totalElements: 0, totalPages: 0 },
+    } as any);
+
+    const { result } = renderHook(
+      () =>
+        useMdsRequests({
+          status: "FAILED",
+          tenantOrProduct: "tenant-a",
+          from: "2026-04-20T00:00:00Z",
+          to: "2026-04-27T23:59:59Z",
+          page: 0,
+          size: 20,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(axios.get).toHaveBeenCalledWith("/api/mds/requests", {
+      headers: { "X-User-Role": "ADMIN" },
+      params: {
+        status: "FAILED",
+        tenantOrProduct: "tenant-a",
+        from: "2026-04-20T00:00:00Z",
+        to: "2026-04-27T23:59:59Z",
+        page: 0,
+        size: 20,
+      },
+    });
+  });
+
+
+  it("carrega artefatos com envelope e lineage", async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        requestId: 12,
+        artifacts: [
+          {
+            artifactId: 401,
+            artifactType: "mechanismSpec",
+            schemaVersion: "v1",
+            version: "v1",
+            status: "VALIDATED",
+            parentArtifactIds: [301],
+            childArtifactIds: [501],
+            content: { intervention: "micro-ciclo" },
+          },
+        ],
+        lineage: [
+          { id: 9001, parentArtifactId: 301, childArtifactId: 401, relationType: "DERIVED_FROM" },
+        ],
+      },
+    } as any);
+
+    const { result } = renderHook(() => useMdsArtifacts(12), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(axios.get).toHaveBeenCalledWith("/api/mds/requests/12/artifacts", {
+      headers: { "X-User-Role": "ADMIN" },
+    });
+    expect(result.current.data?.artifacts[0].content.intervention).toBe("micro-ciclo");
+    expect(result.current.data?.lineage[0].relationType).toBe("DERIVED_FROM");
+  });
+
+
+  it("consulta health do módulo MDS", async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: { status: "ok", module: "mds-admin-api" },
+    } as any);
+
+    const { result } = renderHook(() => useMdsHealth(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(axios.get).toHaveBeenCalledWith("/api/mds/health", {
+      headers: { "X-User-Role": "ADMIN" },
+    });
+  });
+
+  it("executa retry de request com endpoint correto", async () => {
+    vi.mocked(axios.post).mockResolvedValue({
+      data: {
+        requestId: 99,
+        previousStatus: "FAILED",
+        currentStatus: "PENDING",
+        message: "retry accepted",
+      },
+    } as any);
+
+    const { result } = renderHook(() => useRetryMdsRequest(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync(99);
+
+    expect(axios.post).toHaveBeenCalledWith(
+      "/api/mds/requests/99/retry",
+      null,
+      {
+        headers: { "X-User-Role": "ADMIN" },
+      },
+    );
+  });
+});

--- a/frontend/src/api/mds/useMdsAdmin.ts
+++ b/frontend/src/api/mds/useMdsAdmin.ts
@@ -1,0 +1,109 @@
+import { keepPreviousData, useMutation, useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type {
+  MdsAdminArtifactsResponse,
+  MdsAdminRequestDetail,
+  MdsAdminRequestListResponse,
+  MdsHealthResponse,
+  MdsReportResponse,
+  MdsRequestStatus,
+  MdsRetryResponse,
+} from "./types";
+
+type ListParams = {
+  status?: MdsRequestStatus | "";
+  from?: string;
+  to?: string;
+  tenantOrProduct?: string;
+  page?: number;
+  size?: number;
+};
+
+const ADMIN_HEADERS = {
+  "X-User-Role": "ADMIN",
+};
+
+export function useMdsRequests(params: ListParams, autoRefreshEnabled = true) {
+  return useQuery({
+    queryKey: ["mds", "requests", params, autoRefreshEnabled],
+    queryFn: async () => {
+      const { data } = await axios.get<MdsAdminRequestListResponse>("/api/mds/requests", {
+        headers: ADMIN_HEADERS,
+        params,
+      });
+      return data;
+    },
+    staleTime: 15_000,
+    placeholderData: keepPreviousData,
+    refetchInterval: autoRefreshEnabled ? 20_000 : false,
+    refetchOnWindowFocus: autoRefreshEnabled,
+  });
+}
+
+export function useMdsRequestDetail(requestId: number | null) {
+  return useQuery({
+    queryKey: ["mds", "request", requestId],
+    enabled: Boolean(requestId),
+    queryFn: async () => {
+      const { data } = await axios.get<MdsAdminRequestDetail>(`/api/mds/requests/${requestId}`, {
+        headers: ADMIN_HEADERS,
+      });
+      return data;
+    },
+    staleTime: 10_000,
+    refetchInterval: 30_000,
+  });
+}
+
+export function useMdsArtifacts(requestId: number | null) {
+  return useQuery({
+    queryKey: ["mds", "artifacts", requestId],
+    enabled: Boolean(requestId),
+    queryFn: async () => {
+      const { data } = await axios.get<MdsAdminArtifactsResponse>(`/api/mds/requests/${requestId}/artifacts`, {
+        headers: ADMIN_HEADERS,
+      });
+      return data;
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function useMdsReport(requestId: number | null) {
+  return useQuery({
+    queryKey: ["mds", "report", requestId],
+    enabled: Boolean(requestId),
+    queryFn: async () => {
+      const { data } = await axios.get<MdsReportResponse>(`/api/mds/reports/${requestId}`, {
+        headers: ADMIN_HEADERS,
+      });
+      return data;
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function useMdsHealth() {
+  return useQuery({
+    queryKey: ["mds", "health"],
+    queryFn: async () => {
+      const { data } = await axios.get<MdsHealthResponse>("/api/mds/health", {
+        headers: ADMIN_HEADERS,
+      });
+      return data;
+    },
+    staleTime: 10_000,
+    refetchInterval: 30_000,
+  });
+}
+
+export function useRetryMdsRequest() {
+  return useMutation({
+    mutationFn: async (requestId: number) => {
+      const { data } = await axios.post<MdsRetryResponse>(`/api/mds/requests/${requestId}/retry`, null, {
+        headers: ADMIN_HEADERS,
+      });
+      return data;
+    },
+  });
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -35,6 +35,7 @@ import {
   Search,
   Mail,
   Inbox,
+  Microscope,
 } from "lucide-react";
 import experimentIcon from "../assets/icons/experiment-icon.svg";
 import hypothesisIcon from "../assets/icons/hypothesis-icon.svg";
@@ -106,6 +107,7 @@ const NAV_SECTIONS: NavSection[] = [
       { to: "/hypotheses", label: "Hipóteses", icon: hypothesisIcon },
       { to: "/mois", label: "MOIS", icon: Workflow },
       { to: "/oprm", label: "OPRM", icon: Workflow },
+      { to: "/mds", label: "MDS", icon: Microscope },
     ],
   },
   {

--- a/frontend/src/pages/mds/MdsArtifactsPage.test.tsx
+++ b/frontend/src/pages/mds/MdsArtifactsPage.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import MdsArtifactsPage from "./MdsArtifactsPage";
+
+vi.mock("../../api/mds/useMdsAdmin", () => ({
+  useMdsArtifacts: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    data: {
+      requestId: 12,
+      artifacts: [
+        {
+          artifactId: 301,
+          artifactType: "sourceDocument",
+          schemaVersion: "v1",
+          version: "v1",
+          status: "VALIDATED",
+          parentArtifactIds: [],
+          childArtifactIds: [401],
+          content: { sourceUrl: "https://example.org/paper" },
+        },
+        {
+          artifactId: 401,
+          artifactType: "mechanismSpec",
+          schemaVersion: "v1",
+          version: "v2",
+          status: "APPROVED",
+          parentArtifactIds: [301],
+          childArtifactIds: [],
+          content: { intervention: "micro-ciclo" },
+        },
+      ],
+      lineage: [
+        {
+          id: 9001,
+          parentArtifactId: 301,
+          childArtifactId: 401,
+          relationType: "DERIVED_FROM",
+        },
+      ],
+    },
+  })),
+}));
+
+describe("MdsArtifactsPage", () => {
+  it("renderiza envelope canônico e navegação de lineage", () => {
+    render(
+      <MemoryRouter initialEntries={["/mds/requests/12/artifacts"]}>
+        <Routes>
+          <Route path="/mds/requests/:requestId/artifacts" element={<MdsArtifactsPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("MDS · Artefatos da request #12")).toBeTruthy();
+    expect(screen.getByText(/Envelope canônico/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /#401 · APPROVED/i }));
+    expect(screen.getByText(/\"artifactType\": \"mechanismSpec\"/)).toBeTruthy();
+    expect(screen.getByText(/Abrir #301/)).toBeTruthy();
+    expect(screen.getByText(/DERIVED_FROM/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/mds/MdsArtifactsPage.tsx
+++ b/frontend/src/pages/mds/MdsArtifactsPage.tsx
@@ -1,0 +1,183 @@
+import { useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useMdsArtifacts } from "../../api/mds/useMdsAdmin";
+import type { MdsArtifactItem } from "../../api/mds/types";
+
+function toCanonicalEnvelope(artifact: MdsArtifactItem) {
+  return {
+    artifact: {
+      artifactType: artifact.artifactType,
+      artifactVersion: artifact.version,
+      status: artifact.status,
+      parentArtifactIds: artifact.parentArtifactIds,
+      content: artifact.content,
+    },
+  };
+}
+
+export default function MdsArtifactsPage() {
+  const { requestId } = useParams();
+  const id = requestId ? Number(requestId) : null;
+  const artifactsQuery = useMdsArtifacts(id);
+  const [selectedArtifactId, setSelectedArtifactId] = useState<number | null>(null);
+
+  const artifactsByType = useMemo(() => {
+    const list = artifactsQuery.data?.artifacts ?? [];
+    return list.reduce<Record<string, MdsArtifactItem[]>>((acc, artifact) => {
+      if (!acc[artifact.artifactType]) {
+        acc[artifact.artifactType] = [];
+      }
+      acc[artifact.artifactType].push(artifact);
+      return acc;
+    }, {});
+  }, [artifactsQuery.data?.artifacts]);
+
+  const selectedArtifact = useMemo(() => {
+    const list = artifactsQuery.data?.artifacts ?? [];
+    if (!list.length) {
+      return null;
+    }
+    if (selectedArtifactId == null) {
+      return list[0];
+    }
+    return list.find((artifact) => artifact.artifactId === selectedArtifactId) ?? list[0];
+  }, [artifactsQuery.data?.artifacts, selectedArtifactId]);
+
+  if (artifactsQuery.isLoading) {
+    return <div className="d-flex justify-content-center py-5"><span className="spinner-border text-primary" aria-hidden="true" /></div>;
+  }
+  if (artifactsQuery.isError || !artifactsQuery.data) {
+    return <div className="alert alert-danger mb-0">Não foi possível carregar os artefatos.</div>;
+  }
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-wrap justify-content-between align-items-start gap-2">
+        <div>
+          <PageTitle>MDS · Artefatos da request #{artifactsQuery.data.requestId}</PageTitle>
+          <p className="text-secondary mb-0">Auditoria por tipo, envelope canônico e lineage básico entre artefatos.</p>
+        </div>
+        <Link className="btn btn-outline-dark btn-sm" to={`/mds/reports/${artifactsQuery.data.requestId}`}>
+          Ver relatório
+        </Link>
+      </header>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <h2 className="h6 mb-0">Artefatos por tipo</h2>
+          {!artifactsQuery.data.artifacts.length ? (
+            <div className="alert alert-secondary mb-0">Nenhum artefato foi publicado para esta request.</div>
+          ) : (
+            <div className="d-grid gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}>
+              {Object.entries(artifactsByType).map(([artifactType, artifacts]) => (
+                <article className="card border" key={artifactType}>
+                  <div className="card-body d-flex flex-column gap-2">
+                    <div className="d-flex align-items-center justify-content-between">
+                      <h3 className="h6 mb-0">{artifactType}</h3>
+                      <span className="badge text-bg-light">{artifacts.length}</span>
+                    </div>
+                    {artifacts.map((artifact) => (
+                      <button
+                        key={artifact.artifactId}
+                        type="button"
+                        className={`btn btn-sm text-start ${selectedArtifact?.artifactId === artifact.artifactId ? "btn-primary" : "btn-outline-secondary"}`}
+                        onClick={() => setSelectedArtifactId(artifact.artifactId)}
+                      >
+                        #{artifact.artifactId} · {artifact.status}
+                      </button>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <h2 className="h6 mb-0">Envelope canônico</h2>
+          {!selectedArtifact ? (
+            <div className="alert alert-secondary mb-0">Selecione um artefato para visualizar o envelope.</div>
+          ) : (
+            <>
+              <div className="d-flex flex-wrap gap-2 text-secondary small">
+                <span><strong>ID:</strong> #{selectedArtifact.artifactId}</span>
+                <span><strong>Tipo:</strong> {selectedArtifact.artifactType}</span>
+                <span><strong>Schema:</strong> {selectedArtifact.schemaVersion}</span>
+                <span><strong>Versão:</strong> {selectedArtifact.version}</span>
+              </div>
+              <pre className="bg-body-tertiary border rounded-3 p-3 small mb-0" style={{ whiteSpace: "pre-wrap" }}>
+                {JSON.stringify(toCanonicalEnvelope(selectedArtifact), null, 2)}
+              </pre>
+            </>
+          )}
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <h2 className="h6 mb-0">Lineage básico (pais/filhos)</h2>
+          {!selectedArtifact ? (
+            <div className="alert alert-secondary mb-0">Sem artefato selecionado para navegação de lineage.</div>
+          ) : (
+            <div className="row g-3">
+              <div className="col-12 col-lg-6">
+                <h3 className="h6">Pais</h3>
+                {selectedArtifact.parentArtifactIds.length === 0 ? (
+                  <div className="alert alert-secondary mb-0">Sem pais vinculados.</div>
+                ) : (
+                  <div className="d-flex flex-wrap gap-2">
+                    {selectedArtifact.parentArtifactIds.map((parentId) => (
+                      <button
+                        key={parentId}
+                        type="button"
+                        className="btn btn-outline-secondary btn-sm"
+                        onClick={() => setSelectedArtifactId(parentId)}
+                      >
+                        Abrir #{parentId}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="col-12 col-lg-6">
+                <h3 className="h6">Filhos</h3>
+                {selectedArtifact.childArtifactIds.length === 0 ? (
+                  <div className="alert alert-secondary mb-0">Sem filhos vinculados.</div>
+                ) : (
+                  <div className="d-flex flex-wrap gap-2">
+                    {selectedArtifact.childArtifactIds.map((childId) => (
+                      <button
+                        key={childId}
+                        type="button"
+                        className="btn btn-outline-secondary btn-sm"
+                        onClick={() => setSelectedArtifactId(childId)}
+                      >
+                        Abrir #{childId}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="col-12">
+                {artifactsQuery.data.lineage.length === 0 ? (
+                  <div className="alert alert-secondary mb-0">Sem relações de lineage registradas.</div>
+                ) : (
+                  <ul className="list-group list-group-flush">
+                    {artifactsQuery.data.lineage.map((edge) => (
+                      <li className="list-group-item px-0" key={edge.id}>
+                        #{edge.parentArtifactId} → #{edge.childArtifactId} ({edge.relationType})
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/mds/MdsMainFlow.e2e.test.tsx
+++ b/frontend/src/pages/mds/MdsMainFlow.e2e.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import MdsWorkspacePage from "./MdsWorkspacePage";
+import MdsRequestDetailPage from "./MdsRequestDetailPage";
+import MdsArtifactsPage from "./MdsArtifactsPage";
+import MdsReportPage from "./MdsReportPage";
+
+vi.mock("../../api/mds/useMdsAdmin", () => ({
+  useMdsRequests: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    isFetching: false,
+    data: {
+      items: [
+        {
+          requestId: 12,
+          market: "fitness",
+          problem: "plateau",
+          desiredOutcome: "perder gordura",
+          status: "FAILED",
+          currentStage: "pipeline",
+          attempt: 2,
+          lastHeartbeatAt: null,
+          updatedAt: "2026-04-27T10:01:00Z",
+          retryEligible: true,
+          retryReason: "READY",
+        },
+      ],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    },
+  })),
+  useMdsHealth: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    data: { status: "ok", module: "mds-admin-api" },
+  })),
+  useRetryMdsRequest: vi.fn(() => ({
+    isPending: false,
+    mutateAsync: vi.fn().mockResolvedValue({ requestId: 12, previousStatus: "FAILED" }),
+  })),
+  useMdsRequestDetail: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    data: {
+      requestId: 12,
+      status: "FAILED",
+      market: "fitness",
+      problem: "plateau",
+      desiredOutcome: "perder gordura",
+      deliveryConstraint: "30 dias",
+      evidencePreference: "peer-reviewed",
+      correlationId: "tenant-a",
+      failureReason: "timeout",
+      createdAt: "2026-04-27T10:00:00Z",
+      startedAt: "2026-04-27T10:01:00Z",
+      finishedAt: "2026-04-27T10:02:00Z",
+      context: {},
+      timeline: [],
+      failureClassification: "RECOVERABLE",
+      artifactsUrl: "/api/mds/requests/12/artifacts",
+      reportUrl: "/api/mds/reports/12",
+      retryEligible: true,
+      retryReason: "READY",
+    },
+  })),
+  useMdsArtifacts: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    data: {
+      requestId: 12,
+      artifacts: [],
+      lineage: [],
+    },
+  })),
+  useMdsReport: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    data: {
+      requestId: 12,
+      artifactId: 501,
+      artifactType: "mechanismDiscoveryReport",
+      schemaVersion: "v1",
+      version: "v2",
+      status: "VALIDATED",
+      content: { summaryRationale: "ok" },
+    },
+  })),
+}));
+
+describe("MDS main flow e2e", () => {
+  it("navega lista -> detalhe -> artefatos -> relatório", () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/mds"]}>
+          <Routes>
+            <Route path="/mds" element={<MdsWorkspacePage />} />
+            <Route path="/mds/requests/:requestId" element={<MdsRequestDetailPage />} />
+            <Route path="/mds/requests/:requestId/artifacts" element={<MdsArtifactsPage />} />
+            <Route path="/mds/reports/:requestId" element={<MdsReportPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Detalhe" }));
+    expect(screen.getByText("MDS · Request #12")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("link", { name: "Ver artefatos" }));
+    expect(screen.getByText(/Artefatos da request #12/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("link", { name: "Ver relatório" }));
+    expect(screen.getByText(/Relatório da request #12/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/mds/MdsReportPage.test.tsx
+++ b/frontend/src/pages/mds/MdsReportPage.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import MdsReportPage from "./MdsReportPage";
+
+vi.mock("../../api/mds/useMdsAdmin", () => ({
+  useMdsReport: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    data: {
+      requestId: 12,
+      artifactId: 501,
+      artifactType: "mechanismDiscoveryReport",
+      schemaVersion: "v1",
+      version: "v2",
+      status: "VALIDATED",
+      content: {
+        recommendedMechanismCandidateKey: "mc-12",
+        selectedEvidenceIds: ["ev-1", "ev-2"],
+        confidenceLevel: "alta",
+        limitations: ["amostra reduzida"],
+        summaryRationale: "Mecanismo com melhor aderência causal.",
+      },
+    },
+  })),
+}));
+
+describe("MdsReportPage", () => {
+  it("renderiza resumo executivo e payload técnico", () => {
+    render(
+      <MemoryRouter initialEntries={["/mds/reports/12"]}>
+        <Routes>
+          <Route path="/mds/reports/:requestId" element={<MdsReportPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/Mecanismo recomendado:/)).toBeTruthy();
+    expect(screen.getByText("mc-12")).toBeTruthy();
+    expect(screen.getByText("ev-1")).toBeTruthy();
+    expect(screen.getByText(/Visão técnica/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/mds/MdsReportPage.tsx
+++ b/frontend/src/pages/mds/MdsReportPage.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useMdsReport } from "../../api/mds/useMdsAdmin";
+
+function asString(value: unknown, fallback = "-") {
+  return typeof value === "string" && value.trim().length > 0 ? value : fallback;
+}
+
+function asArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((item) => String(item));
+}
+
+export default function MdsReportPage() {
+  const { requestId } = useParams();
+  const id = requestId ? Number(requestId) : null;
+  const reportQuery = useMdsReport(id);
+
+  const reportView = useMemo(() => {
+    const content = reportQuery.data?.content ?? {};
+    return {
+      recommendedMechanism: asString(content.recommendedMechanismCandidateKey ?? content.recommendedMechanism),
+      selectedEvidence: asArray(content.selectedEvidenceIds ?? content.selectedEvidenceKeys),
+      confidenceLevel: asString(content.confidenceLevel),
+      limitations: asArray(content.limitations),
+      summaryRationale: asString(content.summaryRationale ?? content.rationale),
+    };
+  }, [reportQuery.data?.content]);
+
+  if (reportQuery.isLoading) {
+    return <div className="d-flex justify-content-center py-5"><span className="spinner-border text-primary" aria-hidden="true" /></div>;
+  }
+  if (reportQuery.isError || !reportQuery.data) {
+    return <div className="alert alert-danger mb-0">Não foi possível carregar o relatório MDS.</div>;
+  }
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header>
+        <PageTitle>MDS · Relatório da request #{reportQuery.data.requestId}</PageTitle>
+      </header>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <h2 className="h6 mb-0">Resumo executivo</h2>
+          <p className="mb-0"><strong>Mecanismo recomendado:</strong> {reportView.recommendedMechanism}</p>
+          <p className="mb-0"><strong>Nível de confiança:</strong> {reportView.confidenceLevel}</p>
+          <p className="mb-0"><strong>Justificativa resumida:</strong> {reportView.summaryRationale}</p>
+
+          <div>
+            <strong>Evidências selecionadas:</strong>
+            {reportView.selectedEvidence.length === 0 ? (
+              <p className="mb-0 text-secondary">Nenhuma evidência explicitada no relatório.</p>
+            ) : (
+              <ul className="mb-0 mt-1">
+                {reportView.selectedEvidence.map((evidence) => (
+                  <li key={evidence}>{evidence}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div>
+            <strong>Limitações:</strong>
+            {reportView.limitations.length === 0 ? (
+              <p className="mb-0 text-secondary">Sem limitações explícitas no payload.</p>
+            ) : (
+              <ul className="mb-0 mt-1">
+                {reportView.limitations.map((limitation) => (
+                  <li key={limitation}>{limitation}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-2">
+          <h2 className="h6 mb-0">Visão técnica (payload)</h2>
+          <p className="mb-0"><strong>Artefato:</strong> {reportQuery.data.artifactType}</p>
+          <p className="mb-0"><strong>Status:</strong> {reportQuery.data.status}</p>
+          <p className="mb-0"><strong>Versão:</strong> {reportQuery.data.version}</p>
+          <pre className="bg-body-tertiary border rounded-3 p-3 small mb-0" style={{ whiteSpace: "pre-wrap" }}>
+            {JSON.stringify(reportQuery.data.content, null, 2)}
+          </pre>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/mds/MdsRequestDetailPage.test.tsx
+++ b/frontend/src/pages/mds/MdsRequestDetailPage.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import MdsRequestDetailPage from "./MdsRequestDetailPage";
+
+vi.mock("../../api/mds/useMdsAdmin", () => ({
+  useMdsRequestDetail: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    data: {
+      requestId: 12,
+      status: "FAILED",
+      market: "fitness",
+      problem: "plateau",
+      desiredOutcome: "perder gordura",
+      deliveryConstraint: "30 dias",
+      evidencePreference: "peer-reviewed",
+      correlationId: "tenant-a",
+      failureReason: "timeout",
+      createdAt: "2026-04-27T10:00:00Z",
+      startedAt: "2026-04-27T10:01:00Z",
+      finishedAt: "2026-04-27T10:02:00Z",
+      context: {},
+      timeline: [],
+      failureClassification: "RECOVERABLE",
+      artifactsUrl: "/api/mds/requests/12/artifacts",
+      reportUrl: "/api/mds/reports/12",
+      retryEligible: true,
+      retryReason: "READY",
+    },
+  })),
+}));
+
+describe("MdsRequestDetailPage", () => {
+  it("renderiza classificação e timeline vazia", () => {
+    render(
+      <MemoryRouter initialEntries={["/mds/requests/12"]}>
+        <Routes>
+          <Route path="/mds/requests/:requestId" element={<MdsRequestDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("MDS · Request #12")).toBeTruthy();
+    expect(screen.getByText(/RECOVERABLE/)).toBeTruthy();
+    expect(screen.getByText("Sem eventos registrados.")).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/mds/MdsRequestDetailPage.tsx
+++ b/frontend/src/pages/mds/MdsRequestDetailPage.tsx
@@ -1,0 +1,59 @@
+import { Link, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useMdsRequestDetail } from "../../api/mds/useMdsAdmin";
+
+export default function MdsRequestDetailPage() {
+  const { requestId } = useParams();
+  const id = requestId ? Number(requestId) : null;
+  const detailQuery = useMdsRequestDetail(id);
+
+  if (detailQuery.isLoading) {
+    return <div className="d-flex justify-content-center py-5"><span className="spinner-border text-primary" aria-hidden="true" /></div>;
+  }
+
+  if (detailQuery.isError || !detailQuery.data) {
+    return <div className="alert alert-danger mb-0">Não foi possível carregar o detalhe da request.</div>;
+  }
+
+  const detail = detailQuery.data;
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header>
+        <PageTitle>MDS · Request #{detail.requestId}</PageTitle>
+        <p className="text-secondary mb-0">Diagnóstico da execução com timeline de estágios.</p>
+      </header>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-2">
+          <p className="mb-0"><strong>Status:</strong> {detail.status}</p>
+          <p className="mb-0"><strong>Mercado:</strong> {detail.market}</p>
+          <p className="mb-0"><strong>Dor:</strong> {detail.problem}</p>
+          <p className="mb-0"><strong>Resultado esperado:</strong> {detail.desiredOutcome}</p>
+          <p className="mb-0"><strong>Classificação da falha:</strong> {detail.failureClassification}</p>
+          <div className="d-flex gap-2 flex-wrap">
+            <Link className="btn btn-outline-secondary btn-sm" to={`/mds/requests/${detail.requestId}/artifacts`}>Ver artefatos</Link>
+            <Link className="btn btn-outline-dark btn-sm" to={`/mds/reports/${detail.requestId}`}>Ver relatório</Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <h2 className="h6 mb-0">Timeline</h2>
+          {detail.timeline.length === 0 ? <div className="alert alert-secondary mb-0">Sem eventos registrados.</div> : (
+            <ul className="list-group list-group-flush">
+              {detail.timeline.map((event) => (
+                <li className="list-group-item px-0" key={event.eventId}>
+                  <p className="mb-1"><strong>{event.stageName}</strong> · {event.eventType}</p>
+                  <p className="mb-1">{event.message}</p>
+                  <small className="text-secondary">{event.createdAt}</small>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/mds/MdsWorkspacePage.test.tsx
+++ b/frontend/src/pages/mds/MdsWorkspacePage.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import MdsWorkspacePage from "./MdsWorkspacePage";
+
+const invalidateQueries = vi.fn();
+const mutateAsync = vi.fn();
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>(
+    "@tanstack/react-query",
+  );
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries }),
+  };
+});
+
+vi.mock("../../api/mds/useMdsAdmin", () => ({
+  useMdsRequests: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    isFetching: false,
+    data: {
+      items: [
+        {
+          requestId: 12,
+          market: "fitness",
+          problem: "plateau",
+          desiredOutcome: "perder gordura",
+          status: "FAILED",
+          currentStage: "pipeline",
+          attempt: 2,
+          lastHeartbeatAt: null,
+          updatedAt: "2026-04-27T10:01:00Z",
+          retryEligible: true,
+          retryReason: "READY",
+        },
+      ],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    },
+  })),
+  useMdsHealth: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    data: { status: "ok", module: "mds-admin-api" },
+  })),
+  useRetryMdsRequest: vi.fn(() => ({
+    isPending: false,
+    mutateAsync,
+  })),
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <MdsWorkspacePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("MdsWorkspacePage", () => {
+  beforeEach(() => {
+    invalidateQueries.mockClear();
+    mutateAsync.mockResolvedValue({ requestId: 12, previousStatus: "FAILED" });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("dispara refresh com botão atualizar", () => {
+    renderPage();
+    const updateButtons = screen.getAllByRole("button", { name: /Atualizar/i });
+    fireEvent.click(updateButtons[0]);
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["mds", "requests"] });
+  });
+
+  it("executa retry e exibe feedback operacional", async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledWith(12));
+    expect(screen.getByText(/Retry aceito para request #12/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/mds/MdsWorkspacePage.tsx
+++ b/frontend/src/pages/mds/MdsWorkspacePage.tsx
@@ -1,0 +1,257 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { AlertTriangle, CheckCircle2, RefreshCw, RadioTower } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import PageTitle from "../../components/PageTitle";
+import { useMdsHealth, useMdsRequests, useRetryMdsRequest } from "../../api/mds/useMdsAdmin";
+import type { MdsRequestStatus } from "../../api/mds/types";
+
+const STATUS_BADGE: Record<MdsRequestStatus, string> = {
+  PENDING: "text-bg-secondary",
+  IN_PROGRESS: "text-bg-primary",
+  COMPLETED: "text-bg-success",
+  FAILED: "text-bg-danger",
+};
+
+type Feedback = {
+  type: "success" | "error";
+  message: string;
+} | null;
+
+export default function MdsWorkspacePage() {
+  const [status, setStatus] = useState<MdsRequestStatus | "">("");
+  const [tenantOrProduct, setTenantOrProduct] = useState("");
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
+
+  const queryClient = useQueryClient();
+  const requestsQuery = useMdsRequests(
+    {
+      status,
+      tenantOrProduct,
+      from: fromDate ? `${fromDate}T00:00:00Z` : undefined,
+      to: toDate ? `${toDate}T23:59:59Z` : undefined,
+      page: 0,
+      size: 20,
+    },
+    autoRefreshEnabled,
+  );
+  const healthQuery = useMdsHealth();
+  const retryMutation = useRetryMdsRequest();
+
+  const statusCounts = useMemo(() => {
+    const counts: Record<MdsRequestStatus, number> = {
+      PENDING: 0,
+      IN_PROGRESS: 0,
+      COMPLETED: 0,
+      FAILED: 0,
+    };
+    for (const item of requestsQuery.data?.items ?? []) {
+      counts[item.status] += 1;
+    }
+    return counts;
+  }, [requestsQuery.data?.items]);
+
+  async function handleRetry(requestId: number) {
+    try {
+      const result = await retryMutation.mutateAsync(requestId);
+      setFeedback({
+        type: "success",
+        message: `Retry aceito para request #${result.requestId}. Status anterior: ${result.previousStatus}.`,
+      });
+      await queryClient.invalidateQueries({ queryKey: ["mds", "requests"] });
+    } catch {
+      setFeedback({
+        type: "error",
+        message: `Não foi possível reenfileirar a request #${requestId}. Valide elegibilidade e tente novamente.`,
+      });
+    }
+  }
+
+  return (
+    <div className="d-flex flex-column gap-4" aria-live="polite">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>MDS · Requests</PageTitle>
+        <p className="text-secondary mb-0">Visão operacional da fila MDS com filtros e ações administrativas.</p>
+      </header>
+
+      <section className="card border-0 shadow-sm" aria-labelledby="mds-observability-title">
+        <div className="card-body d-flex flex-column gap-3">
+          <div className="d-flex align-items-center justify-content-between flex-wrap gap-2">
+            <h2 id="mds-observability-title" className="h6 mb-0 d-flex align-items-center gap-2">
+              <RadioTower size={16} /> Observabilidade da UI MDS
+            </h2>
+            <button
+              type="button"
+              className={`btn btn-sm ${autoRefreshEnabled ? "btn-outline-success" : "btn-outline-secondary"}`}
+              onClick={() => setAutoRefreshEnabled((value) => !value)}
+              aria-pressed={autoRefreshEnabled}
+            >
+              Auto-refresh: {autoRefreshEnabled ? "ligado" : "desligado"}
+            </button>
+          </div>
+
+          <div className="row g-2">
+            <div className="col-12 col-md-4">
+              <div className="border rounded-3 p-2 h-100">
+                <small className="text-secondary d-block">Saúde do backend MDS</small>
+                {healthQuery.isLoading ? <span className="badge text-bg-light">Verificando...</span> : null}
+                {healthQuery.isError ? <span className="badge text-bg-danger">Indisponível</span> : null}
+                {healthQuery.data ? <span className="badge text-bg-success">{healthQuery.data.status} · {healthQuery.data.module}</span> : null}
+              </div>
+            </div>
+            <div className="col-12 col-md-8">
+              <div className="border rounded-3 p-2 h-100 d-flex flex-wrap gap-2">
+                <span className="badge text-bg-secondary">PENDING: {statusCounts.PENDING}</span>
+                <span className="badge text-bg-primary">IN_PROGRESS: {statusCounts.IN_PROGRESS}</span>
+                <span className="badge text-bg-success">COMPLETED: {statusCounts.COMPLETED}</span>
+                <span className="badge text-bg-danger">FAILED: {statusCounts.FAILED}</span>
+                <span className="badge text-bg-light">Total: {requestsQuery.data?.totalElements ?? 0}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {feedback ? (
+        <div className={`alert mb-0 d-flex align-items-start gap-2 ${feedback.type === "success" ? "alert-success" : "alert-danger"}`} role="alert">
+          {feedback.type === "success" ? <CheckCircle2 size={18} className="mt-1" /> : <AlertTriangle size={18} className="mt-1" />}
+          <div className="d-flex flex-column gap-2">
+            <span>{feedback.message}</span>
+            <button type="button" className="btn btn-sm btn-outline-secondary align-self-start" onClick={() => setFeedback(null)}>
+              Fechar
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <section className="card border-0 shadow-sm" aria-labelledby="mds-filters-title">
+        <div className="card-body">
+          <h2 id="mds-filters-title" className="h6 mb-3">Filtros operacionais</h2>
+          <div className="row g-3 align-items-end">
+            <div className="col-12 col-md-4">
+              <label className="form-label" htmlFor="mds-status">Status</label>
+              <select
+                id="mds-status"
+                className="form-select"
+                value={status}
+                onChange={(event) => setStatus(event.target.value as MdsRequestStatus | "")}
+              >
+                <option value="">Todos</option>
+                <option value="PENDING">Pendente</option>
+                <option value="IN_PROGRESS">Em andamento</option>
+                <option value="COMPLETED">Concluído</option>
+                <option value="FAILED">Falhou</option>
+              </select>
+            </div>
+            <div className="col-12 col-md-4">
+              <label className="form-label" htmlFor="mds-period-from">Período inicial</label>
+              <input
+                id="mds-period-from"
+                type="date"
+                className="form-control"
+                value={fromDate}
+                onChange={(event) => setFromDate(event.target.value)}
+              />
+            </div>
+            <div className="col-12 col-md-4">
+              <label className="form-label" htmlFor="mds-period-to">Período final</label>
+              <input
+                id="mds-period-to"
+                type="date"
+                className="form-control"
+                value={toDate}
+                onChange={(event) => setToDate(event.target.value)}
+              />
+            </div>
+            <div className="col-12 col-md-4">
+              <label className="form-label" htmlFor="mds-tenant">Tenant/produto</label>
+              <input
+                id="mds-tenant"
+                className="form-control"
+                value={tenantOrProduct}
+                onChange={(event) => setTenantOrProduct(event.target.value)}
+                placeholder="Ex.: tenant-a"
+              />
+            </div>
+            <div className="col-12 col-md-4 d-grid">
+              <button
+                type="button"
+                className="btn btn-outline-primary"
+                onClick={() => queryClient.invalidateQueries({ queryKey: ["mds", "requests"] })}
+                disabled={requestsQuery.isFetching}
+                aria-label="Atualizar fila MDS"
+              >
+                {requestsQuery.isFetching ? (
+                  <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+                ) : (
+                  <RefreshCw size={16} aria-hidden="true" />
+                )}
+                <span className="ms-2">Atualizar</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {requestsQuery.isLoading ? (
+        <div className="d-flex justify-content-center py-5">
+          <span className="spinner-border text-primary" aria-hidden="true" />
+        </div>
+      ) : null}
+
+      {requestsQuery.isError ? (
+        <div className="alert alert-danger mb-0">Não foi possível carregar a fila MDS.</div>
+      ) : null}
+
+      {!requestsQuery.isLoading && !requestsQuery.isError ? (
+        <section className="d-grid gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))" }}>
+          {requestsQuery.data?.items.length ? requestsQuery.data.items.map((item) => (
+            <article className="card border-0 shadow-sm" key={item.requestId}>
+              <div className="card-body d-flex flex-column gap-3">
+                <div className="d-flex justify-content-between align-items-start gap-2">
+                  <div>
+                    <h2 className="h6 mb-1">Request #{item.requestId}</h2>
+                    <p className="mb-0 text-secondary">{item.market}</p>
+                  </div>
+                  <span className={`badge ${STATUS_BADGE[item.status]}`}>{item.status}</span>
+                </div>
+                <p className="mb-0"><strong>Dor:</strong> {item.problem}</p>
+                <p className="mb-0"><strong>Resultado:</strong> {item.desiredOutcome}</p>
+                <div className="d-flex flex-column gap-1 text-secondary small">
+                  <span>Estágio: {item.currentStage}</span>
+                  <span>Tentativa: {item.attempt}</span>
+                  <span>Heartbeat: {item.lastHeartbeatAt ?? "-"}</span>
+                </div>
+                {!item.retryEligible ? (
+                  <div className="alert alert-warning py-2 px-3 mb-0 small">
+                    Retry indisponível: {item.retryReason}
+                  </div>
+                ) : null}
+                <div className="d-flex gap-2 flex-wrap">
+                  <Link className="btn btn-outline-primary btn-sm" to={`/mds/requests/${item.requestId}`}>Detalhe</Link>
+                  <Link className="btn btn-outline-secondary btn-sm" to={`/mds/requests/${item.requestId}/artifacts`}>Artefatos</Link>
+                  <Link className="btn btn-outline-dark btn-sm" to={`/mds/reports/${item.requestId}`}>Relatório</Link>
+                  <button
+                    type="button"
+                    className="btn btn-outline-warning btn-sm"
+                    disabled={retryMutation.isPending || !item.retryEligible}
+                    onClick={() => handleRetry(item.requestId)}
+                  >
+                    {retryMutation.isPending ? (
+                      <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+                    ) : (
+                      "Retry"
+                    )}
+                  </button>
+                </div>
+              </div>
+            </article>
+          )) : <div className="alert alert-secondary mb-0">Nenhuma request MDS encontrada para os filtros.</div>}
+        </section>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide an authenticated administrative API surface for the MDS UI to inspect requests, artifacts/lineage, reports and to trigger operational retries. 
- Aggregate timeline, failure classification and lineage in the backend to simplify frontend rendering and reduce round-trips. 
- Ship initial frontend pages, hooks and types for the MDS admin workspace so the UI can drive operations and observability. 

### Description
- Added a new admin controller `MdsAdminController` exposing `GET /api/mds/requests`, `GET /api/mds/requests/{id}`, `GET /api/mds/requests/{id}/artifacts`, `GET /api/mds/reports/{requestId}`, `POST /api/mds/requests/{id}/retry` and `GET /api/mds/health` with header-based role checking via `MdsAdminAuthorizationService`.
- Implemented `MdsAdminService` which contains listing (with `Specification` filters), request detail assembly (timeline, parsed context, failure classification), artifact+lineage aggregation and retry logic that enqueues a processing event and updates request state.
- Introduced DTO records for all admin payloads (`MdsAdminRequestListResponse`, `MdsAdminRequestDetailResponse`, `MdsAdminArtifactsResponse`, `MdsAdminArtifactItemResponse`, `MdsAdminArtifactLineageEdgeResponse`, `MdsAdminProcessingEventResponse`, `MdsAdminRetryResponse`) and added repository query methods in `MdsProcessingEventRepository`, `MdsArtifactLineageEdgeRepository` and `MdsRequestRepository` to support the service logic.
- Frontend additions include React pages (`MdsWorkspacePage`, `MdsRequestDetailPage`, `MdsArtifactsPage`, `MdsReportPage`), navigation entry, typed API layer (`frontend/src/api/mds/types.ts`), hooks (`useMdsAdmin.ts`) and multiple unit/contract and e2e-like tests (`useMdsAdmin.test.tsx`, page tests, `MdsMainFlow.e2e.test.tsx`) to validate contracts and flows.
- UI behavior includes polling/caching defaults, admin header injection (`X-User-Role: ADMIN`) in client hooks, canonical envelope rendering for artifacts, lineage navigation and retry action with feedback.
- Documentation updated with the new administrative endpoints, sprint records and rollout notes in `docs/novos-modulos/MDS/*`.

### Testing
- Ran backend controller contract tests with `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest,MdsInternalControllerContractTest test` and the contract test suite for the admin controller passed. 
- Executed frontend unit and integration tests and builds with `cd frontend && npm run test` and `cd frontend && npm run build`, and the new MDS hook/page tests and E2E flow succeeded in the test environment. 
- CI-local validation included running `cd backend/ads-service && mvn -Dtest=MdsAdminControllerContractTest test` as part of iterative verification and those targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef95698ab483218033f025a9d320f1)