### PR TITLE
Persist landing-page-wireframe model output to Experiment and update docs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -139,6 +139,20 @@ public class GeraLandingStageExecutionService {
         execution.setCompletedAt(Instant.now());
         execution.setStatus(StringUtils.hasText(request.errorMessage()) ? "FALHA" : "CONCLUIDO");
         executionRepository.save(execution);
+        persistWireframeOnExperiment(request);
+    }
+
+    private void persistWireframeOnExperiment(GeraLandingResultReceiveRequest request) {
+        if (!"landing-page-wireframe".equalsIgnoreCase(request.stageCode())) {
+            return;
+        }
+        if (!StringUtils.hasText(request.modelResponse()) || StringUtils.hasText(request.errorMessage())) {
+            return;
+        }
+        Experiment experiment = experimentRepository.findById(request.experimentId())
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + request.experimentId()));
+        experiment.setLandingPageWireframe(request.modelResponse());
+        experimentRepository.save(experiment);
     }
 
     @Transactional(readOnly = true)

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.geralanding;
 
+import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,5 +81,38 @@ class GeraLandingStageExecutionServiceTest {
 
         verify(executionRepository, never()).findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(any(), any());
         verify(executionRepository).save(any(GeraLandingStageExecution.class));
+    }
+
+    @Test
+    void shouldPersistLandingPageWireframeOnExperimentWhenWireframeResultArrives() {
+        GeraLandingResultReceiveRequest request = new GeraLandingResultReceiveRequest(
+                31L,
+                "landing-page-wireframe",
+                "{\"landingPageWireframe\":{\"sectionOrder\":[]}}",
+                null,
+                null,
+                "job-openai-1",
+                100,
+                200,
+                null);
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(31L)
+                .stageCode("landing-page-wireframe")
+                .executionRequestedAt(Instant.parse("2026-05-04T00:00:00Z"))
+                .createdAt(Instant.parse("2026-05-04T00:00:00Z"))
+                .status("EM_PROCESSAMENTO")
+                .idJob("id-ok".getBytes(StandardCharsets.UTF_8))
+                .build();
+        Experiment experiment = new Experiment();
+        experiment.setId(31L);
+
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc("id-ok".getBytes(StandardCharsets.UTF_8)))
+                .thenReturn(Optional.of(execution));
+        when(experimentRepository.findById(31L)).thenReturn(Optional.of(experiment));
+
+        service.receiveResult("id-ok", request);
+
+        assertEquals("{\"landingPageWireframe\":{\"sectionOrder\":[]}}", experiment.getLandingPageWireframe());
+        verify(experimentRepository).save(experiment);
     }
 }

--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -152,7 +152,8 @@ Quando o usuário aciona o botão de geração de wireframe na UI (`gera-landing
 3. **Backend** enfileira/agenda a execução no pipeline para consumo assíncrono pelo Worker AI (sem acesso direto ao banco pelo worker).
 4. **Worker AI** executa scheduler periódico e consulta endpoint do backend para buscar jobs pendentes de `gera-landing`/pipeline.
 5. Ao receber o job, **Worker AI** monta o prompt final da etapa e envia ao backend a telemetria de geração (`experimentId`, `stage`, `executionId`, `prompt montado`).
-6. **Backend** persiste o registro final da execução com vínculo ao experimento e auditoria de prompt para rastreabilidade.
+6. Ao finalizar `landing-page-wireframe`, **Worker AI** envia a saída literal do modelo ao backend no callback de resultado.
+7. **Backend** persiste o registro final da execução com vínculo ao experimento e auditoria de prompt para rastreabilidade, e também grava a saída no campo `experiment.landing_page_wireframe` do `experimentId` em processamento.
 
 Regras mandatórias:
 


### PR DESCRIPTION
### Motivation

- Ensure the literal model output for the `landing-page-wireframe` stage is stored on the corresponding `Experiment` to make the wireframe available as an experiment artifact.
- Document the canonical pipeline behavior so workers and backend follow the same contract for wireframe result handling.

### Description

- Added `persistWireframeOnExperiment(GeraLandingResultReceiveRequest)` and invoked it from `receiveResult` to persist the model output into `experiment.landingPageWireframe` when the stage is `landing-page-wireframe`, the `modelResponse` is present, and there is no `errorMessage`.
- The method retrieves the `Experiment` by `experimentId`, sets `landingPageWireframe` to the `modelResponse`, and saves the `Experiment` via `experimentRepository`.
- Updated unit tests by adding `shouldPersistLandingPageWireframeOnExperimentWhenWireframeResultArrives` in `GeraLandingStageExecutionServiceTest` and added the `Experiment` import used by the test.
- Updated the canonical pipeline documentation file `docs/canonical/experiments-automation-flow-canon.v1.md` to describe that the worker sends the literal model output back and the backend persists it to `experiment.landing_page_wireframe`.

### Testing

- Ran unit tests in `GeraLandingStageExecutionServiceTest`, including `shouldPersistLandingPageWireframeOnExperimentWhenWireframeResultArrives`, and they passed.
- Verified existing `receiveResult` behavior remains covered by tests that still passed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbf98768508321a1255107c7bd3f45)