### PR TITLE
Fix mcp-server compilation by replacing oversized Map.of in GithubActionsService

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/GithubActionsService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/GithubActionsService.java
@@ -139,22 +139,22 @@ public class GithubActionsService {
             }
         }
 
-        return Map.of(
-                "run_id", runId,
-                "workflow_name", stringValue(runPayload.get("name")),
-                "display_title", stringValue(runPayload.get("display_title")),
-                "status", stringValue(runPayload.get("status")),
-                "conclusion", stringValue(runPayload.get("conclusion")),
-                "run_attempt", runPayload.get("run_attempt"),
-                "event", stringValue(runPayload.get("event")),
-                "branch", stringValue(runPayload.get("head_branch")),
-                "html_url", stringValue(runPayload.get("html_url")),
-                "run_api_url", runApiUrl,
-                "jobs_api_url", jobsApiUrl,
-                "failed", "failure".equalsIgnoreCase(stringValue(runPayload.get("conclusion"))),
-                "failed_jobs", failedJobs,
-                "has_job_errors", !failedJobs.isEmpty()
-        );
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("run_id", runId);
+        result.put("workflow_name", stringValue(runPayload.get("name")));
+        result.put("display_title", stringValue(runPayload.get("display_title")));
+        result.put("status", stringValue(runPayload.get("status")));
+        result.put("conclusion", stringValue(runPayload.get("conclusion")));
+        result.put("run_attempt", runPayload.get("run_attempt"));
+        result.put("event", stringValue(runPayload.get("event")));
+        result.put("branch", stringValue(runPayload.get("head_branch")));
+        result.put("html_url", stringValue(runPayload.get("html_url")));
+        result.put("run_api_url", runApiUrl);
+        result.put("jobs_api_url", jobsApiUrl);
+        result.put("failed", "failure".equalsIgnoreCase(stringValue(runPayload.get("conclusion"))));
+        result.put("failed_jobs", failedJobs);
+        result.put("has_job_errors", !failedJobs.isEmpty());
+        return result;
     }
 
     private String stringValue(Object value) {


### PR DESCRIPTION
### Motivation
- Resolve a compilation error in the `mcp-server` module caused by using `Map.of(...)` with more than 10 key/value pairs (Java's `Map.of` limit) which broke CI compilation.

### Description
- Replace the large `Map.of(...)` return in `GithubActionsService` with a `LinkedHashMap` constructed via `put(...)` to avoid the `Map.of` entry limit while preserving output order and values in `mcp-server/src/main/java/com/marketinghub/mcpserver/service/GithubActionsService.java`.
- Preserve all existing response fields and semantics: `run_id`, `workflow_name`, `display_title`, `status`, `conclusion`, `run_attempt`, `event`, `branch`, `html_url`, `run_api_url`, `jobs_api_url`, `failed`, `failed_jobs`, and `has_job_errors`.

### Testing
- Ran `cd mcp-server && mvn -q -DskipTests compile` which completed successfully.
- Ran `cd mcp-server && mvn test -q` which failed during test compilation due to unrelated pre-existing constructor signature mismatches in tests (`ModuleLogServiceTest` and `MetaToolsServiceTest`) for `McpProperties`, and these test errors are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc212e1188321a2a9fc09b81736a4)