### PR TITLE
Show wireframe job immediately after start (optimistic UI)

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -140,6 +140,8 @@ export default function ExperimentDetailPage() {
   const [copiedCardKey, setCopiedCardKey] = useState<string | null>(null);
   const [copyingCardKey, setCopyingCardKey] = useState<string | null>(null);
   const [isStartingWireframe, setIsStartingWireframe] = useState(false);
+  const [optimisticWireframeExecution, setOptimisticWireframeExecution] =
+    useState<GeraLandingStageExecutionItem | null>(null);
   const hadRunningGeraLandingExecutionRef = useRef(false);
   const {
     data: pendingGeraLandingExecutions,
@@ -316,10 +318,16 @@ export default function ExperimentDetailPage() {
         idJob: string;
         status: string;
       }>(`/api/experiments/${expId}/geralanding/wireframe/start`);
+      const localExecutionRequestedAt = new Date().toISOString();
+      setOptimisticWireframeExecution({
+        idJob: startResponse.idJob,
+        status: startResponse.status,
+        executionRequestedAt: localExecutionRequestedAt,
+      });
       toast.success(
         `Solicitação registrada. Código: ${startResponse.idJob} | Status: ${startResponse.status}`,
       );
-      void Promise.all([
+      await Promise.all([
         refetchPendingGeraLandingExecutions(),
         refetchCompletedGeraLandingExecutions(),
       ]);
@@ -347,12 +355,40 @@ export default function ExperimentDetailPage() {
       normalizedStatus,
     );
   };
-  const hasRunningGeraLandingExecution = (pendingGeraLandingExecutions ?? []).some((execution) =>
-    isRunningExecution(execution.status),
+  const mergedPendingGeraLandingExecutions = useMemo(() => {
+    if (!optimisticWireframeExecution) {
+      return pendingGeraLandingExecutions ?? [];
+    }
+    const alreadyPresent = (pendingGeraLandingExecutions ?? []).some(
+      (execution) => execution.idJob === optimisticWireframeExecution.idJob,
+    );
+    if (alreadyPresent) {
+      return pendingGeraLandingExecutions ?? [];
+    }
+    return [optimisticWireframeExecution, ...(pendingGeraLandingExecutions ?? [])];
+  }, [optimisticWireframeExecution, pendingGeraLandingExecutions]);
+
+  useEffect(() => {
+    if (!optimisticWireframeExecution) {
+      return;
+    }
+    const persistedExecution = (pendingGeraLandingExecutions ?? []).some(
+      (execution) => execution.idJob === optimisticWireframeExecution.idJob,
+    );
+    if (persistedExecution) {
+      setOptimisticWireframeExecution(null);
+    }
+  }, [optimisticWireframeExecution, pendingGeraLandingExecutions]);
+
+  const hasRunningGeraLandingExecution = mergedPendingGeraLandingExecutions.some(
+    (execution) => isRunningExecution(execution.status),
   );
   const runningGeraLandingExecutions = useMemo(
-    () => (pendingGeraLandingExecutions ?? []).filter((execution) => isRunningExecution(execution.status)),
-    [pendingGeraLandingExecutions],
+    () =>
+      mergedPendingGeraLandingExecutions.filter((execution) =>
+        isRunningExecution(execution.status),
+      ),
+    [mergedPendingGeraLandingExecutions],
   );
   const hasFailedExecution = (status?: string | null) => {
     const normalizedStatus = (status ?? "").trim().toUpperCase();
@@ -367,7 +403,7 @@ export default function ExperimentDetailPage() {
     );
     return [...failedFromPending, ...completedHistory];
   }, [completedGeraLandingExecutions, pendingGeraLandingExecutions]);
-  const runningGeraLandingJobId = (pendingGeraLandingExecutions ?? []).find((execution) =>
+  const runningGeraLandingJobId = mergedPendingGeraLandingExecutions.find((execution) =>
     isRunningExecution(execution.status),
   )?.idJob;
 


### PR DESCRIPTION
### Motivation
- Users reported that after clicking `Iniciar` a wireframe job did not appear in the executions list until a second click or a later refresh, causing a poor UX. 
- The change aims to provide immediate visual feedback and avoid a race between the POST response and the list refetch.

### Description
- Added an optimistic pending execution state `optimisticWireframeExecution` and set it when the `/geralanding/wireframe/start` call returns to show the job immediately in the UI. 
- Merged the optimistic execution with server-fetched pending executions into `mergedPendingGeraLandingExecutions` so the UI shows the started job without duplicating it. 
- Auto-clear the optimistic state once the backend-pulled list contains the same `idJob`, and changed post-start refresh to `await Promise.all([...refetch...])` to reduce stale timing windows. 
- Updated running-job derivation and components that rely on the pending list to use the merged list so button-disable and job-detail polling remain consistent (file modified: `src/pages/experiment/ExperimentDetailPage.tsx`).

### Testing
- Ran `npm run typecheck` in `frontend` which failed in this environment due to missing local type definition packages and `tsconfig` deprecation warnings unrelated to this change. 
- No frontend unit tests were added or executed as part of this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde0a6d22c8321801db7157853fd2a)