### PR TITLE
Considerar `INICIADO`/`STARTED` como status em execução para Gera WireFrame

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -345,7 +345,7 @@ export default function ExperimentDetailPage() {
 
   const isRunningExecution = (status?: string | null) => {
     const normalizedStatus = (status ?? "").trim().toUpperCase();
-    return ["AGUARDANDO_ENVIO_OPENAI", "EM_PROCESSAMENTO", "PROCESSING", "RUNNING", "IN_PROGRESS", "PENDING"].includes(
+    return ["AGUARDANDO_ENVIO_OPENAI", "EM_PROCESSAMENTO", "PROCESSING", "RUNNING", "IN_PROGRESS", "PENDING", "INICIADO", "STARTED"].includes(
       normalizedStatus,
     );
   };


### PR DESCRIPTION
### Motivation
- Ao clicar em `Iniciar` na aba Gera WireFrame o backend pode retornar `INICIADO`, que não estava na lista de status considerados como "em execução", fazendo a área de jobs ficar vazia apesar do toast mostrar o código e status.

### Description
- Atualizei a função `isRunningExecution` em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` para incluir os status `INICIADO` e `STARTED` na whitelist de estados ativos, permitindo que o job apareça em "jobs pendentes/em execução".

### Testing
- Executei `npm run typecheck` no frontend e o processo falhou por problemas de tipos/ambiente (definições de tipos ausentes e avisos de deprecação do TS) que são independentes desta alteração; não há outros testes automatizados executados para este patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde6081b24832183eb283ef215d1de)