### PR TITLE
Add provisional HTML assembly from wireframe uiTags/uiSizes

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -20,12 +20,15 @@ public class GeraLandingStageExecutionService {
 
     private final ExperimentRepository experimentRepository;
     private final GeraLandingStageExecutionRepository executionRepository;
+    private final WireframeProvisionalHtmlAssembler wireframeProvisionalHtmlAssembler;
 
     public GeraLandingStageExecutionService(
             ExperimentRepository experimentRepository,
-            GeraLandingStageExecutionRepository executionRepository) {
+            GeraLandingStageExecutionRepository executionRepository,
+            WireframeProvisionalHtmlAssembler wireframeProvisionalHtmlAssembler) {
         this.experimentRepository = experimentRepository;
         this.executionRepository = executionRepository;
+        this.wireframeProvisionalHtmlAssembler = wireframeProvisionalHtmlAssembler;
     }
 
     @Transactional
@@ -128,7 +131,10 @@ public class GeraLandingStageExecutionService {
                 .or(() -> executionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(request.experimentId(), request.stageCode()))
                 .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
         execution.setModelResponse(request.modelResponse());
-        execution.setProvisionalHtml(request.provisionalHtml());
+        String provisionalHtml = StringUtils.hasText(request.provisionalHtml())
+                ? request.provisionalHtml()
+                : wireframeProvisionalHtmlAssembler.assemble(request.modelResponse());
+        execution.setProvisionalHtml(provisionalHtml);
         execution.setErrorMessage(StringUtils.hasText(request.errorMessage()) ? request.errorMessage().trim() : null);
         if (request.openAiJobId() != null && !request.openAiJobId().isBlank()) {
             execution.setOpenAiJobId(request.openAiJobId());

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssembler.java
@@ -1,0 +1,84 @@
+package com.marketinghub.geralanding;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class WireframeProvisionalHtmlAssembler {
+
+    private final ObjectMapper objectMapper;
+
+    public WireframeProvisionalHtmlAssembler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @SuppressWarnings("unchecked")
+    public String assemble(String modelResponse) {
+        if (!StringUtils.hasText(modelResponse)) {
+            return null;
+        }
+        try {
+            Map<String, Object> root = objectMapper.readValue(modelResponse, Map.class);
+            Map<String, Object> wireframe = root.get("landingPageWireframe") instanceof Map<?, ?> nested
+                    ? (Map<String, Object>) nested
+                    : root;
+            if (!(wireframe.get("sectionOrder") instanceof List<?> rawSections) || rawSections.isEmpty()) {
+                return null;
+            }
+            StringBuilder sectionsHtml = new StringBuilder();
+            StringBuilder css = new StringBuilder();
+            for (Object rawSection : rawSections) {
+                if (!(rawSection instanceof Map<?, ?> rawSectionMap)) {
+                    continue;
+                }
+                Map<String, Object> section = (Map<String, Object>) rawSectionMap;
+                String uiTags = asText(section.get("uiTags"));
+                String uiSizes = asText(section.get("uiSizes"));
+                if (StringUtils.hasText(uiTags)) {
+                    sectionsHtml.append(uiTags.trim()).append("\n");
+                }
+                if (StringUtils.hasText(uiSizes)) {
+                    css.append("/* ").append(asText(section.get("sectionId"), "section")).append(" */\n")
+                            .append(uiSizes.trim()).append("\n\n");
+                }
+            }
+            if (!StringUtils.hasText(sectionsHtml.toString())) {
+                return null;
+            }
+            return """
+                    <!doctype html>
+                    <html lang="pt-BR">
+                      <head>
+                        <meta charset="UTF-8" />
+                        <meta name="viewport" content="width=device-width,initial-scale=1" />
+                        <title>Wireframe provisório</title>
+                        <style>
+                    """ + css + """
+                        </style>
+                      </head>
+                      <body>
+                    """ + sectionsHtml + """
+                      </body>
+                    </html>
+                    """;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String asText(Object value) {
+        return asText(value, null);
+    }
+
+    private String asText(Object value, String fallback) {
+        if (value == null) {
+            return fallback;
+        }
+        String text = String.valueOf(value).trim();
+        return StringUtils.hasText(text) ? text : fallback;
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -30,6 +30,9 @@ class GeraLandingStageExecutionServiceTest {
     @Mock
     private GeraLandingStageExecutionRepository executionRepository;
 
+    @Mock
+    private WireframeProvisionalHtmlAssembler wireframeProvisionalHtmlAssembler;
+
     @InjectMocks
     private GeraLandingStageExecutionService service;
 
@@ -111,10 +114,12 @@ class GeraLandingStageExecutionServiceTest {
         when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc("id-ok".getBytes(StandardCharsets.UTF_8)))
                 .thenReturn(Optional.of(execution));
         when(experimentRepository.findById(31L)).thenReturn(Optional.of(experiment));
+        when(wireframeProvisionalHtmlAssembler.assemble(request.modelResponse())).thenReturn("<html>provisorio</html>");
 
         service.receiveResult("id-ok", request);
 
         assertEquals("{\"landingPageWireframe\":{\"sectionOrder\":[]}}", experiment.getLandingPageWireframe());
+        assertEquals("<html>provisorio</html>", execution.getProvisionalHtml());
         assertTrue(Arrays.equals("id-ok".getBytes(StandardCharsets.UTF_8), experiment.getLandingPageWireframeJobId()));
         verify(experimentRepository).save(experiment);
     }


### PR DESCRIPTION
### Motivation
- Gerar automaticamente um HTML provisório a partir do JSON de wireframe quando o worker não fornecer `provisionalHtml`, permitindo inspecionar rapidamente a renderização baseada em `uiTags`/`uiSizes` persistidos. 
- Evitar perda de informação na interface de execução e facilitar debugging e visualização das seções geradas pelo modelo.

### Description
- Adiciona o componente `WireframeProvisionalHtmlAssembler` que parseia o `modelResponse` JSON, percorre `landingPageWireframe.sectionOrder`, concatena cada `uiTags` como HTML e `uiSizes` como CSS e monta um documento HTML completo provisório (arquivo `backend/ads-service/src/main/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssembler.java`).
- Atualiza `GeraLandingStageExecutionService` para usar o assembler como fallback: quando `request.provisionalHtml()` estiver vazio chama `wireframeProvisionalHtmlAssembler.assemble(request.modelResponse())` e persiste o resultado (arquivo `backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java`).
- Atualiza o teste `GeraLandingStageExecutionServiceTest` para mockar o assembler e verificar que o `provisionalHtml` gerado é salvo na execução ao receber o resultado do worker (arquivo `backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java`).

### Testing
- Executado o teste de unidade específico com `cd backend/ads-service && ../mvnw -Dtest=GeraLandingStageExecutionServiceTest test`, que passou com sucesso (`Tests run: 3, Failures: 0, Errors: 0`).
- Uma tentativa inicial com `cd backend && ./mvnw -pl ads-service -Dtest=GeraLandingStageExecutionServiceTest test` falhou por seleção incorreta do projeto no reactor do Maven, sem relação com a lógica do código (configuração de execução).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca01616b08321b37819d6210e10f9)