### PR TITLE
Add logging and error handling in MCP controller and enable actuator logfile endpoint

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -5,6 +5,8 @@ import com.marketinghub.mcpserver.service.DatabaseDiagnosticsService;
 import com.marketinghub.mcpserver.service.MetaDiagnosticsService;
 import com.marketinghub.mcpserver.service.ModuleLogService;
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
@@ -22,6 +24,8 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/mcp")
 public class McpController {
+
+    private static final Logger logger = LoggerFactory.getLogger(McpController.class);
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
@@ -195,6 +199,7 @@ public class McpController {
 
         try {
             Map<String, Object> arguments = extractArguments(params);
+            logger.info("MCP tool call recebido: tool={} requestId={} argumentKeys={}", toolName, id, arguments.keySet());
             return switch (toolName) {
                 case "db_health" -> successToolResult(id, databaseDiagnosticsService.checkConnection(),
                         "Database connectivity status");
@@ -209,7 +214,11 @@ public class McpController {
                 default -> error(id, -32602, "Unknown tool: " + toolName);
             };
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP tool call inválido: tool={} requestId={} motivo={}", toolName, id, ex.getMessage());
             return error(id, -32602, ex.getMessage());
+        } catch (Exception ex) {
+            logger.error("Falha inesperada em MCP tool call: tool={} requestId={}", toolName, id, ex);
+            return error(id, -32603, "Unexpected tool failure: " + ex.getMessage());
         }
     }
 

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -21,13 +21,21 @@ management:
     db:
       enabled: false
   endpoint:
+    logfile:
+      enabled: true
     health:
       probes:
         enabled: true
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,logfile
+      path-mapping:
+        logfile: mcp-runtime-log
+
+logging:
+  file:
+    name: ${LOG_FILE_NAME:/tmp/mcp-server.log}
 
 mcp:
   server-name: ${MCP_SERVER_NAME:marketing-hub-mcp}


### PR DESCRIPTION
### Motivation

- Improve observability of MCP tool invocations and capture unexpected failures with structured logs.
- Surface application runtime logfile via Spring Boot Actuator and make file logging configurable.

### Description

- Added an SLF4J `Logger` to `McpController` and instrumented `callTool` with info, warn, and error logs for normal, invalid, and unexpected error cases respectively.  
- Added a generic `catch (Exception)` in `callTool` to return a JSON-RPC error (`-32603`) on unexpected failures and log the exception.  
- Enabled the Actuator `logfile` endpoint and exposed it under `mcp-runtime-log` in `application.yml`, and included `logfile` in `endpoints.web.exposure.include`.  
- Added `logging.file.name` configuration (with `LOG_FILE_NAME` env var) to configure the runtime logfile location via `application.yml`.

### Testing

- Ran the project unit tests with `mvn test`, and all tests passed.  
- Performed a local application start to verify Actuator `/mcp-runtime-log` mapping and that the configured logfile is created, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91e1428908321b64fe87b271e5324)