### PR TITLE
feat(frontend): adiciona aba "Gera landing" na tela de experimento

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1233,6 +1233,9 @@ export default function ExperimentDetailPage() {
           <Tabs.Trigger value="landing" className="nav-link">
             Landing
           </Tabs.Trigger>
+          <Tabs.Trigger value="gera-landing" className="nav-link">
+            Gera landing
+          </Tabs.Trigger>
           <Tabs.Trigger value="sample-emails" className="nav-link">
             E-mails de amostra
           </Tabs.Trigger>
@@ -1290,6 +1293,11 @@ export default function ExperimentDetailPage() {
         </Tabs.Content>
         <Tabs.Content value="landing" asChild>
           <LandingTab experiment={data} />
+        </Tabs.Content>
+        <Tabs.Content value="gera-landing" asChild>
+          <div className="card">
+            <div className="card-body text-muted">Em breve.</div>
+          </div>
         </Tabs.Content>
         <Tabs.Content value="sample-emails" asChild>
           <SampleEmailsTab


### PR DESCRIPTION
### Motivation
- Adicionar uma aba vazia chamada `Gera landing` na página de detalhe do experimento para reservar espaço para a futura funcionalidade de geração de landing pages.

### Description
- Atualizado `frontend/src/pages/experiment/ExperimentDetailPage.tsx` para incluir um novo `Tabs.Trigger` com valor `gera-landing` e um `Tabs.Content` correspondente que exibe um placeholder (`Em breve.`).

### Testing
- Executado `npm --prefix frontend run typecheck`, que falhou no ambiente por ausência de definições de tipo/dependências (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55b8ce1cc8321a565ec89be4c538b)