### PR TITLE
MOIS: Add Automatic Collections page, API hook and types

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -123,6 +123,7 @@ import MoisComparisonPage from "./pages/mois/MoisComparisonPage";
 import MoisOfferBuilderPage from "./pages/mois/MoisOfferBuilderPage";
 import MoisResearchSourcesPage from "./pages/mois/MoisResearchSourcesPage";
 import MoisAutoCollectionPage from "./pages/mois/MoisAutoCollectionPage";
+import MoisAutomaticCollectionsPage from "./pages/mois/MoisAutomaticCollectionsPage";
 import MdsWorkspacePage from "./pages/mds/MdsWorkspacePage";
 import MdsRequestDetailPage from "./pages/mds/MdsRequestDetailPage";
 import MdsArtifactsPage from "./pages/mds/MdsArtifactsPage";
@@ -276,6 +277,7 @@ export default function App() {
               <Route path="/mois/references/new" element={<MoisReferenceIntakePage />} />
               <Route path="/mois/research-sources" element={<MoisResearchSourcesPage />} />
               <Route path="/mois/auto-collection" element={<MoisAutoCollectionPage />} />
+              <Route path="/mois/automatic-collections" element={<MoisAutomaticCollectionsPage />} />
               <Route path="/mois/extraction" element={<MoisExtractionPage />} />
               <Route path="/mois/library" element={<MoisLibraryPage />} />
               <Route path="/mois/comparison" element={<MoisComparisonPage />} />

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -162,6 +162,10 @@ export interface MoisCollectionJob {
   createdAt: string;
 }
 
+export interface MoisCollectionJobListResponse {
+  items: MoisCollectionJob[];
+}
+
 export interface MoisCollectedReference {
   referenceId: string;
   jobId: string;

--- a/frontend/src/api/mois/useMoisCollection.ts
+++ b/frontend/src/api/mois/useMoisCollection.ts
@@ -5,6 +5,7 @@ import type {
   MoisCollectedReferenceLineageResponse,
   MoisCollectedReferenceListResponse,
   MoisCollectionJob,
+  MoisCollectionJobListResponse,
   MoisCreateCollectionJobPayload,
 } from "./types";
 
@@ -24,6 +25,19 @@ export function useCreateMoisCollectionJob() {
     },
     onSuccess: async (data) => {
       await queryClient.invalidateQueries({ queryKey: ["mois", "collection-jobs", data.workspaceId] });
+    },
+  });
+}
+
+export function useMoisCollectionJobs(workspaceId: string, status = "") {
+  return useQuery({
+    queryKey: ["mois", "collection-jobs", workspaceId, status],
+    enabled: workspaceId.trim().length > 0,
+    queryFn: async () => {
+      const { data } = await axios.get<MoisCollectionJobListResponse>("/api/v1/mois/collection-jobs", {
+        params: { workspaceId, status: status || undefined },
+      });
+      return data.items;
     },
   });
 }

--- a/frontend/src/pages/mois/MoisAutomaticCollectionsPage.tsx
+++ b/frontend/src/pages/mois/MoisAutomaticCollectionsPage.tsx
@@ -1,0 +1,179 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useMoisCollectedReferences, useMoisCollectionJobs } from "../../api/mois/useMoisCollection";
+
+const WORKSPACE_ID = "workspace-001";
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "-"
+    : date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
+}
+
+export default function MoisAutomaticCollectionsPage() {
+  const [sourceFilter, setSourceFilter] = useState("");
+  const [confidenceFilter, setConfidenceFilter] = useState("");
+  const [minSuccessScore, setMinSuccessScore] = useState<number>(0);
+
+  const jobsQuery = useMoisCollectionJobs(WORKSPACE_ID);
+  const jobs = jobsQuery.data ?? [];
+  const latestJobId = jobs[0]?.jobId ?? "";
+
+  const filters = useMemo(
+    () => ({
+      source: sourceFilter || undefined,
+      minSuccessScore: minSuccessScore > 0 ? minSuccessScore : undefined,
+      confidenceLevel: confidenceFilter || undefined,
+    }),
+    [confidenceFilter, minSuccessScore, sourceFilter],
+  );
+
+  const referencesQuery = useMoisCollectedReferences(latestJobId, filters);
+  const references = referencesQuery.data ?? [];
+
+  return (
+    <section className="d-flex flex-column gap-4">
+      <header className="d-flex justify-content-between align-items-center">
+        <div>
+          <h1 className="h3 mb-1">MOIS · Coletas automáticas</h1>
+          <p className="text-secondary mb-0">Visualize todas as coletas automáticas e suas URLs sem criar novo job manual.</p>
+        </div>
+        <Link className="btn btn-outline-secondary" to="/mois">
+          Voltar ao workspace
+        </Link>
+      </header>
+
+      <article className="card shadow-sm">
+        <div className="card-body">
+          <div className="d-flex align-items-center justify-content-between mb-3">
+            <h2 className="h5 mb-0">Jobs automáticos ({jobs.length})</h2>
+            {latestJobId ? <span className="badge text-bg-light">Último job: {latestJobId}</span> : null}
+          </div>
+
+          {jobsQuery.isLoading ? <p className="text-secondary mb-0">Carregando jobs automáticos...</p> : null}
+          {jobsQuery.isError ? <p className="text-danger mb-0">Não foi possível carregar os jobs automáticos.</p> : null}
+          {!jobsQuery.isLoading && !jobsQuery.isError && jobs.length === 0 ? (
+            <p className="text-secondary mb-0">Nenhuma coleta automática encontrada para o workspace.</p>
+          ) : null}
+
+          {jobs.length > 0 ? (
+            <div className="table-responsive">
+              <table className="table table-sm align-middle">
+                <thead>
+                  <tr>
+                    <th>Job</th>
+                    <th>Status</th>
+                    <th>Nicho</th>
+                    <th>Tema</th>
+                    <th>Fontes</th>
+                    <th>Janela</th>
+                    <th>Criado em</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {jobs.map((job) => (
+                    <tr key={job.jobId}>
+                      <td>{job.jobId}</td>
+                      <td>
+                        <span className="badge text-bg-light">{job.status}</span>
+                      </td>
+                      <td>{job.niche}</td>
+                      <td>{job.marketTheme || "—"}</td>
+                      <td>{job.sources.join(", ")}</td>
+                      <td>{job.timeWindow}</td>
+                      <td>{formatDate(job.createdAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+        </div>
+      </article>
+
+      <article className="card shadow-sm">
+        <div className="card-body">
+          <div className="d-flex justify-content-between align-items-center mb-3">
+            <h2 className="h5 mb-0">URLs coletadas (último job)</h2>
+          </div>
+
+          <div className="row g-2 mb-3">
+            <div className="col-md-4">
+              <select className="form-select" value={sourceFilter} onChange={(event) => setSourceFilter(event.target.value)}>
+                <option value="">Todas as fontes</option>
+                <option value="HOTMART">HOTMART</option>
+                <option value="CLICKBANK">CLICKBANK</option>
+                <option value="JVZOO">JVZOO</option>
+                <option value="META_AD_LIBRARY">META_AD_LIBRARY</option>
+              </select>
+            </div>
+            <div className="col-md-4">
+              <select
+                className="form-select"
+                value={confidenceFilter}
+                onChange={(event) => setConfidenceFilter(event.target.value)}
+              >
+                <option value="">Todas as confianças</option>
+                <option value="HIGH">HIGH</option>
+                <option value="MEDIUM">MEDIUM</option>
+                <option value="LOW">LOW</option>
+              </select>
+            </div>
+            <div className="col-md-4">
+              <input
+                type="number"
+                min={0}
+                max={100}
+                className="form-control"
+                value={minSuccessScore}
+                onChange={(event) => setMinSuccessScore(Number(event.target.value))}
+                placeholder="Score mínimo"
+              />
+            </div>
+          </div>
+
+          {!latestJobId ? <p className="text-secondary mb-0">Sem job disponível para carregar URLs.</p> : null}
+          {referencesQuery.isLoading ? <p className="text-secondary mb-0">Carregando URLs...</p> : null}
+          {referencesQuery.isError ? <p className="text-danger mb-0">Não foi possível carregar URLs coletadas.</p> : null}
+          {references.length === 0 && !referencesQuery.isLoading && !referencesQuery.isError && latestJobId ? (
+            <p className="text-secondary mb-0">Nenhuma URL encontrada para os filtros atuais.</p>
+          ) : null}
+
+          {references.length > 0 ? (
+            <div className="table-responsive">
+              <table className="table table-sm align-middle">
+                <thead>
+                  <tr>
+                    <th>Título</th>
+                    <th>Fonte</th>
+                    <th>URL do produto</th>
+                    <th>Score</th>
+                    <th>Confiança</th>
+                    <th>Coletado em</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {references.map((item) => (
+                    <tr key={item.referenceId}>
+                      <td>{item.title}</td>
+                      <td>{item.source}</td>
+                      <td>
+                        <a href={item.url} target="_blank" rel="noreferrer" className="small text-break d-inline-block">
+                          {item.url}
+                        </a>
+                      </td>
+                      <td>{item.successScore}</td>
+                      <td>{item.confidenceLevel}</td>
+                      <td>{formatDate(item.collectedAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/frontend/src/pages/mois/MoisWorkspacePage.tsx
+++ b/frontend/src/pages/mois/MoisWorkspacePage.tsx
@@ -62,6 +62,9 @@ export default function MoisWorkspacePage() {
           <Link className="btn btn-outline-secondary btn-sm" to="/mois/auto-collection">
             Coleta automática
           </Link>
+          <Link className="btn btn-outline-secondary btn-sm" to="/mois/automatic-collections">
+            Histórico automático
+          </Link>
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Provide a UI to inspect automatic MOIS collection jobs and the URLs collected by the latest automatic job.  
- Expose an API hook to fetch collection jobs so the new page can list jobs and drive the references view.

### Description
- Add `MoisAutomaticCollectionsPage` which lists automatic collection jobs and the collected URLs with filters for source, confidence and minimum success score.  
- Add `useMoisCollectionJobs` hook to `useMoisCollection.ts` and introduce `MoisCollectionJobListResponse` in `api/mois/types.ts` to support fetching job lists.  
- Register the new page route (`/mois/automatic-collections`) in `App.tsx` and add a link to the new page from `MoisWorkspacePage.tsx`.  
- Minor imports and wiring updates to surface the new page in the application navigation.

### Testing
- Ran a TypeScript frontend build (`yarn build`) to validate types and the new API types; the build completed successfully.  
- Executed the existing frontend unit test suite (`yarn test`); tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3874addd88321a9fc6f17dfe3c13c)