### PR TITLE
Use MoisCollectionPersistenceService to list collection jobs and update tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
@@ -5,6 +5,7 @@ import com.marketinghub.mois.dto.MoisDiscoveryDtos;
 import com.marketinghub.mois.dto.MoisInsightDtos;
 import com.marketinghub.mois.dto.MoisOfferDtos;
 import com.marketinghub.mois.dto.MoisWorkspaceDtos;
+import com.marketinghub.mois.service.MoisCollectionPersistenceService;
 import com.marketinghub.mois.service.MoisModuleGateway;
 import jakarta.validation.Valid;
 import java.util.Map;
@@ -26,6 +27,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class MoisController {
 
     private final MoisModuleGateway gateway;
+    private final MoisCollectionPersistenceService collectionPersistenceService;
 
     @PostMapping("/discovery-requests")
     @ResponseStatus(HttpStatus.ACCEPTED)
@@ -130,7 +132,12 @@ public class MoisController {
             @RequestParam(required = false) String workspaceId,
             @RequestParam(required = false) String status
     ) {
-        return gateway.listCollectionJobs(workspaceId, status);
+        return new MoisWorkspaceDtos.CollectionJobListResponse(collectionPersistenceService
+                .listJobStates(workspaceId, status)
+                .items()
+                .stream()
+                .map(com.marketinghub.mois.dto.MoisCollectionPersistenceDtos.CollectionJobStateResponse::job)
+                .toList());
     }
 
     @GetMapping("/collection-jobs/{jobId}/references")

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
@@ -4,6 +4,8 @@ import com.marketinghub.mois.dto.MoisDiscoveryDtos;
 import com.marketinghub.mois.dto.MoisInsightDtos;
 import com.marketinghub.mois.dto.MoisOfferDtos;
 import com.marketinghub.mois.dto.MoisWorkspaceDtos;
+import com.marketinghub.mois.dto.MoisCollectionPersistenceDtos;
+import com.marketinghub.mois.service.MoisCollectionPersistenceService;
 import com.marketinghub.mois.service.MoisModuleGateway;
 import java.time.Instant;
 import java.util.List;
@@ -36,6 +38,9 @@ class MoisControllerContractTest {
 
     @MockBean
     private MoisModuleGateway gateway;
+
+    @MockBean
+    private MoisCollectionPersistenceService collectionPersistenceService;
 
     @Test
     void shouldAcceptDiscoveryRequest() throws Exception {
@@ -434,19 +439,25 @@ class MoisControllerContractTest {
 
     @Test
     void shouldListCollectionJobsContract() throws Exception {
-        when(gateway.listCollectionJobs(eq("workspace-001"), eq("QUEUED")))
-                .thenReturn(new MoisWorkspaceDtos.CollectionJobListResponse(List.of(
-                        new MoisWorkspaceDtos.CollectionJobResponse(
-                                "mois-collect-001",
-                                "workspace-001",
-                                "nutricao",
-                                "perda de gordura",
-                                "QUEUED",
-                                "LAST_7_DAYS",
-                                50,
-                                60,
-                                List.of("META_AD_LIBRARY"),
-                                Instant.parse("2026-04-25T12:00:00Z")
+        when(collectionPersistenceService.listJobStates(eq("workspace-001"), eq("QUEUED")))
+                .thenReturn(new MoisCollectionPersistenceDtos.CollectionJobStateListResponse(List.of(
+                        new MoisCollectionPersistenceDtos.CollectionJobStateResponse(
+                                new MoisWorkspaceDtos.CollectionJobResponse(
+                                        "mois-collect-001",
+                                        "workspace-001",
+                                        "nutricao",
+                                        "perda de gordura",
+                                        "QUEUED",
+                                        "LAST_7_DAYS",
+                                        50,
+                                        60,
+                                        List.of("META_AD_LIBRARY"),
+                                        Instant.parse("2026-04-25T12:00:00Z")
+                                ),
+                                List.of(),
+                                java.util.Map.of(),
+                                null,
+                                List.of()
                         )
                 )));
 


### PR DESCRIPTION
### Motivation
- Replace direct gateway listing with persistence-backed job state listing to surface collection job states from the persistence service. 

### Description
- Inject `MoisCollectionPersistenceService` into `MoisController` and use `listJobStates(workspaceId, status)` to implement `GET /collection-jobs`. 
- Map `MoisCollectionPersistenceDtos.CollectionJobStateResponse::job` to build a `MoisWorkspaceDtos.CollectionJobListResponse` returned by the controller. 
- Add imports and a new `private final MoisCollectionPersistenceService collectionPersistenceService` field to the controller. 
- Update `MoisControllerContractTest` to mock `MoisCollectionPersistenceService`, return a `CollectionJobStateListResponse`, and assert the same contract fields as before. 

### Testing
- Ran `MoisControllerContractTest` (Web MVC slice) which exercises `createDiscoveryRequest`, `createCollectionJob`, `listCollectionJobs`, and related controller endpoints; the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3aa766b4c8321808b5eb4771f9fe9)