### PR TITLE
Handle 404 during frontend artifact cleanup in CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -79,12 +79,20 @@ jobs:
             const artifactsToDelete = activeArtifacts.slice(maxArtifactsToKeep);
 
             for (const artifact of artifactsToDelete) {
-              await github.rest.actions.deleteArtifact({
-                owner,
-                repo,
-                artifact_id: artifact.id,
-              });
-              core.info(`Deleted artifact ${artifact.name} (${artifact.id}) created at ${artifact.created_at}.`);
+              try {
+                await github.rest.actions.deleteArtifact({
+                  owner,
+                  repo,
+                  artifact_id: artifact.id,
+                });
+                core.info(`Deleted artifact ${artifact.name} (${artifact.id}) created at ${artifact.created_at}.`);
+              } catch (error) {
+                if (error.status === 404) {
+                  core.warning(`Artifact ${artifact.id} was already removed. Skipping.`);
+                  continue;
+                }
+                throw error;
+              }
             }
 
             core.info(`Kept the ${maxArtifactsToKeep} most recent artifacts.`);


### PR DESCRIPTION
### Motivation
- Prevent CI failures when deleting old `frontend-build` artifacts if an artifact listed by the cleanup job was already removed by a concurrent run or expiration.

### Description
- Updated `.github/workflows/frontend.yml` cleanup step to wrap `github.rest.actions.deleteArtifact` in a `try/catch` and ignore `404 Not Found` by logging a warning while rethrowing other errors.

### Testing
- Ran `git status --short` and committed the change with `git commit`, which completed successfully and verified the updated lines in ` .github/workflows/frontend.yml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5d2fb0d883219607866b50d39801)