### PR TITLE
Simplifica agendamento MOIS para heartbeat a cada 20 minutos

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartCollectionScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartCollectionScheduler.java
@@ -1,64 +1,15 @@
 package com.marketinghub.mois.service;
 
-import com.marketinghub.mois.dto.MoisWorkspaceDtos;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 @Component
 @Slf4j
 public class MoisHotmartCollectionScheduler {
 
-    private final MoisModuleGateway gateway;
-    private final MoisHotmartCollectionProperties properties;
-
-    public MoisHotmartCollectionScheduler(MoisModuleGateway gateway, MoisHotmartCollectionProperties properties) {
-        this.gateway = gateway;
-        this.properties = properties;
-    }
-
-    @Scheduled(cron = "0 0 22 * * *")
+    @Scheduled(cron = "0 */20 * * * *")
     public void scheduleCollection() {
-        log.info("Iniciando execução do scheduler MOIS Hotmart (workspaceId={}, enabled={})",
-                properties.getWorkspaceId(), properties.isEnabled());
-
-        if (!properties.isEnabled()) {
-            return;
-        }
-
-        List<String> sanitizedSources = properties.getSources().stream()
-                .filter(StringUtils::hasText)
-                .map(String::trim)
-                .distinct()
-                .toList();
-
-        if (sanitizedSources.isEmpty()) {
-            log.warn("MOIS Hotmart scheduler ignorado: sources vazio (workspaceId={})", properties.getWorkspaceId());
-            return;
-        }
-
-        MoisWorkspaceDtos.CreateCollectionJobRequest request = new MoisWorkspaceDtos.CreateCollectionJobRequest(
-                properties.getWorkspaceId(),
-                properties.getNiche(),
-                properties.getMarketTheme(),
-                sanitizedSources,
-                properties.getTimeWindow(),
-                properties.getLimitPerSource(),
-                properties.getLocale(),
-                properties.getCountry(),
-                properties.getMinSuccessScore()
-        );
-
-        try {
-            MoisWorkspaceDtos.CollectionJobResponse response = gateway.createCollectionJob(request);
-            if (response != null) {
-                log.info("MOIS Hotmart scheduler criou job {} (workspaceId={}, sources={})",
-                        response.jobId(), response.workspaceId(), response.sources());
-            }
-        } catch (Exception ex) {
-            log.error("Falha ao criar job automático MOIS Hotmart (workspaceId={})", properties.getWorkspaceId(), ex);
-        }
+        log.info("MOIS scheduler heartbeat: execução simples a cada 20 minutos.");
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisHotmartCollectionSchedulerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisHotmartCollectionSchedulerTest.java
@@ -1,100 +1,13 @@
 package com.marketinghub.mois.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.marketinghub.mois.dto.MoisWorkspaceDtos;
-import java.time.Instant;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class MoisHotmartCollectionSchedulerTest {
 
-    @Mock
-    private MoisModuleGateway gateway;
-
-    private MoisHotmartCollectionProperties properties;
-    private MoisHotmartCollectionScheduler scheduler;
-
-    @BeforeEach
-    void setUp() {
-        properties = new MoisHotmartCollectionProperties();
-        properties.setEnabled(true);
-        properties.setWorkspaceId("workspace-001");
-        properties.setNiche("marketing-digital");
-        properties.setMarketTheme("ofertas-com-temperatura-alta");
-        properties.setSources(List.of("HOTMART", " HOTMART ", ""));
-        properties.setTimeWindow("LAST_7_DAYS");
-        properties.setLimitPerSource(25);
-        properties.setLocale("pt-BR");
-        properties.setCountry("BR");
-        properties.setMinSuccessScore(80);
-
-        scheduler = new MoisHotmartCollectionScheduler(gateway, properties);
-    }
-
     @Test
-    void shouldCreateCollectionJobWhenEnabled() {
-        when(gateway.createCollectionJob(any())).thenReturn(new MoisWorkspaceDtos.CollectionJobResponse(
-                "mois-collect-001",
-                "workspace-001",
-                "marketing-digital",
-                "ofertas-com-temperatura-alta",
-                "CREATED",
-                "LAST_7_DAYS",
-                25,
-                80,
-                List.of("HOTMART"),
-                Instant.parse("2026-04-27T03:10:00Z")
-        ));
+    void shouldRunSimpleHeartbeatWithoutThrowing() {
+        MoisHotmartCollectionScheduler scheduler = new MoisHotmartCollectionScheduler();
 
         scheduler.scheduleCollection();
-
-        ArgumentCaptor<MoisWorkspaceDtos.CreateCollectionJobRequest> captor =
-                ArgumentCaptor.forClass(MoisWorkspaceDtos.CreateCollectionJobRequest.class);
-        verify(gateway).createCollectionJob(captor.capture());
-
-        MoisWorkspaceDtos.CreateCollectionJobRequest request = captor.getValue();
-        assertEquals("workspace-001", request.workspaceId());
-        assertEquals("marketing-digital", request.niche());
-        assertEquals("LAST_7_DAYS", request.timeWindow());
-        assertEquals(List.of("HOTMART"), request.sources());
-        assertEquals(80, request.minSuccessScore());
-    }
-
-    @Test
-    void shouldSkipWhenDisabled() {
-        properties.setEnabled(false);
-
-        scheduler.scheduleCollection();
-
-        verify(gateway, never()).createCollectionJob(any());
-    }
-
-    @Test
-    void shouldSkipWhenSourcesAreEmptyAfterSanitization() {
-        properties.setSources(List.of(" ", ""));
-
-        scheduler.scheduleCollection();
-
-        verify(gateway, never()).createCollectionJob(any());
-    }
-
-    @Test
-    void shouldSwallowGatewayFailuresToKeepSchedulerAlive() {
-        when(gateway.createCollectionJob(any())).thenThrow(new RuntimeException("gateway down"));
-
-        scheduler.scheduleCollection();
-
-        verify(gateway).createCollectionJob(any());
     }
 }


### PR DESCRIPTION
### Motivation
- Isolar a falha que impedia a execução do agendamento MOIS substituindo a rotina complexa por uma execução mínima para diagnóstico.  
- Tornar o disparo observável via log para confirmar que o scheduler está sendo invocado periodicamente.  
- Fornecer um ponto seguro para reintroduzir a lógica de coleta quando o disparo estiver validado.  

### Description
- Substitui a implementação do scheduler em `backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartCollectionScheduler.java` por uma versão mínima que faz apenas um `log.info` e roda a cada 20 minutos com `@Scheduled(cron = "0 */20 * * * *")`.  
- Removei as dependências ao `MoisModuleGateway` e `MoisHotmartCollectionProperties` e toda a lógica de criação de job para evitar efeitos colaterais durante o diagnóstico.  
- Atualizei o teste em `backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisHotmartCollectionSchedulerTest.java` para um teste simples que instancia o scheduler e chama `scheduleCollection()` verificando que não lança exceção.  

### Testing
- Executando `cd backend/ads-service && ./mvnw -Dtest=MoisHotmartCollectionSchedulerTest test` falhou porque não existe `./mvnw` naquele subdiretório.  
- Executando `cd backend && ./mvnw -pl ads-service -Dtest=MoisHotmartCollectionSchedulerTest test` falhou por não localizar o projeto selecionado no reactor.  
- Executando `cd backend/ads-service && ../mvnw -Dtest=MoisHotmartCollectionSchedulerTest test` (usando o wrapper correto) executou o teste do scheduler e retornou sucesso (`Tests run: 1, Failures: 0, Errors: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15a0d04b88321bba540fda05f7660)