### PR TITLE
Update test to expect canonical landing page image planning contract

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -210,7 +210,7 @@ class ExperimentPipelineOpenAiClientTest {
     }
 
     @Test
-    void prependsLandingImagePlanningGuidanceRequiringFullWireframeCoverage() {
+    void prependsLandingImagePlanningGuidanceAlignedWithCanonicalContract() {
         AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
         ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
                 WebClient.builder().exchangeFunction(capturePayloadExchange(payloadRef)),
@@ -240,12 +240,11 @@ class ExperimentPipelineOpenAiClientTest {
         @SuppressWarnings("unchecked")
         var input = (java.util.List<Map<String, Object>>) payload.get("input");
         String userPrompt = String.valueOf(input.get(0).get("content"));
-        assertThat(userPrompt).contains("`images[]` deve cobrir **100%** dos `sectionId` de `landingPageWireframe.sectionOrder`");
-        assertThat(userPrompt).contains("incluindo seções de formulário");
-        assertThat(userPrompt).contains("é proibido inventar `sectionId` fora do wireframe");
-        assertThat(userPrompt).contains("checklist de cobertura obrigatório");
-        assertThat(userPrompt).contains("extraia a lista literal `requiredSectionIds`");
-        assertThat(userPrompt).contains("só finalize quando `missing=[]` e `extras=[]`");
+        assertThat(userPrompt).contains("Responda em JSON válido e estritamente aderente ao artefato `landingPageImagePlanning`.");
+        assertThat(userPrompt).contains("Campos obrigatórios:");
+        assertThat(userPrompt).contains("- generationPrompt");
+        assertThat(userPrompt).contains("A etapa `landingPageImagePlanning` é responsável somente por gerar o prompt final de execução para o modelo de imagem.");
+        assertThat(userPrompt).contains("Os bindings estruturais de imagem (por seção) são definidos no `landingPageWireframe` e apenas consumidos nesta etapa.");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Align the unit test with a revised canonical contract for the `landingPageImagePlanning` stage so the generated prompt must produce valid, strict JSON and expose required fields. 
- Reflect updated guidance language and clarify the stage responsibility and binding semantics consumed from `landingPageWireframe`.

### Description
- Renamed the test method from `prependsLandingImagePlanningGuidanceRequiringFullWireframeCoverage` to `prependsLandingImagePlanningGuidanceAlignedWithCanonicalContract` to reflect the new intent. 
- Replaced assertions that checked for wireframe coverage checklist strings with assertions that validate the prompt requires strict JSON adherence to the `landingPageImagePlanning` artifact. 
- Added assertions verifying the presence of required fields such as `generationPrompt` and text describing the stage responsibility and that image bindings are defined in `landingPageWireframe`.

### Testing
- Ran the `ExperimentPipelineOpenAiClientTest` suite using `./gradlew :ai-worker:test --tests *ExperimentPipelineOpenAiClientTest` and the tests completed successfully. 
- All modified assertions in `ExperimentPipelineOpenAiClientTest` passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f388e1a7a48321817171f6f1d14725)