### PR TITLE
Add `lhm-` namespace to generated landing HTML classes and require `lhmRuntime.baseCss`

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -150,11 +150,11 @@ public class LandingHtmlModule {
                     visualPreset != null ? visualPreset.contrastMode() : null,
                     asTrimmedString(surface.get("contrastMode")),
                     "normal");
-            String surfaceStyleClass = "surface-" + normalizeCssToken(surfaceStyle);
-            String surfaceContrastClass = "contrast-" + normalizeCssToken(surfaceContrast);
+            String surfaceStyleClass = "lhm-surface-" + normalizeCssToken(surfaceStyle);
+            String surfaceContrastClass = "lhm-" + normalizeCssToken(surfaceContrast);
             boolean isHeroSection = StringUtils.hasText(heroSectionId) && heroSectionId.equalsIgnoreCase(sectionId);
 
-            html.append("<section class=\"card ")
+            html.append("<section class=\"lhm-card ")
                     .append(escapeAttr(surfaceStyleClass))
                     .append(" ")
                     .append(escapeAttr(surfaceContrastClass))

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -2794,7 +2794,9 @@ public class ExperimentPipelineGenerationService {
                                 "type", "object",
                                 "additionalProperties", false,
                                 "properties", Map.of(
-                                        "baseCss", stringSchema(),
+                                        "baseCss", Map.of(
+                                                "type", "string",
+                                                "description", "CSS canônico do LHM. Deve cobrir classes .lhm-card, .lhm-surface-{band|solid|gradient-soft|image-tint} e .lhm-{normal|high|soft}."),
                                         "cssVersion", stringSchema(),
                                         "cssNotes", stringSchema()
                                 ),

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
@@ -119,7 +119,8 @@ class LandingHtmlModuleTest {
         String html = module.assembleHtmlDocument(experiment);
 
         assertTrue(html.contains("data-section-id=\"benefits\""));
-        assertTrue(html.contains("class=\"card surface-solid contrast-high\""));
+        assertTrue(html.contains("class=\"lhm-card lhm-surface-solid lhm-high\""));
+        assertFalse(html.contains("class=\"card surface-solid contrast-high\""));
         assertTrue(html.contains("data-surface-token=\"surface-benefits\""));
         assertTrue(html.contains("data-surface-style=\"solid\""));
         assertTrue(html.contains("data-surface-contrast=\"high\""));
@@ -242,7 +243,8 @@ class LandingHtmlModuleTest {
         String html = module.assembleHtmlDocument(experiment);
 
         assertTrue(html.contains("data-section-id=\"proof\""));
-        assertTrue(html.contains("class=\"card surface-solid contrast-high\""));
+        assertTrue(html.contains("class=\"lhm-card lhm-surface-solid lhm-high\""));
+        assertFalse(html.contains("class=\"card surface-solid contrast-high\""));
         assertTrue(html.contains("data-surface-token=\"surface-proof\""));
         assertTrue(html.contains("data-surface-style=\"solid\""));
         assertTrue(html.contains("data-surface-contrast=\"high\""));

--- a/docs/canonical/matriz-responsabilidades-pipeline-landing.md
+++ b/docs/canonical/matriz-responsabilidades-pipeline-landing.md
@@ -19,6 +19,7 @@ Documento operacional para leitura rápida, separando **quem é responsável por
 
 - **Estrutural (`wireframe`)**: `surfaceToken` + organização da página.
 - **Visual (`designPreset`)**: `surfaceStyle` + `contrastMode` por `sectionId`.
+- **Namespace CSS canônico do LHM**: classes emitidas no HTML determinístico devem seguir prefixo `lhm-` e corresponder aos seletores presentes em `landingPageDesignPreset.lhmRuntime.baseCss`.
 - **HTML final (`LHM`)**: combina os dois contratos e publica os `data-*` aderentes.
 
 ### Regra anti-duplicidade (fonte de verdade única por campo)

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -566,13 +566,15 @@ Para considerar a copy **rica** e **compatível com as especificações**, a eta
 
 Para garantir compatibilidade com o HTML emitido pelo LHM, o CSS canônico deve cobrir no mínimo os seletores abaixo (podendo estender):
 
-- layout base: `body`, `main`, `.card`;
+- layout base: `body`, `main`, `.lhm-card`;
 - tipografia/conteúdo: `h1`, `h2`, `p`, `ul`, `li`;
 - formulário: `form`, `.field`, `label`, `input`, `button`, `#form-feedback`;
 - FAQ: `.faq-list details`, `.faq-list summary`;
 - variações de superfície e contraste usadas pelo wireframe/design preset:
-  - `.surface-band`, `.surface-solid`, `.surface-gradient-soft`, `.surface-image-tint`;
-  - `.contrast-normal`, `.contrast-high`, `.contrast-soft`.
+  - `.lhm-surface-band`, `.lhm-surface-solid`, `.lhm-surface-gradient-soft`, `.lhm-surface-image-tint`;
+  - `.lhm-normal`, `.lhm-high`, `.lhm-soft`.
+
+> **Namespace canônico de classe (LHM):** o HTML determinístico deve usar classes prefixadas com `lhm-` para evitar colisão global e manter alinhamento 1:1 com `landingPageDesignPreset.lhmRuntime.baseCss`.
 
 Se o wireframe/design preset introduzir novos `surfaceStyle` ou `contrastMode`, o `baseCss` correspondente deve ser atualizado no mesmo ciclo de versão.
 


### PR DESCRIPTION
### Motivation

- Ensure the landing HTML uses a deterministic, namespaced CSS class prefix to avoid global collisions and to match the canonical CSS artifact. 
- Surface the canonical `baseCss` location in the design preset contract so runtime CSS is provided by artifacts rather than hardcoded rules. 

### Description

- Updated `LandingHtmlModule` to emit prefixed classes by changing `.card`, `.surface-{...}` and `.contrast-{...}` to `lhm-card`, `lhm-surface-{...}`, and `lhm-{...}` respectively. 
- Adjusted `ExperimentPipelineGenerationService` schema so `landingPageDesignPreset.lhmRuntime.baseCss` is a `string` with a descriptive requirement about covering the `lhm-` selectors. 
- Updated unit tests in `LandingHtmlModuleTest` to assert the new `lhm-` class names and to assert the old class names are not present. 
- Revised documentation under `docs/canonical` to require `lhmRuntime.baseCss`, list the minimum `lhm-` selectors, and describe the canonical class namespace policy. 

### Testing

- Ran the updated unit test `LandingHtmlModuleTest` which verifies emitted class names and data attributes, and it passed. 
- Executed the backend unit test suite for the ads-service module via the project test runner, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24104864c8321940ef4b4d671e426)