### PR TITLE
Validate landing-page HTML reproduces image-planning bindings and fail-fast on mismatch

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -274,6 +274,7 @@ public class ExperimentPipelineOpenAiClient {
             log.info("OpenAI content for job {}: {}", job.id(), content);
             Map<String, Object> parsed = parseResponseContent(content, job);
             enforceLandingHtmlSurfaceBinding(parsed, payload, job, content);
+            enforceLandingHtmlImagePlanningBinding(parsed, payload, job, content);
             validateExpectedResponseContract(parsed, content, job);
             enrichConsistencyChecks(parsed, job);
             String sectionContent = objectMapper.writeValueAsString(parsed);
@@ -539,6 +540,39 @@ public class ExperimentPipelineOpenAiClient {
     }
 
     @SuppressWarnings("unchecked")
+    private void enforceLandingHtmlImagePlanningBinding(Map<String, Object> parsed,
+                                                        Map<String, Object> requestPayload,
+                                                        ExperimentPipelineJobDto job,
+                                                        String rawContent) {
+        if (!isLandingHtmlSection(job) || parsed == null) {
+            return;
+        }
+        Object nestedPayload = parsed.get("landingPageHtml");
+        Map<String, Object> landingPayload = nestedPayload instanceof Map<?, ?> map
+                ? (Map<String, Object>) map
+                : parsed;
+        String htmlDocument = readString(landingPayload, LANDING_HTML_MARKER);
+        if (!StringUtils.hasText(htmlDocument)) {
+            return;
+        }
+        List<SectionImageBindingContract> expectedBindings = extractExpectedImageBindingsFromRequestPayload(requestPayload);
+        if (expectedBindings.isEmpty()) {
+            return;
+        }
+        List<SectionImageBindingContract> expectedSorted = expectedBindings.stream()
+                .sorted(java.util.Comparator.comparing(SectionImageBindingContract::sectionId))
+                .toList();
+        List<SectionImageBindingContract> actualSorted = extractImageBindingsFromHtml(htmlDocument).stream()
+                .sorted(java.util.Comparator.comparing(SectionImageBindingContract::sectionId))
+                .toList();
+        if (!expectedSorted.equals(actualSorted)) {
+            String reason = "Quebra de contrato: LANDING_PAGE_HTML divergente de landing-page-image-planning.images[].sectionId/imageBindingKey.";
+            logContractBreak(job, reason, rawContent, null);
+            throw new IllegalStateException(reason);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
     private List<SectionSurfaceContract> extractExpectedSurfacesFromRequestPayload(Map<String, Object> requestPayload) {
         String userPrompt = extractUserPromptFromRequestPayload(requestPayload);
         if (!StringUtils.hasText(userPrompt)) {
@@ -656,6 +690,79 @@ public class ExperimentPipelineOpenAiClient {
             return null;
         }
         int rootStart = userPrompt.lastIndexOf('{', designPresetKeyIndex);
+        if (rootStart < 0) {
+            return null;
+        }
+        return extractBalancedJsonObject(userPrompt, rootStart);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<SectionImageBindingContract> extractExpectedImageBindingsFromRequestPayload(Map<String, Object> requestPayload) {
+        String userPrompt = extractUserPromptFromRequestPayload(requestPayload);
+        if (!StringUtils.hasText(userPrompt)) {
+            return List.of();
+        }
+        String imagePlanningJson = extractImagePlanningJsonBlock(userPrompt);
+        if (!StringUtils.hasText(imagePlanningJson)) {
+            return List.of();
+        }
+        try {
+            Map<String, Object> root = objectMapper.readValue(imagePlanningJson, new TypeReference<>() {});
+            Object planningNode = root.get("landingPageImagePlanning");
+            Map<String, Object> planning = planningNode instanceof Map<?, ?> map
+                    ? (Map<String, Object>) map
+                    : root;
+            Object imagesNode = planning.get("images");
+            if (!(imagesNode instanceof List<?> images)) {
+                return List.of();
+            }
+            Map<String, SectionImageBindingContract> bindingsBySection = new LinkedHashMap<>();
+            for (Object image : images) {
+                if (!(image instanceof Map<?, ?> imageMap)) {
+                    continue;
+                }
+                Map<String, Object> imageData = (Map<String, Object>) imageMap;
+                String sectionId = normalizeHtmlAttr(readString(imageData, "sectionId"));
+                String imageBindingKey = normalizeHtmlAttr(readString(imageData, "imageBindingKey"));
+                if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(imageBindingKey)) {
+                    continue;
+                }
+                bindingsBySection.put(sectionId, new SectionImageBindingContract(sectionId, imageBindingKey));
+            }
+            return new ArrayList<>(bindingsBySection.values());
+        } catch (Exception ex) {
+            log.warn("Falha ao extrair image planning do prompt para validar imageBindingKey: {}", ex.getMessage());
+            return List.of();
+        }
+    }
+
+    private String extractImagePlanningJsonBlock(String userPrompt) {
+        if (!StringUtils.hasText(userPrompt)) {
+            return null;
+        }
+        List<String> candidateMarkers = List.of(
+                "Planejamento de imagens da landing:",
+                "Planejamento de imagens aprovado (JSON):",
+                "4) Planejamento de imagens aprovado (JSON):");
+        for (String marker : candidateMarkers) {
+            int markerIndex = userPrompt.indexOf(marker);
+            if (markerIndex < 0) {
+                continue;
+            }
+            int jsonStart = userPrompt.indexOf('{', markerIndex);
+            if (jsonStart < 0) {
+                continue;
+            }
+            String jsonBlock = extractBalancedJsonObject(userPrompt, jsonStart);
+            if (StringUtils.hasText(jsonBlock)) {
+                return jsonBlock;
+            }
+        }
+        int planningKeyIndex = userPrompt.indexOf("\"landingPageImagePlanning\"");
+        if (planningKeyIndex < 0) {
+            return null;
+        }
+        int rootStart = userPrompt.lastIndexOf('{', planningKeyIndex);
         if (rootStart < 0) {
             return null;
         }
@@ -822,6 +929,24 @@ public class ExperimentPipelineOpenAiClient {
         return new ArrayList<>(contractsBySectionId.values());
     }
 
+    private List<SectionImageBindingContract> extractImageBindingsFromHtml(String htmlDocument) {
+        if (!StringUtils.hasText(htmlDocument)) {
+            return List.of();
+        }
+        Map<String, SectionImageBindingContract> contractsBySectionId = new LinkedHashMap<>();
+        Matcher tagMatcher = HTML_OPENING_TAG_PATTERN.matcher(htmlDocument);
+        while (tagMatcher.find()) {
+            String tag = tagMatcher.group();
+            String sectionId = normalizeHtmlAttr(readAttribute(tag, "data-image-section-id"));
+            String imageBindingKey = normalizeHtmlAttr(readAttribute(tag, "data-image-binding-key"));
+            if (!StringUtils.hasText(sectionId) || !StringUtils.hasText(imageBindingKey)) {
+                continue;
+            }
+            contractsBySectionId.put(sectionId, new SectionImageBindingContract(sectionId, imageBindingKey));
+        }
+        return new ArrayList<>(contractsBySectionId.values());
+    }
+
     private String readAttribute(String tag, String attributeName) {
         if (!StringUtils.hasText(tag) || !StringUtils.hasText(attributeName)) {
             return "";
@@ -878,6 +1003,9 @@ public class ExperimentPipelineOpenAiClient {
     }
 
     private record SectionVisualPresetContract(String style, String contrastMode) {
+    }
+
+    private record SectionImageBindingContract(String sectionId, String imageBindingKey) {
     }
 
     @SuppressWarnings("unchecked")

--- a/ai-worker/src/main/resources/prompts/experiment/landing-html.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-html.md
@@ -1,5 +1,5 @@
 template_id: landing-html
-template_version: v1
+template_version: v2
 artifact_target: landingPageHtml
 
 SYSTEM_INSTRUCTIONS
@@ -33,6 +33,21 @@ Regras fixas da etapa:
 18. Manter headline curta, títulos comerciais e layout compacto no mobile.
 19. Não usar taxonomia interna (`entryAsset`, `coreOffer` etc.) como rótulo visível da landing.
 20. Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
+21. Antes de começar a escrever o HTML, monte internamente a matriz obrigatória `surfaceMatrix[]` com `sectionId + surfaceToken + surfaceStyle + surfaceContrast` usando `landingPageWireframe.sectionOrder` + `landingPageDesignPreset.sectionPresets`.
+22. Antes de começar a escrever o HTML, monte internamente a matriz obrigatória `imageMatrix[]` com `sectionId + imageBindingKey` usando `landingPageImagePlanning.images[]`.
+23. Renderize explicitamente **todas** as seções de `landingPageWireframe.sectionOrder` e somente elas (proibido faltar ou sobrar `sectionId`).
+24. Cada `<section>` renderizada deve conter: `data-section-id`, `data-surface-token`, `data-surface-style` e `data-surface-contrast` coerentes com a `surfaceMatrix[]`.
+25. Para cada item de `imageMatrix[]`, renderize um nó visual explícito com `data-image-section-id="<sectionId>"` e `data-image-binding-key="<imageBindingKey>"` exatamente iguais ao planejamento.
+26. É proibido reutilizar o mesmo `imageBindingKey` em seção diferente daquela definida em `imageMatrix[]`.
+27. Não finalize sem executar checklist interno obrigatório de contrato:
+    - `missingSections = sectionOrder.sectionId - html[data-section-id]`
+    - `extraSections = html[data-section-id] - sectionOrder.sectionId`
+    - `missingImageBindings = imageMatrix - html[data-image-section-id + data-image-binding-key]`
+    - `extraImageBindings = html[data-image-section-id + data-image-binding-key] - imageMatrix`
+    - só finalize quando `missingSections=[]`, `extraSections=[]`, `missingImageBindings=[]` e `extraImageBindings=[]`.
+28. Se qualquer checklist interno falhar, reescreva o HTML completo antes de responder; não devolva versão parcial.
+29. Use os mesmos `sectionId` e `imageBindingKey` de forma **literal** (case-sensitive, sem renomear, traduzir ou normalizar).
+30. `consistencyChecks` deve refletir esse contrato com evidência objetiva para `IMAGE_PLAN_BINDING` e `SURFACE_SPEC_BINDING`.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -1372,6 +1372,82 @@ class ExperimentPipelineOpenAiClientTest {
                 .hasMessageContaining("Quebra de contrato: LANDING_PAGE_HTML divergente de landing-page-wireframe.sectionOrder.surfaceSpec.");
     }
 
+    @Test
+    void acceptsLandingHtmlWhenImagePlanningBindingsMatchExactly() throws Exception {
+        String htmlText = """
+                {
+                  "landingPageHtml": {
+                    "htmlDocument": "<!doctype html><html><body><section data-section-id='hero' data-surface-token='surface-hero' data-surface-style='band' data-surface-contrast='high'><img data-image-section-id='hero' data-image-binding-key='hero-main' alt='Hero'></section><section data-section-id='proof' data-surface-token='surface-proof' data-surface-style='solid' data-surface-contrast='normal'><img data-image-section-id='proof' data-image-binding-key='proof-packshot' alt='Proof'></section></body></html>",
+                    "summary": "ok",
+                    "formSpec": {"formId": "lead-capture-primary"},
+                    "imagePlacementContract": {"requiredDataAttributes": []},
+                    "consistencyChecks": []
+                  }
+                }
+                """;
+
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(new AtomicReference<>(), htmlText)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        String requestBody = """
+                {
+                  "model":"gpt-5.2",
+                  "input":[
+                    {"role":"user","content":"Prompt\\nWireframe da landing:\\n{\\"landingPageWireframe\\":{\\"sectionOrder\\":[{\\"sectionId\\":\\"hero\\",\\"surfaceSpec\\":{\\"surfaceToken\\":\\"surface-hero\\",\\"style\\":\\"band\\",\\"contrastMode\\":\\"high\\"}},{\\"sectionId\\":\\"proof\\",\\"surfaceSpec\\":{\\"surfaceToken\\":\\"surface-proof\\",\\"style\\":\\"solid\\",\\"contrastMode\\":\\"normal\\"}}]}}\\nPlanejamento de imagens da landing:\\n{\\"landingPageImagePlanning\\":{\\"images\\":[{\\"sectionId\\":\\"hero\\",\\"imageBindingKey\\":\\"hero-main\\"},{\\"sectionId\\":\\"proof\\",\\"imageBindingKey\\":\\"proof-packshot\\"}]}}"}
+                  ]
+                }
+                """;
+
+        ExperimentPipelineJobCompletionPayload payload = client.generate(new ExperimentPipelineJobDto(
+                UUID.randomUUID(), 39L, "landing-page-html", "gpt-5.2", "prompt", requestBody, Instant.now()));
+
+        Map<String, Object> htmlContent = MAPPER.readValue(payload.responseContent(), new TypeReference<>() {});
+        @SuppressWarnings("unchecked")
+        Map<String, Object> html = (Map<String, Object>) htmlContent.get("landingPageHtml");
+        String htmlDocument = String.valueOf(html.get("htmlDocument"));
+        assertThat(htmlDocument).contains("data-image-section-id='hero' data-image-binding-key='hero-main'");
+        assertThat(htmlDocument).contains("data-image-section-id='proof' data-image-binding-key='proof-packshot'");
+    }
+
+    @Test
+    void failsFastWhenLandingHtmlCannotReproduceImagePlanningBinding() {
+        String htmlText = """
+                {
+                  "landingPageHtml": {
+                    "htmlDocument": "<!doctype html><html><body><section data-section-id='hero' data-surface-token='surface-hero' data-surface-style='band' data-surface-contrast='high'><img data-image-section-id='hero' data-image-binding-key='hero-main' alt='Hero'></section><section data-section-id='proof' data-surface-token='surface-proof' data-surface-style='solid' data-surface-contrast='normal'><img data-image-section-id='proof' data-image-binding-key='proof-wrong' alt='Proof'></section></body></html>",
+                    "summary": "ok",
+                    "formSpec": {"formId": "lead-capture-primary"},
+                    "imagePlacementContract": {"requiredDataAttributes": []},
+                    "consistencyChecks": []
+                  }
+                }
+                """;
+
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(new AtomicReference<>(), htmlText)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        String requestBody = """
+                {
+                  "model":"gpt-5.2",
+                  "input":[
+                    {"role":"user","content":"Prompt v2\\n1) Wireframe aprovado (JSON):\\n{\\"landingPageWireframe\\":{\\"sectionOrder\\":[{\\"sectionId\\":\\"hero\\",\\"surfaceSpec\\":{\\"surfaceToken\\":\\"surface-hero\\",\\"style\\":\\"band\\",\\"contrastMode\\":\\"high\\"}},{\\"sectionId\\":\\"proof\\",\\"surfaceSpec\\":{\\"surfaceToken\\":\\"surface-proof\\",\\"style\\":\\"solid\\",\\"contrastMode\\":\\"normal\\"}}]}}\\n2) Copy aprovada (JSON):\\n{}\\n3) Preset de design aprovado (JSON):\\n{}\\n4) Planejamento de imagens aprovado (JSON):\\n{\\"landingPageImagePlanning\\":{\\"images\\":[{\\"sectionId\\":\\"hero\\",\\"imageBindingKey\\":\\"hero-main\\"},{\\"sectionId\\":\\"proof\\",\\"imageBindingKey\\":\\"proof-packshot\\"}]}}"}
+                  ]
+                }
+                """;
+
+        Throwable thrown = catchThrowable(() -> client.generate(new ExperimentPipelineJobDto(
+                UUID.randomUUID(), 40L, "landing-page-html", "gpt-5.2", "prompt", requestBody, Instant.now())));
+
+        assertThat(thrown).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Quebra de contrato: LANDING_PAGE_HTML divergente de landing-page-image-planning.images[].sectionId/imageBindingKey.");
+    }
+
     private ExchangeFunction capturePayloadExchange(AtomicReference<Map<String, Object>> payloadRef) {
         return capturePayloadExchange(payloadRef, "{\"content\":\"ok\"}");
     }

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -249,6 +249,49 @@ class ExperimentPipelineOpenAiClientTest {
     }
 
     @Test
+    void prependsLandingHtmlGuidanceWithExplicitBindingChecklist() {
+        AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(payloadRef)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        ExperimentPipelineJobDto job = new ExperimentPipelineJobDto(
+                UUID.randomUUID(),
+                14L,
+                "landing-page-html",
+                "gpt-5.2",
+                "prompt",
+                """
+                        {
+                          "model": "gpt-5.2",
+                          "input": [
+                            {"role": "user", "content": "Prompt de html"}
+                          ]
+                        }
+                        """,
+                Instant.now());
+
+        client.generate(job);
+
+        Map<String, Object> payload = payloadRef.get();
+        @SuppressWarnings("unchecked")
+        var input = (java.util.List<Map<String, Object>>) payload.get("input");
+        String userPrompt = String.valueOf(input.get(0).get("content"));
+        assertThat(userPrompt).contains("surfaceMatrix[]");
+        assertThat(userPrompt).contains("imageMatrix[]");
+        assertThat(userPrompt).contains("data-image-section-id");
+        assertThat(userPrompt).contains("data-image-binding-key");
+        assertThat(userPrompt).contains("missingSections");
+        assertThat(userPrompt).contains("extraSections");
+        assertThat(userPrompt).contains("missingImageBindings");
+        assertThat(userPrompt).contains("extraImageBindings");
+        assertThat(userPrompt).contains("só finalize quando `missingSections=[]`, `extraSections=[]`, `missingImageBindings=[]` e `extraImageBindings=[]`");
+        assertThat(userPrompt).contains("case-sensitive");
+    }
+
+    @Test
     void injectsStructuredCaseDataBlockIntoSectionTemplate() {
         AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
         ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -261,7 +261,7 @@ class ExperimentPipelineOpenAiClientTest {
                 UUID.randomUUID(),
                 14L,
                 "landing-page-html",
-                "gpt-5.2",
+                "gpt-5.1-codex",
                 "prompt",
                 """
                         {
@@ -643,7 +643,7 @@ class ExperimentPipelineOpenAiClientTest {
                 UUID.randomUUID(),
                 20L,
                 "landing-page-html",
-                "gpt-5.2",
+                "gpt-5.1-codex",
                 "prompt",
                 """
                         {
@@ -697,7 +697,7 @@ class ExperimentPipelineOpenAiClientTest {
                 UUID.randomUUID(),
                 20L,
                 "LANDING_PAGE_HTML",
-                "gpt-5.2",
+                "gpt-5.1-codex",
                 "prompt",
                 """
                         {
@@ -745,7 +745,7 @@ class ExperimentPipelineOpenAiClientTest {
                 UUID.randomUUID(),
                 21L,
                 "LANDING_PAGE_HTML",
-                "gpt-5.2",
+                "gpt-5.1-codex",
                 "prompt",
                 """
                         {
@@ -794,7 +794,7 @@ class ExperimentPipelineOpenAiClientTest {
                 UUID.randomUUID(),
                 22L,
                 "LANDING_PAGE_HTML",
-                "gpt-5.2",
+                "gpt-5.1-codex",
                 "prompt",
                 """
                         {
@@ -838,7 +838,7 @@ class ExperimentPipelineOpenAiClientTest {
                 UUID.randomUUID(),
                 29L,
                 "LANDING_PAGE_HTML",
-                "gpt-5.2",
+                "gpt-5.1-codex",
                 "prompt",
                 """
                         {
@@ -882,7 +882,7 @@ class ExperimentPipelineOpenAiClientTest {
                 UUID.randomUUID(),
                 23L,
                 "LANDING_PAGE_HTML",
-                "gpt-5.2",
+                "gpt-5.1-codex",
                 "prompt",
                 """
                         {
@@ -923,7 +923,7 @@ class ExperimentPipelineOpenAiClientTest {
                 UUID.randomUUID(),
                 30L,
                 "LANDING_PAGE_HTML",
-                "gpt-5.2",
+                "gpt-5.1-codex",
                 "prompt",
                 """
                         {
@@ -1002,6 +1002,46 @@ class ExperimentPipelineOpenAiClientTest {
                 """
                         {
                           "model": "gpt-4o-mini",
+                          "input": [
+                            {"role": "user", "content": "Prompt de landing html"}
+                          ]
+                        }
+                        """,
+                Instant.now());
+
+        client.generate(job);
+
+        Map<String, Object> payload = payloadRef.get();
+        assertThat(payload.get("model")).isEqualTo("gpt-5.1-codex");
+    }
+
+    @Test
+    void enforcesGpt51CodexModelForLandingHtmlPipelineCallWhenSectionIsEnumName() {
+        AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(
+                        payloadRef,
+                        """
+                                <!doctype html>
+                                <html lang="pt-BR">
+                                  <body>
+                                    <form id="lead-capture-primary"></form>
+                                  </body>
+                                </html>
+                                """)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        ExperimentPipelineJobDto job = new ExperimentPipelineJobDto(
+                UUID.randomUUID(),
+                16L,
+                "LANDING_PAGE_HTML",
+                "gpt-5.1-codex",
+                "prompt",
+                """
+                        {
+                          "model": "gpt-5.2",
                           "input": [
                             {"role": "user", "content": "Prompt de landing html"}
                           ]
@@ -1254,7 +1294,7 @@ class ExperimentPipelineOpenAiClientTest {
                 "test-key",
                 "http://openai");
         ExperimentPipelineJobCompletionPayload htmlPayload = htmlClient.generate(new ExperimentPipelineJobDto(
-                UUID.randomUUID(), 34L, "landing-page-html", "gpt-5.2", "prompt",
+                UUID.randomUUID(), 34L, "landing-page-html", "gpt-5.1-codex", "prompt",
                 "{\"model\":\"gpt-5.2\",\"input\":[{\"role\":\"user\",\"content\":\"prompt\"}]}", Instant.now()));
         Map<String, Object> htmlContent = MAPPER.readValue(htmlPayload.responseContent(), new TypeReference<>() {});
         @SuppressWarnings("unchecked")
@@ -1293,7 +1333,7 @@ class ExperimentPipelineOpenAiClientTest {
                 """;
 
         ExperimentPipelineJobCompletionPayload payload = client.generate(new ExperimentPipelineJobDto(
-                UUID.randomUUID(), 35L, "landing-page-html", "gpt-5.2", "prompt", requestBody, Instant.now()));
+                UUID.randomUUID(), 35L, "landing-page-html", "gpt-5.1-codex", "prompt", requestBody, Instant.now()));
 
         Map<String, Object> htmlContent = MAPPER.readValue(payload.responseContent(), new TypeReference<>() {});
         @SuppressWarnings("unchecked")
@@ -1333,7 +1373,7 @@ class ExperimentPipelineOpenAiClientTest {
                 """;
 
         ExperimentPipelineJobCompletionPayload payload = client.generate(new ExperimentPipelineJobDto(
-                UUID.randomUUID(), 38L, "landing-page-html", "gpt-5.2", "prompt", requestBody, Instant.now()));
+                UUID.randomUUID(), 38L, "landing-page-html", "gpt-5.1-codex", "prompt", requestBody, Instant.now()));
 
         Map<String, Object> htmlContent = MAPPER.readValue(payload.responseContent(), new TypeReference<>() {});
         @SuppressWarnings("unchecked")
@@ -1373,7 +1413,7 @@ class ExperimentPipelineOpenAiClientTest {
                 """;
 
         Throwable thrown = catchThrowable(() -> client.generate(new ExperimentPipelineJobDto(
-                UUID.randomUUID(), 36L, "landing-page-html", "gpt-5.2", "prompt", requestBody, Instant.now())));
+                UUID.randomUUID(), 36L, "landing-page-html", "gpt-5.1-codex", "prompt", requestBody, Instant.now())));
 
         assertThat(thrown).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Quebra de contrato: LANDING_PAGE_HTML divergente de landing-page-wireframe.sectionOrder.surfaceSpec.");
@@ -1409,7 +1449,7 @@ class ExperimentPipelineOpenAiClientTest {
                 """;
 
         Throwable thrown = catchThrowable(() -> client.generate(new ExperimentPipelineJobDto(
-                UUID.randomUUID(), 37L, "landing-page-html", "gpt-5.2", "prompt", requestBody, Instant.now())));
+                UUID.randomUUID(), 37L, "landing-page-html", "gpt-5.1-codex", "prompt", requestBody, Instant.now())));
 
         assertThat(thrown).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Quebra de contrato: LANDING_PAGE_HTML divergente de landing-page-wireframe.sectionOrder.surfaceSpec.");
@@ -1445,7 +1485,7 @@ class ExperimentPipelineOpenAiClientTest {
                 """;
 
         ExperimentPipelineJobCompletionPayload payload = client.generate(new ExperimentPipelineJobDto(
-                UUID.randomUUID(), 39L, "landing-page-html", "gpt-5.2", "prompt", requestBody, Instant.now()));
+                UUID.randomUUID(), 39L, "landing-page-html", "gpt-5.1-codex", "prompt", requestBody, Instant.now()));
 
         Map<String, Object> htmlContent = MAPPER.readValue(payload.responseContent(), new TypeReference<>() {});
         @SuppressWarnings("unchecked")
@@ -1485,7 +1525,7 @@ class ExperimentPipelineOpenAiClientTest {
                 """;
 
         Throwable thrown = catchThrowable(() -> client.generate(new ExperimentPipelineJobDto(
-                UUID.randomUUID(), 40L, "landing-page-html", "gpt-5.2", "prompt", requestBody, Instant.now())));
+                UUID.randomUUID(), 40L, "landing-page-html", "gpt-5.1-codex", "prompt", requestBody, Instant.now())));
 
         assertThat(thrown).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Quebra de contrato: LANDING_PAGE_HTML divergente de landing-page-image-planning.images[].sectionId/imageBindingKey.");

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,70 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0010 — Verificação da tentativa `9f5de7ad` (LANDING_PAGE_HTML com divergência de binding de imagens)
+
+- **Data/Hora (UTC):** 2026-04-28
+- **Responsável:** Assistente Codex
+- **Módulo:** backend + ai-worker (contrato entre `landing-page-image-planning` e `landing-page-html`)
+- **Ambiente:** Execução remota exibida no Marketing Hub (`experiments/15`)
+- **Execução/Teste:** Tentativa `9f5de7ad` (erro registrado em `28/04/2026, 12:51:31 BRT`)
+
+#### 1) Erro observado
+- **Sintoma:** etapa `LANDING_PAGE_HTML` finalizou com 422 por quebra de vínculo canônico de imagens por seção.
+- **Endpoint/rota/fila:** fechamento do job em `POST /api/internal/experiment-pipeline/jobs/{jobId}/complete`.
+- **Status code:** 422.
+- **Mensagem de erro literal:** `Divergência de imagens: landing-page-html deve reproduzir o binding explícito canônico do landing-page-image-planning por sectionId/imageBindingKey`.
+- **Payload enviado (literal):** `landingPageHtml.htmlDocument` concluído pelo worker, rejeitado no backend por divergência frente ao `landingPageImagePlanning.images[]`.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** `java_module_logs` (`ai-worker`, 500 linhas) retornou apenas cauda operacional recente; a janela da falha `12:51:31 BRT` já não estava mais presente no tail disponível.
+- **Dados de banco consultados via MCP:** `experiment_pipeline_generation_job` confirmou job `LANDING_PAGE_HTML` (`model=gpt-5.2`, `status=FAILED`, `created_at=2026-04-28 15:49:00 UTC`) com rejeição 422 no endpoint `/api/internal/experiment-pipeline/jobs/9f5de7ad-ea5f-4345-b877-7444a06992ee/complete`; `experiment` confirmou planejamento de imagens persistido com 9 bindings canônicos para o experimento 15.
+- **Trecho canônico consultado:** regra de vínculo explícito entre `landingPageImagePlanning.images[*].sectionId` + `images[*].imageBindingKey` e reprodução obrigatória no artefato `landing-page-html`.
+- **Validação/regra que rejeitou:** validação determinística de binding por seção/imagem no backend ao concluir o job `LANDING_PAGE_HTML`.
+- **Causa raiz provável:** o HTML gerado não refletiu 1:1 o mapa de imagens canônico do planejamento (seção sem chave esperada, chave trocada entre seções ou seção extra/ausente).
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** HTML final que não reproduziu integralmente o binding explícito do plano de imagens (conforme mensagem 422).
+- **O que a especificação esperava (literal):** para cada seção do plano, o HTML deve manter o par canônico `sectionId/imageBindingKey` sem substituições, omissões ou inversões.
+- **Diferença objetiva:** divergência entre o binding esperado em `landing-page-image-planning` e o binding efetivamente materializado em `landing-page-html`.
+- **Ação corretiva recomendada:** antes do `/complete`, validar localmente no worker a matriz `sectionId -> imageBindingKey` extraída do HTML contra o `landingPageImagePlanning.images[]` do payload do job; bloquear finalização quando houver qualquer delta.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** documentação operacional de incidente.
+- **Arquivos alterados:**
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** registro formal da tentativa `9f5de7ad` com diagnóstico 422 no formato SOP obrigatório (modelo entregue vs esperado vs diferença vs ação corretiva).
+
+#### 5) Reteste
+- **Procedimento de reteste:** revalidação via MCP Server com `initialize`, `tools/list`, `db_query` e `java_module_logs`.
+- **Resultado:** verificação concluída com sucesso no MCP (conectividade OK e evidências de banco coletadas); pendente apenas nova execução integrada para confirmar correção funcional.
+- **Evidências (logs/ids/prints):** job com path `/jobs/9f5de7ad-ea5f-4345-b877-7444a06992ee/complete`, mensagem 422 literal e lista canônica de 9 pares `sectionId/imageBindingKey` do planejamento da landing no experimento 15.
+- **Status final:** Pendente.
+
+#### 6) Próximo passo
+- **Ação seguinte:** reexecutar `LANDING_PAGE_HTML` no experimento 15 após validar previamente o binding `sectionId/imageBindingKey` contra o `landingPageImagePlanning` aprovado.
+- **Dono da ação:** Time do AI Worker + operação do experimento.
+- **Prazo:** imediato (próxima janela de reprocessamento).
+
+#### 7) Confirmação MCP (nova tentativa)
+- **MCP Server utilizado:** `https://mcpserverdigi.shop/mcp` (JSON-RPC; chamadas `initialize`, `tools/list`, `tools/call`).
+- **Amostra 1 — job da tentativa `9f5de7ad`:**
+  - `experiment_pipeline_generation_job` retornou `status=FAILED`, `section=LANDING_PAGE_HTML`, `model=gpt-5.2`, `created_at=2026-04-28 15:49:00 UTC`.
+  - `error_message` confirmou 422 literal por divergência de binding de imagens e `path` com o identificador completo da tentativa: `/api/internal/experiment-pipeline/jobs/9f5de7ad-ea5f-4345-b877-7444a06992ee/complete`.
+- **Amostra 2 — vínculo canônico esperado no experimento 15 (`experiment.landing_page_image_planning`):**
+  - O artefato persistido contém 9 entradas em `landingPageImagePlanning.images[]`.
+  - Pares canônicos extraídos via MCP:
+    - `nav-identity -> nav-identity-strip`
+    - `hero-split-form -> hero-whats-preco-pdf`
+    - `pain-quanto-custa-some -> pain-cards-preco-sumi`
+    - `mechanism-ciclo-evolucao-8s -> mechanism-timeline-8w`
+    - `proof-previa-pdf-minikit -> proof-packshot-pdf-minikit`
+    - `offer-gerar-amostra-pdf -> offer-3steps-flow`
+    - `objection-anti-preco-pratica -> usage-whats-flow-cards`
+    - `faq-objections -> faq-trust-privacy`
+    - `footer-legal -> footer-legal-strip`
+- **Conclusão confirmada com MCP:** a tentativa `9f5de7ad` foi rejeitada por não reproduzir fielmente, no HTML final, o binding explícito canônico por `sectionId/imageBindingKey` já aprovado no `landing_page_image_planning` do experimento 15.
+
 ### INC-0009 — Verificação da tentativa `b244db1f` (LANDING_PAGE_HTML com divergência de superfície)
 
 - **Data/Hora (UTC):** 2026-04-28


### PR DESCRIPTION
### Motivation
- Prevent backend 422 errors by verifying that `landing-page-html` reproduces the canonical `landing-page-image-planning` `sectionId/imageBindingKey` bindings before completing the job.
- Detect and fail fast in the worker when generated HTML does not match the approved image planning to avoid wasted processing and improve observability.
- Record the operational incident and guidance in the experiment pipeline SOP for traceability.

### Description
- Call `enforceLandingHtmlImagePlanningBinding` during `generate(...)` to validate image bindings alongside existing surface binding checks.
- Add `enforceLandingHtmlImagePlanningBinding`, `extractExpectedImageBindingsFromRequestPayload`, and `extractImagePlanningJsonBlock` to extract expected image-binding contracts from the prompt payload and compare them to the generated HTML.
- Add `extractImageBindingsFromHtml` and the `SectionImageBindingContract` record to parse `data-image-section-id` and `data-image-binding-key` attributes from HTML and compare canonical mappings.
- Add unit tests `acceptsLandingHtmlWhenImagePlanningBindingsMatchExactly` and `failsFastWhenLandingHtmlCannotReproduceImagePlanningBinding` and update `docs/registro-ajustes-pipeline-experimento.md` with the incident record for the binding mismatch case.

### Testing
- Ran the Java unit test suite including the two new tests in `ExperimentPipelineOpenAiClientTest`; all tests passed locally.
- Exercised the `generate(...)` flow with mock `WebClient` responses to validate both success and fail-fast scenarios via the new tests, which succeeded.
- Confirmed documentation change in `docs/registro-ajustes-pipeline-experimento.md` was added but contains no automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d825aec883218abd8bae9ee4cfa1)