### PR TITLE
Persist Hotmart highlights and metadata to mois_collected_reference and extract highlights from Hotmart parsing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
@@ -118,8 +118,9 @@ public class MoisCollectionPersistenceService {
                         INSERT INTO mois_collected_reference (
                           job_id, workspace_id, reference_id, source, title, url, niche, status, favorite,
                           imported_reference_id, success_score, success_signal, confidence_level, ranking_position,
-                          engagement_relative, recurrence_score, evidence_score, collected_at, updated_at
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                          engagement_relative, recurrence_score, evidence_score, hotmart_description,
+                          hotmart_producer, hotmart_image_url, hotmart_highlight, collected_at, updated_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                 references,
                 references.size(),
@@ -141,10 +142,21 @@ public class MoisCollectionPersistenceService {
                     ps.setDouble(15, item.engagementRelative());
                     ps.setDouble(16, item.recurrenceScore());
                     ps.setDouble(17, item.evidenceScore());
-                    ps.setTimestamp(18, item.collectedAt() == null ? null : Timestamp.from(item.collectedAt()));
-                    ps.setTimestamp(19, Timestamp.from(Instant.now()));
+                    ps.setString(18, metadataValue(item, "hotmartDescription"));
+                    ps.setString(19, metadataValue(item, "hotmartProducer"));
+                    ps.setString(20, metadataValue(item, "hotmartImageUrl"));
+                    ps.setString(21, metadataValue(item, "hotmartHighlight"));
+                    ps.setTimestamp(22, item.collectedAt() == null ? null : Timestamp.from(item.collectedAt()));
+                    ps.setTimestamp(23, Timestamp.from(Instant.now()));
                 }
         );
+    }
+
+    private String metadataValue(com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse item, String key) {
+        if (item.rawMetadata() == null) {
+            return null;
+        }
+        return item.rawMetadata().get(key);
     }
 
     public MoisCollectionPersistenceDtos.SourceHighlightListResponse summarizeBySource(String workspaceId, String status) {

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-05-mois-collected-reference-hotmart-highlights.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-05-mois-collected-reference-hotmart-highlights.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-05-mois-collected-reference-hotmart-highlights
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_collected_reference
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE mois_collected_reference
+                ADD COLUMN hotmart_description VARCHAR(220) NULL AFTER evidence_score,
+                ADD COLUMN hotmart_producer VARCHAR(120) NULL AFTER hotmart_description,
+                ADD COLUMN hotmart_image_url VARCHAR(260) NULL AFTER hotmart_producer,
+                ADD COLUMN hotmart_highlight VARCHAR(220) NULL AFTER hotmart_image_url;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -33,6 +33,9 @@ databaseChangeLog:
       file: changesets/2026-05-04-mois-collected-reference-persistence.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-05-05-mois-collected-reference-hotmart-highlights.yaml
+      relativeToChangelogFile: true
+  - include:
       file: V2037_04_26__widen_experiment_pipeline_job_section_mysql5.sql
       relativeToChangelogFile: true
   - include:

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -142,6 +142,7 @@ Regras operacionais associadas:
 - cada tentativa do robô deve ser persistida (sucesso ou falha) para auditoria operacional e rastreabilidade de execução.
 - o estado consolidado de cada `collection-job` (job, referências, lineage e runtime) deve ser persistido no backend principal em `mois_collection_job_state`, eliminando dependência de memória volátil no serviço de persistência.
 - as referências coletadas por entidade devem ser persistidas relacionalmente em `mois_collected_reference` com chave única (`job_id`, `reference_id`) para consulta histórica por fonte e workspace.
+- para execuções Hotmart, `mois_collected_reference` também deve persistir os campos de destaque operacional (`hotmart_description`, `hotmart_producer`, `hotmart_image_url`, `hotmart_highlight`) para consulta SQL direta sem depender de parse de `payload_json`.
 - o backend disponibiliza agregação executiva de destaques por fonte via `GET /api/v1/mois/persistence/collection-highlights/by-source` a partir dos estados persistidos dos jobs.
 
 ## Atualização incremental — MDS Sprint 1 (orquestração e persistência base)

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -45,3 +45,11 @@
 - Corrigida a resolução de include do Liquibase no `db.changelog-master.yaml` do `backend/ads-service`.
 - O changeset `changesets/2026-04-28-mois-collection-job-state-persistence.yaml` passou a declarar `relativeToChangelogFile: true`, evitando falha de parsing em CI com mensagem de arquivo não encontrado no classpath.
 - Registro criado para rastrear o incidente reportado no build Maven/Liquibase e sua correção.
+
+## 2026-05-05 00:20:00 UTC-3
+- Implementada extração de destaque Hotmart no MOIS com derivação de `hotmartHighlight` a partir da descrição/título durante o parse do marketplace.
+- A persistência relacional foi ampliada para gravar metadados Hotmart diretamente em `mois_collected_reference` (`hotmart_description`, `hotmart_producer`, `hotmart_image_url`, `hotmart_highlight`), reduzindo dependência de leitura de `payload_json`.
+- Criado changeset Liquibase MySQL 5.7 em YAML para adicionar as colunas de destaque e incluído no `db.changelog-master.yaml`.
+- Documento de modelo de dados atualizado para registrar o novo contrato de persistência dos destaques Hotmart.
+- Validação executada: testes unitários direcionados em `backend/ads-service` (`MoisCollectionPersistenceServiceTest`) e `mois` (`MoisHotmartRobotServiceTest`) concluídos com sucesso.
+- Commit relacionado: `ae3a077`.

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
@@ -1284,7 +1284,7 @@ public class MoisDomainService {
                 NormalizedSuccessSignal normalized = normalizeSuccessSignal(metrics, job.minSuccessScore());
                 SourceLead sourceLead = sourceRank <= sourceLeads.size()
                         ? sourceLeads.get(sourceRank - 1)
-                        : new SourceLead(buildCollectionSourceUrl(normalizedSource, niche, sourceRank), null, null, null, null);
+                        : new SourceLead(buildCollectionSourceUrl(normalizedSource, niche, sourceRank), null, null, null, null, null);
                 MoisWorkspaceDtos.CollectedReferenceResponse item = buildCollectedReference(
                         job,
                         normalizedSource,
@@ -1341,6 +1341,9 @@ public class MoisDomainService {
         if (sourceLead.hotmartImageUrl() != null && !sourceLead.hotmartImageUrl().isBlank()) {
             rawMetadata.put("hotmartImageUrl", trimTo(sourceLead.hotmartImageUrl(), 260));
         }
+        if (sourceLead.hotmartHighlight() != null && !sourceLead.hotmartHighlight().isBlank()) {
+            rawMetadata.put("hotmartHighlight", trimTo(sourceLead.hotmartHighlight(), 220));
+        }
         return new MoisWorkspaceDtos.CollectedReferenceResponse(
                 UUID.randomUUID().toString(),
                 job.jobId(),
@@ -1376,7 +1379,7 @@ public class MoisDomainService {
         }
         List<SourceLead> fallback = new ArrayList<>();
         for (int sourceRank = 1; sourceRank <= limitPerSource; sourceRank++) {
-            fallback.add(new SourceLead(buildCollectionSourceUrl(source, niche, sourceRank), null, null, null, null));
+            fallback.add(new SourceLead(buildCollectionSourceUrl(source, niche, sourceRank), null, null, null, null, null));
         }
         return fallback;
     }
@@ -1429,8 +1432,9 @@ public class MoisDomainService {
             String description = decodeHotmartValue(richCardMatcher.group(3));
             String producer = decodeHotmartValue(richCardMatcher.group(4));
             String imageUrl = decodeHotmartValue(richCardMatcher.group(5));
+            String highlight = deriveHotmartHighlight(title, description);
             if (seenUrls.add(decodedUrl)) {
-                leads.add(new SourceLead(decodedUrl, title, description, producer, imageUrl));
+                leads.add(new SourceLead(decodedUrl, title, description, producer, imageUrl, highlight));
             }
         }
 
@@ -1446,7 +1450,7 @@ public class MoisDomainService {
         while (fallbackUrlMatcher.find() && leads.size() < limitPerSource) {
             String url = decodeHotmartValue(fallbackUrlMatcher.group());
             if (seenUrls.add(url)) {
-                leads.add(new SourceLead(url, null, null, null, null));
+                leads.add(new SourceLead(url, null, null, null, null, null));
             }
         }
 
@@ -1458,6 +1462,24 @@ public class MoisDomainService {
             return null;
         }
         return value.replace("\\/", "/").replace("\\u0026", "&").trim();
+    }
+
+    private String deriveHotmartHighlight(String title, String description) {
+        if (description != null && !description.isBlank()) {
+            String normalized = description.replaceAll("\\s+", " ").trim();
+            int sentenceEnd = normalized.indexOf('.');
+            if (sentenceEnd > 0) {
+                return normalized.substring(0, sentenceEnd + 1);
+            }
+            if (normalized.length() > 220) {
+                return normalized.substring(0, 220);
+            }
+            return normalized;
+        }
+        if (title != null && !title.isBlank()) {
+            return title.trim();
+        }
+        return null;
     }
     private String firstNonBlank(String candidate, String fallback) {
         return candidate == null || candidate.isBlank() ? fallback : candidate;
@@ -2122,7 +2144,8 @@ public class MoisDomainService {
             String title,
             String hotmartDescription,
             String hotmartProducer,
-            String hotmartImageUrl
+            String hotmartImageUrl,
+            String hotmartHighlight
     ) {
     }
 


### PR DESCRIPTION
### Motivation
- Add operational Hotmart highlight metadata to collected references so downstream consumers can query highlights directly without parsing raw JSON payloads.
- Extend Hotmart marketplace parsing to derive a short operational highlight from description/title for improved executive aggregation and UI display.

### Description
- Persist four new columns in `mois_collected_reference`: `hotmart_description`, `hotmart_producer`, `hotmart_image_url`, and `hotmart_highlight`, and update the insert statement to write those values.  
- Add a Liquibase changeset `changesets/2026-05-05-mois-collected-reference-hotmart-highlights.yaml` and include it in `db.changelog-master.yaml` to alter the table for MySQL.  
- Propagate a new `hotmartHighlight` field through the Hotmart parsing flow by extending `SourceLead`, adding `deriveHotmartHighlight(...)` to extract a short sentence or fallback from description/title, and storing it in the collected reference `rawMetadata`.  
- Add a helper `metadataValue(...)` in `MoisCollectionPersistenceService` to read metadata keys when mapping batch insert parameters, and update parameter indices to accommodate the extra columns; update docs (`docs/modelo-dados-experimento.md` and `docs/mois/registros.md`) to describe the new fields.

### Testing
- Ran `MoisCollectionPersistenceServiceTest` in `backend/ads-service` and it passed.  
- Ran `MoisHotmartRobotServiceTest` in the `mois` module and it passed.  
- Unit tests in `backend/ads-service` and `mois` covering persistence and Hotmart parsing completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94926bd588321af0e460597682b55)