### PR TITLE
Schedule Hotmart robot to run every 15 minutes (cron update)

### DIFF
--- a/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotProperties.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotProperties.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 public class MoisHotmartRobotProperties {
 
     private boolean enabled = false;
-    private String cron = "0 0 * * * *";
+    private String cron = "0 */15 * * * *";
     private String workspaceId = "workspace-001";
     private String niche = "marketing-digital";
     private String marketTheme = "ofertas-com-temperatura-alta";

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotScheduler.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotScheduler.java
@@ -19,7 +19,7 @@ public class MoisHotmartRobotScheduler {
         this.hotmartRobotService = hotmartRobotService;
     }
 
-    @Scheduled(cron = "${mois.robot.hotmart.cron:0 0 * * * *}")
+    @Scheduled(cron = "${mois.robot.hotmart.cron:0 */15 * * * *}")
     public void run() {
         log.info("MOIS Hotmart scheduler heartbeat: agendamento ativo (enabled={}, cron={})",
                 properties.isEnabled(),

--- a/mois/src/main/resources/application.properties
+++ b/mois/src/main/resources/application.properties
@@ -14,7 +14,7 @@ integrations.backend.persistence.read-timeout=5s
 
 # Robô de coleta Hotmart (executa no container MOIS)
 mois.robot.hotmart.enabled=${MOIS_ROBOT_HOTMART_ENABLED:true}
-mois.robot.hotmart.cron=${MOIS_ROBOT_HOTMART_CRON:0 0 * * * *}
+mois.robot.hotmart.cron=${MOIS_ROBOT_HOTMART_CRON:0 */15 * * * *}
 mois.robot.hotmart.workspace-id=${MOIS_ROBOT_HOTMART_WORKSPACE_ID:workspace-001}
 mois.robot.hotmart.niche=${MOIS_ROBOT_HOTMART_NICHE:marketing-digital}
 mois.robot.hotmart.market-theme=${MOIS_ROBOT_HOTMART_MARKET_THEME:ofertas-com-temperatura-alta}


### PR DESCRIPTION
### Motivation
- Increase the frequency of automated Hotmart data collection by changing the default cron schedule from hourly to every 15 minutes.

### Description
- Updated the default cron expression in `MoisHotmartRobotProperties` from `0 0 * * * *` to `0 */15 * * * *`.
- Updated the `@Scheduled` annotation default in `MoisHotmartRobotScheduler` to `0 */15 * * * *` for `MoisHotmartRobotScheduler#run()`.
- Updated the `application.properties` fallback for `mois.robot.hotmart.cron` to `0 */15 * * * *` so the environment default matches the code.
- No other functional logic changes were introduced.

### Testing
- No automated tests were run as part of this change.
- Existing tests were not modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2478d6a8c8321b12248332a4272ba)