### PR TITLE
Enforce lhmRuntime and surfaceSpec.style/contrastMode in landing presets/wireframes; update schema and tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1407,6 +1407,14 @@ public class ExperimentPipelineGenerationService {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                         "Wireframe da landing com section sem surfaceSpec.surfaceToken");
             }
+            if (!StringUtils.hasText(asTrimmedString(surfaceSpec.get("style")))) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Wireframe da landing com section sem surfaceSpec.style");
+            }
+            if (!StringUtils.hasText(asTrimmedString(surfaceSpec.get("contrastMode")))) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Wireframe da landing com section sem surfaceSpec.contrastMode");
+            }
         }
         Map<String, Object> readingFlowSpec = requiredMap(wireframePayload, "readingFlowSpec",
                 "Wireframe incompleto: readingFlowSpec é obrigatório");
@@ -1510,6 +1518,20 @@ public class ExperimentPipelineGenerationService {
         }
         Map<String, Object> theme = requiredMap(designPayload, "theme",
                 "Preset de design incompleto: theme é obrigatório");
+        Map<String, Object> lhmRuntime = requiredMap(designPayload, "lhmRuntime",
+                "Preset de design incompleto: lhmRuntime é obrigatório");
+        if (!StringUtils.hasText(asTrimmedString(lhmRuntime.get("baseCss")))) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Preset de design incompleto: lhmRuntime.baseCss é obrigatório");
+        }
+        if (!StringUtils.hasText(asTrimmedString(lhmRuntime.get("cssVersion")))) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Preset de design incompleto: lhmRuntime.cssVersion é obrigatório");
+        }
+        if (!StringUtils.hasText(asTrimmedString(lhmRuntime.get("cssNotes")))) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Preset de design incompleto: lhmRuntime.cssNotes é obrigatório");
+        }
         requiredMap(theme, "palette", "Preset de design incompleto: theme.palette é obrigatório");
         Map<String, Object> typography = requiredMap(theme, "typography",
                 "Preset de design incompleto: theme.typography é obrigatório");
@@ -2768,6 +2790,16 @@ public class ExperimentPipelineGenerationService {
                 "additionalProperties", false,
                 "properties", Map.of(
                         "presetId", stringSchema(),
+                        "lhmRuntime", Map.of(
+                                "type", "object",
+                                "additionalProperties", false,
+                                "properties", Map.of(
+                                        "baseCss", stringSchema(),
+                                        "cssVersion", stringSchema(),
+                                        "cssNotes", stringSchema()
+                                ),
+                                "required", List.of("baseCss", "cssVersion", "cssNotes")
+                        ),
                         "theme", Map.of(
                                 "type", "object",
                                 "additionalProperties", false,
@@ -2811,7 +2843,7 @@ public class ExperimentPipelineGenerationService {
                                         "intensity", Map.of("type", "string", "enum", List.of("none", "subtle", "moderate"))),
                                 "required", List.of("enabled", "intensity")),
                         "consistencyChecks", Map.of("type", "array", "minItems", 1, "items", consistencyCheckSchema())),
-                "required", List.of("presetId", "theme", "sectionPresets", "componentPresets", "motion", "consistencyChecks"));
+                "required", List.of("presetId", "lhmRuntime", "theme", "sectionPresets", "componentPresets", "motion", "consistencyChecks"));
     }
 
     private Map<String, Object> landingPageHtmlFieldSchema() {
@@ -3072,7 +3104,7 @@ public class ExperimentPipelineGenerationService {
                         Map.entry("contrastMode", Map.of("type", "string", "enum", List.of("normal", "high", "soft"))),
                         Map.entry("notes", stringSchema())
                 ),
-                "required", List.of("surfaceToken", "notes")
+                "required", List.of("surfaceToken", "style", "contrastMode", "notes")
         );
         Map<String, Object> ctaSlotSchema = Map.of(
                 "type", "object",

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -610,6 +610,7 @@ class ExperimentPipelineGenerationServiceTest {
                 {
                   "landingPageDesignPreset": {
                     "presetId": "preset-88",
+                    "lhmRuntime": {"baseCss":".x{}","cssVersion":"v1","cssNotes":"baseline"},
                     "theme": {
                       "palette": {
                         "background":"#ffffff","surface":"#ffffff","textPrimary":"#111827","textMuted":"#6b7280","brandPrimary":"#2563eb","brandSecondary":"#1d4ed8","border":"#e5e7eb"
@@ -644,8 +645,8 @@ class ExperimentPipelineGenerationServiceTest {
                     "trustSignalsSpec": {"brandIdentityRequired": true, "privacyNoticeNearForm": true, "privacyPolicyUrl": "https://example.com/privacy", "legalFooterItems": ["empresa","contato","política de privacidade"]},
                     "accessibilitySpec": {"minTextContrast":"4.5:1","minTouchTargetPx":44,"formFieldMinHeightPx":44},
                     "sectionOrder": [
-                      {"sectionId":"hero","dropOffRisk":"medio","mobilePriorityScore":8,"surfaceSpec":{"surfaceToken":"surface-base","notes":"hero"}},
-                      {"sectionId":"proof","dropOffRisk":"medio","mobilePriorityScore":7,"surfaceSpec":{"surfaceToken":"surface-alt-1","notes":"proof"}}
+                      {"sectionId":"hero","dropOffRisk":"medio","mobilePriorityScore":8,"surfaceSpec":{"surfaceToken":"surface-base","style":"solid","contrastMode":"high","notes":"hero"}},
+                      {"sectionId":"proof","dropOffRisk":"medio","mobilePriorityScore":7,"surfaceSpec":{"surfaceToken":"surface-alt-1","style":"band","contrastMode":"normal","notes":"proof"}}
                     ]
                   }
                 }
@@ -1026,6 +1027,41 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void completeJobRejectsWireframeWhenSurfaceStyleIsMissing() {
+        Experiment experiment = new Experiment();
+        experiment.setId(422L);
+        ExperimentPipelineGenerationJob job = createJobForSection(experiment, ExperimentPipelineSection.LANDING_PAGE_WIREFRAME);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> service.completeJob(job.getId(), new ExperimentPipelineGenerationJobCompletionRequest(
+                        """
+                                {
+                                  "landingPageWireframe": {
+                                    "readingFlowSpec": {"maxParagraphLinesMobile": 4, "bulletDensityPerSection": 3},
+                                    "conversionPathSpec": {"primaryAction": "Desbloquear", "ctaLabelCanonical": "Desbloquear"},
+                                    "proofPlan": {"requiredProofTypes": ["social-proof","metric-proof"], "proofSectionIds": ["hero"]},
+                                    "trustSignalsSpec": {"brandIdentityRequired": true, "privacyNoticeNearForm": true, "privacyPolicyUrl": "https://example.com/privacy", "legalFooterItems": ["empresa","contato","política de privacidade"]},
+                                    "accessibilitySpec": {"minTextContrast":"4.5:1","minTouchTargetPx":44,"formFieldMinHeightPx":44},
+                                    "sectionOrder": [
+                                      {
+                                        "sectionId": "hero",
+                                        "sectionName": "Hero",
+                                        "objective": "obj",
+                                        "contentType": "hero",
+                                        "mobilePriorityScore": 10,
+                                        "dropOffRisk": "baixo",
+                                        "surfaceSpec": {"surfaceToken": "surface-base", "contrastMode": "normal", "notes": "ok"}
+                                      }
+                                    ]
+                                  }
+                                }
+                                """,
+                        null, null, null, null, null)));
+
+        assertTrue(exception.getReason().contains("surfaceSpec.style"));
+    }
+
+    @Test
     void completeJobRejectsWireframeWhenCanonicalBlocksAreMissing() {
         Experiment experiment = new Experiment();
         experiment.setId(420L);
@@ -1044,7 +1080,7 @@ class ExperimentPipelineGenerationServiceTest {
                                         "contentType": "hero",
                                         "mobilePriorityScore": 9,
                                         "dropOffRisk": "alto",
-                                        "surfaceSpec": {"surfaceToken": "surface-base", "notes": "ok"}
+                                        "surfaceSpec": {"surfaceToken": "surface-base", "style": "band", "contrastMode": "normal", "notes": "ok"}
                                       }
                                     ],
                                     "consistencyChecks": [{"check":"CTA_MATCH","status":"PASS"}],
@@ -1102,6 +1138,7 @@ class ExperimentPipelineGenerationServiceTest {
                                 {
                                   "landingPageDesignPreset": {
                                     "presetId": "preset-1",
+                                    "lhmRuntime": {"baseCss":".x{}","cssVersion":"v1","cssNotes":"baseline"},
                                     "theme": {
                                       "palette": {
                                         "background":"#fff","surface":"#fff","textPrimary":"#111","textMuted":"#666","brandPrimary":"#1d4ed8","brandSecondary":"#1e40af","border":"#e2e8f0"
@@ -1167,6 +1204,7 @@ class ExperimentPipelineGenerationServiceTest {
                                 {
                                   "landingPageDesignPreset": {
                                     "presetId": "preset-421",
+                                    "lhmRuntime": {"baseCss":".x{}","cssVersion":"v1","cssNotes":"baseline"},
                                     "theme": {
                                       "palette": {
                                         "background":"#fff","surface":"#fff","textPrimary":"#111","textMuted":"#666","brandPrimary":"#1d4ed8","brandSecondary":"#1e40af","border":"#e2e8f0"
@@ -1192,6 +1230,62 @@ class ExperimentPipelineGenerationServiceTest {
 
         assertTrue(exception.getReason().contains("CTA_VISUAL_HIERARCHY"));
         assertTrue(exception.getReason().contains("MOBILE_READABILITY"));
+    }
+
+    @Test
+    void completeJobRejectsDesignPresetWhenLhmRuntimeIsMissing() {
+        Experiment experiment = new Experiment();
+        experiment.setId(423L);
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "readingFlowSpec": {"maxParagraphLinesMobile": 4, "bulletDensityPerSection": 3},
+                    "conversionPathSpec": {"primaryAction": "Desbloquear", "ctaLabelCanonical": "Desbloquear"},
+                    "proofPlan": {"requiredProofTypes": ["social-proof","metric-proof"], "proofSectionIds": ["hero"]},
+                    "trustSignalsSpec": {"brandIdentityRequired": true, "privacyNoticeNearForm": true, "privacyPolicyUrl": "https://example.com/privacy", "legalFooterItems": ["empresa","contato","política de privacidade"]},
+                    "accessibilitySpec": {"minTextContrast":"4.5:1","minTouchTargetPx":44,"formFieldMinHeightPx":44},
+                    "sectionOrder": [
+                      {"sectionId":"hero","dropOffRisk":"medio","mobilePriorityScore":8,"surfaceSpec":{"surfaceToken":"surface-base","style":"solid","contrastMode":"high","notes":"hero"}}
+                    ]
+                  }
+                }
+                """);
+        ExperimentPipelineGenerationJob job = createJobForSection(experiment, ExperimentPipelineSection.LANDING_PAGE_DESIGN_PRESET);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> service.completeJob(job.getId(), new ExperimentPipelineGenerationJobCompletionRequest(
+                        """
+                                {
+                                  "landingPageDesignPreset": {
+                                    "presetId": "preset-423",
+                                    "theme": {
+                                      "palette": {
+                                        "background":"#fff","surface":"#fff","textPrimary":"#111","textMuted":"#666","brandPrimary":"#1d4ed8","brandSecondary":"#1e40af","border":"#e2e8f0"
+                                      },
+                                      "typography": {"maxLineLength":"65ch","lineHeightBody":"1.6"},
+                                      "spacing": {"sectionGapMobile":"56px"},
+                                      "accessibility": {"textContrastBody":"4.5:1"}
+                                    },
+                                    "sectionPresets": [
+                                      {"sectionId":"hero","surfaceStyle":"solid","contrastMode":"high","layoutPreset":"hero-focus","emphasis":"primary","notes":"hero"}
+                                    ],
+                                    "componentPresets": {
+                                      "cta": {"stickyMobile":true},
+                                      "trust": {"showLegalFooter":true},
+                                      "proof": {"showIdentity": true}
+                                    },
+                                    "motion": {"enabled": false, "intensity": "none"},
+                                    "consistencyChecks": [
+                                      {"check":"THEME_CONTRAST","status":"PASS"},
+                                      {"check":"CTA_VISUAL_HIERARCHY","status":"PASS"},
+                                      {"check":"MOBILE_READABILITY","status":"PASS"}
+                                    ]
+                                  }
+                                }
+                                """,
+                        null, null, null, null, null)));
+
+        assertTrue(exception.getReason().contains("lhmRuntime"));
     }
 
     @Test
@@ -1349,6 +1443,7 @@ class ExperimentPipelineGenerationServiceTest {
                 {
                   "landingPageDesignPreset": {
                     "presetId": "preset-manual-html",
+                    "lhmRuntime": {"baseCss":".x{}","cssVersion":"v1","cssNotes":"baseline"},
                     "theme": {
                       "palette": {
                         "background":"#ffffff",

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -693,3 +693,69 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 #### 5) Próximo passo
 - Executar o pipeline, enviar o primeiro erro e preencher `INC-0002` com diagnóstico completo.
+
+### INC-0010 — Alinhamento de obrigatoriedade no schema de Design Preset e Wireframe
+
+- **Data/Hora (UTC):** 2026-04-29
+- **Responsável:** Assistente Codex
+- **Módulo:** backend (ads-service) + documentação
+- **Ambiente:** Repositório `marketing-hub`
+- **Execução/Teste:** Verificação de contrato das etapas `LANDING_PAGE_DESIGN_PRESET` e `LANDING_PAGE_WIREFRAME`
+
+#### 1) Erro observado
+- **Sintoma:** o contrato ativo do backend não refletia integralmente a obrigatoriedade canônica esperada para `lhmRuntime` e para campos visuais de `surfaceSpec`.
+- **Endpoint/rota/fila:** geração de schema para payloads das etapas de pipeline (`response_format` JSON Schema).
+- **Status code:** potencial de 422 em etapas posteriores por lacunas contratuais implícitas.
+- **Mensagem de erro literal:** não aplicável (ajuste preventivo por divergência de contrato identificada em revisão).
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** não aplicável (ajuste estrutural de schema).
+- **Dados de banco consultados via MCP:** não aplicável.
+- **Trecho canônico consultado:** `landingPageDesignPreset` com `lhmRuntime.baseCss/cssVersion/cssNotes` e necessidade de superfície/contraste explícitos por seção.
+- **Validação/regra que motivou ajuste:** reduzir ambiguidade do contrato para evitar geração incompleta do preset e wireframe.
+- **Causa raiz:** `landingPageDesignPresetFieldSchema()` não exigia `lhmRuntime` e `landingPageWireframe` aceitava `surfaceSpec.style/contrastMode` como opcionais.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregava/aceitava (literal):**
+  - Design preset podia ser validado sem `lhmRuntime`.
+  - Wireframe podia ser validado com `surfaceSpec` contendo apenas `surfaceToken` e `notes`.
+- **O que a especificação esperava (literal):**
+  - `lhmRuntime` obrigatório com `baseCss`, `cssVersion` e `cssNotes`.
+  - `surfaceSpec` obrigatório com `surfaceToken`, `style`, `contrastMode` e `notes`.
+- **Diferença objetiva:** campos críticos de renderização CSS e contraste ainda opcionais no contrato técnico.
+- **Ação corretiva recomendada:** tornar obrigatórios no schema de geração para eliminar payload implícito.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** contrato/schema backend + registro documental.
+- **Arquivos alterados:**
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:**
+  - incluído `lhmRuntime` no schema de `landingPageDesignPreset` com `required` de `baseCss`, `cssVersion` e `cssNotes`, além de inclusão de `lhmRuntime` no `required` da raiz do preset;
+  - atualizado `required` de `surfaceSpec` no schema de wireframe para exigir `surfaceToken`, `style`, `contrastMode` e `notes`.
+
+#### 5) Reteste
+- **Procedimento de reteste:** execução de teste unitário direcionado do módulo de pipeline.
+- **Resultado:** execução bem-sucedida do teste selecionado.
+- **Evidências (logs/ids/prints):** `mvn -Dtest=ExperimentPipelineGenerationServiceTest test`.
+- **Status final:** Concluído.
+
+#### 6) Próximo passo
+- **Ação seguinte:** monitorar próximas execuções das etapas `LANDING_PAGE_WIREFRAME` e `LANDING_PAGE_DESIGN_PRESET` para confirmar redução de payloads implícitos.
+- **Dono da ação:** Time de operação do pipeline.
+- **Prazo:** imediato (próxima rodada de geração).
+
+### INC-0011 — Validações backend explícitas para `lhmRuntime` e `surfaceSpec` visual
+
+- **Data/Hora (UTC):** 2026-04-29
+- **Responsável:** Assistente Codex
+- **Módulo:** backend (ads-service)
+- **Execução/Teste:** endurecimento de validação no `completeJob` para `LANDING_PAGE_DESIGN_PRESET` e `LANDING_PAGE_WIREFRAME`
+
+#### Ajuste aplicado
+- Validação de wireframe passou a rejeitar seção sem `surfaceSpec.style` e sem `surfaceSpec.contrastMode`.
+- Validação de design preset passou a exigir `lhmRuntime` com `baseCss`, `cssVersion` e `cssNotes` no payload concluído.
+- Atualizados testes unitários para refletir o contrato obrigatório e adicionados cenários de rejeição dedicados.
+
+#### Reteste
+- `mvn -Dtest=ExperimentPipelineGenerationServiceTest test` executado com sucesso após atualização dos cenários.


### PR DESCRIPTION
### Motivation
- Align the backend JSON contract for landing design presets and wireframes so required runtime CSS metadata and surface visual fields are explicit. 
- Prevent downstream 422s and rendering inconsistencies by rejecting payloads that omit `lhmRuntime` or surface visual properties. 
- Make server-side validation and generated JSON Schema consistent with the canonical expectations for rendering and accessibility checks. 

### Description
- Added explicit validation in `ExperimentPipelineGenerationService` to reject wireframe sections missing `surfaceSpec.style` and `surfaceSpec.contrastMode`. 
- Added required `lhmRuntime` object checks (with `baseCss`, `cssVersion`, `cssNotes`) for `landingPageDesignPreset` payloads and updated schema generation to include `lhmRuntime` as required. 
- Updated `surfaceSpec` schema to require `surfaceToken`, `style`, `contrastMode`, and `notes`, and updated the preset root `required` fields to include `lhmRuntime`. 
- Updated unit tests to cover the new rejection paths and adjusted several fixtures to include `lhmRuntime` and `surfaceSpec` visual fields, and documented the change in `docs/registro-ajustes-pipeline-experimento.md`. 

### Testing
- Ran unit tests with `mvn -Dtest=ExperimentPipelineGenerationServiceTest test`, which executed successfully. 
- Added tests `completeJobRejectsWireframeWhenSurfaceStyleIsMissing` and `completeJobRejectsDesignPresetWhenLhmRuntimeIsMissing`, both asserting the new validation failures. 
- Existing tests were updated to include the new `lhmRuntime` and `surfaceSpec` fields where appropriate and all modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21efd811483219d991ca100e545b7)