### PR TITLE
Remove legacy single-version landing links from Landing tab

### DIFF
--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -13,24 +13,12 @@ type FeedbackState = {
   message: string;
 };
 
-type LandingLinks = {
-  standaloneUrl: string;
-  iframeUrl: string;
-};
-
 type VariantLandingLinks = {
   variant: string;
   flowId?: number;
   standaloneUrl?: string | null;
   iframeUrl?: string | null;
 };
-
-const leadPortalBaseUrl = import.meta.env.VITE_LEAD_PORTAL_BASE_URL?.trim() || "https://oportunidadebrasil.shop";
-
-function buildLeadPortalUrl(path: string): string {
-  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  return `${leadPortalBaseUrl.replace(/\/$/, "")}${normalizedPath}`;
-}
 
 function resolveStandaloneLandingUrl(path: string): string {
   if (/^https?:\/\//i.test(path)) {
@@ -46,26 +34,6 @@ function resolveStandaloneLandingUrl(path: string): string {
 
 function normalizeUrl(url?: string | null) {
   return (url ?? "").trim().replace(/\/$/, "");
-}
-
-function buildLandingLinksFromPublicUrl(publicUrl?: string | null): LandingLinks | null {
-  if (!publicUrl) {
-    return null;
-  }
-
-  try {
-    const parsed = new URL(publicUrl);
-    const slug = parsed.pathname.split("/").filter(Boolean).pop();
-    if (!slug) {
-      return null;
-    }
-    return {
-      standaloneUrl: buildLeadPortalUrl(`/api/flows/${encodeURIComponent(slug)}/page`),
-      iframeUrl: buildLeadPortalUrl(`/flows/${encodeURIComponent(slug)}`),
-    };
-  } catch {
-    return null;
-  }
 }
 
 function normalizeVariantLabel(variant: string): string {
@@ -85,7 +53,6 @@ export default function LandingTab({ experiment }: LandingTabProps) {
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const [pendingLandingId, setPendingLandingId] = useState<number | null>(null);
   const [isPublishing, setIsPublishing] = useState(false);
-  const [publishedLinks, setPublishedLinks] = useState<LandingLinks | null>(null);
   const [publishedVariantLinks, setPublishedVariantLinks] = useState<VariantLandingLinks[]>([]);
 
   const sortedLandingPages = useMemo(() => {
@@ -98,19 +65,6 @@ export default function LandingTab({ experiment }: LandingTabProps) {
 
   const selectedDestinationUrl = normalizeUrl(experiment.followUpActionUrl);
   const hasGeneratedLandingHtml = Boolean(experiment.landingPageHtml?.trim());
-  const experimentApprovedLinks = useMemo(() => {
-    if (publishedLinks) {
-      return publishedLinks;
-    }
-    if (!experiment.leadPortalFlowSlug) {
-      return null;
-    }
-    const slug = encodeURIComponent(experiment.leadPortalFlowSlug);
-    return {
-      standaloneUrl: buildLeadPortalUrl(`/api/flows/${slug}/page`),
-      iframeUrl: buildLeadPortalUrl(`/flows/${slug}`),
-    };
-  }, [experiment.leadPortalFlowSlug, publishedLinks]);
 
   const handleApproveAndPublish = async () => {
     if (!hasGeneratedLandingHtml) {
@@ -130,7 +84,6 @@ export default function LandingTab({ experiment }: LandingTabProps) {
         pixelAppliedAutomatically?: boolean;
         variantLinks?: VariantLandingLinks[] | null;
       }>(`/api/experiments/${experiment.id}/pipeline/landing-page-html/approve-and-publish`);
-      setPublishedLinks(buildLandingLinksFromPublicUrl(data?.publicUrl));
       setPublishedVariantLinks(
         Array.isArray(data?.variantLinks)
           ? data.variantLinks.filter((item) => item?.standaloneUrl || item?.iframeUrl)
@@ -239,28 +192,6 @@ export default function LandingTab({ experiment }: LandingTabProps) {
             <p className="text-muted small mt-2 mb-0">
               Gere o HTML na aba Estrutura de conteúdo para habilitar a aprovação nesta aba.
             </p>
-          ) : null}
-          {experimentApprovedLinks ? (
-            <div className="mt-3">
-              <p className="text-muted small mb-1">Link standalone</p>
-              <a
-                href={experimentApprovedLinks.standaloneUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="small text-break d-block"
-              >
-                {experimentApprovedLinks.standaloneUrl}
-              </a>
-              <p className="text-muted small mb-1 mt-2">Link iframe</p>
-              <a
-                href={experimentApprovedLinks.iframeUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="small text-break d-block"
-              >
-                {experimentApprovedLinks.iframeUrl}
-              </a>
-            </div>
           ) : null}
           {publishedVariantLinks.length > 0 ? (
             <div className="mt-3">


### PR DESCRIPTION
### Motivation
- The UI previously showed legacy single-version landing links (`Link standalone` / `Link iframe`) which are obsolete now that the system publishes dual public variants (LHM + IA). 
- Removing the old links and helpers reduces confusion and surface area in the component.

### Description
- Removed the `LandingLinks` type, the `leadPortalBaseUrl` and `buildLeadPortalUrl` helpers, and the `buildLandingLinksFromPublicUrl` function. 
- Removed the `publishedLinks` state and the `experimentApprovedLinks` memo derived from it. 
- Removed the rendered block that displayed the legacy `Link standalone` and `Link iframe` entries, keeping only the `Variantes públicas (LHM + IA)` section. 
- Adjusted `handleApproveAndPublish` to no longer populate the removed single-version links state and cleaned up related unused code in `frontend/src/pages/experiment/LandingTab.tsx`.

### Testing
- Ran `npm --prefix frontend run typecheck`, which failed in this environment due to missing type definition packages (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`).
- Ran `npm --prefix frontend run test -- landingHtmlParser.test.ts --run`, which failed in this environment because `vitest` is not available in `node_modules`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a33bce088321acc792975321016c)