### PR TITLE
Increase backend persistence connect and read timeouts

### DIFF
--- a/mois/src/main/resources/application.properties
+++ b/mois/src/main/resources/application.properties
@@ -9,8 +9,8 @@ logging.file.name=${MOIS_LOG_FILE:/var/log/marketinghub/mois.log}
 management.endpoints.web.base-path=/manage
 
 integrations.backend.persistence.base-url=${BACKEND_BASE_URL:http://191.252.181.168:8000/}
-integrations.backend.persistence.connect-timeout=2s
-integrations.backend.persistence.read-timeout=5s
+integrations.backend.persistence.connect-timeout=8s
+integrations.backend.persistence.read-timeout=20s
 
 # Robô de coleta Hotmart (executa no container MOIS)
 mois.robot.hotmart.enabled=${MOIS_ROBOT_HOTMART_ENABLED:true}


### PR DESCRIPTION
### Motivation
- Make the backend persistence integration more tolerant to latency and slower responses by increasing the connect and read timeouts.

### Description
- Updated `mois/src/main/resources/application.properties` to change `integrations.backend.persistence.connect-timeout` from `2s` to `8s` and `integrations.backend.persistence.read-timeout` from `5s` to `20s`.

### Testing
- No automated tests were modified or executed for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26b1ba1048321be74d3220ffd3c5a)