### PR TITLE
Fix pending/history split for Gera Landing executions

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -350,17 +350,23 @@ export default function ExperimentDetailPage() {
   const hasRunningGeraLandingExecution = (pendingGeraLandingExecutions ?? []).some((execution) =>
     isRunningExecution(execution.status),
   );
+  const runningGeraLandingExecutions = useMemo(
+    () => (pendingGeraLandingExecutions ?? []).filter((execution) => isRunningExecution(execution.status)),
+    [pendingGeraLandingExecutions],
+  );
   const hasFailedExecution = (status?: string | null) => {
     const normalizedStatus = (status ?? "").trim().toUpperCase();
     return ["FALHA", "FAILED", "ERROR", "ERRO"].includes(normalizedStatus);
   };
-  const historyGeraLandingExecutions = useMemo(
-    () =>
-      (completedGeraLandingExecutions ?? []).filter(
-        (execution) => isCompletedExecution(execution.status) || hasFailedExecution(execution.status),
-      ),
-    [completedGeraLandingExecutions],
-  );
+  const historyGeraLandingExecutions = useMemo(() => {
+    const completedHistory = (completedGeraLandingExecutions ?? []).filter(
+      (execution) => isCompletedExecution(execution.status) || hasFailedExecution(execution.status),
+    );
+    const failedFromPending = (pendingGeraLandingExecutions ?? []).filter((execution) =>
+      hasFailedExecution(execution.status),
+    );
+    return [...failedFromPending, ...completedHistory];
+  }, [completedGeraLandingExecutions, pendingGeraLandingExecutions]);
   const runningGeraLandingJobId = (pendingGeraLandingExecutions ?? []).find((execution) =>
     isRunningExecution(execution.status),
   )?.idJob;
@@ -1572,7 +1578,7 @@ export default function ExperimentDetailPage() {
                   </button>
                   {isLoadingPendingGeraLandingExecutions ? (
                     <p className="text-muted mb-0">Carregando jobs da etapa...</p>
-                  ) : !pendingGeraLandingExecutions || pendingGeraLandingExecutions.length === 0 ? (
+                  ) : runningGeraLandingExecutions.length === 0 ? (
                     <p className="text-muted mb-0">Nenhum job pendente ou em execução.</p>
                   ) : (
                     <div className="table-responsive">
@@ -1585,7 +1591,7 @@ export default function ExperimentDetailPage() {
                           </tr>
                         </thead>
                         <tbody>
-                          {pendingGeraLandingExecutions.map((execution) => (
+                          {runningGeraLandingExecutions.map((execution) => (
                             <tr key={execution.idJob}>
                               <td>
                                 <Link


### PR DESCRIPTION
### Motivation
- Corrigir a exibição da aba **Gera WireFrame** para que jobs com falha não permaneçam na lista de pendentes/execução e apareçam apenas no histórico.
- Evitar duplicação entre a tabela de execuções ativas e a tabela de histórico quando a fonte de `pending` contém itens com status de falha.

### Description
- Adicionei `runningGeraLandingExecutions` usando `useMemo` para derivar apenas execuções realmente em andamento a partir de `pendingGeraLandingExecutions` (filtros por status como `EM_PROCESSAMENTO`, `RUNNING`, etc.).
- Montei `historyGeraLandingExecutions` combinando execuções concluídas de `completedGeraLandingExecutions` com falhas extraídas da lista de `pendingGeraLandingExecutions` para garantir que falhas venham para o histórico.
- Atualizei a renderização da tabela superior para usar `runningGeraLandingExecutions` em vez de `pendingGeraLandingExecutions`, removendo itens falhos da visualização ativa.
- Mudanças feitas no arquivo `frontend/src/pages/experiment/ExperimentDetailPage.tsx`.

### Testing
- Executei `npm run typecheck` em `frontend`, que falhou devido a limitações do ambiente local (tipos ausentes: `@testing-library/jest-dom`, `vite/client`, `vitest/globals` e avisos de deprecação em `tsconfig`), portanto não houve validação de tipagem completa aqui.
- Não foram alterados testes automatizados no repositório e nenhum teste unitário adicional foi executado nesta rodada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd58bb0bc4832195acccc8c8e2de37)