### PR TITLE
fix: reinforce slotId as technical in landing-page-copy prompt and register INC-0017

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1084,6 +1084,8 @@ public class ExperimentPipelineGenerationService {
                 sb.append("- sectionId=").append(sectionId)
                         .append(" | copySlots=").append(String.join(", ", slots))
                         .append("\n"));
+        sb.append("Regra crítica: slotId é identificador técnico de slot (NUNCA texto de copy).\n");
+        sb.append("Checklist obrigatório antes de responder: para cada bodySections[] confirmar sectionId preenchido e slotId pertencente a copySlots da mesma seção.\n");
         sb.append("Regra: cada item de landingPageCopy.bodySections deve informar slotId e esse slotId deve existir na lista copySlots da seção correspondente.\n");
     }
 

--- a/docs/diagnosticos/erro-422-experimento-18-2026-04-30.md
+++ b/docs/diagnosticos/erro-422-experimento-18-2026-04-30.md
@@ -1,0 +1,54 @@
+# Diagnóstico 422 — Experimento 18 (Texto da Landing)
+
+Data da análise: 2026-04-30.
+
+## Evidência do erro
+
+Mensagem exibida no fluxo:
+
+- `Copy da landing inválida em bodySections: slotId 'Problema: falta um processo simples e repetível que funcione todo mês' não pertence aos copySlots da sectionId 's0-pain'`.
+
+## O que o modelo entregou (literal)
+
+No campo `bodySections[*].slotId`, o modelo enviou texto de copy (frase longa de dor):
+
+- `Problema: falta um processo simples e repetível que funcione todo mês`.
+
+Esse valor foi associado à `sectionId` `s0-pain`.
+
+## O que a especificação esperava (literal)
+
+Para cada item de `landingPageCopy.bodySections`, quando o wireframe define `copySlots`, o `slotId`:
+
+1. é obrigatório;
+2. deve ser um identificador de slot previsto no wireframe para a mesma `sectionId`.
+
+Ou seja, o valor esperado é algo como `slot-...` previamente declarado em `landingPageWireframe.sectionOrder[].copySlots`, e não um texto de copy.
+
+## Diferença entre entrega e esperado
+
+- **Entregue:** `slotId` recebeu conteúdo semântico de copy (frase de dor).
+- **Esperado:** `slotId` deve receber um ID técnico de slot pertencente aos `copySlots` da seção `s0-pain`.
+- **Resultado:** violação de contrato canônico/validação backend, gerando `422 Unprocessable Entity`.
+
+## Causa raiz
+
+Divergência entre instrução/saída do prompt de geração de `landingPageCopy` e contrato vigente do backend:
+
+- O backend valida estritamente `slotId` contra `copySlots` da seção no wireframe.
+- O payload produzido tratou `slotId` como campo textual de conteúdo, não como chave de slot.
+
+## Ação corretiva recomendada
+
+1. Ajustar prompt de `landing-copy` para reforçar regra estrutural:
+   - `slotId` é identificador técnico, nunca texto de copy.
+   - cada `bodySections[*]` deve reaproveitar exatamente um item de `copySlots` da seção correspondente.
+2. Incluir checklist final obrigatório no prompt:
+   - validar que todo `bodySections[*].slotId` existe em `wireframe.sectionOrder[sectionId].copySlots`.
+3. Opcional (hardening): adicionar validação pré-envio no worker para bloquear payload antes de chamar backend quando `slotId` não pertence aos `copySlots`.
+
+## Referências canônicas e de implementação
+
+- Fonte de verdade canônica de artefatos (`landingPageCopy` e regras de consistência entre artefatos).
+- Regra de precedência canônica (contrato canônico > implementação).
+- Regra de validação ativa no backend para `slotId` x `copySlots`.

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,52 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0017 — Ajuste de prompt da etapa `LANDING_PAGE_COPY` para bloquear uso textual de `slotId`
+
+- **Data/Hora (UTC):** 2026-04-30
+- **Responsável:** Assistente Codex
+- **Módulo:** backend (`ads-service`) + documentação operacional
+- **Ambiente:** Repositório local (`/workspace/marketing-hub`)
+- **Execução/Teste:** Ajuste solicitado após diagnóstico do experimento 18 para reforçar regra canônica de `slotId` em `bodySections`.
+
+#### 1) Erro observado
+- **Sintoma:** modelo preencheu `bodySections[].slotId` com texto semântico de copy, gerando rejeição `422` na validação de vínculo com `copySlots` do wireframe.
+- **Endpoint/rota/fila:** pipeline de geração (`LANDING_PAGE_COPY`).
+- **Status code:** 422.
+- **Mensagem de erro literal:** `Copy da landing inválida em bodySections: slotId 'Problema: falta um processo simples e repetível que funcione todo mês' não pertence aos copySlots da sectionId 's0-pain'`.
+- **Payload enviado (literal):** `bodySections[].slotId` com frase de dor em vez de ID técnico.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** já consolidados no diagnóstico anterior do incidente (experimento 18).
+- **Dados de banco consultados via MCP:** não aplicável para este ajuste incremental.
+- **Trecho canônico consultado:** `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` (contrato de `landingPageCopy` dependente de `landingPageWireframe.sectionOrder[].copySlots`).
+- **Validação/regra que rejeitou:** `slotId` deve pertencer aos `copySlots` da mesma `sectionId`.
+- **Causa raiz:** instrução de prompt precisava enfatizar explicitamente que `slotId` é chave estrutural técnica e nunca campo textual.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** `slotId` com texto de copy.
+- **O que a especificação esperava (literal):** `slotId` com identificador técnico existente em `copySlots(sectionId)`.
+- **Diferença objetiva:** uso semântico vs estrutural do mesmo campo.
+- **Ação corretiva recomendada:** reforçar prompt com regra crítica + checklist obrigatório de pertencimento de `slotId` antes da resposta.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** prompt (instrução operacional montada no backend) + registro operacional.
+- **Arquivos alterados:**
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** inclusão de instrução explícita no bloco de slots canônicos: `slotId` é identificador técnico (nunca texto de copy) e checklist obrigatório para validar `sectionId` + pertencimento de `slotId` em `copySlots` da seção antes de retornar `landingPageCopy`.
+
+#### 5) Reteste
+- **Procedimento de reteste:** execução de teste unitário direcionado do módulo `ads-service`.
+- **Resultado:** aprovado.
+- **Evidências (logs/ids/prints):** `mvn -Dtest=ExperimentPipelineGenerationServiceTest test` com `BUILD SUCCESS`.
+- **Status final:** Resolvido.
+
+#### 6) Próximo passo
+- **Ação seguinte:** reprocessar a etapa `LANDING_PAGE_COPY` do experimento 18 para confirmar ausência de novo `422` por `slotId` inválido.
+- **Dono da ação:** time backend + operação do pipeline.
+- **Prazo:** próxima execução assistida.
+
 ### INC-0016 — Realocação de ownership de imagem: wireframe (estrutura) vs image-planning (prompt)
 
 - **Data/Hora (UTC):** 2026-04-30


### PR DESCRIPTION
### Motivation
- Experimento 18 gerou `422` porque `bodySections[].slotId` recebeu texto de copy em vez de um identificador técnico previsto no `landingPageWireframe`.
- É necessário reduzir recorrência desse descompasso entre saída do modelo e a validação canônica do backend ajustando a orientação de prompt construída pelo backend e registrando a ação.

### Description
- Atualiza `appendWireframeSlotSummary(...)` em `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java` adicionando instruções explícitas: uma regra crítica (`slotId` é identificador técnico, nunca texto de copy) e um checklist obrigatório de pertencimento antes de responder.
- Adiciona o diagnóstico canônico em `docs/diagnosticos/erro-422-experimento-18-2026-04-30.md` detalhando evidência, entrega do modelo, esperado, diferença e ação corretiva.
- Registra o ajuste operacional como `INC-0017` em `docs/registro-ajustes-pipeline-experimento.md` com descrição do erro, diagnóstico, ajuste e reteste.

### Testing
- Executado `cd backend/ads-service && mvn -Dtest=ExperimentPipelineGenerationServiceTest test` e verificado `BUILD SUCCESS` com `Tests run: 42, Failures: 0, Errors: 0, Skipped: 0`.
- As alterações foram validadas pela suíte de testes unitários do serviço alterado sem regressões detectadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3abdf1ea08321a56472746b2021fc)