### PR TITLE
Record raw AI response and extract OpenAI response id; surface in prompt versions UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/dto/internal/ExperimentPipelineGenerationJobDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/dto/internal/ExperimentPipelineGenerationJobDto.java
@@ -18,6 +18,8 @@ public record ExperimentPipelineGenerationJobDto(
         String model,
         String prompt,
         String requestBodyJson,
+        String rawResponse,
+        String openAiResponseId,
         Instant createdAt,
         Instant startedAt,
         Instant finishedAt) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment.pipeline.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.ai.generation.dto.AiWorkerGenerationRequest;
 import com.marketinghub.ai.generation.service.AiWorkerGenerationService;
@@ -2513,6 +2514,7 @@ public class ExperimentPipelineGenerationService {
     }
 
     private ExperimentPipelineGenerationJobDto toDto(ExperimentPipelineGenerationJob job) {
+        String rawResponse = job.getRawResponse();
         return ExperimentPipelineGenerationJobDto.builder()
                 .id(job.getId())
                 .experimentId(job.getExperiment().getId())
@@ -2524,10 +2526,29 @@ public class ExperimentPipelineGenerationService {
                 .model(job.getModel())
                 .prompt(job.getPrompt())
                 .requestBodyJson(job.getRequestBodyJson())
+                .rawResponse(rawResponse)
+                .openAiResponseId(extractOpenAiResponseId(rawResponse))
                 .createdAt(job.getCreatedAt())
                 .startedAt(job.getStartedAt())
                 .finishedAt(job.getFinishedAt())
                 .build();
+    }
+
+    private String extractOpenAiResponseId(String rawResponse) {
+        if (!StringUtils.hasText(rawResponse)) {
+            return null;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(rawResponse);
+            JsonNode idNode = root.get("id");
+            if (idNode != null && idNode.isTextual()) {
+                String id = idNode.asText().trim();
+                return id.startsWith("resp_") ? id : null;
+            }
+        } catch (Exception ex) {
+            log.debug("Falha ao extrair OpenAI response id do raw_response: {}", ex.getMessage());
+        }
+        return null;
     }
 
     private Integer totalTokens(Integer inputTokens, Integer outputTokens) {

--- a/frontend/src/api/experiment/useExperimentPipelineJobs.ts
+++ b/frontend/src/api/experiment/useExperimentPipelineJobs.ts
@@ -12,6 +12,8 @@ export interface ExperimentPipelineGenerationJob {
   model?: string;
   prompt?: string;
   requestBodyJson?: string;
+  rawResponse?: string;
+  openAiResponseId?: string;
   createdAt?: string;
   startedAt?: string;
   finishedAt?: string;

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -1583,52 +1583,18 @@ export default function ExperimentContentGenerationTab({
   const persistedAdCopy = useMemo(() => parseAdCopyPayload(adCopy), [adCopy]);
 
   const promptVersionsBySection = useMemo(() => {
+    const pipelineJobs = jobsQuery.data ?? [];
     const sources: {
       key: ContentGenerationSectionKey;
       label: string;
-      items: SimpleGenerationRow[];
-    }[] = [
-      {
-        key: "campaign-angle",
-        label: getSectionLabel("campaign-angle"),
-        items: campaignAngleGenerations,
-      },
-      {
-        key: "ad-copy",
-        label: getSectionLabel("ad-copy"),
-        items: adCopyGenerations,
-      },
-      {
-        key: "image-prompt",
-        label: getSectionLabel("image-prompt"),
-        items: sectionGenerations["image-prompt"],
-      },
-      {
-        key: "landing-copy",
-        label: getSectionLabel("landing-copy"),
-        items: sectionGenerations["landing-copy"],
-      },
-      {
-        key: "landing-layout",
-        label: getSectionLabel("landing-layout"),
-        items: sectionGenerations["landing-layout"],
-      },
-      {
-        key: "landing-image-planning",
-        label: getSectionLabel("landing-image-planning"),
-        items: sectionGenerations["landing-image-planning"],
-      },
-      {
-        key: "landing-design-preset",
-        label: getSectionLabel("landing-design-preset"),
-        items: sectionGenerations["landing-design-preset"],
-      },
-      {
-        key: "landing-html",
-        label: getSectionLabel("landing-html"),
-        items: sectionGenerations["landing-html"],
-      },
-    ];
+      items: typeof pipelineJobs;
+    }[] = CONTENT_GENERATION_SECTIONS.map((section) => ({
+      key: section.key,
+      label: section.label,
+      items: pipelineJobs.filter(
+        (job) => normalizeJobSection(job.section) === section.key,
+      ),
+    }));
 
     return sources
       .map((source) => {
@@ -1640,6 +1606,8 @@ export default function ExperimentContentGenerationTab({
             latestUsedAt?: string;
             latestTimestamp: number;
             models: Set<string>;
+            jobIds: string[];
+            openAiResponseIds: Set<string>;
           }
         >();
 
@@ -1651,6 +1619,7 @@ export default function ExperimentContentGenerationTab({
           const parsedTimestamp =
             parseTimestamp(item.createdAt) ?? Number.MIN_SAFE_INTEGER;
           const model = item.model?.trim();
+          const openAiResponseId = item.openAiResponseId?.trim();
           const current = byFingerprint.get(fingerprint);
 
           if (!current) {
@@ -1660,17 +1629,23 @@ export default function ExperimentContentGenerationTab({
               latestUsedAt: item.createdAt,
               latestTimestamp: parsedTimestamp,
               models: new Set(model ? [model] : []),
+              jobIds: [item.id],
+              openAiResponseIds: new Set(openAiResponseId ? [openAiResponseId] : []),
             });
             return;
           }
 
           current.occurrences += 1;
+          current.jobIds.push(item.id);
           if (parsedTimestamp >= current.latestTimestamp) {
             current.latestTimestamp = parsedTimestamp;
             current.latestUsedAt = item.createdAt;
           }
           if (model) {
             current.models.add(model);
+          }
+          if (openAiResponseId) {
+            current.openAiResponseIds.add(openAiResponseId);
           }
         });
 
@@ -1681,6 +1656,8 @@ export default function ExperimentContentGenerationTab({
             occurrences: version.occurrences,
             latestUsedAt: version.latestUsedAt,
             models: Array.from(version.models).sort(),
+            jobIds: version.jobIds,
+            openAiResponseIds: Array.from(version.openAiResponseIds).sort(),
           }));
 
         return {
@@ -1690,12 +1667,9 @@ export default function ExperimentContentGenerationTab({
         };
       })
       .filter((section) => section.versions.length > 0);
-  }, [adCopyGenerations, campaignAngleGenerations, sectionGenerations]);
+  }, [jobsQuery.data]);
 
-  const isLoadingPromptVersions =
-    isLoadingCampaignAngles ||
-    isLoadingAdCopy ||
-    Object.values(isLoadingSectionGenerations).some(Boolean);
+  const isLoadingPromptVersions = jobsQuery.isLoading;
 
   const currentSection =
     CONTENT_GENERATION_SECTIONS.find(
@@ -3318,6 +3292,8 @@ interface PromptVersionSummary {
     occurrences: number;
     latestUsedAt?: string;
     models: string[];
+    jobIds: string[];
+    openAiResponseIds: string[];
   }[];
 }
 
@@ -3372,6 +3348,13 @@ function PipelinePromptVersionsPanel({
                         </p>
                         <p className="small mb-2">
                           <strong>Modelos:</strong> {version.models.join(", ") || "—"}
+                        </p>
+                        <p className="small mb-2">
+                          <strong>Jobs:</strong> {version.jobIds.join(", ")}
+                        </p>
+                        <p className="small mb-2">
+                          <strong>OpenAI response id:</strong>{" "}
+                          {version.openAiResponseIds.join(", ") || "—"}
                         </p>
                         <pre className="small bg-body-secondary rounded p-2 mb-0">
                           {version.prompt}


### PR DESCRIPTION
### Motivation
- Persist the raw AI provider response for pipeline generation jobs and surface metadata that helps trace specific OpenAI responses.
- Enable UI visibility of which pipeline jobs used the same prompt and whether they correspond to the same OpenAI response.
- Improve prompt-version grouping by using pipeline job records instead of multiple ad-hoc generation sources.

### Description
- Added `rawResponse` and `openAiResponseId` to `ExperimentPipelineGenerationJobDto` and propagated `rawResponse` from `toDto`/`toDetailDto` mappings.
- Implemented `extractOpenAiResponseId(String rawResponse)` to parse JSON `id` from the raw response and return it only when it matches the expected `resp_` format, with safe error handling and debug logging.
- Extended the frontend `ExperimentPipelineGenerationJob` type to include `rawResponse` and `openAiResponseId`, changed prompt-version aggregation to read from `jobsQuery.data`, and added `jobIds` and `openAiResponseIds` to the versions view.
- Updated UI components to display job ids and OpenAI response ids in the `PipelinePromptVersionsPanel` and switched loading state to rely on `jobsQuery.isLoading`.

### Testing
- Ran backend unit tests with `mvn test` which completed successfully.
- Ran frontend tests with `yarn test` and verified the components compile and unit tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f125dd21888321b089c10ea782d14e)