### PR TITLE
fix(mois): isolar testes de coleta usando workspaceId único

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -28,3 +28,8 @@
   - hidratar estado por workspace/status (`hydrateCollectionState`);
   - hidratar estado por job (`hydrateCollectionStateByJob`).
 - Serialização JSON ajustada com descoberta automática de módulos Jackson para suportar `Instant` no payload de persistência.
+
+## 2026-05-03 23:36:48 UTC-3
+- Ajustados os testes unitários `MoisDomainServiceTest` para evitar flakiness causado por estado persistido de coletas do mesmo `workspaceId` entre execuções.
+- Nos cenários de listagem de jobs e sumário operacional, os `workspaceId` agora são gerados com sufixo UUID por teste, garantindo isolamento sem depender de limpeza externa.
+- Resultado esperado: os asserts de cardinalidade (`totalJobs` e tamanho da lista) voltam a refletir apenas os dados criados no próprio teste.

--- a/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
+++ b/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
@@ -246,9 +246,10 @@ class MoisDomainServiceTest {
 
     @Test
     void shouldCreateAndListCollectionJobsInMoisModule() {
+        String workspaceId = "workspace-001-" + java.util.UUID.randomUUID();
         MoisWorkspaceDtos.CollectionJobResponse created = service.createCollectionJob(
                 new MoisWorkspaceDtos.CreateCollectionJobRequest(
-                        "workspace-001",
+                        workspaceId,
                         "nutricao",
                         "perda de gordura",
                         List.of("CLICKBANK", "JVZOO"),
@@ -260,11 +261,11 @@ class MoisDomainServiceTest {
                 )
         );
 
-        MoisWorkspaceDtos.CollectionJobListResponse jobs = service.listCollectionJobs("workspace-001", "COMPLETED");
+        MoisWorkspaceDtos.CollectionJobListResponse jobs = service.listCollectionJobs(workspaceId, "COMPLETED");
 
         assertThat(created.jobId()).startsWith("mois-collect-");
         assertThat(jobs.items()).hasSize(1);
-        assertThat(jobs.items().getFirst().workspaceId()).isEqualTo("workspace-001");
+        assertThat(jobs.items().getFirst().workspaceId()).isEqualTo(workspaceId);
         assertThat(created.status()).isEqualTo("COMPLETED");
     }
 
@@ -393,9 +394,10 @@ class MoisDomainServiceTest {
 
     @Test
     void shouldExposeCollectionOpsSummaryWithRetriesAndLatency() {
+        String workspaceId = "workspace-ops-" + java.util.UUID.randomUUID();
         service.createCollectionJob(
                 new MoisWorkspaceDtos.CreateCollectionJobRequest(
-                        "workspace-ops",
+                        workspaceId,
                         "nutricao",
                         "perda de gordura",
                         List.of("META_AD_LIBRARY", "CLICKBANK"),
@@ -407,8 +409,8 @@ class MoisDomainServiceTest {
                 )
         );
 
-        MoisWorkspaceDtos.CollectionOpsSummaryResponse summary = service.getCollectionOpsSummary("workspace-ops");
-        assertThat(summary.workspaceId()).isEqualTo("workspace-ops");
+        MoisWorkspaceDtos.CollectionOpsSummaryResponse summary = service.getCollectionOpsSummary(workspaceId);
+        assertThat(summary.workspaceId()).isEqualTo(workspaceId);
         assertThat(summary.totalJobs()).isEqualTo(1);
         assertThat(summary.completedJobs()).isEqualTo(1);
         assertThat(summary.totalRetries()).isGreaterThanOrEqualTo(1);


### PR DESCRIPTION
### Motivation
- Corrigir flakiness em testes de coleção causado por estado persistido/hidratado entre execuções que gerava resultados adicionais nas listagens.
- Garantir isolamento dos testes de coleção criando `workspaceId` únicos por teste para evitar dependência de limpeza externa.
- Documentar a alteração no registro de operação do módulo MOIS conforme política append-only e fuso UTC-3.

### Description
- Nos testes `shouldCreateAndListCollectionJobsInMoisModule` e `shouldExposeCollectionOpsSummaryWithRetriesAndLatency` de `MoisDomainServiceTest` os `workspaceId` fixos foram substituídos por IDs gerados dinamicamente com sufixo `UUID` e asserções atualizadas para usar a variável `workspaceId`.
- Ajustada a chamada de listagem para usar `service.listCollectionJobs(workspaceId, ...)` e a verificação do sumário para `service.getCollectionOpsSummary(workspaceId)` para garantir escopo por teste.
- Acrescentada entrada em `docs/mois/registros.md` (append-only) explicando a motivação e a mudança, com data/hora em UTC-3.

### Testing
- Executado `mvn test -Dtest=MoisDomainServiceTest` e todos os testes da classe passaram com sucesso (`15 tests, 0 failures`).
- Os ajustes estabilizam asserções de cardinalidade relacionadas a jobs de coleção quando o estado de coleta pode ser hidratado do backend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80617415c83218699601dbabfed9d)