### PR TITLE
Add product fields to mois_collected_reference and persist derived product info

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
@@ -119,8 +119,8 @@ public class MoisCollectionPersistenceService {
                           job_id, workspace_id, reference_id, source, title, url, niche, status, favorite,
                           imported_reference_id, success_score, success_signal, confidence_level, ranking_position,
                           engagement_relative, recurrence_score, evidence_score, hotmart_description,
-                          hotmart_producer, hotmart_image_url, hotmart_highlight, collected_at, updated_at
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                          hotmart_producer, hotmart_image_url, hotmart_highlight, product_name, product_url, producer_name, sales_page_url, collected_at, updated_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                 references,
                 references.size(),
@@ -146,10 +146,26 @@ public class MoisCollectionPersistenceService {
                     ps.setString(19, metadataValue(item, "hotmartProducer"));
                     ps.setString(20, metadataValue(item, "hotmartImageUrl"));
                     ps.setString(21, metadataValue(item, "hotmartHighlight"));
-                    ps.setTimestamp(22, item.collectedAt() == null ? null : Timestamp.from(item.collectedAt()));
-                    ps.setTimestamp(23, Timestamp.from(Instant.now()));
+                    ps.setString(22, coalesceNotBlank(item.title(), metadataValue(item, "productName"), metadataValue(item, "hotmartProductName")));
+                    ps.setString(23, coalesceNotBlank(item.url(), metadataValue(item, "productUrl")));
+                    ps.setString(24, coalesceNotBlank(metadataValue(item, "hotmartProducer"), metadataValue(item, "producerName"), metadataValue(item, "producer")));
+                    ps.setString(25, coalesceNotBlank(metadataValue(item, "salesPageUrl"), metadataValue(item, "checkoutUrl"), item.url()));
+                    ps.setTimestamp(26, item.collectedAt() == null ? null : Timestamp.from(item.collectedAt()));
+                    ps.setTimestamp(27, Timestamp.from(Instant.now()));
                 }
         );
+    }
+
+    private String coalesceNotBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
     }
 
     private String metadataValue(com.marketinghub.mois.dto.MoisWorkspaceDtos.CollectedReferenceResponse item, String key) {

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-06-mois-collected-reference-product-fields.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-06-mois-collected-reference-product-fields.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-06-mois-collected-reference-product-fields
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_collected_reference
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE mois_collected_reference
+                ADD COLUMN product_name VARCHAR(260) NULL AFTER title,
+                ADD COLUMN product_url VARCHAR(512) NULL AFTER url,
+                ADD COLUMN producer_name VARCHAR(191) NULL AFTER hotmart_producer,
+                ADD COLUMN sales_page_url VARCHAR(512) NULL AFTER product_url;
+
+              UPDATE mois_collected_reference
+                 SET product_name = COALESCE(NULLIF(title, ''), product_name),
+                     product_url = COALESCE(NULLIF(url, ''), product_url),
+                     sales_page_url = COALESCE(NULLIF(url, ''), sales_page_url),
+                     producer_name = COALESCE(NULLIF(hotmart_producer, ''), producer_name)
+               WHERE product_name IS NULL
+                  OR product_url IS NULL
+                  OR sales_page_url IS NULL
+                  OR producer_name IS NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -40,6 +40,9 @@ databaseChangeLog:
       file: changesets/2026-05-05-mois-collected-reference-hotmart-highlights.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-05-06-mois-collected-reference-product-fields.yaml
+      relativeToChangelogFile: true
+  - include:
       file: V2037_04_26__widen_experiment_pipeline_job_section_mysql5.sql
       relativeToChangelogFile: true
   - include:

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -53,3 +53,15 @@
 - Documento de modelo de dados atualizado para registrar o novo contrato de persistência dos destaques Hotmart.
 - Validação executada: testes unitários direcionados em `backend/ads-service` (`MoisCollectionPersistenceServiceTest`) e `mois` (`MoisHotmartRobotServiceTest`) concluídos com sucesso.
 - Commit relacionado: `ae3a077`.
+
+## 2026-05-06 09:35:00 UTC-3
+- Registrada evolução da persistência relacional do MOIS para tornar `mois_collected_reference` operacionalmente útil para análise comercial de produtos Hotmart.
+- Novos campos adicionados e preenchidos no fluxo de coleta/persistência:
+  - `product_name`
+  - `product_url`
+  - `producer_name`
+  - `sales_page_url`
+- A escrita desses campos no backend agora usa fallback determinístico entre campos principais e metadados (`rawMetadata`) para reduzir lacunas em registros parcialmente estruturados.
+- Incluído changeset Liquibase incremental (MySQL 5.7, YAML) com backfill dos registros já persistidos para reaproveitar `title`, `url` e `hotmart_producer` quando disponíveis.
+- Objetivo: permitir consulta SQL direta sem depender de parsing do `payload_json` para identificar nome do produto, URL pública, produtor e página de vendas.
+- Commit relacionado: `66c7cda`.


### PR DESCRIPTION
### Motivation
- Make `mois_collected_reference` operationally useful for Hotmart product analysis by adding explicit product fields and reducing dependence on parsing `payload_json`.
- Populate new fields deterministically at write time using existing attributes and `rawMetadata` fallbacks to reduce gaps in partially structured records.

### Description
- Add Liquibase changeset `changesets/2026-05-06-mois-collected-reference-product-fields.yaml` that adds `product_name`, `product_url`, `producer_name`, and `sales_page_url` columns and backfills them from `title`, `url`, and `hotmart_producer` when available.
- Include the new changeset in `db.changelog-master.yaml` so the schema change runs during deployments.
- Update `MoisCollectionPersistenceService.persistCollectedReferences` to extend the `INSERT` statement and parameter mapping to write the new columns, shifting timestamps accordingly.
- Add a `coalesceNotBlank` helper and use `metadataValue(...)` fallbacks to derive `product_name`, `product_url`, `producer_name`, and `sales_page_url` before persisting.

### Testing
- Executed `MoisCollectionPersistenceServiceTest` and related backend unit tests and they passed.
- Executed `MoisHotmartRobotServiceTest` for Hotmart parsing regressions and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa857a44908321ac6e7e32e135b7e2)