### PR TITLE
Log OpenAI request and response in GeraLanding client

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
@@ -76,6 +76,7 @@ public class GeraLandingOpenAiBatchClient {
     }
 
     private OpenAiResponse callOpenAi(Map<String, Object> payload) {
+        log.info("callOpenAI [gera-landing] requestPayload={}", safeJson(payload));
         OpenAiResponse response = webClient.post()
                 .uri("/responses")
                 .bodyValue(payload)
@@ -88,6 +89,7 @@ public class GeraLandingOpenAiBatchClient {
         if (response.hasError()) {
             throw new IllegalStateException(response.errorMessage());
         }
+        log.info("callOpenAI [gera-landing] responseBody={}", safeJson(response));
         return response;
     }
 


### PR DESCRIPTION
### Motivation
- Improve observability for the GeraLanding OpenAI integration by recording the request payload and response body to aid debugging and tracing.

### Description
- Add `log.info` calls in `GeraLandingOpenAiBatchClient`'s `callOpenAi` to emit `requestPayload` and `responseBody` using the existing `safeJson` serializer.

### Testing
- Ran existing automated unit tests with `./gradlew test` and static checks, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa817c39608321862dd2d7e2227539)