### PR TITLE
Add activation log to MoisHotmartRobotScheduler.run

### DIFF
--- a/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotScheduler.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotScheduler.java
@@ -20,6 +20,9 @@ public class MoisHotmartRobotScheduler {
 
     @Scheduled(cron = "${mois.robot.hotmart.cron:0 0 14 * * *}")
     public void run() {
+        log.info("MOIS Hotmart scheduler acionado (enabled={}, cron={})",
+                properties.isEnabled(),
+                properties.getCron());
         if (!properties.isEnabled()) {
             log.warn("MOIS Hotmart scheduler ignorado: robot desabilitado (cron={})", properties.getCron());
             return;


### PR DESCRIPTION
### Motivation
- Add a lightweight diagnostic log entry when the Hotmart scheduler is triggered to surface the `enabled` flag and effective `cron` expression.

### Description
- Inserted an initial `log.info` call in `MoisHotmartRobotScheduler.run()` to log `(enabled={}, cron={})` using `properties.isEnabled()` and `properties.getCron()` before checking the enabled flag.

### Testing
- No automated tests were added or executed for this trivial logging change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0fa135ca483218a985af28da1780a)