### PR TITLE
Fix mois-hotmart-collector Docker build artifact path

### DIFF
--- a/mois-hotmart-collector/Dockerfile
+++ b/mois-hotmart-collector/Dockerfile
@@ -6,6 +6,6 @@ RUN mvn -q -DskipTests package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /app
-COPY --from=build /app/target/mois-hotmart-collector-0.1.0-SNAPSHOT.jar app.jar
+COPY --from=build /app/target/mois-hotmart-collector.jar app.jar
 EXPOSE 8096
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
### Motivation
- Fix a Docker image build failure caused by the `COPY --from=build` referencing a non-existent versioned JAR name instead of the actual Maven output filename.

### Description
- Updated `mois-hotmart-collector/Dockerfile` to copy `/app/target/mois-hotmart-collector.jar` (the `finalName` produced by Maven) into the runtime image instead of `/app/target/mois-hotmart-collector-0.1.0-SNAPSHOT.jar`.

### Testing
- Ran unit tests with `mvn -q test` in `mois-hotmart-collector`, which completed successfully.
- Attempted `docker build` to validate the image stage, but the Docker CLI is unavailable in this environment (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc1da2f248321bc6f522e7992447f)