### PR TITLE
fix(frontend): add marketNicheId to CreateProduct and disable save button while submitting

### DIFF
--- a/frontend/src/api/product/useCreateProduct.ts
+++ b/frontend/src/api/product/useCreateProduct.ts
@@ -4,6 +4,7 @@ import { Product } from "./useProducts";
 
 export interface CreateProduct {
   niche: string;
+  marketNicheId?: number;
   avatar: string;
   instagramAccountId?: number;
   explicitPain: string;

--- a/frontend/src/pages/product/NewProductPage.tsx
+++ b/frontend/src/pages/product/NewProductPage.tsx
@@ -148,8 +148,15 @@ export default function NewProductPage() {
         value={form.aiCost}
         onChange={(e) => setForm({ ...form, aiCost: e.target.value })}
       />
-      <button className="btn btn-primary" onClick={submit}>
-        Salvar
+      <button className="btn btn-primary" onClick={submit} disabled={create.isPending}>
+        {create.isPending ? (
+          <>
+            <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
+            Salvando...
+          </>
+        ) : (
+          "Salvar"
+        )}
       </button>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript error where `NewProductPage` submitted `marketNicheId` but the `CreateProduct` type did not include that property (TS2353). 
- Apply frontend guideline to disable buttons and show a loading indicator during async operations.

### Description
- Added `marketNicheId?: number` to the `CreateProduct` interface in `frontend/src/api/product/useCreateProduct.ts` so the page can send the selected niche id without type errors. 
- Updated `frontend/src/pages/product/NewProductPage.tsx` to disable the Save button while the create mutation is pending and display a spinner with the text `Salvando...` during submission. 
- Kept existing payload conversions (`Number(form.marketNicheId) || undefined`, `Number(form.instagramAccountId) || undefined`, `Number(form.aiCost)`) to preserve runtime behavior.

### Testing
- Ran `cd frontend && npm run typecheck`, which confirmed the original `marketNicheId` property error is resolved. 
- `tsc` still fails in this environment due to missing global type definition packages (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`), which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3953f078483219052731216056da1)