### PR TITLE
Use UUID idJob in GeraLandingStageExecutionDto and update GeraLandingExecutionService flow

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -51,11 +51,10 @@ public class GeraLandingExecutionService {
                     execution.stageCode(),
                     null,
                     null,
-                    execution.promptContent(),
+                    "{}",
                     Instant.now());
-            String promptMontado = geraLandingService.montarERegistrarPromptEtapa(job, normalizedStage, execution.idJob());
-            UUID idJob = UUID.fromString(execution.idJob());
-            backendClient.receivePrompt(idJob, execution.experimentId(), execution.stageCode(), promptMontado);
+            String promptMontado = geraLandingService.montarERegistrarPromptEtapa(job, normalizedStage, execution.idJob() != null ? execution.idJob().toString() : null);
+            backendClient.receivePrompt(execution.idJob(), execution.experimentId(), execution.stageCode(), promptMontado);
             log.info("Prompt de gera-landing wireframe montado para executionId={} (experimentId={})",
                     execution.idJob(), execution.experimentId());
         } catch (Exception ex) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingStageExecutionDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingStageExecutionDto.java
@@ -1,16 +1,10 @@
 package com.marketinghub.worker.geralanding;
 
-import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record GeraLandingStageExecutionDto(
         Long experimentId,
-        String stageCode,
-        LocalDateTime executionRequestedAt,
-        String promptTemplateId,
-        String promptContent,
-        String status,
-        String idJob,
-        LocalDateTime createdAt,
-        LocalDateTime processingStartedAt,
-        LocalDateTime completedAt) {
+        UUID idJob,
+        String stageCode
+) {
 }


### PR DESCRIPTION
### Motivation

- Simplify the execution DTO to carry only the data required by the worker and switch `idJob` to a `UUID` to avoid string parsing and potential format errors.
- Ensure prompt assembly and delivery use the new `UUID` typed `idJob` and avoid relying on `promptContent` coming from the DTO.

### Description

- Reduced `GeraLandingStageExecutionDto` to `experimentId`, `idJob` (as `UUID`) and `stageCode`, removing multiple timestamp and status fields.
- Updated `GeraLandingExecutionService.processExecution` to accept the `UUID` `idJob` directly, to construct `ExperimentPipelineJobDto` with a default prompt content of `"{}"`, and to pass the `idJob` string (when present) into `montarERegistrarPromptEtapa` while passing the `UUID` into `backendClient.receivePrompt`.
- Normalized stage handling and preserved existing wireframe-only processing and logging, and removed now-unused imports/fields.

### Testing

- Ran the project test suite with `./mvnw test` and the build with `./mvnw package`, and the automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f899207c1083219b9337f0f83a0afe)