### PR TITLE
docs(ai-worker): add module compilation instructions to AGENTS.md

### DIFF
--- a/ai-worker/AGENTS.md
+++ b/ai-worker/AGENTS.md
@@ -18,3 +18,12 @@
   - implementar uma classe `*Service` com a lógica de geração;
   - criar um `*Scheduler` com `@Scheduled` para executar o serviço periodicamente;
   - encapsular qualquer cliente do ChatGPT dentro do mesmo pacote.
+
+## Compilação do módulo
+- O `pom.xml` deste módulo fica em `ai-worker/pom.xml` e **não** existe reactor Maven na raiz do repositório.
+- Para compilar corretamente a partir da raiz do projeto, use:
+  - `mvn -f ai-worker/pom.xml -DskipTests compile`
+- Alternativamente:
+  - `cd ai-worker && mvn -DskipTests compile`
+- Se ocorrer erro de dependência `com.marketinghub:ads-service:0.0.1-SNAPSHOT`, publique/instale primeiro a dependência localmente:
+  - `mvn -f backend/ads-service/pom.xml -DskipTests install`


### PR DESCRIPTION
### Motivation
- Clarify how to build the `ai-worker` module from the repository root and avoid common dependency errors when no Maven reactor is present.

### Description
- Added a "Compilação do módulo" section to `ai-worker/AGENTS.md` with explicit commands to compile the module from the root or from the module folder and guidance to install the local `ads-service` dependency when needed.

### Testing
- Ran `mvn -f ai-worker/pom.xml -DskipTests compile` and `mvn -f backend/ads-service/pom.xml -DskipTests install` to verify the documented commands and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa78ac23708321a4387fe0b6344fee)