### PR TITLE
Fail fast in LandingHtmlModule when canonical artifacts are missing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -28,13 +28,17 @@ public class LandingHtmlModule {
         if (experiment == null) {
             return "";
         }
+        String landingPageWireframe = requireArtifact(experiment.getLandingPageWireframe(), "landingPageWireframe");
+        String landingPageCopy = requireArtifact(experiment.getLandingPageCopy(), "landingPageCopy");
+        String landingPageDesignPreset = requireArtifact(experiment.getLandingPageDesignPreset(), "landingPageDesignPreset");
+        String landingPageImagePlanning = requireArtifact(experiment.getLandingPageImagePlanning(), "landingPageImagePlanning");
         StringBuilder sb = new StringBuilder();
         sb.append("\nPrompt v2 (inputs mínimos para LANDING_PAGE_HTML):\n");
         sb.append("Use apenas os 4 insumos abaixo como fonte de verdade para montar o HTML final.\n");
-        appendIfPresent(sb, "1) Wireframe aprovado (JSON)", experiment.getLandingPageWireframe());
-        appendIfPresent(sb, "2) Texto da landing aprovado (JSON)", experiment.getLandingPageCopy());
-        appendIfPresent(sb, "3) Preset de design aprovado (JSON)", experiment.getLandingPageDesignPreset());
-        String imageUrls = summarizeImageUrlsFromPlanning(experiment.getLandingPageImagePlanning());
+        appendIfPresent(sb, "1) Wireframe aprovado (JSON)", landingPageWireframe);
+        appendIfPresent(sb, "2) Texto da landing aprovado (JSON)", landingPageCopy);
+        appendIfPresent(sb, "3) Preset de design aprovado (JSON)", landingPageDesignPreset);
+        String imageUrls = summarizeImageUrlsFromPlanning(landingPageImagePlanning);
         if (StringUtils.hasText(imageUrls)) {
             sb.append("4) URLs de imagens aprovadas por seção:\n").append(imageUrls);
         } else {
@@ -48,7 +52,12 @@ public class LandingHtmlModule {
         if (experiment == null) {
             return "";
         }
-        Map<String, Object> wireframeRoot = safeReadObject(experiment.getLandingPageWireframe());
+        String landingPageWireframe = requireArtifact(experiment.getLandingPageWireframe(), "landingPageWireframe");
+        String landingPageCopy = requireArtifact(experiment.getLandingPageCopy(), "landingPageCopy");
+        String landingPageDesignPreset = requireArtifact(experiment.getLandingPageDesignPreset(), "landingPageDesignPreset");
+        String landingPageImagePlanning = requireArtifact(experiment.getLandingPageImagePlanning(), "landingPageImagePlanning");
+
+        Map<String, Object> wireframeRoot = safeReadObject(landingPageWireframe, "landingPageWireframe");
         Map<String, Object> wireframe = unwrapSectionPayload(wireframeRoot, "landingPageWireframe");
         Map<String, Object> formSpec = wireframe.get("formSpec") instanceof Map<?, ?> form
                 ? (Map<String, Object>) form
@@ -61,7 +70,7 @@ public class LandingHtmlModule {
                 .toList()
                 : List.of();
 
-        Map<String, Object> copyRoot = safeReadObject(experiment.getLandingPageCopy());
+        Map<String, Object> copyRoot = safeReadObject(landingPageCopy, "landingPageCopy");
         Map<String, Object> copy = unwrapSectionPayload(copyRoot, "landingPageCopy");
         Map<String, Object> heroCopy = copy.get("hero") instanceof Map<?, ?> rawHero
                 ? (Map<String, Object>) rawHero
@@ -102,8 +111,8 @@ public class LandingHtmlModule {
         String heroHeadline = resolveHeroHeadline(copy, heroCopy, pageTitle);
         String sanitizedPageSummary = sanitizePageSummary(pageSummary, heroHeadline, heroCopy);
 
-        List<Map<String, Object>> plannedImages = extractImages(experiment.getLandingPageImagePlanning());
-        Map<String, Object> designRoot = safeReadObject(experiment.getLandingPageDesignPreset());
+        List<Map<String, Object>> plannedImages = extractImages(landingPageImagePlanning);
+        Map<String, Object> designRoot = safeReadObject(landingPageDesignPreset, "landingPageDesignPreset");
         Map<String, Object> designPreset = unwrapSectionPayload(designRoot, "landingPageDesignPreset");
         Map<String, Object> palette = extractPalette(designPreset);
         Map<String, Object> typography = extractTypography(designPreset);
@@ -206,43 +215,36 @@ public class LandingHtmlModule {
 
     @SuppressWarnings("unchecked")
     private String summarizeImageUrlsFromPlanning(String imagePlanningPayload) {
-        if (!StringUtils.hasText(imagePlanningPayload)) {
+        Map<String, Object> root = safeReadObject(imagePlanningPayload, "landingPageImagePlanning");
+        Map<String, Object> payload = unwrapSectionPayload(root, "landingPageImagePlanning");
+        if (!(payload.get("images") instanceof List<?> rawImages)) {
             return null;
         }
-        try {
-            Map<String, Object> root = objectMapper.readValue(imagePlanningPayload, Map.class);
-            Map<String, Object> payload = unwrapSectionPayload(root, "landingPageImagePlanning");
-            if (!(payload.get("images") instanceof List<?> rawImages)) {
-                return null;
+        StringBuilder sb = new StringBuilder();
+        int index = 0;
+        for (Object rawImage : rawImages) {
+            if (!(rawImage instanceof Map<?, ?> rawImageMap)) {
+                continue;
             }
-            StringBuilder sb = new StringBuilder();
-            int index = 0;
-            for (Object rawImage : rawImages) {
-                if (!(rawImage instanceof Map<?, ?> rawImageMap)) {
-                    continue;
-                }
-                Map<String, Object> image = (Map<String, Object>) rawImageMap;
-                String sectionId = asTrimmedString(image.get("sectionId"));
-                String bindingKey = asTrimmedString(image.get("imageBindingKey"));
-                String url = firstNonBlank(
-                        asTrimmedString(image.get("webUrl")),
-                        asTrimmedString(image.get("imageUrl")),
-                        asTrimmedString(image.get("sourceUrl")),
-                        asTrimmedString(image.get("url")));
-                if (!StringUtils.hasText(url)) {
-                    continue;
-                }
-                index++;
-                sb.append("- #").append(index)
-                        .append(" | sectionId=").append(StringUtils.hasText(sectionId) ? sectionId : "(sem sectionId)")
-                        .append(" | imageBindingKey=").append(StringUtils.hasText(bindingKey) ? bindingKey : "(sem binding)")
-                        .append(" | url=").append(url)
-                        .append("\n");
+            Map<String, Object> image = (Map<String, Object>) rawImageMap;
+            String sectionId = asTrimmedString(image.get("sectionId"));
+            String bindingKey = asTrimmedString(image.get("imageBindingKey"));
+            String url = firstNonBlank(
+                    asTrimmedString(image.get("webUrl")),
+                    asTrimmedString(image.get("imageUrl")),
+                    asTrimmedString(image.get("sourceUrl")),
+                    asTrimmedString(image.get("url")));
+            if (!StringUtils.hasText(url)) {
+                continue;
             }
-            return sb.length() > 0 ? sb.toString() : null;
-        } catch (Exception ex) {
-            return null;
+            index++;
+            sb.append("- #").append(index)
+                    .append(" | sectionId=").append(StringUtils.hasText(sectionId) ? sectionId : "(sem sectionId)")
+                    .append(" | imageBindingKey=").append(StringUtils.hasText(bindingKey) ? bindingKey : "(sem binding)")
+                    .append(" | url=").append(url)
+                    .append("\n");
         }
+        return sb.length() > 0 ? sb.toString() : null;
     }
 
     @SuppressWarnings("unchecked")
@@ -283,20 +285,17 @@ public class LandingHtmlModule {
         return null;
     }
 
-    private Map<String, Object> safeReadObject(String raw) {
-        if (!StringUtils.hasText(raw)) {
-            return Map.of();
-        }
+    private Map<String, Object> safeReadObject(String raw, String artifactKey) {
         try {
             return objectMapper.readValue(raw, Map.class);
         } catch (Exception ex) {
-            return Map.of();
+            throw new IllegalStateException("Artefato %s contém JSON inválido.".formatted(artifactKey), ex);
         }
     }
 
     @SuppressWarnings("unchecked")
     private List<Map<String, Object>> extractImages(String raw) {
-        Map<String, Object> root = safeReadObject(raw);
+        Map<String, Object> root = safeReadObject(raw, "landingPageImagePlanning");
         Map<String, Object> payload = unwrapSectionPayload(root, "landingPageImagePlanning");
         if (!(payload.get("images") instanceof List<?> rawImages)) {
             return List.of();
@@ -306,6 +305,13 @@ public class LandingHtmlModule {
                 .map(Map.class::cast)
                 .map(item -> (Map<String, Object>) item)
                 .toList();
+    }
+
+    private String requireArtifact(String raw, String artifactKey) {
+        if (!StringUtils.hasText(raw)) {
+            throw new IllegalStateException("Artefato obrigatório ausente: %s.".formatted(artifactKey));
+        }
+        return raw;
     }
 
     @SuppressWarnings("unchecked")

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.Experiment;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -15,6 +16,7 @@ class LandingHtmlModuleTest {
     void assembleHtmlDocumentIncludesCanonicalAsyncSubmitRuntime() {
         Experiment experiment = new Experiment();
         applyBaseCssContract(experiment);
+        applyImagePlanningContract(experiment);
         experiment.setName("Teste LHM");
         experiment.setLandingPageWireframe("""
                 {
@@ -45,10 +47,25 @@ class LandingHtmlModuleTest {
                 """);
         experiment.setLandingPageCopy("""
                 {
+                  "landingPageCopy": {}
+                }
+                """);
+        experiment.setLandingPageCopy("""
+                {
                   "landingPageCopy": {
                     "headline": "Headline de teste",
                     "summary": "Resumo de teste"
                   }
+                }
+                """);
+        experiment.setLandingPageCopy("""
+                {
+                  "landingPageCopy": {}
+                }
+                """);
+        experiment.setLandingPageCopy("""
+                {
+                  "landingPageCopy": {}
                 }
                 """);
 
@@ -69,6 +86,7 @@ class LandingHtmlModuleTest {
     void assembleHtmlDocumentKeepsExactSurfaceContractFromWireframe() {
         Experiment experiment = new Experiment();
         applyBaseCssContract(experiment);
+        applyImagePlanningContract(experiment);
         experiment.setName("Teste LHM Surface");
         experiment.setLandingPageWireframe("""
                 {
@@ -96,6 +114,7 @@ class LandingHtmlModuleTest {
                   }
                 }
                 """);
+        experiment.setLandingPageCopy("{\"landingPageCopy\":{}}");
 
         String html = module.assembleHtmlDocument(experiment);
 
@@ -112,6 +131,7 @@ class LandingHtmlModuleTest {
     void assembleHtmlDocumentRendersBodyFaqAndCtaFromLandingCopy() {
         Experiment experiment = new Experiment();
         applyBaseCssContract(experiment);
+        applyImagePlanningContract(experiment);
         experiment.setName("Teste LHM Copy Completa");
         experiment.setLandingPageWireframe("""
                 {
@@ -171,6 +191,7 @@ class LandingHtmlModuleTest {
     @Test
     void assembleHtmlDocumentUsesDesignPresetForStyleAndContrastMode() {
         Experiment experiment = new Experiment();
+        applyImagePlanningContract(experiment);
         experiment.setName("Teste LHM Surface Preset");
         experiment.setLandingPageWireframe("""
                 {
@@ -212,6 +233,11 @@ class LandingHtmlModuleTest {
                   }
                 }
                 """);
+        experiment.setLandingPageCopy("""
+                {
+                  "landingPageCopy": {}
+                }
+                """);
 
         String html = module.assembleHtmlDocument(experiment);
 
@@ -228,6 +254,7 @@ class LandingHtmlModuleTest {
     void assembleHtmlDocumentUsesHeroSectionInsteadOfFirstWireframeSectionForH1() {
         Experiment experiment = new Experiment();
         applyBaseCssContract(experiment);
+        applyImagePlanningContract(experiment);
         experiment.setName("Teste LHM Hero");
         experiment.setLandingPageWireframe("""
                 {
@@ -268,6 +295,7 @@ class LandingHtmlModuleTest {
     void assembleHtmlDocumentAvoidsRepeatingPromiseWhenDuplicateOfHeroHeadline() {
         Experiment experiment = new Experiment();
         applyBaseCssContract(experiment);
+        applyImagePlanningContract(experiment);
         experiment.setName("Teste LHM Dedup");
         experiment.setLandingPageWireframe("""
                 {
@@ -302,6 +330,16 @@ class LandingHtmlModuleTest {
         assertFalse(html.contains("<p class=\"section-objective\">Mesma mensagem da promessa</p>"));
     }
 
+    @Test
+    void assembleHtmlDocumentThrowsWhenArtifactIsMissing() {
+        Experiment experiment = new Experiment();
+        applyBaseCssContract(experiment);
+        experiment.setLandingPageWireframe("{\"landingPageWireframe\":{}}");
+        experiment.setLandingPageCopy("{\"landingPageCopy\":{}}");
+
+        assertThrows(IllegalStateException.class, () -> module.assembleHtmlDocument(experiment));
+    }
+
     private void applyBaseCssContract(Experiment experiment) {
         experiment.setLandingPageDesignPreset("""
                 {
@@ -309,6 +347,16 @@ class LandingHtmlModuleTest {
                     "lhmRuntime": {
                       "baseCss": "body{margin:0}.card{padding:16px}.surface-band{background:#fff}.surface-solid{background:#fff}.contrast-high{border-color:#bfd0ee}.contrast-soft{border-color:#e8edf6}"
                     }
+                  }
+                }
+                """);
+    }
+
+    private void applyImagePlanningContract(Experiment experiment) {
+        experiment.setLandingPageImagePlanning("""
+                {
+                  "landingPageImagePlanning": {
+                    "images": []
                   }
                 }
                 """);


### PR DESCRIPTION
### Motivation
- Ensure LandingHtmlModule fails fast when any canonical artifact is missing or contains invalid JSON so rendering errors are surfaced instead of silently producing incorrect output.

### Description
- Added `requireArtifact` and called it from `buildPromptV2Inputs` and `assembleHtmlDocument` to enforce presence of `landingPageWireframe`, `landingPageCopy`, `landingPageDesignPreset`, and `landingPageImagePlanning` and throw `IllegalStateException` when absent.
- Replaced silent JSON fallbacks with `safeReadObject(raw, artifactKey)` which throws `IllegalStateException` on invalid JSON and updated `summarizeImageUrlsFromPlanning` and `extractImages` to use it.
- Updated prompt assembly to use the validated artifact variables and adjusted related helper calls accordingly.
- Updated tests: added `assembleHtmlDocumentThrowsWhenArtifactIsMissing`, added `applyImagePlanningContract` fixture, and adjusted existing tests to provide the now-required artifacts.

### Testing
- Ran targeted unit tests with `mvn -Dtest=LandingHtmlModuleTest test`, which initially reported errors prior to test updates but after the test fixes the targeted suite completed successfully.
- Attempted `./gradlew` runs but the wrapper is not present in the repository, so Maven was used for test execution instead.
- Final automated run of `LandingHtmlModuleTest` passed with no failing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f235a6295c8321ac132b10de7d5d1c)