### PR TITLE
Add logging context to montarPromptEtapa in AI Worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
@@ -20,6 +20,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -27,6 +29,8 @@ import org.springframework.core.io.ClassPathResource;
 
 @Service
 public class GeraLandingService {
+
+    private static final Logger log = LoggerFactory.getLogger(GeraLandingService.class);
 
     private static final String GERALANDING_PROMPT_BASE_PATH = "prompts/geralanding/";
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\{(prompt|dados)-([a-zA-Z0-9_-]+)}");
@@ -69,6 +73,11 @@ public class GeraLandingService {
         if (!StringUtils.hasText(etapa)) {
             throw new IllegalArgumentException("Nome da etapa é obrigatório");
         }
+        log.info(
+                "Montando prompt da etapa. experimentoId={}, jobId={}, etapa={}",
+                job != null ? job.experimentId() : null,
+                job != null ? job.id() : null,
+                etapa);
         String template = carregarPromptBase(etapa.trim() + ".md");
         Map<String, Object> dadosPayload = obterDadosDoJob(job);
         return resolverPlaceholders(template, dadosPayload);


### PR DESCRIPTION
### Motivation
- Provide operational traceability and easier debugging when assembling prompts by recording which experiment, job and etapa are being processed before prompt resolution. 

### Description
- Added an `slf4j` `Logger` to `GeraLandingService` and imported `Logger`/`LoggerFactory` to the class. 
- Inserted an `info` log call at the start of `montarPromptEtapa` that logs `experimentoId`, `jobId` and `etapa` prior to loading and resolving the prompt template. 
- Change is located in `ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java` and only affects prompt-assembly observability. 

### Testing
- Attempted to run `mvn -q -Dtest=GeraLandingServiceTest test` in `ai-worker`, but `./mvnw` was not present so the wrapper invocation failed. 
- Running `mvn -q -Dtest=GeraLandingServiceTest test` ran but could not complete the build due to an external dependency resolution error (`401 Unauthorized` when resolving `com.marketinghub:ads-service` from the GitHub Packages repository), so unit tests could not be executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a01db0a083219a9077b1c37e9522)