### PR TITLE
Ordena histórico do Gera WireFrame por data (mais recentes primeiro)

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -401,7 +401,15 @@ export default function ExperimentDetailPage() {
     const failedFromPending = (pendingGeraLandingExecutions ?? []).filter((execution) =>
       hasFailedExecution(execution.status),
     );
-    return [...failedFromPending, ...completedHistory];
+
+    return [...failedFromPending, ...completedHistory].sort((leftExecution, rightExecution) => {
+      const leftTimestamp = Date.parse(leftExecution.executionRequestedAt ?? "");
+      const rightTimestamp = Date.parse(rightExecution.executionRequestedAt ?? "");
+      const normalizedLeftTimestamp = Number.isNaN(leftTimestamp) ? 0 : leftTimestamp;
+      const normalizedRightTimestamp = Number.isNaN(rightTimestamp) ? 0 : rightTimestamp;
+
+      return normalizedRightTimestamp - normalizedLeftTimestamp;
+    });
   }, [completedGeraLandingExecutions, pendingGeraLandingExecutions]);
   const runningGeraLandingJobId = mergedPendingGeraLandingExecutions.find((execution) =>
     isRunningExecution(execution.status),


### PR DESCRIPTION
### Motivation
- Melhorar a usabilidade exibindo primeiro as execuções mais recentes no painel "Gera WireFrame" para facilitar acompanhamento operacional.

### Description
- Ajusta a construção de `historyGeraLandingExecutions` em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` para ordenar por `executionRequestedAt` em ordem decrescente usando `Date.parse` e normalizando timestamps inválidos para `0`.

### Testing
- Executei `npm run typecheck` na pasta `frontend`, que falhou por limitações de ambiente (definições de tipos ausentes e opções depreciadas no `tsconfig`), sem relação com a mudança de ordenação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1368ee1c8321aac6b0ed09e2a630)