### PR TITLE
Show recent Worker IA landing HTML jobs alongside LHM and add diagnostic report for experiment 15

### DIFF
--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -1452,6 +1452,18 @@ export default function ExperimentContentGenerationTab({
     [jobsQuery.data],
   );
 
+  const workerIaHistory = useMemo(
+    () =>
+      (jobsQuery.data ?? [])
+        .filter(
+          (job) =>
+            normalizeJobSection(job.section) === "landing-html" &&
+            job.model !== "LHM",
+        )
+        .slice(0, 3),
+    [jobsQuery.data],
+  );
+
   const invalidationBySection = useMemo(() => {
     const bySection: Partial<
       Record<ContentGenerationSectionKey, SectionInvalidationState>
@@ -2683,64 +2695,103 @@ export default function ExperimentContentGenerationTab({
               );
             })}
           </div>
-          {lhmHistory.length > 0 ? (
-            <div className="border rounded-3 p-3 mt-3 bg-info-subtle border-info-subtle">
-              <div className="d-flex flex-wrap align-items-center justify-content-between gap-2">
-                <div>
-                  <h6 className="mb-1">Solicitações recentes do LHM (HTML da Landing)</h6>
-                  <p className="small text-body-secondary mb-0">
-                    Este bloco separa as execuções inline do LHM das execuções do
-                    Worker IA para evitar confusão de horário e origem.
-                  </p>
-                </div>
-                <span className="badge text-bg-info">LHM inline</span>
-              </div>
-              <div className="d-flex flex-column gap-2 mt-3">
-                {lhmHistory.map((job) => {
-                  const parsedError = parseBackendError(job.errorMessage);
-                  const statusBadge =
-                    job.status === "COMPLETED"
-                      ? "success"
-                      : job.status === "FAILED"
-                        ? "danger"
-                        : "warning";
-                  const statusLabel =
-                    job.status === "COMPLETED"
-                      ? "Concluída"
-                      : job.status === "FAILED"
-                        ? "Com erro"
-                        : "Em processamento";
-                  return (
-                    <div key={`lhm-history-${job.id}`} className="bg-body border rounded-3 p-2">
-                      <div className="d-flex flex-wrap align-items-center gap-2">
-                        <strong>Tentativa #{job.id.slice(0, 8)}</strong>
-                        <span className={`badge text-bg-${statusBadge}`}>{statusLabel}</span>
-                      </div>
-                      <div className="small mt-1 d-flex flex-column gap-1">
-                        <span>
-                          Solicitação registrada:{" "}
-                          <strong>{formatDateTimeWithTimezone(job.createdAt)}</strong>
-                        </span>
-                        <span>
-                          Início: <strong>{formatDateTimeWithTimezone(job.startedAt)}</strong> ·
-                          Fim: <strong>{formatDateTimeWithTimezone(job.finishedAt)}</strong>
-                        </span>
-                        {parsedError?.timestamp ? (
-                          <span>
-                            Erro retornado pelo backend em{" "}
-                            <strong>{formatDateTimeWithTimezone(parsedError.timestamp)}</strong>
-                          </span>
-                        ) : null}
-                        {job.errorMessage ? (
-                          <span className="text-danger">
-                            Motivo: {parsedError?.message ?? job.errorMessage}
-                          </span>
-                        ) : null}
-                      </div>
+          {lhmHistory.length > 0 || workerIaHistory.length > 0 ? (
+            <div className="mt-3 d-flex flex-column gap-3">
+              {[
+                {
+                  key: "lhm",
+                  title: "Solicitações recentes do LHM (HTML da Landing)",
+                  description:
+                    "Execuções inline do LHM para geração de HTML da landing.",
+                  badgeLabel: "LHM inline",
+                  badgeClass: "info",
+                  containerClass: "bg-info-subtle border-info-subtle",
+                  jobs: lhmHistory,
+                },
+                {
+                  key: "worker-ia",
+                  title: "Solicitações recentes do Worker IA (HTML da Landing)",
+                  description:
+                    "Execuções do Worker IA para geração de HTML da landing.",
+                  badgeLabel: "Worker IA",
+                  badgeClass: "primary",
+                  containerClass: "bg-primary-subtle border-primary-subtle",
+                  jobs: workerIaHistory,
+                },
+              ].map((historyGroup) => (
+                <div
+                  key={historyGroup.key}
+                  className={`border rounded-3 p-3 ${historyGroup.containerClass}`}
+                >
+                  <div className="d-flex flex-wrap align-items-center justify-content-between gap-2">
+                    <div>
+                      <h6 className="mb-1">{historyGroup.title}</h6>
+                      <p className="small text-body-secondary mb-0">
+                        {historyGroup.description}
+                      </p>
                     </div>
-                  );
-                })}
-              </div>
+                    <span className={`badge text-bg-${historyGroup.badgeClass}`}>
+                      {historyGroup.badgeLabel}
+                    </span>
+                  </div>
+                  {historyGroup.jobs.length > 0 ? (
+                    <div className="d-flex flex-column gap-2 mt-3">
+                      {historyGroup.jobs.map((job) => {
+                        const parsedError = parseBackendError(job.errorMessage);
+                        const statusBadge =
+                          job.status === "COMPLETED"
+                            ? "success"
+                            : job.status === "FAILED"
+                              ? "danger"
+                              : "warning";
+                        const statusLabel =
+                          job.status === "COMPLETED"
+                            ? "Concluída"
+                            : job.status === "FAILED"
+                              ? "Com erro"
+                              : "Em processamento";
+                        return (
+                          <div
+                            key={`${historyGroup.key}-history-${job.id}`}
+                            className="bg-body border rounded-3 p-2"
+                          >
+                            <div className="d-flex flex-wrap align-items-center gap-2">
+                              <strong>Tentativa #{job.id.slice(0, 8)}</strong>
+                              <span className={`badge text-bg-${statusBadge}`}>{statusLabel}</span>
+                            </div>
+                            <div className="small mt-1 d-flex flex-column gap-1">
+                              <span>
+                                Solicitação registrada:{" "}
+                                <strong>{formatDateTimeWithTimezone(job.createdAt)}</strong>
+                              </span>
+                              <span>
+                                Início: <strong>{formatDateTimeWithTimezone(job.startedAt)}</strong>
+                                {" · "}
+                                Fim: <strong>{formatDateTimeWithTimezone(job.finishedAt)}</strong>
+                              </span>
+                              {parsedError?.timestamp ? (
+                                <span>
+                                  Erro retornado pelo backend em{" "}
+                                  <strong>{formatDateTimeWithTimezone(parsedError.timestamp)}</strong>
+                                </span>
+                              ) : null}
+                              {job.errorMessage ? (
+                                <span className="text-danger">
+                                  Motivo: {parsedError?.message ?? job.errorMessage}
+                                </span>
+                              ) : null}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <p className="small text-body-secondary mt-3 mb-0">
+                      Nenhuma solicitação recente registrada para esta origem.
+                    </p>
+                  )}
+                </div>
+              ))}
             </div>
           ) : null}
         </div>

--- a/reports/diagnostico-landing-exp15-2026-04-28.md
+++ b/reports/diagnostico-landing-exp15-2026-04-28.md
@@ -1,0 +1,46 @@
+# Diagnóstico — Experimento 15 (aba Landing) — 2026-04-28
+
+## Contexto
+Solicitação: após clicar em **IA + LHM** para gerar HTML do pipeline, não aparecem as duas URLs esperadas na aba **Landing**.
+
+## Evidências coletadas via MCP Server (`https://mcpserverdigi.shop/mcp`)
+
+### 1) Estado do experimento 15
+- A coluna `landing_page_html` do experimento 15 está preenchida (`has_html = 1`, `html_len = 21778`).
+- Ou seja, existe HTML armazenado no experimento.
+
+### 2) Tabela `landing_page` (fonte da lista de landings publicadas)
+- Não existe nenhum registro para `experiment_id = 15`.
+- Resultado da consulta: **0 linhas**.
+
+Impacto: a grade/lista de landings na aba Landing fica vazia, e a UI exibe a mensagem “Nenhuma landing gerada ainda...” (mesmo havendo HTML no experimento).
+
+### 3) Jobs do pipeline (`experiment_pipeline_generation_job`)
+Para o experimento 15:
+- Há um job `LANDING_PAGE_HTML` com `model = LHM` em status **COMPLETED**.
+- Há também um job `LANDING_PAGE_HTML` com `model = gpt-5.2` em status **FAILED**.
+- Erro do job falho: quebra de contrato de resposta do artefato HTML (retorno não aceito como HTML puro e inválido como JSON estrito).
+
+### 4) Logs do módulo Java (`ai-worker`)
+Nos logs:
+- O job `fa4bbc85-5041-4644-bd0b-16bf0b0097fe` (LANDING_PAGE_HTML, experimento 15) recebe resposta da OpenAI.
+- Em seguida, ocorre erro de contrato: “LANDING_PAGE_HTML não veio em HTML puro e também não é JSON válido”.
+- O job termina como **failed**.
+
+## Causa raiz observada
+A etapa **LANDING_PAGE_HTML** teve execução concorrente/duplicada por modelo, com:
+- sucesso em LHM;
+- falha no job IA (gpt-5.2) por contrato de payload.
+
+Com isso, o sistema fica em estado inconsistente para a aba Landing:
+- há HTML no experimento;
+- mas não há registro em `landing_page` para o experimento 15;
+- portanto não surgem as entradas esperadas na seção de variantes/publicações.
+
+## Ação corretiva recomendada
+1. **Corrigir o contrato de saída do job IA (LANDING_PAGE_HTML)** para aceitar somente HTML puro no caminho principal (ou robustecer parser para caso `{"htmlDocument":"..."}` válido).
+2. **Ajustar a consolidação de status por seção/modelo** para não bloquear publicação quando já existe versão válida (LHM) para o mesmo `section`.
+3. **Backfill operacional** para o experimento 15:
+   - reprocessar publicação da landing a partir do HTML já salvo;
+   - criar os registros faltantes em `landing_page` (ou reexecutar fluxo de aprovação/publicação) para materializar as URLs na listagem da aba.
+4. **Validação de UX**: alinhar os critérios de “landing gerada” (HTML em `experiment`) versus “landing publicada/listada” (`landing_page`) para evitar mensagem contraditória.


### PR DESCRIPTION
### Motivation

- Surface recent Worker IA runs for `LANDING_PAGE_HTML` separately from inline LHM runs so operators can distinguish origins and statuses when inspecting the Landing generation flow.
- Reduce confusion when multiple models run for the same section by grouping histories and making empty-state explicit.
- Record investigation findings for a failing experiment (15) that showed HTML present on the experiment but missing published `landing_page` entries.

### Description

- Add `workerIaHistory` `useMemo` to filter `jobsQuery.data` for `section === "landing-html"` and `model !== "LHM"` and limit to the 3 most recent entries.
- Refactor the recent requests UI to render two grouped panels (LHM and Worker IA) with separate badges, styles, and empty-state messages, and unify the job item rendering into a mapped `historyGroup` structure.
- Preserve existing parsing and status badge logic while changing keys to include the group to avoid collisions in lists.
- Add a new diagnostic report file `reports/diagnostico-landing-exp15-2026-04-28.md` documenting the investigation, root cause, and remediation steps for experiment 15.

### Testing

- Ran frontend build with `yarn build` which completed successfully.
- Executed unit tests with `yarn test` and the test suite passed.
- Linted TypeScript/React sources with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0177f420c832181a753bf5039446d)