### PR TITLE
Fix ai-worker test to match expanded receivePrompt signature

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
@@ -39,7 +39,10 @@ class GeraLandingServiceTest {
                         Mockito.eq("id-job-original"),
                         Mockito.eq(10L),
                         Mockito.eq("test-placeholder"),
-                        Mockito.eq(prompt));
+                        Mockito.eq(prompt),
+                        Mockito.isNull(),
+                        Mockito.isNull(),
+                        Mockito.anyString());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- The unit test used the old 4-argument call while `GeraLandingBackendClient.receivePrompt(...)` was expanded to 7 arguments, causing a compilation failure in CI.

### Description
- Updated `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java` to verify `receivePrompt` with the three additional parameters (`openAiRequestBody` and `schemaJson` asserted as `null`, and `promptMarkdownContent` asserted as any non-null string).

### Testing
- Ran `mvn -f ai-worker/pom.xml -Dtest=GeraLandingServiceTest test` which verified the original compile error is fixed but test execution was blocked by dependency resolution failure for `com.marketinghub:ads-service:0.0.1-SNAPSHOT` (401 Unauthorized), so the full test run could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb317d000483218638e1c95e8a5751)