### PR TITLE
Fix ai-worker compile error in gera-landing prompt registration

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
@@ -177,7 +177,7 @@ public class GeraLandingService {
         return new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
     }
 
-    private void registrarPromptMontado(GeraLandingPromptContext context, String etapa, String promptMontado) {
+    private void registrarPromptMontado(GeraLandingPromptContext context, String etapa, String promptMontado) throws IOException {
         if (context == null || promptMontado == null || promptMontado.isBlank()) {
             return;
         }
@@ -186,6 +186,14 @@ public class GeraLandingService {
                 etapa,
                 context.idJob());
         log.info("Registrando prompt montado com referencia={}", referencia);
-        backendClient.receivePrompt(context.idJob(), context.experimentId(), etapa, promptMontado);
+        String promptMarkdownContent = carregarPromptMarkdownCru(etapa);
+        backendClient.receivePrompt(
+                context.idJob(),
+                context.experimentId(),
+                etapa,
+                promptMontado,
+                null,
+                null,
+                promptMarkdownContent);
     }
 }


### PR DESCRIPTION
### Motivation
- Fix a compilation failure caused by a signature change in `GeraLandingBackendClient.receivePrompt` which required 7 arguments instead of the previous 4.  
- Ensure prompt registration sends the raw markdown content to the backend so the client contract is satisfied and richer metadata is available.

### Description
- Updated `registrarPromptMontado` in `GeraLandingService` to declare `throws IOException` so it can load prompt markdown from classpath via `carregarPromptMarkdownCru(etapa)`.  
- Changed the call to `backendClient.receivePrompt` to the new 7-argument signature and passed the loaded `promptMarkdownContent` while sending `null` for `openAiRequestBody` and `schemaJson` in this early registration path.  
- Preserved the existing null/blank checks and logging behavior when registering the assembled prompt.

### Testing
- Ran `mvn -f backend/ads-service/pom.xml -DskipTests install` which completed successfully.  
- Recompiled the module with `mvn -f ai-worker/pom.xml -DskipTests compile` which completed successfully and resolved the previous compilation error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2e24376c8321b9e6d390c17c740c)