### PR TITLE
Fix MOIS Hotmart Collector deploy port mapping to 8096

### DIFF
--- a/mois-hotmart-collector/docker-compose.deploy.yml
+++ b/mois-hotmart-collector/docker-compose.deploy.yml
@@ -5,4 +5,4 @@ services:
     container_name: mois-hotmart-collector
     restart: unless-stopped
     ports:
-      - "8095:8080"
+      - "8096:8096"


### PR DESCRIPTION
### Motivation
- Avoid deployment failure caused by a host port collision where the deploy override exposed host port `8095` that was already allocated on the target server.

### Description
- Update `mois-hotmart-collector/docker-compose.deploy.yml` to change the port mapping from `"8095:8080"` to `"8096:8096"`, aligning the deploy override with the base service configuration and the runtime port `MOIS_HOTMART_PORT=8096`.

### Testing
- Attempted to validate the composed configuration with `docker compose -f mois-hotmart-collector/docker-compose.yml -f mois-hotmart-collector/docker-compose.deploy.yml config`, but the Docker CLI is not available in this environment so the automated compose validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc9c4a3a083218747bfdc4b238656)