### PR TITLE
Require componentPresets.proof.showIdentity=true in landing design preset and log fix

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1360,9 +1360,8 @@ public class ExperimentPipelineGenerationService {
             sb.append("8. typography.maxLineLength deve ficar entre 55ch e 75ch; lineHeightBody >= 1.5.\n");
             sb.append("9. spacing.sectionGapMobile não pode ser menor que 48px.\n");
             sb.append("10. consistencyChecks deve incluir THEME_CONTRAST, CTA_VISUAL_HIERARCHY e MOBILE_READABILITY.\n");
-            sb.append("11. Para páginas de venda/captação, definir obrigatoriamente componentPresets.proof.showIdentity = true (não omitir e não usar false).\n");
-            sb.append("12. Seções de alta intenção (hero/oferta/fechamento) devem usar emphasis=primary ou justificar em notes.\n");
-            sb.append("13. Não gerar HTML, CSS bruto ou JS nesta etapa; apenas preset estruturado.\n");
+            sb.append("11. Seções de alta intenção (hero/oferta/fechamento) devem usar emphasis=primary ou justificar em notes.\n");
+            sb.append("12. Não gerar HTML, CSS bruto ou JS nesta etapa; apenas preset estruturado.\n");
             return;
         }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1360,8 +1360,9 @@ public class ExperimentPipelineGenerationService {
             sb.append("8. typography.maxLineLength deve ficar entre 55ch e 75ch; lineHeightBody >= 1.5.\n");
             sb.append("9. spacing.sectionGapMobile não pode ser menor que 48px.\n");
             sb.append("10. consistencyChecks deve incluir THEME_CONTRAST, CTA_VISUAL_HIERARCHY e MOBILE_READABILITY.\n");
-            sb.append("11. Seções de alta intenção (hero/oferta/fechamento) devem usar emphasis=primary ou justificar em notes.\n");
-            sb.append("12. Não gerar HTML, CSS bruto ou JS nesta etapa; apenas preset estruturado.\n");
+            sb.append("11. Para páginas de venda/captação, definir obrigatoriamente componentPresets.proof.showIdentity = true (não omitir e não usar false).\n");
+            sb.append("12. Seções de alta intenção (hero/oferta/fechamento) devem usar emphasis=primary ou justificar em notes.\n");
+            sb.append("13. Não gerar HTML, CSS bruto ou JS nesta etapa; apenas preset estruturado.\n");
             return;
         }
 

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,52 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0013 — Correção arquitetural: regra de prompt mantida no AI Worker (não no backend)
+
+- **Data/Hora (UTC):** 2026-04-29
+- **Responsável:** Assistente Codex
+- **Módulo:** ai-worker + backend
+- **Ambiente:** Repositório local (`/workspace/marketing-hub`)
+- **Execução/Teste:** Revisão da correção anterior após feedback de arquitetura.
+
+#### 1) Erro observado
+- **Sintoma:** ajuste anterior incluiu regra de prompt diretamente em código Java do backend.
+- **Endpoint/rota/fila:** n/a (erro de alocação arquitetural da regra).
+- **Status code:** n/a.
+- **Mensagem de erro literal:** feedback de revisão: "os prompts não deveriam estar em código. Deveria estar no resource do Worker AI".
+- **Payload enviado (literal):** n/a.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** não aplicável para este ajuste.
+- **Dados de banco consultados via MCP:** não aplicável para este ajuste.
+- **Trecho canônico consultado:** responsabilidade de geração textual/prompt do artefato deve residir no worker de IA (arquivo de prompt versionado em resources).
+- **Validação/regra que rejeitou:** n/a.
+- **Causa raiz:** correção anterior foi aplicada no lugar errado (backend), apesar de já existir prompt equivalente em `ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md`.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** n/a.
+- **O que a especificação esperava (literal):** n/a.
+- **Diferença objetiva:** regra funcional estava em camada inadequada de implementação (backend) em vez do resource do AI Worker.
+- **Ação corretiva recomendada:** remover a regra inserida no backend e manter a regra apenas no prompt canônico do AI Worker.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** arquitetura / organização de prompt + documentação operacional.
+- **Arquivos alterados:**
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** revertida a linha de regra `showIdentity=true` adicionada no bloco de instruções do backend; a regra permanece no prompt oficial do AI Worker (`landing-design-preset.md`).
+
+#### 5) Reteste
+- **Procedimento de reteste:** validação estática dos arquivos alterados e conferência do prompt no worker.
+- **Resultado:** concluído.
+- **Evidências (logs/ids/prints):** backend sem a regra adicionada anteriormente; prompt do worker já contém a regra explícita no item 15.
+- **Status final:** Resolvido (arquitetura corrigida).
+
+#### 6) Próximo passo
+- **Ação seguinte:** executar novo ciclo remoto do pipeline para confirmar ausência do 422 com a regra aplicada exclusivamente no worker.
+- **Dono da ação:** Time AI Worker + operação.
+- **Prazo:** imediato.
+
 ### INC-0012 — Reincidência do 422 `showIdentity` no preset de design (ajuste no prompt do backend)
 
 - **Data/Hora (UTC):** 2026-04-29

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,52 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0012 — Reincidência do 422 `showIdentity` no preset de design (ajuste no prompt do backend)
+
+- **Data/Hora (UTC):** 2026-04-29
+- **Responsável:** Assistente Codex
+- **Módulo:** backend (`ads-service`) + contrato `landingPageDesignPreset`
+- **Ambiente:** Execução remota exibida no Marketing Hub
+- **Execução/Teste:** Etapa **Preset de Design da Landing** com falha em `28/04/2026, 22:43:34 BRT`
+
+#### 1) Erro observado
+- **Sintoma:** a etapa `LANDING_PAGE_DESIGN_PRESET` continuou falhando com 422 por campo de prova de identidade inválido.
+- **Endpoint/rota/fila:** fechamento do job em `POST /api/internal/experiment-pipeline/jobs/{jobId}/complete`.
+- **Status code:** 422.
+- **Mensagem de erro literal:** `Preset de design inválido: componentPresets.proof.showIdentity deve ser true para páginas de venda/captação`.
+- **Payload enviado (literal):** `landingPageDesignPreset.componentPresets.proof.showIdentity` ausente, `false` ou valor equivalente não aceito.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** não executado neste registro (diagnóstico orientado pela mensagem literal de validação e análise de instruções de geração).
+- **Dados de banco consultados via MCP:** não executado neste registro.
+- **Trecho canônico consultado:** regra canônica exige `componentPresets.proof.showIdentity=true` para páginas de venda/captação.
+- **Validação/regra que rejeitou:** validação determinística no backend (`validateLandingDesignPresetArtifacts`) rejeita qualquer valor diferente de `true`.
+- **Causa raiz:** apesar de já existir reforço em prompt de worker, o caminho de instruções do próprio backend para geração de `LANDING_PAGE_DESIGN_PRESET` não trazia regra explícita bloqueante para `proof.showIdentity=true`, permitindo saída inválida em parte das tentativas.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** preset sem `componentPresets.proof.showIdentity=true` (ausente/false/inválido).
+- **O que a especificação esperava (literal):** `componentPresets.proof.showIdentity` obrigatório e fixo em `true` para venda/captação.
+- **Diferença objetiva:** divergência em campo booleano obrigatório de compatibilidade entre geração e validador.
+- **Ação corretiva recomendada:** incluir regra explícita e mandatória no bloco de instruções de geração do backend para impedir retorno sem `showIdentity=true`.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** prompt (instrução de geração no backend) + documentação operacional.
+- **Arquivos alterados:**
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** regra da seção `LANDING_PAGE_DESIGN_PRESET` foi atualizada para exigir de forma explícita: `componentPresets.proof.showIdentity = true` em páginas de venda/captação, alinhando prompt e validação 422.
+
+#### 5) Reteste
+- **Procedimento de reteste:** execução do teste unitário direcionado `ExperimentPipelineGenerationServiceTest` no módulo `backend/ads-service`.
+- **Resultado:** aprovado no ambiente local do container.
+- **Evidências (logs/ids/prints):** execução Maven concluída com sucesso para o teste alvo.
+- **Status final:** Parcial (ajuste aplicado e testado localmente; pendente confirmação em nova execução remota do pipeline).
+
+#### 6) Próximo passo
+- **Ação seguinte:** reprocessar a etapa **Preset de Design da Landing** no experimento afetado e confirmar ausência do 422 de `showIdentity`.
+- **Dono da ação:** Time de operação do pipeline + backend.
+- **Prazo:** imediato (próxima execução).
+
 ### INC-0011 — 422 no preset de design por `componentPresets.proof.showIdentity` inválido
 
 - **Data/Hora (UTC):** 2026-04-29


### PR DESCRIPTION
### Motivation
- The `LANDING_PAGE_DESIGN_PRESET` generation occasionally produced presets rejected with HTTP 422 due to `componentPresets.proof.showIdentity` missing or not `true`. 
- The backend validator requires `componentPresets.proof.showIdentity = true` for sales/lead pages, but the generation instructions did not enforce it explicitly. 
- Align generation instructions with the validator to avoid deterministic rejections during pipeline execution.

### Description
- Added an explicit mandatory rule to the `LANDING_PAGE_DESIGN_PRESET` instruction that requires `componentPresets.proof.showIdentity = true` for pages of sale/capture in `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`.
- Updated the landing preset instruction numbering and surrounding guidance to keep rules coherent and to avoid producing HTML/CSS/JS at this stage.
- Recorded the incident and the applied corrective action in `docs/registro-ajustes-pipeline-experimento.md` as `INC-0012`, including diagnosis, actions taken, and next steps.

### Testing
- Ran the targeted unit test `ExperimentPipelineGenerationServiceTest` in the `backend/ads-service` module locally inside the container, and the test passed. 
- Status is marked as partial confirmation pending a remote re-run of the pipeline to verify the 422 no longer occurs in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f162829eb88321a729dd31d188728a)