### PR TITLE
Allow OPTIONS preflight to bypass TenantContextFilter and add unit tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/salesvideo/tenant/TenantContextFilter.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/salesvideo/tenant/TenantContextFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
@@ -32,6 +33,9 @@ public class TenantContextFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            return true;
+        }
         String path = request.getRequestURI();
         if (path == null) {
             return true;

--- a/backend/ads-service/src/test/java/com/marketinghub/salesvideo/tenant/TenantContextFilterTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/salesvideo/tenant/TenantContextFilterTest.java
@@ -1,0 +1,47 @@
+package com.marketinghub.salesvideo.tenant;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TenantContextFilterTest {
+
+    private TenantContextFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new TenantContextFilter();
+    }
+
+    @Test
+    void shouldSkipTenantValidationForOptionsPreflightRequests() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("OPTIONS", "/api/products/1/sales-videos/profiles");
+        request.addHeader("Origin", "http://191.252.181.168:5173");
+        request.addHeader("Access-Control-Request-Method", "GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        Mockito.verify(chain).doFilter(Mockito.any(), Mockito.any());
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldRejectTenantProtectedEndpointsWhenHeaderIsMissing() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/products/1/sales-videos/profiles");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        Mockito.verify(chain, Mockito.never()).doFilter(Mockito.any(), Mockito.any());
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getContentAsString()).contains("TENANT_HEADER_REQUIRED");
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure CORS preflight `OPTIONS` requests are not blocked by tenant validation so browsers can complete preflight checks.

### Description

- Added an `HttpMethod.OPTIONS` check in `shouldNotFilter` of `TenantContextFilter` to skip tenant validation for preflight requests.  
- Imported `HttpMethod` and kept existing logic to enforce tenant headers for protected endpoints and internal system context handling.  
- Added `TenantContextFilterTest` with a test for skipping `OPTIONS` preflight and a test for rejecting tenant-protected endpoints when the `X-Tenant-ID` header is missing.

### Testing

- Ran the new unit tests in `TenantContextFilterTest` (two tests) as part of the project's test suite.  
- Both tests passed: the preflight test verifies `chain.doFilter` is invoked and the missing-tenant test verifies a `400` response containing `TENANT_HEADER_REQUIRED`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c5bd67548321b1e0705d1cfe20e5)