### PR TITLE
Add `com.marketinghub.geralanding` package and registros doc

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/package-info.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Pacote base do módulo Gera Landing no backend.
+ */
+package com.marketinghub.geralanding;

--- a/docs/gera-landing/registros.md
+++ b/docs/gera-landing/registros.md
@@ -1,1 +1,5 @@
+# Registros — Gera Landing
 
+> Orientação: todos os registros deste documento devem sempre incluir **data e hora no fuso UTC-3**.
+
+- 2026-05-01 23:33:32 (UTC-3): criado o pacote `com.marketinghub.geralanding` no backend (`ads-service`) para centralizar os componentes do módulo Gera Landing.


### PR DESCRIPTION
### Motivation
- Introduce a base package for the Gera Landing module in the backend to centralize module components and record the change in project docs.

### Description
- Add `backend/ads-service/src/main/java/com/marketinghub/geralanding/package-info.java` with package documentation and add `docs/gera-landing/registros.md` with a UTC-3 timestamped entry noting the package creation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5610a381c8321bbd609b8b3eef53a)