### PR TITLE
Introduce mois-hotmart-collector submodule: standalone Spring Boot service with Docker image and basic endpoints

### DIFF
--- a/docs/mois/mois-hotmart-collector-submodulo-2026-05-06.md
+++ b/docs/mois/mois-hotmart-collector-submodulo-2026-05-06.md
@@ -1,0 +1,22 @@
+# MOIS Hotmart Collector — Submódulo separado
+
+Data: 2026-05-06
+
+## Decisão
+
+Foi criado o submódulo `mois-hotmart-collector` como aplicação Spring Boot independente, com container e imagem Docker separados.
+
+## Motivação
+
+- Isolar riscos operacionais da automação web (sessão, captcha, mudanças de layout).
+- Permitir ciclo de deploy independente do `mois` principal.
+- Facilitar evolução para Playwright + sessão persistida sem acoplamento ao núcleo de domínio.
+
+## Contrato inicial
+
+- `GET /api/v1/mois-hotmart/health`
+- `POST /api/v1/mois-hotmart/collections`
+
+## Próximo passo técnico
+
+Implementar adaptador Playwright no serviço de coleta, mantendo o MOIS principal como orquestrador consumidor da API deste submódulo.

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -116,3 +116,9 @@
 - Ajustado o submódulo `mois-hotmart-collector` para privilegiar distribuição como JAR executável.
 - `pom.xml` atualizado com repackage explícito do Spring Boot e geração de artefato final `target/mois-hotmart-collector.jar` com `executable=true`.
 - Adicionado script `run-local-jar.sh` para execução direta do JAR e README atualizado com fluxo recomendado `mvn clean package` + execução do jar.
+
+## 2026-05-06 12:38:09 UTC-3
+- Evoluído o submódulo `mois-hotmart-collector` para coleta com Playwright em modo headless por padrão.
+- `HotmartCollectorService` atualizado para abrir Chromium headless, navegar para `https://app.hotmart.com/market/search` e extrair links de produtos (`/market/products/`) até o limite solicitado.
+- `collector.playwright.headless` parametrizado (default `true`) com opção de override para debug local.
+- Teste de controller isolado com `@MockBean` para evitar dependência de rede/browser durante testes unitários.

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -102,3 +102,12 @@
   - `enrichedLeads`, `totalLeads`, `limitPerSource` e `bodyLength`.
 - Objetivo: diferenciar com evidência de log quando a coleta está encontrando cards ricos (com descrição/produtor/imagem) versus quando está caindo majoritariamente no fallback por URL, cenário que explica campos de produto nulos na persistência relacional.
 - Commit relacionado: `a5c4341`.
+
+## 2026-05-06 12:13:34 UTC-3
+- Criado o submódulo independente `mois-hotmart-collector` para coleta Hotmart com aplicação, container e imagem Docker separados do MOIS principal.
+- Publicado contrato inicial do submódulo com endpoints:
+  - `GET /api/v1/mois-hotmart/health`
+  - `POST /api/v1/mois-hotmart/collections`
+- Estrutura inicial preparada para evolução para automação Playwright com sessão persistida, mantendo desacoplamento operacional do núcleo de domínio do MOIS.
+- Registro adicionado para atender solicitação explícita de documentação em `docs/mois/registros.md`.
+- Commit relacionado: `52082a1`.

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -111,3 +111,8 @@
 - Estrutura inicial preparada para evolução para automação Playwright com sessão persistida, mantendo desacoplamento operacional do núcleo de domínio do MOIS.
 - Registro adicionado para atender solicitação explícita de documentação em `docs/mois/registros.md`.
 - Commit relacionado: `52082a1`.
+
+## 2026-05-06 12:17:38 UTC-3
+- Ajustado o submódulo `mois-hotmart-collector` para privilegiar distribuição como JAR executável.
+- `pom.xml` atualizado com repackage explícito do Spring Boot e geração de artefato final `target/mois-hotmart-collector.jar` com `executable=true`.
+- Adicionado script `run-local-jar.sh` para execução direta do JAR e README atualizado com fluxo recomendado `mvn clean package` + execução do jar.

--- a/mois-hotmart-collector/Dockerfile
+++ b/mois-hotmart-collector/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/target/mois-hotmart-collector-0.1.0-SNAPSHOT.jar app.jar
+EXPOSE 8096
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/mois-hotmart-collector/README.md
+++ b/mois-hotmart-collector/README.md
@@ -41,3 +41,15 @@ docker compose up --build
 
 Sim. Este módulo roda em Linux (host ou container) com Java 21+ instalado.
 O script `run-local-jar.sh` executa via `java -jar`, evitando dependência de permissão de execução direta no arquivo JAR.
+
+
+## Playwright (headless padrão)
+
+- O coletor agora usa Playwright em **modo headless por padrão** (`collector.playwright.headless=true`).
+- Para depuração local, rode com `collector.playwright.headless=false`.
+
+Exemplo:
+
+```bash
+java -jar target/mois-hotmart-collector.jar --collector.playwright.headless=false
+```

--- a/mois-hotmart-collector/README.md
+++ b/mois-hotmart-collector/README.md
@@ -25,7 +25,7 @@ mvn spring-boot:run
 
 ```bash
 mvn clean package
-./run-local-jar.sh
+bash ./run-local-jar.sh
 ```
 
 > O build gera `target/mois-hotmart-collector.jar` como JAR executável (fat jar Spring Boot).
@@ -35,3 +35,9 @@ mvn clean package
 ```bash
 docker compose up --build
 ```
+
+
+## Compatibilidade Linux
+
+Sim. Este módulo roda em Linux (host ou container) com Java 21+ instalado.
+O script `run-local-jar.sh` executa via `java -jar`, evitando dependência de permissão de execução direta no arquivo JAR.

--- a/mois-hotmart-collector/README.md
+++ b/mois-hotmart-collector/README.md
@@ -1,0 +1,26 @@
+# MOIS Hotmart Collector
+
+Submódulo separado do MOIS para automatização da coleta de produtos quentes na Hotmart, com aplicação, container e imagem próprios.
+
+## Objetivo
+
+- Isolar o fluxo de automação web da Hotmart em serviço independente.
+- Publicar imagem Docker dedicada para deploy separado.
+- Expor contrato HTTP para orquestração pelo MOIS principal.
+
+## Endpoints iniciais
+
+- `GET /api/v1/mois-hotmart/health`
+- `POST /api/v1/mois-hotmart/collections`
+
+## Execução local
+
+```bash
+mvn spring-boot:run
+```
+
+## Docker
+
+```bash
+docker compose up --build
+```

--- a/mois-hotmart-collector/README.md
+++ b/mois-hotmart-collector/README.md
@@ -15,9 +15,20 @@ Submódulo separado do MOIS para automatização da coleta de produtos quentes n
 
 ## Execução local
 
+### Modo desenvolvimento
+
 ```bash
 mvn spring-boot:run
 ```
+
+### Modo JAR executável (recomendado para este módulo)
+
+```bash
+mvn clean package
+./run-local-jar.sh
+```
+
+> O build gera `target/mois-hotmart-collector.jar` como JAR executável (fat jar Spring Boot).
 
 ## Docker
 

--- a/mois-hotmart-collector/docker-compose.yml
+++ b/mois-hotmart-collector/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  mois-hotmart-collector:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: marketinghub/mois-hotmart-collector:0.1.0-snapshot
+    container_name: mois-hotmart-collector
+    environment:
+      - MOIS_HOTMART_PORT=8096
+    ports:
+      - "8096:8096"

--- a/mois-hotmart-collector/pom.xml
+++ b/mois-hotmart-collector/pom.xml
@@ -38,10 +38,21 @@
     </dependencies>
 
     <build>
+        <finalName>mois-hotmart-collector</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <executable>true</executable>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/mois-hotmart-collector/pom.xml
+++ b/mois-hotmart-collector/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.marketinghub</groupId>
+    <artifactId>mois-hotmart-collector</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>mois-hotmart-collector</name>
+    <description>Submódulo separado do MOIS para coleta Hotmart</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mois-hotmart-collector/pom.xml
+++ b/mois-hotmart-collector/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>1.53.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/mois-hotmart-collector/run-local-jar.sh
+++ b/mois-hotmart-collector/run-local-jar.sh
@@ -9,4 +9,9 @@ if [[ ! -f "$JAR_PATH" ]]; then
   exit 1
 fi
 
-exec "$JAR_PATH"
+if ! command -v java >/dev/null 2>&1; then
+  echo "Java não encontrado no PATH. Instale Java 21+ para executar o coletor."
+  exit 1
+fi
+
+exec java -jar "$JAR_PATH"

--- a/mois-hotmart-collector/run-local-jar.sh
+++ b/mois-hotmart-collector/run-local-jar.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JAR_PATH="$SCRIPT_DIR/target/mois-hotmart-collector.jar"
+
+if [[ ! -f "$JAR_PATH" ]]; then
+  echo "Jar não encontrado em $JAR_PATH. Execute: mvn clean package"
+  exit 1
+fi
+
+exec "$JAR_PATH"

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/MoisHotmartCollectorApplication.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/MoisHotmartCollectorApplication.java
@@ -1,0 +1,12 @@
+package com.marketinghub.moishotmart;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MoisHotmartCollectorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MoisHotmartCollectorApplication.class, args);
+    }
+}

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/dto/HotmartDtos.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/dto/HotmartDtos.java
@@ -1,0 +1,33 @@
+package com.marketinghub.moishotmart.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+import java.util.List;
+
+public final class HotmartDtos {
+
+    private HotmartDtos() {
+    }
+
+    public record HotmartCollectionRequest(
+            @NotBlank String source,
+            int maxProducts
+    ) {
+    }
+
+    public record HotmartProductSnapshot(
+            String title,
+            String rating,
+            String commission,
+            String detailsUrl,
+            Instant collectedAt
+    ) {
+    }
+
+    public record HotmartCollectionResponse(
+            String status,
+            String message,
+            List<HotmartProductSnapshot> products
+    ) {
+    }
+}

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -1,0 +1,25 @@
+package com.marketinghub.moishotmart.service;
+
+import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionRequest;
+import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionResponse;
+import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartProductSnapshot;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class HotmartCollectorService {
+
+    public HotmartCollectionResponse collect(HotmartCollectionRequest request) {
+        int boundedMax = request.maxProducts() <= 0 ? 10 : Math.min(request.maxProducts(), 50);
+        List<HotmartProductSnapshot> samples = List.of(
+                new HotmartProductSnapshot("Produto quente (placeholder)", "4.7", "R$ 350,00", "https://app.hotmart.com/market/search", Instant.now())
+        );
+
+        return new HotmartCollectionResponse(
+                "READY_FOR_AUTOMATION",
+                "Submódulo separado criado. Próximo passo: integrar Playwright com sessão persistida para coletar até " + boundedMax + " produtos.",
+                samples
+        );
+    }
+}

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -3,23 +3,66 @@ package com.marketinghub.moishotmart.service;
 import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionRequest;
 import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionResponse;
 import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartProductSnapshot;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 public class HotmartCollectorService {
 
+    private static final String HOTMART_MARKET_URL = "https://app.hotmart.com/market/search";
+
+    private final boolean headless;
+
+    public HotmartCollectorService(@Value("${collector.playwright.headless:true}") boolean headless) {
+        this.headless = headless;
+    }
+
     public HotmartCollectionResponse collect(HotmartCollectionRequest request) {
         int boundedMax = request.maxProducts() <= 0 ? 10 : Math.min(request.maxProducts(), 50);
-        List<HotmartProductSnapshot> samples = List.of(
-                new HotmartProductSnapshot("Produto quente (placeholder)", "4.7", "R$ 350,00", "https://app.hotmart.com/market/search", Instant.now())
-        );
 
-        return new HotmartCollectionResponse(
-                "READY_FOR_AUTOMATION",
-                "Submódulo separado criado. Próximo passo: integrar Playwright com sessão persistida para coletar até " + boundedMax + " produtos.",
-                samples
-        );
+        List<HotmartProductSnapshot> products = new ArrayList<>();
+        String status = "COLLECTION_EXECUTED";
+        String message = "Coleta executada com Playwright em modo headless=" + headless + ".";
+
+        try (Playwright playwright = Playwright.create()) {
+            Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(headless));
+            BrowserContext context = browser.newContext();
+            Page page = context.newPage();
+            page.navigate(HOTMART_MARKET_URL, new Page.NavigateOptions().setTimeout(60_000));
+            page.waitForTimeout(1_500);
+
+            int cardsCount = page.locator("a[href*='/market/products/']").count();
+            int maxToRead = Math.min(cardsCount, boundedMax);
+            for (int i = 0; i < maxToRead; i++) {
+                String title = page.locator("a[href*='/market/products/']").nth(i).innerText();
+                String detailsUrl = page.locator("a[href*='/market/products/']").nth(i).getAttribute("href");
+                if (detailsUrl != null && detailsUrl.startsWith("/")) {
+                    detailsUrl = "https://app.hotmart.com" + detailsUrl;
+                }
+                products.add(new HotmartProductSnapshot(
+                        title == null || title.isBlank() ? "Produto sem título" : title,
+                        "N/A",
+                        "N/A",
+                        detailsUrl == null ? HOTMART_MARKET_URL : detailsUrl,
+                        Instant.now()
+                ));
+            }
+
+            context.close();
+            browser.close();
+        } catch (Exception ex) {
+            status = "COLLECTION_ERROR";
+            message = "Falha na coleta Playwright: " + ex.getMessage();
+        }
+
+        return new HotmartCollectionResponse(status, message, products);
     }
 }

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/web/HotmartCollectorController.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/web/HotmartCollectorController.java
@@ -1,0 +1,32 @@
+package com.marketinghub.moishotmart.web;
+
+import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionRequest;
+import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionResponse;
+import com.marketinghub.moishotmart.service.HotmartCollectorService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/mois-hotmart")
+public class HotmartCollectorController {
+
+    private final HotmartCollectorService collectorService;
+
+    public HotmartCollectorController(HotmartCollectorService collectorService) {
+        this.collectorService = collectorService;
+    }
+
+    @GetMapping("/health")
+    public String health() {
+        return "ok";
+    }
+
+    @PostMapping("/collections")
+    public HotmartCollectionResponse collect(@Valid @RequestBody HotmartCollectionRequest request) {
+        return collectorService.collect(request);
+    }
+}

--- a/mois-hotmart-collector/src/main/resources/application.properties
+++ b/mois-hotmart-collector/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.application.name=mois-hotmart-collector
+server.port=${MOIS_HOTMART_PORT:8096}

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/web/HotmartCollectorControllerTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/web/HotmartCollectorControllerTest.java
@@ -1,14 +1,20 @@
 package com.marketinghub.moishotmart.web;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionResponse;
+import com.marketinghub.moishotmart.service.HotmartCollectorService;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -19,14 +25,22 @@ class HotmartCollectorControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private HotmartCollectorService collectorService;
+
     @Test
     void healthShouldReturnOk() throws Exception {
-        mockMvc.perform(get("/api/v1/mois-hotmart/health"))
-                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/mois-hotmart/health")).andExpect(status().isOk());
     }
 
     @Test
-    void collectShouldReturnBootstrapResponse() throws Exception {
+    void collectShouldReturnCollectionResponse() throws Exception {
+        when(collectorService.collect(any())).thenReturn(new HotmartCollectionResponse(
+                "COLLECTION_EXECUTED",
+                "Coleta executada com Playwright em modo headless=true.",
+                List.of()
+        ));
+
         mockMvc.perform(post("/api/v1/mois-hotmart/collections")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -36,6 +50,6 @@ class HotmartCollectorControllerTest {
                                 }
                                 """))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("READY_FOR_AUTOMATION"));
+                .andExpect(jsonPath("$.status").value("COLLECTION_EXECUTED"));
     }
 }

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/web/HotmartCollectorControllerTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/web/HotmartCollectorControllerTest.java
@@ -1,0 +1,41 @@
+package com.marketinghub.moishotmart.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HotmartCollectorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthShouldReturnOk() throws Exception {
+        mockMvc.perform(get("/api/v1/mois-hotmart/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void collectShouldReturnBootstrapResponse() throws Exception {
+        mockMvc.perform(post("/api/v1/mois-hotmart/collections")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "source": "hotmart-market",
+                                  "maxProducts": 20
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("READY_FOR_AUTOMATION"));
+    }
+}


### PR DESCRIPTION
### Motivation

- Isolate Hotmart web automation risks and enable an independent deployment cycle by moving collection logic out of the MOIS core. 

### Description

- Add new `mois-hotmart-collector` submodule providing a standalone Spring Boot application with entrypoint `MoisHotmartCollectorApplication` and basic HTTP contract `GET /api/v1/mois-hotmart/health` and `POST /api/v1/mois-hotmart/collections`.
- Provide DTOs (`HotmartDtos`), service (`HotmartCollectorService`) that returns a bootstrap response, and controller (`HotmartCollectorController`) exposing the endpoints.
- Add build and deployment artifacts: `pom.xml`, `Dockerfile`, `docker-compose.yml`, `application.properties`, and `README.md` with run instructions and initial API contract.
- Add documentation entries: new decision doc `docs/mois/mois-hotmart-collector-submodulo-2026-05-06.md` and registry update in `docs/mois/registros.md` describing the rationale and next steps toward Playwright integration.

### Testing

- Add Spring Boot integration tests in `src/test/java/.../HotmartCollectorControllerTest.java` which contain two tests: `healthShouldReturnOk` and `collectShouldReturnBootstrapResponse`.
- Running `mvn test` executes the added tests and they pass (both tests green).
- The Docker build in the provided `Dockerfile` is configured to skip tests during the multi-stage build using `mvn -DskipTests package` as part of image creation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb575f23148321853a688a7dc014dc)