### PR TITLE
fix(liquibase): resolve MOIS changelog include path

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -16,6 +16,7 @@ databaseChangeLog:
       relativeToChangelogFile: true
   - include:
       file: changesets/2026-04-28-mois-collection-job-state-persistence.yaml
+      relativeToChangelogFile: true
   - include:
       file: changesets/2026-05-04-mois-collected-reference-persistence.yaml
       relativeToChangelogFile: true

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -40,3 +40,8 @@
   - sincronização relacional por job em `mois_collected_reference` (delete + batch insert);
   - agregação executiva de destaques por fonte (`collection-highlights/by-source`) com ordenação por score médio e cálculo de sinal predominante.
 - Registro operacional para rastrear revisão da PR "Persist collected references and add source-highlight aggregation endpoint" após feedback de qualidade.
+
+## 2026-05-04 09:55:00 UTC-3
+- Corrigida a resolução de include do Liquibase no `db.changelog-master.yaml` do `backend/ads-service`.
+- O changeset `changesets/2026-04-28-mois-collection-job-state-persistence.yaml` passou a declarar `relativeToChangelogFile: true`, evitando falha de parsing em CI com mensagem de arquivo não encontrado no classpath.
+- Registro criado para rastrear o incidente reportado no build Maven/Liquibase e sua correção.


### PR DESCRIPTION
### Motivation
- Corrigir falha de parsing do Liquibase causada por um `include` que não estava sendo resolvido no classpath, evitando o erro “file was not found in the configured search path”.

### Description
- Adicionado `relativeToChangelogFile: true` ao `include` do changeset `changesets/2026-04-28-mois-collection-job-state-persistence.yaml` em `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` e registrado o ajuste em `docs/mois/registros.md`.

### Testing
- Executado `mvn -q -DskipTests liquibase:validate` em `backend/ads-service`, que não pôde concluir neste ambiente por falta de configuração da URL do banco (`The database URL has not been specified`).
- Executado `mvn -q test -DskipITs` em `backend/ads-service`; a execução rodou mas apresentou falhas já existentes/independentes (`BadSqlGrammarException` em tarefa agendada), sem relação com a correção do include.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d2e815cc8321941622a8a9c3fa8c)