### PR TITLE
Fix gera-landing batch prompt field accessor

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
@@ -81,7 +81,7 @@ public class GeraLandingOpenAiBatchClient {
             return new GeraLandingJobCompletionPayload(
                     modelResponse,
                     rawOutput,
-                    job.originalPrompt(),
+                    job.requestBodyJson(),
                     response.id(),
                     inputTokens,
                     outputTokens,


### PR DESCRIPTION
### Motivation
- Fix a compilation error caused by calling a non-existent accessor on `GeraLandingJobDto` when building the completion payload for gera-landing batch jobs.

### Description
- Replace `job.originalPrompt()` with `job.requestBodyJson()` in `GeraLandingOpenAiBatchClient` to match the `GeraLandingJobDto` record and ensure the correct request body is passed to `GeraLandingJobCompletionPayload`.

### Testing
- Ran `mvn -f backend/ads-service/pom.xml -DskipTests install` to install the local dependency required by the `ai-worker` module and it succeeded; ran `mvn -f ai-worker/pom.xml test` and the module tests completed successfully (`BUILD SUCCESS`, `107` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab5f3598083218a1bdf99a910379a)