### PR TITLE
Canonicalize imageBindingKey in LandingHtmlModule and log 422 in controller

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -5,6 +5,7 @@ import com.marketinghub.experiment.Experiment;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import java.text.Normalizer;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -418,7 +419,11 @@ public class LandingHtmlModule {
 
     private String buildImageTag(Map<String, Object> image) {
         String sectionId = firstNonBlank(asTrimmedString(image.get("sectionId")), "section");
-        String bindingKey = firstNonBlank(asTrimmedString(image.get("imageBindingKey")), "image");
+        String bindingKey = firstNonBlank(
+                slugifyBindingKey(asTrimmedString(image.get("imageBindingKey"))),
+                slugifyBindingKey(asTrimmedString(image.get("imageRole"))),
+                slugifyBindingKey(sectionId),
+                "image");
         String imageRole = firstNonBlank(asTrimmedString(image.get("imageRole")), "image");
         String conversionRole = firstNonBlank(asTrimmedString(image.get("conversionRole")), "support");
         String attentionPriority = firstNonBlank(asTrimmedString(image.get("attentionPriority")), "medium");
@@ -442,6 +447,22 @@ public class LandingHtmlModule {
                 + "\" data-visual-weight=\"" + escapeAttr(visualWeight)
                 + "\" data-distance-to-cta=\"" + escapeAttr(distanceToCta)
                 + "\" data-supports-form-conversion=\"" + supportsFormConversion + "\" />";
+    }
+
+    private String slugifyBindingKey(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "";
+        }
+        String normalized = Normalizer.normalize(value, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "")
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("-{2,}", "-")
+                .replaceAll("^-|-$", "");
+        if (normalized.length() > 64) {
+            normalized = normalized.substring(0, 64).replaceAll("-+$", "");
+        }
+        return normalized.length() >= 3 ? normalized : "";
     }
 
     private String buildHeroCopyMarkup(Map<String, Object> heroCopy,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/web/ExperimentPipelineController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/web/ExperimentPipelineController.java
@@ -11,6 +11,8 @@ import com.marketinghub.experiment.pipeline.service.ExperimentPipelineGeneration
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +27,8 @@ import org.springframework.web.server.ResponseStatusException;
 @RestController
 @RequestMapping("/api/experiments/{id}/pipeline")
 public class ExperimentPipelineController {
+    private static final Logger log = LoggerFactory.getLogger(ExperimentPipelineController.class);
+
     private final ExperimentPipelineGenerationService generationService;
 
     public ExperimentPipelineController(ExperimentPipelineGenerationService generationService) {
@@ -57,7 +61,14 @@ public class ExperimentPipelineController {
 
     @PostMapping("/landing-page-html/generate-with-lhm")
     public ExperimentDto generateLandingHtmlWithLhm(@PathVariable Long id) {
-        return generationService.generateLandingHtmlWithLhm(id);
+        try {
+            return generationService.generateLandingHtmlWithLhm(id);
+        } catch (ResponseStatusException ex) {
+            if (ex.getStatusCode() == HttpStatus.UNPROCESSABLE_ENTITY) {
+                log.warn("Geração LHM da landing falhou com 422 (experimentId={}): {}", id, ex.getReason());
+            }
+            throw ex;
+        }
     }
 
     @GetMapping("/jobs")

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -819,3 +819,36 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 #### Reteste
 - Execução de `mvn -Dtest=ExperimentPipelineOpenAiClientTest test` bloqueada por dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` (401 no GitHub Packages).
+
+### INC-0013 — Correção de 422 no LHM por divergência de `imageBindingKey` no HTML final
+
+- **Data/Hora (UTC):** 2026-04-29
+- **Responsável:** Assistente Codex
+- **Módulo:** backend (ads-service) + documentação
+- **Execução/Teste:** ajuste no renderizador determinístico `LandingHtmlModule` para aderência ao contrato canônico de image binding
+
+#### 1) Erro observado
+- **Sintoma:** ao executar **Gerar HTML (LHM + IA)**, a chamada `POST /api/experiments/{id}/pipeline/landing-page-html/generate-with-lhm` retornava `422 Unprocessable Entity`.
+- **Mensagem de erro literal:** `Divergência de imagens: landing-page-html deve reproduzir o binding explícito canônico do landing-page-image-planning por sectionId/imageBindingKey`.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Trecho canônico consultado:** `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` (vínculo explícito `sectionId/imageBindingKey` entre `landingPageImagePlanning` e `landing-page-html`).
+- **Validação backend relacionada:** comparação determinística entre pares esperados (`landingPageImagePlanning.images[*]`) e pares materializados no HTML publicado.
+- **Causa raiz:** o LHM estava escrevendo `data-image-binding-key` sem normalização canônica; em cenários com chave ausente/fora do padrão, o backend normalizava de forma diferente na validação e rejeitava o payload com 422.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo/LHM entregava (literal):** `data-image-binding-key` cru (ou fallback genérico) no HTML, sem slug canônico garantido.
+- **O que a especificação esperava (literal):** `data-image-binding-key` reproduzindo o binding canônico do planejamento (`sectionId/imageBindingKey`) com formato normalizado válido.
+- **Diferença objetiva:** chave de binding materializada no HTML podia divergir da chave canônica usada pela validação determinística.
+- **Ação corretiva recomendada:** normalizar `imageBindingKey` no próprio LHM com a mesma regra de slug canônico antes de renderizar o `<img>`.
+
+#### 4) Ajuste aplicado
+- **Arquivo alterado:** `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java`
+- **Resumo técnico da mudança:**
+  - inclusão de normalização canônica (`slugifyBindingKey`) no LHM;
+  - `buildImageTag` agora prioriza `imageBindingKey` normalizado e fallback normalizado por `imageRole`/`sectionId`, evitando chave inválida/bruta no HTML final;
+  - mantém os demais atributos `data-image-*` inalterados.
+
+#### 5) Reteste
+- **Procedimento de reteste:** execução de teste unitário do módulo LHM.
+- **Status final:** concluído após ajuste.


### PR DESCRIPTION
### Motivation
- Fix a `422 Unprocessable Entity` rejection caused by mismatched `data-image-binding-key` in the LHM-generated HTML versus the canonical binding used by the image planning validation. 
- Add contextual logging when the LHM generation endpoint fails with `422` to aid future debugging of binding/validation issues.

### Description
- Add a `slugifyBindingKey` method in `LandingHtmlModule` to normalize and slugify binding keys (unicode normalization, remove diacritics, allowed chars `[a-z0-9-]`, collapse runs, trim, max length 64, require min length 3) before rendering.
- Update `buildImageTag` to prefer the slugified `imageBindingKey` and to fall back to slugified `imageRole` and `sectionId` before using a generic fallback, ensuring the rendered `data-image-binding-key` matches the canonical format.
- Import `java.text.Normalizer` and related utilities required for normalization and keep other `data-image-*` attributes unchanged.
- Wrap `generateLandingHtmlWithLhm` in `ExperimentPipelineController` with a `try/catch` to log a warning when a `ResponseStatusException` with status `UNPROCESSABLE_ENTITY` is thrown, then rethrow the exception.
- Update documentation `docs/registro-ajustes-pipeline-experimento.md` with an incident note describing the issue and the fix.

### Testing
- Executed unit tests for the Landing HTML module (`LandingHtmlModule`) after the change, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2900a558c8321b0a322851a4a4c3f)