### PR TITLE
Add scheduler to resume experiment pipeline after framework image planning completes

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImagePipelineResumeScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImagePipelineResumeScheduler.java
@@ -1,0 +1,46 @@
+package com.marketinghub.experiment.frameworkimage.service;
+
+import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageGenerationJobDto;
+import com.marketinghub.experiment.pipeline.service.ExperimentPipelineGenerationService;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FrameworkImagePipelineResumeScheduler {
+
+    private final FrameworkImageGenerationService frameworkImageGenerationService;
+    private final ExperimentPipelineGenerationService experimentPipelineGenerationService;
+    private final boolean enabled;
+    private final int batchSize;
+
+    public FrameworkImagePipelineResumeScheduler(FrameworkImageGenerationService frameworkImageGenerationService,
+                                                 ExperimentPipelineGenerationService experimentPipelineGenerationService,
+                                                 @Value("${framework-image.pipeline-resume.enabled:true}") boolean enabled,
+                                                 @Value("${framework-image.pipeline-resume.batch-size:50}") int batchSize) {
+        this.frameworkImageGenerationService = frameworkImageGenerationService;
+        this.experimentPipelineGenerationService = experimentPipelineGenerationService;
+        this.enabled = enabled;
+        this.batchSize = Math.max(1, batchSize);
+    }
+
+    @Scheduled(fixedDelayString = "${framework-image.pipeline-resume.fixed-delay-ms:60000}")
+    public void run() {
+        if (!enabled) {
+            return;
+        }
+
+        Set<Long> experimentIds = new LinkedHashSet<>();
+        for (FrameworkImageGenerationJobDto job : frameworkImageGenerationService.listPendingJobs(batchSize)) {
+            if (job.experimentId() != null) {
+                experimentIds.add(job.experimentId());
+            }
+        }
+
+        for (Long experimentId : experimentIds) {
+            experimentPipelineGenerationService.resumeFlowAfterImagePlanningIfReady(experimentId);
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -187,6 +187,24 @@ public class ExperimentPipelineGenerationService {
         return experimentMapper.toDto(experiment);
     }
 
+
+    @Transactional
+    public void resumeFlowAfterImagePlanningIfReady(Long experimentId) {
+        if (experimentId == null || !frameworkImageGenerationService.allPlanningImagesCompleted(experimentId)) {
+            return;
+        }
+        try {
+            generate(experimentId,
+                    ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET,
+                    new ExperimentPipelineGenerationRequest());
+        } catch (ResponseStatusException ex) {
+            if (ex.getStatusCode() != HttpStatus.CONFLICT) {
+                throw ex;
+            }
+            log.debug("Retomada automática ignorada para experimento {}: {}", experimentId, ex.getReason());
+        }
+    }
+
     @Transactional
     public List<ExperimentPipelineGenerationJobDto> listPendingJobs(int limit) {
         return jobRepository.findByStatusAndExperimentStatusInOrderByCreatedAtAsc(

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImagePipelineResumeSchedulerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImagePipelineResumeSchedulerTest.java
@@ -1,0 +1,67 @@
+package com.marketinghub.experiment.frameworkimage.service;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageGenerationJobDto;
+import com.marketinghub.experiment.pipeline.service.ExperimentPipelineGenerationService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FrameworkImagePipelineResumeSchedulerTest {
+
+    @Mock
+    private FrameworkImageGenerationService frameworkImageGenerationService;
+
+    @Mock
+    private ExperimentPipelineGenerationService experimentPipelineGenerationService;
+
+    @Test
+    void runResumesFlowForDistinctExperimentIds() {
+        FrameworkImagePipelineResumeScheduler scheduler = new FrameworkImagePipelineResumeScheduler(
+                frameworkImageGenerationService,
+                experimentPipelineGenerationService,
+                true,
+                50);
+
+        when(frameworkImageGenerationService.listPendingJobs(50)).thenReturn(List.of(
+                job(11L),
+                job(11L),
+                job(12L)));
+
+        scheduler.run();
+
+        verify(experimentPipelineGenerationService, times(1)).resumeFlowAfterImagePlanningIfReady(11L);
+        verify(experimentPipelineGenerationService, times(1)).resumeFlowAfterImagePlanningIfReady(12L);
+    }
+
+    @Test
+    void runDoesNothingWhenDisabled() {
+        FrameworkImagePipelineResumeScheduler scheduler = new FrameworkImagePipelineResumeScheduler(
+                frameworkImageGenerationService,
+                experimentPipelineGenerationService,
+                false,
+                50);
+
+        scheduler.run();
+
+        verify(frameworkImageGenerationService, never()).listPendingJobs(50);
+        verify(experimentPipelineGenerationService, never()).resumeFlowAfterImagePlanningIfReady(11L);
+    }
+
+    private FrameworkImageGenerationJobDto job(Long experimentId) {
+        return FrameworkImageGenerationJobDto.builder()
+                .id(UUID.randomUUID())
+                .experimentId(experimentId)
+                .planningItemKey("key")
+                .status("PENDING")
+                .build();
+    }
+}


### PR DESCRIPTION
### Motivation
- Automatically resume experiment pipeline flow once framework image planning for an experiment finishes to avoid manual intervention and keep pipelines progressing.
- Make the resume behavior configurable and rate-limited to avoid overwhelming the pipeline service when many image jobs are pending.

### Description
- Add a Spring `@Component` `FrameworkImagePipelineResumeScheduler` that periodically polls pending framework image jobs via `frameworkImageGenerationService.listPendingJobs(...)`, deduplicates experiment IDs, and invokes `experimentPipelineGenerationService.resumeFlowAfterImagePlanningIfReady(...)` for each distinct experiment.
- Add `resumeFlowAfterImagePlanningIfReady(Long)` to `ExperimentPipelineGenerationService` which checks `frameworkImageGenerationService.allPlanningImagesCompleted(...)` and, if ready, invokes `generate(...)` for the `LANDING_PAGE_DESIGN_PRESET`, swallowing `HttpStatus.CONFLICT` errors and rethrowing others.
- Make the scheduler configurable via properties `framework-image.pipeline-resume.enabled`, `framework-image.pipeline-resume.batch-size`, and `framework-image.pipeline-resume.fixed-delay-ms` and ensure `batch-size` is clamped to at least `1`.
- Add unit tests `FrameworkImagePipelineResumeSchedulerTest` to verify distinct experiment deduplication and disabled-mode behavior.

### Testing
- Added `FrameworkImagePipelineResumeSchedulerTest` with two tests that validate distinct experiment resume calls and that no work is done when the scheduler is disabled, and both tests passed locally.
- Existing build and unit test suite were run and completed successfully (including the new tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15077bd5c8321bef4422832fbf204)