### PR TITLE
GeraLanding: fallback lookup by experiment/stage for prompt receive and client endpoint fix

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingBackendClient.java
@@ -44,12 +44,11 @@ public class GeraLandingBackendClient {
     }
 
     public void receivePrompt(String idJob, Long experimentId, String stageCode, String prompt) {
-        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix,
-                "/internal/geralanding/stage-executions/receive-prompt");
+        String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix,
+                "/internal/geralanding/stage-executions");
         webClient.post()
-                .uri(url)
+                .uri(baseUrl + "/{idJob}/receive-prompt", idJob)
                 .bodyValue(Map.of(
-                        "idJob", idJob,
                         "experimentId", experimentId,
                         "stageCode", stageCode,
                         "prompt", prompt))

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionRepository.java
@@ -8,5 +8,8 @@ import java.util.Optional;
 public interface GeraLandingStageExecutionRepository extends JpaRepository<GeraLandingStageExecution, GeraLandingStageExecutionId> {
     Optional<GeraLandingStageExecution> findTopByIdJobOrderByExecutionRequestedAtDesc(String idJob);
 
+    Optional<GeraLandingStageExecution> findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(Long experimentId,
+                                                                                                           String stageCode);
+
     List<GeraLandingStageExecution> findTop20ByStatusOrderByExecutionRequestedAtAsc(String status);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -77,6 +77,7 @@ public class GeraLandingStageExecutionService {
                 request.prompt() != null ? request.prompt().length() : 0);
 
         GeraLandingStageExecution execution = executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(idJob)
+                .or(() -> fallbackExecutionByExperimentAndStage(request))
                 .orElseThrow(() -> {
                     log.error(
                             "GeraLanding execution not found before prompt persistence. idJob={}, experimentId={}, stageCode={}",
@@ -99,6 +100,17 @@ public class GeraLandingStageExecutionService {
         execution.setStatus("EM_PROCESSAMENTO");
         executionRepository.save(execution);
         log.info("GeraLanding prompt persisted. idJob={}, newStatus={}", idJob, execution.getStatus());
+    }
+
+    private java.util.Optional<GeraLandingStageExecution> fallbackExecutionByExperimentAndStage(
+            GeraLandingPromptReceiveRequest request) {
+        log.warn(
+                "Primary lookup by idJob failed. Trying fallback by experiment/stage. experimentId={}, stageCode={}",
+                request.experimentId(),
+                request.stageCode());
+        return executionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                request.experimentId(),
+                request.stageCode());
     }
 
     @Transactional(readOnly = true)

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -1,0 +1,83 @@
+package com.marketinghub.geralanding;
+
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GeraLandingStageExecutionServiceTest {
+
+    @Mock
+    private ExperimentRepository experimentRepository;
+
+    @Mock
+    private GeraLandingStageExecutionRepository executionRepository;
+
+    @InjectMocks
+    private GeraLandingStageExecutionService service;
+
+    @Test
+    void shouldFallbackToExperimentAndStageWhenLookupByIdJobFails() {
+        GeraLandingPromptReceiveRequest request =
+                new GeraLandingPromptReceiveRequest(19L, "landing-page-wireframe", "prompt final");
+
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(19L)
+                .stageCode("landing-page-wireframe")
+                .executionRequestedAt(Instant.parse("2026-05-04T00:00:00Z"))
+                .createdAt(Instant.parse("2026-05-04T00:00:00Z"))
+                .status("INICIADO")
+                .idJob("real-id-job")
+                .promptContent("prompt base")
+                .build();
+
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc("id-corrompido"))
+                .thenReturn(Optional.empty());
+        when(executionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(19L,
+                "landing-page-wireframe")).thenReturn(Optional.of(execution));
+
+        service.receivePrompt("id-corrompido", request);
+
+        ArgumentCaptor<GeraLandingStageExecution> captor = ArgumentCaptor.forClass(GeraLandingStageExecution.class);
+        verify(executionRepository).save(captor.capture());
+        assertEquals("EM_PROCESSAMENTO", captor.getValue().getStatus());
+        assertEquals("prompt final", captor.getValue().getPrompt());
+    }
+
+    @Test
+    void shouldUseIdJobLookupWhenItExists() {
+        GeraLandingPromptReceiveRequest request =
+                new GeraLandingPromptReceiveRequest(19L, "landing-page-wireframe", "prompt final");
+
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(19L)
+                .stageCode("landing-page-wireframe")
+                .executionRequestedAt(Instant.parse("2026-05-04T00:00:00Z"))
+                .createdAt(Instant.parse("2026-05-04T00:00:00Z"))
+                .status("INICIADO")
+                .idJob("id-ok")
+                .promptContent("prompt base")
+                .build();
+
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc("id-ok"))
+                .thenReturn(Optional.of(execution));
+
+        service.receivePrompt("id-ok", request);
+
+        verify(executionRepository, never()).findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(any(), any());
+        verify(executionRepository).save(any(GeraLandingStageExecution.class));
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure prompts can be associated with the correct execution when the original `idJob` lookup fails by attempting a fallback lookup by `experimentId` and `stageCode`.
- Align the backend client to address the receive-prompt endpoint using a path parameter for `idJob` instead of embedding it in the request body.

### Description

- Added repository method `findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc` to support fallback lookup by experiment and stage.
- Updated `GeraLandingStageExecutionService.receivePrompt` to attempt a fallback lookup via `fallbackExecutionByExperimentAndStage` when `findTopByIdJobOrderByExecutionRequestedAtDesc` returns empty, and added warning logs for the fallback path.
- Modified `GeraLandingBackendClient.receivePrompt` to call `POST /{idJob}/receive-prompt` and removed `idJob` from the request body payload.
- Added unit tests in `GeraLandingStageExecutionServiceTest` covering the fallback behavior and the normal `idJob`-based lookup path.

### Testing

- Added and ran `GeraLandingStageExecutionServiceTest` which contains two tests: `shouldFallbackToExperimentAndStageWhenLookupByIdJobFails` and `shouldUseIdJobLookupWhenItExists`; both tests passed.
- Ran the module unit test suite involving the changed classes and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e2f1aca48321bd67a1e3cc62ae04)