### PR TITLE
Import Collections to fix ai-worker compilation

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineBackendClient.java
@@ -2,6 +2,7 @@ package com.marketinghub.worker.experimentpipeline;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.util.UrlUtils;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;


### PR DESCRIPTION
### Motivation
- Fix `cannot find symbol: variable Collections` compilation error in `ExperimentPipelineBackendClient` caused by use of `Collections.singletonMap(...)`.

### Description
- Add `import java.util.Collections;` to `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineBackendClient.java`.

### Testing
- Ran `mvn test -DskipITs` in `ai-worker`, which compiles past the previous `Collections` symbol error but fails dependency resolution for `com.marketinghub:ads-service:0.0.1-SNAPSHOT` with `401 Unauthorized`, so full tests are blocked by external artifact access; running `mvn -pl ai-worker test -DskipITs` from the repo root also failed because the module was not found in the reactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b9abcb048321882f9886449b5eac)