### PR TITLE
Add 400-error debugging guidance, adjust frontend API base handling, and add diagnostics report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ Toda decisão de arquitetura, dados, prompts, automações, integrações e arte
 
 ## 3. Orientações Práticas:
 
+- **Erro 400 (Bad Request) em APIs**: em validações de contrato/payload, o backend pode responder `400 Bad Request` sem registrar detalhes úteis no log de aplicação. Nesses casos, **não basta procurar logs**; é obrigatório inspecionar a requisição enviada (URL, método, headers, body) e comparar com DTO/contrato esperado para identificar campo, estrutura ou tipo inválido.
+
 - **Erro 422 (Procedimento Obrigatório / SOP)**: Trate toda ocorrência de `422 Unprocessable Entity` como divergência entre payload gerado pelo modelo e contrato/validação do backend até prova em contrário.
   - **Fluxo obrigatório (sempre nesta ordem):**
     1. Acessar logs do backend via MCP Server (`https://mcpserverdigi.shop/mcp`, JSON-RPC).

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,4 +1,5 @@
-const defaultApiBaseUrl = `${window.location.protocol}//${window.location.hostname}:8000`;
-const envApiUrl = import.meta.env.VITE_API_URL;
+const envApiUrl = import.meta.env.VITE_API_URL?.trim();
 
-export const apiBaseUrl = envApiUrl && envApiUrl.length > 0 ? envApiUrl : defaultApiBaseUrl;
+// Default to same-origin so browser requests go through the current host
+// (and reverse proxy), avoiding CORS issues when frontend runs on :5173.
+export const apiBaseUrl = envApiUrl && envApiUrl.length > 0 ? envApiUrl : "";

--- a/reports/diagnostico-sales-video-erro-400-2026-04-30.md
+++ b/reports/diagnostico-sales-video-erro-400-2026-04-30.md
@@ -1,0 +1,36 @@
+# Diagnóstico — Erro ao criar novo vídeo (HTTP 400)
+
+Data/hora da análise: 2026-04-30 19:25 UTC.
+
+## Evidências coletadas
+
+- MCP `initialize` respondeu OK em `https://mcpserverdigi.shop/mcp`.
+- MCP `tools/list` mostrou a ferramenta `java_module_logs` disponível.
+- Consulta `java_module_logs` para o módulo `backend` com 400 e 500 linhas retornou dados com sucesso.
+- A origem configurada para logs do módulo `backend` retornada pelo MCP foi:
+  - `http://191.252.120.96:4567/worker-observability/logfile`
+
+## Resultado da verificação
+
+Nas últimas 500 linhas do log retornado para `backend`, não foram encontrados registros contendo:
+
+- rota `/api/products/1/sales-videos/profiles`
+- rota `/api/sales-videos/profiles`
+- erros `400 Bad Request` associados à criação de perfil de vídeo
+- stacktrace de validação (`MethodArgumentNotValidException`, `HttpMessageNotReadableException`) no recorte consultado
+
+## Observações
+
+- O print do navegador mostra falha **400** na chamada:
+  - `POST http://191.252.181.168:8000/api/products/1/sales-videos/profiles`
+- Porém, esse erro não apareceu no recorte recente de logs retornado pela fonte atual do MCP.
+- Isso indica uma das possibilidades:
+  1. O erro ocorreu fora da janela das últimas 500 linhas.
+  2. A rota foi rejeitada antes do ponto onde o app grava log de exceção (ex.: camada de proxy/filtro).
+  3. A fonte de log associada ao módulo `backend` no MCP não está apontando para o stream esperado do serviço que atende `:8000`.
+
+## Próximo passo recomendado
+
+1. Repetir o teste e informar o horário exato (UTC) da tentativa.
+2. Consultar novamente logs imediatamente após a tentativa.
+3. Se possível, capturar e comparar o payload enviado no POST para validar campos obrigatórios do endpoint de criação de profile.


### PR DESCRIPTION
### Motivation

- Clarify the troubleshooting process for `400 Bad Request` API failures so engineers inspect the actual HTTP request (URL, method, headers, body) rather than only logs. 
- Prevent accidental whitespace and CORS surprises from `VITE_API_URL` by normalizing the env variable and preferring same-origin requests through the reverse proxy. 
- Preserve the findings from a recent incident investigation by adding a formal diagnostics report for the sales-video `400` failure. 

### Description

- Update `AGENTS.md` to add an explicit rule for `400 (Bad Request)` investigations that requires inspecting the sent request (`URL`, `method`, `headers`, `body`).
- Change `frontend/src/config/api.ts` to trim `VITE_API_URL` and default `apiBaseUrl` to `""` with a comment to prefer same-origin/reverse-proxy behavior to avoid CORS when the frontend runs on `:5173`.
- Add `reports/diagnostico-sales-video-erro-400-2026-04-30.md` containing evidence collected from MCP logs, analysis of why the backend `400` did not appear in recent log slices, and recommended next steps. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ab4302ac8321bed3a7b78aea76f0)