### PR TITLE
Refina prompt do design preset para acabamento premium de superfícies

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
@@ -31,13 +31,14 @@ Regras:
 15. Para páginas de venda/captação, definir obrigatoriamente `componentPresets.proof.showIdentity = true` (não omitir e não usar `false`).
 16. Incorporar no preset os padrões da seção "Padrões de CSS e componentes por elemento" de `docs/pesquisa-profunda/pesquisa-profunda-html-estilos.md`, cobrindo explicitamente: `<p>`, `<h1>`, `<h2>`, `<h3>`, `<ul>/<li>`, `<button>`/CTA, `<form>`, `<label>`, `<input>`, `<img>`.
 17. Para cada elemento listado, declarar atributos visuais trabalhados e os tokens correspondentes no preset (tipografia, espaçamento, dimensões, contraste, foco e superfície), mantendo consistência com `theme` e `componentPresets.primitives`.
-18. `lhmRuntime` é obrigatório e deve conter:
+18. Distribuir no preset (de forma natural e não mecânica) diretrizes de acabamento premium para **todas** as superfícies e variações (`.lhm-surface-band`, `.lhm-surface-solid`, `.lhm-surface-gradient-soft`, `.lhm-surface-image-tint`), combinando ao menos: borda sutil, raio coerente, sombra de profundidade, respiro interno responsivo, controle de overflow e estados visuais consistentes com os tokens de `theme.radius`, `theme.shadow`, `theme.spacing` e `theme.palette`.
+19. `lhmRuntime` é obrigatório e deve conter:
    - `baseCss`: string com o CSS base que sustenta classes/superfícies do preset.
    - `cssVersion`: string de versão da malha CSS (ex.: `lhm-css-v1`).
    - `cssNotes`: string curta explicando escopo e compatibilidade da versão.
-19. Nunca omitir `lhmRuntime` e nunca serializar esse bloco como texto/JSON escapado (deve ser objeto JSON real).
-20. Saída obrigatoriamente em JSON válido no envelope do artefato, sem markdown, sem bloco de código e sem texto adicional.
-21. A resposta deve aderir estritamente ao schema JSON canônico da etapa `landingPageDesignPreset`; não incluir campos fora do contrato.
+20. Nunca omitir `lhmRuntime` e nunca serializar esse bloco como texto/JSON escapado (deve ser objeto JSON real).
+21. Saída obrigatoriamente em JSON válido no envelope do artefato, sem markdown, sem bloco de código e sem texto adicional.
+22. A resposta deve aderir estritamente ao schema JSON canônico da etapa `landingPageDesignPreset`; não incluir campos fora do contrato.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}

--- a/backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md
+++ b/backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md
@@ -8,6 +8,7 @@ Regras mandatórias da Sprint 1:
 - Garantir legibilidade e toque mínimo de CTA/form com foco visual perceptível.
 - Incorporar no preset os padrões da seção "Padrões de CSS e componentes por elemento" de `docs/pesquisa-profunda/pesquisa-profunda-html-estilos.md`, cobrindo explicitamente os elementos: `<p>`, `<h1>`, `<h2>`, `<h3>`, `<ul>/<li>`, `<button>`/CTA, `<form>`, `<label>`, `<input>`, `<img>`.
 - Para cada elemento acima, declarar no preset os atributos visuais relevantes (tipografia, espaçamento, dimensão, contraste, foco, superfície, etc.) e os tokens correspondentes.
+- Distribuir no preset (de forma natural e não mecânica) diretrizes de acabamento premium para **todas** as superfícies e variações (`.lhm-surface-band`, `.lhm-surface-solid`, `.lhm-surface-gradient-soft`, `.lhm-surface-image-tint`), combinando ao menos: borda sutil, raio coerente, sombra de profundidade, respiro interno responsivo, controle de overflow e estados visuais consistentes com os tokens de `theme.radius`, `theme.shadow`, `theme.spacing` e `theme.palette`.
 - A etapa deve exigir resposta estritamente aderente ao schema JSON canônico de `landingPageDesignPreset`, sem campos fora do contrato.
 
 Saída:


### PR DESCRIPTION
### Motivation
- Melhorar a qualidade perceptual dos `landingPageDesignPreset` para evitar superfícies "chapadas" (ex.: `.lhm-surface-solid`) e elevar a experiência visual das landings. 
- Manter a responsabilidade da decisão visual no modelo/prompt, evitando hardcode de estilos no backend Java conforme contrato do pipeline. 
- Garantir consistência entre o prompt canônico do AI Worker e sua versão espelhada no backend para reduzir divergências de geração. 

### Description
- Adiciona em `ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md` uma diretriz diluída exigindo acabamento premium para todas as superfícies (`.lhm-surface-band`, `.lhm-surface-solid`, `.lhm-surface-gradient-soft`, `.lhm-surface-image-tint`) com borda sutil, raio coerente, sombra, respiro interno responsivo, controle de overflow e alinhamento com tokens `theme.radius`, `theme.shadow`, `theme.spacing` e `theme.palette`.
- Espelha a mesma orientação no prompt do backend em `backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md` para manter paridade entre pontos de geração.
- Renumera levemente as regras subsequentes sem alterar o contrato JSON de saída (`landingPageDesignPreset`) e sem modificar código de execução ou schemas. 

### Testing
- Verificações de presença e contexto do trecho foram realizadas com buscas (`rg`) e inspeção de arquivo (`nl -ba` / `sed`) para confirmar a inclusão; todas as verificações retornaram o conteúdo esperado. 
- A alteração foi aplicada por script (`python` snippet) que atualizou os dois prompts e o diff foi validado com `git diff` mostrando as inserções esperadas. 
- O change set foi commitado (`git commit`) com mensagem descritiva e o commit resultante confirmou 2 arquivos alterados; operação bem-sucedida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f529095b908321a844e045e1b9d042)