### PR TITLE
Reforça instruções de ordem de camadas CSS no preset de landing

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
@@ -32,13 +32,14 @@ Regras:
 16. Incorporar no preset os padrões da seção "Padrões de CSS e componentes por elemento" de `docs/pesquisa-profunda/pesquisa-profunda-html-estilos.md`, cobrindo explicitamente: `<p>`, `<h1>`, `<h2>`, `<h3>`, `<ul>/<li>`, `<button>`/CTA, `<form>`, `<label>`, `<input>`, `<img>`.
 17. Para cada elemento listado, declarar atributos visuais trabalhados e os tokens correspondentes no preset (tipografia, espaçamento, dimensões, contraste, foco e superfície), mantendo consistência com `theme` e `componentPresets.primitives`.
 18. Distribuir no preset (de forma natural e não mecânica) diretrizes de acabamento premium para **todas** as superfícies e variações (`.lhm-surface-band`, `.lhm-surface-solid`, `.lhm-surface-gradient-soft`, `.lhm-surface-image-tint`), combinando ao menos: borda sutil, raio coerente, sombra de profundidade, respiro interno responsivo, controle de overflow e estados visuais consistentes com os tokens de `theme.radius`, `theme.shadow`, `theme.spacing` e `theme.palette`.
-19. `lhmRuntime` é obrigatório e deve conter:
+19. No `lhmRuntime.baseCss`, preservar rigorosamente a ordem das declarações CSS e regras de camadas (base → componentes → utilitários → overrides, e superfícies/background antes de conteúdo/efeitos), evitando sobrescritas destrutivas que degradem acabamentos premium das camadas elaboradas.
+20. `lhmRuntime` é obrigatório e deve conter:
    - `baseCss`: string com o CSS base que sustenta classes/superfícies do preset.
    - `cssVersion`: string de versão da malha CSS (ex.: `lhm-css-v1`).
    - `cssNotes`: string curta explicando escopo e compatibilidade da versão.
-20. Nunca omitir `lhmRuntime` e nunca serializar esse bloco como texto/JSON escapado (deve ser objeto JSON real).
-21. Saída obrigatoriamente em JSON válido no envelope do artefato, sem markdown, sem bloco de código e sem texto adicional.
-22. A resposta deve aderir estritamente ao schema JSON canônico da etapa `landingPageDesignPreset`; não incluir campos fora do contrato.
+21. Nunca omitir `lhmRuntime` e nunca serializar esse bloco como texto/JSON escapado (deve ser objeto JSON real).
+22. Saída obrigatoriamente em JSON válido no envelope do artefato, sem markdown, sem bloco de código e sem texto adicional.
+23. A resposta deve aderir estritamente ao schema JSON canônico da etapa `landingPageDesignPreset`; não incluir campos fora do contrato.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}

--- a/backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md
+++ b/backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md
@@ -9,6 +9,7 @@ Regras mandatórias da Sprint 1:
 - Incorporar no preset os padrões da seção "Padrões de CSS e componentes por elemento" de `docs/pesquisa-profunda/pesquisa-profunda-html-estilos.md`, cobrindo explicitamente os elementos: `<p>`, `<h1>`, `<h2>`, `<h3>`, `<ul>/<li>`, `<button>`/CTA, `<form>`, `<label>`, `<input>`, `<img>`.
 - Para cada elemento acima, declarar no preset os atributos visuais relevantes (tipografia, espaçamento, dimensão, contraste, foco, superfície, etc.) e os tokens correspondentes.
 - Distribuir no preset (de forma natural e não mecânica) diretrizes de acabamento premium para **todas** as superfícies e variações (`.lhm-surface-band`, `.lhm-surface-solid`, `.lhm-surface-gradient-soft`, `.lhm-surface-image-tint`), combinando ao menos: borda sutil, raio coerente, sombra de profundidade, respiro interno responsivo, controle de overflow e estados visuais consistentes com os tokens de `theme.radius`, `theme.shadow`, `theme.spacing` e `theme.palette`.
+- No `lhmRuntime.baseCss`, preservar rigorosamente a ordem das declarações CSS e das camadas (base → componentes → utilitários → overrides, e superfícies/background antes de conteúdo/efeitos), evitando sobrescritas destrutivas e preservando o acabamento premium das camadas mais elaboradas.
 - A etapa deve exigir resposta estritamente aderente ao schema JSON canônico de `landingPageDesignPreset`, sem campos fora do contrato.
 
 Saída:


### PR DESCRIPTION
### Motivation
- The landing design preset generation was producing destructive visual overrides because the model did not preserve a strict order of CSS declarations and layering, degrading premium finishes and elaborate surfaces.
- The pipeline needs an explicit, strong instruction in the prompts to ensure generated `lhmRuntime.baseCss` follows the intended layering (base → components → utilities → overrides; surfaces/background before content/effects). 

### Description
- Added a mandatory rule to `lhmRuntime.baseCss` instructing the model to preserve CSS declaration and layering order in `backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md`.
- Added the equivalent strong directive and adjusted rule numbering in `ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md` to keep prompt consistency across pipeline stages.
- Changes ensure the preset guidance emphasizes surfaces/background being declared before content/effects to avoid destructive overrides and to preserve premium layer finishes.

### Testing
- Ran `mvn -q -f backend/ads-service/pom.xml -Dtest=PromptAttributeServiceTest test` and the backend unit test completed successfully.
- Ran `mvn -q -f ai-worker/pom.xml -Dtest=PromptTemplateRendererTest test` and the `ai-worker` test failed due to external dependency resolution failing with a `401 Unauthorized` from the private Maven GitHub registry for `com.marketinghub:ads-service` (environment limitation prevents resolving the dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53d436bbc8321a4fdbd1f38c6ca21)