### PR TITLE
feat(mcp-server): log each incoming MCP request

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -67,11 +67,12 @@ public class McpController {
     public ResponseEntity<Map<String, Object>> handleRequest(@RequestBody Map<String, Object> request,
                                                              HttpServletRequest httpServletRequest) {
         Object id = request.get("id");
+        String method = String.valueOf(request.getOrDefault("method", ""));
+        logger.info("Nova requisição MCP recebida: requestId={} method={} remoteAddr={} userAgent={}",
+                id, method, httpServletRequest.getRemoteAddr(), httpServletRequest.getHeader("User-Agent"));
         if (!isAuthorized(httpServletRequest)) {
             return ResponseEntity.status(401).body(error(id, -32001, "Unauthorized"));
         }
-
-        String method = String.valueOf(request.getOrDefault("method", ""));
 
         return switch (method) {
             case "initialize" -> ResponseEntity.ok(success(id, Map.of(


### PR DESCRIPTION
### Motivation
- Melhorar observabilidade do MCP registrando todas as requisições que chegam no endpoint `/mcp` antes da verificação de autorização.

### Description
- Adicionado `logger.info` em `McpController.handleRequest` (`mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java`) que registra `requestId`, `method`, `remoteAddr` e `User-Agent`; os logs de tool-calls existentes foram mantidos.

### Testing
- Executado `mvn -q -Dtest=McpControllerTest test` dentro de `mcp-server` e os testes passaram com sucesso enquanto os novos logs aparecem nas saídas do teste.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc22e19388321be6c2a4c0f5dcd02)