### PR TITLE
Adicionar fonte de logs 'mois-hotmart' ao tool `java_module_logs` do MCP

### DIFF
--- a/mcp-server/AGENTS.md
+++ b/mcp-server/AGENTS.md
@@ -10,6 +10,7 @@ Manter os seguintes endpoints como defaults de origem de logs no módulo `mcp-se
 - Facebook Ads Worker: `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`
 - Lead Portal: `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`
 - Portal Pagamentos (Lead Portal): `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`
+- Mois Coletor Hotmart: `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`
 
 Sempre que houver alteração desses endpoints, atualizar em conjunto:
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -17,7 +17,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `db_list_tables`: lista todas as tabelas disponíveis no schema atual.
 - `db_read_table`: lê dados de uma tabela com paginação (`table`, `limit`, `offset`).
 - `db_query`: executa SQL de leitura (`SELECT`/`WITH`) com limite de linhas.
-- `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`).
+- `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-hotmart`).
 - `meta_docs_get`: busca páginas de documentação da Meta em hosts aprovados.
 - `meta_graph_get`: executa leitura (`GET`) da Graph API com token configurado no MCP.
 - `meta_graph_debug_token`: executa `debug_token` para validar tokens.
@@ -53,7 +53,8 @@ O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou
 - `MCP_LOG_EMAIL_SERVICE_PATH` (default `http://191.252.120.96:8086/ops-email-gateway-7xk9/email-service-audit-log`);
 - `MCP_LOG_LEAD_PORTAL_PAYMENT_PATH` (default `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`);
 - `MCP_LOG_MDS_PATH` (default `http://177.153.62.107:8091/actuator/logfile`);
-- `MCP_LOG_MOIS_PATH` (default `http://177.153.62.107:8094/manage/logfile`).
+- `MCP_LOG_MOIS_PATH` (default `http://177.153.62.107:8094/manage/logfile`);
+- `MCP_LOG_MOIS_HOTMART_PATH` (default `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`).
 - `MCP_LOG_FETCH_TIMEOUT_SECONDS` (default `45`);
 - `MCP_LOG_FETCH_ATTEMPTS` (default `3`), número de tentativas para leitura HTTP de logs;
 - `MCP_LOG_FETCH_RETRY_DELAY_MILLIS` (default `400`), intervalo entre tentativas de leitura HTTP;

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -29,6 +29,7 @@ public record McpProperties(
             @NotBlank String leadPortalPaymentPath,
             @NotBlank String mdsPath,
             @NotBlank String moisPath,
+            @NotBlank String moisHotmartPath,
             @Positive int fetchTimeoutSeconds,
             @Positive int fetchAttempts,
             @Positive int fetchRetryDelayMillis,

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -127,13 +127,13 @@ public class McpController {
                     ),
                     Map.of(
                             "name", "java_module_logs",
-                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois).",
+                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart).",
                             "inputSchema", Map.of(
                                     "type", "object",
                                     "properties", Map.of(
                                             "module", Map.of("type", "string",
                                                     "enum", List.of("backend", "ai-worker", "lead-portal", "facebook-ads",
-                                                            "email-service", "lead-portal-payment", "mds", "mois"),
+                                                            "email-service", "lead-portal-payment", "mds", "mois", "mois-hotmart"),
                                                     "description", "Módulo Java para consultar logs."),
                                             "lines", Map.of("type", "integer", "minimum", 1,
                                                     "maximum", moduleLogService.maxLines(),

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -196,6 +196,7 @@ public class ModuleLogService {
             case "lead-portal-payment" -> properties.logs().leadPortalPaymentPath();
             case "mds" -> properties.logs().mdsPath();
             case "mois" -> properties.logs().moisPath();
+            case "mois-hotmart" -> properties.logs().moisHotmartPath();
             default -> throw new IllegalArgumentException("Unknown module: " + module);
         };
     }
@@ -208,10 +209,10 @@ public class ModuleLogService {
         String normalized = module.trim().toLowerCase();
         return switch (normalized) {
             case "backend", "ai-worker", "lead-portal", "facebook-ads", "email-service", "lead-portal-payment",
-                 "mds", "mois" -> normalized;
+                 "mds", "mois", "mois-hotmart" -> normalized;
             default -> throw new IllegalArgumentException(
                     "module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, " +
-                            "lead-portal-payment, mds, mois");
+                            "lead-portal-payment, mds, mois, mois-hotmart");
         };
     }
 

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -50,6 +50,7 @@ mcp:
     lead-portal-payment-path: ${MCP_LOG_LEAD_PORTAL_PAYMENT_PATH:http://191.252.102.54:8092/api/v1/logs/runtime?lines=200}
     mds-path: ${MCP_LOG_MDS_PATH:http://177.153.62.107:8091/actuator/logfile}
     mois-path: ${MCP_LOG_MOIS_PATH:http://177.153.62.107:8094/manage/logfile}
+    mois-hotmart-path: ${MCP_LOG_MOIS_HOTMART_PATH:http://177.153.62.107:8096/ops-monitor/mois-hotmart-log}
     fetch-timeout-seconds: ${MCP_LOG_FETCH_TIMEOUT_SECONDS:45}
     fetch-attempts: ${MCP_LOG_FETCH_ATTEMPTS:3}
     fetch-retry-delay-millis: ${MCP_LOG_FETCH_RETRY_DELAY_MILLIS:400}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -47,6 +47,7 @@ class McpControllerTest {
                 () -> TEST_LOG_DIR.resolve("lead-portal-payment.log").toString());
         registry.add("mcp.logs.mds-path", () -> TEST_LOG_DIR.resolve("mds.log").toString());
         registry.add("mcp.logs.mois-path", () -> TEST_LOG_DIR.resolve("mois.log").toString());
+        registry.add("mcp.logs.mois-hotmart-path", () -> TEST_LOG_DIR.resolve("mois-hotmart.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
         registry.add("mcp.meta.enabled", () -> "false");
         registry.add("mcp.meta.graph-base-url", () -> "https://graph.facebook.com");
@@ -187,7 +188,7 @@ class McpControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.error.code").value(-32602))
                 .andExpect(jsonPath("$.error.message")
-                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois"));
+                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart"));
     }
 
     @Test
@@ -267,6 +268,7 @@ class McpControllerApiKeyEnabledTest {
                 () -> TEST_LOG_DIR.resolve("lead-portal-payment.log").toString());
         registry.add("mcp.logs.mds-path", () -> TEST_LOG_DIR.resolve("mds.log").toString());
         registry.add("mcp.logs.mois-path", () -> TEST_LOG_DIR.resolve("mois.log").toString());
+        registry.add("mcp.logs.mois-hotmart-path", () -> TEST_LOG_DIR.resolve("mois-hotmart.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
         registry.add("mcp.meta.enabled", () -> "false");
         registry.add("mcp.meta.graph-base-url", () -> "https://graph.facebook.com");

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -32,7 +32,7 @@ class MetaToolsServiceTest {
                 "marketing-hub-mcp",
                 "1.0.0",
                 null,
-                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", 45, 3, 400, 500, 262144),
+                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", 45, 3, 400, 500, 262144),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
@@ -64,6 +64,7 @@ class ModuleLogServiceTest {
                 logUrl,
                 logUrl,
                 logUrl,
+                logUrl,
                 2,
                 3,
                 1,


### PR DESCRIPTION
### Motivation
- Disponibilizar os logs do novo módulo "Mois Coletor Hotmart" via MCP para permitir inspeção operacional centralizada. 
- Manter documentação, configuração e validações em sincronia com a nova origem de logs.

### Description
- Adiciona a propriedade de configuração `mcp.logs.mois-hotmart-path` com variável de ambiente `MCP_LOG_MOIS_HOTMART_PATH` e default `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log` em `application.yml`. 
- Estende o record `McpProperties.Logs` com o campo `moisHotmartPath` para binding/validação da nova configuração. 
- Atualiza o tool `java_module_logs` em `McpController` para aceitar `mois-hotmart` no contrato JSON-RPC (descrição e `enum`). 
- Atualiza `ModuleLogService` para resolver `mois-hotmart` para `properties.logs().moisHotmartPath()` e ajustar a validação/erro para listar a nova opção. 
- Sincroniza documentação operacional e defaults em `README.md` e `AGENTS.md`. 
- Atualiza testes que dependem da estrutura de `Logs` e das listas de módulos (`McpControllerTest`, `ModuleLogServiceTest`, `MetaToolsServiceTest`).

### Testing
- Executado `mvn test -q` no módulo `mcp-server` e todos os testes automatizados passaram com sucesso. 
- Testes de unidade relevantes atualizados e verificados localmente (`McpControllerTest`, `ModuleLogServiceTest`, `MetaToolsServiceTest`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0dd134fc8321b8963726f4b960c6)