### PR TITLE
Support wireframe copy slot ordering and rich-text rendering for landing page body copy

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/ExperimentPipelineSection.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/ExperimentPipelineSection.java
@@ -6,8 +6,8 @@ public enum ExperimentPipelineSection {
     CAMPAIGN_ANGLE("campaign-angle", null),
     AD_COPY("ad-copy", CAMPAIGN_ANGLE),
     AD_IMAGE_BRIEFING("ad-image-briefing", AD_COPY),
-    LANDING_PAGE_COPY("landing-page-copy", AD_IMAGE_BRIEFING),
-    LANDING_PAGE_WIREFRAME("landing-page-wireframe", LANDING_PAGE_COPY),
+    LANDING_PAGE_WIREFRAME("landing-page-wireframe", AD_IMAGE_BRIEFING),
+    LANDING_PAGE_COPY("landing-page-copy", LANDING_PAGE_WIREFRAME),
     LANDING_PAGE_IMAGE_PLANNING("landing-page-image-planning", LANDING_PAGE_WIREFRAME),
     LANDING_PAGE_DESIGN_PRESET("landing-page-design-preset", LANDING_PAGE_IMAGE_PLANNING),
     LANDING_PAGE_HTML("landing-page-html", LANDING_PAGE_DESIGN_PRESET);

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -176,7 +176,7 @@ public class LandingHtmlModule {
             if (!isHeroSection && StringUtils.hasText(sectionObjective)) {
                 html.append("<p class=\"section-objective\">").append(escapeHtml(sectionObjective)).append("</p>");
             }
-            html.append(buildBodySectionCopyMarkup(sectionId, bodySectionsCopy));
+            html.append(buildBodySectionCopyMarkup(section, bodySectionsCopy));
             html.append(buildFaqMarkup(sectionId, faqCopy));
             html.append(buildCtaBlocksMarkup(sectionId, ctaBlocksCopy));
 
@@ -571,9 +571,26 @@ public class LandingHtmlModule {
         return maxSize == 0 ? 0d : ((double) intersection / maxSize);
     }
 
-    private String buildBodySectionCopyMarkup(String sectionId, List<Map<String, Object>> bodySectionsCopy) {
+    private String buildBodySectionCopyMarkup(Map<String, Object> section, List<Map<String, Object>> bodySectionsCopy) {
+        String sectionId = section == null ? null : asTrimmedString(section.get("sectionId"));
         if (!StringUtils.hasText(sectionId) || bodySectionsCopy == null || bodySectionsCopy.isEmpty()) {
             return "";
+        }
+
+        List<String> orderedSlotIds = extractCopySlots(section);
+        if (!orderedSlotIds.isEmpty()) {
+            StringBuilder slotted = new StringBuilder();
+            for (String slotId : orderedSlotIds) {
+                for (Map<String, Object> bodySection : bodySectionsCopy) {
+                    if (!slotId.equalsIgnoreCase(asTrimmedString(bodySection.get("slotId")))) {
+                        continue;
+                    }
+                    appendBodySectionBlock(slotted, bodySection);
+                }
+            }
+            if (slotted.length() > 0) {
+                return slotted.toString();
+            }
         }
         for (Map<String, Object> bodySection : bodySectionsCopy) {
             String bodySectionId = asTrimmedString(bodySection.get("sectionId"));
@@ -581,27 +598,43 @@ public class LandingHtmlModule {
                 continue;
             }
             StringBuilder sb = new StringBuilder();
-            appendParagraph(sb, asTrimmedString(bodySection.get("summary")));
-            appendParagraph(sb, asTrimmedString(bodySection.get("copy")));
-            if (bodySection.get("bullets") instanceof List<?> rawBullets) {
-                StringBuilder bulletsMarkup = new StringBuilder();
-                for (Object rawBullet : rawBullets) {
-                    String bullet = asTrimmedString(rawBullet);
-                    if (!StringUtils.hasText(bullet)) {
-                        continue;
-                    }
-                    bulletsMarkup.append("<li>").append(escapeHtml(bullet)).append("</li>");
-                }
-                if (bulletsMarkup.length() > 0) {
-                    sb.append("<ul>").append(bulletsMarkup).append("</ul>");
-                }
-            }
-            appendParagraph(sb, asTrimmedString(bodySection.get("ctaSupport")));
+            appendBodySectionBlock(sb, bodySection);
             return sb.toString();
         }
         return "";
     }
 
+
+
+    @SuppressWarnings("unchecked")
+    private List<String> extractCopySlots(Map<String, Object> section) {
+        if (section == null || !(section.get("copySlots") instanceof List<?> rawSlots)) {
+            return List.of();
+        }
+        return rawSlots.stream()
+                .map(this::asTrimmedString)
+                .filter(StringUtils::hasText)
+                .toList();
+    }
+
+    private void appendBodySectionBlock(StringBuilder sb, Map<String, Object> bodySection) {
+        appendRichText(sb, asTrimmedString(bodySection.get("summary")));
+        appendRichText(sb, asTrimmedString(bodySection.get("copy")));
+        if (bodySection.get("bullets") instanceof List<?> rawBullets) {
+            StringBuilder bulletsMarkup = new StringBuilder();
+            for (Object rawBullet : rawBullets) {
+                String bullet = asTrimmedString(rawBullet);
+                if (!StringUtils.hasText(bullet)) {
+                    continue;
+                }
+                bulletsMarkup.append("<li>").append(escapeHtml(bullet)).append("</li>");
+            }
+            if (bulletsMarkup.length() > 0) {
+                sb.append("<ul>").append(bulletsMarkup).append("</ul>");
+            }
+        }
+        appendParagraph(sb, asTrimmedString(bodySection.get("ctaSupport")));
+    }
     private String buildFaqMarkup(String sectionId, List<Map<String, Object>> faqCopy) {
         if (!StringUtils.hasText(sectionId) || faqCopy == null || faqCopy.isEmpty()) {
             return "";
@@ -655,7 +688,7 @@ public class LandingHtmlModule {
                         .append(escapeHtml(ctaLabel))
                         .append("</a></p>");
             }
-            appendParagraph(sb, ctaSupport);
+            appendRichText(sb, ctaSupport);
         }
         return sb.toString();
     }
@@ -664,9 +697,48 @@ public class LandingHtmlModule {
         if (!StringUtils.hasText(text)) {
             return;
         }
-        sb.append("<p>").append(escapeHtml(text)).append("</p>");
+        appendRichText(sb, text);
     }
 
+
+    private void appendRichText(StringBuilder sb, String text) {
+        if (!StringUtils.hasText(text)) {
+            return;
+        }
+        String normalized = text.replace("\r\n", "\n").trim();
+        if (!StringUtils.hasText(normalized)) {
+            return;
+        }
+        String[] blocks = normalized.split("\n\s*\n");
+        for (String rawBlock : blocks) {
+            String block = rawBlock.trim();
+            if (!StringUtils.hasText(block)) {
+                continue;
+            }
+            if (block.lines().allMatch(line -> line.trim().matches("[-*]\\s+.+"))) {
+                sb.append("<ul>");
+                block.lines().forEach(line -> sb.append("<li>").append(formatInlineText(line.replaceFirst("^[-*]\\s+", ""))).append("</li>"));
+                sb.append("</ul>");
+                continue;
+            }
+            if (block.lines().allMatch(line -> line.trim().matches("\\d+[).]\\s+.+"))) {
+                sb.append("<ol>");
+                block.lines().forEach(line -> sb.append("<li>").append(formatInlineText(line.replaceFirst("^\\d+[).]\\s+", ""))).append("</li>"));
+                sb.append("</ol>");
+                continue;
+            }
+            String paragraph = block.replace("\n", "<br>");
+            sb.append("<p>").append(formatInlineText(paragraph)).append("</p>");
+        }
+    }
+
+    private String formatInlineText(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "";
+        }
+        String escaped = escapeHtml(value);
+        return escaped.replaceAll("\\*\\*(.+?)\\*\\*", "<strong>$1</strong>");
+    }
     private String buildSubmissionScript(String formId) {
         return """
                 <script>

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1049,6 +1049,9 @@ public class ExperimentPipelineGenerationService {
         if (section == ExperimentPipelineSection.LANDING_PAGE_HTML) {
             appendImageBindingSummary(sb, experiment);
         }
+        if (section == ExperimentPipelineSection.LANDING_PAGE_COPY) {
+            appendWireframeSlotSummary(sb, experiment);
+        }
     }
 
     private void appendImageBindingSummary(StringBuilder sb, Experiment experiment) {
@@ -1069,6 +1072,19 @@ public class ExperimentPipelineGenerationService {
                     .append("\n");
         }
         sb.append("Para cada imagem acima, declare data-image-section-id, data-image-binding-key, data-image-role, data-conversion-role, data-attention-priority, data-visual-weight, data-distance-to-cta e data-supports-form-conversion.\n");
+    }
+
+    private void appendWireframeSlotSummary(StringBuilder sb, Experiment experiment) {
+        Map<String, List<String>> slotsBySection = loadWireframeCopySlots(experiment);
+        if (slotsBySection.isEmpty()) {
+            return;
+        }
+        sb.append("\nSlots canônicos de copy vindos do wireframe (obrigatório respeitar e retornar em bodySections[].slotId):\n");
+        slotsBySection.forEach((sectionId, slots) ->
+                sb.append("- sectionId=").append(sectionId)
+                        .append(" | copySlots=").append(String.join(", ", slots))
+                        .append("\n"));
+        sb.append("Regra: cada item de landingPageCopy.bodySections deve informar slotId e esse slotId deve existir na lista copySlots da seção correspondente.\n");
     }
 
     private List<String> loadWireframeSectionIds(Experiment experiment) {
@@ -1115,6 +1131,52 @@ public class ExperimentPipelineGenerationService {
         } catch (Exception ex) {
             log.warn("Falha inesperada ao carregar bindings de imagem para o prompt: {}", ex.getMessage());
             return List.of();
+        }
+    }
+
+    private Map<String, Set<String>> loadAllowedCopySlotsBySection(Experiment experiment) {
+        Map<String, List<String>> slotsBySection = loadWireframeCopySlots(experiment);
+        if (slotsBySection.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Set<String>> allowed = new LinkedHashMap<>();
+        slotsBySection.forEach((sectionId, slots) -> allowed.put(sectionId, new LinkedHashSet<>(slots)));
+        return allowed;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, List<String>> loadWireframeCopySlots(Experiment experiment) {
+        if (experiment == null || !StringUtils.hasText(experiment.getLandingPageWireframe())) {
+            return Map.of();
+        }
+        try {
+            Map<String, Object> root = readObject(experiment.getLandingPageWireframe(), "Wireframe da landing inválido");
+            Map<String, Object> payload = unwrapSectionPayload(root, "landingPageWireframe");
+            if (!(payload.get("sectionOrder") instanceof List<?> rawSections) || rawSections.isEmpty()) {
+                return Map.of();
+            }
+            Map<String, List<String>> slotsBySection = new LinkedHashMap<>();
+            for (Object rawSection : rawSections) {
+                if (!(rawSection instanceof Map<?, ?> rawSectionMap)) {
+                    continue;
+                }
+                Map<String, Object> section = (Map<String, Object>) rawSectionMap;
+                String sectionId = asTrimmedString(section.get("sectionId"));
+                if (!StringUtils.hasText(sectionId) || !(section.get("copySlots") instanceof List<?> rawSlots)) {
+                    continue;
+                }
+                List<String> slots = rawSlots.stream()
+                        .map(this::asTrimmedString)
+                        .filter(StringUtils::hasText)
+                        .toList();
+                if (!slots.isEmpty()) {
+                    slotsBySection.put(sectionId, slots);
+                }
+            }
+            return slotsBySection;
+        } catch (Exception ex) {
+            log.warn("Falha ao carregar copySlots do wireframe para o prompt: {}", ex.getMessage());
+            return Map.of();
         }
     }
 
@@ -1202,7 +1264,7 @@ public class ExperimentPipelineGenerationService {
             case AD_COPY -> experiment.setAdCopy(normalized);
             case AD_IMAGE_BRIEFING -> experiment.setAdImageBriefing(normalized);
             case LANDING_PAGE_COPY -> {
-                validateLandingCopyArtifacts(normalized);
+                validateLandingCopyArtifacts(experiment, normalized);
                 experiment.setLandingPageCopy(normalized);
             }
             case LANDING_PAGE_WIREFRAME -> {
@@ -1228,7 +1290,7 @@ public class ExperimentPipelineGenerationService {
     }
 
     @SuppressWarnings("unchecked")
-    private void validateLandingCopyArtifacts(String landingCopyContent) {
+    private void validateLandingCopyArtifacts(Experiment experiment, String landingCopyContent) {
         if (!StringUtils.hasText(landingCopyContent)) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Copy da landing vazia");
         }
@@ -1251,6 +1313,7 @@ public class ExperimentPipelineGenerationService {
         }
 
         if (hasCanonicalHero) {
+            Map<String, Set<String>> allowedSlotsBySection = loadAllowedCopySlotsBySection(experiment);
             if (!(copyPayload.get("bodySections") instanceof List<?> rawBodySections) || rawBodySections.isEmpty()) {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Copy da landing sem bodySections estruturado");
             }
@@ -1260,11 +1323,23 @@ public class ExperimentPipelineGenerationService {
                 }
                 Map<String, Object> bodySection = (Map<String, Object>) rawBodySectionMap;
                 String sectionId = asTrimmedString(bodySection.get("sectionId"));
+                String slotId = asTrimmedString(bodySection.get("slotId"));
                 String summary = asTrimmedString(bodySection.get("summary"));
                 String copy = asTrimmedString(bodySection.get("copy"));
                 if (!StringUtils.hasText(sectionId) || (!StringUtils.hasText(summary) && !StringUtils.hasText(copy))) {
                     throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                             "Copy da landing inválida em bodySections: cada item exige sectionId e summary/copy");
+                }
+                if (!allowedSlotsBySection.isEmpty()) {
+                    if (!StringUtils.hasText(slotId)) {
+                        throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                                "Copy da landing inválida em bodySections: slotId é obrigatório quando wireframe define copySlots");
+                    }
+                    Set<String> allowedSlots = allowedSlotsBySection.get(sectionId);
+                    if (allowedSlots == null || allowedSlots.isEmpty() || !allowedSlots.contains(slotId)) {
+                        throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                                "Copy da landing inválida em bodySections: slotId '" + slotId + "' não pertence aos copySlots da sectionId '" + sectionId + "'");
+                    }
                 }
             }
             if (!(copyPayload.get("consistencyChecks") instanceof List<?> rawChecks) || rawChecks.isEmpty()) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -2965,6 +2965,7 @@ public class ExperimentPipelineGenerationService {
                 "additionalProperties", false,
                 "properties", Map.ofEntries(
                         Map.entry("sectionId", stringSchema()),
+                        Map.entry("slotId", stringSchema()),
                         Map.entry("sectionType", Map.of(
                                 "type", "string",
                                 "enum", List.of("hero", "pain", "mechanism", "proof", "offer", "cta", "faq", "bonus", "objection")
@@ -3138,6 +3139,7 @@ public class ExperimentPipelineGenerationService {
                         Map.entry("uiNotes", stringSchema()),
                         Map.entry("messageMatchDependency", stringSchema()),
                         Map.entry("sectionDependsOn", stringSchema()),
+                        Map.entry("copySlots", Map.of("type", "array", "minItems", 1, "items", stringSchema())),
                         Map.entry("mobilePriorityScore", integerSchema(1, 10)),
                         Map.entry("dropOffRisk", Map.of("type", "string", "enum", List.of("baixo", "medio", "alto"))),
                         Map.entry("surfaceSpec", surfaceSpecSchema),

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
@@ -332,6 +332,49 @@ class LandingHtmlModuleTest {
         assertFalse(html.contains("<p class=\"section-objective\">Mesma mensagem da promessa</p>"));
     }
 
+
+    @Test
+    void assembleHtmlDocumentUsesWireframeCopySlotsToPositionBodyText() {
+        Experiment experiment = new Experiment();
+        applyBaseCssContract(experiment);
+        applyImagePlanningContract(experiment);
+        experiment.setName("Teste LHM Slots");
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {"sectionId": "mechanism_01", "sectionName": "Mecanismo", "contentType": "split", "copySlots": ["slot-mech-2", "slot-mech-1"], "surfaceSpec": {"surfaceToken": "surface-mech", "style": "solid", "contrastMode": "normal"}}
+                    ],
+                    "formSpec": {
+                      "formId": "lead-capture-primary",
+                      "submitTarget": "/api/flows/submissions",
+                      "submitLabel": "Enviar",
+                      "fields": [{"name": "nome", "type": "text", "required": true}]
+                    }
+                  }
+                }
+                """);
+        experiment.setLandingPageCopy("""
+                {
+                  "landingPageCopy": {
+                    "hero": {"headline":"h","promise":"p","ctaLabel":"c","ctaMatchNotes":"ok"},
+                    "bodySections": [
+                      {"sectionId": "mechanism_01", "slotId":"slot-mech-1", "sectionType": "mechanism", "title": "T1", "summary": "Primeiro", "messageMatchNotes": "ok"},
+                      {"sectionId": "mechanism_01", "slotId":"slot-mech-2", "sectionType": "mechanism", "title": "T2", "summary": "Segundo", "messageMatchNotes": "ok"}
+                    ],
+                    "ctaBlocks": [],
+                    "faq": [],
+                    "consistencyChecks": [{"check":"CTA_MATCH","status":"ok"},{"check":"PROMISE_MATCH","status":"ok"}],
+                    "pageGoal":"g","messageMatchSource":"s","primaryCTA":"cta"
+                  }
+                }
+                """);
+
+        String html = module.assembleHtmlDocument(experiment);
+
+        assertTrue(html.indexOf("Segundo") < html.indexOf("Primeiro"));
+    }
+
     @Test
     void assembleHtmlDocumentThrowsWhenArtifactIsMissing() {
         Experiment experiment = new Experiment();

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,52 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0014 — Landing copy orientada por slots canônicos do wireframe
+
+- **Data/Hora (UTC):** 2026-04-29
+- **Responsável:** Assistente Codex
+- **Módulo:** backend
+- **Ambiente:** Repositório local (`/workspace/marketing-hub`)
+- **Execução/Teste:** Ajuste estrutural solicitado para garantir posicionamento do texto por slot.
+
+#### 1) Erro observado
+- **Sintoma:** a etapa de geração de texto da landing não recebia instruções explícitas dos slots canônicos do wireframe e a validação não cobrava alinhamento obrigatório de `slotId`.
+- **Endpoint/rota/fila:** pipeline de geração (`LANDING_PAGE_COPY`).
+- **Status code:** n/a (risco de inconsistência sem bloqueio forte).
+- **Mensagem de erro literal:** n/a.
+- **Payload enviado (literal):** n/a.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** não aplicável.
+- **Dados de banco consultados via MCP:** não aplicável.
+- **Trecho canônico consultado:** `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` (wireframe/copy como artefatos canônicos da landing).
+- **Validação/regra que rejeitou:** ausência de regra explícita para `slotId` vinculado a `copySlots`.
+- **Causa raiz:** schema e prompt da etapa `LANDING_PAGE_COPY` ainda permitiam saída sem vínculo obrigatório aos slots definidos pelo wireframe.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** body sections potencialmente sem `slotId` ou com `slotId` fora do wireframe.
+- **O que a especificação esperava (literal):** `bodySections[].slotId` alinhado a `landingPageWireframe.sectionOrder[].copySlots` da seção correspondente.
+- **Diferença objetiva:** faltava enforcement de contrato entre nome do slot no wireframe e nome do slot na copy.
+- **Ação corretiva recomendada:** incluir resumo de slots no prompt da etapa de copy e validar no backend o vínculo `sectionId + slotId`.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** contrato + validação + instrução de prompt.
+- **Arquivos alterados:**
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** backend passou a anexar no prompt da etapa `LANDING_PAGE_COPY` o resumo de `copySlots` por `sectionId` do wireframe; validação de copy agora exige `slotId` quando houver slots canônicos e rejeita valores fora da lista permitida.
+
+#### 5) Reteste
+- **Procedimento de reteste:** execução de testes unitários da montagem/renderização da landing e validação de compilação do módulo.
+- **Resultado:** concluído com sucesso.
+- **Evidências (logs/ids/prints):** build `ads-service` com testes `LandingHtmlModuleTest` aprovados.
+- **Status final:** Resolvido.
+
+#### 6) Próximo passo
+- **Ação seguinte:** acompanhar execuções reais do pipeline para confirmar que o modelo está retornando `slotId` aderente sem regressões.
+- **Dono da ação:** time backend + pipeline.
+- **Prazo:** próximo ciclo de execução assistida.
+
 ### INC-0013 — Correção arquitetural: regra de prompt mantida no AI Worker (não no backend)
 
 - **Data/Hora (UTC):** 2026-04-29


### PR DESCRIPTION
### Motivation

- Ensure landing page body text can be positioned according to wireframe `copySlots` so authored copy can be slotted into specific regions.  
- Improve body and CTA text rendering to support simple rich-text (paragraphs, lists, inline bold) instead of plain paragraphs.  
- Fix an ordering bug in the pipeline section enum so the wireframe and copy sections are linked in the intended predecessor/successor chain.

### Description

- Reordered `ExperimentPipelineSection` entries to make `landing-page-wireframe` the predecessor of `landing-page-copy` by swapping their declaration order.  
- Changed `LandingHtmlModule.buildBodySectionCopyMarkup` to accept the section object and use `copySlots` from the wireframe for ordering, delegating block rendering to a new `appendBodySectionBlock` helper.  
- Added `extractCopySlots`, `appendBodySectionBlock`, `appendRichText`, and `formatInlineText` to parse and render rich-text blocks, including unordered lists, ordered lists, paragraph line breaks, and `**bold**` inline formatting.  
- Switched CTA support rendering to use `appendRichText` and made `appendParagraph` delegate to the new rich-text rendering.  
- Extended the JSON schema in `ExperimentPipelineGenerationService` to include `slotId` on body sections and `copySlots` on wireframe `section` definitions.  
- Added a unit test `assembleHtmlDocumentUsesWireframeCopySlotsToPositionBodyText` to verify slot-based ordering of body sections in the assembled HTML.

### Testing

- Ran unit tests in `LandingHtmlModuleTest` including the new `assembleHtmlDocumentUsesWireframeCopySlotsToPositionBodyText` test, and they passed.  
- Ran the module test suite with `mvn test` and the test run completed successfully.  
- No automated test failures observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f246d647c88321b347ebae85bf674e)