### PR TITLE
Update landing-page-html test to use valid HTML mock response

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -252,7 +252,16 @@ class ExperimentPipelineOpenAiClientTest {
     void prependsLandingHtmlGuidanceWithExplicitBindingChecklist() {
         AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
         ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
-                WebClient.builder().exchangeFunction(capturePayloadExchange(payloadRef)),
+                WebClient.builder().exchangeFunction(capturePayloadExchange(
+                        payloadRef,
+                        """
+                                <!doctype html>
+                                <html lang="pt-BR">
+                                  <body>
+                                    <form id="lead-capture-primary"></form>
+                                  </body>
+                                </html>
+                                """)),
                 MAPPER,
                 "test-key",
                 "http://openai");


### PR DESCRIPTION
### Motivation
- The test `prependsLandingHtmlGuidanceWithExplicitBindingChecklist` used the default mock payload `{"content":"ok"}`, which started to fail because `LANDING_PAGE_HTML` responses now must provide raw HTML/`htmlDocument`, causing an `IllegalStateException` before the prompt assertions could run.

### Description
- Replace the default mock response in `ExperimentPipelineOpenAiClientTest.prependsLandingHtmlGuidanceWithExplicitBindingChecklist` with a small valid HTML snippet passed to `capturePayloadExchange` so the test exercises prompt-generation assertions instead of failing on output-contract validation.
- File changed: `ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java`.

### Testing
- Tried `mvn -pl ai-worker test -Dtest=ExperimentPipelineOpenAiClientTest` from the repo root, which failed because the selected project was not found in the reactor. 
- Ran `mvn test -Dtest=ExperimentPipelineOpenAiClientTest` in `ai-worker`, but the build was blocked by an unresolved private dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT` returning `401 Unauthorized` from GitHub Packages, so tests could not be fully validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e7763fb48321846e3b208e68ecc4)