### PR TITLE
Exibir modelo usado na página de detalhe do Gera Landing

### DIFF
--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -12,9 +12,20 @@ function formatDateTime(value?: string) {
   return date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
 }
 
+function extractModelFromRequestBody(raw?: string) {
+  if (!raw) return "—";
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed?.model === "string" && parsed.model.trim() ? parsed.model : "—";
+  } catch {
+    return "—";
+  }
+}
+
 export default function ExperimentGeraLandingExecutionDetailPage() {
   const { id: experimentId, jobId } = useParams();
   const detailQuery = useGeraLandingStageExecutionDetail(experimentId, jobId);
+  const modelUsed = extractModelFromRequestBody(detailQuery.data?.openAiRequestBody);
 
   return (
     <div className="d-flex flex-column gap-3">
@@ -52,6 +63,7 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                 <div className="col-md-6"><strong>Status:</strong> {detailQuery.data.status}</div>
                 <div className="col-md-6"><strong>Stage:</strong> {detailQuery.data.stageCode}</div>
                 <div className="col-md-6"><strong>OpenAI Job ID:</strong> {detailQuery.data.openAiJobId ?? "—"}</div>
+                <div className="col-md-6"><strong>Modelo usado:</strong> {modelUsed}</div>
                 <div className="col-md-6"><strong>Solicitado em:</strong> {formatDateTime(detailQuery.data.executionRequestedAt)}</div>
                 <div className="col-md-6"><strong>Criado em:</strong> {formatDateTime(detailQuery.data.createdAt)}</div>
                 <div className="col-md-6"><strong>Processamento iniciado:</strong> {formatDateTime(detailQuery.data.processingStartedAt)}</div>


### PR DESCRIPTION
### Motivation
- A tela de detalhe da execução Gera Landing não mostrava qual modelo foi efetivamente usado na chamada ao OpenAI, dificultando auditoria e rastreabilidade do pipeline.

### Description
- Adiciona o helper `extractModelFromRequestBody(raw)` e inclui o campo de apresentação **Modelo usado** na página `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx`, extraindo o valor do campo `model` presente em `openAiRequestBody` com fallback seguro para `—` quando o JSON estiver ausente, inválido ou sem o campo; alteração é apenas de apresentação no frontend e não quebra contratos de API.

### Testing
- Nenhum teste automatizado foi executado para esta alteração (mudança pequena de UI apenas); recomenda-se rodar a build/checagem TypeScript e testes de frontend antes de mergear.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb72cc2c948321a6cb88528bb7b3c8)