### PR TITLE
Fix completed-only visibility in Gera WireFrame history

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -240,8 +240,21 @@ export default function ExperimentDetailPage() {
       normalizedStatus,
     );
   };
+  const isCompletedExecution = (status?: string | null) => {
+    const normalizedStatus = (status ?? "").trim().toUpperCase();
+    return ["CONCLUIDO", "CONCLUÍDO", "COMPLETED", "SUCCESS", "SUCCEEDED", "DONE"].includes(
+      normalizedStatus,
+    );
+  };
   const hasRunningGeraLandingExecution = (pendingGeraLandingExecutions ?? []).some((execution) =>
     isRunningExecution(execution.status),
+  );
+  const completedHistoryGeraLandingExecutions = useMemo(
+    () =>
+      (completedGeraLandingExecutions ?? []).filter((execution) =>
+        isCompletedExecution(execution.status),
+      ),
+    [completedGeraLandingExecutions],
   );
   const runningGeraLandingJobId = (pendingGeraLandingExecutions ?? []).find((execution) =>
     isRunningExecution(execution.status),
@@ -1436,7 +1449,7 @@ export default function ExperimentDetailPage() {
                 <h5 className="card-title mb-0">Histórico de execuções concluídas</h5>
                 {isLoadingCompletedGeraLandingExecutions ? (
                   <p className="text-muted mb-0">Carregando execuções...</p>
-                ) : !completedGeraLandingExecutions || completedGeraLandingExecutions.length === 0 ? (
+                ) : completedHistoryGeraLandingExecutions.length === 0 ? (
                   <p className="text-muted mb-0">Nenhuma execução concluída registrada para esta etapa.</p>
                 ) : (
                   <div className="table-responsive">
@@ -1449,7 +1462,7 @@ export default function ExperimentDetailPage() {
                         </tr>
                       </thead>
                       <tbody>
-                        {completedGeraLandingExecutions.map((execution) => (
+                        {completedHistoryGeraLandingExecutions.map((execution) => (
                           <tr key={execution.idJob}>
                             <td>
                               <Link


### PR DESCRIPTION
### Motivation
- Evitar que jobs recém-criados (ex.: status `INICIADO`/`PENDING`) apareçam imediatamente na seção “Histórico de execuções concluídas”.

### Description
- Adicionada a função `isCompletedExecution` para normalizar e validar estados finais de execução no arquivo `frontend/src/pages/experiment/ExperimentDetailPage.tsx`.
- Criada a lista derivada `completedHistoryGeraLandingExecutions` usando `useMemo` para filtrar `completedGeraLandingExecutions` mantendo apenas estados concluídos. 
- Atualizada a renderização da tabela de histórico para usar `completedHistoryGeraLandingExecutions` tanto na checagem de vazio quanto no `map`, preservando o comportamento da lista de pending/running.

### Testing
- Executado `cd frontend && npm install` sem erros; dependências instaladas com sucesso.
- Executado `cd frontend && npm run typecheck` e o `tsc --noEmit` completou sem erros, confirmando tipagem consistente no TypeScript.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5a0dc5fc83219b57f2e773061069)