### PR TITLE
ci: acelerar build da imagem backend com Buildx cache e .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+**/.git
+**/node_modules
+**/dist
+**/build
+**/target
+**/.idea
+**/.vscode
+**/.DS_Store
+*.log
+tmp
+artifacts

--- a/.github/workflows/deploy-containers.yml
+++ b/.github/workflows/deploy-containers.yml
@@ -69,8 +69,18 @@ jobs:
             -Dliquibase.username=root \
             -Dliquibase.password=root
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Docker image
-        run: docker build -f backend/ads-service/Dockerfile -t ${BACKEND_IMAGE}:${{ github.sha }} .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/ads-service/Dockerfile
+          tags: ${{ env.BACKEND_IMAGE }}:${{ github.sha }}
+          load: true
+          cache-from: type=gha,scope=backend-image
+          cache-to: type=gha,mode=max,scope=backend-image
 
       - name: Save image as artifact
         run: docker save ${BACKEND_IMAGE}:${{ github.sha }} -o backend-image.tar


### PR DESCRIPTION
### Motivation
- O job `Backend – build image` estava demorando muito porque cada execução refazia downloads e passos que poderiam ser reaproveitados sem cache de camadas Docker.

### Description
- Substituí o passo `docker build` pelo `docker/build-push-action@v6` usando Buildx e adicionei `docker/setup-buildx-action@v3` para habilitar o buildx toolchain.
- Configurei cache de camadas via `cache-from`/`cache-to` com escopo `backend-image` e mantive `load: true` para preservar o fluxo atual de `docker save` e upload de artifact.
- Adicionei um arquivo `/.dockerignore` na raiz para reduzir o contexto enviado ao daemon Docker e evitar incluir arquivos desnecessários no build.

### Testing
- Validei o YAML do workflow carregando `.github/workflows/deploy-containers.yml` com o loader YAML do Ruby e a validação foi bem-sucedida.
- Tentei validar com um script Python que usa `PyYAML` e a execução falhou devido à ausência do módulo `yaml` no ambiente local, sem impacto no commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0273bb8b4832199aecf5efaf140e9)