### PR TITLE
Enforce canonical `slotId` usage in landing-copy prompt; update test and docs

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
@@ -35,6 +35,7 @@ Regras fixas da etapa:
 20. `ctaUrl` nunca pode conter placeholders (ex.: `{slug}`); sempre retornar URL resolvida para o fluxo atual.
 21. Quando `CASE_DATA` incluir `landingPageWireframe` com `copySlots`, cada item de `bodySections` deve informar `sectionId` + `slotId` exatamente como definidos no wireframe (sem inventar ids e sem reutilizar slots de hero).
 22. Preserve a promessa/argumentação, mas mapeie a copy nos slots válidos do wireframe atual para manter compatibilidade de contrato com o backend.
+22.1. `slotId` deve ser sempre o identificador técnico literal do `copySlots[].slotId` da mesma `sectionId`; não usar `purpose` como `slotId` (ex.: `headline`, `subheadline`, `promise`) e não usar aliases genéricos.
 23. Evitar texto raso: proibido output composto apenas por rótulos de seção sem desenvolvimento argumentativo/comercial.
 24. Se faltar dado crítico para cumprir uma regra, registre em `consistencyChecks` com `status: FAIL` e detalhe objetivo do gap.
 

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -152,6 +152,7 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("complianceNotes");
         assertThat(userPrompt).contains("Quando `CASE_DATA` incluir `landingPageWireframe` com `copySlots`");
         assertThat(userPrompt).contains("cada item de `bodySections` deve informar `sectionId` + `slotId` exatamente como definidos no wireframe");
+        assertThat(userPrompt).contains("não usar `purpose` como `slotId` (ex.: `headline`, `subheadline`, `promise`)");
         assertThat(userPrompt).contains("Preserve a promessa/argumentação, mas mapeie a copy nos slots válidos do wireframe atual");
     }
 

--- a/docs/diagnosticos/erro-422-experimento-19-2026-05-01.md
+++ b/docs/diagnosticos/erro-422-experimento-19-2026-05-01.md
@@ -1,0 +1,44 @@
+# Diagnóstico 422 — Experimento 19 (etapa texto da landing)
+
+- **Data/hora do erro:** 01/05/2026 14:06:26 (BRT)
+- **Endpoint:** `/api/internal/experiment-pipeline/jobs/f8629983-915f-42e4-88c2-37f05bde1125/complete`
+- **Status:** `422 Unprocessable Entity`
+- **Mensagem literal:** `Copy da landing inválida em bodySections: slotId 'headline' não pertence aos copySlots da sectionId 's1-hero'`
+
+## O que o modelo entregou (literal)
+No payload de `landingPageCopy.bodySections`, foi enviado um item com:
+- `sectionId: "s1-hero"`
+- `slotId: "headline"`
+
+## O que a especificação esperava (literal)
+Pelo contrato canônico, quando existe `landingPageWireframe.sectionOrder[].copySlots`, cada item de `landingPageCopy.bodySections` deve usar:
+- `sectionId` existente no wireframe;
+- `slotId` **literalmente igual** a um dos valores de `copySlots` da mesma seção.
+
+## Diferença entre entregue e esperado
+- **Entregue:** `slotId` semântico/genérico (`headline`).
+- **Esperado:** `slotId` técnico/canônico da seção `s1-hero` (valor exato declarado em `copySlots`, por exemplo `hero-headline`, `slot-hero-01`, etc., conforme wireframe real).
+
+## Validação correspondente que rejeitou
+Validação de compatibilidade estrutural `sectionId + slotId` no backend da etapa de copy: `slotId` deve pertencer à lista `copySlots` da `sectionId` correspondente.
+
+## Causa raiz
+O modelo tratou `slotId` como rótulo funcional (`headline`) em vez de identificador técnico canônico do wireframe.
+
+## Evidência confirmada em log/telemetria
+Consulta em `experiment_pipeline_generation_job` para `experiment_id=19` confirmou o erro literal salvo pelo worker/backend, sem inferência:
+
+- `created_at: 2026-05-01T17:03:18`
+- `error_message`: `Rejeitado pelo backend ao completar o job (422). Motivo: {"timestamp":"2026-05-01T14:06:26.567559167-03:00","status":422,"error":"Unprocessable Entity","message":"Copy da landing inválida em bodySections: slotId 'headline' não pertence aos copySlots da sectionId 's1-hero'","path":"/api/internal/experiment-pipeline/jobs/f8629983-915f-42e4-88c2-37f05bde1125/complete"}`
+
+Também foram encontrados erros equivalentes no mesmo experimento com variações de seção/casing:
+
+- `slotId 'Headline'` em `sectionId 's1_hero_preview'` (timestamp do backend `2026-05-01T14:04:38.548722482-03:00`)
+- `slotId 'headline'` em `sectionId 's1-hero-proof'` (timestamp do backend `2026-04-30T23:57:48.867073312-03:00`)
+
+Isso confirma que o padrão recorrente é uso de alias semântico (`headline`) no lugar do `copySlots[].slotId` canônico.
+
+## Ação corretiva recomendada
+1. Reforçar prompt da etapa `landing-copy` para proibir uso de `purpose`/alias como `slotId` (ex.: `headline`, `subheadline`, `promise`).
+2. Exigir uso literal de `copySlots[].slotId` do wireframe em `bodySections[].slotId`.
+3. Manter fallback canônico: se faltar slot válido, registrar `FAIL` em `consistencyChecks` em vez de inventar valor.

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -1069,3 +1069,40 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
   4. Prompt do ai-worker atualizado para orientar uso explícito da copy do `slotId` correspondente na composição do `imagePrompt`.
   5. Documentação canônica e matriz de responsabilidades atualizadas para refletir o novo contrato.
 - **Resultado esperado:** cada prompt de imagem nasce ancorado ao slot de copy correto, preservando coerência dor→resultado por seção e eliminando deriva entre wireframe, copy e planejamento visual.
+
+### INC-0019 — Validação confirmada em log para 422 de `slotId` na etapa LANDING_PAGE_COPY (experimento 19)
+
+- **Data/Hora (UTC):** 2026-05-01
+- **Responsável:** Assistente Codex
+- **Módulo:** ai-worker + operação de pipeline (diagnóstico)
+- **Execução/Teste:** confirmação da hipótese por evidência direta em log/telemetria via MCP
+
+#### 1) Erro observado
+- **Sintoma:** etapa de texto da landing falhando com `422` ao concluir job.
+- **Mensagem literal:** `Copy da landing inválida em bodySections: slotId 'headline' não pertence aos copySlots da sectionId 's1-hero'`.
+- **Path literal:** `/api/internal/experiment-pipeline/jobs/f8629983-915f-42e4-88c2-37f05bde1125/complete`.
+
+#### 2) Diagnóstico (MCP + logs)
+- Consulta MCP em `experiment_pipeline_generation_job` (experimento `19`, status `FAILED`) retornou `error_message` literal com o mesmo `422` acima, timestamp backend `2026-05-01T14:06:26.567559167-03:00`.
+- Foram encontradas recorrências equivalentes no mesmo experimento:
+  - `slotId 'Headline'` em `sectionId 's1_hero_preview'`;
+  - `slotId 'headline'` em `sectionId 's1-hero-proof'`.
+- Conclusão: hipótese confirmada por log; o padrão recorrente é uso de alias semântico (`headline`) em vez de `copySlots[].slotId` canônico.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** `bodySections[].slotId = "headline"` (ou `"Headline"`).
+- **O que a especificação esperava (literal):** `bodySections[].slotId` igual ao identificador técnico existente em `landingPageWireframe.sectionOrder[].copySlots` da mesma `sectionId`.
+- **Diferença objetiva:** valor semântico/alias no lugar de id técnico canônico.
+- **Ação corretiva recomendada:** instrução explícita no prompt proibindo alias de `purpose` como `slotId` e exigindo valor literal do wireframe.
+
+#### 4) Ajuste aplicado
+- Prompt de `landing-copy` reforçado com regra explícita anti-alias (`slotId` técnico literal; não usar `headline/subheadline/promise`).
+- Teste de prompt atualizado para garantir presença da regra.
+- Diagnóstico operacional formalizado em `docs/diagnosticos/erro-422-experimento-19-2026-05-01.md`.
+
+#### 5) Evidências (comandos)
+- `curl -sS https://mcpserverdigi.shop/mcp ... tools/call db_query` (consulta em `experiment_pipeline_generation_job` para `experiment_id=19`).
+- `curl -sS https://mcpserverdigi.shop/mcp ... tools/call java_module_logs` (backend/ai-worker).
+
+#### 6) Próximo passo
+- Reprocessar etapa `LANDING_PAGE_COPY` do experimento 19 e confirmar ausência de novo `422` por `slotId` fora de `copySlots`.


### PR DESCRIPTION
### Motivation
- Backend rejected landing copy with `422` because models used semantic aliases like `headline` instead of the technical `copySlots[].slotId`, breaking wireframe mapping. 
- The prompt needs to explicitly forbid using `purpose`/alias as `slotId` so generated payloads conform to the canonical contract and avoid pipeline failures. 
- Documentation and operational records must reflect the incident, root cause and the corrective guidance applied. 

### Description
- Added a new rule to the landing-copy prompt (`ai-worker/src/main/resources/prompts/experiment/landing-copy.md`) that requires `slotId` to be the literal `copySlots[].slotId` and forbids using `purpose` aliases (rule `22.1`).
- Updated the unit test `ExperimentPipelineOpenAiClientTest` to assert the presence of the new anti-alias guidance in the generated prompt. 
- Added a diagnostic file `docs/diagnosticos/erro-422-experimento-19-2026-05-01.md` documenting the `422` incident, root cause and corrective actions. 
- Recorded the change in the pipeline adjustments log `docs/registro-ajustes-pipeline-experimento.md` as `INC-0019` with the applied prompt and validation fixes. 

### Testing
- Ran the updated unit test `ExperimentPipelineOpenAiClientTest` which now checks for the new guidance text and it passed. 
- Confirmed the diagnostic doc and registry entry were added to the docs tree; no automated doc-tests were required for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4de2c6b50832197bd5f2d5585e904)