### PR TITLE
Sanitize landing wireframe proofPlan.sectionIds and update prompt guidance

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -273,7 +273,6 @@ public class ExperimentPipelineOpenAiClient {
             }
             log.info("OpenAI content for job {}: {}", job.id(), content);
             Map<String, Object> parsed = parseResponseContent(content, job);
-            sanitizeLandingWireframeProofPlan(parsed, job);
             enforceLandingHtmlSurfaceBinding(parsed, payload, job, content);
             validateExpectedResponseContract(parsed, content, job);
             enrichConsistencyChecks(parsed, job);
@@ -551,62 +550,6 @@ public class ExperimentPipelineOpenAiClient {
             throw new IllegalStateException(reason);
         }
         landingPayload.put(LANDING_HTML_MARKER, synchronizedHtml);
-    }
-
-    @SuppressWarnings("unchecked")
-    private void sanitizeLandingWireframeProofPlan(Map<String, Object> parsed, ExperimentPipelineJobDto job) {
-        if (!isLandingLayoutSection(job) || parsed == null) {
-            return;
-        }
-        Map<String, Object> wireframe = parsed.get("landingPageWireframe") instanceof Map<?, ?> nested
-                ? (Map<String, Object>) nested
-                : parsed;
-        if (!(wireframe.get("sectionOrder") instanceof List<?> sections) || sections.isEmpty()) {
-            return;
-        }
-        Set<String> existingSectionIds = new LinkedHashSet<>();
-        for (Object section : sections) {
-            if (section instanceof Map<?, ?> map) {
-                String sectionId = readString((Map<String, Object>) map, "sectionId");
-                if (StringUtils.hasText(sectionId)) {
-                    existingSectionIds.add(sectionId.trim());
-                }
-            }
-        }
-        if (existingSectionIds.isEmpty()) {
-            return;
-        }
-        if (!(wireframe.get("proofPlan") instanceof Map<?, ?> rawProofPlan)) {
-            return;
-        }
-        Map<String, Object> proofPlan = (Map<String, Object>) rawProofPlan;
-        if (!(proofPlan.get("proofSectionIds") instanceof List<?> rawProofSectionIds)) {
-            return;
-        }
-        List<String> sanitizedProofSectionIds = new ArrayList<>();
-        for (Object item : rawProofSectionIds) {
-            if (!(item instanceof String sectionId) || !StringUtils.hasText(sectionId)) {
-                continue;
-            }
-            String normalizedId = sectionId.trim();
-            if (existingSectionIds.contains(normalizedId) && !sanitizedProofSectionIds.contains(normalizedId)) {
-                sanitizedProofSectionIds.add(normalizedId);
-            }
-        }
-        if (sanitizedProofSectionIds.isEmpty()) {
-            String fallbackSectionId = existingSectionIds.stream()
-                    .filter(id -> id.toLowerCase(Locale.ROOT).contains("proof"))
-                    .findFirst()
-                    .orElse(existingSectionIds.iterator().next());
-            sanitizedProofSectionIds.add(fallbackSectionId);
-        }
-        if (!sanitizedProofSectionIds.equals(rawProofSectionIds)) {
-            log.warn("Wireframe proofPlan.proofSectionIds ajustado para seções existentes (jobId={}, before={}, after={})",
-                    job != null ? job.id() : null,
-                    rawProofSectionIds,
-                    sanitizedProofSectionIds);
-            proofPlan.put("proofSectionIds", sanitizedProofSectionIds);
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -273,6 +273,7 @@ public class ExperimentPipelineOpenAiClient {
             }
             log.info("OpenAI content for job {}: {}", job.id(), content);
             Map<String, Object> parsed = parseResponseContent(content, job);
+            sanitizeLandingWireframeProofPlan(parsed, job);
             enforceLandingHtmlSurfaceBinding(parsed, payload, job, content);
             validateExpectedResponseContract(parsed, content, job);
             enrichConsistencyChecks(parsed, job);
@@ -550,6 +551,62 @@ public class ExperimentPipelineOpenAiClient {
             throw new IllegalStateException(reason);
         }
         landingPayload.put(LANDING_HTML_MARKER, synchronizedHtml);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void sanitizeLandingWireframeProofPlan(Map<String, Object> parsed, ExperimentPipelineJobDto job) {
+        if (!isLandingLayoutSection(job) || parsed == null) {
+            return;
+        }
+        Map<String, Object> wireframe = parsed.get("landingPageWireframe") instanceof Map<?, ?> nested
+                ? (Map<String, Object>) nested
+                : parsed;
+        if (!(wireframe.get("sectionOrder") instanceof List<?> sections) || sections.isEmpty()) {
+            return;
+        }
+        Set<String> existingSectionIds = new LinkedHashSet<>();
+        for (Object section : sections) {
+            if (section instanceof Map<?, ?> map) {
+                String sectionId = readString((Map<String, Object>) map, "sectionId");
+                if (StringUtils.hasText(sectionId)) {
+                    existingSectionIds.add(sectionId.trim());
+                }
+            }
+        }
+        if (existingSectionIds.isEmpty()) {
+            return;
+        }
+        if (!(wireframe.get("proofPlan") instanceof Map<?, ?> rawProofPlan)) {
+            return;
+        }
+        Map<String, Object> proofPlan = (Map<String, Object>) rawProofPlan;
+        if (!(proofPlan.get("proofSectionIds") instanceof List<?> rawProofSectionIds)) {
+            return;
+        }
+        List<String> sanitizedProofSectionIds = new ArrayList<>();
+        for (Object item : rawProofSectionIds) {
+            if (!(item instanceof String sectionId) || !StringUtils.hasText(sectionId)) {
+                continue;
+            }
+            String normalizedId = sectionId.trim();
+            if (existingSectionIds.contains(normalizedId) && !sanitizedProofSectionIds.contains(normalizedId)) {
+                sanitizedProofSectionIds.add(normalizedId);
+            }
+        }
+        if (sanitizedProofSectionIds.isEmpty()) {
+            String fallbackSectionId = existingSectionIds.stream()
+                    .filter(id -> id.toLowerCase(Locale.ROOT).contains("proof"))
+                    .findFirst()
+                    .orElse(existingSectionIds.iterator().next());
+            sanitizedProofSectionIds.add(fallbackSectionId);
+        }
+        if (!sanitizedProofSectionIds.equals(rawProofSectionIds)) {
+            log.warn("Wireframe proofPlan.proofSectionIds ajustado para seções existentes (jobId={}, before={}, after={})",
+                    job != null ? job.id() : null,
+                    rawProofSectionIds,
+                    sanitizedProofSectionIds);
+            proofPlan.put("proofSectionIds", sanitizedProofSectionIds);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/ai-worker/src/main/resources/prompts/experiment/landing-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-wireframe.md
@@ -33,8 +33,10 @@ Regras fixas da etapa:
 18. Em `readingFlowSpec`, garantir `maxParagraphLinesMobile <= 4` e `bulletDensityPerSection >= 3` (especialmente em argumento/prova).
 19. Em `conversionPathSpec`, manter continuidade com CTA principal da copy (`primaryAction` + `ctaLabelCanonical`) e listar variações apenas em `ctaLabelVariantsAllowed`.
 20. Em `proofPlan`, incluir pelo menos 2 tipos distintos de prova e mapear `proofSectionIds` apenas para seções existentes em `sectionOrder`.
-21. Em `trustSignalsSpec`, para páginas com formulário: `brandIdentityRequired=true`, `privacyNoticeNearForm=true`, `privacyPolicyUrl` preenchida e `legalFooterItems` com empresa/contato/política.
-22. Em `accessibilitySpec`, respeitar mínimos canônicos: `minTextContrast` >= 4.5:1, `minTouchTargetPx` >= 44 e `formFieldMinHeightPx` >= 44.
+21. Para evitar erro 422, monte `proofPlan.proofSectionIds` somente após finalizar `sectionOrder`: copie os `sectionId` literalmente de `sectionOrder` (sem renomear, traduzir, resumir ou inventar IDs).
+22. Antes de responder, faça checklist final obrigatório: para cada item em `proofPlan.proofSectionIds`, confirme correspondência exata (match 1:1) com algum `sectionOrder[*].sectionId`; se não existir correspondência exata, corrija/remova o item.
+23. Em `trustSignalsSpec`, para páginas com formulário: `brandIdentityRequired=true`, `privacyNoticeNearForm=true`, `privacyPolicyUrl` preenchida e `legalFooterItems` com empresa/contato/política.
+24. Em `accessibilitySpec`, respeitar mínimos canônicos: `minTextContrast` >= 4.5:1, `minTouchTargetPx` >= 44 e `formFieldMinHeightPx` >= 44.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -1133,47 +1133,6 @@ class ExperimentPipelineOpenAiClientTest {
     }
 
     @Test
-    void sanitizesWireframeProofPlanSectionIdsBeforeCompletion() throws Exception {
-        String openAiText = MAPPER.writeValueAsString(Map.of(
-                "landingPageWireframe", Map.of(
-                        "pageGoal", "captura",
-                        "variantLayoutId", "form-first",
-                        "sectionOrder", List.of(
-                                Map.of("sectionId", "hero-message-match", "surfaceSpec",
-                                        Map.of("surfaceToken", "surface-hero", "style", "solid", "contrastMode", "high")),
-                                Map.of("sectionId", "proof-packshot-preview", "surfaceSpec",
-                                        Map.of("surfaceToken", "surface-proof", "style", "band", "contrastMode", "normal"))),
-                        "proofPlan", Map.of(
-                                "requiredProofTypes", List.of("Prévia visual", "Aplicação prática"),
-                                "proofSectionIds", List.of("proof-previa-pdf-minikit", "proof-packshot-preview"),
-                                "proofContinuityNotes", "ok"),
-                        "consistencyChecks", List.of()
-                )));
-        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
-                WebClient.builder().exchangeFunction(capturePayloadExchange(new AtomicReference<>(), openAiText)),
-                MAPPER,
-                "test-key",
-                "http://openai");
-
-        ExperimentPipelineJobCompletionPayload payload = client.generate(new ExperimentPipelineJobDto(
-                UUID.randomUUID(),
-                36L,
-                "landing-page-wireframe",
-                "gpt-5.2",
-                "prompt",
-                "{\"model\":\"gpt-5.2\",\"input\":[{\"role\":\"user\",\"content\":\"prompt\"}]}",
-                Instant.now()));
-
-        Map<String, Object> content = MAPPER.readValue(payload.responseContent(), new TypeReference<>() {});
-        @SuppressWarnings("unchecked")
-        Map<String, Object> wireframe = (Map<String, Object>) content.get("landingPageWireframe");
-        @SuppressWarnings("unchecked")
-        Map<String, Object> proofPlan = (Map<String, Object>) wireframe.get("proofPlan");
-        assertThat(proofPlan.get("proofSectionIds"))
-                .isEqualTo(List.of("proof-packshot-preview"));
-    }
-
-    @Test
     void synchronizesLandingHtmlSurfaceAttributesFromWireframeBeforeCompletion() throws Exception {
         String htmlText = """
                 {

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -200,6 +200,9 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("readingFlowSpec");
         assertThat(userPrompt).contains("conversionPathSpec");
         assertThat(userPrompt).contains("proofPlan");
+        assertThat(userPrompt).contains("Para evitar erro 422");
+        assertThat(userPrompt).contains("copie os `sectionId` literalmente de `sectionOrder`");
+        assertThat(userPrompt).contains("match 1:1");
         assertThat(userPrompt).contains("trustSignalsSpec");
         assertThat(userPrompt).contains("accessibilitySpec");
         assertThat(userPrompt).contains("maxParagraphLinesMobile <= 4");
@@ -1127,6 +1130,47 @@ class ExperimentPipelineOpenAiClientTest {
         Map<String, Object> html = (Map<String, Object>) htmlContent.get("landingPageHtml");
         assertThat(readCheckStatus(html, "SECTION_THEME_VARIATION")).isEqualTo("FAIL");
         assertThat(readCheckStatus(html, "PREVIEW_CONCRETENESS")).isEqualTo("WARN");
+    }
+
+    @Test
+    void sanitizesWireframeProofPlanSectionIdsBeforeCompletion() throws Exception {
+        String openAiText = MAPPER.writeValueAsString(Map.of(
+                "landingPageWireframe", Map.of(
+                        "pageGoal", "captura",
+                        "variantLayoutId", "form-first",
+                        "sectionOrder", List.of(
+                                Map.of("sectionId", "hero-message-match", "surfaceSpec",
+                                        Map.of("surfaceToken", "surface-hero", "style", "solid", "contrastMode", "high")),
+                                Map.of("sectionId", "proof-packshot-preview", "surfaceSpec",
+                                        Map.of("surfaceToken", "surface-proof", "style", "band", "contrastMode", "normal"))),
+                        "proofPlan", Map.of(
+                                "requiredProofTypes", List.of("Prévia visual", "Aplicação prática"),
+                                "proofSectionIds", List.of("proof-previa-pdf-minikit", "proof-packshot-preview"),
+                                "proofContinuityNotes", "ok"),
+                        "consistencyChecks", List.of()
+                )));
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(new AtomicReference<>(), openAiText)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        ExperimentPipelineJobCompletionPayload payload = client.generate(new ExperimentPipelineJobDto(
+                UUID.randomUUID(),
+                36L,
+                "landing-page-wireframe",
+                "gpt-5.2",
+                "prompt",
+                "{\"model\":\"gpt-5.2\",\"input\":[{\"role\":\"user\",\"content\":\"prompt\"}]}",
+                Instant.now()));
+
+        Map<String, Object> content = MAPPER.readValue(payload.responseContent(), new TypeReference<>() {});
+        @SuppressWarnings("unchecked")
+        Map<String, Object> wireframe = (Map<String, Object>) content.get("landingPageWireframe");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> proofPlan = (Map<String, Object>) wireframe.get("proofPlan");
+        assertThat(proofPlan.get("proofSectionIds"))
+                .isEqualTo(List.of("proof-packshot-preview"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Prevent backend 422 errors and contract mismatches when `proofPlan.proofSectionIds` contains IDs not present in `sectionOrder` for landing wireframes.
- Make the prompt explicit so model outputs assemble `proofSectionIds` only after `sectionOrder` is finalized and match section IDs exactly.

### Description
- Add `sanitizeLandingWireframeProofPlan` to `ExperimentPipelineOpenAiClient` to normalize and sanitize `proofPlan.proofSectionIds` by trimming, deduplicating, restricting to `sectionOrder` IDs, and falling back to a sensible section when no matches exist.
- Invoke the sanitizer after parsing the OpenAI response in the job `generate` flow so the final payload uses corrected `proofSectionIds` before downstream checks.
- Update `landing-wireframe.md` prompt to require building `proofPlan.proofSectionIds` only after `sectionOrder` is finalized and to perform a 1:1 match check to avoid mismatches and 422 errors.
- Add unit test `sanitizesWireframeProofPlanSectionIdsBeforeCompletion` and extend existing prompt-related assertions in `ExperimentPipelineOpenAiClientTest` to cover the new guidance text.

### Testing
- Ran unit tests in `ExperimentPipelineOpenAiClientTest`, including `sanitizesWireframeProofPlanSectionIdsBeforeCompletion`, `synchronizesLandingHtmlSurfaceAttributesFromWireframeBeforeCompletion`, and prompt-assembly assertions, and they passed locally.
- Verified the new sanitizer adjusts `proofPlan.proofSectionIds` from non-matching to only existing `sectionOrder` IDs in the test payload.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc0711808832190c8cf865a2e05ec)