### PR TITLE
Add deployment workflow for MOIS Hotmart Collector container

### DIFF
--- a/.github/workflows/mois-hotmart-collector-ci.yml
+++ b/.github/workflows/mois-hotmart-collector-ci.yml
@@ -1,0 +1,118 @@
+name: CI - MOIS Hotmart Collector
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "mois-hotmart-collector/**"
+      - ".github/workflows/mois-hotmart-collector-ci.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "mois-hotmart-collector/**"
+      - ".github/workflows/mois-hotmart-collector-ci.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/mois-hotmart-collector
+
+jobs:
+  test:
+    name: Test (MOIS Hotmart Collector)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Maven test
+        working-directory: mois-hotmart-collector
+        run: mvn -B test
+
+  build-and-push:
+    name: Build and Push Image (MOIS Hotmart Collector)
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=sha-${{ github.sha }}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mois-hotmart-collector
+          file: ./mois-hotmart-collector/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    name: Deploy (MOIS Hotmart Collector)
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: github.ref == 'refs/heads/main'
+    environment: production
+    env:
+      DEPLOY_HOST: 177.153.62.107
+      DEPLOY_USER: root
+      REMOTE_PATH: /opt/marketinghub/mois-hotmart-collector
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare SSH
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_CHAVE != '' && secrets.VPS_SSH_CHAVE || secrets.VPS_SSH_KEY != '' && secrets.VPS_SSH_KEY || secrets.SSH_PRIVATE_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          printf '%s\n' "SSH_COMMON_ARGS=-i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=yes -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -o ConnectTimeout=60" >> "$GITHUB_ENV"
+
+      - name: Sync project files
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p ${REMOTE_PATH}"
+          rsync -az --delete -e "ssh ${SSH_COMMON_ARGS}" --exclude '.git' --exclude 'target' --exclude '.idea' --exclude '.vscode' --exclude '.DS_Store' \
+            mois-hotmart-collector/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_PATH}"
+
+      - name: Deploy with Docker Compose
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "set -euo pipefail \
+            && cd ${REMOTE_PATH} \
+            && export MOIS_HOTMART_COLLECTOR_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA} \
+            && export COMPOSE_PROJECT_NAME=marketinghub-mois-hotmart-collector \
+            && docker login ${{ env.REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml pull \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml up -d --remove-orphans \
+            && docker image prune -af"

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -122,3 +122,13 @@
 - `HotmartCollectorService` atualizado para abrir Chromium headless, navegar para `https://app.hotmart.com/market/search` e extrair links de produtos (`/market/products/`) até o limite solicitado.
 - `collector.playwright.headless` parametrizado (default `true`) com opção de override para debug local.
 - Teste de controller isolado com `@MockBean` para evitar dependência de rede/browser durante testes unitários.
+
+## 2026-05-06 20:50:00 UTC
+- Atendida a solicitação de tornar o deploy do `mois-hotmart-collector` automático via GitHub Actions.
+- Criado workflow dedicado `.github/workflows/mois-hotmart-collector-ci.yml` com pipeline completo:
+  1. testes Maven (`mvn -B test`),
+  2. build e push da imagem para GHCR,
+  3. deploy automático por SSH no mesmo host do MOIS principal (`177.153.62.107`) usando `docker compose`.
+- README do submódulo atualizado para documentar o novo fluxo de deploy automático.
+- Registro criado conforme solicitação explícita: `docs/mois/registros.md`.
+- Commit relacionado: `88064ce`.

--- a/mois-hotmart-collector/README.md
+++ b/mois-hotmart-collector/README.md
@@ -53,3 +53,22 @@ Exemplo:
 ```bash
 java -jar target/mois-hotmart-collector.jar --collector.playwright.headless=false
 ```
+
+## Deploy no mesmo host do MOIS principal
+
+Use o script central do repositório para build/push/deploy:
+
+```bash
+cd /workspace/marketing-hub
+DEPLOY_HOST=ubuntu@191.252.120.96 \
+IMAGE_TAG=2026.05.06-1 \
+IMAGE_REPO=marketinghub/mois-hotmart-collector \
+bash ./scripts/deploy-mois-hotmart-collector.sh
+```
+
+### O que o script faz
+
+1. Build da imagem Docker do módulo `mois-hotmart-collector`.
+2. Push da imagem para o registry configurado.
+3. Copia `docker-compose.deploy.yml` para o host remoto.
+4. Executa `docker compose up -d` no mesmo host usado pelo MOIS principal.

--- a/mois-hotmart-collector/README.md
+++ b/mois-hotmart-collector/README.md
@@ -54,6 +54,17 @@ Exemplo:
 java -jar target/mois-hotmart-collector.jar --collector.playwright.headless=false
 ```
 
+
+## Deploy automático (GitHub Actions)
+
+O deploy deste módulo agora é automático via workflow:
+
+- Arquivo: `.github/workflows/mois-hotmart-collector-ci.yml`
+- Fluxo em `push` na `main` para alterações em `mois-hotmart-collector/**`:
+  1. roda testes (`mvn test`),
+  2. builda e publica imagem no GHCR,
+  3. faz deploy no mesmo host do MOIS principal (`177.153.62.107`).
+
 ## Deploy no mesmo host do MOIS principal
 
 Use o script central do repositório para build/push/deploy:

--- a/mois-hotmart-collector/docker-compose.deploy.yml
+++ b/mois-hotmart-collector/docker-compose.deploy.yml
@@ -1,0 +1,8 @@
+services:
+  mois-hotmart-collector:
+    image: ${MOIS_HOTMART_COLLECTOR_IMAGE}
+    build: null
+    container_name: mois-hotmart-collector
+    restart: unless-stopped
+    ports:
+      - "8095:8080"

--- a/scripts/deploy-mois-hotmart-collector.sh
+++ b/scripts/deploy-mois-hotmart-collector.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy do módulo mois-hotmart-collector no mesmo host do MOIS principal.
+# Pré-requisitos:
+# - Docker + Docker Compose plugin no host remoto
+# - Acesso SSH configurado
+# - Registry acessível para pull da imagem
+#
+# Variáveis obrigatórias:
+#   DEPLOY_HOST=usuario@host
+#   IMAGE_TAG=2026.05.06-1
+#
+# Variáveis opcionais:
+#   IMAGE_REPO=marketinghub/mois-hotmart-collector
+#   REMOTE_DIR=/opt/marketinghub/mois-hotmart-collector
+#   SSH_OPTS='-o StrictHostKeyChecking=no'
+
+: "${DEPLOY_HOST:?DEPLOY_HOST é obrigatório (ex.: ubuntu@191.252.120.96)}"
+: "${IMAGE_TAG:?IMAGE_TAG é obrigatório (ex.: 2026.05.06-1)}"
+
+IMAGE_REPO="${IMAGE_REPO:-marketinghub/mois-hotmart-collector}"
+REMOTE_DIR="${REMOTE_DIR:-/opt/marketinghub/mois-hotmart-collector}"
+SSH_OPTS="${SSH_OPTS:-}"
+IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+
+printf '==> Build da imagem %s\n' "$IMAGE"
+docker build -t "$IMAGE" ./mois-hotmart-collector
+
+printf '==> Push da imagem %s\n' "$IMAGE"
+docker push "$IMAGE"
+
+printf '==> Preparando diretório remoto %s:%s\n' "$DEPLOY_HOST" "$REMOTE_DIR"
+ssh $SSH_OPTS "$DEPLOY_HOST" "mkdir -p '$REMOTE_DIR'"
+
+printf '==> Enviando compose de deploy\n'
+scp $SSH_OPTS ./mois-hotmart-collector/docker-compose.deploy.yml "$DEPLOY_HOST:$REMOTE_DIR/docker-compose.yml"
+
+printf '==> Subindo container remoto com nova imagem\n'
+ssh $SSH_OPTS "$DEPLOY_HOST" \
+  "cd '$REMOTE_DIR' && MOIS_HOTMART_COLLECTOR_IMAGE='$IMAGE' docker compose pull && MOIS_HOTMART_COLLECTOR_IMAGE='$IMAGE' docker compose up -d"
+
+printf '==> Deploy concluído em %s com imagem %s\n' "$DEPLOY_HOST" "$IMAGE"


### PR DESCRIPTION
### Motivation
- Provide an automated, repeatable way to build, publish and deploy the `mois-hotmart-collector` service as a separate container on the same host used by the main MOIS module. 
- Make remote deploys safe and reproducible by using a small compose file that consumes an externally-provided image tag and a single deploy script to run build/push/remote-compose operations.

### Description
- Added `mois-hotmart-collector/docker-compose.deploy.yml` which uses the environment variable `MOIS_HOTMART_COLLECTOR_IMAGE` and exposes `8095:8080` for isolated deployment. 
- Added `scripts/deploy-mois-hotmart-collector.sh` which automates `docker build`, `docker push`, copies the deploy compose to the remote host and runs `docker compose up -d` via SSH, and requires `DEPLOY_HOST` and `IMAGE_TAG`. 
- Updated `mois-hotmart-collector/README.md` with usage example for the central deploy script and a short description of the steps the script executes. 
- The deploy flow supports optional overrides via `IMAGE_REPO`, `REMOTE_DIR`, and `SSH_OPTS` and keeps the compose minimal so the remote host pulls the declared image.

### Testing
- Ran module unit tests with `cd mois-hotmart-collector && mvn test` and the build completed successfully. 
- Module test results: `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0` and `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba54a5af48321961392881479f7a2)