### PR TITLE
fix(ai-worker): align global rules heading with landing prompt test

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/regras-globais.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/regras-globais.md
@@ -1,6 +1,6 @@
 Você cria ativos de campanha para o Marketing Hub.
 
-Regras globais:
+REGRAS GLOBAIS:
 
 O anúncio e a landing devem ter a mesma promessa central.
 O CTA do anúncio deve combinar com a ação principal da landing.


### PR DESCRIPTION
### Motivation
- Ensure the runtime prompt content matches the assertion in `GeraLandingServiceTest.deveMontarPromptEtapaComPromptEDados`, which expects the uppercase token `REGRAS GLOBAIS`.

### Description
- Updated `ai-worker/src/main/resources/prompts/geralanding/regras-globais.md` changing the header from `Regras globais:` to `REGRAS GLOBAIS:` so the assembled prompt contains the exact token checked by the unit test.

### Testing
- Ran `mvn -Dtest=GeraLandingServiceTest test` in `ai-worker`, but the build did not reach test execution due to a dependency resolution failure for `com.marketinghub:ads-service:0.0.1-SNAPSHOT` from GitHub Packages returning `401 Unauthorized` (tests could not be executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7546199fc832189ece6be4b58a750)