### PR TITLE
Fix ai-worker compilation by adding missing StringUtils import

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineGenerationWorkerService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineGenerationWorkerService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.util.StringUtils;
 
 @Service
 public class ExperimentPipelineGenerationWorkerService {


### PR DESCRIPTION
### Motivation
- Restore compilation for the `ai-worker` module by fixing a missing symbol error caused by a missing `StringUtils` import in the pipeline worker class.

### Description
- Added `import org.springframework.util.StringUtils;` to `ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineGenerationWorkerService.java` and no other behavior changes were made.

### Testing
- Attempted `cd ai-worker && mvn test -DskipITs` but the build was blocked by a private dependency resolution/authentication error (`401 Unauthorized` for `com.marketinghub:ads-service:0.0.1-SNAPSHOT`), and a root-level `mvn -pl ai-worker test -DskipITs` attempt failed because the module was not found in the reactor; the code-level compilation issue is addressed by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fb5acd0c83218c751665fa98a943)