### PR TITLE
fix(frontend): prevent duplicate sequential generation requests in pipeline auto queue

### DIFF
--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -1912,6 +1912,16 @@ export default function ExperimentContentGenerationTab({
     }
 
     const [nextSectionKey, ...remaining] = autoQueue.pending;
+    const nextSectionRequest = mergedRequestsBySection[nextSectionKey];
+    if (nextSectionRequest.status !== "IDLE") {
+      setAutoQueue({
+        isActive: true,
+        waitingFor: nextSectionKey,
+        pending: remaining,
+      });
+      return;
+    }
+
     if (
       autoQueue.waitingFor === "landing-image-planning" &&
       (nextSectionKey === "landing-design-preset" ||


### PR DESCRIPTION
### Motivation
- Corrige condição de corrida na fila automática do frontend que podia disparar solicitações duplicadas da próxima etapa do pipeline (por exemplo, "Texto da Landing") quando o backend já havia enfileirado ou concluído a etapa seguinte.

### Description
- Adiciona uma verificação em `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx` que checa `mergedRequestsBySection[nextSectionKey].status` e, se for diferente de `IDLE`, avança o estado da fila (`waitingFor`) sem reenviar a requisição, evitando duplicidade de jobs.

### Testing
- Executei `npm --prefix frontend install`, `npm --prefix frontend run typecheck` e `npm --prefix frontend run test -- src/pages/experiment/ExperimentContentGenerationTab.report.test.ts`, com `typecheck` e os testes Vitest (3 testes) passando com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11e4a00f88321801cc5db73f28185)