### PR TITLE
Remover abas E-mails e Entregáveis da tela de Experimento

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -14,7 +14,6 @@ import { getExperimentStageLabel } from "./stageLabels";
 import nicheIcon from "../../assets/icons/niche-icon.svg";
 import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import CriativosTab from "./CriativosTab";
-import EmailsTab from "./EmailsTab";
 import SampleEmailsTab from "./SampleEmailsTab";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 import * as Tabs from "@radix-ui/react-tabs";
@@ -30,7 +29,6 @@ import {
   type ExperimentCampaignResetSummary,
 } from "../../api/experiment/useExperimentCampaignReset";
 import type { JourneyAssignment, JourneyStep } from "../../api/journey/types";
-import DeliverablesTab from "./DeliverablesTab";
 import LeadPortalFlowTab from "./LeadPortalFlowTab";
 import TargetingTab from "./TargetingTab";
 import ExperimentFunnelTab from "./ExperimentFunnelTab";
@@ -1235,19 +1233,11 @@ export default function ExperimentDetailPage() {
           <Tabs.Trigger value="landing" className="nav-link">
             Landing
           </Tabs.Trigger>
-          {hasEmailSteps ? (
-            <Tabs.Trigger value="emails" className="nav-link">
-              E-mails
-            </Tabs.Trigger>
-          ) : null}
           <Tabs.Trigger value="sample-emails" className="nav-link">
             E-mails de amostra
           </Tabs.Trigger>
           <Tabs.Trigger value="lead-portal" className="nav-link">
             Portal do Lead
-          </Tabs.Trigger>
-          <Tabs.Trigger value="deliverables" className="nav-link">
-            Entregáveis
           </Tabs.Trigger>
           <Tabs.Trigger value="content-structure" className="nav-link">
             Estrutura de conteúdo
@@ -1301,17 +1291,6 @@ export default function ExperimentDetailPage() {
         <Tabs.Content value="landing" asChild>
           <LandingTab experiment={data} />
         </Tabs.Content>
-        {hasEmailSteps ? (
-          <Tabs.Content value="emails" asChild>
-            <EmailsTab
-              experimentId={expId}
-              requestedEmails={data.emailsToGenerate}
-              journeyId={journeyAssignments?.journeyId ?? undefined}
-              steps={templateSteps}
-              experimentName={data.name}
-            />
-          </Tabs.Content>
-        ) : null}
         <Tabs.Content value="sample-emails" asChild>
           <SampleEmailsTab
             experimentId={expId}
@@ -1323,9 +1302,6 @@ export default function ExperimentDetailPage() {
         </Tabs.Content>
         <Tabs.Content value="lead-portal" asChild>
           <LeadPortalFlowTab experiment={data} />
-        </Tabs.Content>
-        <Tabs.Content value="deliverables" asChild>
-          <DeliverablesTab experiment={data} nicheName={niche?.name} />
         </Tabs.Content>
         <Tabs.Content value="content-structure" asChild>
           <ExperimentContentGenerationTab


### PR DESCRIPTION
### Motivation
- Remover as abas desnecessárias para simplificar a UI da página de detalhe do experimento conforme solicitado.
- Manter as funcionalidades essenciais (por exemplo, **E-mails de amostra**) visíveis e sem alterar o fluxo de navegação existente.

### Description
- Removeu os triggers de navegação das abas `emails` e `deliverables` em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` para que não sejam mais exibidas na lista de abas. 
- Removeu os respectivos blocos `Tabs.Content` que renderizavam `EmailsTab` e `DeliverablesTab` para evitar que os painéis sejam montados. 
- Removeu as importações não utilizadas de `EmailsTab` e `DeliverablesTab` e ajustou a ordem/indentação dos itens restantes sem mudar outras abas (por exemplo, `sample-emails` permanece). 

### Testing
- Executada tentativa de lint com `npm run -s lint -- src/pages/experiment/ExperimentDetailPage.tsx`, que retornou código de saída não conclusivo no ambiente atual. 
- Executado `npx eslint src/pages/experiment/ExperimentDetailPage.tsx`, que falhou por ausência de `eslint.config.*` compatível com ESLint v9 no ambiente de execução, portanto não foi possível validar via ESLint localmente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f555eea52c8321a23b7e9f26735e8b)