### PR TITLE
Add logging and simplify upsert path handling in MoisBackendPersistenceGateway

### DIFF
--- a/mois/src/main/java/com/marketinghub/mois/service/MoisBackendPersistenceGateway.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisBackendPersistenceGateway.java
@@ -2,6 +2,8 @@ package com.marketinghub.mois.service;
 
 import com.marketinghub.mois.dto.MoisCollectionPersistenceDtos;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -15,6 +17,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 public class MoisBackendPersistenceGateway {
+
+    private static final Logger log = LoggerFactory.getLogger(MoisBackendPersistenceGateway.class);
 
     private final MoisBackendPersistenceProperties properties;
     private final RestTemplateBuilder restTemplateBuilder;
@@ -35,10 +39,12 @@ public class MoisBackendPersistenceGateway {
         if (!isEnabled()) {
             return;
         }
-        exchange("/api/v1/mois/persistence/collection-jobs/" + jobId,
+        String path = "/api/v1/mois/persistence/collection-jobs/" + jobId;
+        log.info("MOIS backend persistence request (method={}, path={}, payload={})",
                 HttpMethod.PUT,
-                payload,
-                MoisCollectionPersistenceDtos.CollectionJobStateResponse.class);
+                path,
+                payload);
+        exchange(path, HttpMethod.PUT, payload, MoisCollectionPersistenceDtos.CollectionJobStateResponse.class);
     }
 
     public Optional<MoisCollectionPersistenceDtos.CollectionJobStateResponse> getCollectionJobState(String jobId) {


### PR DESCRIPTION
### Motivation

- Improve observability for backend persistence requests and simplify the path construction for the collection job upsert call to aid debugging and readability.

### Description

- Added an SLF4J `Logger` and import and declared `log` in `MoisBackendPersistenceGateway`.
- Construct the request `path` as a local variable in `upsertCollectionJobState` and log the method, path, and payload via `log.info` before sending the request.
- Updated the `exchange` call in `upsertCollectionJobState` to use `exchange(path, HttpMethod.PUT, payload, MoisCollectionPersistenceDtos.CollectionJobStateResponse.class)`.

### Testing

- Ran the `mois` module unit tests with `mvn -pl mois test` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2907fb09483218b1dc745c5d8d67b)