### PR TITLE
Apply design preset to fill missing surface style/contrast and validate landing-page HTML

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -548,6 +548,8 @@ public class ExperimentPipelineOpenAiClient {
         if (!StringUtils.hasText(wireframeJson)) {
             return List.of();
         }
+        String designPresetJson = extractDesignPresetJsonBlock(userPrompt);
+        Map<String, SectionVisualPresetContract> visualPresetBySection = extractSectionVisualPresetsBySection(designPresetJson);
         try {
             Map<String, Object> root = objectMapper.readValue(wireframeJson, new TypeReference<>() {});
             Object wireframeNode = root.get("landingPageWireframe");
@@ -571,8 +573,13 @@ public class ExperimentPipelineOpenAiClient {
                 }
                 Map<String, Object> surface = (Map<String, Object>) surfaceMap;
                 String surfaceToken = normalizeHtmlAttr(readString(surface, "surfaceToken"));
-                String style = normalizeHtmlAttr(readString(surface, "style"));
-                String contrastMode = normalizeHtmlAttr(readString(surface, "contrastMode"));
+                SectionVisualPresetContract visualPreset = visualPresetBySection.get(normalizeLookupKey(sectionId));
+                String style = normalizeHtmlAttr(firstNonBlank(
+                        visualPreset != null ? visualPreset.style() : null,
+                        readString(surface, "style")));
+                String contrastMode = normalizeHtmlAttr(firstNonBlank(
+                        visualPreset != null ? visualPreset.contrastMode() : null,
+                        readString(surface, "contrastMode")));
                 if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(surfaceToken)
                         || !StringUtils.hasText(style) || !StringUtils.hasText(contrastMode)) {
                     continue;
@@ -584,6 +591,91 @@ public class ExperimentPipelineOpenAiClient {
             log.warn("Falha ao extrair wireframe do prompt para validar surfaceSpec: {}", ex.getMessage());
             return List.of();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, SectionVisualPresetContract> extractSectionVisualPresetsBySection(String designPresetJson) {
+        if (!StringUtils.hasText(designPresetJson)) {
+            return Map.of();
+        }
+        try {
+            Map<String, Object> root = objectMapper.readValue(designPresetJson, new TypeReference<>() {});
+            Object designNode = root.get("landingPageDesignPreset");
+            Map<String, Object> designPreset = designNode instanceof Map<?, ?> map
+                    ? (Map<String, Object>) map
+                    : root;
+            Object rawSectionPresets = designPreset.get("sectionPresets");
+            if (!(rawSectionPresets instanceof List<?> sectionPresets)) {
+                return Map.of();
+            }
+            Map<String, SectionVisualPresetContract> visualPresets = new LinkedHashMap<>();
+            for (Object rawPreset : sectionPresets) {
+                if (!(rawPreset instanceof Map<?, ?> rawPresetMap)) {
+                    continue;
+                }
+                Map<String, Object> sectionPreset = (Map<String, Object>) rawPresetMap;
+                String sectionId = normalizeLookupKey(readString(sectionPreset, "sectionId"));
+                String style = normalizeHtmlAttr(readString(sectionPreset, "surfaceStyle"));
+                String contrastMode = normalizeHtmlAttr(readString(sectionPreset, "contrastMode"));
+                if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(style) || !StringUtils.hasText(contrastMode)) {
+                    continue;
+                }
+                visualPresets.put(sectionId, new SectionVisualPresetContract(style, contrastMode));
+            }
+            return visualPresets;
+        } catch (Exception ex) {
+            log.warn("Falha ao extrair design preset do prompt para validar surfaceSpec: {}", ex.getMessage());
+            return Map.of();
+        }
+    }
+
+    private String extractDesignPresetJsonBlock(String userPrompt) {
+        if (!StringUtils.hasText(userPrompt)) {
+            return null;
+        }
+        List<String> candidateMarkers = List.of(
+                "Preset de design da landing:",
+                "Preset de design aprovado (JSON):",
+                "3) Preset de design aprovado (JSON):");
+        for (String marker : candidateMarkers) {
+            int markerIndex = userPrompt.indexOf(marker);
+            if (markerIndex < 0) {
+                continue;
+            }
+            int jsonStart = userPrompt.indexOf('{', markerIndex);
+            if (jsonStart < 0) {
+                continue;
+            }
+            String jsonBlock = extractBalancedJsonObject(userPrompt, jsonStart);
+            if (StringUtils.hasText(jsonBlock)) {
+                return jsonBlock;
+            }
+        }
+        int designPresetKeyIndex = userPrompt.indexOf("\"landingPageDesignPreset\"");
+        if (designPresetKeyIndex < 0) {
+            return null;
+        }
+        int rootStart = userPrompt.lastIndexOf('{', designPresetKeyIndex);
+        if (rootStart < 0) {
+            return null;
+        }
+        return extractBalancedJsonObject(userPrompt, rootStart);
+    }
+
+    private String normalizeLookupKey(String value) {
+        return normalizeHtmlAttr(value).toLowerCase(Locale.ROOT);
+    }
+
+    private String firstNonBlank(String... values) {
+        if (values == null) {
+            return "";
+        }
+        for (String value : values) {
+            if (StringUtils.hasText(value)) {
+                return value.trim();
+            }
+        }
+        return "";
     }
 
     private String extractWireframeJsonBlock(String userPrompt) {
@@ -783,6 +875,9 @@ public class ExperimentPipelineOpenAiClient {
     }
 
     private record SectionSurfaceContract(String sectionId, String surfaceToken, String style, String contrastMode) {
+    }
+
+    private record SectionVisualPresetContract(String style, String contrastMode) {
     }
 
     @SuppressWarnings("unchecked")

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -1261,6 +1261,46 @@ class ExperimentPipelineOpenAiClientTest {
     }
 
     @Test
+    void synchronizesLandingHtmlSurfaceAttributesUsingDesignPresetWhenWireframeOmitsStyleAndContrast() throws Exception {
+        String htmlText = """
+                {
+                  "landingPageHtml": {
+                    "htmlDocument": "<!doctype html><html><body><section data-section-id='hero'></section><section data-section-id='proof'></section></body></html>",
+                    "summary": "ok",
+                    "formSpec": {"formId": "lead-capture-primary"},
+                    "imagePlacementContract": {"requiredDataAttributes": []},
+                    "consistencyChecks": []
+                  }
+                }
+                """;
+
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(new AtomicReference<>(), htmlText)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        String requestBody = """
+                {
+                  "model":"gpt-5.2",
+                  "input":[
+                    {"role":"user","content":"Prompt v2\\n1) Wireframe aprovado (JSON):\\n{\\"landingPageWireframe\\":{\\"sectionOrder\\":[{\\"sectionId\\":\\"hero\\",\\"surfaceSpec\\":{\\"surfaceToken\\":\\"surface-hero\\",\\"notes\\":\\"hero\\"}},{\\"sectionId\\":\\"proof\\",\\"surfaceSpec\\":{\\"surfaceToken\\":\\"surface-proof\\",\\"notes\\":\\"proof\\"}}]}}\\n2) Texto da landing aprovado (JSON):\\n{}\\n3) Preset de design aprovado (JSON):\\n{\\"landingPageDesignPreset\\":{\\"sectionPresets\\":[{\\"sectionId\\":\\"hero\\",\\"surfaceStyle\\":\\"band\\",\\"contrastMode\\":\\"high\\"},{\\"sectionId\\":\\"proof\\",\\"surfaceStyle\\":\\"solid\\",\\"contrastMode\\":\\"normal\\"}]}}"}
+                  ]
+                }
+                """;
+
+        ExperimentPipelineJobCompletionPayload payload = client.generate(new ExperimentPipelineJobDto(
+                UUID.randomUUID(), 38L, "landing-page-html", "gpt-5.2", "prompt", requestBody, Instant.now()));
+
+        Map<String, Object> htmlContent = MAPPER.readValue(payload.responseContent(), new TypeReference<>() {});
+        @SuppressWarnings("unchecked")
+        Map<String, Object> html = (Map<String, Object>) htmlContent.get("landingPageHtml");
+        String htmlDocument = String.valueOf(html.get("htmlDocument"));
+        assertThat(htmlDocument).contains("data-section-id='hero' data-surface-token=\"surface-hero\" data-surface-style=\"band\" data-surface-contrast=\"high\"");
+        assertThat(htmlDocument).contains("data-section-id='proof' data-surface-token=\"surface-proof\" data-surface-style=\"solid\" data-surface-contrast=\"normal\"");
+    }
+
+    @Test
     void failsFastWhenLandingHtmlCannotReproduceWireframeSurfaceSpec() {
         String htmlText = """
                 {

--- a/docs/canonical/matriz-responsabilidades-pipeline-landing.md
+++ b/docs/canonical/matriz-responsabilidades-pipeline-landing.md
@@ -19,6 +19,14 @@ Documento operacional para leitura rápida, separando **quem é responsável por
 - **Visual (`designPreset`)**: `surfaceStyle` + `contrastMode` por `sectionId`.
 - **HTML final (`LHM`)**: combina os dois contratos e publica os `data-*` aderentes.
 
+### Regra anti-duplicidade (fonte de verdade única por campo)
+
+- Não há duplicidade de responsabilidade quando os campos são separados por natureza:
+  - `surfaceToken` → **exclusivo** do `landingPageWireframe.sectionOrder[*].surfaceSpec`.
+  - `surfaceStyle` e `contrastMode` → **exclusivos** do `landingPageDesignPreset.sectionPresets[*]`.
+- Se `style/contrastMode` aparecerem no wireframe por legado, devem ser tratados apenas como fallback transitório; a fonte de verdade vigente continua sendo o design preset.
+- Em conflito entre valores, prevalece `landingPageDesignPreset` para `style/contrastMode` e prevalece o wireframe para `surfaceToken` e `sectionId`.
+
 ## Gate antecipado antes de HTML
 
 Além do fechamento de cada etapa, o backend executa pré-validação antes de gerar `landingPageHtml` para bloquear inconsistências de artefatos cedo (sem esperar o erro final de publicação).

--- a/docs/canonical/matriz-responsabilidades-pipeline-landing.md
+++ b/docs/canonical/matriz-responsabilidades-pipeline-landing.md
@@ -3,6 +3,8 @@
 ## Objetivo
 Documento operacional para leitura rápida, separando **quem é responsável por cada item** no pipeline e quais validações de fechamento existem em cada etapa.
 
+> Para visão campo-a-campo com dono único, consulte também: `docs/canonical/matriz-responsaveis-unicos-itens-artefato.md`.
+
 ## Mapa por etapa
 
 | Etapa | Responsabilidade principal | Itens canônicos sob responsabilidade | Validação pesada no fechamento (`complete`) |

--- a/docs/canonical/matriz-responsaveis-unicos-itens-artefato.md
+++ b/docs/canonical/matriz-responsaveis-unicos-itens-artefato.md
@@ -1,0 +1,98 @@
+# Matriz detalhada — responsável único por item de artefato (pipeline de experimento)
+
+## Objetivo
+Definir, sem ambiguidade, **um único responsável canônico por campo/path** dos artefatos do pipeline de experimento, evitando co-ownership e divergência entre módulos/etapas.
+
+## Regra geral de ownership
+- Cada campo/path abaixo possui **apenas 1 dono canônico**.
+- Outros estágios podem **consumir** o campo, mas não redefinir sua fonte de verdade.
+- Em conflito, prevalece sempre o dono indicado nesta matriz.
+
+## Convenção de leitura
+- **Dono canônico**: etapa/módulo autorizado a definir o valor final do campo.
+- **Consumidores principais**: etapas que usam o campo sem serem donas.
+- **Gate de validação**: onde o backend rejeita inconsistência.
+
+---
+
+## 1) Envelope e metadados comuns
+
+| Path canônico | Dono canônico | Consumidores principais | Gate de validação |
+|---|---|---|---|
+| `experimentMetadata.primary_variable` | `campaign-angle` | todas as etapas seguintes | validação de metadados no `complete` da etapa atual |
+| `experimentMetadata.variant_id` | Backend (orquestração do experimento) | todas as etapas | criação de prompt e validação de lineage |
+| `experimentMetadata.stage` | Backend (estado do experimento) | todas as etapas | validação de consistência de estágio |
+| `experimentMetadata.control_or_treatment` | Backend (orquestração) | todas as etapas | validação de metadado obrigatório |
+| `experimentMetadata.asset_role` | Etapa dona do artefato corrente | backend + worker | validação de contrato por seção |
+
+## 2) `campaignAngle`
+
+| Path canônico | Dono canônico | Consumidores principais | Gate de validação |
+|---|---|---|---|
+| `campaignAngle.primaryMessage` | `campaign-angle` | `ad-copy`, `landingPageCopy` | `complete` da etapa `campaign-angle` |
+| `campaignAngle.mechanismSummary` | `campaign-angle` | `landingPageCopy`, `landingPageWireframe` | `complete` da etapa `campaign-angle` |
+| `campaignAngle.proofSummary` | `campaign-angle` | `landingPageCopy`, `landingPageWireframe` | `complete` da etapa `campaign-angle` |
+| `campaignAngle.ctaAnchor` | `campaign-angle` | `ad-copy`, `landingPageCopy`, `landingPageWireframe` | checks de continuidade |
+
+## 3) `landingPageCopy`
+
+| Path canônico | Dono canônico | Consumidores principais | Gate de validação |
+|---|---|---|---|
+| `landingPageCopy.pageGoal` | `landing-page-copy` | `landingPageWireframe`, `landingPageHtml` | `complete` da etapa `landing-page-copy` |
+| `landingPageCopy.primaryCTA` | `landing-page-copy` | `landingPageWireframe`, `landingPageHtml` | checks `CTA_MATCH` |
+| `landingPageCopy.hero.*` | `landing-page-copy` | `landingPageHtml` | estrutura mínima de hero no fechamento |
+| `landingPageCopy.bodySections[*]` | `landing-page-copy` | `landingPageWireframe`, `landingPageHtml` | validação de lista e conteúdo |
+| `landingPageCopy.ctaBlocks[*]` | `landing-page-copy` | `landingPageHtml` | coerência de CTA |
+| `landingPageCopy.consistencyChecks` | `landing-page-copy` | backend (gate) | obrigatórios `CTA_MATCH` + `PROMISE_MATCH` |
+
+## 4) `landingPageWireframe`
+
+| Path canônico | Dono canônico | Consumidores principais | Gate de validação |
+|---|---|---|---|
+| `landingPageWireframe.sectionOrder[*].sectionId` | `landing-page-wireframe` | `landingPageImagePlanning`, `landingPageDesignPreset`, `landingPageHtml` | validação de estrutura e cobertura por seção |
+| `landingPageWireframe.sectionOrder[*].surfaceSpec.surfaceToken` | `landing-page-wireframe` | `landingPageHtml` | validação de surface binding |
+| `landingPageWireframe.sectionOrder[*].surfaceSpec.notes` | `landing-page-wireframe` | `landingPageHtml` (suporte) | validação estrutural do wireframe |
+| `landingPageWireframe.formSpec.*` | `landing-page-wireframe` | `landingPageHtml`, apply-to-form | validação determinística de formulário |
+| `landingPageWireframe.readingFlowSpec.*` | `landing-page-wireframe` | `landingPageHtml` | gate de qualidade do wireframe |
+| `landingPageWireframe.conversionPathSpec.*` | `landing-page-wireframe` | `landingPageHtml` | gate de continuidade/comercial |
+
+## 5) `landingPageImagePlanning`
+
+| Path canônico | Dono canônico | Consumidores principais | Gate de validação |
+|---|---|---|---|
+| `landingPageImagePlanning.images[*].sectionId` | `landing-page-image-planning` | `landingPageHtml` | cobertura obrigatória de todas as seções do wireframe |
+| `landingPageImagePlanning.images[*].imageBindingKey` | `landing-page-image-planning` | `landingPageHtml` | unicidade e vínculo por seção |
+| `landingPageImagePlanning.images[*].(webUrl/imageUrl/sourceUrl/url)` | `landing-page-image-planning` | `landingPageHtml` | validação de imagem canônica |
+| `landingPageImagePlanning.consistencyChecks` | `landing-page-image-planning` | backend (gate) | obrigatórios `IMAGE_MESSAGE_MATCH` + `CTA_CONTINUITY` |
+
+## 6) `landingPageDesignPreset`
+
+| Path canônico | Dono canônico | Consumidores principais | Gate de validação |
+|---|---|---|---|
+| `landingPageDesignPreset.sectionPresets[*].sectionId` | `landing-page-design-preset` | `landingPageHtml` | cobertura 1:1 com `wireframe.sectionOrder.sectionId` |
+| `landingPageDesignPreset.sectionPresets[*].surfaceStyle` | `landing-page-design-preset` | `landingPageHtml` | validação de surface binding visual |
+| `landingPageDesignPreset.sectionPresets[*].contrastMode` | `landing-page-design-preset` | `landingPageHtml` | validação de surface binding visual |
+| `landingPageDesignPreset.theme.*` | `landing-page-design-preset` | `landingPageHtml` | validação de tema e acessibilidade |
+| `landingPageDesignPreset.componentPresets.*` | `landing-page-design-preset` | `landingPageHtml` | validação de completude de preset |
+| `landingPageDesignPreset.consistencyChecks` | `landing-page-design-preset` | backend (gate) | checks obrigatórios do preset |
+
+## 7) `landingPageHtml`
+
+| Path canônico | Dono canônico | Consumidores principais | Gate de validação |
+|---|---|---|---|
+| `landingPageHtml.htmlDocument` | `landing-page-html` | publicação + apply-to-form + Lead Portal | validação determinística final |
+| `htmlDocument[data-section-id]` | `landing-page-html` (implementação), com source-of-truth de `wireframe.sectionId` | backend (validador) | divergência de superfície (422) |
+| `htmlDocument[data-surface-token]` | `landing-page-html` (implementação), com source-of-truth de `wireframe.surfaceToken` | backend (validador) | divergência de superfície (422) |
+| `htmlDocument[data-surface-style]` | `landing-page-html` (implementação), com source-of-truth de `designPreset.surfaceStyle` | backend (validador) | divergência de superfície (422) |
+| `htmlDocument[data-surface-contrast]` | `landing-page-html` (implementação), com source-of-truth de `designPreset.contrastMode` | backend (validador) | divergência de superfície (422) |
+| `landingPageHtml.formSpec.*` | `landing-page-html` (implementação), com source-of-truth de `wireframe.formSpec` | apply-to-form | divergência de formulário (422) |
+
+---
+
+## Regra de precedência para conflitos (normativa)
+1. **Estrutura** (`sectionId`, `surfaceToken`, `formSpec`) → prevalece `landingPageWireframe`.
+2. **Visual por seção** (`surfaceStyle`, `contrastMode`) → prevalece `landingPageDesignPreset`.
+3. **Renderização final** (`htmlDocument`) deve refletir fielmente 1 + 2; divergência reprova no `complete`.
+
+## Escopo
+Esta matriz cobre os artefatos canônicos do pipeline principal de experimento (`campaign-angle` até `landing-page-html`). Artefatos de Avatar Sales Video permanecem sob seu cânone específico.

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -331,6 +331,7 @@ Para considerar a copy **rica** e **compatível com as especificações**, a eta
 > **Responsabilidade canônica (vigente):**
 > - `landingPageWireframe` define **estrutura** (ordem, hierarquia, intenção de seção) e mantém em `surfaceSpec` apenas a âncora estrutural (`surfaceToken` + `notes`).
 > - `style` e `contrastMode` são responsabilidade da etapa `landingPageDesignPreset.sectionPresets` (detalhe visual por `sectionId`).
+> - Não existe co-ownership de campo: `surfaceToken` pertence ao wireframe; `style/contrastMode` pertencem ao design preset. Em caso de divergência, `landingPageDesignPreset` prevalece para os campos visuais.
 > - Após `complete` da etapa de wireframe, o backend valida presença de `sectionOrder` estruturado e `surfaceSpec.surfaceToken` por seção antes de aceitar o artefato.
 > - Antes de iniciar `landingPageHtml`, o backend executa pré-validação de consistência entre wireframe e design preset para antecipar falhas que antes apareciam apenas no fim do pipeline.
 

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,51 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0009 — Verificação da tentativa `b244db1f` (LANDING_PAGE_HTML com divergência de superfície)
+
+- **Data/Hora (UTC):** 2026-04-28
+- **Responsável:** Assistente Codex
+- **Módulo:** backend + ai-worker (integração de contrato)
+- **Ambiente:** Execução remota exibida no Marketing Hub (`experiments/15`)
+- **Execução/Teste:** Tentativa `b244db1f` (erro registrado em `28/04/2026, 10:14:37 BRT`)
+
+#### 1) Erro observado
+- **Sintoma:** etapa `LANDING_PAGE_HTML` terminou com erro de contrato de superfície.
+- **Endpoint/rota/fila:** fechamento do job em `POST /api/internal/experiment-pipeline/jobs/{jobId}/complete`.
+- **Status code:** 422.
+- **Mensagem de erro literal:** `Divergência de superfície: landing-page-html deve reproduzir exatamente landing-page-wireframe.sectionOrder.surfaceSpec`.
+- **Payload enviado (literal):** `landingPageHtml.htmlDocument` concluído pelo worker, porém rejeitado na validação determinística do backend.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** não disponível neste ambiente local (sem servidor MCP configurado no container).
+- **Dados de banco consultados via MCP:** não disponível neste ambiente local.
+- **Trecho canônico consultado:** `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` (contrato de superfície por seção para `landing-page-html`).
+- **Validação/regra que rejeitou:** comparação exata entre superfícies esperadas do wireframe e superfícies encontradas no HTML final.
+- **Causa raiz provável:** o HTML gerado para a tentativa não preservou correspondência 1:1 de `sectionId` + atributos `data-surface-*` exigidos pelo `sectionOrder.surfaceSpec` canônico.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** HTML final aceito sintaticamente, mas com conjunto de superfícies divergente do wireframe aprovado.
+- **O que a especificação esperava (literal):** todas as seções do `landingPageWireframe.sectionOrder` renderizadas no HTML com `data-section-id`, `data-surface-token`, `data-surface-style` e `data-surface-contrast` equivalentes.
+- **Diferença objetiva:** divergência de superfície (falta/sobra de seção e/ou atributos de superfície diferentes do wireframe/preset por seção).
+- **Ação corretiva recomendada:** regenerar `LANDING_PAGE_HTML` usando exatamente o wireframe/preset já aprovados e validar localmente a matriz `sectionId + surfaceSpec` antes do `/complete`.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** documentação operacional de incidente.
+- **Arquivos alterados:**
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** inclusão do registro formal da verificação da tentativa `b244db1f`, com diagnóstico estruturado 422 e ação corretiva orientada a contrato canônico.
+
+#### 5) Reteste
+- **Procedimento de reteste:** não executado neste container (somente registro e análise documental da tentativa remota).
+- **Resultado:** pendente de nova execução integrada no ambiente alvo.
+- **Evidências (logs/ids/prints):** print da UI com tentativa `b244db1f` e mensagem de erro de divergência de superfície.
+- **Status final:** Pendente (aguarda nova tentativa após regeneração do HTML).
+
+#### 6) Próximo passo
+- **Ação seguinte:** disparar nova execução de `LANDING_PAGE_HTML` no experimento 15 após confirmar alinhamento estrito de `surfaceSpec` por seção.
+- **Dono da ação:** Time do AI Worker + responsável da operação do experimento.
+- **Prazo:** imediata (na próxima janela de reprocessamento).
+
 ### INC-0008 — LANDING_PAGE_HTML não validava surfaceSpec quando prompt vinha no formato “Prompt v2”
 
 - **Data/Hora (UTC):** 2026-04-28

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -120,6 +120,17 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 - **Dono da ação:** Time do AI Worker + responsável da operação do experimento.
 - **Prazo:** imediata (na próxima janela de reprocessamento).
 
+#### 7) Confirmação MCP (amostras da execução mais recente do experimento 15)
+- **MCP Server utilizado:** `https://mcpserverdigi.shop/mcp` (JSON-RPC, ferramentas `db_query` e `java_module_logs`).
+- **Amostra 1 — tentativa com erro (`b244db1f-aa3d-41a5-9c65-5e68cf372016`):**
+  - `experiment_pipeline_generation_job.error_message` retornou `422` com mensagem literal de divergência de superfície.
+  - Em `request_body_json` da mesma tentativa (Prompt v2), o `landingPageWireframe.sectionOrder` trazia `footer-legal` com `contrastMode=normal`.
+  - No mesmo prompt, `landingPageDesignPreset.sectionPresets` trazia `footer-legal` com `contrastMode=soft`.
+- **Amostra 2 — estado mais recente persistido no experimento 15 (`experiment.landing_page_html`):**
+  - Extração do HTML persistido mostrou `data-section-id="footer-legal"` com `data-surface-contrast="soft"`.
+  - Isso confirma o contrato atual: `surfaceToken` vem do wireframe, enquanto `style/contrast` devem seguir o design preset por seção.
+- **Conclusão confirmada com MCP:** a diferença crítica observada na execução recente foi a seção `footer-legal` (`normal` no wireframe vs `soft` no design preset), validando que o worker precisa priorizar preset para `style/contrast` na etapa `LANDING_PAGE_HTML`.
+
 ### INC-0008 — LANDING_PAGE_HTML não validava surfaceSpec quando prompt vinha no formato “Prompt v2”
 
 - **Data/Hora (UTC):** 2026-04-28

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -463,11 +463,12 @@ Regras:
 14. Não criar seções desnecessárias.
 15. Cada seção deve declarar mediaSlot (none, image, illustration, chart, icon-set ou video-thumb) com a função visual esperada.
 16. Cada seção deve declarar compositionNotes com instruções de composição e hierarquia visual para guiar a etapa de HTML.
-17. Cada seção deve declarar surfaceSpec com: surfaceToken, style, contrastMode e notes para formalizar a superfície visual.
+17. Cada seção deve declarar surfaceSpec com: surfaceToken e notes (âncora estrutural da seção).
 18. Use surfaceToken alternando entre surface-base e surface-alt-* para melhorar escaneabilidade entre seções consecutivas.
-19. Não transformar o layout em HTML final; foque apenas em ordem, hierarquia, slots e leitura mobile-first.
-20. Se a estrutura puder servir para qualquer nicho, reescreva até ficar específica para {nicho}.
-21. Defina formSpec como contrato estruturado único do formulário com:
+19. Não definir style/contrastMode no wireframe como fonte primária; esses campos pertencem ao landing-page-design-preset.sectionPresets.
+20. Não transformar o layout em HTML final; foque apenas em ordem, hierarquia, slots e leitura mobile-first.
+21. Se a estrutura puder servir para qualquer nicho, reescreva até ficar específica para {nicho}.
+22. Defina formSpec como contrato estruturado único do formulário com:
     - formId: "lead-capture-primary"
     - title: "Receber a prévia do Kit (IA)"
     - submitLabel: "Desbloquear o Kit (receber a prévia gerada por IA)"
@@ -502,8 +503,6 @@ artifact {
     "sectionDependsOn": "",
     "surfaceSpec": {
       "surfaceToken": "surface-alt-1",
-      "style": "band",
-      "contrastMode": "normal",
       "notes": "Seção com fundo alternado para contraste sutil com a anterior"
     }
       }
@@ -537,7 +536,10 @@ Regras:
    - layout da landing para ordem/hierarquia e mediaSlot;
    - planejamento de imagens para posicionamento visual e altText;
    - wireframe.formSpec para renderizar exatamente os campos e obrigatoriedade do formulário.
-7. Aplicar cada wireframe.sectionOrder[i].surfaceSpec sem reinterpretar, usando data-section-id + data-surface-token + data-surface-style + data-surface-contrast na seção correspondente.
+7. Aplicar superfícies por origem canônica dividida:
+   - data-surface-token vem de wireframe.sectionOrder[i].surfaceSpec.surfaceToken
+   - data-surface-style e data-surface-contrast vêm de landingPageDesignPreset.sectionPresets por sectionId
+   - usar data-section-id na seção correspondente para binding determinístico.
 8. Não inventar estrutura visual fora do layout/plano de imagens sem justificar nos consistencyChecks.
 9. É proibido inventar/remover/renomear campos do formulário fora do formSpec.
 10. Não usar dependências externas.


### PR DESCRIPTION
### Motivation
- Ensure the worker validates `landing-page-html` against the canonical `landingPageWireframe.sectionOrder.surfaceSpec` even when the wireframe omits `style`/`contrastMode` by using an approved design preset present in the prompt.
- Improve robustness of surface attribute extraction so different prompt variants (e.g. "Prompt v2") are parsed correctly.

### Description
- Updated `extractExpectedSurfacesFromRequestPayload` to consider a per-section visual preset when `style` or `contrastMode` are omitted in the wireframe by calling `extractDesignPresetJsonBlock` and `extractSectionVisualPresetsBySection`.
- Added `extractDesignPresetJsonBlock`, `extractSectionVisualPresetsBySection`, `normalizeLookupKey`, and `firstNonBlank` helpers plus a new `SectionVisualPresetContract` record to parse and normalize design-preset JSON embedded in prompts.
- Kept existing wireframe JSON extraction behavior and used `firstNonBlank` to prefer preset values while falling back to explicit wireframe fields.
- Documented the operational incident in `docs/registro-ajustes-pipeline-experimento.md` and added a unit test `synchronizesLandingHtmlSurfaceAttributesUsingDesignPresetWhenWireframeOmitsStyleAndContrast` in `ExperimentPipelineOpenAiClientTest` to cover the new behavior.

### Testing
- Ran unit tests in `ExperimentPipelineOpenAiClientTest`, including the new `synchronizesLandingHtmlSurfaceAttributesUsingDesignPresetWhenWireframeOmitsStyleAndContrast` test, and they succeeded.
- Ran the affected HTML-surface contract validation tests and they passed, verifying that `data-surface-style` and `data-surface-contrast` are applied from the design preset when wireframe omits them.
- No automated integration tests were modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b3031e5883219b9d8fd96d06bff5)