### PR TITLE
Corrige compilação em ai-worker trocando `job.stage()` por `job.section()`

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
@@ -68,7 +68,7 @@ public class GeraLandingOpenAiBatchClient {
         } catch (WebClientResponseException ex) {
             HttpStatusCode statusCode = ex.getStatusCode();
             log.error("Falha HTTP OpenAI no gera-landing [jobId={}, stage={}, status={}, responseBody={}]",
-                    job.id(), job.stage(), statusCode.value(), ex.getResponseBodyAsString());
+                    job.id(), job.section(), statusCode.value(), ex.getResponseBodyAsString());
             throw new IllegalStateException("Falha HTTP ao gerar conteúdo de gera-landing", ex);
         } catch (Exception ex) {
             throw new IllegalStateException("Falha ao gerar conteúdo de gera-landing", ex);


### PR DESCRIPTION
### Motivation
- Corrigir erro de compilação causado pela chamada ao método inexistente `stage()` em `ExperimentPipelineJobDto` ao registrar falhas HTTP da OpenAI.

### Description
- Substitui `job.stage()` por `job.section()` no log de erro em `GeraLandingOpenAiBatchClient` (`ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java`).

### Testing
- Rodei `mvn compile` dentro do módulo `ai-worker` e a compilação avançou além do erro original, porém o build completo falhou na resolução de dependências devido a autenticação em GitHub Packages (`com.marketinghub:ads-service:0.0.1-SNAPSHOT` retornando HTTP 401).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa7893044c832196d7e255dbe18b56)