### PR TITLE
docs: atualizar canônico do Gera Landing com fluxo wireframe end-to-end

### DIFF
--- a/docs/gera-landing/modelo-canonico-gera-landing.md
+++ b/docs/gera-landing/modelo-canonico-gera-landing.md
@@ -2,148 +2,290 @@
 
 ## Objetivo
 
-Este documento define, de forma canônica, duas dimensões do módulo **Gera Landing**:
+Este documento descreve, no nível operacional e de contrato, o fluxo **implementado** do módulo Gera Landing, tomando o código atual (backend + ai-worker) como fonte de verdade.
 
-1. **Modelo de dados canônico** (estrutura persistida no banco);
-2. **Fluxos canônicos** (comportamentos operacionais do módulo).
+Escopo desta versão:
 
-> Nesta versão, o documento registra o **primeiro fluxo canônico** do módulo: geração de prompts pelo Worker AI.
+1. Jornada completa da solicitação do usuário até a conclusão da geração de wireframe.
+2. Montagem de prompt, schema, payload OpenAI e execução em modo batch.
+3. Recuperação de resultado e persistência no backend.
+4. Modelo de dados da tabela `gera_landing_stage_execution` com campos de rastreabilidade ponta-a-ponta.
 
 ---
 
-## PARTE A — MODELO DE DADOS CANÔNICO
+## 1) Modelo de dados canônico (`gera_landing_stage_execution`)
 
-### Tabela de controle de jobs
+### 1.1 Finalidade
 
-### Nome da tabela
+A tabela registra o ciclo de vida completo de uma execução de etapa do Gera Landing (hoje: `landing-page-wireframe`), incluindo:
 
-- `gera_landing_stage_execution`
+- solicitação inicial;
+- prompt final montado;
+- payload OpenAI efetivamente enviado;
+- schema aplicado;
+- identificador do job OpenAI;
+- resposta final do modelo e métricas (tokens/custo);
+- timestamps de início e término do processamento.
 
-### Finalidade
+### 1.2 Campos canônicos
 
-Registrar cada execução de etapa do fluxo Gera Landing, com:
-
-- identificação do experimento;
-- identificação da etapa;
-- marca temporal da solicitação;
-- dados de prompt de entrada e prompt final montado;
-- status e identificador do job;
-- timestamps de ciclo de vida da execução.
-
-### Definição canônica dos campos (aderente ao código e Liquibase atual)
-
-| Campo | Tipo (MySQL 5.7) | Obrigatório | Regra canônica |
+| Campo | Tipo (MySQL 5.7) | Obrigatório | Origem/uso no fluxo |
 |---|---|---:|---|
-| `experiment_id` | `BIGINT` | Sim | Identificador do experimento. FK para `experiment.id`. |
-| `stage_code` | `VARCHAR(100)` | Sim | Código da etapa do Gera Landing (ex.: `landing-page-wireframe`). |
-| `execution_requested_at` | `DATETIME(3)` | Sim | Momento da solicitação da execução da etapa. Default `CURRENT_TIMESTAMP(3)`. |
-| `prompt_template_id` | `VARCHAR(191)` | Não | Identificador técnico do template/origem do prompt inicial da execução. |
-| `prompt_content` | `LONGTEXT` | Sim | Conteúdo de prompt recebido no início da execução da etapa. |
-| `status` | `VARCHAR(50)` | Sim | Estado atual da execução. Valor inicial: `INICIADO`. |
-| `id_job` | `CHAR(36)` | Sim | Identificador do job em formato textual UUID. É a chave primária atual. |
-| `created_at` | `DATETIME(3)` | Sim | Momento de criação do registro no banco. Default `CURRENT_TIMESTAMP(3)`. |
-| `processing_started_at` | `DATETIME(3)` | Não | Momento em que o processamento efetivo da execução iniciou. |
-| `completed_at` | `DATETIME(3)` | Não | Momento de conclusão da execução da etapa. |
-| `prompt` | `LONGTEXT` | Não | Prompt final montado pelo Worker AI para a execução da etapa. |
+| `id_job` | `BINARY(36)` físico (mapeado em `byte[]`) | Sim | Chave primária da execução. Exposto na API como texto UUID por conversão UTF-8. |
+| `experiment_id` | `BIGINT` | Sim | Experimento associado; FK para `experiment.id`. |
+| `stage_code` | `VARCHAR(100)` | Sim | Etapa da execução (`landing-page-wireframe`). |
+| `execution_requested_at` | `DATETIME(3)` | Sim | Timestamp da solicitação da etapa. |
+| `created_at` | `DATETIME(3)` | Sim | Timestamp de criação do registro. |
+| `processing_started_at` | `DATETIME(3)` | Não | Preenchido no recebimento do prompt pelo backend. |
+| `completed_at` | `DATETIME(3)` | Não | Preenchido no recebimento do resultado final do modelo. |
+| `prompt_template_id` | `VARCHAR(191)` | Não | Origem técnica do prompt inicial (`manual/start` no início manual). |
+| `prompt_content` | `LONGTEXT` | Sim | Prompt base da solicitação inicial. |
+| `prompt` | `LONGTEXT` | Não | Prompt final montado pelo worker (já com placeholders resolvidos e envelope de tarefa). |
+| `openai_request_body` | `LONGTEXT` | Não | JSON do request da Responses API enviado em batch. |
+| `schema_json` | `LONGTEXT` | Não | Schema JSON usado em `text.format` (json_schema strict). |
+| `prompt_markdown_content` | `LONGTEXT` | Não | Conteúdo markdown cru do template da etapa (`prompts/geralanding/*.md`). |
+| `status` | `VARCHAR(50)` | Sim | Estados atuais: `INICIADO` → `EM_PROCESSAMENTO` → `CONCLUIDO`. |
+| `openai_job_id` | `VARCHAR(120)` | Não | ID de resposta/job da OpenAI retornado ao fim do batch. |
+| `model_response` | `LONGTEXT` | Não | Conteúdo final gerado pelo modelo (`responseContent`). |
+| `input_tokens` | `INT` | Não | Tokens de entrada efetivos do uso OpenAI. |
+| `output_tokens` | `INT` | Não | Tokens de saída efetivos do uso OpenAI. |
+| `cost_usd` | `DECIMAL(12,6)` | Não | Estimativa de custo USD calculada no worker. |
 
-### Chaves e restrições
+### 1.3 Índices e chaves
 
-- **Chave primária**: `id_job`.
-- **Chave estrangeira**: `experiment_id` referencia `experiment.id` com `ON DELETE CASCADE`.
-- **Índice auxiliar**: `idx_gera_landing_stage_execution_experiment` em `experiment_id`.
-
-### Validação da PARTE A contra implementação atual
-
-Resultado da verificação: **PARTE A foi ajustada para refletir exatamente o estado atual do código e do schema**.
-
-Principais confirmações:
-
-- `prompt_content` e `prompt` estão em `LONGTEXT` no schema vigente.
-- `id_job` está em `CHAR(36)` no schema, mesmo com mapeamento JPA em `byte[]` (conversão UTF-8 no serviço).
-- chave primária ativa é `id_job`.
-- pendência oficial continua sendo `status = INICIADO`.
+- PK: `id_job`.
+- FK: `experiment_id -> experiment.id` (com relacionamento JPA `ManyToOne`).
+- Consultas operacionais usam:
+  - `findTop20ByStatusOrderByExecutionRequestedAtAsc("INICIADO")` para pendências;
+  - lookup prioritário por `id_job`, com fallback por `experiment_id + stage_code`.
 
 ---
 
-## PARTE B — FLUXOS CANÔNICOS DO MÓDULO
+## 2) Arquitetura operacional do fluxo wireframe
 
-### Catálogo de fluxos desta versão
+## 2.1 Entrada do usuário (frontend/admin)
 
-- **Fluxo 01 — Geração de prompts pelo Worker AI (geralanding)**: detalhado abaixo.
+1. Usuário aciona **Iniciar** no card de Gera Landing (wireframe).
+2. Backend recebe `POST /api/experiments/{experimentId}/geralanding/wireframe/start`.
+3. Serviço cria execução inicial com:
+   - `stageCode = "landing-page-wireframe"`
+   - `promptTemplateId = "manual/start"`
+   - `promptContent = "Início manual via interface do experimento."`
+   - `status = "INICIADO"`
+   - `idJob = UUID`.
+4. Retorno: `202 Accepted` com `{ idJob, status }`.
 
-### Fluxo 01 — geração de prompts pelo Worker AI
+## 2.2 Polling do worker para capturar pendências
 
-> Este fluxo descreve o caminho oficial e atual do processamento assíncrono do Gera Landing, da busca de pendências até a persistência do prompt final no backend.
+1. Scheduler do ai-worker roda por cron (`geralanding.execution.fixed-cron`, default a cada 1 minuto).
+2. `GeraLandingExecutionService.processPendingExecutions()`:
+   - valida se OpenAI está habilitada (`OPENAI_API_KEY`);
+   - chama backend para pendências.
+3. Endpoint consultado: `GET /api/internal/geralanding/stage-executions/pending`.
+4. Backend retorna lista mínima de pendências (`experimentId`, `idJob`, `stageCode`) com status `INICIADO`.
 
-### 1) Criação do job no backend com status inicial
+## 2.3 Seleção e validação da etapa no worker
 
-1. O backend registra execução inicial da etapa `landing-page-wireframe` em `gera_landing_stage_execution`.
-2. O registro nasce com:
-   - `status = INICIADO`;
-   - `id_job` gerado por UUID;
-   - `execution_requested_at` e `created_at` preenchidos com timestamp atual;
-   - `prompt_template_id = manual/start`;
-   - `prompt_content = "Início manual via interface do experimento."`.
-3. Este status inicial é a condição de elegibilidade para o polling do Worker AI.
+Para cada item pendente:
 
-### 2) Agendamento do Worker AI (polling contínuo)
+- valida presença de `stageCode` e `idJob`;
+- normaliza `stageCode` para lower-case/trim;
+- processa apenas `landing-page-wireframe` (demais etapas são ignoradas com log).
 
-1. O Worker AI executa um agendamento com cron padrão `0 */1 * * * *` (a cada 1 minuto).
-2. Em cada ciclo, chama `processPendingExecutions()`.
-3. O tamanho do lote é controlado por `geralanding.execution.pending-limit` (default `20`, com mínimo efetivo `1`).
+---
 
-### 3) Busca de jobs pendentes no endpoint interno do backend
+## 3) Montagem detalhada de prompt no ai-worker
 
-1. O Worker AI chama `GET /api/internal/geralanding/stage-executions/pending?limit={n}`.
-2. O backend retorna lista com payload por item: `experimentId`, `idJob`, `stageCode`.
-3. O backend monta essa lista buscando somente registros com `status = INICIADO`, ordenados por `execution_requested_at` ascendente.
-4. Observação importante de implementação: o parâmetro `limit` enviado pelo Worker não é aplicado no serviço backend atual, que usa `findTop20ByStatusOrderByExecutionRequestedAtAsc("INICIADO")`.
+## 3.1 Fonte de template
 
-### 4) Loop de processamento no Worker AI
+- Template principal: `classpath:prompts/geralanding/{etapa}.md`.
+- Exemplo da etapa atual: `landing-page-wireframe.md`.
 
-Para cada item retornado no lote:
+## 3.2 Resolução de placeholders
 
-1. O Worker valida presença de `stageCode` e `idJob`; itens inválidos são ignorados com log de aviso.
-2. O `stageCode` é normalizado (`trim + lowerCase`).
-3. Nesta versão canônica, apenas `landing-page-wireframe` entra no fluxo de geração; outras etapas são ignoradas sem erro.
-4. O contexto é montado como `GeraLandingPromptContext(experimentId, idJob, stageCode, Collections.emptyMap())`.
+Motor de resolução em `GeraLandingService` suporta:
 
-### 5) Montagem do prompt da etapa no Worker AI
+- `{prompt-xxx}`: inclui outro markdown da pasta `prompts/geralanding/xxx.md` (resolução recursiva).
+- `{dados-xxx}`: injeta JSON pretty de `context.dados().get("xxx")`.
 
-1. O Worker chama `GeraLandingService.montarERegistrarPromptEtapa(context, etapa)`.
-2. A montagem usa:
-   - template base em `prompts/geralanding/{etapa}.md`;
-   - resolução de placeholders `{prompt-*}` com inclusão recursiva de outros prompts;
-   - resolução de placeholders `{dados-*}` via serialização JSON pretty do mapa `dados` do contexto.
-3. Proteção aplicada: referência circular entre prompts gera erro explícito (`IllegalStateException`).
-4. Como o fluxo atual cria `context.dados` vazio, placeholders `{dados-*}` resultam em string vazia na versão corrente.
+Regras implementadas:
 
-### 6) Envio do prompt montado para persistência no backend
+- detecção de referência circular entre prompts (lança `IllegalStateException`);
+- se dado não existir, substitui por string vazia.
 
-1. Após montar o prompt, o Worker chama `POST /api/internal/geralanding/stage-executions/{idJob}/receive-prompt`.
-2. O `idJob` do path **é exatamente o mesmo** recebido no item de pendência retornado por `GET /pending`.
-3. Body enviado pelo Worker:
-   - `experimentId`
-   - `stageCode`
-   - `prompt`
-4. O contrato do endpoint exige os três campos (`@NotNull` / `@NotBlank`).
+Observação importante do estado atual:
 
-### 7) Persistência final no backend e atualização de status
+- o contexto hoje é criado com `Collections.emptyMap()`; portanto, placeholders `{dados-*}` tendem a ficar vazios no fluxo wireframe atual.
 
-1. O backend tenta localizar a execução por `idJob` usando `findTopByIdJobOrderByExecutionRequestedAtDesc`.
-2. Se não encontrar, aplica fallback por `experimentId + stageCode` (`findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc`).
-3. Em caso de ausência em ambos os critérios, retorna erro de entidade não encontrada e registra log de diagnóstico.
-4. Em caso de sucesso, persiste:
-   - `prompt` com o texto final montado;
-   - `processing_started_at` com timestamp atual;
-   - `status = EM_PROCESSAMENTO`.
-5. O endpoint responde `202 Accepted` ao Worker.
+## 3.3 Envelope final do prompt de usuário
 
-## Escopo desta versão
+Após resolver o markdown, o worker encapsula no formato:
 
-Este documento cobre:
+- seção `# Tarefa` instruindo a executar a etapa;
+- seção `# Instruções do usuário` com o prompt resolvido.
 
-- **PARTE A (Modelo)**: modelo canônico da tabela `gera_landing_stage_execution` validado contra Liquibase e backend;
-- **PARTE B (Fluxos)**: fluxo 01 de geração/persistência de prompts pelo Worker AI, com comportamento real atual (incluindo limitações já observadas em código).
+Esse texto vira o `prompt` canônico da execução.
 
-Evoluções de novas etapas do Gera Landing e novos estados do ciclo devem ser versionadas neste mesmo cânone.
+---
+
+## 4) Montagem do schema e payload OpenAI
+
+## 4.1 Schema de saída
+
+- O worker carrega `classpath:prompts/geralanding/landing-page-wireframe-schema.json`.
+- O schema é usado de duas formas:
+  1. inserido no body OpenAI (`text.format.schema`);
+  2. serializado e enviado ao backend em `schemaJson` para auditoria.
+
+## 4.2 Payload OpenAI (Responses API)
+
+O worker monta um JSON com:
+
+- `model`: atualmente `gpt-5.2`;
+- `input`:
+  - role `system` com instrução de especialista em pipeline;
+  - role `user` com conteúdo do prompt final (tipo `input_text`);
+- `text.format`:
+  - `type: "json_schema"`
+  - `name: "experiment_pipeline_landing_page_copy"` (nome técnico atual implementado)
+  - `schema`: conteúdo do schema de wireframe
+  - `strict: true`.
+
+O body completo é persistido no backend em `openai_request_body`.
+
+---
+
+## 5) Handoff Worker → Backend antes da geração
+
+Antes de chamar a OpenAI, o worker executa:
+
+`POST /api/internal/geralanding/stage-executions/{idJob}/receive-prompt`
+
+Body enviado:
+
+- `experimentId`
+- `stageCode`
+- `prompt`
+- `openAiRequestBody`
+- `schemaJson`
+- `promptMarkdownContent`
+
+No backend, `receivePrompt(...)`:
+
+1. busca execução por `idJob` (fallback por `experimentId + stageCode`);
+2. persiste os campos de prompt/auditoria;
+3. define:
+   - `processing_started_at = now`
+   - `status = "EM_PROCESSAMENTO"`.
+
+---
+
+## 6) Execução OpenAI em modo batch (implementação atual)
+
+## 6.1 Estratégia batch
+
+`GeraLandingOpenAiBatchClient.generate(...)` executa ciclo completo:
+
+1. monta **uma linha JSONL** com request para `/v1/responses` (`custom_id = idJob`);
+2. upload em `/files` com `purpose=batch`;
+3. cria batch em `/batches` (`endpoint=/v1/responses`, `completion_window=24h`);
+4. polling de status em `/batches/{id}` até `completed` (timeout configurável);
+5. baixa output em `/files/{output_file_id}/content`;
+6. parse da primeira linha JSONL para extrair `response.body`;
+7. extrai texto final (`firstText()`), uso de tokens e custo estimado.
+
+Status terminais inválidos (`failed`, `expired`, `cancelled`) geram erro.
+
+## 6.2 Resultado consolidado no worker
+
+O worker monta `GeraLandingJobCompletionPayload` com:
+
+- `responseContent` (resposta final);
+- `rawResponse` (saída bruta JSONL);
+- `openAiJobId`;
+- `inputTokens`, `outputTokens`;
+- `costUsd` estimado.
+
+---
+
+## 7) Handoff Worker → Backend de resultado final
+
+Após sucesso no batch:
+
+`POST /api/internal/geralanding/stage-executions/{idJob}/receive-result`
+
+Body enviado:
+
+- `experimentId`
+- `stageCode`
+- `modelResponse`
+- `inputTokens`
+- `outputTokens`
+- `costUsd`
+- `openAiJobId`
+
+Backend `receiveResult(...)` persiste:
+
+- `model_response`
+- `openai_job_id` (quando informado)
+- `input_tokens`
+- `output_tokens`
+- `cost_usd`
+- `completed_at = now`
+- `status = "CONCLUIDO"`.
+
+---
+
+## 8) Endpoints canônicos do fluxo wireframe
+
+## 8.1 Públicos (admin/backend)
+
+- `POST /api/experiments/{experimentId}/geralanding/wireframe/start`
+- `GET /api/experiments/{experimentId}/geralanding/stage-executions`
+- `GET /api/experiments/{experimentId}/geralanding/stage-executions/{idJob}`
+
+## 8.2 Internos backend↔worker
+
+- `GET /api/internal/geralanding/stage-executions/pending`
+- `POST /api/internal/geralanding/stage-executions/{idJob}/receive-prompt`
+- `POST /api/internal/geralanding/stage-executions/{idJob}/receive-result`
+- `POST /api/internal/geralanding/stage-executions` (registro técnico alternativo via worker)
+- `POST /api/internal/geralanding/stage-executions/receive-prompt` (rota body-based mantida para compatibilidade)
+
+---
+
+## 9) Máquina de estados canônica (estado atual)
+
+1. **INICIADO**
+   - criado no start manual;
+   - elegível para polling.
+
+2. **EM_PROCESSAMENTO**
+   - prompt recebido e persistido;
+   - payload/schema registrados.
+
+3. **CONCLUIDO**
+   - resultado OpenAI persistido;
+   - tokens/custo registrados;
+   - `completed_at` preenchido.
+
+---
+
+## 10) Observações de aderência ao código
+
+- O `id_job` é armazenado no banco como binário (`byte[]`), mas trafega na API como string UUID por conversão UTF-8 no serviço.
+- O endpoint de pendências atualmente não aplica parâmetro `limit` no backend; usa consulta fixa top 20.
+- A execução atual trata apenas `landing-page-wireframe` no worker.
+- A auditoria persiste simultaneamente o prompt renderizado, markdown original, schema e request OpenAI, permitindo reconstituição completa da geração.
+
+---
+
+## 11) Fonte de verdade desta versão
+
+Este documento foi atualizado a partir da implementação vigente em:
+
+- backend (`com.marketinghub.geralanding`)
+- ai-worker (`com.marketinghub.worker.geralanding`)
+- recursos de prompt/schema em `ai-worker/src/main/resources/prompts/geralanding`.
+
+Qualquer mudança de contrato, estados, payloads ou armazenamento deve atualizar este arquivo imediatamente para manter caráter canônico.


### PR DESCRIPTION
### Motivation

- Atualizar o documento canônico para refletir o comportamento implementado do módulo Gera Landing (backend + ai-worker) como fonte de verdade. 
- Registrar de forma operacional a jornada completa desde a solicitação manual (start) até a persistência do resultado OpenAI (status CONCLUIDO). 
- Fornecer rastreabilidade e contrato claro para auditoria de prompts, payload OpenAI, schema e estados do job.

### Description

- Atualiza `docs/gera-landing/modelo-canonico-gera-landing.md` detalhando o modelo de dados canônico da tabela `gera_landing_stage_execution` incluindo campos de auditoria OpenAI (`openai_request_body`, `schema_json`, `prompt_markdown_content`, `openai_job_id`, `model_response`, `input_tokens`, `output_tokens`, `cost_usd`) e observação sobre armazenamento de `id_job` como binário mapeado em `byte[]`.
- Documenta o fluxo end-to-end: API de start manual (`POST /api/experiments/{experimentId}/geralanding/wireframe/start`), polling do worker (`GET /api/internal/geralanding/stage-executions/pending`), montagem de prompt em `GeraLandingService` (resolução de `{prompt-*}` e `{dados-*}`, detecção de ciclos), envelope final do prompt e registro pré-OpenAI (`POST .../{idJob}/receive-prompt`).
- Descreve a montagem do payload para a Responses API (inserção do `json_schema` strict), uso do schema de wireframe, e a execução em modo batch pelo `GeraLandingOpenAiBatchClient` (upload JSONL em `/files`, criação de `/batches`, polling até `completed`, download e parsing do output).
- Explica o handoff de resultado (`POST .../{idJob}/receive-result`), a persistência final no backend (model_response, tokens, custo, timestamps) e a máquina de estados canônica (`INICIADO -> EM_PROCESSAMENTO -> CONCLUIDO`), além do catálogo de endpoints públicos e internos.

### Testing

- Nenhum teste automatizado foi executado para esta alteração, pois a mudança é exclusivamente documental e alinhada ao código-fonte já existente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb748fab948321856aace7c097a9f6)