### PR TITLE
feat: adiciona card Gera WireFrame e endpoint placeholder

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingWireframeController.java
@@ -1,0 +1,17 @@
+package com.marketinghub.geralanding;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/experiments/{experimentId}/geralanding")
+public class GeraLandingWireframeController {
+
+  @PostMapping("/wireframe/start")
+  public ResponseEntity<Void> startWireframe(@PathVariable Long experimentId) {
+    return ResponseEntity.accepted().build();
+  }
+}

--- a/docs/gera-landing/registros.md
+++ b/docs/gera-landing/registros.md
@@ -3,3 +3,4 @@
 > Orientação: todos os registros deste documento devem sempre incluir **data e hora no fuso UTC-3**.
 
 - 2026-05-01 23:33:32 (UTC-3): criado o pacote `com.marketinghub.geralanding` no backend (`ads-service`) para centralizar os componentes do módulo Gera Landing.
+- 2026-05-02 00:00:00 (UTC-3): adicionados o card **Gera WireFrame** e o botão **Iniciar** na aba "Gera landing" da tela de experimento no frontend; o botão agora envia POST para `/api/experiments/{experimentId}/geralanding/wireframe/start` no backend (package `com.marketinghub.geralanding`) com retorno `202 Accepted` sem processamento adicional neste momento.

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -83,6 +83,7 @@ export default function ExperimentDetailPage() {
   const { data: facebookCampaigns, isLoading: isLoadingFacebookCampaigns } =
     useExperimentFacebookCampaigns(expId);
   const [isResetModalOpen, setIsResetModalOpen] = useState(false);
+  const [isStartingWireframe, setIsStartingWireframe] = useState(false);
   const { data: readinessSummary, isLoading: isLoadingReadiness } =
     useExperimentReadiness(expId);
   const {
@@ -190,6 +191,23 @@ export default function ExperimentDetailPage() {
           "Não foi possível liberar o experimento para o Facebook.")
         : "Não foi possível liberar o experimento para o Facebook.";
       toast.error(message);
+    }
+  };
+
+  const handleStartWireframe = async () => {
+    try {
+      setIsStartingWireframe(true);
+      await axios.post(`/api/experiments/${expId}/geralanding/wireframe/start`);
+      toast.success("Solicitação para iniciar o WireFrame registrada.");
+    } catch (error) {
+      const message = axios.isAxiosError(error)
+        ? (error.response?.data?.message ??
+          error.response?.data?.detail ??
+          "Não foi possível iniciar o WireFrame.")
+        : "Não foi possível iniciar o WireFrame.";
+      toast.error(message);
+    } finally {
+      setIsStartingWireframe(false);
     }
   };
 
@@ -1296,7 +1314,30 @@ export default function ExperimentDetailPage() {
         </Tabs.Content>
         <Tabs.Content value="gera-landing" asChild>
           <div className="card">
-            <div className="card-body text-muted">Em breve.</div>
+            <div className="card-body d-flex flex-column gap-3">
+              <h5 className="card-title mb-0">Gera WireFrame</h5>
+              <div>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={handleStartWireframe}
+                  disabled={isStartingWireframe}
+                >
+                  {isStartingWireframe ? (
+                    <>
+                      <span
+                        className="spinner-border spinner-border-sm me-2"
+                        role="status"
+                        aria-hidden="true"
+                      />
+                      Iniciando...
+                    </>
+                  ) : (
+                    "Iniciar"
+                  )}
+                </button>
+              </div>
+            </div>
           </div>
         </Tabs.Content>
         <Tabs.Content value="sample-emails" asChild>


### PR DESCRIPTION
### Motivation
- Permitir iniciar o fluxo de WireFrame a partir da aba "Gera landing" do detalhe do experimento e estabelecer o contrato frontend↔backend para evoluções futuras.

### Description
- Adiciona no frontend (`frontend/src/pages/experiment/ExperimentDetailPage.tsx`) um card com título **Gera WireFrame** e botão **Iniciar** que exibe estado de loading (spinner + texto) e fica desabilitado enquanto a requisição está em andamento.
- Implementa o handler `handleStartWireframe` que faz `POST /api/experiments/{experimentId}/geralanding/wireframe/start` usando `axios`.
- Cria um endpoint placeholder no backend no package `com.marketinghub.geralanding`: `GeraLandingWireframeController.startWireframe(@PathVariable Long experimentId)` retornando `202 Accepted` sem lógica adicional (`backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingWireframeController.java`).
- Registra a alteração em `docs/gera-landing/registros.md` com data/hora em UTC-3 conforme convenção do projeto.

### Testing
- Executed backend unit tests with `mvn -q -DskipITs test` in `backend/ads-service`, the suite ran and exercised many tests; no failures were observed that could be attributed to the new controller, however the test run printed unrelated H2/scheduler warnings in the environment and should be verified by CI.
- No automated frontend tests were added; the UI change is limited to the experiment detail page and the button behaviour is implemented as described.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f564c4bbe48321b79e19eac842b105)