### PR TITLE
Enforce canonical image bindings for LHM; fail on missing sectionId or imageBindingKey and adjust HTML parsing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -418,12 +418,14 @@ public class LandingHtmlModule {
     }
 
     private String buildImageTag(Map<String, Object> image) {
-        String sectionId = firstNonBlank(asTrimmedString(image.get("sectionId")), "section");
-        String bindingKey = firstNonBlank(
-                slugifyBindingKey(asTrimmedString(image.get("imageBindingKey"))),
-                slugifyBindingKey(asTrimmedString(image.get("imageRole"))),
-                slugifyBindingKey(sectionId),
-                "image");
+        String sectionId = asTrimmedString(image.get("sectionId"));
+        if (!StringUtils.hasText(sectionId)) {
+            throw new IllegalStateException("landingPageImagePlanning.images[].sectionId é obrigatório para renderização LHM canônica.");
+        }
+        String bindingKey = slugifyBindingKey(asTrimmedString(image.get("imageBindingKey")));
+        if (!StringUtils.hasText(bindingKey)) {
+            throw new IllegalStateException("landingPageImagePlanning.images[].imageBindingKey é obrigatório para renderização LHM canônica.");
+        }
         String imageRole = firstNonBlank(asTrimmedString(image.get("imageRole")), "image");
         String conversionRole = firstNonBlank(asTrimmedString(image.get("conversionRole")), "support");
         String attentionPriority = firstNonBlank(asTrimmedString(image.get("attentionPriority")), "medium");

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -3678,7 +3678,7 @@ public class ExperimentPipelineGenerationService {
         while (tagMatcher.find()) {
             String tag = tagMatcher.group();
             Map<String, String> attrs = parseHtmlAttributes(tag);
-            String sectionId = normalizeHtmlAttr(attrs.get("data-image-section-id"));
+            String sectionId = resolveImageSectionIdFromHtmlAttrs(attrs);
             String imageBindingKey = resolveBindingKeyFromHtmlAttrs(attrs);
             String imageRole = normalizeHtmlAttr(attrs.get("data-image-role"));
             String conversionRole = normalizeHtmlAttr(attrs.get("data-conversion-role"));
@@ -3745,6 +3745,14 @@ public class ExperimentPipelineGenerationService {
         }
         usedKeys.add(candidate);
         return candidate;
+    }
+
+    private String resolveImageSectionIdFromHtmlAttrs(Map<String, String> attrs) {
+        String sectionId = normalizeHtmlAttr(attrs.get("data-image-section-id"));
+        if (StringUtils.hasText(sectionId)) {
+            return sectionId;
+        }
+        return normalizeHtmlAttr(attrs.get("data-section-id"));
     }
 
     private String resolveBindingKeyFromHtmlAttrs(Map<String, String> attrs) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java
@@ -385,6 +385,47 @@ class LandingHtmlModuleTest {
         assertThrows(IllegalStateException.class, () -> module.assembleHtmlDocument(experiment));
     }
 
+    @Test
+    void assembleHtmlDocumentThrowsWhenImageBindingKeyIsMissingFromCanonicalPlanning() {
+        Experiment experiment = new Experiment();
+        applyBaseCssContract(experiment);
+        experiment.setLandingPageWireframe("""
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {
+                        "sectionId": "hero",
+                        "sectionName": "Hero",
+                        "contentType": "hero",
+                        "surfaceSpec": {
+                          "surfaceToken": "surface-hero",
+                          "style": "band",
+                          "contrastMode": "normal"
+                        }
+                      }
+                    ],
+                    "formSpec": {"formId": "lead-capture-primary"}
+                  }
+                }
+                """);
+        experiment.setLandingPageCopy("{\"landingPageCopy\":{}}");
+        experiment.setLandingPageImagePlanning("""
+                {
+                  "landingPageImagePlanning": {
+                    "images": [
+                      {
+                        "sectionId": "hero",
+                        "imageRole": "Hero Pain Anchor"
+                      }
+                    ]
+                  }
+                }
+                """);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> module.assembleHtmlDocument(experiment));
+        assertTrue(ex.getMessage().contains("imageBindingKey é obrigatório"));
+    }
+
     private void applyBaseCssContract(Experiment experiment) {
         experiment.setLandingPageDesignPreset("""
                 {

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,53 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0015 — LHM estrito ao artefato canônico de imagens (`sectionId/imageBindingKey`)
+
+- **Data/Hora (UTC):** 2026-04-30
+- **Responsável:** Assistente Codex
+- **Módulo:** backend (`ads-service`)
+- **Ambiente:** Repositório local (`/workspace/marketing-hub`)
+- **Execução/Teste:** Geração de landing no fluxo **LHM + IA** com erro 422 por divergência de bindings de imagem.
+
+#### 1) Erro observado
+- **Sintoma:** backend rejeitou a saída de `landing-page-html` com `422 Unprocessable Entity`.
+- **Endpoint/rota/fila:** `POST /api/experiments/{id}/pipeline/landing-page-html/generate-with-lhm` e validação no fechamento do job `LANDING_PAGE_HTML`.
+- **Status code:** 422.
+- **Mensagem de erro literal:** `Divergência de imagens: landing-page-html deve reproduzir o binding explícito canônico do landing-page-image-planning por sectionId/imageBindingKey`.
+- **Payload enviado (literal):** HTML com `<img ...>` cujo par `sectionId/imageBindingKey` não reproduzia exatamente o planejado.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** não executado neste registro local; diagnóstico baseado na validação determinística do backend e no fluxo LHM.
+- **Dados de banco consultados via MCP:** não executado neste registro local.
+- **Trecho canônico consultado:** `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` (vínculo explícito canônico entre `landingPageImagePlanning.images[]` e marcações da landing HTML).
+- **Validação/regra que rejeitou:** comparação estrita entre bindings esperados (do `landingPageImagePlanning`) e bindings extraídos do HTML final.
+- **Causa raiz:** o LHM ainda permitia fallback/síntese de `imageBindingKey` em cenário sem chave explícita, abrindo brecha para divergência em relação ao contrato canônico.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** HTML com bindings de imagem não exatamente equivalentes ao contrato de planejamento.
+- **O que a especificação esperava (literal):** igualdade exata de pares `sectionId/imageBindingKey` entre planejamento e HTML.
+- **Diferença objetiva:** ausência/variação de `imageBindingKey` explícito no insumo propagava saída não-canônica.
+- **Ação corretiva recomendada:** tornar o LHM estrito, exigindo `sectionId` e `imageBindingKey` obrigatórios no `landingPageImagePlanning` antes de renderizar `<img>`.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** validação determinística + reforço de contrato canônico.
+- **Arquivos alterados:**
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java`
+  - `backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModuleTest.java`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** `buildImageTag` passou a falhar rápido (`IllegalStateException`) quando `sectionId` ou `imageBindingKey` estiver ausente no `landingPageImagePlanning.images[]`; removida síntese permissiva de binding key por fallback semântico.
+
+#### 5) Reteste
+- **Procedimento de reteste:** execução direcionada dos testes `LandingHtmlModuleTest` e `ExperimentPipelineGenerationServiceTest`.
+- **Resultado:** aprovado.
+- **Evidências (logs/ids/prints):** `BUILD SUCCESS` com `Tests run: 51, Failures: 0, Errors: 0, Skipped: 0`.
+- **Status final:** Resolvido.
+
+#### 6) Próximo passo
+- **Ação seguinte:** reexecutar geração do HTML no experimento com falha anterior para confirmar ausência de 422 por divergência de binding.
+- **Dono da ação:** time backend + operação de pipeline.
+- **Prazo:** imediato (próxima execução assistida).
+
 ### INC-0014 — Landing copy orientada por slots canônicos do wireframe
 
 - **Data/Hora (UTC):** 2026-04-29


### PR DESCRIPTION
### Motivation
- The LHM renderer allowed synthesizing image binding keys when `landingPageImagePlanning` lacked explicit `sectionId` or `imageBindingKey`, which caused downstream 422 rejections due to divergence from the canonical image plan. 
- The change aims to make HTML generation deterministic and strictly reproduce the `sectionId/imageBindingKey` pairs from the canonical `landingPageImagePlanning` artifact.

### Description
- `LandingHtmlModule.buildImageTag` now requires `sectionId` and `imageBindingKey` and throws an `IllegalStateException` when either is missing, removing permissive fallback synthesis of the binding key. 
- `ExperimentPipelineGenerationService` adds `resolveImageSectionIdFromHtmlAttrs` and uses it in `extractImagePlanBindingsFromHtmlDocument` to prefer `data-image-section-id` and fall back to `data-section-id` when parsing `<img>` tags. 
- Added unit test `assembleHtmlDocumentThrowsWhenImageBindingKeyIsMissingFromCanonicalPlanning` in `LandingHtmlModuleTest` to assert the new failure mode. 
- Documented the change in `docs/registro-ajustes-pipeline-experimento.md` (INC-0015) describing the validation and remediation.

### Testing
- Ran the updated unit tests including `LandingHtmlModuleTest` and the experiment pipeline parsing tests, and the suite completed successfully. 
- Build verification produced `BUILD SUCCESS` with `Tests run: 51, Failures: 0, Errors: 0, Skipped: 0`. 
- The new test `assembleHtmlDocumentThrowsWhenImageBindingKeyIsMissingFromCanonicalPlanning` passed as expected by asserting the thrown `IllegalStateException`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b4a7b5ac8321871bdf9d100e126d)