### PR TITLE
Introduce GeraLandingService and LandingPageWireframeDto for typed experiment payload access

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
@@ -1,0 +1,63 @@
+package com.marketinghub.worker.geralanding;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.AdCopy;
+import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.AdImageBriefing;
+import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.CampaignAngle;
+import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.ExperimentMetadata;
+import com.marketinghub.worker.experimentpipeline.ExperimentPipelineJobDto;
+import java.util.Collections;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GeraLandingService {
+
+    private static final String CAMPAIGN_ANGLE = "campaignAngle";
+    private static final String AD_COPY = "adCopy";
+    private static final String AD_IMAGE_BRIEFING = "adImageBriefing";
+    private static final String LANDING_PAGE_WIREFRAME = "landingPageWireframe";
+    private static final String EXPERIMENT_METADATA = "experimentMetadata";
+
+    private final ObjectMapper objectMapper;
+
+    public GeraLandingService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public CampaignAngle obterCampaignAngle(ExperimentPipelineJobDto job) throws JsonProcessingException {
+        return objectMapper.convertValue(obterMapa(job, CAMPAIGN_ANGLE), CampaignAngle.class);
+    }
+
+    public AdCopy obterAdCopy(ExperimentPipelineJobDto job) throws JsonProcessingException {
+        return objectMapper.convertValue(obterMapa(job, AD_COPY), AdCopy.class);
+    }
+
+    public AdImageBriefing obterAdImageBriefing(ExperimentPipelineJobDto job) throws JsonProcessingException {
+        return objectMapper.convertValue(obterMapa(job, AD_IMAGE_BRIEFING), AdImageBriefing.class);
+    }
+
+    public LandingPageWireframeDto obterLandingPageWireframe(ExperimentPipelineJobDto job) throws JsonProcessingException {
+        return new LandingPageWireframeDto(obterMapa(job, LANDING_PAGE_WIREFRAME));
+    }
+
+    public ExperimentMetadata obterExperimentMetadata(ExperimentPipelineJobDto job) throws JsonProcessingException {
+        return objectMapper.convertValue(obterMapa(job, EXPERIMENT_METADATA), ExperimentMetadata.class);
+    }
+
+    private Map<String, Object> obterMapa(ExperimentPipelineJobDto job, String campo) throws JsonProcessingException {
+        if (job == null || job.requestBodyJson() == null || job.requestBodyJson().isBlank()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Object> payload = objectMapper.readValue(job.requestBodyJson(), new TypeReference<>() {});
+        Object valor = payload.get(campo);
+        if (valor instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+
+        return Collections.emptyMap();
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/LandingPageWireframeDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/LandingPageWireframeDto.java
@@ -1,0 +1,5 @@
+package com.marketinghub.worker.geralanding;
+
+import java.util.Map;
+
+public record LandingPageWireframeDto(Map<String, Object> data) {}

--- a/docs/gera-landing/registros.md
+++ b/docs/gera-landing/registros.md
@@ -4,3 +4,5 @@
 
 - 2026-05-01 23:33:32 (UTC-3): criado o pacote `com.marketinghub.geralanding` no backend (`ads-service`) para centralizar os componentes do módulo Gera Landing.
 - 2026-05-02 00:00:00 (UTC-3): adicionados o card **Gera WireFrame** e o botão **Iniciar** na aba "Gera landing" da tela de experimento no frontend; o botão agora envia POST para `/api/experiments/{experimentId}/geralanding/wireframe/start` no backend (package `com.marketinghub.geralanding`) com retorno `202 Accepted` sem processamento adicional neste momento.
+
+- 2026-05-03 09:00:00 (UTC-3): no `ai-worker`, refatorado `GeraLandingService` para expor métodos tipados de leitura de `campaignAngle`, `adCopy`, `adImageBriefing` e `experimentMetadata` com DTOs existentes; criado `LandingPageWireframeDto` no pacote `geralanding` para encapsular `landingPageWireframe`.


### PR DESCRIPTION
### Motivation

- Centralize and simplify reading typed pieces of `requestBodyJson` from experiment jobs (campaign angle, ad copy, ad image briefing, landing page wireframe and experiment metadata). 
- Provide a dedicated DTO for the landing page wireframe to encapsulate its payload shape and make downstream code consumption safer.
- Record the change in the Gera Landing documentation to track the backend refactor.

### Description

- Added `GeraLandingService` with typed accessors `obterCampaignAngle`, `obterAdCopy`, `obterAdImageBriefing`, `obterLandingPageWireframe` and `obterExperimentMetadata` that parse `ExperimentPipelineJobDto.requestBodyJson` using `ObjectMapper`. 
- Implemented a private helper `obterMapa` in `GeraLandingService` to safely extract a named field as a `Map<String,Object>` with defensive checks. 
- Added `LandingPageWireframeDto` as a record to encapsulate the `landingPageWireframe` payload. 
- Updated `docs/gera-landing/registros.md` with an entry describing the refactor and the new DTO.

### Testing

- Ran the project build and unit tests with `./gradlew build` for the `ai-worker` module and the build completed successfully. 
- Ran the unit test suite with `./gradlew test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f616b950dc8321b16f5d6d10777332)