### PR TITLE
fix(frontend): restore default backend base URL fallback

### DIFF
--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,5 +1,4 @@
+const defaultApiBaseUrl = `${window.location.protocol}//${window.location.hostname}:8000`;
 const envApiUrl = import.meta.env.VITE_API_URL?.trim();
 
-// Default to same-origin so browser requests go through the current host
-// (and reverse proxy), avoiding CORS issues when frontend runs on :5173.
-export const apiBaseUrl = envApiUrl && envApiUrl.length > 0 ? envApiUrl : "";
+export const apiBaseUrl = envApiUrl && envApiUrl.length > 0 ? envApiUrl : defaultApiBaseUrl;


### PR DESCRIPTION
### Motivation
- Fix blank frontend screens by restoring a safe default API base URL when `VITE_API_URL` is not set so runtime URL construction doesn't produce invalid/empty bases.

### Description
- Reintroduced a `defaultApiBaseUrl` computed as ```${window.location.protocol}//${window.location.hostname}:8000``` and used it as the fallback in `frontend/src/config/api.ts` instead of an empty string.

### Testing
- Ran `cd frontend && npm run build` to validate the change but the build could not run in this environment due to `vite` not being available (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c25c74f88321962dc9d61ccaecad)