### PR TITLE
MCP: Conditional GitHub property validation when integration is disabled

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -48,13 +48,22 @@ public record McpProperties(
     ) {
     }
 
-    public record Github(
+        public record Github(
             boolean enabled,
             @NotBlank String apiBaseUrl,
-            @NotBlank String owner,
-            @NotBlank String repo,
+            String owner,
+            String repo,
             String token
     ) {
+        @jakarta.validation.constraints.AssertTrue(message = "mcp.github.owner must not be blank when mcp.github.enabled=true")
+        private boolean isOwnerValid() {
+            return !enabled || (owner != null && !owner.isBlank());
+        }
+
+        @jakarta.validation.constraints.AssertTrue(message = "mcp.github.repo must not be blank when mcp.github.enabled=true")
+        private boolean isRepoValid() {
+            return !enabled || (repo != null && !repo.isBlank());
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- The MCP server failed to start because `mcp.github.owner` and `mcp.github.repo` were unconditionally validated as non-blank, which caused binding validation errors when the GitHub integration was disabled and environment variables were empty.

### Description
- Modified `mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java` to remove unconditional `@NotBlank` from `owner` and `repo` in the `McpProperties.Github` record.
- Added two `@AssertTrue` methods that enforce `owner` and `repo` are non-blank only when `mcp.github.enabled == true` so validation remains strict when GitHub tools are enabled.
- Kept existing validation for other fields (e.g., `apiBaseUrl`) and preserved the overall `@Validated` configuration behavior.

### Testing
- Ran unit tests for the module with `mvn test -q` inside `mcp-server`, and the test suite completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9eaf1e6883219cf276b18983df7f)