### PR TITLE
test: alinhar expectativa de landing copy com wireframe slots

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -150,8 +150,9 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("ctaBlocks[]");
         assertThat(userPrompt).contains("consistencyChecks[]");
         assertThat(userPrompt).contains("complianceNotes");
-        assertThat(userPrompt).contains("copy **não pode depender** de campos, `sectionId` ou estrutura do `landingPageWireframe`");
-        assertThat(userPrompt).doesNotContain("compatível com os `sectionId` previstos no wireframe recebido em `CASE_DATA`");
+        assertThat(userPrompt).contains("Quando `CASE_DATA` incluir `landingPageWireframe` com `copySlots`");
+        assertThat(userPrompt).contains("cada item de `bodySections` deve informar `sectionId` + `slotId` exatamente como definidos no wireframe");
+        assertThat(userPrompt).contains("Preserve a promessa/argumentação, mas mapeie a copy nos slots válidos do wireframe atual");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- O teste `prependsLandingCopyGuidanceForLandingCopySection` estava desatualizado em relação ao prompt atual da etapa `landingPageCopy` que agora exige mapeamento para `landingPageWireframe.copySlots` via `sectionId`+`slotId` em vez de independência do wireframe.
- Atualizar a verificação do teste evita falsos positivos/negativos e mantém a validação do cliente OpenAI alinhada com o contrato canônico do artefato.

### Description
- Atualiza asserções no arquivo `ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java` para esperar as instruções atuais sobre `landingPageWireframe.copySlots` e o mapeamento `sectionId + slotId` em vez da expectativa antiga de independência do wireframe.
- Substitui as duas antigas checagens por três novas `assertThat(...).contains(...)` que validam explicitamente as frases orientadoras presentes no prompt atual.
- A mudança é restrita ao teste e não altera lógica de produção nem prompts em `src/main`.

### Testing
- Executei `mvn -Dtest=ExperimentPipelineOpenAiClientTest test` no módulo `ai-worker` para rodar apenas o teste modificado, porém a execução não pôde ser concluída devido a resolução de dependências.
- A execução falhou na fase de resolução de dependências com erro de autorização ao tentar baixar `com.marketinghub:ads-service:0.0.1-SNAPSHOT` de GitHub Packages (`401 Unauthorized`), portanto não foi possível verificar o teste em tempo de execução no ambiente atual.
- Nenhum teste automatizado adicional foi alterado ou executado com sucesso por causa da limitação de ambiente descrita acima.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41c07c2f48321a8c71cfde4156e65)