### PR TITLE
Preservar quebras de linha em strings no CollapsibleJsonViewer

### DIFF
--- a/frontend/src/components/CollapsibleJsonViewer.tsx
+++ b/frontend/src/components/CollapsibleJsonViewer.tsx
@@ -34,10 +34,21 @@ function JsonNode({
   const spacing = { marginLeft: depth === 0 ? 0 : 12 };
 
   if (value === null || typeof value !== "object") {
+    const isString = typeof value === "string";
+
     return (
       <div style={spacing} className="small">
         {label ? <strong>{label}: </strong> : null}
-        <code>{JSON.stringify(value)}</code>
+        {isString ? (
+          <pre
+            className="mb-0 d-inline"
+            style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}
+          >
+            {value}
+          </pre>
+        ) : (
+          <code>{JSON.stringify(value)}</code>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
### Motivation
- Fazer com que campos de texto multilinha (ex.: `Prompt` e `Conteúdo do arquivo .md usado no prompt`) sejam exibidos com quebras de linha visíveis em vez de mostrar `\n` escapados. 

### Description
- Alterado `frontend/src/components/CollapsibleJsonViewer.tsx` para renderizar valores JSON do tipo `string` dentro de um `<pre>` com `white-space: pre-wrap` preservando new lines, mantendo `JSON.stringify` apenas para primitivos não-string. 

### Testing
- Executado `npx prettier --write src/components/CollapsibleJsonViewer.tsx` com sucesso; 
- Tentativa de `npm run build` falhou por falta do binário `vite` no ambiente (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb360a4b24832198740ac8e694a7f4)