### PR TITLE
Fix /api/flows/{slug}/page rendering when stored payload has JSON prefix

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
@@ -59,7 +59,27 @@ public class LeadPortalPublicFlowController {
         if (StringUtils.hasText(extractedFromHybrid)) {
             return extractedFromHybrid;
         }
+        String extractedFromInlineHtml = tryExtractInlineHtmlDocument(sourceHtml);
+        if (StringUtils.hasText(extractedFromInlineHtml)) {
+            return extractedFromInlineHtml;
+        }
         return sourceHtml;
+    }
+
+    private String tryExtractInlineHtmlDocument(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        String lowered = value.toLowerCase();
+        int doctypeIndex = lowered.indexOf("<!doctype html");
+        if (doctypeIndex >= 0) {
+            return value.substring(doctypeIndex).trim();
+        }
+        int htmlIndex = lowered.indexOf("<html");
+        if (htmlIndex >= 0) {
+            return value.substring(htmlIndex).trim();
+        }
+        return null;
     }
 
     private boolean looksLikeJsonPayload(String value) {

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
@@ -190,4 +190,26 @@ class LeadPortalPublicFlowControllerTest {
                 .andExpect(content().contentType("text/html;charset=UTF-8"))
                 .andExpect(content().string(nestedDocument));
     }
+
+    @Test
+    void getLandingPageBySlugExtractsInlineHtmlWhenPayloadHasJsonPrefix() throws Exception {
+        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Teste").build());
+        String nestedDocument = "<!doctype html><html lang=\"pt-BR\"><body><main><h1>Landing extraída</h1></main></body></html>";
+        String prefixedPayload = """
+                {"landingPageHtml":"{\\"htmlDocument\\":\\"texto quebrado\\"}"}
+                %s
+                """.formatted(nestedDocument);
+        flowRepository.save(LeadPortalFlow.builder()
+                .name("Fluxo Landing")
+                .slug("exp-18-landing")
+                .approved(true)
+                .marketNiche(niche)
+                .customFormHtml(prefixedPayload)
+                .build());
+
+        mockMvc.perform(get("/api/flows/exp-18-landing/page"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/html;charset=UTF-8"))
+                .andExpect(content().string(nestedDocument));
+    }
 }


### PR DESCRIPTION
### Motivation
- Some stored `customFormHtml` values contain mixed content (a JSON-like prefix followed by a real HTML document), which caused the endpoint `/api/flows/{slug}/page` to return the full mixed string and display JSON at the top of the rendered page.  
- The goal is to ensure the endpoint returns the pure HTML document that browsers expect, preserving existing JSON and hybrid extraction logic.

### Description
- Added a fallback extractor `tryExtractInlineHtmlDocument` to `LeadPortalPublicFlowController` that finds and returns the substring starting at `<!doctype html` or `<html` when previous JSON/hybrid extraction fails.  
- Integrated the new fallback into `extractHtmlDocument` so it runs after the existing JSON and hybrid parsing paths.  
- Added a regression unit test `getLandingPageBySlugExtractsInlineHtmlWhenPayloadHasJsonPrefix` in `LeadPortalPublicFlowControllerTest` to cover payloads with a JSON prefix followed by raw HTML.  
- No changes to the public API surface; behavior is more robust for polluted/mixed payloads.

### Testing
- Ran the controller tests locally with: `../mvnw test -Dtest=LeadPortalPublicFlowControllerTest` from `backend/ads-service`, and the suite passed with `7 tests, 0 failures`.  
- The new test `getLandingPageBySlugExtractsInlineHtmlWhenPayloadHasJsonPrefix` was executed as part of that run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ef0f08e88321af58075f6d138d92)