### PR TITLE
Reforça framework DOR→RESULTADO no prompt de planejamento de imagem

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md
@@ -37,6 +37,11 @@ Regras fixas da etapa:
     - não altere cobertura/ownership estrutural;
     - entregue o prompt final com instruções claras de execução visual.
 21. Se houver conflito entre criatividade e contrato estrutural, prevalece o contrato recebido do wireframe.
+22. Enfatize o framework de hipótese **DOR → RESULTADO** como eixo principal de cada imagem: a cena deve materializar a dor real atual e o estado transformado desejado.
+23. Toda imagem deve conectar pessoas reais ao contexto da dor e do resultado com sinais visuais concretos (expressão, ambiente, ação, consequência), evitando abstrações genéricas.
+24. O `imagePrompt` deve criar identificação imediata e inconsciente: quem vê precisa reconhecer “isso é sobre mim agora” (dor) e “é assim que quero ficar” (resultado).
+25. Evite metáforas vagas e símbolos desconectados; priorize situações humanas específicas, plausíveis e emocionalmente reconhecíveis no nicho/contexto recebido.
+26. Garanta contraste visual entre “antes/dor” e “depois/resultado” de forma ética e sem promessas irreais, mantendo continuidade com copy e oferta aprovadas.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}


### PR DESCRIPTION
### Motivation
- Fortalecer o briefing de imagem para que cada geração visual materialize a DOR e o RESULTADO de forma direta, aumentando identificação do público e coerência com a copy/oferta.

### Description
- Adicionadas regras (linhas 22–26) ao template `ai-worker/src/main/resources/prompts/experiment/landing-image-planning.md` exigindo que o `imagePrompt` use o framework DOR→RESULTADO, conecte pessoas reais ao contexto (expressão, ambiente, ação, consequência), promova identificação imediata, evite metáforas vagas e mantenha contraste ético entre antes/depois.

### Testing
- Executei `mvn test -q` em `ai-worker`, que foi disparado porém falhou por resolução de dependência privada `com.marketinghub:ads-service` com status 401 no repositório GitHub Packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3929d9ab48321a185dc22a56b12f2)