### PR TITLE
Run Hotmart scheduler every 20 minutes and convert scheduler to heartbeat-only (remove service execution)

### DIFF
--- a/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotProperties.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotProperties.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 public class MoisHotmartRobotProperties {
 
     private boolean enabled = false;
-    private String cron = "0 0 14 * * *";
+    private String cron = "0 */20 * * * *";
     private String workspaceId = "workspace-001";
     private String niche = "marketing-digital";
     private String marketTheme = "ofertas-com-temperatura-alta";

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotScheduler.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotScheduler.java
@@ -11,34 +11,14 @@ public class MoisHotmartRobotScheduler {
     private static final Logger log = LoggerFactory.getLogger(MoisHotmartRobotScheduler.class);
 
     private final MoisHotmartRobotProperties properties;
-    private final MoisHotmartRobotService service;
-
-    public MoisHotmartRobotScheduler(MoisHotmartRobotProperties properties, MoisHotmartRobotService service) {
+    public MoisHotmartRobotScheduler(MoisHotmartRobotProperties properties) {
         this.properties = properties;
-        this.service = service;
     }
 
-    @Scheduled(cron = "${mois.robot.hotmart.cron:0 0 14 * * *}")
+    @Scheduled(cron = "${mois.robot.hotmart.cron:0 */20 * * * *}")
     public void run() {
-        log.info("MOIS Hotmart scheduler acionado (enabled={}, cron={})",
+        log.info("MOIS Hotmart scheduler heartbeat: agendamento ativo (enabled={}, cron={})",
                 properties.isEnabled(),
                 properties.getCron());
-        if (!properties.isEnabled()) {
-            log.warn("MOIS Hotmart scheduler ignorado: robot desabilitado (cron={})", properties.getCron());
-            return;
-        }
-        long startedAt = System.currentTimeMillis();
-        log.info("MOIS Hotmart scheduler iniciado (cron={}, workspaceId={}, niche={}, marketTheme={})",
-                properties.getCron(),
-                properties.getWorkspaceId(),
-                properties.getNiche(),
-                properties.getMarketTheme());
-        try {
-            service.triggerScheduledRun();
-            log.info("MOIS Hotmart scheduler finalizado com sucesso (elapsedMs={})",
-                    System.currentTimeMillis() - startedAt);
-        } catch (RuntimeException ex) {
-            log.error("Falha no robô diário do Hotmart no MOIS.", ex);
-        }
     }
 }

--- a/mois/src/main/resources/application.properties
+++ b/mois/src/main/resources/application.properties
@@ -14,7 +14,7 @@ integrations.backend.persistence.read-timeout=5s
 
 # Robô de coleta Hotmart (executa no container MOIS)
 mois.robot.hotmart.enabled=${MOIS_ROBOT_HOTMART_ENABLED:true}
-mois.robot.hotmart.cron=${MOIS_ROBOT_HOTMART_CRON:0 0 17 * * *}
+mois.robot.hotmart.cron=${MOIS_ROBOT_HOTMART_CRON:0 */20 * * * *}
 mois.robot.hotmart.workspace-id=${MOIS_ROBOT_HOTMART_WORKSPACE_ID:workspace-001}
 mois.robot.hotmart.niche=${MOIS_ROBOT_HOTMART_NICHE:marketing-digital}
 mois.robot.hotmart.market-theme=${MOIS_ROBOT_HOTMART_MARKET_THEME:ofertas-com-temperatura-alta}


### PR DESCRIPTION
### Motivation
- Increase the Hotmart robot scheduling frequency to run every 20 minutes instead of once daily.
- Temporarily disable the robot's active execution path in the scheduler while keeping a scheduled heartbeat for monitoring.
- Provide a safer default while operations or integration changes are being made to the Hotmart service invocation.

### Description
- Changed the default cron expression from `0 0 14 * * *` / `0 0 17 * * *` to `0 */20 * * * *` in `MoisHotmartRobotProperties` and `application.properties`.
- Updated the `@Scheduled` annotation default cron in `MoisHotmartRobotScheduler` to `0 */20 * * * *`.
- Removed the `MoisHotmartRobotService` injection and all execution logic from `MoisHotmartRobotScheduler`, leaving a heartbeat log only (`run()` now only logs scheduler heartbeat and properties).
- Adjusted the scheduler log message text to indicate a heartbeat and that scheduling is active.

### Testing
- No automated tests were run on the modified code.
- The change is limited to scheduler configuration and removal of service invocation and should be validated by running the application to observe the heartbeat log at the new frequency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15dfc84308321b1d30df6fccc5491)