### PR TITLE
test(mois): validar extração de nomes de produtos em destaque da Hotmart

### DIFF
--- a/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
+++ b/mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java
@@ -437,6 +437,25 @@ class MoisDomainServiceTest {
         org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () -> service.createCollectionJob(request));
     }
 
+
+    @Test
+    void shouldExtractHotmartHighlightedProductNamesFromMarketplacePayload() throws Exception {
+        String hotmartPayload = """
+                {"name":"Produto Alpha","fullLink":"https:\\/\\/www.hotmart.com\\/product\\/produto-alpha\","description":"Transforme sua rotina com método validado.","producerName":"Produtor A","image":"https:\\/\\/cdn.hotmart.com\\/produto-alpha.jpg"}
+                {"name":"Produto Beta","fullLink":"https:\\/\\/www.hotmart.com\\/product\\/produto-beta\","description":"Ganhe clareza e performance.","producerName":"Produtor B","image":"https:\\/\\/cdn.hotmart.com\\/produto-beta.jpg"}
+                """;
+
+        var method = MoisDomainService.class.getDeclaredMethod("parseHotmartMarketplaceLeads", String.class, int.class);
+        method.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<Object> leads = (List<Object>) method.invoke(service, hotmartPayload, 10);
+
+        assertThat(leads).hasSize(2);
+        assertThat(leads.get(0).toString()).contains("Produto Alpha");
+        assertThat(leads.get(1).toString()).contains("Produto Beta");
+    }
+
     private static class HtmlHandler implements HttpHandler {
         private final String body;
 


### PR DESCRIPTION
### Motivation
- Validar que o módulo MOIS consegue extrair os nomes de produtos em destaque (`name`) do payload retornado pelo marketplace da Hotmart para garantir que esses títulos sejam capturados como `SourceLead.title`.

### Description
- Adiciona um teste unitário em `mois/src/test/java/com/marketinghub/mois/service/MoisDomainServiceTest.java` que injeta um payload de exemplo (dois cards: `Produto Alpha` e `Produto Beta`), invoca por reflexão o método `parseHotmartMarketplaceLeads` e verifica que ambos os nomes são extraídos.

### Testing
- Executei `cd mois && mvn -q -Dtest=MoisDomainServiceTest test` e a suíte de teste específica passou com sucesso, observando apenas avisos de rede (`Network is unreachable`) nos logs para integrações externas, sem falha de teste.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2a41f3fc8321a7d7900335f21f9b)