### PR TITLE
Enforce CSS layer order in landingPageDesignPreset prompts and record the adjustment

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
@@ -32,13 +32,14 @@ Regras:
 16. Incorporar no preset os padrões da seção "Padrões de CSS e componentes por elemento" de `docs/pesquisa-profunda/pesquisa-profunda-html-estilos.md`, cobrindo explicitamente: `<p>`, `<h1>`, `<h2>`, `<h3>`, `<ul>/<li>`, `<button>`/CTA, `<form>`, `<label>`, `<input>`, `<img>`.
 17. Para cada elemento listado, declarar atributos visuais trabalhados e os tokens correspondentes no preset (tipografia, espaçamento, dimensões, contraste, foco e superfície), mantendo consistência com `theme` e `componentPresets.primitives`.
 18. Distribuir no preset (de forma natural e não mecânica) diretrizes de acabamento premium para **todas** as superfícies e variações (`.lhm-surface-band`, `.lhm-surface-solid`, `.lhm-surface-gradient-soft`, `.lhm-surface-image-tint`), combinando ao menos: borda sutil, raio coerente, sombra de profundidade, respiro interno responsivo, controle de overflow e estados visuais consistentes com os tokens de `theme.radius`, `theme.shadow`, `theme.spacing` e `theme.palette`.
-19. `lhmRuntime` é obrigatório e deve conter:
+19. No `lhmRuntime.baseCss`, preservar rigorosamente a ordem das declarações CSS e regras de camadas (base → componentes → utilitários → overrides, e superfícies/background antes de conteúdo/efeitos), evitando sobrescritas destrutivas que degradem acabamentos premium das camadas elaboradas.
+20. `lhmRuntime` é obrigatório e deve conter:
    - `baseCss`: string com o CSS base que sustenta classes/superfícies do preset.
    - `cssVersion`: string de versão da malha CSS (ex.: `lhm-css-v1`).
    - `cssNotes`: string curta explicando escopo e compatibilidade da versão.
-20. Nunca omitir `lhmRuntime` e nunca serializar esse bloco como texto/JSON escapado (deve ser objeto JSON real).
-21. Saída obrigatoriamente em JSON válido no envelope do artefato, sem markdown, sem bloco de código e sem texto adicional.
-22. A resposta deve aderir estritamente ao schema JSON canônico da etapa `landingPageDesignPreset`; não incluir campos fora do contrato.
+21. Nunca omitir `lhmRuntime` e nunca serializar esse bloco como texto/JSON escapado (deve ser objeto JSON real).
+22. Saída obrigatoriamente em JSON válido no envelope do artefato, sem markdown, sem bloco de código e sem texto adicional.
+23. A resposta deve aderir estritamente ao schema JSON canônico da etapa `landingPageDesignPreset`; não incluir campos fora do contrato.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}

--- a/backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md
+++ b/backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md
@@ -9,6 +9,7 @@ Regras mandatórias da Sprint 1:
 - Incorporar no preset os padrões da seção "Padrões de CSS e componentes por elemento" de `docs/pesquisa-profunda/pesquisa-profunda-html-estilos.md`, cobrindo explicitamente os elementos: `<p>`, `<h1>`, `<h2>`, `<h3>`, `<ul>/<li>`, `<button>`/CTA, `<form>`, `<label>`, `<input>`, `<img>`.
 - Para cada elemento acima, declarar no preset os atributos visuais relevantes (tipografia, espaçamento, dimensão, contraste, foco, superfície, etc.) e os tokens correspondentes.
 - Distribuir no preset (de forma natural e não mecânica) diretrizes de acabamento premium para **todas** as superfícies e variações (`.lhm-surface-band`, `.lhm-surface-solid`, `.lhm-surface-gradient-soft`, `.lhm-surface-image-tint`), combinando ao menos: borda sutil, raio coerente, sombra de profundidade, respiro interno responsivo, controle de overflow e estados visuais consistentes com os tokens de `theme.radius`, `theme.shadow`, `theme.spacing` e `theme.palette`.
+- No `lhmRuntime.baseCss`, preservar rigorosamente a ordem das declarações CSS e das camadas (base → componentes → utilitários → overrides, e superfícies/background antes de conteúdo/efeitos), evitando sobrescritas destrutivas e preservando o acabamento premium das camadas mais elaboradas.
 - A etapa deve exigir resposta estritamente aderente ao schema JSON canônico de `landingPageDesignPreset`, sem campos fora do contrato.
 
 Saída:

--- a/docs/registro-ajustes-pipeline-experimento.md
+++ b/docs/registro-ajustes-pipeline-experimento.md
@@ -75,6 +75,53 @@ Registrar, de forma rastreável, cada erro identificado em execução, o diagnó
 
 > Novas entradas sempre no topo.
 
+### INC-0019 — Reforço da ordem de camadas CSS no preset para preservar acabamento premium
+
+- **Data/Hora (UTC):** 2026-05-02
+- **Responsável:** Assistente Codex
+- **Módulo:** backend (`ads-service`) + ai-worker + documentação operacional
+- **Ambiente:** Repositório local (`/workspace/marketing-hub`)
+- **Execução/Teste:** Revisão pós-feedback do PR "Reforça instruções de ordem de camadas CSS no preset de landing".
+
+#### 1) Erro observado
+- **Sintoma:** o visual de presets com acabamento premium era degradado por sobrescritas destrutivas quando o modelo alterava a ordem das classes/camadas CSS no `lhmRuntime.baseCss`.
+- **Endpoint/rota/fila:** etapa `LANDING_PAGE_DESIGN_PRESET` do pipeline de experimento.
+- **Status code:** sem novo código HTTP nesta revisão local (ajuste preventivo de qualidade visual).
+- **Mensagem de erro literal:** n/a.
+- **Payload enviado (literal):** n/a (problema identificado no resultado visual/CSS gerado).
+
+#### 2) Diagnóstico (MCP + Cânone)
+- **Logs consultados via MCP:** não aplicável nesta revisão (sem incidente HTTP novo).
+- **Dados de banco consultados via MCP:** não aplicável.
+- **Trecho canônico consultado:** `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` (artefato `landingPageDesignPreset`).
+- **Validação/regra que rejeitou:** n/a.
+- **Causa raiz:** falta de instrução suficientemente forte sobre precedência e ordem de camadas CSS na geração do preset.
+
+#### 3) Divergência (formato obrigatório para 422)
+- **O que o modelo entregou (literal):** CSS com ordem inconsistente de camadas (potencialmente aplicando efeitos/conteúdo antes de base/superfície).
+- **O que a especificação esperava (literal):** ordem controlada de camadas (`base → componentes → utilitários → overrides`; superfícies/background antes de conteúdo/efeitos).
+- **Diferença objetiva:** ausência de garantia explícita de precedência de camadas no prompt.
+- **Ação corretiva recomendada:** reforçar regra mandatória em ambos os prompts (backend e ai-worker) para travar ordem e minimizar sobrescrita destrutiva.
+
+#### 4) Ajuste aplicado
+- **Tipo de ajuste:** prompt + registro operacional.
+- **Arquivos alterados:**
+  - `backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md`
+  - `ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md`
+  - `docs/registro-ajustes-pipeline-experimento.md`
+- **Resumo técnico da mudança:** inclusão de diretriz mandatória para preservar ordem de declarações e camadas no `lhmRuntime.baseCss`, com foco em manter superfícies/background antes de conteúdo/efeitos e evitar degradação de acabamento premium.
+
+#### 5) Reteste
+- **Procedimento de reteste:** execução de teste unitário direcionado no backend + tentativa de teste direcionado no ai-worker.
+- **Resultado:** backend aprovado; ai-worker bloqueado por dependência privada não resolvida no ambiente.
+- **Evidências (logs/ids/prints):** `mvn -q -f backend/ads-service/pom.xml -Dtest=PromptAttributeServiceTest test` (sucesso) e `mvn -q -f ai-worker/pom.xml -Dtest=PromptTemplateRendererTest test` (falha 401 ao resolver `com.marketinghub:ads-service`).
+- **Status final:** Parcial.
+
+#### 6) Próximo passo
+- **Ação seguinte:** validar em execução real da etapa `LANDING_PAGE_DESIGN_PRESET` se a ordem de camadas permanece estável em múltiplos nichos/layouts e monitorar regressão visual.
+- **Dono da ação:** time ai-worker + backend + operação do pipeline.
+- **Prazo:** próximo ciclo assistido de experimento.
+
 ### INC-0018 — Alinhamento canônico de `slotId` na `landingPageCopy` para reduzir 422 sem reprocessamento
 
 - **Data/Hora (UTC):** 2026-05-01


### PR DESCRIPTION
### Motivation
- Prevent destructive CSS overrides that degraded premium visual finishes by ensuring the generator preserves explicit layer ordering in the `lhmRuntime.baseCss` block. 
- Align instructions across `ai-worker` and `backend` prompt assets and create an auditable record of the corrective change. 

### Description
- Add a mandatory directive to `ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md` requiring strict preservation of CSS layer order in `lhmRuntime.baseCss` (base → components → utilities → overrides, and surfaces/background before content/effects). 
- Add the same directive to `backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md` to keep backend and worker prompts consistent. 
- Update `docs/registro-ajustes-pipeline-experimento.md` with an `INC-0019` entry documenting the issue, diagnosis, applied change, and retest notes. 
- Changed prompt item numbering and related wording to integrate the new requirement while keeping `lhmRuntime` mandatory and serialized as a JSON object. 

### Testing
- Ran the backend unit test with `mvn -q -f backend/ads-service/pom.xml -Dtest=PromptAttributeServiceTest test`, which succeeded. 
- Ran the ai-worker unit test with `mvn -q -f ai-worker/pom.xml -Dtest=PromptTemplateRendererTest test`, which failed due to a `401` when resolving the private dependency `com.marketinghub:ads-service`. 
- Overall status is Partial: backend changes validated; ai-worker tests are blocked by an environment dependency resolution error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53d436bbc8321a4fdbd1f38c6ca21)