### PR TITLE
Use ParameterizedTypeReference for hypotheses response deserialization

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingBackendClient.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -76,7 +77,7 @@ public class GeraLandingBackendClient {
         List<Map<String, Object>> hypotheses = webClient.get()
                 .uri(hypothesesUrl)
                 .retrieve()
-                .bodyToFlux(Map.class)
+                .bodyToFlux(new ParameterizedTypeReference<Map<String, Object>>() {})
                 .collectList()
                 .onErrorReturn(List.of())
                 .block();


### PR DESCRIPTION
### Motivation
- Ensure correct deserialization of the hypotheses endpoint into a `Map<String,Object>` with generics preserved when using Reactor `WebClient`, avoiding raw-type/type-erasure issues.

### Description
- Added `ParameterizedTypeReference` import and replaced `.bodyToFlux(Map.class)` with `.bodyToFlux(new ParameterizedTypeReference<Map<String, Object>>() {})` in `populateHypothesisFields` of `GeraLandingBackendClient` to preserve the generic map type.

### Testing
- Ran the project's unit tests via `mvn test` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc15a29a208321a0db9e67c9f27fad)