### PR TITLE
Sprint 2: endurece slotDefs no wireframe e LHM prioriza slotDefs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -657,7 +657,21 @@ public class LandingHtmlModule {
 
     @SuppressWarnings("unchecked")
     private List<String> extractCopySlots(Map<String, Object> section) {
-        if (section == null || !(section.get("copySlots") instanceof List<?> rawSlots)) {
+        if (section == null) {
+            return List.of();
+        }
+        if (section.get("slotDefs") instanceof List<?> rawSlotDefs) {
+            List<String> slotKeys = rawSlotDefs.stream()
+                    .filter(Map.class::isInstance)
+                    .map(Map.class::cast)
+                    .map(item -> asTrimmedString(((Map<String, Object>) item).get("slotKey")))
+                    .filter(StringUtils::hasText)
+                    .toList();
+            if (!slotKeys.isEmpty()) {
+                return slotKeys;
+            }
+        }
+        if (!(section.get("copySlots") instanceof List<?> rawSlots)) {
             return List.of();
         }
         return rawSlots.stream()

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -1437,6 +1437,7 @@ public class ExperimentPipelineGenerationService {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                         "Wireframe da landing inválido: sectionId duplicado em sectionOrder (" + sectionId + ")");
             }
+            validateSprint2SlotDefs(sectionId, section);
             String dropOffRisk = asTrimmedString(section.get("dropOffRisk"));
             Integer mobilePriorityScore = asInteger(section.get("mobilePriorityScore"));
             if ("alto".equalsIgnoreCase(dropOffRisk) && (mobilePriorityScore == null || mobilePriorityScore < 8)) {
@@ -1548,6 +1549,32 @@ public class ExperimentPipelineGenerationService {
         if (formFieldMinHeightPx == null || formFieldMinHeightPx < 44) {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
                     "Wireframe inválido: accessibilitySpec.formFieldMinHeightPx deve ser >= 44");
+        }
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private void validateSprint2SlotDefs(String sectionId, Map<String, Object> section) {
+        if (!(section.get("slotDefs") instanceof List<?> rawSlotDefs) || rawSlotDefs.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Wireframe inválido: sectionId '" + sectionId + "' sem slotDefs estruturado");
+        }
+        Set<String> slotKeys = new LinkedHashSet<>();
+        for (Object rawSlotDef : rawSlotDefs) {
+            if (!(rawSlotDef instanceof Map<?, ?> rawSlotDefMap)) {
+                continue;
+            }
+            Map<String, Object> slotDef = (Map<String, Object>) rawSlotDefMap;
+            String slotKey = asTrimmedString(slotDef.get("slotKey"));
+            String componentKey = asTrimmedString(slotDef.get("componentKey"));
+            if (!StringUtils.hasText(slotKey) || !StringUtils.hasText(componentKey)) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Wireframe inválido: slotDefs da sectionId '" + sectionId + "' exige slotKey e componentKey");
+            }
+            if (!slotKeys.add(normalizeLookupKey(slotKey))) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Wireframe inválido: slotKey duplicado em slotDefs da sectionId '" + sectionId + "' (" + slotKey + ")");
+            }
         }
     }
 
@@ -3251,6 +3278,20 @@ public class ExperimentPipelineGenerationService {
                         Map.entry("messageMatchDependency", stringSchema()),
                         Map.entry("sectionDependsOn", stringSchema()),
                         Map.entry("copySlots", Map.of("type", "array", "minItems", 1, "items", stringSchema())),
+                        Map.entry("slotDefs", Map.of(
+                                "type", "array",
+                                "minItems", 1,
+                                "items", Map.of(
+                                        "type", "object",
+                                        "additionalProperties", false,
+                                        "properties", Map.of(
+                                                "slotKey", stringSchema(),
+                                                "componentKey", stringSchema(),
+                                                "required", Map.of("type", "boolean")
+                                        ),
+                                        "required", List.of("slotKey", "componentKey", "required")
+                                )
+                        )),
                         Map.entry("mobilePriorityScore", integerSchema(1, 10)),
                         Map.entry("dropOffRisk", Map.of("type", "string", "enum", List.of("baixo", "medio", "alto"))),
                         Map.entry("surfaceSpec", surfaceSpecSchema),

--- a/docs/pesquisa-profunda/analise-pipeline-landing-atual-e-plano-sprints.md
+++ b/docs/pesquisa-profunda/analise-pipeline-landing-atual-e-plano-sprints.md
@@ -177,6 +177,14 @@ Adotar formalmente o fluxo:
 - Redução mensurável de incidentes 422 por divergência estrutural de landing.
 - HTML final sem inferência de blocos principais fora do contrato.
 
+
+### Registro no plano — Sprint 2 (2026-05-01)
+
+- ✅ Validação backend de `landingPageWireframe` endurecida para exigir `slotDefs` por seção com `slotKey` + `componentKey` únicos, reduzindo ambiguidade estrutural antes das próximas etapas.
+- ✅ Schema JSON da etapa `LANDING_PAGE_WIREFRAME` atualizado para exigir `slotDefs[]` tipado, alinhando solicitação de modelo com contrato canônico.
+- ✅ LHM atualizado para resolver slots priorizando `slotDefs.slotKey` (com fallback legado para `copySlots`), reforçando composição determinística por contrato explícito.
+- ✅ Plano da Sprint 2 atualizado com rastreabilidade do que foi implementado.
+
 ## Sprint 3 — Auditorias pós-render + qualidade comercial
 
 **Objetivo:** transformar qualidade visual/comercial em gate automatizado.


### PR DESCRIPTION
### Motivation
- Reduzir ambiguidade estrutural entre wireframe → copy → HTML tornando a composição por slots determinística. 
- Garantir que etapas com IA sigam um contrato JSON explícito para evitar 422s por divergência estrutural e manter o documento canônico como fonte de verdade. 

### Description
- Endurece validação de `landingPageWireframe` para exigir `slotDefs[]` por seção e validação de `slotKey` + `componentKey` com unicidade por seção, adicionando o método `validateSprint2SlotDefs` em `ExperimentPipelineGenerationService`. 
- Atualiza o schema JSON de `landingPageWireframe` para incluir `slotDefs` tipado (`slotKey`, `componentKey`, `required`) para alinhar solicitação de modelo ao contrato canônico. 
- Ajusta o LHM (`LandingHtmlModule`) para resolver slots priorizando `slotDefs.slotKey` e mantendo fallback legado para `copySlots`, reduzindo heurísticas de inferência. 
- Atualiza o documento de pesquisa `docs/pesquisa-profunda/analise-pipeline-landing-atual-e-plano-sprints.md` registrando o que foi implementado na Sprint 2. 

### Testing
- Executei os testes do backend com `cd backend/ads-service && mvn -DskipITs test` para validar compilação e suites unitárias do módulo. 
- A execução iniciou e a suíte de testes do módulo foi executada; não houve erros de compilação, porém os logs de teste mostram um erro de runtime relacionado a um scheduler/consulta em H2 (`Table

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f481b1a083219e5e54ec8b77ccbe)