### PR TITLE
Persist MOIS collection job state to MySQL and enhance collection pipeline (Hotmart support)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
@@ -1,39 +1,102 @@
 package com.marketinghub.mois.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.mois.dto.MoisCollectionPersistenceDtos;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class MoisCollectionPersistenceService {
 
-    private final Map<String, MoisCollectionPersistenceDtos.CollectionJobStateResponse> statesByJobId = new ConcurrentHashMap<>();
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
 
     public MoisCollectionPersistenceDtos.CollectionJobStateResponse upsertJobState(
             String jobId,
             MoisCollectionPersistenceDtos.CollectionJobStateResponse state
     ) {
-        statesByJobId.put(jobId, state);
+        String workspaceId = state.job() != null ? state.job().workspaceId() : null;
+        String status = state.job() != null ? state.job().status() : null;
+
+        jdbcTemplate.update(
+                """
+                        INSERT INTO mois_collection_job_state (
+                          job_id,
+                          workspace_id,
+                          status,
+                          payload_json,
+                          updated_at
+                        ) VALUES (?, ?, ?, ?, ?)
+                        ON DUPLICATE KEY UPDATE
+                          workspace_id = VALUES(workspace_id),
+                          status = VALUES(status),
+                          payload_json = VALUES(payload_json),
+                          updated_at = VALUES(updated_at)
+                        """,
+                jobId,
+                workspaceId,
+                status,
+                writeState(state),
+                Timestamp.from(Instant.now())
+        );
+
         return state;
     }
 
     public Optional<MoisCollectionPersistenceDtos.CollectionJobStateResponse> getJobState(String jobId) {
-        return Optional.ofNullable(statesByJobId.get(jobId));
+        List<MoisCollectionPersistenceDtos.CollectionJobStateResponse> items = jdbcTemplate.query(
+                "SELECT payload_json FROM mois_collection_job_state WHERE job_id = ?",
+                (rs, rowNum) -> readState(rs.getString("payload_json")),
+                jobId
+        );
+        return items.stream().findFirst();
     }
 
     public MoisCollectionPersistenceDtos.CollectionJobStateListResponse listJobStates(String workspaceId, String status) {
-        List<MoisCollectionPersistenceDtos.CollectionJobStateResponse> items = statesByJobId.values().stream()
-                .filter(item -> item.job() != null)
-                .filter(item -> workspaceId == null || workspaceId.isBlank() || workspaceId.equals(item.job().workspaceId()))
-                .filter(item -> status == null || status.isBlank() || status.equalsIgnoreCase(item.job().status()))
-                .sorted(Comparator.comparing((MoisCollectionPersistenceDtos.CollectionJobStateResponse item) -> item.job().createdAt())
-                        .reversed())
-                .toList();
+        StringBuilder sql = new StringBuilder("SELECT payload_json FROM mois_collection_job_state WHERE 1=1");
+        List<Object> params = new ArrayList<>();
+
+        if (workspaceId != null && !workspaceId.isBlank()) {
+            sql.append(" AND workspace_id = ?");
+            params.add(workspaceId);
+        }
+        if (status != null && !status.isBlank()) {
+            sql.append(" AND status = ?");
+            params.add(status);
+        }
+
+        sql.append(" ORDER BY updated_at DESC");
+
+        List<MoisCollectionPersistenceDtos.CollectionJobStateResponse> items = jdbcTemplate.query(
+                sql.toString(),
+                (rs, rowNum) -> readState(rs.getString("payload_json")),
+                params.toArray()
+        );
+
         return new MoisCollectionPersistenceDtos.CollectionJobStateListResponse(new ArrayList<>(items));
+    }
+
+    private String writeState(MoisCollectionPersistenceDtos.CollectionJobStateResponse state) {
+        try {
+            return objectMapper.writeValueAsString(state);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Falha ao serializar estado de coleta MOIS", ex);
+        }
+    }
+
+    private MoisCollectionPersistenceDtos.CollectionJobStateResponse readState(String payload) {
+        try {
+            return objectMapper.readValue(payload, MoisCollectionPersistenceDtos.CollectionJobStateResponse.class);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Falha ao desserializar estado de coleta MOIS", ex);
+        }
     }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-28-mois-collection-job-state-persistence.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-04-28-mois-collection-job-state-persistence.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-04-28-mois-collection-job-state-persistence
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: mois_collection_job_state
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_collection_job_state (
+                job_id VARCHAR(80) NOT NULL,
+                workspace_id VARCHAR(80) NULL,
+                status VARCHAR(32) NULL,
+                payload_json LONGTEXT NOT NULL,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (job_id),
+                KEY idx_mois_collection_job_state_workspace_status (workspace_id, status),
+                KEY idx_mois_collection_job_state_updated_at (updated_at)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-04-28-mois-collection-job-state-persistence.yaml
+      relativeToChangelogFile: true
+  - include:
       file: V2037_04_26__widen_experiment_pipeline_job_section_mysql5.sql
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisCollectionPersistenceServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisCollectionPersistenceServiceTest.java
@@ -1,0 +1,91 @@
+package com.marketinghub.mois.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.mois.dto.MoisCollectionPersistenceDtos;
+import com.marketinghub.mois.dto.MoisWorkspaceDtos;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+@ExtendWith(MockitoExtension.class)
+class MoisCollectionPersistenceServiceTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private MoisCollectionPersistenceService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MoisCollectionPersistenceService(jdbcTemplate, new ObjectMapper().findAndRegisterModules());
+    }
+
+    @Test
+    void upsertJobStatePersistsPayloadInDatabase() {
+        MoisCollectionPersistenceDtos.CollectionJobStateResponse state = sampleState("workspace-001", "COMPLETED");
+
+        MoisCollectionPersistenceDtos.CollectionJobStateResponse response = service.upsertJobState("job-1", state);
+
+        assertThat(response).isEqualTo(state);
+        verify(jdbcTemplate).update(anyString(), eq("job-1"), eq("workspace-001"), eq("COMPLETED"), anyString(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void getJobStateReadsSerializedPayloadFromDatabase() throws Exception {
+        MoisCollectionPersistenceDtos.CollectionJobStateResponse state = sampleState("workspace-001", "QUEUED");
+        String payload = new ObjectMapper().findAndRegisterModules().writeValueAsString(state);
+
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), eq("job-1"))).thenAnswer(invocation -> {
+            RowMapper<MoisCollectionPersistenceDtos.CollectionJobStateResponse> mapper = invocation.getArgument(1);
+            java.sql.ResultSet rs = org.mockito.Mockito.mock(java.sql.ResultSet.class);
+            when(rs.getString("payload_json")).thenReturn(payload);
+            return List.of(mapper.mapRow(rs, 0));
+        });
+
+        assertThat(service.getJobState("job-1")).contains(state);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void listJobStatesAppliesWorkspaceAndStatusFilters() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class))).thenReturn(List.of());
+
+        service.listJobStates("workspace-001", "FAILED");
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class), any(Object[].class));
+        assertThat(sqlCaptor.getValue()).contains("workspace_id = ?");
+        assertThat(sqlCaptor.getValue()).contains("status = ?");
+    }
+
+    private MoisCollectionPersistenceDtos.CollectionJobStateResponse sampleState(String workspaceId, String status) {
+        MoisWorkspaceDtos.CollectionJobResponse job = new MoisWorkspaceDtos.CollectionJobResponse(
+                "job-1",
+                workspaceId,
+                "marketing-digital",
+                "ofertas-quentes",
+                status,
+                "LAST_7_DAYS",
+                25,
+                80,
+                List.of("HOTMART"),
+                Instant.parse("2026-04-28T00:00:00Z")
+        );
+        return new MoisCollectionPersistenceDtos.CollectionJobStateResponse(job, List.of(), java.util.Map.of(), null, List.of());
+    }
+}

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -140,6 +140,7 @@ Regras operacionais associadas:
 - o backend principal passa a oferecer gatilho manual (`POST /api/v1/mois/hotmart-collection-runs/trigger`) e histórico (`GET /api/v1/mois/hotmart-collection-runs`) para a coleta do Hotmart;
 - o agendamento diário usa o contrato já existente de `collection-jobs` do MOIS, com filtro de temperatura via `minSuccessScore` configurável;
 - cada tentativa do robô deve ser persistida (sucesso ou falha) para auditoria operacional e rastreabilidade de execução.
+- o estado consolidado de cada `collection-job` (job, referências, lineage e runtime) deve ser persistido no backend principal em `mois_collection_job_state`, eliminando dependência de memória volátil no serviço de persistência.
 
 ## Atualização incremental — MDS Sprint 1 (orquestração e persistência base)
 

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
@@ -1260,53 +1260,143 @@ public class MoisDomainService {
         boolean hasFailure = false;
         int retries = 0;
         long totalLatencyMs = 0;
+        int safeLimitPerSource = Math.max(1, job.limitPerSource());
+        collectedReferencesByJob.put(job.jobId(), new ArrayList<>());
         for (String source : job.sources()) {
-            index++;
-            SourceExecutionOutcome outcome = executeSourceCollection(job.workspaceId(), source, index);
+            String normalizedSource = source == null ? "UNKNOWN" : source.trim().toUpperCase();
+            SourceExecutionOutcome outcome = executeSourceCollection(job.workspaceId(), source, index + 1);
             retries += outcome.retries();
             totalLatencyMs += outcome.latencyMs();
             if (!outcome.success()) {
                 hasFailure = true;
                 continue;
             }
-            SourceMetricSnapshot metrics = buildSourceMetricSnapshot(job, source, index);
-            NormalizedSuccessSignal normalized = normalizeSuccessSignal(metrics, job.minSuccessScore());
-            items.add(new MoisWorkspaceDtos.CollectedReferenceResponse(
-                    UUID.randomUUID().toString(),
-                    job.jobId(),
-                    source,
-                    "Referência " + index + " (" + source + ")",
-                    "https://example.com/" + source.toLowerCase() + "/offer-" + index,
-                    niche,
-                    "ACTIVE",
-                    false,
-                    null,
-                    normalized.successScore(),
-                    normalized.successSignal(),
-                    normalized.confidenceLevel(),
-                    index,
-                    normalized.engagementRelative(),
-                    normalized.recurrenceScore(),
-                    normalized.evidenceScore(),
-                    job.createdAt().minusSeconds(index * 120L),
-                    Map.of(
-                            "status", "ACTIVE",
-                            "timeWindow", job.timeWindow(),
-                            "attempts", String.valueOf(outcome.attempts()),
-                            "retries", String.valueOf(outcome.retries()),
-                            "latencyMs", String.valueOf(outcome.latencyMs()),
-                            "engagementRaw", String.valueOf(metrics.engagementRaw()),
-                            "recurrenceRaw", String.valueOf(metrics.recurrenceRaw()),
-                            "evidenceRaw", String.valueOf(metrics.evidenceRaw()),
-                            "normalizationPolicy", "v1:0.45*engagement+0.35*recurrence+0.20*evidence"
-                    )
-            ));
+            List<String> sourceUrls = resolveSourceUrls(normalizedSource, niche, safeLimitPerSource);
+            for (int sourceRank = 1; sourceRank <= safeLimitPerSource; sourceRank++) {
+                index++;
+                SourceMetricSnapshot metrics = buildSourceMetricSnapshot(job, source, index);
+                NormalizedSuccessSignal normalized = normalizeSuccessSignal(metrics, job.minSuccessScore());
+                String sourceUrl = sourceRank <= sourceUrls.size()
+                        ? sourceUrls.get(sourceRank - 1)
+                        : buildCollectionSourceUrl(normalizedSource, niche, sourceRank);
+                MoisWorkspaceDtos.CollectedReferenceResponse item = buildCollectedReference(
+                        job,
+                        normalizedSource,
+                        niche,
+                        sourceUrl,
+                        index,
+                        sourceRank,
+                        outcome,
+                        metrics,
+                        normalized
+                );
+                items.add(item);
+                collectedReferencesByJob.put(job.jobId(), reRank(items));
+                persistCollectionState(job.jobId());
+            }
         }
         return new CollectionExecutionResult(
                 reRank(items),
                 hasFailure,
                 new CollectionJobRuntimeStats(job.jobId(), retries, totalLatencyMs, Instant.now())
         );
+    }
+
+    private MoisWorkspaceDtos.CollectedReferenceResponse buildCollectedReference(
+            MoisWorkspaceDtos.CollectionJobResponse job,
+            String source,
+            String niche,
+            String sourceUrl,
+            int globalIndex,
+            int sourceRank,
+            SourceExecutionOutcome outcome,
+            SourceMetricSnapshot metrics,
+            NormalizedSuccessSignal normalized
+    ) {
+        String title = "HOTMART".equals(source)
+                ? "Oferta Hotmart #" + sourceRank + " • " + trimTo(niche, 50)
+                : "Referência " + sourceRank + " (" + source + ")";
+        return new MoisWorkspaceDtos.CollectedReferenceResponse(
+                UUID.randomUUID().toString(),
+                job.jobId(),
+                source,
+                title,
+                sourceUrl,
+                niche,
+                "ACTIVE",
+                false,
+                null,
+                normalized.successScore(),
+                normalized.successSignal(),
+                normalized.confidenceLevel(),
+                globalIndex,
+                normalized.engagementRelative(),
+                normalized.recurrenceScore(),
+                normalized.evidenceScore(),
+                job.createdAt().minusSeconds(globalIndex * 120L),
+                Map.of(
+                        "status", "ACTIVE",
+                        "timeWindow", job.timeWindow(),
+                        "attempts", String.valueOf(outcome.attempts()),
+                        "retries", String.valueOf(outcome.retries()),
+                        "latencyMs", String.valueOf(outcome.latencyMs()),
+                        "engagementRaw", String.valueOf(metrics.engagementRaw()),
+                        "recurrenceRaw", String.valueOf(metrics.recurrenceRaw()),
+                        "evidenceRaw", String.valueOf(metrics.evidenceRaw()),
+                        "normalizationPolicy", "v1:0.45*engagement+0.35*recurrence+0.20*evidence"
+                )
+        );
+    }
+
+    private List<String> resolveSourceUrls(String source, String niche, int limitPerSource) {
+        if ("HOTMART".equals(source)) {
+            List<String> hotmartUrls = fetchHotmartProductUrls(niche, limitPerSource);
+            if (!hotmartUrls.isEmpty()) {
+                return hotmartUrls;
+            }
+        }
+        List<String> fallback = new ArrayList<>();
+        for (int sourceRank = 1; sourceRank <= limitPerSource; sourceRank++) {
+            fallback.add(buildCollectionSourceUrl(source, niche, sourceRank));
+        }
+        return fallback;
+    }
+
+    private List<String> fetchHotmartProductUrls(String niche, int limitPerSource) {
+        String marketplaceUrl = buildCollectionSourceUrl("HOTMART", niche, 1);
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(marketplaceUrl))
+                    .GET()
+                    .timeout(Duration.ofSeconds(10))
+                    .header("User-Agent", "Mozilla/5.0 (compatible; MarketingHub-MOIS/1.0)")
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300 || response.body() == null) {
+                return List.of();
+            }
+            Pattern linkPattern = Pattern.compile("\"fullLink\":\"(https:\\\\/\\\\/www\\.hotmart\\.com\\\\/product\\\\/[^\"]+)\"");
+            Matcher matcher = linkPattern.matcher(response.body());
+            List<String> links = new ArrayList<>();
+            while (matcher.find() && links.size() < limitPerSource) {
+                String decoded = matcher.group(1).replace("\\/", "/").replace("\\u0026", "&");
+                if (!links.contains(decoded)) {
+                    links.add(decoded);
+                }
+            }
+            return links;
+        } catch (Exception ex) {
+            log.warn("mois_hotmart_product_url_fetch_failed niche={} reason={}", niche, ex.getMessage());
+            return List.of();
+        }
+    }
+
+    private String buildCollectionSourceUrl(String source, String niche, int sourceRank) {
+        String encodedNiche = URLEncoder.encode(niche == null ? "" : niche, StandardCharsets.UTF_8);
+        if ("HOTMART".equals(source)) {
+            return "https://www.hotmart.com/pt-br/marketplace?query=" + encodedNiche + "&page=" + sourceRank;
+        }
+        return "https://example.com/" + source.toLowerCase() + "/offer-" + sourceRank;
     }
 
     private SourceExecutionOutcome executeSourceCollection(String workspaceId, String source, int index) {

--- a/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
+++ b/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
@@ -290,7 +290,7 @@ class MoisDomainServiceTest {
         MoisWorkspaceDtos.CollectedReferenceListResponse references =
                 service.listCollectedReferencesByJob(created.jobId(), null, null, null, null).orElseThrow();
 
-        assertThat(references.items()).hasSize(1);
+        assertThat(references.items()).hasSize(20);
         assertThat(references.items().getFirst().source()).isEqualTo("CLICKBANK");
         assertThat(references.items().getFirst().successScore()).isGreaterThanOrEqualTo(65);
         assertThat(references.items().getFirst().confidenceLevel()).isIn("LOW", "MEDIUM", "HIGH");


### PR DESCRIPTION
### Motivation

- Persist collection job state to durable storage to remove reliance on in-memory state and enable operational traceability. 
- Support richer, incremental collection results (multiple per-source items and Hotmart product URL extraction) and persist interim state during collection runs. 

### Description

- Replace the in-memory `ConcurrentHashMap` in `MoisCollectionPersistenceService` with a database-backed implementation using `JdbcTemplate` and `ObjectMapper`, adding `writeState`/`readState` JSON serialization. 
- Add a Liquibase changeset `2026-04-28-mois-collection-job-state-persistence.yaml` and include it in `db.changelog-master.yaml` to create the `mois_collection_job_state` table with indexes. 
- Update `MoisDomainService` collection flow to honor `limitPerSource`, generate multiple collected references per source, re-rank and persist interim collection state via `persistCollectionState`, and add Hotmart-specific URL resolution with `fetchHotmartProductUrls` and `resolveSourceUrls`. 
- Add unit tests `MoisCollectionPersistenceServiceTest` (mocking `JdbcTemplate`) and adjust `MoisDomainServiceTest` expectations for the expanded per-source result set. 

### Testing

- Ran unit tests for `MoisCollectionPersistenceServiceTest` which mock `JdbcTemplate` and verify `update`/`query` interactions, and they passed. 
- Ran updated `MoisDomainServiceTest` which now asserts expanded collected references per job and it passed. 
- Executed the test suite via the build (`mvn test`) and all automated unit tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f02a39e5188321821b66883fe9f313)