### PR TITLE
Improve MCP log fetch resilience to prevent repeated timeouts

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -104,7 +104,7 @@ O `docker-compose.yml` deste diretório sobe dois containers:
 - `mcp-server` (interno, exposto apenas na rede Docker em `8096`);
 - `nginx` (público, escutando na porta `80` e fazendo proxy para o MCP).
 
-O compose aguarda o health-check do `mcp-server` (`/actuator/health`) antes de subir o Nginx, reduzindo erros de timeout durante boot.
+O compose aguarda o health-check de liveness do `mcp-server` (`/actuator/health/liveness`) antes de subir o Nginx, evitando bloquear o proxy quando apenas a conectividade com banco estiver degradada.
 
 ### Tolerância a indisponibilidade temporária do banco
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -51,6 +51,8 @@ O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou
 - `MCP_LOG_LEAD_PORTAL_PAYMENT_PATH` (default `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`);
 - `MCP_LOG_MDS_PATH` (default `http://177.153.62.107:8091/actuator/logfile`);
 - `MCP_LOG_MOIS_PATH` (default `http://177.153.62.107:8094/manage/logfile`).
+- `MCP_LOG_FETCH_TIMEOUT_SECONDS` (default `45`);
+- `MCP_LOG_HTTP_TAIL_RANGE_BYTES` (default `262144`), usado para enviar `Range: bytes=-N` nas leituras HTTP de logs e reduzir timeout em arquivos grandes.
 
 > Em produção, configure explicitamente os `MCP_LOG_*_PATH` via variáveis de ambiente (arquivo `.env` do host) para apontar para o destino de log aprovado.
 

--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     expose:
       - "8096"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8096/actuator/health >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8096/actuator/health/liveness >/dev/null || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 8

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -29,7 +29,8 @@ public record McpProperties(
             @NotBlank String mdsPath,
             @NotBlank String moisPath,
             @Positive int fetchTimeoutSeconds,
-            @Positive int maxLines
+            @Positive int maxLines,
+            @Positive int httpTailRangeBytes
     ) {
     }
 

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -26,10 +26,12 @@ public class ModuleLogService {
     private final McpProperties properties;
     private final HttpClient httpClient;
     private final Duration logFetchTimeout;
+    private final long httpTailRangeBytes;
 
     public ModuleLogService(McpProperties properties) {
         this.properties = properties;
         this.logFetchTimeout = Duration.ofSeconds(properties.logs().fetchTimeoutSeconds());
+        this.httpTailRangeBytes = properties.logs().httpTailRangeBytes();
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(logFetchTimeout)
                 .build();
@@ -88,6 +90,7 @@ public class ModuleLogService {
 
         HttpRequest request = HttpRequest.newBuilder(URI.create(configuredUrl))
                 .timeout(logFetchTimeout)
+                .header("Range", "bytes=-" + httpTailRangeBytes)
                 .GET()
                 .build();
 

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
       minimum-idle: ${DB_MIN_IDLE:0}
 
 management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
   endpoints:
     web:
       exposure:

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -37,6 +37,7 @@ mcp:
     mois-path: ${MCP_LOG_MOIS_PATH:http://177.153.62.107:8094/manage/logfile}
     fetch-timeout-seconds: ${MCP_LOG_FETCH_TIMEOUT_SECONDS:45}
     max-lines: ${MCP_LOG_MAX_LINES:500}
+    http-tail-range-bytes: ${MCP_LOG_HTTP_TAIL_RANGE_BYTES:262144}
   meta:
     enabled: ${MCP_META_ENABLED:true}
     graph-base-url: ${MCP_META_GRAPH_BASE_URL:https://graph.facebook.com}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -32,7 +32,7 @@ class MetaToolsServiceTest {
                 "marketing-hub-mcp",
                 "1.0.0",
                 null,
-                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", 45, 500),
+                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", 45, 500, 262144),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",


### PR DESCRIPTION
### Motivation
- Remote log endpoints (e.g. `/logfile`) can grow very large and fetching the full body causes long blocking reads and timeouts when the `/mcp` tool `java_module_logs` requests them. 
- The change aims to make HTTP log reads resilient by fetching only the tail portion of the remote file to reduce latency and avoid repeated timeouts.

### Description
- Add a typed `httpTailRangeBytes` field to `McpProperties.Logs` and expose it via `mcp.logs.httpTailRangeBytes` (env `MCP_LOG_HTTP_TAIL_RANGE_BYTES`) with a default of `262144` bytes in `application.yml`.
- Update `ModuleLogService` to send an HTTP header `Range: bytes=-N` when reading logs over HTTP, using the configured `httpTailRangeBytes` to limit the transferred payload.
- Update `README.md` to document the new `MCP_LOG_HTTP_TAIL_RANGE_BYTES` configuration and the behavior for HTTP log reads.
- Adjust unit tests that instantiate `McpProperties.Logs` to include the new constructor field so the test suite stays consistent with the updated record signature.

### Testing
- Ran `mvn test -q` after the initial change, which failed compilation because tests needed the new `Logs` parameter; tests were updated accordingly.
- Re-ran `mvn test -q` after updating the tests and the suite completed successfully (all automated unit tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80a1e4080832192f72568f9d2d62e)