### PR TITLE
Persist collected references and add source-highlight aggregation endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisCollectionPersistenceDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisCollectionPersistenceDtos.java
@@ -27,4 +27,19 @@ public final class MoisCollectionPersistenceDtos {
 
     public record CollectionJobStateListResponse(List<CollectionJobStateResponse> items) {
     }
+
+    public record SourceHighlightResponse(
+            String source,
+            int totalReferences,
+            double averageSuccessScore,
+            double averageEngagementRelative,
+            double averageRecurrenceScore,
+            double averageEvidenceScore,
+            int favorites,
+            String topSuccessSignal
+    ) {
+    }
+
+    public record SourceHighlightListResponse(List<SourceHighlightResponse> items) {
+    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
@@ -6,7 +6,10 @@ import com.marketinghub.mois.dto.MoisCollectionPersistenceDtos;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -47,6 +50,7 @@ public class MoisCollectionPersistenceService {
                 writeState(state),
                 Timestamp.from(Instant.now())
         );
+        persistCollectedReferences(jobId, workspaceId, state.references());
 
         return state;
     }
@@ -98,5 +102,91 @@ public class MoisCollectionPersistenceService {
         } catch (JsonProcessingException ex) {
             throw new IllegalStateException("Falha ao desserializar estado de coleta MOIS", ex);
         }
+    }
+
+    private void persistCollectedReferences(
+            String jobId,
+            String workspaceId,
+            List<com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse> references
+    ) {
+        jdbcTemplate.update("DELETE FROM mois_collected_reference WHERE job_id = ?", jobId);
+        if (references == null || references.isEmpty()) {
+            return;
+        }
+        jdbcTemplate.batchUpdate(
+                """
+                        INSERT INTO mois_collected_reference (
+                          job_id, workspace_id, reference_id, source, title, url, niche, status, favorite,
+                          imported_reference_id, success_score, success_signal, confidence_level, ranking_position,
+                          engagement_relative, recurrence_score, evidence_score, collected_at, updated_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                references,
+                references.size(),
+                (ps, item) -> {
+                    ps.setString(1, jobId);
+                    ps.setString(2, workspaceId);
+                    ps.setString(3, item.referenceId());
+                    ps.setString(4, item.source());
+                    ps.setString(5, item.title());
+                    ps.setString(6, item.url());
+                    ps.setString(7, item.niche());
+                    ps.setString(8, item.status());
+                    ps.setBoolean(9, item.favorite());
+                    ps.setString(10, item.importedReferenceId());
+                    ps.setInt(11, item.successScore());
+                    ps.setString(12, item.successSignal());
+                    ps.setString(13, item.confidenceLevel());
+                    ps.setInt(14, item.rankingPosition());
+                    ps.setDouble(15, item.engagementRelative());
+                    ps.setDouble(16, item.recurrenceScore());
+                    ps.setDouble(17, item.evidenceScore());
+                    ps.setTimestamp(18, item.collectedAt() == null ? null : Timestamp.from(item.collectedAt()));
+                    ps.setTimestamp(19, Timestamp.from(Instant.now()));
+                }
+        );
+    }
+
+    public MoisCollectionPersistenceDtos.SourceHighlightListResponse summarizeBySource(String workspaceId, String status) {
+        List<MoisCollectionPersistenceDtos.CollectionJobStateResponse> states = listJobStates(workspaceId, status).items();
+        Map<String, List<com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse>> bySource = new HashMap<>();
+        for (MoisCollectionPersistenceDtos.CollectionJobStateResponse state : states) {
+            if (state.references() == null) {
+                continue;
+            }
+            for (com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse reference : state.references()) {
+                bySource.computeIfAbsent(reference.source() == null ? "UNKNOWN" : reference.source(), key -> new ArrayList<>())
+                        .add(reference);
+            }
+        }
+        List<MoisCollectionPersistenceDtos.SourceHighlightResponse> items = bySource.entrySet().stream()
+                .map(entry -> toSourceHighlight(entry.getKey(), entry.getValue()))
+                .sorted(Comparator.comparing(MoisCollectionPersistenceDtos.SourceHighlightResponse::averageSuccessScore).reversed())
+                .toList();
+        return new MoisCollectionPersistenceDtos.SourceHighlightListResponse(items);
+    }
+
+    private MoisCollectionPersistenceDtos.SourceHighlightResponse toSourceHighlight(
+            String source,
+            List<com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse> references
+    ) {
+        int total = references.size();
+        int favorites = (int) references.stream().filter(com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse::favorite).count();
+        double avgSuccess = references.stream().mapToInt(com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse::successScore).average().orElse(0);
+        double avgEngagement = references.stream().mapToDouble(com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse::engagementRelative).average().orElse(0);
+        double avgRecurrence = references.stream().mapToDouble(com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse::recurrenceScore).average().orElse(0);
+        double avgEvidence = references.stream().mapToDouble(com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse::evidenceScore).average().orElse(0);
+        String topSignal = references.stream()
+                .filter(r -> r.successSignal() != null && !r.successSignal().isBlank())
+                .collect(java.util.stream.Collectors.groupingBy(
+                        com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse::successSignal,
+                        java.util.stream.Collectors.counting()))
+                .entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse("N/A");
+        return new MoisCollectionPersistenceDtos.SourceHighlightResponse(
+                source, total, avgSuccess, avgEngagement, avgRecurrence, avgEvidence, favorites, topSignal
+        );
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisCollectionPersistenceController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisCollectionPersistenceController.java
@@ -43,4 +43,12 @@ public class MoisCollectionPersistenceController {
     ) {
         return service.listJobStates(workspaceId, status);
     }
+
+    @GetMapping("/collection-highlights/by-source")
+    public MoisCollectionPersistenceDtos.SourceHighlightListResponse listSourceHighlights(
+            @RequestParam(required = false) String workspaceId,
+            @RequestParam(required = false) String status
+    ) {
+        return service.summarizeBySource(workspaceId, status);
+    }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-04-mois-collected-reference-persistence.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-04-mois-collected-reference-persistence.yaml
@@ -1,0 +1,44 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-04-mois-collected-reference-persistence
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: mois_collected_reference
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_collected_reference (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                job_id VARCHAR(80) NOT NULL,
+                workspace_id VARCHAR(80) NULL,
+                reference_id VARCHAR(80) NOT NULL,
+                source VARCHAR(64) NULL,
+                title VARCHAR(512) NULL,
+                url VARCHAR(1024) NULL,
+                niche VARCHAR(255) NULL,
+                status VARCHAR(32) NULL,
+                favorite BIT(1) NOT NULL DEFAULT b'0',
+                imported_reference_id VARCHAR(80) NULL,
+                success_score INT NOT NULL,
+                success_signal VARCHAR(255) NULL,
+                confidence_level VARCHAR(32) NULL,
+                ranking_position INT NOT NULL,
+                engagement_relative DECIMAL(8,4) NOT NULL,
+                recurrence_score DECIMAL(8,4) NOT NULL,
+                evidence_score DECIMAL(8,4) NOT NULL,
+                collected_at TIMESTAMP NULL,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_mois_collected_reference_job_reference (job_id, reference_id),
+                KEY idx_mois_collected_reference_workspace_source (workspace_id, source),
+                KEY idx_mois_collected_reference_workspace_score (workspace_id, success_score),
+                KEY idx_mois_collected_reference_collected_at (collected_at)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -16,6 +16,8 @@ databaseChangeLog:
       relativeToChangelogFile: true
   - include:
       file: changesets/2026-04-28-mois-collection-job-state-persistence.yaml
+  - include:
+      file: changesets/2026-05-04-mois-collected-reference-persistence.yaml
       relativeToChangelogFile: true
   - include:
       file: V2037_04_26__widen_experiment_pipeline_job_section_mysql5.sql

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisCollectionPersistenceServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisCollectionPersistenceServiceTest.java
@@ -6,12 +6,14 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.mois.dto.MoisCollectionPersistenceDtos;
 import com.marketinghub.mois.dto.MoisWorkspaceDtos;
 import java.time.Instant;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.ParameterizedPreparedStatementSetter;
 import org.springframework.jdbc.core.RowMapper;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,6 +38,7 @@ class MoisCollectionPersistenceServiceTest {
     }
 
     @Test
+    @DisplayName("upsert persiste estado consolidado e sincroniza referências relacionais")
     void upsertJobStatePersistsPayloadInDatabase() {
         MoisCollectionPersistenceDtos.CollectionJobStateResponse state = sampleState("workspace-001", "COMPLETED");
 
@@ -42,6 +46,8 @@ class MoisCollectionPersistenceServiceTest {
 
         assertThat(response).isEqualTo(state);
         verify(jdbcTemplate).update(anyString(), eq("job-1"), eq("workspace-001"), eq("COMPLETED"), anyString(), any());
+        verify(jdbcTemplate).update("DELETE FROM mois_collected_reference WHERE job_id = ?", "job-1");
+        verify(jdbcTemplate, never()).batchUpdate(anyString(), eq(List.of()), eq(0), any(ParameterizedPreparedStatementSetter.class));
     }
 
     @SuppressWarnings("unchecked")
@@ -71,6 +77,43 @@ class MoisCollectionPersistenceServiceTest {
         verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class), any(Object[].class));
         assertThat(sqlCaptor.getValue()).contains("workspace_id = ?");
         assertThat(sqlCaptor.getValue()).contains("status = ?");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("sumário por fonte agrega referências e ordena por score médio")
+    void summarizeBySourceAggregatesReferences() throws Exception {
+        MoisWorkspaceDtos.CollectedReferenceResponse hotmartRef1 = new MoisWorkspaceDtos.CollectedReferenceResponse(
+                "ref-1", "job-1", "HOTMART", "Oferta A", "https://x", "niche", "COLLECTED",
+                true, null, 90, "Alto ROI", "HIGH", 1, 0.8, 0.7, 0.6, Instant.parse("2026-05-04T01:00:00Z"), java.util.Map.of());
+        MoisWorkspaceDtos.CollectedReferenceResponse hotmartRef2 = new MoisWorkspaceDtos.CollectedReferenceResponse(
+                "ref-2", "job-1", "HOTMART", "Oferta B", "https://y", "niche", "COLLECTED",
+                false, null, 80, "Alto ROI", "MEDIUM", 2, 0.6, 0.5, 0.4, Instant.parse("2026-05-04T01:10:00Z"), java.util.Map.of());
+        MoisWorkspaceDtos.CollectedReferenceResponse metaRef = new MoisWorkspaceDtos.CollectedReferenceResponse(
+                "ref-3", "job-2", "META", "Oferta C", "https://z", "niche", "COLLECTED",
+                false, null, 60, "CTR forte", "MEDIUM", 1, 0.4, 0.3, 0.2, Instant.parse("2026-05-04T01:20:00Z"), java.util.Map.of());
+        MoisCollectionPersistenceDtos.CollectionJobStateResponse state = new MoisCollectionPersistenceDtos.CollectionJobStateResponse(
+                sampleState("workspace-001", "COMPLETED").job(),
+                List.of(hotmartRef1, hotmartRef2, metaRef),
+                java.util.Map.of(),
+                null,
+                List.of()
+        );
+        String payload = new ObjectMapper().findAndRegisterModules().writeValueAsString(state);
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class))).thenAnswer(invocation -> {
+            RowMapper<MoisCollectionPersistenceDtos.CollectionJobStateResponse> mapper = invocation.getArgument(1);
+            java.sql.ResultSet rs = org.mockito.Mockito.mock(java.sql.ResultSet.class);
+            when(rs.getString("payload_json")).thenReturn(payload);
+            return List.of(mapper.mapRow(rs, 0));
+        });
+
+        MoisCollectionPersistenceDtos.SourceHighlightListResponse response = service.summarizeBySource("workspace-001", "COMPLETED");
+
+        assertThat(response.items()).hasSize(2);
+        assertThat(response.items().get(0).source()).isEqualTo("HOTMART");
+        assertThat(response.items().get(0).totalReferences()).isEqualTo(2);
+        assertThat(response.items().get(0).topSuccessSignal()).isEqualTo("Alto ROI");
+        assertThat(response.items().get(0).favorites()).isEqualTo(1);
     }
 
     private MoisCollectionPersistenceDtos.CollectionJobStateResponse sampleState(String workspaceId, String status) {

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -141,6 +141,8 @@ Regras operacionais associadas:
 - o agendamento diário usa o contrato já existente de `collection-jobs` do MOIS, com filtro de temperatura via `minSuccessScore` configurável;
 - cada tentativa do robô deve ser persistida (sucesso ou falha) para auditoria operacional e rastreabilidade de execução.
 - o estado consolidado de cada `collection-job` (job, referências, lineage e runtime) deve ser persistido no backend principal em `mois_collection_job_state`, eliminando dependência de memória volátil no serviço de persistência.
+- as referências coletadas por entidade devem ser persistidas relacionalmente em `mois_collected_reference` com chave única (`job_id`, `reference_id`) para consulta histórica por fonte e workspace.
+- o backend disponibiliza agregação executiva de destaques por fonte via `GET /api/v1/mois/persistence/collection-highlights/by-source` a partir dos estados persistidos dos jobs.
 
 ## Atualização incremental — MDS Sprint 1 (orquestração e persistência base)
 

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -33,3 +33,10 @@
 - Ajustados os testes unitários `MoisDomainServiceTest` para evitar flakiness causado por estado persistido de coletas do mesmo `workspaceId` entre execuções.
 - Nos cenários de listagem de jobs e sumário operacional, os `workspaceId` agora são gerados com sufixo UUID por teste, garantindo isolamento sem depender de limpeza externa.
 - Resultado esperado: os asserts de cardinalidade (`totalJobs` e tamanho da lista) voltam a refletir apenas os dados criados no próprio teste.
+
+## 2026-05-04 10:40:00 UTC-3
+- Endurecida a entrega de persistência MOIS com cobertura de testes unitários no backend (`MoisCollectionPersistenceServiceTest`).
+- Validado via testes o comportamento de:
+  - sincronização relacional por job em `mois_collected_reference` (delete + batch insert);
+  - agregação executiva de destaques por fonte (`collection-highlights/by-source`) com ordenação por score médio e cálculo de sinal predominante.
+- Registro operacional para rastrear revisão da PR "Persist collected references and add source-highlight aggregation endpoint" após feedback de qualidade.


### PR DESCRIPTION
### Motivation

- Persist collected references relationally for auditability and efficient queries by `job_id` and `workspace_id` instead of keeping them only inside serialized job state.
- Provide an executive aggregation over collected references to surface highlights per source (e.g. average success score, top success signal) for operational reporting.
- Ensure the new persistence and aggregation behavior are covered by unit tests to avoid regressions.

### Description

- Add a new Liquibase changeset `2026-05-04-mois-collected-reference-persistence.yaml` and include it in `db.changelog-master.yaml` to create the `mois_collected_reference` table with appropriate indexes and a unique key on `(job_id, reference_id)`.
- Introduce `SourceHighlightResponse` and `SourceHighlightListResponse` DTO records in `MoisCollectionPersistenceDtos` for the aggregation payload.
- Implement `persistCollectedReferences` in `MoisCollectionPersistenceService` to `DELETE` existing rows for a job and `batchInsert` the job references, and call it from `upsertJobState` after saving the consolidated payload.
- Add `summarizeBySource` and helper `toSourceHighlight` in the service to aggregate persisted job states by `source`, compute averages, favorites and top success signal, and sort results by `averageSuccessScore` descending.
- Expose the aggregation via a controller endpoint `GET /api/v1/mois/persistence/collection-highlights/by-source` wired to `summarizeBySource`.
- Update documentation files to describe the new relational persistence and the highlights endpoint.

### Testing

- Unit tests in `MoisCollectionPersistenceServiceTest` were extended with `upsertJobStatePersistsPayloadInDatabase` to verify the `DELETE` for `mois_collected_reference` is invoked and that no `batchUpdate` is called for an empty references list, and this test passed.
- A new unit test `summarizeBySourceAggregatesReferences` constructs sample `CollectedReferenceResponse` items, exercises `summarizeBySource`, and asserts aggregation, ordering and top signal computation, and this test passed.
- Existing unit tests for `getJobState` and `listJobStates` continue to run and passed as part of the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8adaa530c832187eb1d4029e333b7)