### PR TITLE
Sanitize uiTags and convert JSON uiSizes to CSS in Wireframe assembler; add tests and sample HTML

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssembler.java
@@ -43,14 +43,14 @@ public class WireframeProvisionalHtmlAssembler {
                 String uiSizes = asText(section.get("uiSizes"));
                 String uiSizeTexts = asText(section.get("uiSizeTexts"));
                 if (StringUtils.hasText(uiTags)) {
-                    sectionsHtml.append(uiTags.trim()).append("\n");
+                    sectionsHtml.append(sanitizeUiTags(uiTags)).append("\n");
                 }
                 if (StringUtils.hasText(uiSizeTexts)) {
                     sectionsHtml.append(buildLoremPreview(uiSizeTexts));
                 }
                 if (StringUtils.hasText(uiSizes)) {
                     css.append("/* ").append(asText(section.get("sectionId"), "section")).append(" */\n")
-                            .append(uiSizes.trim()).append("\n\n");
+                            .append(normalizeUiSizes(uiSizes)).append("\n\n");
                 }
             }
             if (!StringUtils.hasText(sectionsHtml.toString())) {
@@ -77,6 +77,62 @@ public class WireframeProvisionalHtmlAssembler {
         }
     }
 
+
+    @SuppressWarnings("unchecked")
+    private String normalizeUiSizes(String uiSizes) {
+        if (!StringUtils.hasText(uiSizes)) {
+            return "";
+        }
+        String trimmed = uiSizes.trim();
+        if (!trimmed.startsWith("{")) {
+            return trimmed;
+        }
+        try {
+            Map<String, Object> jsonCss = objectMapper.readValue(trimmed, Map.class);
+            StringBuilder css = new StringBuilder();
+            for (Map.Entry<String, Object> entry : jsonCss.entrySet()) {
+                appendCssRule(css, entry.getKey(), entry.getValue());
+            }
+            return css.toString();
+        } catch (Exception ignored) {
+            return trimmed;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void appendCssRule(StringBuilder css, String selector, Object value) {
+        if (!(value instanceof Map<?, ?> rawProps) || !StringUtils.hasText(selector)) {
+            return;
+        }
+        css.append(selector.trim()).append(" {\n");
+        for (Map.Entry<?, ?> prop : rawProps.entrySet()) {
+            String name = prop.getKey() == null ? null : toKebabCase(String.valueOf(prop.getKey()).trim());
+            String val = prop.getValue() == null ? null : String.valueOf(prop.getValue()).trim();
+            if (StringUtils.hasText(name) && StringUtils.hasText(val)) {
+                css.append("  ").append(name).append(": ").append(val).append(";\n");
+            }
+        }
+        css.append("}\n");
+    }
+
+    private String toKebabCase(String input) {
+        if (!StringUtils.hasText(input)) {
+            return "";
+        }
+        return input.replaceAll("([a-z0-9])([A-Z])", "$1-$2").toLowerCase();
+    }
+
+    private String sanitizeUiTags(String uiTags) {
+        if (!StringUtils.hasText(uiTags)) {
+            return "";
+        }
+        String cleaned = uiTags.trim();
+        cleaned = cleaned.replaceAll("(?is)<!doctype[^>]*>", "");
+        cleaned = cleaned.replaceAll("(?is)</?html[^>]*>", "");
+        cleaned = cleaned.replaceAll("(?is)</?head[^>]*>", "");
+        cleaned = cleaned.replaceAll("(?is)</?body[^>]*>", "");
+        return cleaned.trim();
+    }
     private String asText(Object value) {
         return asText(value, null);
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssemblerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/WireframeProvisionalHtmlAssemblerTest.java
@@ -3,6 +3,9 @@ package com.marketinghub.geralanding;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -33,5 +36,27 @@ class WireframeProvisionalHtmlAssemblerTest {
         assertTrue(html.contains("data-wireframe-lorem-slot=\"s1-title\""));
         assertTrue(html.contains("data-wireframe-lorem-slot=\"s1-sub\""));
         assertTrue(html.contains("Lorem ipsum"));
+    }
+
+    @Test
+    void assembleConvertsJsonCssToValidCssAndSanitizesUiTags() throws Exception {
+        Map<String, Object> section = Map.of(
+                "sectionId", "s1-hero-form",
+                "uiTags", "<!doctype html><html><body><section id='s1-hero-form'><h1 id='s1-h1'></h1></section></body></html>",
+                "uiSizes", "{\"#s1-hero-form\":{\"padding\":\"20px 16px\"},\"#s1-wrap\":{\"gridTemplateColumns\":\"1fr\"}}"
+        );
+        Map<String, Object> model = Map.of(
+                "landingPageWireframe", Map.of("sectionOrder", List.of(section))
+        );
+        String modelResponse = new ObjectMapper().writeValueAsString(model);
+
+        String html = assembler.assemble(modelResponse);
+
+        assertNotNull(html);
+        assertTrue(html.contains("#s1-hero-form {"));
+        assertTrue(html.contains("padding: 20px 16px;"));
+        assertTrue(html.contains("grid-template-columns: 1fr;"));
+        assertTrue(html.contains("<section id='s1-hero-form'>"));
+        assertTrue(!html.toLowerCase().contains("<html><body><section"));
     }
 }

--- a/frontend/wireframe-provisorio-fixo.html
+++ b/frontend/wireframe-provisorio-fixo.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Wireframe provisório (fixo)</title>
+    <style>
+      :root {
+        --max-w: 1120px;
+        --max-w-narrow: 900px;
+      }
+
+      * { box-sizing: border-box; }
+      body { margin: 0; font-family: Arial, sans-serif; color: #111; }
+      section, footer { padding: 18px 16px; }
+      h1, h2, h3, p { margin: 0; }
+      ul, ol { margin: 0; padding-left: 18px; }
+      a { color: inherit; }
+
+      /* s1-hero-form */
+      #s1-hero-form { padding-top: 20px; }
+      #s1-wrap {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 16px;
+        max-width: var(--max-w);
+        margin: 0 auto;
+      }
+      #s1-copy { display: flex; flex-direction: column; gap: 10px; }
+      #s1-h1 { font-size: clamp(28px, 4vw, 44px); line-height: 1.1; }
+      #s1-sub { font-size: 16px; line-height: 1.4; }
+      #s1-bullets { display: grid; gap: 8px; }
+      #s1-form-col { display: flex; flex-direction: column; gap: 12px; }
+      #s1-product-mock { width: 100%; height: 180px; border-radius: 12px; background: #e9eef5; }
+      #briefing-form { display: grid; gap: 10px; }
+      #f-submit { height: 48px; width: 100%; border-radius: 10px; border: 0; background: #111; color: #fff; }
+      #f-privacy { font-size: 12px; line-height: 1.3; }
+
+      /* s2-how-it-works */
+      #s2-wrap { max-width: var(--max-w-narrow); margin: 0 auto; display: grid; gap: 12px; }
+      #s2-h2 { font-size: clamp(20px, 3vw, 28px); line-height: 1.2; }
+      #s2-steps { display: grid; gap: 10px; }
+      #s2-note { font-size: 14px; line-height: 1.4; }
+      #s2-backlink { font-size: 14px; text-decoration: underline; }
+
+      /* s3-what-you-get */
+      #s3-wrap {
+        max-width: var(--max-w);
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 14px;
+      }
+      #s3-left { display: grid; gap: 10px; }
+      #s3-mini-kit-visual { width: 100%; height: 200px; border-radius: 12px; background: #e9eef5; }
+      #s3-cta, #s5-cta, #s7-cta {
+        display: inline-block;
+        padding: 12px 14px;
+        border-radius: 10px;
+        background: #111;
+        color: #fff;
+        text-decoration: none;
+      }
+
+      /* s4-why-this-helps */
+      #s4-wrap { max-width: var(--max-w); margin: 0 auto; display: grid; gap: 12px; }
+      #s4-compare { display: grid; grid-template-columns: 1fr; gap: 12px; }
+      #s4-without, #s4-with { padding: 12px; border-radius: 12px; background: #f6f7f8; }
+      #s4-without-list, #s4-with-list { display: grid; gap: 8px; }
+      #s4-closer { font-size: 14px; line-height: 1.4; }
+
+      /* s5-preview-proof */
+      #s5-wrap { max-width: var(--max-w); margin: 0 auto; display: grid; gap: 12px; }
+      #s5-grid { display: grid; grid-template-columns: 1fr; gap: 14px; }
+      #s5-pdf-mock { width: 100%; height: 260px; border-radius: 12px; background: #e9eef5; }
+
+      /* s6-objections-faq */
+      #s6-wrap { max-width: var(--max-w-narrow); margin: 0 auto; display: grid; gap: 12px; }
+      #s6-faq { display: grid; gap: 10px; }
+      #s6-faq details { padding: 12px; border-radius: 12px; background: #f6f7f8; }
+      #s6-faq summary { cursor: pointer; font-size: 16px; }
+      #s6-faq p { margin-top: 8px; font-size: 14px; line-height: 1.4; }
+
+      /* s7-final-cta */
+      #s7-wrap {
+        max-width: var(--max-w-narrow);
+        margin: 0 auto;
+        display: grid;
+        gap: 12px;
+        text-align: left;
+      }
+      #s7-recap { display: grid; gap: 8px; }
+
+      /* s8-legal-footer */
+      #s8-wrap { max-width: var(--max-w); margin: 0 auto; display: grid; gap: 10px; }
+      #s8-links { display: flex; gap: 12px; flex-wrap: wrap; }
+      #s8-wrap p, #s8-links a { font-size: 12px; line-height: 1.35; }
+      #s8-links a { text-decoration: underline; }
+
+      @media (min-width: 900px) {
+        #s4-compare { grid-template-columns: 1fr 1fr; }
+      }
+      @media (min-width: 960px) {
+        #s1-wrap { grid-template-columns: 1.1fr 0.9fr; align-items: start; }
+        #s1-product-mock { height: 220px; }
+        #s3-wrap { grid-template-columns: 1fr 0.9fr; align-items: center; }
+        #s3-mini-kit-visual { height: 260px; }
+        #s5-grid { grid-template-columns: 1fr 0.9fr; align-items: center; }
+        #s5-pdf-mock { height: 340px; }
+      }
+    </style>
+  </head>
+  <body>
+    <section id="s1-hero-form"><div id="s1-wrap"><div id="s1-copy"><p id="s1-kicker">Kicker</p><h1 id="s1-h1">Headline</h1><p id="s1-sub">Subheadline</p><ul id="s1-bullets"><li>Bullet 1</li><li>Bullet 2</li><li>Bullet 3</li><li>Bullet 4</li></ul><div id="s1-proof-chips">Provas</div></div><div id="s1-form-col"><div id="s1-product-mock" aria-hidden="true"></div><form id="briefing-form"><div id="f-row-1">Campo 1</div><div id="f-row-2">Campo 2</div><div id="f-row-3">Campo 3</div><div id="f-consent">Consentimento</div><button id="f-submit" type="submit">Enviar</button><p id="f-privacy">Texto de privacidade</p></form></div></div></section>
+    <section id="s2-how-it-works"><div id="s2-wrap"><h2 id="s2-h2">Como funciona</h2><ol id="s2-steps"><li>Passo 1</li><li>Passo 2</li><li>Passo 3</li></ol><p id="s2-note">Nota</p><a id="s2-backlink" href="#briefing-form">Voltar ao formulário</a></div></section>
+    <section id="s3-what-you-get"><div id="s3-wrap"><div id="s3-left"><h2 id="s3-h2">O que você recebe</h2><ul id="s3-deliverables"><li>Entregável 1</li><li>Entregável 2</li></ul><ul id="s3-benefits"><li>Benefício 1</li><li>Benefício 2</li><li>Benefício 3</li></ul><a id="s3-cta" href="#briefing-form">Quero agora</a></div><div id="s3-right" aria-hidden="true"><div id="s3-mini-kit-visual"></div></div></div></section>
+    <section id="s4-why-this-helps"><div id="s4-wrap"><h2 id="s4-h2">Por que ajuda</h2><div id="s4-compare"><div id="s4-without"><h3 id="s4-without-h3">Sem isso</h3><ul id="s4-without-list"><li>Problema 1</li><li>Problema 2</li><li>Problema 3</li></ul></div><div id="s4-with"><h3 id="s4-with-h3">Com isso</h3><ul id="s4-with-list"><li>Ganho 1</li><li>Ganho 2</li><li>Ganho 3</li></ul></div></div><p id="s4-closer">Fechamento</p></div></section>
+    <section id="s5-preview-proof"><div id="s5-wrap"><h2 id="s5-h2">Prévia</h2><p id="s5-sub">Sub</p><div id="s5-grid"><div id="s5-left"><ul id="s5-proof-bullets"><li>Prova 1</li><li>Prova 2</li><li>Prova 3</li></ul><a id="s5-cta" href="#briefing-form">Quero acessar</a></div><div id="s5-right" aria-hidden="true"><div id="s5-pdf-mock"></div></div></div></div></section>
+    <section id="s6-objections-faq"><div id="s6-wrap"><h2 id="s6-h2">FAQ</h2><div id="s6-faq"><details id="s6-q1"><summary>Pergunta 1</summary><p>Resposta 1</p></details><details id="s6-q2"><summary>Pergunta 2</summary><p>Resposta 2</p></details><details id="s6-q3"><summary>Pergunta 3</summary><p>Resposta 3</p></details><details id="s6-q4"><summary>Pergunta 4</summary><p>Resposta 4</p></details><details id="s6-q5"><summary>Pergunta 5</summary><p>Resposta 5</p></details><details id="s6-q6"><summary>Pergunta 6</summary><p>Resposta 6</p></details></div></div></section>
+    <section id="s7-final-cta"><div id="s7-wrap"><h2 id="s7-h2">CTA Final</h2><ul id="s7-recap"><li>Resumo 1</li><li>Resumo 2</li><li>Resumo 3</li></ul><a id="s7-cta" href="#briefing-form">Começar</a></div></section>
+    <footer id="s8-legal-footer"><div id="s8-wrap"><p id="s8-brand">Marca</p><nav id="s8-links"><a id="s8-privacy" target="_blank" href="/privacy">Privacidade</a><a id="s8-terms" target="_blank" href="/terms">Termos</a><a id="s8-contact" target="_blank" href="/contact">Contato</a></nav><p id="s8-disclaimer">Disclaimer</p></div></footer>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Ensure CSS and HTML fragments produced from model responses are safe and well-formed before embedding in the provisional wireframe output.
- Support a compact JSON representation for `uiSizes` produced by the model and generate valid kebab-cased CSS properties for the assembled page.

### Description
- Update `WireframeProvisionalHtmlAssembler` to sanitize incoming `uiTags` via `sanitizeUiTags(...)` and to normalize `uiSizes` JSON into CSS via `normalizeUiSizes(...)` and `appendCssRule(...)` while preserving existing fallback behavior.
- Add `toKebabCase(...)` helper to convert camelCase JSON property names into CSS kebab-case names and robust null/empty guarding in the new helpers.
- Replace direct appends of `uiTags` and `uiSizes` with sanitized/normalized results in `assemble(...)` so embedded fragments won't include full `<html>/<body>` wrappers and JSON CSS becomes valid CSS blocks.
- Add a static example wireframe file at `frontend/wireframe-provisorio-fixo.html` to serve as a fixed preview/template for the wireframe output.

### Testing
- Added unit test `assembleConvertsJsonCssToValidCssAndSanitizesUiTags` in `WireframeProvisionalHtmlAssemblerTest` and kept the existing lorem-text preview test `assembleAddsLoremBasedOnUiSizeTexts` to validate behavior.
- Ran the unit test suite for `WireframeProvisionalHtmlAssemblerTest` and the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd079cd01c832197b51a2939479497)