### PR TITLE
Ajusta regra de espaçamento no prompt de geração de wireframe

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -72,6 +72,7 @@ Regras fixas da etapa:
 - Defina `formSpec` como contrato funcional do formulário (campos, consentimento e successState).
 - Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
 - Manter hero compacto e alta densidade útil acima da dobra no mobile.
+- Permitir respiros visuais entre blocos para legibilidade, porém evitar grandes áreas vazias; distribua conteúdo e elementos para não criar “buracos” extensos no layout (especialmente no mobile).
 - Reduzir distância entre promessa, prova, CTA e entendimento da oferta nas primeiras seções.
 - A seção de oferta deve acomodar `entryAsset` e `coreOffer` quando ambos existirem, sem assumir nomes fixos.
 - Se não houver distinção clara entre ativo inicial e oferta principal, projetar seção única coerente (sem forçar duas camadas artificiais).


### PR DESCRIPTION
### Motivation
- Evitar wireframes gerados com grandes áreas vazias que prejudicam a densidade informativa e a conversão, permitindo respiros visuais controlados especialmente no mobile.

### Description
- Atualiza o prompt `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` adicionando a regra: "Permitir respiros visuais entre blocos para legibilidade, porém evitar grandes áreas vazias; distribua conteúdo e elementos para não criar ‘buracos’ extensos no layout (especialmente no mobile)".

### Testing
- Nenhum teste automatizado foi necessário por se tratar de alteração estritamente textual; verifiquei o status e commit do repositório com `git -C /workspace/marketing-hub status --short` e `git -C /workspace/marketing-hub commit -m "Ajusta regra de respiro no prompt de wireframe"`, ambos concluídos com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5247fb4483219f6f07a5dfebf12a)