### PR TITLE
Adjust landingPageDesignPreset JSON schema; add unit test and incident log

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -3041,7 +3041,7 @@ public class ExperimentPipelineGenerationService {
     private Map<String, Object> landingPageDesignPresetFieldSchema() {
         Map<String, Object> paletteSchema = Map.of(
                 "type", "object",
-                "additionalProperties", false,
+                "additionalProperties", true,
                 "properties", Map.of(
                         "background", stringSchema(),
                         "surface", stringSchema(),
@@ -3049,8 +3049,27 @@ public class ExperimentPipelineGenerationService {
                         "textMuted", stringSchema(),
                         "brandPrimary", stringSchema(),
                         "brandSecondary", stringSchema(),
-                        "border", stringSchema()),
-                "required", List.of("background", "surface", "textPrimary", "textMuted", "brandPrimary", "brandSecondary", "border"));
+                        "ctaPrimary", stringSchema()),
+                "required", List.of("background", "surface", "textPrimary", "textMuted", "brandPrimary", "brandSecondary", "ctaPrimary"));
+        Map<String, Object> typographySchema = Map.of(
+                "type", "object",
+                "additionalProperties", true,
+                "properties", Map.of(
+                        "lineHeightBody", stringSchema(),
+                        "maxLineLength", stringSchema()),
+                "required", List.of("lineHeightBody", "maxLineLength"));
+        Map<String, Object> spacingSchema = Map.of(
+                "type", "object",
+                "additionalProperties", true,
+                "properties", Map.of(
+                        "sectionGapMobile", stringSchema()),
+                "required", List.of("sectionGapMobile"));
+        Map<String, Object> accessibilitySchema = Map.of(
+                "type", "object",
+                "additionalProperties", true,
+                "properties", Map.of(
+                        "textContrastBody", stringSchema()),
+                "required", List.of("textContrastBody"));
         Map<String, Object> sectionPresetSchema = Map.of(
                 "type", "object",
                 "additionalProperties", false,
@@ -3072,12 +3091,36 @@ public class ExperimentPipelineGenerationService {
                                 "additionalProperties", false,
                                 "properties", Map.of(
                                         "palette", paletteSchema,
-                                        "typography", Map.of("type", "object", "additionalProperties", true),
+                                        "typography", typographySchema,
+                                        "spacing", spacingSchema,
+                                        "accessibility", accessibilitySchema,
                                         "radius", Map.of("type", "object", "additionalProperties", true),
                                         "shadow", Map.of("type", "object", "additionalProperties", true)),
-                                "required", List.of("palette")),
+                                "required", List.of("palette", "typography", "spacing", "accessibility")),
                         "sectionPresets", Map.of("type", "array", "minItems", 1, "items", sectionPresetSchema),
-                        "componentPresets", Map.of("type", "object", "additionalProperties", true),
+                        "componentPresets", Map.of(
+                                "type", "object",
+                                "additionalProperties", true,
+                                "properties", Map.of(
+                                        "proof", Map.of(
+                                                "type", "object",
+                                                "additionalProperties", true,
+                                                "properties", Map.of(
+                                                        "showIdentity", Map.of("type", "boolean")),
+                                                "required", List.of("showIdentity")),
+                                        "trust", Map.of(
+                                                "type", "object",
+                                                "additionalProperties", true,
+                                                "properties", Map.of(
+                                                        "showLegalFooter", Map.of("type", "boolean")),
+                                                "required", List.of("showLegalFooter")),
+                                        "cta", Map.of(
+                                                "type", "object",
+                                                "additionalProperties", true,
+                                                "properties", Map.of(
+                                                        "stickyMobile", Map.of("type", "boolean")),
+                                                "required", List.of("stickyMobile"))),
+                                "required", List.of("proof", "trust", "cta")),
                         "motion", Map.of(
                                 "type", "object",
                                 "additionalProperties", false,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -532,6 +532,49 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void generateLandingDesignPresetIncludesMinimumCanonicalTokensInJsonSchema() {
+        Experiment experiment = new Experiment();
+        experiment.setId(132L);
+        experiment.setName("Experimento 132");
+        experiment.setCampaignAngle("{\"campaignAngle\":true}");
+        experiment.setAdCopy("{\"adCopy\":true}");
+        experiment.setAdImageBriefing("{\"adImageBriefing\":true}");
+        experiment.setLandingPageCopy("{\"landingPageCopy\":true}");
+        experiment.setLandingPageWireframe("{\"landingPageWireframe\":{\"sectionOrder\":[{\"sectionId\":\"hero\"}]}}");
+        experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":{\"images\":[{\"sectionId\":\"hero\",\"imagePrompt\":\"x\"}]}}");
+
+        when(experimentRepository.findById(132L)).thenReturn(Optional.of(experiment));
+        when(frameworkImageGenerationService.allPlanningImagesCompleted(132L)).thenReturn(true);
+        when(jobRepository.findByExperimentIdAndStatusInOrderByCreatedAtDesc(
+                132L,
+                Set.of(ExperimentPipelineGenerationJobStatus.PENDING, ExperimentPipelineGenerationJobStatus.PROCESSING)))
+                .thenReturn(List.of());
+        when(jobRepository.findLatestCompletedPerSectionByExperimentId(132L, null))
+                .thenReturn(List.of(
+                        completedJob(experiment, ExperimentPipelineSection.CAMPAIGN_ANGLE, experiment.getCampaignAngle()),
+                        completedJob(experiment, ExperimentPipelineSection.AD_COPY, experiment.getAdCopy()),
+                        completedJob(experiment, ExperimentPipelineSection.AD_IMAGE_BRIEFING, experiment.getAdImageBriefing()),
+                        completedJob(experiment, ExperimentPipelineSection.LANDING_PAGE_COPY, experiment.getLandingPageCopy()),
+                        completedJob(experiment, ExperimentPipelineSection.LANDING_PAGE_WIREFRAME, experiment.getLandingPageWireframe()),
+                        completedJob(experiment, ExperimentPipelineSection.LANDING_PAGE_IMAGE_PLANNING, experiment.getLandingPageImagePlanning())));
+        when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(experimentMapper.toDto(experiment)).thenReturn(new ExperimentDto());
+
+        service.generate(132L, ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET, new ExperimentPipelineGenerationRequest());
+
+        verify(jobRepository).save(argThat(job -> {
+            String requestBodyJson = job.getRequestBodyJson();
+            return requestBodyJson != null
+                    && requestBodyJson.contains("\"sectionGapMobile\"")
+                    && requestBodyJson.contains("\"textContrastBody\"")
+                    && requestBodyJson.contains("\"showIdentity\"")
+                    && requestBodyJson.contains("\"showLegalFooter\"")
+                    && requestBodyJson.contains("\"stickyMobile\"")
+                    && requestBodyJson.contains("\"ctaPrimary\"");
+        }));
+    }
+
+    @Test
     void generateRejectsNewStageWhenAnotherStageIsAlreadyActiveForExperiment() {
         Experiment experiment = new Experiment();
         experiment.setId(14L);

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,53 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0004 — Ajuste de granularidade do schema de `landingPageDesignPreset` após revisão
+
+- **Data/Hora (UTC):** 2026-04-28
+- **Responsável:** Assistente Codex
+- **Módulo:** backend
+- **Ambiente:** Repositório `marketing-hub`
+- **Execução/Teste:** Revisão do PR `Fix landing design preset schema to enforce canonical required tokens`
+
+#### 1) Erro observado
+- **Sintoma:** Ajuste anterior tornou o schema da etapa `LANDING_PAGE_DESIGN_PRESET` rígido em excesso para campos não bloqueantes da validação canônica de conclusão.
+- **Endpoint/rota/fila:** geração de payload `response_format` para jobs `LANDING_PAGE_DESIGN_PRESET`.
+- **Status code:** n/a (ajuste preventivo de contrato antes de execução).
+- **Mensagem de erro literal:** n/a.
+- **Payload enviado (literal):** n/a.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** referência do incidente anterior com 422 (`theme.spacing é obrigatório`) já confirmada.
+- **Dados de banco consultados via MCP:** referência do incidente anterior para experimentId `15`.
+- **Trecho canônico consultado:** regras de tokens mínimos do `landingPageDesignPreset` (tema mínimo + `componentPresets.cta`/`trust`) e validações de backend em `completeJob`.
+- **Validação/regra que rejeitou:** previamente, `theme.spacing` ausente; nesta revisão, foco em evitar sobre-restrição desnecessária.
+- **Causa raiz:** schema anterior passou a exigir muitos subcampos detalhados além do mínimo bloqueante.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** no incidente original, preset sem `theme.spacing`.
+- **O que a especificação esperava (literal):** presença dos tokens mínimos canônicos para prosseguir (`theme.palette`, `theme.typography`, `theme.spacing`, `theme.accessibility`, `componentPresets.cta`, `componentPresets.trust`) e `proof.showIdentity=true` para validação operacional.
+- **Diferença objetiva:** ausência de token mínimo (incidente original) e excesso de rigidez do schema no ajuste anterior.
+- **Ação corretiva recomendada:** manter exigência dos mínimos canônicos/bloqueantes e relaxar campos não críticos para reduzir rejeições desnecessárias.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** contrato + teste.
+- **Arquivos alterados:**
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`
+  - `backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** schema de `landingPageDesignPreset` foi recalibrado para exigir o núcleo mínimo bloqueante (tema mínimo + `componentPresets` essenciais, incluindo `proof.showIdentity`) com flexibilidade em campos complementares; teste unitário atualizado para validar os tokens mínimos.
+
+#### 5) Reteste
+- **Procedimento de reteste:** execução da suíte `ExperimentPipelineGenerationServiceTest`.
+- **Resultado:** aprovado.
+- **Evidências (logs/ids/prints):** `../mvnw -Dtest=ExperimentPipelineGenerationServiceTest test` com `Tests run: 40, Failures: 0, Errors: 0`.
+- **Status final:** Resolvido.
+
+#### 6) Próximo passo
+- **Ação seguinte:** monitorar novas execuções de `LANDING_PAGE_DESIGN_PRESET` no experimento 15 para confirmar redução de 422 por contrato.
+- **Dono da ação:** Time de operação do pipeline.
+- **Prazo:** próxima execução do pipeline.
+
 ### INC-0003 — Reforço de instruções no prompt do worker para cobertura 1:1 de `sectionId` em `images[]`
 
 - **Data/Hora (UTC):** 2026-04-27


### PR DESCRIPTION
### Motivation
- Prevent over-strict validation while enforcing the canonical minimal tokens required for `LANDING_PAGE_DESIGN_PRESET` payloads to avoid unnecessary 422 rejections.
- Ensure the pipeline requires the minimal theme and component tokens that downstream validation and runtime expect.

### Description
- Reworked `landingPageDesignPresetFieldSchema` to relax non-critical properties (`additionalProperties: true` for palette and new sub-schemas) and to add explicit minimal sub-schemas for `typography`, `spacing`, and `accessibility` with required canonical tokens.
- Replaced `border` with `ctaPrimary` in the palette and made `theme` require `palette`, `typography`, `spacing`, and `accessibility` as the minimal set.
- Expanded `componentPresets` to declare required `proof`, `trust`, and `cta` objects and required boolean tokens (`proof.showIdentity`, `trust.showLegalFooter`, `cta.stickyMobile`).
- Added a unit test `generateLandingDesignPresetIncludesMinimumCanonicalTokensInJsonSchema` to assert the generated job request includes the canonical tokens (`sectionGapMobile`, `textContrastBody`, `showIdentity`, `showLegalFooter`, `stickyMobile`, `ctaPrimary`).
- Added an incident log entry `INC-0004` in `docs/registro-ajustes-pipeline-experimento.md` documenting the change and rationale.

### Testing
- Ran the `ExperimentPipelineGenerationServiceTest` suite via `../mvnw -Dtest=ExperimentPipelineGenerationServiceTest test` and the tests passed with `Tests run: 40, Failures: 0, Errors: 0`.
- The new test `generateLandingDesignPresetIncludesMinimumCanonicalTokensInJsonSchema` passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00fcba8648321aecc2fe1d2e415e6)