### PR TITLE
Adicionar timeout por requisição nas chamadas de batch OpenAI (ChatGptClient)

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java
@@ -83,6 +83,7 @@ public class ChatGptClient {
     private static final String COMPLETION_WINDOW = "24h";
     private static final Duration BATCH_POLL_INTERVAL = Duration.ofMillis(500);
     private static final Duration BATCH_TIMEOUT = Duration.ofMinutes(2);
+    private static final Duration OPENAI_REQUEST_TIMEOUT = Duration.ofSeconds(30);
     private static final Set<String> TERMINAL_BATCH_STATUSES = Set.of("completed", "failed", "expired", "cancelled");
 
     public ChatGptClient(WebClient.Builder builder,
@@ -363,7 +364,7 @@ public class ChatGptClient {
                 .body(BodyInserters.fromMultipartData(multipart))
                 .retrieve()
                 .bodyToMono(OpenAiFile.class)
-                .block();
+                .block(OPENAI_REQUEST_TIMEOUT);
         if (file == null || file.id() == null || file.id().isBlank()) {
             throw new IllegalStateException("OpenAI file upload failed for batch");
         }
@@ -380,7 +381,7 @@ public class ChatGptClient {
                 .bodyValue(payload)
                 .retrieve()
                 .bodyToMono(OpenAiBatch.class)
-                .block();
+                .block(OPENAI_REQUEST_TIMEOUT);
         if (batch == null || batch.id() == null) {
             throw new IllegalStateException("OpenAI batch creation failed");
         }
@@ -404,7 +405,7 @@ public class ChatGptClient {
                     .uri("/batches/{id}", current.id())
                     .retrieve()
                     .bodyToMono(OpenAiBatch.class)
-                    .block();
+                    .block(OPENAI_REQUEST_TIMEOUT);
             if (current == null) {
                 throw new IllegalStateException("OpenAI returned null batch while polling");
             }
@@ -431,7 +432,7 @@ public class ChatGptClient {
                 .uri("/files/{id}/content", fileId)
                 .retrieve()
                 .bodyToMono(String.class)
-                .block();
+                .block(OPENAI_REQUEST_TIMEOUT);
     }
 
     private Map<String, OpenAiResponse> parseBatchOutput(String content) {


### PR DESCRIPTION
### Motivation
- The niche batch workflow could appear to hang when individual WebClient calls to the OpenAI Batch API never returned, causing schedulers to stall. 
- Add per-request guardrails so a single stalled HTTP call fails fast while preserving the overall batch lifecycle timeout.

### Description
- Introduced `OPENAI_REQUEST_TIMEOUT = Duration.ofSeconds(30)` in `ai-worker/src/main/java/com/marketinghub/worker/niche/ChatGptClient.java`.
- Applied the timeout to all blocking WebClient calls that previously used `.block()` without a timeout: file upload (`/files`), batch creation (`/batches`), batch polling (`/batches/{id}`) and output download (`/files/{id}/content`).
- Kept the existing macro batch timeout `BATCH_TIMEOUT = Duration.ofMinutes(2)` intact to preserve batch-level semantics.
- Commit message: "Fix OpenAI batch calls hanging in niche worker" (1 file changed: `ChatGptClient.java`).

### Testing
- Ran `mvn -Dtest=com.marketinghub.worker.niche.NicheHypothesisServiceTest test` inside `ai-worker`, which failed to execute due to external dependency resolution error (`401 Unauthorized` when fetching `com.marketinghub:ads-service` from GitHub Packages). 
- No unit tests were able to complete in this environment because of the Maven auth failure, so behavior validated by code inspection and targeted change of `.block()` calls to `.block(OPENAI_REQUEST_TIMEOUT)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15eb8a21883218a86aed1db1497f5)