### PR TITLE
feat(pipeline): expose separate public URLs for LHM and 'Gerar com IA' landing variants

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -85,6 +85,7 @@ public class ExperimentPipelineGenerationService {
     private static final Pattern IMG_TAG_PATTERN = Pattern.compile("(?is)<img\\b[^>]*>");
     private static final String DEFAULT_MODEL = "gpt-5.2";
     private static final String LHM_MODEL = "LHM";
+    private static final String GERAR_COM_IA_MODEL = "GERAR_COM_IA";
     private static final String LHM_WORKER_ID = "lhm-inline";
     private static final Duration STALE_PENDING_TIMEOUT = Duration.ofMinutes(10);
     private static final Duration STALE_PROCESSING_TIMEOUT = Duration.ofMinutes(20);
@@ -392,7 +393,11 @@ public class ExperimentPipelineGenerationService {
                     HttpStatus.CONFLICT,
                     "HTML determinístico (LHM) está vazio. Gere novamente em 'LHM + IA' antes de publicar.");
         }
-        LeadPortalFlow iaFlow = upsertLandingVariantFlow(experiment, "ia", "WORKER_IA", experiment.getLandingPageHtml());
+        LeadPortalFlow iaFlow = upsertLandingVariantFlow(
+                experiment,
+                "gerar-com-ia",
+                GERAR_COM_IA_MODEL,
+                experiment.getLandingPageHtml());
         LeadPortalFlow lhmFlow = upsertLandingVariantFlow(experiment, "lhm", LHM_MODEL, lhmHtml);
 
         for (LeadPortalFlow flow : List.of(iaFlow, lhmFlow)) {
@@ -416,7 +421,7 @@ public class ExperimentPipelineGenerationService {
         experimentRepository.save(experiment);
 
         List<LandingPageVariantLinksDto> variantLinks = List.of(
-                toVariantLinks("IA", iaFlow),
+                toVariantLinks("Gerar com IA", iaFlow),
                 toVariantLinks("LHM", lhmFlow));
 
         String pixelId = iaFlow.getMarketNiche() != null ? iaFlow.getMarketNiche().getFacebookPixelId() : null;

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -370,7 +370,7 @@ class ExperimentPipelineGenerationServiceTest {
     void approveAndPublishLandingPageReturnsPublicationFeedback() {
         LeadPortalFlow iaFlow = new LeadPortalFlow();
         iaFlow.setId(902L);
-        iaFlow.setSlug("exp-22-landing-ia");
+        iaFlow.setSlug("exp-22-landing-gerar-com-ia");
         iaFlow.setApproved(false);
 
         LeadPortalFlow lhmFlow = new LeadPortalFlow();
@@ -396,13 +396,13 @@ class ExperimentPipelineGenerationServiceTest {
                 ExperimentPipelineSection.LANDING_PAGE_HTML,
                 ExperimentPipelineGenerationJobStatus.COMPLETED,
                 "LHM")).thenReturn(Optional.of(lhmJob));
-        when(leadPortalFlowRepository.findBySlug("exp-22-landing-ia")).thenReturn(Optional.of(iaFlow));
+        when(leadPortalFlowRepository.findBySlug("exp-22-landing-gerar-com-ia")).thenReturn(Optional.of(iaFlow));
         when(leadPortalFlowRepository.findBySlug("exp-22-landing-lhm")).thenReturn(Optional.of(lhmFlow));
         when(leadPortalFlowRepository.save(any(LeadPortalFlow.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(experimentRepository.save(any(Experiment.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(landingPageImageInjector.injectImages(22L, "<section>ia</section>")).thenReturn("<section>ia</section>");
         when(landingPageImageInjector.injectImages(22L, "<section>lhm</section>")).thenReturn("<section>lhm</section>");
-        when(leadPortalPublicUrlResolver.resolve(iaFlow)).thenReturn("https://lead.portal/flows/exp-22-landing-ia");
+        when(leadPortalPublicUrlResolver.resolve(iaFlow)).thenReturn("https://lead.portal/flows/exp-22-landing-gerar-com-ia");
         when(leadPortalPublicUrlResolver.resolve(lhmFlow)).thenReturn("https://lead.portal/flows/exp-22-landing-lhm");
 
         LandingPagePublicationResultDto result = service.approveAndPublishLandingPage(22L);
@@ -412,10 +412,10 @@ class ExperimentPipelineGenerationServiceTest {
         assertTrue(result.published());
         assertTrue(result.pixelAppliedAutomatically());
         assertEquals("pixel-abc", result.facebookPixelId());
-        assertEquals("https://lead.portal/flows/exp-22-landing-ia", result.publicUrl());
+        assertEquals("https://lead.portal/flows/exp-22-landing-gerar-com-ia", result.publicUrl());
         assertEquals(2, result.variantLinks().size());
-        assertEquals("IA", result.variantLinks().get(0).variant());
-        assertEquals("https://lead.portal/api/flows/exp-22-landing-ia/page", result.variantLinks().get(0).standaloneUrl());
+        assertEquals("Gerar com IA", result.variantLinks().get(0).variant());
+        assertEquals("https://lead.portal/api/flows/exp-22-landing-gerar-com-ia/page", result.variantLinks().get(0).standaloneUrl());
         assertEquals("LHM", result.variantLinks().get(1).variant());
         assertEquals("https://lead.portal/api/flows/exp-22-landing-lhm/page", result.variantLinks().get(1).standaloneUrl());
         verify(leadPortalFlowPublisher, times(2)).publish(any(LeadPortalFlow.class));

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -73,8 +73,8 @@ function normalizeVariantLabel(variant: string): string {
   if (upper === "LHM") {
     return "LHM (determinística)";
   }
-  if (upper === "IA" || upper === "WORKER_IA") {
-    return "IA";
+  if (upper === "IA" || upper === "WORKER_IA" || upper === "GERAR COM IA" || upper === "GERAR_COM_IA") {
+    return "Gerar com IA";
   }
   return variant;
 }


### PR DESCRIPTION
### Motivation
- The experiment pipeline must publish two distinct public landing variants at the end: one deterministic (LHM) and one produced by the "Gerar com IA" flow, each with its own URL and label.

### Description
- Added a dedicated model constant `GERAR_COM_IA` and changed the IA variant slug to `gerar-com-ia` so the IA-produced landing is stored and published separately from the `lhm` variant.
- Updated `approveAndPublishLandingPage` to create/upsert two LeadPortal flows (variants) and return both variant links, labeling the IA variant as `Gerar com IA` and keeping the LHM variant as `LHM`.
- Adjusted the backend unit test `ExperimentPipelineGenerationServiceTest.approveAndPublishLandingPageReturnsPublicationFeedback` to expect the new slug/URLs and label for the IA variant.
- Normalized frontend label handling in `LandingTab.tsx` so variants coming as `GERAR_COM_IA` (or variants of that string) are displayed as `Gerar com IA` and `LHM` remains `LHM (determinística)`.

### Testing
- Ran `../mvnw -Dtest=ExperimentPipelineGenerationServiceTest test` in `backend/ads-service`, which executed the test class `ExperimentPipelineGenerationServiceTest` and passed: 39 tests, 0 failures (BUILD SUCCESS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00bab7d748321ba31fb0fd298af0c)