### PR TITLE
Update ExperimentPipelineOpenAiClient test to accept plain HTML responses

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -776,14 +776,13 @@ class ExperimentPipelineOpenAiClientTest {
     }
 
     @Test
-    void failsWhenLandingPageHtmlReturnsJsonInsteadOfPureHtml() {
+    void acceptsLandingPageHtmlWithoutJsonEnvelope() throws Exception {
         String openAiText = """
-                {
-                  "landingPageHtml": {
-                    "htmlDocument": "<!DOCTYPE html>\\n<html lang=\\"pt-BR\\">\\n<head><meta charset=\\"UTF-8\\"></head>
-<body><form id=\\"lead-capture-primary\\"><input type=\\"text\\" name=\\"nome\\" /></form></body></html>"
-                  }
-                }
+                <!doctype html>
+                <html lang="pt-BR">
+                <head><meta charset="UTF-8"></head>
+                <body><form id="lead-capture-primary"><input type="text" name="nome" /></form></body>
+                </html>
                 """;
 
         ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
@@ -808,13 +807,16 @@ class ExperimentPipelineOpenAiClientTest {
                         """,
                 Instant.now());
 
-        Throwable error = catchThrowable(() -> client.generate(job));
+        ExperimentPipelineJobCompletionPayload payload = client.generate(job);
+        Map<String, Object> content = MAPPER.readValue(payload.responseContent(), new TypeReference<>() {});
+        @SuppressWarnings("unchecked")
+        Map<String, Object> landingPageHtml = (Map<String, Object>) content.get("landingPageHtml");
+        String htmlDocument = String.valueOf(landingPageHtml.get("htmlDocument")).toLowerCase();
 
-        assertThat(error).isInstanceOf(IllegalStateException.class);
-        assertThat(error).hasMessageContaining("Falha ao gerar seção LANDING_PAGE_HTML do experimento 29");
-        assertThat(error.getCause())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("LANDING_PAGE_HTML exige HTML puro");
+        assertThat(htmlDocument).contains("<!doctype html>");
+        assertThat(htmlDocument).contains("name=\"nome\"");
+        assertThat(htmlDocument).doesNotContain("name=\"email\"");
+        assertThat(htmlDocument).doesNotContain("name=\"whatsapp\"");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- The test previously expected an exception when the OpenAI response contained a JSON envelope around HTML, but the client should accept plain HTML responses without a JSON envelope.

### Description
- Renamed the test from `failsWhenLandingPageHtmlReturnsJsonInsteadOfPureHtml` to `acceptsLandingPageHtmlWithoutJsonEnvelope` and changed its behavior to validate accepted plain-HTML responses.
- Replaced the example OpenAI response from a JSON object to a raw HTML document string and updated the test to parse the generated `ExperimentPipelineJobCompletionPayload` with `MAPPER.readValue`.
- Replaced the previous exception expectation with assertions that verify the returned HTML (`htmlDocument`) contains `<!doctype html>` and the expected form field `name="nome"`, and does not contain `name="email"` or `name="whatsapp"`.
- Adjusted the test signature to throw `Exception` to simplify parsing and assertion code.

### Testing
- Ran the unit test `ExperimentPipelineOpenAiClientTest` that includes `acceptsLandingPageHtmlWithoutJsonEnvelope` and the test passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f033c0c5688321a0713d5fce25cdfa)