### PR TITLE
Adicionar telemetria de diagnóstico ao parser Hotmart e registrar resumo de parsing

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -65,3 +65,12 @@
 - Incluído changeset Liquibase incremental (MySQL 5.7, YAML) com backfill dos registros já persistidos para reaproveitar `title`, `url` e `hotmart_producer` quando disponíveis.
 - Objetivo: permitir consulta SQL direta sem depender de parsing do `payload_json` para identificar nome do produto, URL pública, produtor e página de vendas.
 - Commit relacionado: `66c7cda`.
+
+## 2026-05-05 22:49:17 UTC-3
+- Adicionada telemetria de diagnóstico no parser de marketplace Hotmart (`parseHotmartMarketplaceLeads`) para investigar lacunas de metadados de produto no MOIS.
+- O parser agora registra um resumo estruturado (`mois_hotmart_parse_summary`) com:
+  - `richCardMatches` e `richCardDuplicates`;
+  - `fallbackMatches` e `fallbackDuplicates`;
+  - `enrichedLeads`, `totalLeads`, `limitPerSource` e `bodyLength`.
+- Objetivo: diferenciar com evidência de log quando a coleta está encontrando cards ricos (com descrição/produtor/imagem) versus quando está caindo majoritariamente no fallback por URL, cenário que explica campos de produto nulos na persistência relacional.
+- Commit relacionado: `a5c4341`.

--- a/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
+++ b/mois/src/main/java/com/marketinghub/mois/service/MoisDomainService.java
@@ -1421,12 +1421,18 @@ public class MoisDomainService {
     private List<SourceLead> parseHotmartMarketplaceLeads(String body, int limitPerSource) {
         List<SourceLead> leads = new ArrayList<>();
         Set<String> seenUrls = new HashSet<>();
+        int richCardMatches = 0;
+        int richCardDuplicates = 0;
+        int fallbackMatches = 0;
+        int fallbackDuplicates = 0;
+        int enrichedLeads = 0;
 
         Pattern richCardPattern = Pattern.compile(
                 "\"name\":\"([^\"]+)\".*?\"fullLink\":\"(https:\\\\/\\\\/www\\.hotmart\\.com\\\\/product\\\\/[^\"]+)\".*?\"description\":\"([^\"]*)\".*?\"producerName\":\"([^\"]*)\".*?\"image\":\"([^\"]*)\""
         );
         Matcher richCardMatcher = richCardPattern.matcher(body);
         while (richCardMatcher.find() && leads.size() < limitPerSource) {
+            richCardMatches++;
             String title = decodeHotmartValue(richCardMatcher.group(1));
             String decodedUrl = decodeHotmartValue(richCardMatcher.group(2));
             String description = decodeHotmartValue(richCardMatcher.group(3));
@@ -1434,11 +1440,18 @@ public class MoisDomainService {
             String imageUrl = decodeHotmartValue(richCardMatcher.group(5));
             String highlight = deriveHotmartHighlight(title, description);
             if (seenUrls.add(decodedUrl)) {
+                if (title != null || description != null || producer != null || imageUrl != null || highlight != null) {
+                    enrichedLeads++;
+                }
                 leads.add(new SourceLead(decodedUrl, title, description, producer, imageUrl, highlight));
+            } else {
+                richCardDuplicates++;
             }
         }
 
         if (leads.size() >= limitPerSource) {
+            log.info("mois_hotmart_parse_summary limitPerSource={} richCardMatches={} richCardDuplicates={} fallbackMatches={} fallbackDuplicates={} enrichedLeads={} totalLeads={} bodyLength={}",
+                    limitPerSource, richCardMatches, richCardDuplicates, fallbackMatches, fallbackDuplicates, enrichedLeads, leads.size(), body.length());
             return leads;
         }
 
@@ -1448,12 +1461,17 @@ public class MoisDomainService {
         );
         Matcher fallbackUrlMatcher = fallbackUrlPattern.matcher(body);
         while (fallbackUrlMatcher.find() && leads.size() < limitPerSource) {
+            fallbackMatches++;
             String url = decodeHotmartValue(fallbackUrlMatcher.group());
             if (seenUrls.add(url)) {
                 leads.add(new SourceLead(url, null, null, null, null, null));
+            } else {
+                fallbackDuplicates++;
             }
         }
 
+        log.info("mois_hotmart_parse_summary limitPerSource={} richCardMatches={} richCardDuplicates={} fallbackMatches={} fallbackDuplicates={} enrichedLeads={} totalLeads={} bodyLength={}",
+                limitPerSource, richCardMatches, richCardDuplicates, fallbackMatches, fallbackDuplicates, enrichedLeads, leads.size(), body.length());
         return leads;
     }
 


### PR DESCRIPTION
### Motivation
- Investigar por que muitos registros persistidos ficam com campos de produto nulos ao diferenciar quando o parser encontra cards ricos vs. quando cai no fallback por URL.

### Description
- Adicionado contadores e lógica de telemetria em `parseHotmartMarketplaceLeads` dentro de `MoisDomainService.java` para computar `richCardMatches`, `richCardDuplicates`, `fallbackMatches`, `fallbackDuplicates` e `enrichedLeads`.
- Registrado um resumo estruturado via log com a chave `mois_hotmart_parse_summary` incluindo `richCardMatches`, `richCardDuplicates`, `fallbackMatches`, `fallbackDuplicates`, `enrichedLeads`, `totalLeads`, `limitPerSource` e `bodyLength` nos pontos de retorno antecipado e ao final do parsing.
- Ajustada a contagem de duplicatas usando o resultado de `seenUrls.add(...)` e marcada como enriquecida (`enrichedLeads`) qualquer lead que contenha título, descrição, produtor, imagem ou destaque.
- Atualizado `docs/mois/registros.md` para documentar a adição da telemetria e o objetivo da mudança.

### Testing
- Não foram adicionados testes automatizados neste PR; nenhuma suíte de teste foi modificada ou executada como parte desta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9c51cef483219a447da76256dd69)