### PR TITLE
Return concatenated log text for java_module_logs tool and update tests

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/mcp")
@@ -264,13 +265,25 @@ public class McpController {
 
         try {
             Map<String, Object> result = moduleLogService.readModuleLogs(module, lines);
-            return successToolResult(id, result,
-                    "Read " + result.get("returnedLines") + " log lines from module " + result.get("module"));
+            return successToolResult(id, result, buildJavaModuleLogsText(result));
         } catch (IllegalArgumentException ex) {
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
             return error(id, -32603, "Failed to read module logs: " + ex.getMessage());
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private String buildJavaModuleLogsText(Map<String, Object> result) {
+        String header = "Read " + result.get("returnedLines") + " log lines from module " + result.get("module");
+        Object rawLines = result.get("lines");
+        if (!(rawLines instanceof List<?> lines) || lines.isEmpty()) {
+            return header;
+        }
+        String logLines = lines.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining("\n"));
+        return header + "\n" + logLines;
     }
 
     private Map<String, Object> callMetaDocsTool(Object id, Map<String, Object> arguments) {

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -168,6 +168,7 @@ class McpControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.structuredContent.module").value("backend"))
                 .andExpect(jsonPath("$.result.structuredContent.returnedLines").value(2))
+                .andExpect(jsonPath("$.result.content[0].text").value(org.hamcrest.Matchers.containsString("line-2")))
                 .andExpect(jsonPath("$.result.structuredContent.lines[0]").value("line-2"))
                 .andExpect(jsonPath("$.result.structuredContent.lines[1]").value("line-3"));
     }


### PR DESCRIPTION
### Motivation
- Improve the `java_module_logs` tool output by providing a single textual representation of the returned log lines for easier consumption by clients.
- Ensure the controller assembles a readable text block in addition to the structured `lines` array.

### Description
- Replaced the inline success message in `callJavaModuleLogsTool` with a call to a new helper `buildJavaModuleLogsText` to construct the response text. 
- Added `buildJavaModuleLogsText(Map<String,Object>)` which builds a header and concatenates `lines` into a newline-delimited string while safely handling empty or non-list values. 
- Imported `java.util.stream.Collectors` to support joining the log lines. 
- Updated `McpControllerTest` to assert that the returned `content[0].text` contains the concatenated log text for the `shouldReadJavaModuleLogs` test.

### Testing
- Ran the unit tests in `McpControllerTest`, including `shouldReadJavaModuleLogs` and related controller tests, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50cd6add083218ffa986345ff9065)