### PR TITLE
Fix ai-worker test compilation error for checked IOException

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mockito;
 class GeraLandingExecutionServiceTest {
 
     @Test
-    void processPendingExecutionsShouldSendPromptToOpenAiAndRegisterResult() {
+    void processPendingExecutionsShouldSendPromptToOpenAiAndRegisterResult() throws Exception {
         GeraLandingBackendClient backendClient = Mockito.mock(GeraLandingBackendClient.class);
         GeraLandingService geraLandingService = Mockito.mock(GeraLandingService.class);
         ExperimentPipelineOpenAiClient openAiClient = Mockito.mock(ExperimentPipelineOpenAiClient.class);


### PR DESCRIPTION
### Motivation
- Resolve a test compilation failure caused by an unreported checked `IOException` when mocking `montarERegistrarPromptEtapa(...)` in the `ai-worker` module.

### Description
- Updated the test method signature in `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` to declare `throws Exception`, allowing Mockito stubbing of a method that can throw a checked `IOException`.

### Testing
- Ran `mvn -Dtest=GeraLandingExecutionServiceTest test` and confirmed the original compilation error was resolved, but the run failed later during dependency resolution with a `401 Unauthorized` for `com.marketinghub:ads-service:0.0.1-SNAPSHOT` when fetching from GitHub Packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa25a70214832199e2b44574830350)