### PR TITLE
Fix GeraLandingExecutionServiceTest payload type mismatch

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.experimentpipeline.ExperimentPipelineJobCompletionPayload;
 import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -24,7 +23,7 @@ class GeraLandingExecutionServiceTest {
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
                 new GeraLandingStageExecutionDto(19L, "dd8a7dac-ce15-4858-99b4-45a7a18591fa", "landing-page-wireframe")));
         when(geraLandingService.montarERegistrarPromptEtapa(any(), any())).thenReturn("prompt-content");
-        when(openAiClient.generate(any())).thenReturn(new ExperimentPipelineJobCompletionPayload(
+        when(openAiClient.generate(any())).thenReturn(new GeraLandingJobCompletionPayload(
                 "{\"ok\":true}", "raw", "request", "openai-job", 10, 20, BigDecimal.ONE));
 
         GeraLandingExecutionService service =


### PR DESCRIPTION
### Motivation
- Fix compilation failure in the ai-worker tests caused by stubbing `openAiClient.generate(...)` with the wrong payload type which produced a Mockito type mismatch during test compilation.

### Description
- Updated `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` to remove the incorrect `ExperimentPipelineJobCompletionPayload` usage/import and return a `GeraLandingJobCompletionPayload` from `when(openAiClient.generate(...))` so the stub matches the method's declared return type.

### Testing
- Executed `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test`, which progresses past the previous compile error but the run still fails due to inability to resolve `com.marketinghub:ads-service:0.0.1-SNAPSHOT` from GitHub Packages (401 Unauthorized), an external dependency resolution issue unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa96617aec832196b362782afa1a3f)