### PR TITLE
Change Hotmart robot default cron schedule to hourly

### DIFF
--- a/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotProperties.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotProperties.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 public class MoisHotmartRobotProperties {
 
     private boolean enabled = false;
-    private String cron = "0 */15 * * * *";
+    private String cron = "0 0 * * * *";
     private String workspaceId = "workspace-001";
     private String niche = "marketing-digital";
     private String marketTheme = "ofertas-com-temperatura-alta";

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotScheduler.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisHotmartRobotScheduler.java
@@ -19,7 +19,7 @@ public class MoisHotmartRobotScheduler {
         this.hotmartRobotService = hotmartRobotService;
     }
 
-    @Scheduled(cron = "${mois.robot.hotmart.cron:0 */15 * * * *}")
+    @Scheduled(cron = "${mois.robot.hotmart.cron:0 0 * * * *}")
     public void run() {
         log.info("MOIS Hotmart scheduler heartbeat: agendamento ativo (enabled={}, cron={})",
                 properties.isEnabled(),

--- a/mois/src/main/resources/application.properties
+++ b/mois/src/main/resources/application.properties
@@ -15,7 +15,7 @@ integrations.backend.persistence.read-timeout=20s
 
 # Robô de coleta Hotmart (executa no container MOIS)
 mois.robot.hotmart.enabled=${MOIS_ROBOT_HOTMART_ENABLED:true}
-mois.robot.hotmart.cron=${MOIS_ROBOT_HOTMART_CRON:0 */15 * * * *}
+mois.robot.hotmart.cron=${MOIS_ROBOT_HOTMART_CRON:0 0 * * * *}
 mois.robot.hotmart.workspace-id=${MOIS_ROBOT_HOTMART_WORKSPACE_ID:workspace-001}
 mois.robot.hotmart.niche=${MOIS_ROBOT_HOTMART_NICHE:marketing-digital}
 mois.robot.hotmart.market-theme=${MOIS_ROBOT_HOTMART_MARKET_THEME:ofertas-com-temperatura-alta}


### PR DESCRIPTION
### Motivation
- Reduce the execution frequency of the Hotmart collection robot from every 15 minutes to once per hour by changing the default cron to `0 0 * * * *`.

### Description
- Updated the default cron expression to `0 0 * * * *` in `MoisHotmartRobotProperties`, the `@Scheduled` annotation in `MoisHotmartRobotScheduler`, and the default in `application.properties`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cd6b9e0c83219b41048e256207db)