### PR TITLE
Add enable flag for backend persistence and gate gateway calls

### DIFF
--- a/mois/src/main/java/com/marketinghub/mois/service/MoisBackendPersistenceGateway.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisBackendPersistenceGateway.java
@@ -32,7 +32,7 @@ public class MoisBackendPersistenceGateway {
     }
 
     public boolean isEnabled() {
-        return StringUtils.hasText(properties.getBaseUrl());
+        return properties.isEnabled() && StringUtils.hasText(properties.getBaseUrl());
     }
 
     public void upsertCollectionJobState(String jobId, MoisCollectionPersistenceDtos.CollectionJobStateResponse payload) {

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisBackendPersistenceProperties.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisBackendPersistenceProperties.java
@@ -8,9 +8,18 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "integrations.backend.persistence")
 public class MoisBackendPersistenceProperties {
 
+    private boolean enabled = false;
     private String baseUrl = "";
     private Duration connectTimeout = Duration.ofSeconds(2);
     private Duration readTimeout = Duration.ofSeconds(5);
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
 
     public String getBaseUrl() {
         return baseUrl;

--- a/mois/src/main/resources/application.properties
+++ b/mois/src/main/resources/application.properties
@@ -8,6 +8,7 @@ management.endpoint.health.show-details=never
 logging.file.name=${MOIS_LOG_FILE:/var/log/marketinghub/mois.log}
 management.endpoints.web.base-path=/manage
 
+integrations.backend.persistence.enabled=${MOIS_BACKEND_PERSISTENCE_ENABLED:false}
 integrations.backend.persistence.base-url=${BACKEND_BASE_URL:http://191.252.181.168:8000/}
 integrations.backend.persistence.connect-timeout=8s
 integrations.backend.persistence.read-timeout=20s


### PR DESCRIPTION
### Motivation
- Provide a runtime toggle to enable or disable the backend persistence integration independently of the base URL to avoid accidental outbound calls in environments without the backend.

### Description
- Add an `enabled` boolean property to `MoisBackendPersistenceProperties` with default `false` and a getter/setter.
- Update `MoisBackendPersistenceGateway.isEnabled()` to return `properties.isEnabled() && StringUtils.hasText(properties.getBaseUrl())` so requests are suppressed when the integration is disabled.
- Add `integrations.backend.persistence.enabled=${MOIS_BACKEND_PERSISTENCE_ENABLED:false}` to `application.properties` so the toggle can be controlled via the `MOIS_BACKEND_PERSISTENCE_ENABLED` environment variable.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bae2ab0c8321b3646351dbd0bfc9)