### PR TITLE
Require 1:1 wireframe coverage for landing image planning (prompt + backend + tests)

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md
@@ -32,6 +32,12 @@ Regras fixas da etapa:
 17. Reagir ao tipo concreto de oferta atual sem inventar objetos não presentes nos artefatos.
 18. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
 19. Antes de finalizar, execute checklist de cobertura obrigatório: compare `landingPageWireframe.sectionOrder[*].sectionId` com `images[*].sectionId` e só responda quando todos estiverem presentes, sem faltas e sem excedentes.
+20. Fluxo obrigatório interno antes da resposta:
+    - extraia a lista literal `requiredSectionIds` de `landingPageWireframe.sectionOrder[*].sectionId`;
+    - monte `images[]` cobrindo 1:1 cada item de `requiredSectionIds`;
+    - valide internamente `missing = requiredSectionIds - images.sectionId` e `extras = images.sectionId - requiredSectionIds`;
+    - só finalize quando `missing=[]` e `extras=[]`.
+21. Se existir seção de objeção/oferta/faq no wireframe (ex.: `objection-*`, `offer-*`, `faq-*`), ela também é obrigatória em `images[]` e não pode ser omitida.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -244,6 +244,8 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("incluindo seções de formulário");
         assertThat(userPrompt).contains("é proibido inventar `sectionId` fora do wireframe");
         assertThat(userPrompt).contains("checklist de cobertura obrigatório");
+        assertThat(userPrompt).contains("extraia a lista literal `requiredSectionIds`");
+        assertThat(userPrompt).contains("só finalize quando `missing=[]` e `extras=[]`");
     }
 
     @Test

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1275,6 +1275,7 @@ public class ExperimentPipelineGenerationService {
         }
 
         if (section == ExperimentPipelineSection.LANDING_PAGE_IMAGE_PLANNING) {
+            List<String> wireframeSectionIds = loadWireframeSectionIds(experiment);
             sb.append("\nDiretriz específica para Planejamento de Imagens da Landing:\n");
             sb.append(COMMON_CAMPAIGN_ASSET_RULES).append("\n");
             sb.append("Contexto do nicho: ").append(niche).append("\n");
@@ -1287,6 +1288,11 @@ public class ExperimentPipelineGenerationService {
             appendIfPresent(sb, "Linha de match com landing", landingMatchLine);
             sb.append("\nObjetivo:\n");
             sb.append("Planejar todas as imagens da landing antes do HTML final, conectando ângulo da campanha, copy da landing e layout aprovado.\n\n");
+            if (!wireframeSectionIds.isEmpty()) {
+                sb.append("Checklist de cobertura obrigatório (wireframe.sectionOrder):\n");
+                sb.append("- sectionId obrigatórias: ").append(String.join(", ", wireframeSectionIds)).append("\n");
+                sb.append("- Antes de responder, confirme que images[].sectionId contém exatamente esta lista (sem faltas e sem excedentes).\n\n");
+            }
             sb.append("Regras:\n");
             sb.append("1. images[] deve ter no mínimo 4 itens com sectionId e sectionName existentes no wireframe.\n");
             sb.append("2. Cada item precisa trazer imagePrompt, objective, visualStyle, composition, focalPoint, supportingElements e mood.\n");
@@ -1396,6 +1402,36 @@ public class ExperimentPipelineGenerationService {
                     .append("\n");
         }
         sb.append("Para cada imagem acima, declare data-image-section-id, data-image-binding-key, data-image-role, data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion.\n");
+    }
+
+    private List<String> loadWireframeSectionIds(Experiment experiment) {
+        if (experiment == null || !StringUtils.hasText(experiment.getLandingPageWireframe())) {
+            return List.of();
+        }
+        try {
+            Map<String, Object> root = readObject(experiment.getLandingPageWireframe(), "Wireframe da landing inválido");
+            Map<String, Object> payload = unwrapSectionPayload(root, "landingPageWireframe");
+            if (!(payload.get("sectionOrder") instanceof List<?> rawSections)) {
+                return List.of();
+            }
+            Set<String> sectionIds = new LinkedHashSet<>();
+            for (Object rawSection : rawSections) {
+                if (!(rawSection instanceof Map<?, ?> rawSectionMap)) {
+                    continue;
+                }
+                String sectionId = asTrimmedString(rawSectionMap.get("sectionId"));
+                if (StringUtils.hasText(sectionId)) {
+                    sectionIds.add(sectionId);
+                }
+            }
+            return List.copyOf(sectionIds);
+        } catch (ResponseStatusException ex) {
+            log.warn("Falha ao carregar sectionId do wireframe para checklist do prompt: {}", ex.getReason());
+            return List.of();
+        } catch (RuntimeException ex) {
+            log.warn("Falha inesperada ao carregar sectionId do wireframe para checklist do prompt: {}", ex.getMessage());
+            return List.of();
+        }
     }
 
     private List<ImagePlanBindingContract> loadImagePlanBindings(Experiment experiment) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -488,6 +488,50 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void generateImagePlanningIncludesExplicitWireframeCoverageChecklistInPrompt() {
+        Experiment experiment = new Experiment();
+        experiment.setId(131L);
+        experiment.setName("Experimento 131");
+        experiment.setCampaignAngle("{\"campaignAngle\":\"angulo\"}");
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {"sectionId":"hero"},
+                      {"sectionId":"objection-anti-preco-pratica"},
+                      {"sectionId":"faq-objections"}
+                    ]
+                  }
+                }
+                """);
+
+        when(experimentRepository.findById(131L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.findByExperimentIdAndStatusInOrderByCreatedAtDesc(
+                131L,
+                Set.of(ExperimentPipelineGenerationJobStatus.PENDING, ExperimentPipelineGenerationJobStatus.PROCESSING)))
+                .thenReturn(List.of());
+        when(jobRepository.findLatestCompletedPerSectionByExperimentId(131L, null))
+                .thenReturn(List.of(
+                        completedJob(experiment, ExperimentPipelineSection.CAMPAIGN_ANGLE, "{\"campaignAngle\":true}"),
+                        completedJob(experiment, ExperimentPipelineSection.AD_COPY, "{\"adCopy\":true}"),
+                        completedJob(experiment, ExperimentPipelineSection.AD_IMAGE_BRIEFING, "{\"adImageBriefing\":true}"),
+                        completedJob(experiment, ExperimentPipelineSection.LANDING_PAGE_COPY, "{\"landingPageCopy\":true}"),
+                        completedJob(experiment, ExperimentPipelineSection.LANDING_PAGE_WIREFRAME, experiment.getLandingPageWireframe())));
+        when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(experimentMapper.toDto(experiment)).thenReturn(new ExperimentDto());
+
+        service.generate(131L, ExperimentPipelineSection.LANDING_PAGE_IMAGE_PLANNING, new ExperimentPipelineGenerationRequest());
+
+        verify(jobRepository).save(argThat(job -> {
+            String prompt = job.getPrompt();
+            return prompt != null
+                    && prompt.contains("Checklist de cobertura obrigatório")
+                    && prompt.contains("sectionId obrigatórias: hero, objection-anti-preco-pratica, faq-objections")
+                    && prompt.contains("images[].sectionId contém exatamente esta lista");
+        }));
+    }
+
+    @Test
     void generateRejectsNewStageWhenAnotherStageIsAlreadyActiveForExperiment() {
         Experiment experiment = new Experiment();
         experiment.setId(14L);

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,56 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0003 — Reforço de instruções no prompt do worker para cobertura 1:1 de `sectionId` em `images[]`
+
+- **Data/Hora (UTC):** 2026-04-27
+- **Responsável:** Assistente Codex
+- **Módulo:** ai-worker + backend
+- **Ambiente:** Repositório `marketing-hub`
+- **Execução/Teste:** Pipeline do experimento `15` (etapa "Planejamento de Imagens da Landing")
+
+#### 1) Erro observado
+- **Sintoma:** Etapa de planejamento de imagens permanece vulnerável a 422 por cobertura incompleta de `sectionId`.
+- **Endpoint/rota/fila:** conclusão de job da etapa `LANDING_PAGE_IMAGE_PLANNING`.
+- **Status code:** 422 `UNPROCESSABLE_ENTITY`.
+- **Mensagem de erro literal:** `Planejamento de imagens incompleto: faltam sectionId do wireframe em images[]. Faltando: [objection-anti-preco-pratica]`.
+- **Payload enviado (literal):** `images[]` sem item correspondente ao `sectionId` obrigatório listado acima.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** não executado neste registro (diagnóstico guiado por validação literal do backend + evidência de UI).
+- **Dados de banco consultados via MCP:** não executado neste registro.
+- **Trecho canônico consultado:** regra de cobertura total em `landingPageImagePlanning.images[].sectionId` vs `landingPageWireframe.sectionOrder[*].sectionId`.
+- **Validação/regra que rejeitou:** verificação de conjunto esperado vs planejado em `validateLandingImagePlanningArtifacts`.
+- **Causa raiz:** instrução anterior não estava suficientemente prescritiva no template do worker para forçar validação interna de `missing/extras` antes da resposta final.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** `images[]` sem `sectionId` `objection-anti-preco-pratica`.
+- **O que a especificação esperava (literal):** `images[]` contendo todos os `sectionId` de `landingPageWireframe.sectionOrder`, sem faltas e sem excedentes.
+- **Diferença objetiva:** omissão de seção obrigatória do wireframe no artefato final.
+- **Ação corretiva recomendada:** fortalecer o template `landing-image-planning` com fluxo obrigatório explícito (`requiredSectionIds`, cálculo de `missing/extras` e bloqueio de finalização até zerar diferenças).
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** prompt + robustez backend + teste.
+- **Arquivos alterados:**
+  - `ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md`
+  - `ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java`
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** template do worker ganhou fluxo interno obrigatório 1:1 por `sectionId`; teste unitário passou a validar presença das novas instruções; helper do backend para checklist no prompt passou a registrar log em caso de falha ao carregar wireframe, evitando fallback silencioso.
+
+#### 5) Reteste
+- **Procedimento de reteste:** execução de testes unitários focados em backend e ai-worker.
+- **Resultado:** backend aprovado; ai-worker bloqueado por dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` indisponível no ambiente.
+- **Evidências (logs/ids/prints):**
+  - `backend/ads-service`: suite `ExperimentPipelineGenerationServiceTest` aprovada.
+  - `ai-worker`: erro de resolução de dependência durante `mvn test`.
+- **Status final:** Parcial (ajuste aplicado; validação automatizada completa depende de credencial/repositório para dependência privada).
+
+#### 6) Próximo passo
+- **Ação seguinte:** reexecutar etapa de planejamento de imagens no experimento 15 e validar que `images[]` cobre integralmente `sectionOrder` (incluindo `objection-*`, `offer-*`, `faq-*` quando presentes).
+- **Dono da ação:** Time de operação do pipeline.
+- **Prazo:** imediato (próxima execução).
+
 ### INC-0002 — 422 no planejamento de imagens por cobertura incompleta de `sectionId`
 
 - **Data/Hora (UTC):** 2026-04-27


### PR DESCRIPTION
### Motivation
- Prevent incomplete `landingPageImagePlanning.images[]` responses that omit or invent `sectionId` values compared to the wireframe and cause 422 errors in the pipeline. 
- Make the worker prompt and backend generation logic explicitly enforce and communicate a 1:1 coverage checklist for `landingPageWireframe.sectionOrder[*].sectionId`.

### Description
- Strengthened the `landing-image-planning` prompt template by adding an internal mandatory flow that extracts `requiredSectionIds`, enforces `images[]` to cover each `requiredSectionIds` 1:1, validates `missing` and `extras`, and blocks finalization until `missing=[]` and `extras=[]` are satisfied (`ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md`).
- Added `loadWireframeSectionIds(Experiment)` helper to the backend to extract `sectionOrder[*].sectionId` from `experiment.getLandingPageWireframe()` and surface a checklist of required `sectionId` values into the generated prompt, with defensive parsing and logging on failure (`backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`).
- Updated unit tests to assert the presence of the new checklist/instructions in generated prompts: added/adjusted tests in `ExperimentPipelineOpenAiClientTest` and `ExperimentPipelineGenerationServiceTest` to validate the new prompt text (`ai-worker/src/test/...`, `backend/ads-service/src/test/...`).
- Documented the change and incident in `docs/registro-ajustes-pipeline-experimento.md` describing the root cause, fix, and retest notes.

### Testing
- Ran backend unit suite `ExperimentPipelineGenerationServiceTest` which includes a test `generateImagePlanningIncludesExplicitWireframeCoverageChecklistInPrompt`, and it passed. 
- Attempted to run `ai-worker` tests including `ExperimentPipelineOpenAiClientTest`, but the `mvn test` run was blocked by a missing private dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT`, causing the `ai-worker` test execution to fail to complete. 
- Overall status: backend automated tests passed; ai-worker test execution is pending resolution of the private dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd6b9cb448321ac2f30c20b67d3a4)