### PR TITLE
Melhora prompt de wireframe (gera-landing) para maior riqueza de imagens alinhadas ao nicho

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -88,6 +88,10 @@ Responda em JSON válido e estritamente aderente ao artefato `landingPageWirefra
 ### Responsabilidade canônica de imagem nesta etapa
 
 - Defina no wireframe todos os itens estruturais de imagem por seção (ex.: `sectionId`, `imageBindingKey`, objetivo visual e restrições de composição/layout).
+- A página deve ser visualmente rica: planeje imagens em alta cobertura de seções, priorizando hero, dor, mecanismo, prova, oferta e CTA com contexto visual claro (evitar blocos longos sem apoio visual).
+- Cada seção com potencial de conversão deve explicitar imagem conectada ao eixo **Dor → Resultado** do nicho (mostrar problema real, transformação esperada e evidência prática da melhora).
+- Em cada objetivo visual, descreva a cena de forma concreta para refletir a dor principal do nicho e o resultado desejado (antes/depois, contraste de estado, ganho percebido, redução de esforço).
+- Variar o tipo de imagem entre seções (ex.: contexto da dor, demonstração de mecanismo, prova social/documental, visual da oferta) para evitar repetição e aumentar percepção de valor.
 - O estágio `landing-page-image-planning` **não pode redefinir** esses campos estruturais; ele apenas consome o que veio do wireframe e gera o prompt final para o modelo de imagem.
 Campos obrigatórios:
 - pageGoal


### PR DESCRIPTION
### Motivation
- O gerador de wireframes vinha produzindo páginas com poucas imagens, portanto é necessário reforçar o prompt para aumentar a cobertura visual e assegurar que as imagens ilustram o eixo Dor → Resultado do nicho.

### Description
- Atualizei `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` adicionando regras que exigem alta cobertura de imagens nas seções críticas (hero, dor, mecanismo, prova, oferta, CTA), descrição concreta das cenas ligada à dor/resultado e variação de tipos de imagem entre seções.

### Testing
- Nenhum teste unitário foi executado; validei a alteração com `git -C /workspace/marketing-hub status --short` e confirmei o `commit` aplicado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd36973318832181efe117afa322b3)