### PR TITLE
Improve gera-landing wireframe prompt guidance for mobile-first layouts

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -74,6 +74,15 @@ Regras fixas da etapa:
 - Manter hero compacto e alta densidade útil acima da dobra no mobile.
 - Permitir respiros visuais entre blocos para legibilidade, porém evitar grandes áreas vazias; distribua conteúdo e elementos para não criar “buracos” extensos no layout (especialmente no mobile).
 - Reduzir distância entre promessa, prova, CTA e entendimento da oferta nas primeiras seções.
+- Mobile-first obrigatório (prioridade total): projetar cada seção primeiro para viewport entre 320px e 430px; desktop é adaptação posterior.
+- Em mobile, **proibir layout de duas colunas simultâneas para conteúdo principal** (texto + imagem lado a lado no mesmo nível). Empilhar sempre em coluna única, com ordem narrativa: promessa → explicação curta → prova/lista → CTA.
+- Cada seção deve nascer com sequência vertical explícita em `uiNotes` (ordem de leitura mobile), evitando alternância confusa esquerda/direita entre blocos consecutivos.
+- Limitar blocos de texto no mobile: no máximo 1 título + 1 parágrafo curto + 1 lista curta por seção (quando aplicável). Quebrar conteúdo longo em novas seções ao invés de condensar.
+- Para listas (`<ul>`), usar itens curtos e escaneáveis no mobile (frases objetivas), evitando listas extensas que empurrem o CTA para muito abaixo.
+- Toda seção com imagem deve definir em `uiSizes` comportamento mobile sem “vazios”: imagem com largura fluida (`width: 100%`), altura proporcional e alinhamento consistente com o bloco de texto da seção.
+- Em mobile, evitar espaços verticais excessivos: definir espaçamentos progressivos e compactos entre título, texto, lista, imagem e CTA, sem áreas mortas grandes entre seções.
+- Reforçar densidade de conversão no mobile: o primeiro CTA principal deve aparecer até o final da segunda seção e se repetir em pontos de prova/oferta sem quebrar fluidez.
+- Em `mobilePriorityScore`, seções críticas de conversão (hero, prova principal, oferta e CTA) devem receber prioridade alta e tratamento de layout compacto orientado a ação.
 - A seção de oferta deve acomodar `entryAsset` e `coreOffer` quando ambos existirem, sem assumir nomes fixos.
 - Se não houver distinção clara entre ativo inicial e oferta principal, projetar seção única coerente (sem forçar duas camadas artificiais).
 - Não usar nomenclaturas internas (`entryAsset`, `coreOffer` etc.) como rótulo visível do wireframe; usar linguagem comercial apropriada ao caso.


### PR DESCRIPTION
### Motivation
- The generated landing wireframes produced poor mobile results (side-by-side columns, large empty areas, CTA pushed far below fold) and need stronger prompt-level guardrails to ensure readable, conversion-focused mobile output.
- Enforce mobile-first composition rules at the wireframe prompt layer so the model outputs mobile-optimized structure without adding hardcoded rendering logic.

### Description
- Strengthened the gera-landing wireframe prompt by updating `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` with explicit mobile-first rules and constraints. 
- Added requirements including: mandatory mobile-first target viewport (320–430px), prohibition of two-column primary layouts on mobile (force vertical stacking), explicit mobile reading order in `uiNotes`, limits on text/list density per section, image sizing/behavior rules (`width: 100%` mobile guidance), compact vertical spacing, CTA placement density (first CTA by second section), and guidance to prioritize `mobilePriorityScore` for conversion-critical sections.
- Preserved the canonical artifact contract (`landingPageWireframe`) and kept all previously required fields and consistency checks intact.

### Testing
- Ran targeted unit tests for the ai-worker module with `mvn -f ai-worker/pom.xml -Dtest=GeraLandingServiceTest test` to validate integration of prompt resources; the build failed during dependency resolution. 
- Failure reason: Maven could not resolve the private artifact `com.marketinghub:ads-service:0.0.1-SNAPSHOT` from the GitHub Maven registry (401 Unauthorized), so tests could not complete in this environment.
- No other automated test failures were introduced by the edit (change is limited to prompt text); CI verification in the normal environment with access to private artifacts is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd59e769f483218d6ad6b9ab1b450d)