### PR TITLE
docs: exigir HTML puro em saída de `landingPageHtml` (Worker IA) e tratar JSON como quebra de contrato

### DIFF
--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -606,6 +606,11 @@ Para considerar a copy **rica** e **compatível com as especificações**, a eta
 > - é proibido retornar envelope JSON, markdown, bloco ``` ou campo textual contendo JSON serializado;
 > - o backend do Lead Portal **não** deve tentar “desempacotar” HTML de payload misto/JSON: entradas fora de HTML puro devem ser rejeitadas.
 > - para atributos canônicos de binding/superfície no HTML (`data-section-id`, `data-surface-token`, `data-surface-style`, `data-surface-contrast`), o backend normaliza artefatos de serialização antes da validação estrita: aspas codificadas (`&quot;`, `&#34;`, `&#x22;`), versões escapadas com barra invertida (ex.: `\\&quot;`) e tokens de quebra de linha escapados (`\\n`, `\\r`, `\\t`). O warning operacional deve permanecer para correção definitiva no worker/prompt.
+>
+> **Atualização canônica (2026-04-28) — entrada/saída da etapa `landingPageHtml`:**
+> - para execução do job `LANDING_PAGE_HTML` no Worker IA, o conteúdo retornado pelo modelo deve chegar em `response.output_text` como **texto HTML bruto**;
+> - respostas no formato `{"landingPageHtml":{"htmlDocument":"..."}}` passam a ser consideradas **quebra de contrato de etapa** (não apenas variação de formato);
+> - o parse canônico da etapa deve priorizar texto HTML puro e rejeitar qualquer tentativa de interpretar JSON como fallback funcional.
 
 ```json
 {


### PR DESCRIPTION
### Motivation

- Garantir interpretação consistente e segura da etapa `landingPageHtml` quando executada pelo Worker IA, evitando fallback para envelopes JSON que causem divergência de comportamento.
- Tornar explícito o contrato de entrada/saída para facilitar validações canônicas e integração com o backend do Lead Portal.

### Description

- Adiciona a atualização canônica datada `2026-04-28` que exige que o conteúdo retornado pelo modelo para o job `LANDING_PAGE_HTML` chegue em `response.output_text` como texto HTML bruto.
- Declara que respostas no formato `{"landingPageHtml":{"htmlDocument":"..."}}` são consideradas uma quebra de contrato de etapa e não um simples variação de formato.
- Especifica que o parse canônico deve priorizar texto HTML puro e rejeitar tentativas de interpretar JSON como fallback funcional, mantendo a normalização já definida para atributos de binding/superfície.

### Testing

- Nenhum teste automatizado foi executado para esta documentação; alteração limitada ao conteúdo do arquivo de especificação (`docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f02f84f0cc8321878a8914f2860aa5)