### PR TITLE
feat(frontend): MOIS job details page with formatted JSON

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -124,6 +124,7 @@ import MoisOfferBuilderPage from "./pages/mois/MoisOfferBuilderPage";
 import MoisResearchSourcesPage from "./pages/mois/MoisResearchSourcesPage";
 import MoisAutoCollectionPage from "./pages/mois/MoisAutoCollectionPage";
 import MoisAutomaticCollectionsPage from "./pages/mois/MoisAutomaticCollectionsPage";
+import MoisCollectionJobDetailPage from "./pages/mois/MoisCollectionJobDetailPage";
 import MdsWorkspacePage from "./pages/mds/MdsWorkspacePage";
 import MdsRequestDetailPage from "./pages/mds/MdsRequestDetailPage";
 import MdsArtifactsPage from "./pages/mds/MdsArtifactsPage";
@@ -278,6 +279,7 @@ export default function App() {
               <Route path="/mois/research-sources" element={<MoisResearchSourcesPage />} />
               <Route path="/mois/auto-collection" element={<MoisAutoCollectionPage />} />
               <Route path="/mois/automatic-collections" element={<MoisAutomaticCollectionsPage />} />
+              <Route path="/mois/automatic-collections/:jobId" element={<MoisCollectionJobDetailPage />} />
               <Route path="/mois/extraction" element={<MoisExtractionPage />} />
               <Route path="/mois/library" element={<MoisLibraryPage />} />
               <Route path="/mois/comparison" element={<MoisComparisonPage />} />

--- a/frontend/src/pages/mois/MoisAutomaticCollectionsPage.tsx
+++ b/frontend/src/pages/mois/MoisAutomaticCollectionsPage.tsx
@@ -74,7 +74,11 @@ export default function MoisAutomaticCollectionsPage() {
                 <tbody>
                   {jobs.map((job) => (
                     <tr key={job.jobId}>
-                      <td>{job.jobId}</td>
+                      <td>
+                        <Link to={`/mois/automatic-collections/${job.jobId}`} className="fw-semibold text-decoration-none">
+                          {job.jobId}
+                        </Link>
+                      </td>
                       <td>
                         <span className="badge text-bg-light">{job.status}</span>
                       </td>

--- a/frontend/src/pages/mois/MoisCollectionJobDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisCollectionJobDetailPage.tsx
@@ -1,0 +1,46 @@
+import { Link, useParams } from "react-router-dom";
+import { useMoisCollectedReferences, useMoisCollectionJobs } from "../../api/mois/useMoisCollection";
+
+const WORKSPACE_ID = "workspace-001";
+
+export default function MoisCollectionJobDetailPage() {
+  const { jobId = "" } = useParams();
+  const jobsQuery = useMoisCollectionJobs(WORKSPACE_ID);
+  const job = (jobsQuery.data ?? []).find((item) => item.jobId === jobId);
+  const referencesQuery = useMoisCollectedReferences(jobId, {});
+
+  const detailPayload = {
+    job,
+    references: referencesQuery.data ?? [],
+  };
+
+  return (
+    <section className="d-flex flex-column gap-4">
+      <header className="d-flex justify-content-between align-items-center">
+        <div>
+          <h1 className="h3 mb-1">MOIS · Detalhes do job</h1>
+          <p className="text-secondary mb-0">Visualize os dados completos do job em JSON formatado.</p>
+        </div>
+        <Link className="btn btn-outline-secondary" to="/mois/automatic-collections">
+          Voltar para jobs
+        </Link>
+      </header>
+
+      <article className="card shadow-sm">
+        <div className="card-body">
+          {jobsQuery.isLoading ? <p className="text-secondary mb-0">Carregando detalhes do job...</p> : null}
+          {jobsQuery.isError ? <p className="text-danger mb-0">Não foi possível carregar os detalhes do job.</p> : null}
+          {!jobsQuery.isLoading && !jobsQuery.isError && !job ? (
+            <p className="text-secondary mb-0">Job não encontrado para o identificador informado.</p>
+          ) : null}
+
+          {job ? (
+            <pre className="bg-light border rounded p-3 mb-0" style={{ maxHeight: "70vh", overflow: "auto" }}>
+              <code>{JSON.stringify(detailPayload, null, 2)}</code>
+            </pre>
+          ) : null}
+        </div>
+      </article>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Permitir que o usuário clique em um job na lista de coletas automáticas e veja os dados completos do job de forma legível com JSON formatado.
- Reutilizar as queries e endpoints já existentes do módulo MOIS sem necessidade de alterações no backend.

### Description
- Adicionada a nova página de detalhe `frontend/src/pages/mois/MoisCollectionJobDetailPage.tsx` que busca `job` e `references` e exibe o payload em JSON formatado dentro de um `<pre><code>`.
- Tornei o `jobId` clicável em `frontend/src/pages/mois/MoisAutomaticCollectionsPage.tsx` para navegar para a nova rota de detalhe via `Link`.
- Registrada a rota `'/mois/automatic-collections/:jobId'` e importada `MoisCollectionJobDetailPage` em `frontend/src/App.tsx` para habilitar navegação direta por URL.
- A página reutiliza `useMoisCollectionJobs` e `useMoisCollectedReferences` para obter dados e não exige novo contrato backend.

### Testing
- Executei `npm install` no diretório `frontend` e a instalação das dependências foi concluída com sucesso.
- Executei `npm run build` no `frontend` e o `vite build` finalizou com sucesso (build gerado com warning de chunk grande, sem falha).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c529326083218e4f2705adda69eb)