### PR TITLE
Add commercial playbooks & conversion event tracking to Sales Video profile

### DIFF
--- a/frontend/src/api/salesVideo/types.ts
+++ b/frontend/src/api/salesVideo/types.ts
@@ -223,3 +223,84 @@ export interface LandingVideoSlotHistory {
   publishedAt?: string | null;
   notes?: string | null;
 }
+
+
+export type SalesVideoConversionEventType =
+  | "VIEW"
+  | "LEAD"
+  | "QUALIFIED_LEAD"
+  | "CHECKOUT_STARTED"
+  | "PURCHASE";
+
+export interface SalesVideoCommercialPlaybook {
+  id: number;
+  profileId: number;
+  tenantId?: string | null;
+  nicheKey: string;
+  variantKey: string;
+  objectionText: string;
+  ctaText: string;
+  active: boolean;
+  createdBy?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface CreateSalesVideoCommercialPlaybookPayload {
+  nicheKey: string;
+  variantKey: string;
+  objectionText: string;
+  ctaText: string;
+  active?: boolean;
+  createdBy: string;
+}
+
+export interface SalesVideoConversionEvent {
+  id: number;
+  profileId: number;
+  scriptId?: number | null;
+  jobId?: number | null;
+  eventType: SalesVideoConversionEventType;
+  eventValue?: number | null;
+  currency?: string | null;
+  occurredAt: string;
+  source?: string | null;
+  metadataJson?: string | null;
+}
+
+export interface CreateSalesVideoConversionEventPayload {
+  scriptId?: number;
+  jobId?: number;
+  eventType: SalesVideoConversionEventType;
+  eventValue?: number;
+  currency?: string;
+  occurredAt?: string;
+  source?: string;
+  metadataJson?: string;
+}
+
+export interface SalesVideoVariantPerformance {
+  variantKey: string;
+  scriptId?: number | null;
+  providerName?: string | null;
+  views: number;
+  leads: number;
+  qualifiedLeads: number;
+  checkoutStarted: number;
+  purchases: number;
+  revenue: number;
+  conversionRatePercent: number;
+}
+
+export interface SalesVideoPerformanceSummary {
+  profileId: number;
+  from?: string | null;
+  to?: string | null;
+  totalViews: number;
+  totalLeads: number;
+  totalQualifiedLeads: number;
+  totalCheckoutStarted: number;
+  totalPurchases: number;
+  totalRevenue: number;
+  variants: SalesVideoVariantPerformance[];
+}

--- a/frontend/src/api/salesVideo/useCreateSalesVideoCommercialPlaybook.ts
+++ b/frontend/src/api/salesVideo/useCreateSalesVideoCommercialPlaybook.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { CreateSalesVideoCommercialPlaybookPayload, SalesVideoCommercialPlaybook } from "./types";
+
+export function useCreateSalesVideoCommercialPlaybook(profileId?: string | number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: CreateSalesVideoCommercialPlaybookPayload) => {
+      if (!profileId) throw new Error("Perfil inválido para criar playbook comercial");
+      const { data } = await axios.post<SalesVideoCommercialPlaybook>(
+        `/api/sales-videos/profiles/${profileId}/commercial-playbooks`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sales-video-commercial-playbooks", profileId] });
+    },
+  });
+}

--- a/frontend/src/api/salesVideo/useCreateSalesVideoConversionEvent.ts
+++ b/frontend/src/api/salesVideo/useCreateSalesVideoConversionEvent.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { CreateSalesVideoConversionEventPayload, SalesVideoConversionEvent } from "./types";
+
+export function useCreateSalesVideoConversionEvent(profileId?: string | number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: CreateSalesVideoConversionEventPayload) => {
+      if (!profileId) throw new Error("Perfil inválido para registrar conversão");
+      const { data } = await axios.post<SalesVideoConversionEvent>(
+        `/api/sales-videos/profiles/${profileId}/conversion-events`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sales-video-performance-summary", profileId] });
+    },
+  });
+}

--- a/frontend/src/api/salesVideo/useSalesVideoCommercialPlaybooks.ts
+++ b/frontend/src/api/salesVideo/useSalesVideoCommercialPlaybooks.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { SalesVideoCommercialPlaybook } from "./types";
+
+export function useSalesVideoCommercialPlaybooks(profileId?: string | number) {
+  return useQuery({
+    queryKey: ["sales-video-commercial-playbooks", profileId],
+    enabled: Boolean(profileId),
+    queryFn: async () => {
+      const { data } = await axios.get<SalesVideoCommercialPlaybook[]>(
+        `/api/sales-videos/profiles/${profileId}/commercial-playbooks`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/api/salesVideo/useSalesVideoPerformanceSummary.ts
+++ b/frontend/src/api/salesVideo/useSalesVideoPerformanceSummary.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { SalesVideoPerformanceSummary } from "./types";
+
+export function useSalesVideoPerformanceSummary(profileId?: string | number) {
+  return useQuery({
+    queryKey: ["sales-video-performance-summary", profileId],
+    enabled: Boolean(profileId),
+    queryFn: async () => {
+      const { data } = await axios.get<SalesVideoPerformanceSummary>(
+        `/api/sales-videos/profiles/${profileId}/performance-summary`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/salesVideo/SalesVideoProfileDetailPage.tsx
+++ b/frontend/src/pages/salesVideo/SalesVideoProfileDetailPage.tsx
@@ -15,8 +15,13 @@ import { useSalesVideoScripts } from "../../api/salesVideo/useSalesVideoScripts"
 import { useLandingVideoSlotHistory } from "../../api/salesVideo/useLandingVideoSlotHistory";
 import { useRetrySalesVideoJob } from "../../api/salesVideo/useRetrySalesVideoJob";
 import { useUpdateSalesVideoCompliance } from "../../api/salesVideo/useUpdateSalesVideoCompliance";
+import { useSalesVideoCommercialPlaybooks } from "../../api/salesVideo/useSalesVideoCommercialPlaybooks";
+import { useCreateSalesVideoCommercialPlaybook } from "../../api/salesVideo/useCreateSalesVideoCommercialPlaybook";
+import { useCreateSalesVideoConversionEvent } from "../../api/salesVideo/useCreateSalesVideoConversionEvent";
+import { useSalesVideoPerformanceSummary } from "../../api/salesVideo/useSalesVideoPerformanceSummary";
 import {
   LandingVideoSlot,
+  SalesVideoConversionEventType,
   SalesVideoExecutionMode,
   SalesVideoJob,
   SalesVideoProviderFamily,
@@ -84,6 +89,29 @@ export default function SalesVideoProfileDetailPage() {
   const updateSlot = useUpdateLandingVideoSlot(landingId);
   const retryJob = useRetrySalesVideoJob();
   const updateCompliance = useUpdateSalesVideoCompliance(profileId);
+  const { data: commercialPlaybooks } = useSalesVideoCommercialPlaybooks(profileId);
+  const { data: performanceSummary } = useSalesVideoPerformanceSummary(profileId);
+  const createCommercialPlaybook = useCreateSalesVideoCommercialPlaybook(profileId);
+  const createConversionEvent = useCreateSalesVideoConversionEvent(profileId);
+  const CONVERSION_EVENT_TYPES: SalesVideoConversionEventType[] = [
+    "VIEW",
+    "LEAD",
+    "QUALIFIED_LEAD",
+    "CHECKOUT_STARTED",
+    "PURCHASE",
+  ];
+  const [playbookForm, setPlaybookForm] = useState({
+    nicheKey: "",
+    variantKey: "default",
+    objectionText: "",
+    ctaText: "",
+  });
+  const [conversionForm, setConversionForm] = useState({
+    eventType: "VIEW" as SalesVideoConversionEventType,
+    eventValue: "",
+    currency: "BRL",
+    source: "manual-admin",
+  });
   const RETRY_REASONS: SalesVideoRetryReason[] = [
     "MANUAL_INTERVENTION",
     "PROVIDER_FAILURE",
@@ -243,6 +271,27 @@ export default function SalesVideoProfileDetailPage() {
       toast.error(message);
     }
   };
+  const handleCommercialPlaybookSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await createCommercialPlaybook.mutateAsync({
+      nicheKey: playbookForm.nicheKey,
+      variantKey: playbookForm.variantKey,
+      objectionText: playbookForm.objectionText,
+      ctaText: playbookForm.ctaText,
+      createdBy: tenantContext.userEmail,
+    });
+    toast.success("Playbook comercial criado");
+  };
+  const handleConversionEventSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await createConversionEvent.mutateAsync({
+      eventType: conversionForm.eventType,
+      eventValue: conversionForm.eventValue ? Number(conversionForm.eventValue) : undefined,
+      currency: conversionForm.currency || undefined,
+      source: conversionForm.source || undefined,
+    });
+    toast.success("Evento de conversão registrado");
+  };
 
   const parseNumber = (value: string) => {
     if (!value.trim()) return undefined;
@@ -355,6 +404,77 @@ export default function SalesVideoProfileDetailPage() {
               <strong>Landing:</strong> {profile.landingPageId ?? "—"}
             </div>
           </div>
+        </div>
+      </section>
+      <section className="mb-4">
+        <h2 className="h5">Comercial (Playbooks + Conversão)</h2>
+        <div className="row g-3">
+          <div className="col-lg-6">
+            <div className="card p-3 h-100">
+              <h3 className="h6">Novo playbook comercial</h3>
+              <form className="row g-2" onSubmit={handleCommercialPlaybookSubmit}>
+                <div className="col-md-6">
+                  <label className="form-label">Nicho *</label>
+                  <input className="form-control" required value={playbookForm.nicheKey} onChange={(e) => setPlaybookForm((p) => ({ ...p, nicheKey: e.target.value }))} />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label">Variação *</label>
+                  <input className="form-control" required value={playbookForm.variantKey} onChange={(e) => setPlaybookForm((p) => ({ ...p, variantKey: e.target.value }))} />
+                </div>
+                <div className="col-12">
+                  <label className="form-label">Objeção *</label>
+                  <textarea className="form-control" required value={playbookForm.objectionText} onChange={(e) => setPlaybookForm((p) => ({ ...p, objectionText: e.target.value }))} />
+                </div>
+                <div className="col-12">
+                  <label className="form-label">CTA *</label>
+                  <textarea className="form-control" required value={playbookForm.ctaText} onChange={(e) => setPlaybookForm((p) => ({ ...p, ctaText: e.target.value }))} />
+                </div>
+                <div className="col-12">
+                  <button className="btn btn-primary" type="submit" disabled={createCommercialPlaybook.isPending}>
+                    {createCommercialPlaybook.isPending && <span className="spinner-border spinner-border-sm me-2" />}
+                    {createCommercialPlaybook.isPending ? "Salvando..." : "Salvar playbook"}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+          <div className="col-lg-6">
+            <div className="card p-3 h-100">
+              <h3 className="h6">Registrar conversão</h3>
+              <form className="row g-2" onSubmit={handleConversionEventSubmit}>
+                <div className="col-md-6">
+                  <label className="form-label">Evento *</label>
+                  <select className="form-select" value={conversionForm.eventType} onChange={(e) => setConversionForm((p) => ({ ...p, eventType: e.target.value as SalesVideoConversionEventType }))}>
+                    {CONVERSION_EVENT_TYPES.map((type) => <option key={type} value={type}>{type}</option>)}
+                  </select>
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label">Valor (opcional)</label>
+                  <input className="form-control" type="number" value={conversionForm.eventValue} onChange={(e) => setConversionForm((p) => ({ ...p, eventValue: e.target.value }))} />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label">Moeda</label>
+                  <input className="form-control" value={conversionForm.currency} onChange={(e) => setConversionForm((p) => ({ ...p, currency: e.target.value }))} />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label">Origem</label>
+                  <input className="form-control" value={conversionForm.source} onChange={(e) => setConversionForm((p) => ({ ...p, source: e.target.value }))} />
+                </div>
+                <div className="col-12">
+                  <button className="btn btn-primary" type="submit" disabled={createConversionEvent.isPending}>
+                    {createConversionEvent.isPending && <span className="spinner-border spinner-border-sm me-2" />}
+                    {createConversionEvent.isPending ? "Registrando..." : "Registrar evento"}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div className="card p-3 mt-3">
+          <h3 className="h6">Resumo de performance</h3>
+          <p className="mb-1">Views: {performanceSummary?.totalViews ?? 0} · Leads: {performanceSummary?.totalLeads ?? 0} · Compras: {performanceSummary?.totalPurchases ?? 0}</p>
+          <p className="mb-2">Receita: {(performanceSummary?.totalRevenue ?? 0).toLocaleString("pt-BR", { style: "currency", currency: "BRL" })}</p>
+          <small className="text-muted">Playbooks cadastrados: {commercialPlaybooks?.length ?? 0}</small>
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Add commercial playbook management and conversion event tracking to the Sales Video profile to support manual creation of playbooks and recording of conversion metrics. 
- Provide a simple performance summary and client-side API hooks so the UI can create/read related resources and refresh relevant caches.

### Description
- Extended `frontend/src/api/salesVideo/types.ts` with `SalesVideoCommercialPlaybook`, `SalesVideoConversionEvent`, `SalesVideoPerformanceSummary`, `SalesVideoVariantPerformance`, `CreateSalesVideoCommercialPlaybookPayload`, `CreateSalesVideoConversionEventPayload`, and `SalesVideoConversionEventType` types. 
- Added React Query hooks: `useSalesVideoCommercialPlaybooks`, `useCreateSalesVideoCommercialPlaybook`, `useCreateSalesVideoConversionEvent`, and `useSalesVideoPerformanceSummary` for CRUD and summary endpoints using `axios` and appropriate query invalidation keys. 
- Updated `SalesVideoProfileDetailPage.tsx` to import the new hooks and types, add local form state and handlers (`handleCommercialPlaybookSubmit`, `handleConversionEventSubmit`), render forms for creating playbooks and registering conversions, and show a small performance summary with counts and revenue. 
- Mutation handlers invalidate related queries (`sales-video-commercial-playbooks` and `sales-video-performance-summary`) so UI updates after changes.

### Testing
- No automated tests were added for this change and no test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f385c74580832193b3c1726f619f89)