### PR TITLE
fix(ai-worker): align GeraLandingExecutionServiceTest with ObjectMapper constructor dependency

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.experimentpipeline.ExperimentPipelineJobCompletionPayload;
 import com.marketinghub.worker.experimentpipeline.ExperimentPipelineOpenAiClient;
 import java.math.BigDecimal;
@@ -18,6 +19,7 @@ class GeraLandingExecutionServiceTest {
         GeraLandingBackendClient backendClient = Mockito.mock(GeraLandingBackendClient.class);
         GeraLandingService geraLandingService = Mockito.mock(GeraLandingService.class);
         ExperimentPipelineOpenAiClient openAiClient = Mockito.mock(ExperimentPipelineOpenAiClient.class);
+        ObjectMapper objectMapper = new ObjectMapper();
 
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
@@ -26,7 +28,8 @@ class GeraLandingExecutionServiceTest {
         when(openAiClient.generate(any())).thenReturn(new ExperimentPipelineJobCompletionPayload(
                 "{\"ok\":true}", "raw", "request", "openai-job", 10, 20, BigDecimal.ONE));
 
-        GeraLandingExecutionService service = new GeraLandingExecutionService(backendClient, geraLandingService, openAiClient, 20);
+        GeraLandingExecutionService service =
+                new GeraLandingExecutionService(backendClient, geraLandingService, openAiClient, objectMapper, 20);
         service.processPendingExecutions();
 
         verify(openAiClient).generate(any());


### PR DESCRIPTION
### Motivation
- The `GeraLandingExecutionService` constructor now requires an `ObjectMapper`, causing the unit test to fail compilation until the test is updated to provide that dependency.

### Description
- Updated `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` to import and instantiate an `ObjectMapper` and pass it into the `GeraLandingExecutionService` constructor so the test matches the current signature.

### Testing
- Ran `mvn -Dtest=GeraLandingExecutionServiceTest test`, which failed to complete because Maven could not resolve a private dependency (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`) from GitHub Packages (HTTP 401 Unauthorized), so tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa62c5abcc832193b863549192ed71)