### PR TITLE
feat(frontend): adicionar botão de download JSON no detalhe de execução Gera Landing

### DIFF
--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -34,6 +34,16 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
     : "";
   const provisionalHtmlFileName = `provisional-html-${detailQuery.data?.idJob ?? "geralanding"}.html`;
 
+  const buildJsonDownloadProps = (fieldName: string, value?: string | null) => {
+    if (!value) return null;
+
+    const fileName = `${fieldName}-${detailQuery.data?.idJob ?? "geralanding"}.json`;
+    return {
+      href: `data:application/json;charset=utf-8,${encodeURIComponent(value)}`,
+      fileName,
+    };
+  };
+
   const handleCopyJson = async (label: string, value?: string | null) => {
     if (!value) return;
 
@@ -115,6 +125,15 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                   >
                     {copiedField === "promptContent" ? "Copiado!" : "Copiar JSON"}
                   </button>
+                  {(() => {
+                    const download = buildJsonDownloadProps("prompt-content", detailQuery.data.promptContent);
+                    if (!download) return null;
+                    return (
+                      <a href={download.href} download={download.fileName} className="btn btn-sm btn-outline-secondary">
+                        Baixar JSON
+                      </a>
+                    );
+                  })()}
                 </div>
                 <CollapsibleJsonViewer content={detailQuery.data.promptContent} />
               </div>
@@ -128,6 +147,15 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                   >
                     {copiedField === "prompt" ? "Copiado!" : "Copiar JSON"}
                   </button>
+                  {(() => {
+                    const download = buildJsonDownloadProps("prompt", detailQuery.data.prompt);
+                    if (!download) return null;
+                    return (
+                      <a href={download.href} download={download.fileName} className="btn btn-sm btn-outline-secondary">
+                        Baixar JSON
+                      </a>
+                    );
+                  })()}
                 </div>
                 <CollapsibleJsonViewer content={detailQuery.data.prompt} />
               </div>
@@ -141,6 +169,15 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                   >
                     {copiedField === "openAiRequestBody" ? "Copiado!" : "Copiar JSON"}
                   </button>
+                  {(() => {
+                    const download = buildJsonDownloadProps("openai-request-body", detailQuery.data.openAiRequestBody);
+                    if (!download) return null;
+                    return (
+                      <a href={download.href} download={download.fileName} className="btn btn-sm btn-outline-secondary">
+                        Baixar JSON
+                      </a>
+                    );
+                  })()}
                 </div>
                 <CollapsibleJsonViewer content={detailQuery.data.openAiRequestBody} />
               </div>
@@ -154,6 +191,15 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                   >
                     {copiedField === "schemaJson" ? "Copiado!" : "Copiar JSON"}
                   </button>
+                  {(() => {
+                    const download = buildJsonDownloadProps("schema-json", detailQuery.data.schemaJson);
+                    if (!download) return null;
+                    return (
+                      <a href={download.href} download={download.fileName} className="btn btn-sm btn-outline-secondary">
+                        Baixar JSON
+                      </a>
+                    );
+                  })()}
                 </div>
                 <CollapsibleJsonViewer content={detailQuery.data.schemaJson} />
               </div>
@@ -171,6 +217,15 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                   >
                     {copiedField === "modelResponse" ? "Copiado!" : "Copiar JSON"}
                   </button>
+                  {(() => {
+                    const download = buildJsonDownloadProps("model-response", detailQuery.data.modelResponse);
+                    if (!download) return null;
+                    return (
+                      <a href={download.href} download={download.fileName} className="btn btn-sm btn-outline-secondary">
+                        Baixar JSON
+                      </a>
+                    );
+                  })()}
                 </div>
                 <CollapsibleJsonViewer content={detailQuery.data.modelResponse} />
               </div>


### PR DESCRIPTION
### Motivation
- Facilitar a inspeção e exportação dos payloads JSON gerados pela execução Gera Landing sem necessidade de backend adicional.
- Fornecer ação direta de download ao lado dos botões existentes de cópia para melhorar a análise e auditoria dos dados de execução.

### Description
- Adiciona o helper `buildJsonDownloadProps` em `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx` para construir `href` `data:application/json` e nome de arquivo baseado no `jobId`.
- Insere botão `Baixar JSON` ao lado de `Copiar JSON` para os blocos `promptContent`, `prompt`, `openAiRequestBody`, `schemaJson` e `modelResponse` usando links de dados client-side (sem mudança backend).
- Arquivo alterado: `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx`.

### Testing
- Executei `npm --prefix frontend run -s prettier -- --check src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx`, que retornou código de saída não-zero (no output) numa checagem de formatação do ambiente.
- Executei `npm run typecheck` no `frontend`, que falhou por problemas de dependências/tipagens e opções deprecated no `tsconfig` já presentes no projeto, sem relação direta com as mudanças implementadas.
- Nenhum teste automatizado específico ao novo código falhou como resultado direto da alteração (as falhas acima são de validação de ambiente geral).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5a5a0a98832194e0c4b9367af6c9)