### PR TITLE
mcp-server: configurable log fetch timeout and increased nginx proxy timeouts

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -54,6 +54,8 @@ O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou
 
 > Em produção, configure explicitamente os `MCP_LOG_*_PATH` via variáveis de ambiente (arquivo `.env` do host) para apontar para o destino de log aprovado.
 
+Timeout de leitura HTTP por módulo: `MCP_LOG_FETCH_TIMEOUT_SECONDS` (default `45`).
+
 Limite máximo por chamada: `MCP_LOG_MAX_LINES` (default `500`).
 
 ## Ferramentas de diagnóstico Meta

--- a/mcp-server/nginx/default.conf
+++ b/mcp-server/nginx/default.conf
@@ -25,9 +25,9 @@ server {
     location / {
         proxy_pass http://mcp-server:8096;
         proxy_http_version 1.1;
-        proxy_connect_timeout 10s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_connect_timeout 15s;
+        proxy_send_timeout 180s;
+        proxy_read_timeout 180s;
 
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/mcp-server/nginx/default.http.conf
+++ b/mcp-server/nginx/default.http.conf
@@ -9,9 +9,9 @@ server {
     location / {
         proxy_pass http://mcp-server:8096;
         proxy_http_version 1.1;
-        proxy_connect_timeout 10s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_connect_timeout 15s;
+        proxy_send_timeout 180s;
+        proxy_read_timeout 180s;
 
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -28,6 +28,7 @@ public record McpProperties(
             @NotBlank String leadPortalPaymentPath,
             @NotBlank String mdsPath,
             @NotBlank String moisPath,
+            @Positive int fetchTimeoutSeconds,
             @Positive int maxLines
     ) {
     }

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -22,15 +22,16 @@ import java.util.stream.Stream;
 public class ModuleLogService {
 
     private static final int DEFAULT_LINES = 200;
-    private static final Duration LOG_FETCH_TIMEOUT = Duration.ofSeconds(10);
 
     private final McpProperties properties;
     private final HttpClient httpClient;
+    private final Duration logFetchTimeout;
 
     public ModuleLogService(McpProperties properties) {
         this.properties = properties;
+        this.logFetchTimeout = Duration.ofSeconds(properties.logs().fetchTimeoutSeconds());
         this.httpClient = HttpClient.newBuilder()
-                .connectTimeout(LOG_FETCH_TIMEOUT)
+                .connectTimeout(logFetchTimeout)
                 .build();
     }
 
@@ -86,7 +87,7 @@ public class ModuleLogService {
         response.put("source", "http");
 
         HttpRequest request = HttpRequest.newBuilder(URI.create(configuredUrl))
-                .timeout(LOG_FETCH_TIMEOUT)
+                .timeout(logFetchTimeout)
                 .GET()
                 .build();
 

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -35,6 +35,7 @@ mcp:
     lead-portal-payment-path: ${MCP_LOG_LEAD_PORTAL_PAYMENT_PATH:http://191.252.102.54:8092/api/v1/logs/runtime?lines=200}
     mds-path: ${MCP_LOG_MDS_PATH:http://177.153.62.107:8091/actuator/logfile}
     mois-path: ${MCP_LOG_MOIS_PATH:http://177.153.62.107:8094/manage/logfile}
+    fetch-timeout-seconds: ${MCP_LOG_FETCH_TIMEOUT_SECONDS:45}
     max-lines: ${MCP_LOG_MAX_LINES:500}
   meta:
     enabled: ${MCP_META_ENABLED:true}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -32,7 +32,7 @@ class MetaToolsServiceTest {
                 "marketing-hub-mcp",
                 "1.0.0",
                 null,
-                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", 500),
+                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", 45, 500),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",


### PR DESCRIPTION
### Motivation
- Reduce intermittent `upstream connect error ... connection timeout` failures when `java_module_logs` reads remote module logs and make the HTTP fetch timeout configurable.
- Avoid false timeouts for larger or slower remote log streams by aligning application HTTP client timeouts with proxy timeouts.

### Description
- Added `mcp.logs.fetch-timeout-seconds` (`MCP_LOG_FETCH_TIMEOUT_SECONDS`, default `45`) to `src/main/resources/application.yml` and documented it in `README.md`.
- Extended `McpProperties.Logs` with a new `fetchTimeoutSeconds` field and updated the `MetaToolsServiceTest` fixture to match the new signature.
- Updated `ModuleLogService` to use the configured timeout for the Java `HttpClient` connect timeout and request timeout when fetching logs over HTTP.
- Increased Nginx upstream timeouts in `nginx/default.conf` and `nginx/default.http.conf` (`proxy_connect_timeout` → `15s`, `proxy_send_timeout`/`proxy_read_timeout` → `180s`).

### Testing
- Ran `mvn test` in the `mcp-server` module and the test suite completed successfully.
- Unit tests including updated `MetaToolsServiceTest` compiled and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80105a1c08321827ca8251d9f5cc9)