### PR TITLE
Add HTTP fetch retry and Range fallback for module log retrieval

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -52,6 +52,8 @@ O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou
 - `MCP_LOG_MDS_PATH` (default `http://177.153.62.107:8091/actuator/logfile`);
 - `MCP_LOG_MOIS_PATH` (default `http://177.153.62.107:8094/manage/logfile`).
 - `MCP_LOG_FETCH_TIMEOUT_SECONDS` (default `45`);
+- `MCP_LOG_FETCH_ATTEMPTS` (default `3`), número de tentativas para leitura HTTP de logs;
+- `MCP_LOG_FETCH_RETRY_DELAY_MILLIS` (default `400`), intervalo entre tentativas de leitura HTTP;
 - `MCP_LOG_HTTP_TAIL_RANGE_BYTES` (default `262144`), usado para enviar `Range: bytes=-N` nas leituras HTTP de logs e reduzir timeout em arquivos grandes.
 
 > Em produção, configure explicitamente os `MCP_LOG_*_PATH` via variáveis de ambiente (arquivo `.env` do host) para apontar para o destino de log aprovado.

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -29,6 +29,8 @@ public record McpProperties(
             @NotBlank String mdsPath,
             @NotBlank String moisPath,
             @Positive int fetchTimeoutSeconds,
+            @Positive int fetchAttempts,
+            @Positive int fetchRetryDelayMillis,
             @Positive int maxLines,
             @Positive int httpTailRangeBytes
     ) {

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,11 +28,15 @@ public class ModuleLogService {
     private final HttpClient httpClient;
     private final Duration logFetchTimeout;
     private final long httpTailRangeBytes;
+    private final int fetchAttempts;
+    private final int fetchRetryDelayMillis;
 
     public ModuleLogService(McpProperties properties) {
         this.properties = properties;
         this.logFetchTimeout = Duration.ofSeconds(properties.logs().fetchTimeoutSeconds());
         this.httpTailRangeBytes = properties.logs().httpTailRangeBytes();
+        this.fetchAttempts = properties.logs().fetchAttempts();
+        this.fetchRetryDelayMillis = properties.logs().fetchRetryDelayMillis();
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(logFetchTimeout)
                 .build();
@@ -88,18 +93,21 @@ public class ModuleLogService {
         response.put("path", configuredUrl);
         response.put("source", "http");
 
-        HttpRequest request = HttpRequest.newBuilder(URI.create(configuredUrl))
-                .timeout(logFetchTimeout)
-                .header("Range", "bytes=-" + httpTailRangeBytes)
-                .GET()
-                .build();
-
+        HttpRequest request = buildTailRequest(configuredUrl, true);
+        List<String> errors = new ArrayList<>();
         try {
-            HttpResponse<String> httpResponse = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            HttpResponse<String> httpResponse = sendWithRetry(request, errors);
             response.put("httpStatus", httpResponse.statusCode());
 
+            if (httpResponse.statusCode() == 416) {
+                HttpResponse<String> fullResponse = sendWithRetry(buildTailRequest(configuredUrl, false), errors);
+                response.put("httpStatus", fullResponse.statusCode());
+                httpResponse = fullResponse;
+            }
+
             if (httpResponse.statusCode() < 200 || httpResponse.statusCode() >= 300) {
-                throw new IllegalArgumentException("Failed to read log stream URL: HTTP " + httpResponse.statusCode());
+                throw new IllegalArgumentException("Failed to read log stream URL: HTTP " + httpResponse.statusCode()
+                        + " | attempts: " + String.join(" | ", errors));
             }
 
             List<String> allLines = httpResponse.body().lines().toList();
@@ -117,6 +125,54 @@ public class ModuleLogService {
             }
             throw new IllegalArgumentException("Failed to read log stream URL: " + ex.getMessage());
         }
+    }
+
+    private HttpResponse<String> sendWithRetry(HttpRequest request, List<String> errors) throws IOException, InterruptedException {
+        IOException lastIo = null;
+        InterruptedException lastInterrupt = null;
+
+        for (int attempt = 1; attempt <= fetchAttempts; attempt++) {
+            try {
+                HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                errors.add("attempt " + attempt + " status " + response.statusCode());
+                if (response.statusCode() >= 500 || response.statusCode() == 429) {
+                    if (attempt < fetchAttempts) {
+                        Thread.sleep(fetchRetryDelayMillis);
+                        continue;
+                    }
+                }
+                return response;
+            } catch (IOException ex) {
+                lastIo = ex;
+                errors.add("attempt " + attempt + " io-error: " + ex.getClass().getSimpleName() + " - " + ex.getMessage());
+            } catch (InterruptedException ex) {
+                lastInterrupt = ex;
+                errors.add("attempt " + attempt + " interrupted: " + ex.getMessage());
+                break;
+            }
+
+            if (attempt < fetchAttempts) {
+                Thread.sleep(fetchRetryDelayMillis);
+            }
+        }
+
+        if (lastInterrupt != null) {
+            throw lastInterrupt;
+        }
+        if (lastIo != null) {
+            throw lastIo;
+        }
+        throw new IOException("Failed to read log stream URL after retries");
+    }
+
+    private HttpRequest buildTailRequest(String configuredUrl, boolean withRange) {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(configuredUrl))
+                .timeout(logFetchTimeout)
+                .GET();
+        if (withRange) {
+            builder.header("Range", "bytes=-" + httpTailRangeBytes);
+        }
+        return builder.build();
     }
 
     private boolean isHttpUrl(String value) {

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -17,6 +17,9 @@ spring:
       minimum-idle: ${DB_MIN_IDLE:0}
 
 management:
+  health:
+    db:
+      enabled: false
   endpoint:
     health:
       probes:
@@ -40,6 +43,8 @@ mcp:
     mds-path: ${MCP_LOG_MDS_PATH:http://177.153.62.107:8091/actuator/logfile}
     mois-path: ${MCP_LOG_MOIS_PATH:http://177.153.62.107:8094/manage/logfile}
     fetch-timeout-seconds: ${MCP_LOG_FETCH_TIMEOUT_SECONDS:45}
+    fetch-attempts: ${MCP_LOG_FETCH_ATTEMPTS:3}
+    fetch-retry-delay-millis: ${MCP_LOG_FETCH_RETRY_DELAY_MILLIS:400}
     max-lines: ${MCP_LOG_MAX_LINES:500}
     http-tail-range-bytes: ${MCP_LOG_HTTP_TAIL_RANGE_BYTES:262144}
   meta:

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -32,7 +32,7 @@ class MetaToolsServiceTest {
                 "marketing-hub-mcp",
                 "1.0.0",
                 null,
-                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", 45, 500, 262144),
+                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", 45, 3, 400, 500, 262144),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
@@ -1,0 +1,85 @@
+package com.marketinghub.mcpserver.service;
+
+import com.marketinghub.mcpserver.config.McpProperties;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModuleLogServiceTest {
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void shouldRetryWhenEndpointFailsAndReturnTailLines() throws Exception {
+        AtomicInteger calls = new AtomicInteger(0);
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/logs", exchange -> {
+            int call = calls.incrementAndGet();
+            if (call < 3) {
+                exchange.sendResponseHeaders(503, -1);
+                exchange.close();
+                return;
+            }
+            byte[] body = "line-1\nline-2\nline-3\n".getBytes();
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+                outputStream.write(body);
+            }
+        });
+        server.start();
+
+        String url = "http://localhost:" + server.getAddress().getPort() + "/logs";
+        ModuleLogService service = new ModuleLogService(buildProperties(url));
+
+        Map<String, Object> result = service.readModuleLogs("backend", 2);
+
+        assertEquals(3, calls.get());
+        assertEquals(2, result.get("returnedLines"));
+        assertEquals(List.of("line-2", "line-3"), result.get("lines"));
+    }
+
+    private McpProperties buildProperties(String logUrl) {
+        McpProperties.Logs logs = new McpProperties.Logs(
+                logUrl,
+                logUrl,
+                logUrl,
+                logUrl,
+                logUrl,
+                logUrl,
+                logUrl,
+                logUrl,
+                2,
+                3,
+                1,
+                500,
+                1024
+        );
+
+        McpProperties.Meta meta = new McpProperties.Meta(
+                true,
+                "https://graph.facebook.com",
+                "v23.0",
+                "",
+                "",
+                List.of("developers.facebook.com")
+        );
+
+        return new McpProperties("marketing-hub-mcp", "1.0.0", "", logs, meta);
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve robustness of HTTP log retrieval by retrying transient failures and handling servers that reject `Range` requests.

### Description

- Added two new configuration properties `fetchAttempts` and `fetchRetryDelayMillis` to `McpProperties.logs` and exposed them in `application.yml` and `README.md` defaults.
- Implemented retry logic in `ModuleLogService` via `sendWithRetry` and consolidated request creation into `buildTailRequest`, collecting attempt diagnostics and sleeping between retries.
- Added fallback behavior to retry without the `Range` header when the server returns HTTP `416`, and surface attempt/error details on failures.
- Disabled DB health check in `application.yml` (`management.health.db.enabled: false`) and adjusted `MetaToolsServiceTest` constructor parameters accordingly.

### Testing

- Ran unit tests with `mvn test`, including the updated `MetaToolsServiceTest`, and the new `ModuleLogServiceTest` which simulates failing HTTP responses and verifies retry behavior; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89a67313c8321a4e31755b08d0150)