### PR TITLE
Set Hotmart robot default cron to 17:00

### DIFF
--- a/mois/src/main/resources/application.properties
+++ b/mois/src/main/resources/application.properties
@@ -14,7 +14,7 @@ integrations.backend.persistence.read-timeout=5s
 
 # Robô de coleta Hotmart (executa no container MOIS)
 mois.robot.hotmart.enabled=${MOIS_ROBOT_HOTMART_ENABLED:true}
-mois.robot.hotmart.cron=${MOIS_ROBOT_HOTMART_CRON:0 0 14 * * *}
+mois.robot.hotmart.cron=${MOIS_ROBOT_HOTMART_CRON:0 0 17 * * *}
 mois.robot.hotmart.workspace-id=${MOIS_ROBOT_HOTMART_WORKSPACE_ID:workspace-001}
 mois.robot.hotmart.niche=${MOIS_ROBOT_HOTMART_NICHE:marketing-digital}
 mois.robot.hotmart.market-theme=${MOIS_ROBOT_HOTMART_MARKET_THEME:ofertas-com-temperatura-alta}


### PR DESCRIPTION
### Motivation
- Update the default scheduled time for the Hotmart collection robot to run at 17:00 instead of 14:00 by changing the default cron expression in configuration.

### Description
- Change `mois.robot.hotmart.cron` default value from `0 0 14 * * *` to `0 0 17 * * *` in `mois/src/main/resources/application.properties`.

### Testing
- No automated tests were executed for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ee41703883218a79e07940e51df3)