### PR TITLE
Fix React hook-order crash on Experiment detail page

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -234,29 +234,6 @@ export default function ExperimentDetailPage() {
     }
   };
 
-  if (isLoading) return <p>Carregando...</p>;
-  if (!data) return <p>Não encontrado</p>;
-  const preset = presets?.find((p) => p.id === data.metricPresetId);
-  const resetPreviewSummary: ExperimentCampaignResetSummary =
-    resetPreviewData ?? { campaigns: 0, adSets: 0, ads: 0, creatives: 0 };
-  const totalItemsToReset =
-    resetPreviewSummary.campaigns +
-    resetPreviewSummary.adSets +
-    resetPreviewSummary.ads +
-    resetPreviewSummary.creatives;
-  const hasItemsToReset = totalItemsToReset > 0;
-  const previewErrorMessage = isResetPreviewError
-    ? resetPreviewError && resetPreviewError instanceof Error
-      ? resetPreviewError.message
-      : "Não foi possível carregar a prévia do reset."
-    : null;
-  const confirmResetDisabled =
-    isFetchingResetPreview ||
-    !hasItemsToReset ||
-    Boolean(previewErrorMessage) ||
-    resetCampaigns.isPending;
-  const readinessIssues = readinessSummary?.issues ?? [];
-  const hasReadinessIssues = readinessIssues.length > 0;
   const isRunningExecution = (status?: string | null) => {
     const normalizedStatus = (status ?? "").trim().toUpperCase();
     return ["EM_PROCESSAMENTO", "PROCESSING", "RUNNING", "IN_PROGRESS", "PENDING"].includes(
@@ -292,6 +269,29 @@ export default function ExperimentDetailPage() {
     refetchPendingGeraLandingExecutions,
     refetchCompletedGeraLandingExecutions,
   ]);
+  if (isLoading) return <p>Carregando...</p>;
+  if (!data) return <p>Não encontrado</p>;
+  const preset = presets?.find((p) => p.id === data.metricPresetId);
+  const resetPreviewSummary: ExperimentCampaignResetSummary =
+    resetPreviewData ?? { campaigns: 0, adSets: 0, ads: 0, creatives: 0 };
+  const totalItemsToReset =
+    resetPreviewSummary.campaigns +
+    resetPreviewSummary.adSets +
+    resetPreviewSummary.ads +
+    resetPreviewSummary.creatives;
+  const hasItemsToReset = totalItemsToReset > 0;
+  const previewErrorMessage = isResetPreviewError
+    ? resetPreviewError && resetPreviewError instanceof Error
+      ? resetPreviewError.message
+      : "Não foi possível carregar a prévia do reset."
+    : null;
+  const confirmResetDisabled =
+    isFetchingResetPreview ||
+    !hasItemsToReset ||
+    Boolean(previewErrorMessage) ||
+    resetCampaigns.isPending;
+  const readinessIssues = readinessSummary?.issues ?? [];
+  const hasReadinessIssues = readinessIssues.length > 0;
   const formatCurrency = (n?: number | null) =>
     n != null
       ? new Intl.NumberFormat("pt-BR", {


### PR DESCRIPTION
### Motivation
- The Experiment detail page sometimes triggered React's hook-order violation (minified error #310) because the component returned early (`isLoading`/`!data`) before all hooks were declared.

### Description
- Move the `if (isLoading)` and `if (!data)` early-return guards to after all hooks so hook invocation order is stable across renders.
- Keep `useGeraLandingStageExecutionDetail` and its associated `useEffect` mounted consistently to preserve polling/refetch behavior and avoid changing the hook tree between renders.
- Change applied to `frontend/src/pages/experiment/ExperimentDetailPage.tsx` to reorder the relevant block of code.

### Testing
- Attempted to build the frontend with `cd frontend && npm run -s build`, which failed due to missing tooling in the environment: `vite: not found`.
- No automated unit or integration tests were executed successfully in this environment; no further CI results are available from this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb53bb32048321867e65158dba812e)