### PR TITLE
AI Hub: Resumo:
- Desativei explicitamente o Open Session in View do backend do Lead Portal adicionando `spring.jpa.open-in-view=false` em `lead-portal/backend/src/main/resources/application.properties`, alinhando a aplicação com a recomendação operaciona…

### DIFF
--- a/docs/operations/lead-portal-log-review-2026-04-21.md
+++ b/docs/operations/lead-portal-log-review-2026-04-21.md
@@ -57,4 +57,5 @@ Resultado: sem `ERROR` no arquivo atual, apenas 3 `WARN` de inicialização.
 1. Planejar decisão canônica: manter MySQL 5.7 com dialect legado suportado **ou** migrar para MySQL 8 (registrar em ADR/cânone).
 2. Remover configuração explícita de dialect no `lead-portal/backend`.
 3. Testar e, se aprovado, definir `spring.jpa.open-in-view=false` no Lead Portal backend.
+   - Atualização: `spring.jpa.open-in-view=false` foi definido em `lead-portal/backend/src/main/resources/application.properties` para evitar Open Session in View habilitado por padrão.
 4. Se houver runbook usando `/api/actuator/*`, atualizar para `/api/ops-lp-observability-v2/*` para evitar falso diagnóstico de erro.

--- a/lead-portal/backend/src/main/resources/application.properties
+++ b/lead-portal/backend/src/main/resources/application.properties
@@ -25,3 +25,4 @@ spring.datasource.hikari.max-lifetime=${SPRING_DATASOURCE_HIKARI_MAX_LIFETIME:55
 spring.datasource.hikari.keepalive-time=${SPRING_DATASOURCE_HIKARI_KEEPALIVE_TIME:45000}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+spring.jpa.open-in-view=false


### PR DESCRIPTION
Correção automática gerada pelo sandbox do AI Hub.

**Descrição da tarefa:**
tente fazer um pr

**Resumo das alterações:**
Resumo:
- Desativei explicitamente o Open Session in View do backend do Lead Portal adicionando `spring.jpa.open-in-view=false` em `lead-portal/backend/src/main/resources/application.properties`, alinhando a aplicação com a recomendação operacional de reduzir acoplamento entre camadas web e JPA.
- Atualizei `docs/operations/lead-portal-log-review-2026-04-21.md` para registrar que a ação corretiva sobre o Open Session in View já foi aplicada, facilitando o acompanhamento do plano de mitigação descrito no diagnóstico.

Testes:
- `cd lead-portal/backend && mvn test` (sucesso).