### PR TITLE
Ajusta histórico de execuções dentro do card Gera WireFrame

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1441,45 +1441,44 @@ export default function ExperimentDetailPage() {
                       </table>
                     </div>
                   )}
-                </div>
-              </div>
-            </div>
-            <div className="card">
-              <div className="card-body d-flex flex-column gap-3">
-                <h5 className="card-title mb-0">Histórico de execuções concluídas</h5>
-                {isLoadingCompletedGeraLandingExecutions ? (
-                  <p className="text-muted mb-0">Carregando execuções...</p>
-                ) : completedHistoryGeraLandingExecutions.length === 0 ? (
-                  <p className="text-muted mb-0">Nenhuma execução concluída registrada para esta etapa.</p>
-                ) : (
-                  <div className="table-responsive">
-                    <table className="table table-sm align-middle mb-0">
-                      <thead>
-                        <tr>
-                          <th scope="col">Job ID</th>
-                          <th scope="col">Status</th>
-                          <th scope="col">Data-hora</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {completedHistoryGeraLandingExecutions.map((execution) => (
-                          <tr key={execution.idJob}>
-                            <td>
-                              <Link
-                                to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
-                                className="fw-semibold text-decoration-none"
-                              >
-                                {execution.idJob}
-                              </Link>
-                            </td>
-                            <td>{execution.status}</td>
-                            <td>{formatDateTimeValue(execution.executionRequestedAt)}</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
+
+                  <div className="rounded border bg-light-subtle p-3 d-flex flex-column gap-3">
+                    <h6 className="mb-0">Histórico de execuções concluídas</h6>
+                    {isLoadingCompletedGeraLandingExecutions ? (
+                      <p className="text-muted mb-0">Carregando execuções...</p>
+                    ) : completedHistoryGeraLandingExecutions.length === 0 ? (
+                      <p className="text-muted mb-0">Nenhuma execução concluída registrada para esta etapa.</p>
+                    ) : (
+                      <div className="table-responsive">
+                        <table className="table table-sm align-middle mb-0">
+                          <thead>
+                            <tr>
+                              <th scope="col">Job ID</th>
+                              <th scope="col">Status</th>
+                              <th scope="col">Data-hora</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {completedHistoryGeraLandingExecutions.map((execution) => (
+                              <tr key={execution.idJob}>
+                                <td>
+                                  <Link
+                                    to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                    className="fw-semibold text-decoration-none"
+                                  >
+                                    {execution.idJob}
+                                  </Link>
+                                </td>
+                                <td>{execution.status}</td>
+                                <td>{formatDateTimeValue(execution.executionRequestedAt)}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
                   </div>
-                )}
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Manter a seção de "Histórico de execuções concluídas" no mesmo card do bloco `Gera WireFrame` e diferenciá-la visualmente para melhorar o contexto e a usabilidade.

### Description
- Move a seção de histórico para dentro do card `Gera WireFrame` e remove o card separado de histórico.
- Envolve a lista de histórico em um container com classes `rounded border bg-light-subtle p-3 d-flex flex-column gap-3` e ajusta o título para `h6` para hierarquia visual.
- Mantém a tabela, colunas e os links de `Job ID` inalterados para preservar a navegação existente.

### Testing
- Executado `npm --prefix frontend run typecheck`, que falhou no ambiente por ausência das definições de tipo `@testing-library/jest-dom`, `vite/client` e `vitest/globals`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5db2bfec832190246c528ce605ba)