### PR TITLE
Require landingPageCopy.bodySections.slotId to match wireframe copySlots and update prompts/docs

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
@@ -33,8 +33,8 @@ Regras fixas da etapa:
 18. `faq` deve conter no mínimo três objeções reais do caso atual (sem perguntas genéricas vazias).
 19. `ctaBlocks` deve conter no mínimo duas variações posicionais de CTA (ex.: hero+final ou mid+final), mantendo coerência com `primaryCTA`.
 20. `ctaUrl` nunca pode conter placeholders (ex.: `{slug}`); sempre retornar URL resolvida para o fluxo atual.
-21. Esta etapa acontece **antes** do wireframe: a copy **não pode depender** de campos, `sectionId` ou estrutura do `landingPageWireframe`.
-22. Estruture a copy com ids e blocos semânticos canônicos próprios, para o wireframe posterior mapear layout sem alterar promessa/argumentação.
+21. Quando `CASE_DATA` incluir `landingPageWireframe` com `copySlots`, cada item de `bodySections` deve informar `sectionId` + `slotId` exatamente como definidos no wireframe (sem inventar ids e sem reutilizar slots de hero).
+22. Preserve a promessa/argumentação, mas mapeie a copy nos slots válidos do wireframe atual para manter compatibilidade de contrato com o backend.
 23. Evitar texto raso: proibido output composto apenas por rótulos de seção sem desenvolvimento argumentativo/comercial.
 24. Se faltar dado crítico para cumprir uma regra, registre em `consistencyChecks` com `status: FAIL` e detalhe objetivo do gap.
 
@@ -55,6 +55,7 @@ Diretriz obrigatória para títulos de seção:
 32. Títulos devem ser comerciais e específicos ao caso atual, porém reutilizáveis para hipóteses futuras.
 33. Não usar rótulos internos de taxonomia no output.
 34. Não fixar nomenclaturas da oferta atual como padrão universal.
+35. Para evitar reprocessamentos: se faltar `sectionId`/`copySlots` válidos no `CASE_DATA`, não invente `slotId`; registre `FAIL` em `consistencyChecks` com detalhe objetivo e mantenha os demais campos aderentes ao contrato.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -68,13 +69,14 @@ Campos obrigatórios:
 - primaryCTA
 - complianceNotes
 - hero { eyebrow, headline, subheadline, promise, supportingCopy, proofBadge, microcopy, ctaLabel, ctaUrl, ctaMatchNotes }
-- bodySections[] com sectionId, sectionType, title, summary, bullets, copy, ctaSupport, sectionDependsOn, messageMatchNotes
+- bodySections[] com sectionId, slotId, sectionType, title, summary, bullets, copy, ctaSupport, sectionDependsOn, messageMatchNotes
 - ctaBlocks[] com placement, ctaVariant, ctaLabel, ctaUrl, matchAdCta, ctaSupport, messageMatchNotes
 - faq[] com question, answer, objectionTag
 - consistencyChecks[] com check, status (PASS/FAIL/WARNING), details
 
 Critérios mínimos de aceite no próprio output:
 - `bodySections.length >= 4`
+- Se `landingPageWireframe.copySlots` existir, `bodySections[i].slotId` deve pertencer aos copySlots da `sectionId` correspondente.
 - cada `bodySections[i].bullets.length >= 3`
 - `faq.length >= 3`
 - `ctaBlocks.length >= 2`

--- a/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
+++ b/docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md
@@ -136,6 +136,7 @@ Este documento contém **apenas o esquema canônico** dos artefatos do pipeline.
   "bodySections": [
     {
       "sectionId": "string",
+      "slotId": "string",
       "sectionType": "string",
       "title": "string",
       "summary": "string",
@@ -192,6 +193,7 @@ Para considerar a copy **rica** e **compatível com as especificações**, a eta
 3. **Dependência da etapa de wireframe (ordem canônica)**
    - A geração de `landingPageCopy` acontece **depois** de `landingPageWireframe`; portanto, a copy **deve usar** os sinais estruturais definidos no wireframe (por exemplo, `sectionOrder`, `ctaSlot` e hierarquia de blocos) para manter consistência de narrativa e layout.
    - O alinhamento estrutural com layout acontece no `landingPageWireframe` e é refinado na `landingPageCopy`, preservando promessa, argumentação e clareza comercial.
+   - Quando o wireframe definir `sectionOrder[].copySlots`, cada item de `landingPageCopy.bodySections` deve usar `sectionId` + `slotId` existentes nesse wireframe (sem inventar slots e sem usar texto livre em `slotId`).
    - Toda `ctaUrl` deve ser resolvida (sem placeholders como `{slug}`).
 
 4. **Consistência de promessa e CTA**

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,53 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0018 — Alinhamento canônico de `slotId` na `landingPageCopy` para reduzir 422 sem reprocessamento
+
+- **Data/Hora (UTC):** 2026-05-01
+- **Responsável:** Assistente Codex
+- **Módulo:** ai-worker + documentação canônica
+- **Ambiente:** Repositório local (`/workspace/marketing-hub`)
+- **Execução/Teste:** Revisão pós-feedback para sincronizar prompt e schema canônico do artefato `landingPageCopy`.
+
+#### 1) Erro observado
+- **Sintoma:** geração da etapa de copy retornava `slotId` inválido para a `sectionId`, provocando `422`.
+- **Endpoint/rota/fila:** fechamento de job do pipeline `LANDING_PAGE_COPY`.
+- **Status code:** 422.
+- **Mensagem de erro literal:** `Copy da landing inválida em bodySections: slotId '<valor>' não pertence aos copySlots da sectionId '<sectionId>'`.
+- **Payload enviado (literal):** `bodySections[].slotId` fora da lista de `copySlots` da seção correspondente.
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** não executado nesta revisão local (baseado em erro já capturado no histórico da execução).
+- **Dados de banco consultados via MCP:** não aplicável nesta revisão documental/prompt.
+- **Trecho canônico consultado:** `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` (`landingPageCopy` + dependência de wireframe).
+- **Validação/regra que rejeitou:** compatibilidade de `slotId` com `copySlots(sectionId)` no backend.
+- **Causa raiz:** desalinhamento entre instruções de prompt e contrato canônico/validação para mapeamento estrutural de `bodySections`.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** `slotId` não pertencente aos `copySlots` da seção (ou textual sem vínculo estrutural).
+- **O que a especificação esperava (literal):** `slotId` técnico existente em `landingPageWireframe.sectionOrder[].copySlots` para a mesma `sectionId`.
+- **Diferença objetiva:** valor inválido/não canônico em campo estrutural.
+- **Ação corretiva recomendada:** reforçar prompt + schema canônico para exigir `slotId` e instruir fallback controlado (`consistencyChecks=FAIL`) sem inventar dados.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** prompt + schema canônico + registro operacional.
+- **Arquivos alterados:**
+  - `ai-worker/src/main/resources/prompts/experiment/landing-copy.md`
+  - `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** inclusão explícita de `slotId` no schema canônico de `landingPageCopy.bodySections`; reforço no prompt para mapear `sectionId`+`slotId` ao wireframe e orientação anti-reprocessamento para registrar `FAIL` em `consistencyChecks` quando faltar dado estrutural válido em vez de inventar slot.
+
+#### 5) Reteste
+- **Procedimento de reteste:** validação estática de consistência entre prompt e contrato canônico + revisão de diff.
+- **Resultado:** aprovado para alinhamento documental/contratual.
+- **Evidências (logs/ids/prints):** diff dos três arquivos alterados e commit no branch.
+- **Status final:** Resolvido.
+
+#### 6) Próximo passo
+- **Ação seguinte:** executar nova rodada da etapa `LANDING_PAGE_COPY` em experimento real monitorando ausência de `422` por `slotId`.
+- **Dono da ação:** operação do pipeline + ai-worker.
+- **Prazo:** próxima execução assistida.
+
 ### INC-0017 — Ajuste de prompt da etapa `LANDING_PAGE_COPY` para bloquear uso textual de `slotId`
 
 - **Data/Hora (UTC):** 2026-04-30


### PR DESCRIPTION
### Motivation
- Fix recurring 422 rejections caused by `bodySections[].slotId` values that did not belong to the `copySlots` declared in the corresponding `landingPageWireframe.sectionId`. 
- Prevent the model from inventing textual `slotId` values and reduce reprocessing by recommending a controlled fallback when structural data is missing. 
- Align the prompt, canonical schema and operational runbook so the copy generation step maps structurally to the wireframe and fails safely when data is absent.

### Description
- Added `slotId` to the canonical `landingPageCopy.bodySections` schema in `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` and updated acceptance criteria to require `slotId` membership in the wireframe `copySlots` when present. 
- Updated the `landing-copy.md` prompt to instruct the generator to map copy into `sectionId`+`slotId` from the `landingPageWireframe`, to record a `consistencyChecks` `FAIL` when valid slots are missing, and to avoid inventing slot identifiers. 
- Recorded the operational incident and applied changes in `docs/registro-ajustes-pipeline-experimento.md` with an entry (`INC-0018`) describing the diagnosis, corrective actions, and next steps to prevent future 422 errors.

### Testing
- Performed a static consistency validation between the updated prompt and the canonical schema, which passed and the change was approved. 
- Conducted a diff/review retest verifying the documentation/prompt/schema alignment, resulting in a resolved status for the applied adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f419b5334c8321a41b71e791865994)