### PR TITLE
Add Actuator with configurable base path and restrict exposed endpoints in mois-hotmart-collector

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -132,3 +132,10 @@
 - README do submódulo atualizado para documentar o novo fluxo de deploy automático.
 - Registro criado conforme solicitação explícita: `docs/mois/registros.md`.
 - Commit relacionado: `88064ce`.
+
+## 2026-05-06 22:38:07 UTC-3
+- Ajustado o endpoint base do Actuator no `mois-hotmart-collector` para reduzir previsibilidade de rota pública de observabilidade.
+- O base path deixou de ser fixo em `/actuator` e passou a usar configuração externa:
+  - `management.endpoints.web.base-path=${ACTUATOR_BASE_PATH:/internal/ops-monitor}`
+- Mantida exposição apenas dos endpoints `health`, `info` e `loggers`, preservando o objetivo operacional de monitoramento e ajuste de nível de logs em runtime.
+- README do submódulo atualizado para refletir o novo path padrão e orientar customização por variável de ambiente.

--- a/mois-hotmart-collector/README.md
+++ b/mois-hotmart-collector/README.md
@@ -12,6 +12,10 @@ Submódulo separado do MOIS para automatização da coleta de produtos quentes n
 
 - `GET /api/v1/mois-hotmart/health`
 - `POST /api/v1/mois-hotmart/collections`
+- `GET /internal/ops-monitor/health`
+- `GET /internal/ops-monitor/loggers`
+
+> O path base dos endpoints de observabilidade pode (e deve) ser customizado via variável de ambiente `ACTUATOR_BASE_PATH`.
 
 ## Execução local
 

--- a/mois-hotmart-collector/pom.xml
+++ b/mois-hotmart-collector/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.playwright</groupId>
             <artifactId>playwright</artifactId>
             <version>1.53.0</version>

--- a/mois-hotmart-collector/src/main/resources/application.properties
+++ b/mois-hotmart-collector/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 spring.application.name=mois-hotmart-collector
 server.port=${MOIS_HOTMART_PORT:8096}
+
+# Actuator observability
+management.endpoints.web.base-path=${ACTUATOR_BASE_PATH:/internal/ops-monitor}
+management.endpoints.web.exposure.include=health,info,loggers
+management.endpoint.health.show-details=always


### PR DESCRIPTION
### Motivation
- Reduce predictability of the public Actuator route and improve operational security for the `mois-hotmart-collector` service. 
- Provide minimal, runtime observability (`health`, `info`, `loggers`) while allowing operators to customize the Actuator path via environment variable. 

### Description
- Added `spring-boot-starter-actuator` dependency to `mois-hotmart-collector/pom.xml` to enable Actuator features. 
- Introduced configuration in `mois-hotmart-collector/src/main/resources/application.properties` to set `management.endpoints.web.base-path=${ACTUATOR_BASE_PATH:/internal/ops-monitor}`, to expose only `health,info,loggers`, and to enable health details with `management.endpoint.health.show-details=always`. 
- Updated `mois-hotmart-collector/README.md` to document the new Actuator endpoints and the `ACTUATOR_BASE_PATH` environment variable. 
- Recorded the change in `docs/mois/registros.md` with the new timestamped entry describing the base-path hardening and README update. 

### Testing
- Automated CI runs `mvn -B test` as part of the pipeline and the test stage completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe781214483219a5d31099869947a)