### PR TITLE
fix(ai-worker): ajustar GeraLandingServiceTest para usar GeraLandingBackendClient e atualizar verificação

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.experimentpipeline.ExperimentPipelineBackendClient;
 import com.marketinghub.worker.experimentpipeline.ExperimentPipelineJobDto;
 import java.time.Instant;
 import java.util.UUID;
@@ -14,7 +13,7 @@ import org.mockito.Mockito;
 
 class GeraLandingServiceTest {
 
-    private final ExperimentPipelineBackendClient backendClient = Mockito.mock(ExperimentPipelineBackendClient.class);
+    private final GeraLandingBackendClient backendClient = Mockito.mock(GeraLandingBackendClient.class);
     private final GeraLandingService service = new GeraLandingService(new ObjectMapper(), backendClient);
 
     @Test
@@ -37,14 +36,12 @@ class GeraLandingServiceTest {
         String prompt = service.montarERegistrarPromptEtapa(job, "test-placeholder", "exec-7");
 
         assertThat(prompt).contains("Resultado claro");
-        verify(backendClient).recordGenerationLog(
-                Mockito.eq(job.id()),
-                Mockito.eq(prompt),
-                Mockito.contains("exp:10|etapa:test-placeholder|exec:exec-7|job:"),
-                Mockito.eq("gpt-4.1"),
-                Mockito.isNull(),
-                Mockito.isNull(),
-                Mockito.isNull());
+        verify(backendClient)
+                .receivePrompt(
+                        Mockito.eq("exec-7"),
+                        Mockito.eq(10L),
+                        Mockito.eq("test-placeholder"),
+                        Mockito.eq(prompt));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Corrigir incompatibilidade de tipos no teste que instanciava `GeraLandingService` com um mock do cliente errado, o que impedia a compilação. 
- Alinhar o teste ao contrato atual do serviço para refletir a API real usada em produção.

### Description
- Substituído o mock de `ExperimentPipelineBackendClient` por `GeraLandingBackendClient` em `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java`.
- Atualizada a verificação de interação para usar `receivePrompt(execId, experimentId, etapa, prompt)` em vez do método legado `recordGenerationLog(...)`.
- Removido o import agora desnecessário de `ExperimentPipelineBackendClient`.

### Testing
- Executado `mvn -pl ai-worker -Dtest=GeraLandingServiceTest test` a partir da raiz, que falhou porque o módulo `ai-worker` não foi localizado no reactor. 
- Executado `mvn -Dtest=GeraLandingServiceTest test` dentro de `ai-worker/`, que terminou em falha por resolução de dependência privada (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`) retornando `401 Unauthorized`, impedindo a conclusão dos testes integrados; não foram observados erros de compilação relacionados à alteração do teste antes do ponto de falha.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f901a14d248321b2afe0546d25472a)