### PR TITLE
Hotmart collector: add authenticated Playwright support, session-cookie handling, config and docs updates

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -139,3 +139,23 @@
   - `management.endpoints.web.base-path=${ACTUATOR_BASE_PATH:/internal/ops-monitor}`
 - Mantida exposição apenas dos endpoints `health`, `info` e `loggers`, preservando o objetivo operacional de monitoramento e ajuste de nível de logs em runtime.
 - README do submódulo atualizado para refletir o novo path padrão e orientar customização por variável de ambiente.
+
+## 2026-05-07 01:34:12 UTC-3
+- Revisada a implementação do coletor Hotmart no módulo `mois` para uso de área logada (`https://app.hotmart.com/market/search`) com suporte a navegação headless via Playwright.
+- Adicionada configuração por ambiente para operação autenticada:
+  - `MOIS_HOTMART_SEARCH_URL`
+  - `MOIS_HOTMART_USE_PLAYWRIGHT`
+  - `MOIS_HOTMART_SESSION_COOKIE`
+- Ajustado o fluxo para fallback seguro quando a sessão autenticada não estiver disponível, evitando quebra do job de coleta e mantendo rastreabilidade por log.
+- Dependência `com.microsoft.playwright:playwright` adicionada ao módulo `mois` para habilitar renderização e extração em página JS-driven.
+- Registro criado por solicitação explícita: `registre o trabalho em /docs/mois/registros.md`.
+- Commit relacionado: `93a04c8`.
+
+## 2026-05-07 01:37:00 UTC-3
+- Correção de escopo: os ajustes de coleta Hotmart com Playwright/sessão autenticada foram realocados do módulo `mois` para o projeto correto `mois-hotmart-collector`.
+- Revertida a alteração indevida no `mois` principal (`MoisDomainService` + `mois/pom.xml`) para preservar a separação arquitetural entre núcleo de domínio MOIS e coletor especializado.
+- No `mois-hotmart-collector`, adicionadas configurações de coleta autenticada:
+  - `collector.hotmart.search-url`
+  - `collector.hotmart.session-cookie`
+  - reutilização de `collector.playwright.headless`
+- O serviço do coletor agora encerra com `COLLECTION_SKIPPED` quando a sessão não está configurada, evitando falsa execução "ok" sem autenticação real.

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -159,3 +159,13 @@
   - `collector.hotmart.session-cookie`
   - reutilização de `collector.playwright.headless`
 - O serviço do coletor agora encerra com `COLLECTION_SKIPPED` quando a sessão não está configurada, evitando falsa execução "ok" sem autenticação real.
+
+## 2026-05-07 01:40:00 UTC-3
+- Ajustado o `mois-hotmart-collector` para execução automática **de hora em hora**, evitando dependência de disparo manual único.
+- Habilitado agendamento no aplicativo com `@EnableScheduling`.
+- Criado scheduler `HotmartCollectorScheduler` com cron padrão `0 0 * * * *` e controles por configuração:
+  - `collector.scheduler.enabled`
+  - `collector.scheduler.cron`
+  - `collector.scheduler.source`
+  - `collector.scheduler.max-products`
+- Mantida possibilidade de override por variáveis de ambiente (`COLLECTOR_SCHEDULER_*`).

--- a/mois-hotmart-collector/README.md
+++ b/mois-hotmart-collector/README.md
@@ -54,6 +54,10 @@ O script `run-local-jar.sh` executa via `java -jar`, evitando dependência de pe
 - A coleta autenticada usa:
   - `collector.hotmart.search-url` (default: `https://app.hotmart.com/market/search`)
   - `collector.hotmart.session-cookie` (obrigatório para área logada)
+- Agendamento automático:
+  - `collector.scheduler.enabled=true`
+  - `collector.scheduler.cron=0 0 * * * *` (**executa de hora em hora**)
+  - `collector.scheduler.max-products=25`
 
 Exemplo:
 

--- a/mois-hotmart-collector/README.md
+++ b/mois-hotmart-collector/README.md
@@ -51,6 +51,9 @@ O script `run-local-jar.sh` executa via `java -jar`, evitando dependência de pe
 
 - O coletor agora usa Playwright em **modo headless por padrão** (`collector.playwright.headless=true`).
 - Para depuração local, rode com `collector.playwright.headless=false`.
+- A coleta autenticada usa:
+  - `collector.hotmart.search-url` (default: `https://app.hotmart.com/market/search`)
+  - `collector.hotmart.session-cookie` (obrigatório para área logada)
 
 Exemplo:
 

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/MoisHotmartCollectorApplication.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/MoisHotmartCollectorApplication.java
@@ -2,8 +2,10 @@ package com.marketinghub.moishotmart;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MoisHotmartCollectorApplication {
 
     public static void main(String[] args) {

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -1,0 +1,43 @@
+package com.marketinghub.moishotmart.service;
+
+import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionRequest;
+import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HotmartCollectorScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(HotmartCollectorScheduler.class);
+
+    private final HotmartCollectorService collectorService;
+    private final boolean enabled;
+    private final String source;
+    private final int maxProducts;
+
+    public HotmartCollectorScheduler(
+            HotmartCollectorService collectorService,
+            @Value("${collector.scheduler.enabled:true}") boolean enabled,
+            @Value("${collector.scheduler.source:hotmart-market}") String source,
+            @Value("${collector.scheduler.max-products:25}") int maxProducts
+    ) {
+        this.collectorService = collectorService;
+        this.enabled = enabled;
+        this.source = source;
+        this.maxProducts = maxProducts;
+    }
+
+    @Scheduled(cron = "${collector.scheduler.cron:0 0 * * * *}")
+    public void collectHourly() {
+        if (!enabled) {
+            log.info("Hotmart scheduler desabilitado por configuração.");
+            return;
+        }
+        HotmartCollectionResponse response = collectorService.collect(new HotmartCollectionRequest(source, maxProducts));
+        log.info("Hotmart scheduler executado status={} produtos={} mensagem={}",
+                response.status(), response.products().size(), response.message());
+    }
+}

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -8,6 +8,8 @@ import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.Cookie;
+import com.microsoft.playwright.options.WaitUntilState;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,12 +19,18 @@ import org.springframework.stereotype.Service;
 @Service
 public class HotmartCollectorService {
 
-    private static final String HOTMART_MARKET_URL = "https://app.hotmart.com/market/search";
-
     private final boolean headless;
+    private final String hotmartMarketUrl;
+    private final String hotmartSessionCookie;
 
-    public HotmartCollectorService(@Value("${collector.playwright.headless:true}") boolean headless) {
+    public HotmartCollectorService(
+            @Value("${collector.playwright.headless:true}") boolean headless,
+            @Value("${collector.hotmart.search-url:https://app.hotmart.com/market/search}") String hotmartMarketUrl,
+            @Value("${collector.hotmart.session-cookie:}") String hotmartSessionCookie
+    ) {
         this.headless = headless;
+        this.hotmartMarketUrl = hotmartMarketUrl;
+        this.hotmartSessionCookie = hotmartSessionCookie;
     }
 
     public HotmartCollectionResponse collect(HotmartCollectionRequest request) {
@@ -31,12 +39,26 @@ public class HotmartCollectorService {
         List<HotmartProductSnapshot> products = new ArrayList<>();
         String status = "COLLECTION_EXECUTED";
         String message = "Coleta executada com Playwright em modo headless=" + headless + ".";
+        if (hotmartSessionCookie == null || hotmartSessionCookie.isBlank()) {
+            return new HotmartCollectionResponse(
+                    "COLLECTION_SKIPPED",
+                    "Sessão Hotmart ausente. Configure collector.hotmart.session-cookie.",
+                    products
+            );
+        }
 
         try (Playwright playwright = Playwright.create()) {
             Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(headless));
             BrowserContext context = browser.newContext();
+            context.addCookies(List.of(new Cookie("hotmart_session", hotmartSessionCookie)
+                    .setDomain(".hotmart.com")
+                    .setPath("/")
+                    .setHttpOnly(true)
+                    .setSecure(true)));
             Page page = context.newPage();
-            page.navigate(HOTMART_MARKET_URL, new Page.NavigateOptions().setTimeout(60_000));
+            page.navigate(hotmartMarketUrl, new Page.NavigateOptions()
+                    .setTimeout(60_000)
+                    .setWaitUntil(WaitUntilState.NETWORKIDLE));
             page.waitForTimeout(1_500);
 
             int cardsCount = page.locator("a[href*='/market/products/']").count();
@@ -51,7 +73,7 @@ public class HotmartCollectorService {
                         title == null || title.isBlank() ? "Produto sem título" : title,
                         "N/A",
                         "N/A",
-                        detailsUrl == null ? HOTMART_MARKET_URL : detailsUrl,
+                        detailsUrl == null ? hotmartMarketUrl : detailsUrl,
                         Instant.now()
                 ));
             }

--- a/mois-hotmart-collector/src/main/resources/application.properties
+++ b/mois-hotmart-collector/src/main/resources/application.properties
@@ -14,3 +14,9 @@ management.endpoint.health.show-details=always
 collector.playwright.headless=${COLLECTOR_PLAYWRIGHT_HEADLESS:true}
 collector.hotmart.search-url=${COLLECTOR_HOTMART_SEARCH_URL:https://app.hotmart.com/market/search}
 collector.hotmart.session-cookie=${COLLECTOR_HOTMART_SESSION_COOKIE:}
+
+# Automatic hourly execution
+collector.scheduler.enabled=${COLLECTOR_SCHEDULER_ENABLED:true}
+collector.scheduler.cron=${COLLECTOR_SCHEDULER_CRON:0 0 * * * *}
+collector.scheduler.source=${COLLECTOR_SCHEDULER_SOURCE:hotmart-market}
+collector.scheduler.max-products=${COLLECTOR_SCHEDULER_MAX_PRODUCTS:25}

--- a/mois-hotmart-collector/src/main/resources/application.properties
+++ b/mois-hotmart-collector/src/main/resources/application.properties
@@ -9,3 +9,8 @@ management.endpoints.web.exposure.include=health,loggers,logfile
 management.endpoints.web.base-path=/ops-monitor
 management.endpoints.web.path-mapping.logfile=mois-hotmart-log
 management.endpoint.health.show-details=always
+
+# Hotmart authenticated collection
+collector.playwright.headless=${COLLECTOR_PLAYWRIGHT_HEADLESS:true}
+collector.hotmart.search-url=${COLLECTOR_HOTMART_SEARCH_URL:https://app.hotmart.com/market/search}
+collector.hotmart.session-cookie=${COLLECTOR_HOTMART_SESSION_COOKIE:}


### PR DESCRIPTION
### Motivation
- Enable reliable scraping of Hotmart product pages that require an authenticated session and JS rendering by integrating Playwright into the `mois-hotmart-collector` service. 
- Provide environment-driven configuration for headless operation and session credentials to allow safe automated runs and local debugging.

### Description
- Added constructor-injected properties `collector.playwright.headless`, `collector.hotmart.search-url` and `collector.hotmart.session-cookie` and wired them in `HotmartCollectorService`. 
- Implemented authenticated navigation by adding a `hotmart_session` cookie into the Playwright `BrowserContext` and using `WaitUntilState.NETWORKIDLE` for page navigation. 
- Short-circuited collection when no session cookie is configured by returning a `HotmartCollectionResponse` with status `COLLECTION_SKIPPED` to avoid false-positive runs. 
- Updated `application.properties`, `README.md` and `docs/mois/registros.md` to document the new configuration, the CI/deploy workflow, and the move of collector responsibilities into `mois-hotmart-collector`.

### Testing
- CI pipeline runs `mvn -B test` as part of the workflow for `mois-hotmart-collector` and the module unit tests were executed successfully in the CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1337d3348321bb0096b0e824860e)