### PR TITLE
Add market niche select to NewProductPage and submit numeric marketNicheId

### DIFF
--- a/frontend/src/pages/product/NewProductPage.tsx
+++ b/frontend/src/pages/product/NewProductPage.tsx
@@ -2,13 +2,17 @@ import { useState } from "react";
 import PageTitle from "../../components/PageTitle";
 import { useCreateProduct } from "../../api/product/useCreateProduct";
 import { useInstagramAccounts } from "../../api/useInstagramAccounts";
+import { useNiches } from "../../api/niche/useNiches";
 
 export default function NewProductPage() {
   const create = useCreateProduct();
   const { data: accountsData } = useInstagramAccounts();
+  const { data: nichesData } = useNiches();
   const accounts = Array.isArray(accountsData) ? accountsData : [];
+  const niches = Array.isArray(nichesData) ? nichesData : [];
   const [form, setForm] = useState({
     niche: "",
+    marketNicheId: "",
     avatar: "",
     instagramAccountId: "",
     explicitPain: "",
@@ -27,6 +31,7 @@ export default function NewProductPage() {
   const submit = () => {
     create.mutate({
       ...form,
+      marketNicheId: Number(form.marketNicheId) || undefined,
       instagramAccountId: Number(form.instagramAccountId) || undefined,
       aiCost: Number(form.aiCost),
     });
@@ -35,12 +40,26 @@ export default function NewProductPage() {
   return (
     <div>
       <PageTitle>Novo Produto</PageTitle>
-      <input
-        className="form-control mb-2"
-        placeholder="Nicho"
-        value={form.niche}
-        onChange={(e) => setForm({ ...form, niche: e.target.value })}
-      />
+      <label className="form-label mb-1">Nicho *</label>
+      <select
+        className="form-select mb-2"
+        value={form.marketNicheId}
+        onChange={(e) =>
+          setForm({
+            ...form,
+            marketNicheId: e.target.value,
+            niche:
+              niches.find((niche) => String(niche.id) === e.target.value)?.name ?? "",
+          })
+        }
+      >
+        <option value="">Selecione o Nicho</option>
+        {niches.map((niche) => (
+          <option key={niche.id} value={niche.id}>
+            {niche.name}
+          </option>
+        ))}
+      </select>
       <input
         className="form-control mb-2"
         placeholder="Avatar"


### PR DESCRIPTION
### Motivation

- Replace the free-text niche field with a controlled selection from existing market niches so products can be linked to a canonical niche.

### Description

- Import and use `useNiches` and expose `niches` to the component for rendering the select options.
- Add `marketNicheId` to the form state and replace the previous niche text input with a labeled `<select>` populated from `niches`.
- When a niche is selected, store the selected `marketNicheId` and also set the human-readable `niche` name in the form.
- Convert `marketNicheId` to a numeric value (or `undefined`) on submit and preserve existing behavior for `instagramAccountId` and `aiCost` conversions.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f391187dbc8321bd06aa1217ce13a0)