### PR TITLE
Add provisional HTML download link on Gera Landing execution detail page

### DIFF
--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -26,6 +26,11 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
   const { id: experimentId, jobId } = useParams();
   const detailQuery = useGeraLandingStageExecutionDetail(experimentId, jobId);
   const modelUsed = extractModelFromRequestBody(detailQuery.data?.openAiRequestBody);
+  const provisionalHtml = detailQuery.data?.provisionalHtml?.trim() ?? "";
+  const provisionalHtmlDownloadHref = provisionalHtml
+    ? `data:text/html;charset=utf-8,${encodeURIComponent(provisionalHtml)}`
+    : "";
+  const provisionalHtmlFileName = `provisional-html-${detailQuery.data?.idJob ?? "geralanding"}.html`;
 
   return (
     <div className="d-flex flex-column gap-3">
@@ -100,14 +105,19 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
               </div>
               <div>
                 <h6>HTML provisório</h6>
-                {detailQuery.data.provisionalHtml?.trim() ? (
-                  <Link
-                    to={`/experiments/${experimentId}/geralanding/stage-executions/${detailQuery.data.idJob}/provisional-html`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Abrir HTML provisório em nova aba
-                  </Link>
+                {provisionalHtml ? (
+                  <div className="d-flex flex-column gap-2">
+                    <Link
+                      to={`/experiments/${experimentId}/geralanding/stage-executions/${detailQuery.data.idJob}/provisional-html`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Abrir HTML provisório em nova aba
+                    </Link>
+                    <a href={provisionalHtmlDownloadHref} download={provisionalHtmlFileName}>
+                      Baixar HTML provisório
+                    </a>
+                  </div>
                 ) : (
                   <p className="text-muted mb-0">Nenhum HTML provisório disponível para este registro.</p>
                 )}


### PR DESCRIPTION
### Motivation
- Users need an easy way to both open the provisional HTML in a new tab and download the provisional HTML file from the execution detail view.
- Keep the existing "open in new tab" behavior while providing a direct file download for offline inspection or saving.

### Description
- Added `provisionalHtml`, `provisionalHtmlDownloadHref` (data:text/html URL) and `provisionalHtmlFileName` computed from `idJob` to `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx`.
- Render the existing link that opens the provisional HTML in a new tab and grouped a new `<a download>` link labeled "Baixar HTML provisório" alongside it.
- Preserved the open-in-new-tab link with `target="_blank"` to respect the frontend guideline for external viewing while the download link uses the `download` attribute to trigger a file save.
- Change is entirely frontend-only in the specified page component and does not alter backend contracts.

### Testing
- Attempted `npm --prefix frontend run build` to validate the frontend bundle, but the command failed in this environment because `vite` is not installed (`sh: 1: vite: not found`).
- No other automated tests (unit or CI) were executed in this environment due to missing frontend dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd31bb268483218e4bb01e8ecfea97)