### PR TITLE
Add lorem-preview generation from `uiSizeTexts` in WireframeProvisionalHtmlAssembler

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssembler.java
@@ -4,8 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Component
 public class WireframeProvisionalHtmlAssembler {
@@ -38,8 +41,12 @@ public class WireframeProvisionalHtmlAssembler {
                 Map<String, Object> section = (Map<String, Object>) rawSectionMap;
                 String uiTags = asText(section.get("uiTags"));
                 String uiSizes = asText(section.get("uiSizes"));
+                String uiSizeTexts = asText(section.get("uiSizeTexts"));
                 if (StringUtils.hasText(uiTags)) {
                     sectionsHtml.append(uiTags.trim()).append("\n");
+                }
+                if (StringUtils.hasText(uiSizeTexts)) {
+                    sectionsHtml.append(buildLoremPreview(uiSizeTexts));
                 }
                 if (StringUtils.hasText(uiSizes)) {
                     css.append("/* ").append(asText(section.get("sectionId"), "section")).append(" */\n")
@@ -81,4 +88,66 @@ public class WireframeProvisionalHtmlAssembler {
         String text = String.valueOf(value).trim();
         return StringUtils.hasText(text) ? text : fallback;
     }
+
+    private String buildLoremPreview(String uiSizeTexts) {
+        List<TextSlotSpec> specs = parseTextSpecs(uiSizeTexts);
+        if (specs.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder("\n<!-- lhm-text-preview -->\n");
+        for (TextSlotSpec spec : specs) {
+            sb.append("<p data-wireframe-lorem-slot=\"")
+                    .append(spec.slotId())
+                    .append("\">")
+                    .append(generateLorem(spec.maxLength() > 0 ? spec.maxLength() : spec.minLength()))
+                    .append("</p>\n");
+        }
+        return sb.toString();
+    }
+
+    private List<TextSlotSpec> parseTextSpecs(String uiSizeTexts) {
+        if (!StringUtils.hasText(uiSizeTexts)) {
+            return List.of();
+        }
+        List<TextSlotSpec> specs = new ArrayList<>();
+        for (String token : uiSizeTexts.split(";")) {
+            if (!StringUtils.hasText(token)) {
+                continue;
+            }
+            String trimmed = token.trim();
+            String slotId = trimmed.contains("(") ? trimmed.substring(0, trimmed.indexOf('(')).trim() : trimmed;
+            int min = extractBound(trimmed, "min");
+            int max = extractBound(trimmed, "max");
+            if (!StringUtils.hasText(slotId) || (min <= 0 && max <= 0)) {
+                continue;
+            }
+            specs.add(new TextSlotSpec(slotId, min, max));
+        }
+        return specs;
+    }
+
+    private int extractBound(String spec, String key) {
+        Matcher matcher = Pattern.compile(key + "\\s*:\\s*(\\d+)", Pattern.CASE_INSENSITIVE).matcher(spec);
+        if (!matcher.find()) {
+            return -1;
+        }
+        return Integer.parseInt(matcher.group(1));
+    }
+
+    private String generateLorem(int length) {
+        if (length <= 0) {
+            return "";
+        }
+        String seed = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+        StringBuilder sb = new StringBuilder();
+        while (sb.length() < length) {
+            if (sb.length() > 0) {
+                sb.append(' ');
+            }
+            sb.append(seed);
+        }
+        return sb.substring(0, Math.min(length, sb.length())).trim();
+    }
+
+    private record TextSlotSpec(String slotId, int minLength, int maxLength) {}
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssemblerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssemblerTest.java
@@ -1,0 +1,37 @@
+package com.marketinghub.geralanding;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WireframeProvisionalHtmlAssemblerTest {
+
+    private final WireframeProvisionalHtmlAssembler assembler = new WireframeProvisionalHtmlAssembler(new ObjectMapper());
+
+    @Test
+    void assembleAddsLoremBasedOnUiSizeTexts() {
+        String modelResponse = """
+                {
+                  "landingPageWireframe": {
+                    "sectionOrder": [
+                      {
+                        "sectionId": "s1-hero",
+                        "uiTags": "<section id='s1-hero'><h1 id='s1-title'></h1><p id='s1-sub'></p></section>",
+                        "uiSizeTexts": "s1-title(min:20,max:30); s1-sub(min:60,max:90)",
+                        "uiSizes": "#s1-hero{padding:20px}"
+                      }
+                    ]
+                  }
+                }
+                """;
+
+        String html = assembler.assemble(modelResponse);
+
+        assertNotNull(html);
+        assertTrue(html.contains("data-wireframe-lorem-slot=\"s1-title\""));
+        assertTrue(html.contains("data-wireframe-lorem-slot=\"s1-sub\""));
+        assertTrue(html.contains("Lorem ipsum"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide provisional textual placeholders for wireframe previews by honoring the `uiSizeTexts` annotations so rendered HTML includes realistic-length text for each text slot.

### Description
- Parse the new `uiSizeTexts` field in `WireframeProvisionalHtmlAssembler.assemble` and append a preview block when present by calling `buildLoremPreview`.
- Implement `buildLoremPreview`, `parseTextSpecs`, `extractBound`, and `generateLorem` to parse slot specs like `slot(min:20,max:30)` and produce `<p data-wireframe-lorem-slot="...">` elements populated with generated lorem text; introduce a `TextSlotSpec` record for spec storage.
- Add necessary imports (`ArrayList`, `Pattern`, `Matcher`) and small helper `asText` usage to safely read the field.
- Add a unit test `WireframeProvisionalHtmlAssemblerTest` with `assembleAddsLoremBasedOnUiSizeTexts` that verifies slot attributes and presence of lorem text in the assembled HTML.

### Testing
- Ran the unit test `WireframeProvisionalHtmlAssemblerTest.assembleAddsLoremBasedOnUiSizeTexts` which passed and validated that the output contains `data-wireframe-lorem-slot` attributes and `Lorem ipsum` text.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc9782a0c83218345b45610fd190e)