### PR TITLE
Improve Hotmart fetch logging with HTTP method and final URL

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -2,3 +2,11 @@
 
 > Orientação: todos os registros deste documento devem sempre incluir **data e hora no fuso UTC-3**.
 > Neste documento segue política de **append-only** (não pode ter nenhuma linha apagada; apenas inserções).
+
+## 2026-05-03 18:45:13 UTC-3
+- Ajustado o diagnóstico de coletas Hotmart no `MoisDomainService` para registrar explicitamente:
+  - `method=GET` no início da tentativa;
+  - `requestedUrl` e `finalUrl` nos logs de resposta rejeitada (`statusCode` fora de 2xx);
+  - `requestedUrl`, `finalUrl`, `statusCode` e método no log de finalização.
+- Objetivo: facilitar rastreabilidade de redirecionamentos HTTP 301 e identificar com precisão qual URL foi solicitada e qual URL final foi retornada pelo cliente HTTP.
+- Commit relacionado: `356c904`.

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
@@ -1375,8 +1375,9 @@ public class MoisDomainService {
 
     private List<SourceLead> fetchHotmartProductLeads(String niche, int limitPerSource) {
         String marketplaceUrl = buildCollectionSourceUrl("HOTMART", niche, 1);
-        log.info("mois_hotmart_product_url_fetch_started niche={} url={} limitPerSource={}",
-                niche, marketplaceUrl, limitPerSource);
+        String httpMethod = "GET";
+        log.info("mois_hotmart_product_url_fetch_started niche={} method={} url={} limitPerSource={}",
+                niche, httpMethod, marketplaceUrl, limitPerSource);
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(marketplaceUrl))
@@ -1386,8 +1387,8 @@ public class MoisDomainService {
                     .build();
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() < 200 || response.statusCode() >= 300 || response.body() == null) {
-                log.warn("mois_hotmart_product_url_fetch_rejected niche={} statusCode={} hasBody={}",
-                        niche, response.statusCode(), response.body() != null);
+                log.warn("mois_hotmart_product_url_fetch_rejected niche={} method={} requestedUrl={} finalUrl={} statusCode={} hasBody={}",
+                        niche, httpMethod, marketplaceUrl, response.uri(), response.statusCode(), response.body() != null);
                 return List.of();
             }
             Pattern cardPattern = Pattern.compile(
@@ -1406,8 +1407,8 @@ public class MoisDomainService {
                     leads.add(new SourceLead(decodedUrl, title, description, producer, imageUrl));
                 }
             }
-            log.info("mois_hotmart_product_url_fetch_finished niche={} statusCode={} parsedLeads={} responseLength={}",
-                    niche, response.statusCode(), leads.size(), response.body().length());
+            log.info("mois_hotmart_product_url_fetch_finished niche={} method={} requestedUrl={} finalUrl={} statusCode={} parsedLeads={} responseLength={}",
+                    niche, httpMethod, marketplaceUrl, response.uri(), response.statusCode(), leads.size(), response.body().length());
             return leads;
         } catch (Exception ex) {
             log.warn("mois_hotmart_product_url_fetch_failed niche={} reason={}", niche, ex.getMessage());


### PR DESCRIPTION
### Motivation
- Make Hotmart marketplace scraping easier to diagnose by adding request context to logs.
- Capture HTTP method and both requested and final URLs to help trace redirects and failures.
- Provide more detailed logging on rejected responses to speed up troubleshooting.

### Description
- Added a local `httpMethod` variable and included it in `mois_hotmart_product_url_fetch_started` and `mois_hotmart_product_url_fetch_finished` log messages. 
- Enhanced the rejection log `mois_hotmart_product_url_fetch_rejected` to include `method`, `requestedUrl`, `finalUrl`, `statusCode`, and whether the response has a body. 
- Continued to parse Hotmart product cards from the response body and return parsed `SourceLead` objects when available, falling back to an empty list on non-2xx responses or exceptions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bd9663ec83219d156ddadb08a609)