### PR TITLE
Add detailed binding-pairs diff message to landing HTML validation and include it in error response

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -3633,9 +3633,14 @@ public class ExperimentPipelineGenerationService {
                     experiment.getId(),
                     expectedBindingPairs,
                     actualBindingPairs);
+            String bindingPairsDiffMessage = String.format(
+                    "Divergência de imagens: landing-page-html deve reproduzir o binding explícito canônico do landing-page-image-planning por sectionId/imageBindingKey. expectedBindingPairs=%s actualBindingPairs=%s",
+                    expectedBindingPairs,
+                    actualBindingPairs);
+            log.warn("Validação landing HTML (experimentId={}): {}", experiment.getId(), bindingPairsDiffMessage);
             throw new ResponseStatusException(
                     HttpStatus.UNPROCESSABLE_ENTITY,
-                    "Divergência de imagens: landing-page-html deve reproduzir o binding explícito canônico do landing-page-image-planning por sectionId/imageBindingKey");
+                    bindingPairsDiffMessage);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Improve diagnostics when image binding mismatches are detected by providing a clear, specific diff message that explains the expected vs actual `sectionId/imageBindingKey` pairs.

### Description
- Create a `bindingPairsDiffMessage` string containing the expected and actual binding pairs, log it with `log.warn`, and pass it into the thrown `ResponseStatusException` so the error response contains the same detailed message. 

### Testing
- Ran the existing automated test suite with `mvn test` and verified that all tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cb9937508321b17edc5a670379d2)