### PR TITLE
Reduce heartbeat logging verbosity by switching to DEBUG

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmHeartbeatController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmHeartbeatController.java
@@ -16,9 +16,8 @@ public class OprmHeartbeatController {
 
     @PostMapping
     public ResponseEntity<Void> heartbeat(@Valid @RequestBody OprmHeartbeatRequestDto request) {
-        log.info("oprm-heartbeat workerId={} workerVersion={} sentAt={} counters={}",
+        log.debug("oprm-heartbeat workerId={} workerVersion={} sentAt={} counters={}",
                 request.workerId(), request.workerVersion(), request.sentAt(), request.counters());
         return ResponseEntity.accepted().build();
     }
 }
-


### PR DESCRIPTION
### Motivation
- Reduce noisy INFO-level logs emitted by the heartbeat endpoint so routine heartbeat requests don't clutter logs.

### Description
- Change the log level in `OprmHeartbeatController` for the heartbeat endpoint from `log.info` to `log.debug` so heartbeat payloads are only logged at debug level.

### Testing
- Ran the existing automated test suite via `mvn test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21f6b49ec8321ac521249a09bc399)