### PR TITLE
Refina prompt de preset para evitar conflitos de cascata CSS

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md
@@ -41,6 +41,12 @@ Regras:
 22. Saída obrigatoriamente em JSON válido no envelope do artefato, sem markdown, sem bloco de código e sem texto adicional.
 23. A resposta deve aderir estritamente ao schema JSON canônico da etapa `landingPageDesignPreset`; não incluir campos fora do contrato.
 
+24. Em `lhmRuntime.baseCss`, separar responsabilidades de estilo para evitar conflitos de cascata:
+   - `.lhm-card` controla apenas estrutura/componente (padding, raio, borda, sombra, blur) e deve consumir variáveis (`--lhm-card-bg`, `--lhm-card-border`, `--lhm-card-text`, `--lhm-card-shadow`) sem hardcode destrutivo de `background`.
+   - `.lhm-surface-*` define aparência de superfície por meio dessas variáveis (especialmente `--lhm-card-bg` e `--lhm-card-border`), sem competir com a estrutura do card.
+   - `.lhm-high`, `.lhm-normal` e `.lhm-soft` precisam produzir contraste visual distinto entre si (texto principal, texto secundário/muted e links), proibido manter as três classes com a mesma cor final.
+   - Garantir uma base comum para superfícies (`.lhm-surface`) aplicada às variações (`.lhm-surface-band`, `.lhm-surface-solid`, `.lhm-surface-gradient-soft`, `.lhm-surface-image-tint`) para preservar `position`, `overflow` e consistência de renderização.
+
 CASE_DATA
 {{CASE_DATA_BLOCK}}
 

--- a/backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md
+++ b/backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md
@@ -10,6 +10,8 @@ Regras mandatórias da Sprint 1:
 - Para cada elemento acima, declarar no preset os atributos visuais relevantes (tipografia, espaçamento, dimensão, contraste, foco, superfície, etc.) e os tokens correspondentes.
 - Distribuir no preset (de forma natural e não mecânica) diretrizes de acabamento premium para **todas** as superfícies e variações (`.lhm-surface-band`, `.lhm-surface-solid`, `.lhm-surface-gradient-soft`, `.lhm-surface-image-tint`), combinando ao menos: borda sutil, raio coerente, sombra de profundidade, respiro interno responsivo, controle de overflow e estados visuais consistentes com os tokens de `theme.radius`, `theme.shadow`, `theme.spacing` e `theme.palette`.
 - No `lhmRuntime.baseCss`, preservar rigorosamente a ordem das declarações CSS e das camadas (base → componentes → utilitários → overrides, e superfícies/background antes de conteúdo/efeitos), evitando sobrescritas destrutivas e preservando o acabamento premium das camadas mais elaboradas.
+- Separar responsabilidades em `lhmRuntime.baseCss`: `.lhm-card` estrutural consumindo variáveis (`--lhm-card-bg`, `--lhm-card-border`, `--lhm-card-text`, `--lhm-card-shadow`), `.lhm-surface-*` configurando essas variáveis, e contraste real entre `.lhm-high`/`.lhm-normal`/`.lhm-soft` (proibido classes equivalentes).
+- Garantir base comum `.lhm-surface` aplicada às variações para manter `position`, `overflow` e consistência visual sem conflitos de cascata.
 - A etapa deve exigir resposta estritamente aderente ao schema JSON canônico de `landingPageDesignPreset`, sem campos fora do contrato.
 
 Saída:


### PR DESCRIPTION
### Motivation
- External analysis showed generated presets caused CSS cascade conflicts where `.lhm-card` overwrote `.lhm-surface-*` backgrounds and `lhm-high`/`lhm-normal`/`lhm-soft` produced no real contrast, so the prompt must force architectural separation.

### Description
- Added an explicit rule to `ai-worker/src/main/resources/prompts/experiment/landing-design-preset.md` requiring `.lhm-card` to be structural (consume variables) and `.lhm-surface-*` to define appearance via variables like `--lhm-card-bg`, `--lhm-card-border`, `--lhm-card-text`, and `--lhm-card-shadow`.
- Mirrored the same guidance in `backend/ads-service/src/main/resources/prompts/experiment-pipeline/landing-page-design-preset/user.md` to keep generator and orchestrator aligned.
- The new rules also mandate a common `.lhm-surface` base for position/overflow consistency and require distinct visual tokens for `.lhm-high`, `.lhm-normal`, and `.lhm-soft` so they produce perceptible contrast differences.

### Testing
- Ran `git diff` to verify the two prompt files reflect the new rule and the diff shows the inserted lines, and the command completed successfully.
- Ran `git status --short` to confirm the working tree contains the modified prompt files and the command completed successfully.
- Queried `git rev-parse --short HEAD` to capture the current repository state and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5462f673083219952f43bb63e1da2)