### PR TITLE
fix(frontend): add `error` field to `ParsedBackendError` type

### DIFF
--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -158,6 +158,7 @@ interface SectionRequestState {
 
 interface ParsedBackendError {
   timestamp?: string;
+  error?: string;
   message?: string;
   status?: number;
   path?: string;


### PR DESCRIPTION
### Motivation
- Fix a TypeScript runtime error where the code accessed `backendError.error` but the frontend type `ParsedBackendError` did not include that property.

### Description
- Add the optional `error?: string` property to the `ParsedBackendError` interface in `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx` to align the type with the backend error payload.

### Testing
- Ran `npm run typecheck` in `frontend`; the original `TS2339` for `backendError.error` is resolved, but the overall typecheck still fails in this environment due to missing type definition packages (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f411818e948321b93f5722dd0e6ea8)