### PR TITLE
Robust wireframe JSON extraction for Prompt v2 and add unit test

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -544,15 +544,7 @@ public class ExperimentPipelineOpenAiClient {
         if (!StringUtils.hasText(userPrompt)) {
             return List.of();
         }
-        int markerIndex = userPrompt.indexOf("Wireframe da landing:");
-        if (markerIndex < 0) {
-            return List.of();
-        }
-        int jsonStart = userPrompt.indexOf('{', markerIndex);
-        if (jsonStart < 0) {
-            return List.of();
-        }
-        String wireframeJson = extractBalancedJsonObject(userPrompt, jsonStart);
+        String wireframeJson = extractWireframeJsonBlock(userPrompt);
         if (!StringUtils.hasText(wireframeJson)) {
             return List.of();
         }
@@ -592,6 +584,39 @@ public class ExperimentPipelineOpenAiClient {
             log.warn("Falha ao extrair wireframe do prompt para validar surfaceSpec: {}", ex.getMessage());
             return List.of();
         }
+    }
+
+    private String extractWireframeJsonBlock(String userPrompt) {
+        if (!StringUtils.hasText(userPrompt)) {
+            return null;
+        }
+        List<String> candidateMarkers = List.of(
+                "Wireframe da landing:",
+                "Wireframe aprovado (JSON):",
+                "1) Wireframe aprovado (JSON):");
+        for (String marker : candidateMarkers) {
+            int markerIndex = userPrompt.indexOf(marker);
+            if (markerIndex < 0) {
+                continue;
+            }
+            int jsonStart = userPrompt.indexOf('{', markerIndex);
+            if (jsonStart < 0) {
+                continue;
+            }
+            String jsonBlock = extractBalancedJsonObject(userPrompt, jsonStart);
+            if (StringUtils.hasText(jsonBlock)) {
+                return jsonBlock;
+            }
+        }
+        int wireframeKeyIndex = userPrompt.indexOf("\"landingPageWireframe\"");
+        if (wireframeKeyIndex < 0) {
+            return null;
+        }
+        int rootStart = userPrompt.lastIndexOf('{', wireframeKeyIndex);
+        if (rootStart < 0) {
+            return null;
+        }
+        return extractBalancedJsonObject(userPrompt, rootStart);
     }
 
     @SuppressWarnings("unchecked")

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -1296,6 +1296,42 @@ class ExperimentPipelineOpenAiClientTest {
                 .hasMessageContaining("Quebra de contrato: LANDING_PAGE_HTML divergente de landing-page-wireframe.sectionOrder.surfaceSpec.");
     }
 
+    @Test
+    void failsFastWhenLandingHtmlCannotReproduceWireframeSurfaceSpecUsingPromptV2Marker() {
+        String htmlText = """
+                {
+                  "landingPageHtml": {
+                    "htmlDocument": "<!doctype html><html><body><section data-section-id='proof'></section></body></html>",
+                    "summary": "ok",
+                    "formSpec": {"formId": "lead-capture-primary"},
+                    "imagePlacementContract": {"requiredDataAttributes": []},
+                    "consistencyChecks": []
+                  }
+                }
+                """;
+
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(new AtomicReference<>(), htmlText)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        String requestBody = """
+                {
+                  "model":"gpt-5.2",
+                  "input":[
+                    {"role":"user","content":"Prompt v2\\n1) Wireframe aprovado (JSON):\\n{\\"landingPageWireframe\\":{\\"sectionOrder\\":[{\\"sectionId\\":\\"hero-proof-form\\",\\"surfaceSpec\\":{\\"surfaceToken\\":\\"surface-hero\\",\\"style\\":\\"band\\",\\"contrastMode\\":\\"normal\\"}},{\\"sectionId\\":\\"proof\\",\\"surfaceSpec\\":{\\"surfaceToken\\":\\"surface-proof\\",\\"style\\":\\"solid\\",\\"contrastMode\\":\\"normal\\"}}]}}\\n2) Copy aprovada (JSON):\\n{}"}
+                  ]
+                }
+                """;
+
+        Throwable thrown = catchThrowable(() -> client.generate(new ExperimentPipelineJobDto(
+                UUID.randomUUID(), 37L, "landing-page-html", "gpt-5.2", "prompt", requestBody, Instant.now())));
+
+        assertThat(thrown).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Quebra de contrato: LANDING_PAGE_HTML divergente de landing-page-wireframe.sectionOrder.surfaceSpec.");
+    }
+
     private ExchangeFunction capturePayloadExchange(AtomicReference<Map<String, Object>> payloadRef) {
         return capturePayloadExchange(payloadRef, "{\"content\":\"ok\"}");
     }

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,53 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0008 — LANDING_PAGE_HTML não validava surfaceSpec quando prompt vinha no formato “Prompt v2”
+
+- **Data/Hora (UTC):** 2026-04-28
+- **Responsável:** Assistente Codex
+- **Módulo:** ai-worker
+- **Ambiente:** Repositório `marketing-hub`
+- **Execução/Teste:** Tentativa `ca004a13-e78a-4ada-81d2-f7d4bbfe00ec` (experimento 15)
+
+#### 1) Erro observado
+- **Sintoma:** job `LANDING_PAGE_HTML` falhou no backend com `422` por divergência de superfície (`surfaceSpec`), apesar de o worker ter seguido para `/complete`.
+- **Endpoint/rota/fila:** `POST /api/internal/experiment-pipeline/jobs/{jobId}/complete`.
+- **Status code:** 422.
+- **Mensagem de erro literal:** `Divergência de superfície: landing-page-html deve reproduzir exatamente landing-page-wireframe.sectionOrder.surfaceSpec`.
+- **Payload enviado (literal):** conteúdo de `landingPageHtml` com `htmlDocument` de 36199 caracteres; logs do worker mostram seções enviadas sem correspondência exata 1:1 com `sectionOrder` esperado no wireframe.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** `java_module_logs` do `ai-worker` com job `ca004a13...` mostrando envio para `/complete` e retorno 422.
+- **Dados de banco consultados via MCP:** `experiment_pipeline_generation_job` (erro 422) e `experiment.landing_page_wireframe` (surfaceSpec esperado por seção para o experimento 15).
+- **Trecho canônico consultado:** `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` e regra de contrato da etapa `landing-page-html` no prompt.
+- **Validação/regra que rejeitou:** validação de igualdade exata `expectedSurfaces` vs `actualSurfaces` no backend.
+- **Causa raiz:** no worker, a extração de `surfaceSpec` esperado do `request_body_json` dependia apenas do marcador textual `Wireframe da landing:`. No formato atual (“Prompt v2”, com `1) Wireframe aprovado (JSON):`), a extração retornava vazio e a validação preventiva do worker era pulada.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** HTML com conjunto de `data-section-id` diferente do `sectionOrder` canônico (faltando seção esperada e incluindo seção extra).
+- **O que a especificação esperava (literal):** reprodução exata de `landingPageWireframe.sectionOrder[*].surfaceSpec` no HTML (`data-section-id`, `data-surface-token`, `data-surface-style`, `data-surface-contrast`) sem sobras/faltas.
+- **Diferença objetiva:** worker não validou localmente devido falha de parsing do wireframe no prompt v2; backend validou e rejeitou.
+- **Ação corretiva recomendada:** robustecer extração do wireframe no worker para múltiplos marcadores de prompt e fallback por chave `landingPageWireframe`.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** parsing + validação preventiva + teste.
+- **Arquivos alterados:**
+  - `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java`
+  - `ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** extração do JSON de wireframe agora aceita marcadores legados e do prompt v2 (`Wireframe aprovado (JSON)`), com fallback por chave `landingPageWireframe`; adicionada cobertura de teste para falha rápida no cenário de prompt v2 quando o HTML não reproduz `surfaceSpec`.
+
+#### 5) Reteste
+- **Procedimento de reteste:** `mvn -Dtest=ExperimentPipelineOpenAiClientTest test` no módulo `ai-worker`.
+- **Resultado:** não executado com sucesso por dependência privada inacessível no ambiente (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`).
+- **Evidências (logs/ids/prints):** erro Maven `401 Unauthorized` ao resolver artefato no GitHub Packages.
+- **Status final:** Parcial (correção aplicada; reteste automatizado pendente em ambiente com credencial).
+
+#### 6) Próximo passo
+- **Ação seguinte:** reexecutar a suíte de testes do `ai-worker` em ambiente autenticado e disparar nova tentativa de `LANDING_PAGE_HTML` para o experimento 15.
+- **Dono da ação:** Time do AI Worker.
+- **Prazo:** próxima janela de validação integrada.
+
 ### INC-0007 — LANDING_PAGE_HTML com contrato de saída em HTML puro (sem JSON)
 
 - **Data/Hora (UTC):** 2026-04-28


### PR DESCRIPTION
### Motivation
- The worker failed to validate `surfaceSpec` when the prompt used alternate markers (Prompt v2), causing downstream 422 errors because the expected wireframe JSON was not extracted.
- Make the wireframe extraction more resilient to different prompt formats and add a test to cover the Prompt v2 marker case.

### Description
- Replaced inline marker parsing in `extractExpectedSurfacesFromRequestPayload` to call a new helper `extractWireframeJsonBlock` that tries multiple markers and a fallback by locating the `"landingPageWireframe"` key. 
- Implemented `extractWireframeJsonBlock` to scan for candidate markers (`"Wireframe da landing:"`, `"Wireframe aprovado (JSON):"`, `"1) Wireframe aprovado (JSON):"`) and to extract a balanced JSON object using the existing `extractBalancedJsonObject` helper, with a fallback to locate the nearest root object when only the `landingPageWireframe` key is present. 
- Added a unit test `failsFastWhenLandingHtmlCannotReproduceWireframeSurfaceSpecUsingPromptV2Marker` in `ExperimentPipelineOpenAiClientTest` that asserts the client fails fast when HTML cannot reproduce `surfaceSpec` and the prompt uses the Prompt v2 marker. 
- Updated `docs/registro-ajustes-pipeline-experimento.md` with an incident entry describing the issue, diagnosis, change and next steps.

### Testing
- Added the test `failsFastWhenLandingHtmlCannotReproduceWireframeSurfaceSpecUsingPromptV2Marker` in `ai-worker` tests and exercised it via the module test command `mvn -Dtest=ExperimentPipelineOpenAiClientTest test` as described in the change record. 
- The automated test execution was not completed successfully due to an external artifact resolution failure (`401 Unauthorized` when resolving `com.marketinghub:ads-service:0.0.1-SNAPSHOT`), so the CI/local run is pending in an authenticated environment. 
- Unit test semantics were verified locally in-code review and the change includes logging for parse failures; full automated verification remains to be executed after resolving repository credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a24bf9e08321b6fa351346eeb894)