### PR TITLE
Use GeraLandingBackendClient to send assembled prompts and add logging

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingBackendClient.java
@@ -46,6 +46,13 @@ public class GeraLandingBackendClient {
     public void receivePrompt(String idJob, Long experimentId, String stageCode, String prompt) {
         String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix,
                 "/internal/geralanding/stage-executions");
+        log.info(
+                "Sending gera-landing prompt. endpoint={}/{{idJob}}/receive-prompt, idJob={}, experimentId={}, stageCode={}, promptLength={}",
+                baseUrl,
+                idJob,
+                experimentId,
+                stageCode,
+                prompt != null ? prompt.length() : 0);
         webClient.post()
                 .uri(baseUrl + "/{idJob}/receive-prompt", idJob)
                 .bodyValue(Map.of(

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -57,8 +57,7 @@ public class GeraLandingExecutionService {
                     null,
                     "{}",
                     Instant.now());
-            String promptMontado = geraLandingService.montarERegistrarPromptEtapa(job, normalizedStage, execution.idJob());
-            backendClient.receivePrompt(execution.idJob(), execution.experimentId(), execution.stageCode(), promptMontado);
+            geraLandingService.montarERegistrarPromptEtapa(job, normalizedStage, execution.idJob());
             log.info("Prompt de gera-landing wireframe montado para executionId={} (experimentId={})",
                     execution.idJob(), execution.experimentId());
         } catch (Exception ex) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
@@ -7,7 +7,6 @@ import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.AdCopy;
 import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.AdImageBriefing;
 import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.CampaignAngle;
 import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.ExperimentMetadata;
-import com.marketinghub.worker.experimentpipeline.ExperimentPipelineBackendClient;
 import com.marketinghub.worker.experimentpipeline.ExperimentPipelineJobDto;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -19,7 +18,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -42,9 +40,9 @@ public class GeraLandingService {
     private static final String EXPERIMENT_METADATA = "experimentMetadata";
 
     private final ObjectMapper objectMapper;
-    private final ExperimentPipelineBackendClient backendClient;
+    private final GeraLandingBackendClient backendClient;
 
-    public GeraLandingService(ObjectMapper objectMapper, ExperimentPipelineBackendClient backendClient) {
+    public GeraLandingService(ObjectMapper objectMapper, GeraLandingBackendClient backendClient) {
         this.objectMapper = objectMapper;
         this.backendClient = backendClient;
     }
@@ -164,14 +162,11 @@ public class GeraLandingService {
                 etapa,
                 StringUtils.hasText(execucaoId) ? execucaoId : "default",
                 job.id());
-        UUID referenceJobId = job.id() != null ? job.id() : UUID.randomUUID();
-        backendClient.recordGenerationLog(
-                referenceJobId,
-                promptMontado,
-                referencia,
-                job.model(),
-                null,
-                null,
-                null);
+        log.info("Registrando prompt montado com referencia={}", referencia);
+        if (!StringUtils.hasText(execucaoId)) {
+            log.warn("Não foi possível enviar prompt montado: execucaoId ausente. referencia={}", referencia);
+            return;
+        }
+        backendClient.receivePrompt(execucaoId, job.experimentId(), etapa, promptMontado);
     }
 }


### PR DESCRIPTION
### Motivation
- Centralize prompt delivery for the gera-landing wireframe stage so the service itself is responsible for submitting assembled prompts to the backend.
- Improve observability when sending prompts by logging endpoint, IDs and prompt length.
- Replace usage of the generic experiment pipeline logging with a dedicated geralanding backend flow that validates presence of execution id before sending.

### Description
- Replaced `ExperimentPipelineBackendClient` with `GeraLandingBackendClient` in `GeraLandingService` and updated the constructor injection to use the dedicated client.
- Moved prompt submission into `GeraLandingService` by updating `registrarPromptMontado` to call `backendClient.receivePrompt(execucaoId, job.experimentId(), etapa, promptMontado)` and to validate `execucaoId` before sending.
- Removed direct call to `backendClient.receivePrompt` from `GeraLandingExecutionService` so the service now assembles and submits prompts itself, and added logging around prompt assembly completion.
- Added informational logging in `GeraLandingBackendClient.receivePrompt` to output the endpoint, `idJob`, `experimentId`, `stageCode`, and `promptLength` prior to performing the POST to `/{idJob}/receive-prompt`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f89b6dd483218148100d18aec792)