### PR TITLE
Require `uiTags` in landing page wireframe schema

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -65,6 +65,7 @@
           "contentType",
           "copySource",
           "uiNotes",
+          "uiTags",
           "messageMatchDependency",
           "sectionDependsOn",
           "mobilePriorityScore",

--- a/docs/geralanding/registrros.md
+++ b/docs/geralanding/registrros.md
@@ -1,0 +1,20 @@
+# Registros de ajustes — Gera Landing
+
+## 2026-05-06 — Correção de schema `landing-page-wireframe-schema.json`
+
+### Contexto
+Foi identificado erro `400 invalid_json_schema` no `response_format` `experiment_pipeline_landing_page_copy`.
+
+Mensagem principal retornada pela API:
+- `Missing 'uiTags'`
+- `param: text.format.schema`
+
+### Causa raiz
+No schema de wireframe da landing, o campo `uiTags` já existia em `properties` de `sectionOrder.items`, mas não estava presente no array `required` do mesmo nível.
+
+### Ajuste aplicado
+No arquivo `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json`, foi adicionado `"uiTags"` em `sectionOrder.items.required`.
+
+### Resultado esperado
+- Eliminar erro de validação de schema no envio do `response_format`.
+- Garantir que cada seção do wireframe de landing informe explicitamente `uiTags`.


### PR DESCRIPTION
### Motivation
- Ensure every landing page wireframe section includes `uiTags` metadata so UI consumers and downstream checks can rely on tag presence.

### Description
- Add `"uiTags"` to the `required` properties for section objects in `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` so the schema enforces this field.

### Testing
- Ran automated tests including `./gradlew test` and JSON schema validation against sample fixtures, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbbdaabe508321a964d261df1b6d71)