### PR TITLE
Align landing design preset prompt with canonical requirements

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
@@ -23,7 +23,12 @@ Regras:
    - `MOBILE_READABILITY`
 8. `layoutPreset` só pode ser: `hero-focus`, `form-focus`, `proof-grid`, `narrative-stack`, `faq-clean`, `cta-strong`.
 9. `motion.enabled` deve ser booleano (`true` ou `false`).
-10. Saída obrigatoriamente em JSON válido no envelope do artefato, sem markdown, sem bloco de código e sem texto adicional.
+10. `theme.typography.maxLineLength` deve ficar entre `55ch` e `75ch`.
+11. `theme.typography.lineHeightBody` deve ser `>= 1.5`.
+12. `theme.spacing.sectionGapMobile` deve ser `>= 48px`.
+13. `theme.palette.ctaPrimary` deve ter contraste AA com o fundo predominante da seção.
+14. O preset deve conter obrigatoriamente os tokens mínimos: `theme.palette`, `theme.typography`, `theme.spacing`, `theme.accessibility`, `componentPresets.cta`, `componentPresets.trust`.
+15. Saída obrigatoriamente em JSON válido no envelope do artefato, sem markdown, sem bloco de código e sem texto adicional.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -41,12 +46,35 @@ Responda em JSON válido no formato:
         "textMuted": "string",
         "brandPrimary": "string",
         "brandSecondary": "string",
+        "ctaPrimary": "string",
+        "ctaPrimaryHover": "string",
+        "success": "string",
+        "warning": "string",
         "border": "string"
       },
       "typography": {
         "fontFamily": "string",
         "baseSize": "string",
-        "headingScale": "string"
+        "headingScale": "string",
+        "lineHeightBody": "string",
+        "lineHeightHeading": "string",
+        "fontWeightRegular": "string",
+        "fontWeightSemibold": "string",
+        "fontWeightBold": "string",
+        "maxLineLength": "string"
+      },
+      "spacing": {
+        "scaleBase": "4|8",
+        "sectionGapDesktop": "string",
+        "sectionGapMobile": "string",
+        "containerWidthDesktop": "string",
+        "containerPaddingMobile": "string"
+      },
+      "accessibility": {
+        "textContrastBody": "string",
+        "textContrastSmall": "string",
+        "focusVisibleStyle": "string",
+        "touchTargetMinPx": "string"
       },
       "radius": {
         "card": "string",
@@ -72,15 +100,34 @@ Responda em JSON válido no formato:
       "hero": {
         "titleMaxWidth": "string",
         "summaryMaxWidth": "string",
-        "ctaVariant": "primary | ghost"
+        "ctaVariant": "primary | ghost",
+        "mediaPlacement": "left | right | center | background"
       },
       "form": {
         "fieldSpacing": "string",
         "labelWeight": "string",
-        "submitStyle": "pill | block"
+        "submitStyle": "pill | block",
+        "fieldHeight": "string",
+        "errorStyle": "inline | tooltip"
       },
       "faq": {
         "variant": "accordion | stacked-cards"
+      },
+      "proof": {
+        "cardVariant": "metric-first | testimonial-first | mixed",
+        "showIdentity": "boolean",
+        "highlightMetric": "boolean"
+      },
+      "trust": {
+        "showBrandLockupInHero": "boolean",
+        "showLegalFooter": "boolean",
+        "privacyMicrocopyNearForm": "boolean",
+        "authorityStripVariant": "logo-row | credential-cards | mixed"
+      },
+      "cta": {
+        "stickyMobile": "boolean",
+        "stickyOffsetBottom": "string",
+        "pulseOnScrollStop": "boolean"
       }
     },
     "motion": {


### PR DESCRIPTION
### Motivation
- The worker prompt for `landing-design-preset` was missing canonical `theme` tokens and quality rules, which caused backend validation failures such as `Preset de design incompleto: theme.spacing é obrigatório`.
- Aligning the prompt contract with the canonical artifact avoids models emitting incomplete payloads that get rejected by the backend validations.
- The change brings prompt expectations in sync with `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` to reduce 422s in the pipeline.

### Description
- Updated `ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md` to add explicit quality rules (`theme.typography.maxLineLength`, `theme.typography.lineHeightBody`, `theme.spacing.sectionGapMobile`, CTA contrast and mandatory minimal tokens) in the prompt instructions.
- Expanded the `OUTPUT_CONTRACT` JSON schema to include the full canonical `theme` structure (`palette`, `typography`, `spacing`, `accessibility`, `radius`, `shadow`) and added missing palette tokens like `ctaPrimary`/`ctaPrimaryHover` and status colors.
- Expanded `componentPresets` with canonical fields (`proof`, `trust`, `cta`) and additional `hero`/`form` fields to match backend expectations and avoid omitted required fields.
- Kept the requirement that the model returns a valid JSON envelope for the `landingPageDesignPreset` artifact and committed the updated prompt file.

### Testing
- Attempted `mvn -q -DskipTests compile` in `ai-worker`, which failed due to dependency resolution against a private GitHub Packages artifact returning `401 Unauthorized` for `com.marketinghub:ads-service:0.0.1-SNAPSHOT` (environment/credentials issue), so a local compile could not be validated.
- No additional automated unit tests were executed as part of this change due to the compile dependency failure.
- The prompt file was committed and a PR record was created for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efeaf3e368832180b08dc40367cb7e)