### PR TITLE
Align wireframe generation tests and canonical ordering

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -426,6 +426,7 @@ class ExperimentPipelineGenerationServiceTest {
         Experiment experiment = new Experiment();
         experiment.setId(12L);
         experiment.setName("Experimento 12");
+        experiment.setAdImageBriefing("{\"adImageBriefing\":\"predecessor-ready\"}");
         experiment.setLandingPageCopy("{\"landingPageCopy\":\"predecessor-ready\"}");
 
         when(experimentRepository.findById(12L)).thenReturn(Optional.of(experiment));
@@ -452,7 +453,7 @@ class ExperimentPipelineGenerationServiceTest {
                     && prompt.contains("Ângulo da campanha:")
                     && prompt.contains("Texto do anúncio:")
                     && prompt.contains("Briefing da imagem:")
-                    && prompt.contains("Textos da landing:")
+                    && !prompt.contains("Textos da landing:")
                     && !prompt.contains("Wireframe da landing:")
                     && !prompt.contains("Planejamento de imagens da landing:");
         }));
@@ -463,6 +464,7 @@ class ExperimentPipelineGenerationServiceTest {
         Experiment experiment = new Experiment();
         experiment.setId(13L);
         experiment.setName("Experimento 13");
+        experiment.setAdImageBriefing("{\"adImageBriefing\":\"persisted\"}");
         experiment.setLandingPageCopy("{\"landingPageCopy\":\"persisted\"}");
         experiment.setLandingPageWireframe("{\"landingPageWireframe\":\"persisted\"}");
         experiment.setLandingPageImagePlanning("{\"landingPageImagePlanning\":\"persisted\"}");

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -189,9 +189,9 @@ Para considerar a copy **rica** e **compatível com as especificações**, a eta
    - `faq` deve conter no mínimo 3 perguntas com `question` e `answer` preenchidos.
    - `ctaBlocks` deve conter no mínimo 2 variações (por exemplo: `mid` e `final` ou `hero` e `final`).
 
-3. **Independência da etapa de wireframe (ordem canônica)**
-   - A geração de `landingPageCopy` acontece **antes** de `landingPageWireframe`; portanto, a copy **não pode depender** de `sectionOrder`, `ctaSlot` ou qualquer campo de wireframe inexistente nessa etapa.
-   - O alinhamento estrutural com layout acontece na etapa posterior (`landingPageWireframe`), preservando a promessa e a argumentação aprovadas na copy.
+3. **Dependência da etapa de wireframe (ordem canônica)**
+   - A geração de `landingPageCopy` acontece **depois** de `landingPageWireframe`; portanto, a copy **deve usar** os sinais estruturais definidos no wireframe (por exemplo, `sectionOrder`, `ctaSlot` e hierarquia de blocos) para manter consistência de narrativa e layout.
+   - O alinhamento estrutural com layout acontece no `landingPageWireframe` e é refinado na `landingPageCopy`, preservando promessa, argumentação e clareza comercial.
    - Toda `ctaUrl` deve ser resolvida (sem placeholders como `{slug}`).
 
 4. **Consistência de promessa e CTA**


### PR DESCRIPTION
### Motivation

- Two unit tests failed due to an updated pipeline predecessor requirement where `landing-page-wireframe` depends on `ad-image-briefing` being present, causing test/CI breakage.
- The canonical artifact document for the pipeline was inconsistent with current behavior and needed to reflect the true ordering and expectations between `landingPageWireframe` and `landingPageCopy`.

### Description

- Updated `ExperimentPipelineGenerationServiceTest` to include `adImageBriefing` fixtures in the wireframe scenarios so the tests reflect the current predecessor requirement. 
- Adjusted the prompt-scoping assertion in `generateWireframeKeepsPromptScopedToPredecessorChain` to match the updated expected prompt content (removed expectation that wireframe prompt contains landing copy tokens).
- Updated `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` to state that `landingPageCopy` is generated after `landingPageWireframe` and must use structural signals from the wireframe (e.g., `sectionOrder`, `ctaSlot`).

### Testing

- Ran the two failing unit tests locally with `mvn -Dtest=ExperimentPipelineGenerationServiceTest#generateWireframeKeepsPromptScopedToPredecessorChain,ExperimentPipelineGenerationServiceTest#generateWireframeDoesNotReusePersistedExperimentArtifactsWithoutCompletedJobs test` and verified both tests pass after the fixes. 
- Noted the original CI failure reported 2 test errors in the full suite; this PR fixes the two targeted test cases that caused the failure.
- Only targeted unit tests were executed in validation; full module test suite was not rerun in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25c79f41c8321acd603592932a69c)