### PR TITLE
Change Hotmart robot default schedule from every 20 minutes to hourly

### DIFF
--- a/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotProperties.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotProperties.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 public class MoisHotmartRobotProperties {
 
     private boolean enabled = false;
-    private String cron = "0 */20 * * * *";
+    private String cron = "0 0 * * * *";
     private String workspaceId = "workspace-001";
     private String niche = "marketing-digital";
     private String marketTheme = "ofertas-com-temperatura-alta";

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotScheduler.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotScheduler.java
@@ -15,7 +15,7 @@ public class MoisHotmartRobotScheduler {
         this.properties = properties;
     }
 
-    @Scheduled(cron = "${mois.robot.hotmart.cron:0 */20 * * * *}")
+    @Scheduled(cron = "${mois.robot.hotmart.cron:0 0 * * * *}")
     public void run() {
         log.info("MOIS Hotmart scheduler heartbeat: agendamento ativo (enabled={}, cron={})",
                 properties.isEnabled(),

--- a/mois/src/main/resources/application.properties
+++ b/mois/src/main/resources/application.properties
@@ -14,7 +14,7 @@ integrations.backend.persistence.read-timeout=5s
 
 # Robô de coleta Hotmart (executa no container MOIS)
 mois.robot.hotmart.enabled=${MOIS_ROBOT_HOTMART_ENABLED:true}
-mois.robot.hotmart.cron=${MOIS_ROBOT_HOTMART_CRON:0 */20 * * * *}
+mois.robot.hotmart.cron=${MOIS_ROBOT_HOTMART_CRON:0 0 * * * *}
 mois.robot.hotmart.workspace-id=${MOIS_ROBOT_HOTMART_WORKSPACE_ID:workspace-001}
 mois.robot.hotmart.niche=${MOIS_ROBOT_HOTMART_NICHE:marketing-digital}
 mois.robot.hotmart.market-theme=${MOIS_ROBOT_HOTMART_MARKET_THEME:ofertas-com-temperatura-alta}


### PR DESCRIPTION
### Motivation
- Reduce the execution frequency of the Hotmart collection robot from every 20 minutes to once per hour to lower runtime load and better align with data freshness requirements.

### Description
- Updated the default cron expression from `0 */20 * * * *` to `0 0 * * * *` in `MoisHotmartRobotProperties`, the `@Scheduled` annotation in `MoisHotmartRobotScheduler`, and the fallback value in `application.properties`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ed4593e88321983efc31a78f223a)