### PR TITLE
Fix frontend blank screen when Facebook configuration API returns partial payload

### DIFF
--- a/frontend/src/api/useFacebookConfigurationStatus.ts
+++ b/frontend/src/api/useFacebookConfigurationStatus.ts
@@ -33,14 +33,34 @@ export interface FacebookConfigurationStatus {
   tokenRenewal: TokenRenewalDiagnostics;
 }
 
+function normalizeFacebookConfigurationStatus(
+  payload: Partial<FacebookConfigurationStatus> | undefined,
+): FacebookConfigurationStatus {
+  return {
+    hasConfiguredPages: payload?.hasConfiguredPages ?? false,
+    worker: {
+      hasAccount: payload?.worker?.hasAccount ?? false,
+      ready: payload?.worker?.ready ?? false,
+      accountId: payload?.worker?.accountId ?? null,
+      accountName: payload?.worker?.accountName ?? null,
+      messages: payload?.worker?.messages ?? [],
+    },
+    tokenRenewal: {
+      enabledAccounts: payload?.tokenRenewal?.enabledAccounts ?? 0,
+      eligibleAccounts: payload?.tokenRenewal?.eligibleAccounts ?? 0,
+      accounts: payload?.tokenRenewal?.accounts ?? [],
+    },
+  };
+}
+
 export function useFacebookConfigurationStatus() {
   return useQuery({
     queryKey: ["facebook-configuration-status"],
     queryFn: async () => {
-      const { data } = await axios.get<FacebookConfigurationStatus>(
+      const { data } = await axios.get<Partial<FacebookConfigurationStatus>>(
         "/api/facebook/configuration-status",
       );
-      return data;
+      return normalizeFacebookConfigurationStatus(data);
     },
     staleTime: 1000 * 30,
   });


### PR DESCRIPTION
### Motivation

- Prevent the frontend from crashing with `TypeError` when `/api/facebook/configuration-status` returns a partial or missing nested payload (e.g. missing `worker` or `tokenRenewal`).

### Description

- Added `normalizeFacebookConfigurationStatus(payload)` to `frontend/src/api/useFacebookConfigurationStatus.ts` to provide safe defaults and a complete `FacebookConfigurationStatus` shape.
- Adjusted the `queryFn` to fetch `Partial<FacebookConfigurationStatus>` and return the normalized object to callers.
- This change prevents components like `GlobalAutomationAlerts` from reading properties (e.g. `ready`) on `undefined` and restores UI stability when backend responses are incomplete.

### Testing

- Ran `npm install` in `frontend/` successfully.
- Executed `npm run build` in `frontend/` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ba1a82a08321a164e19ba7e1d85c)