### PR TITLE
Add Playwright-based HotmartAuthMain tester and update registros.md

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -180,3 +180,9 @@
   - reforço da diretriz: execução automática agendada (de hora em hora), sem depender de disparo manual.
 - Registro criado por solicitação explícita: "e registre o trabalho em /docs/mois/registros.md".
 - Commits relacionados: `3ac1f55` (compose) e `329d8b0` (documentação).
+
+## 2026-05-08 14:15:35 UTC-3
+- Criada a estrutura `testes` no submódulo `mois-hotmart-collector` com a classe `HotmartAuthMain` para validação isolada de autenticação Hotmart via username/password.
+- A classe lê `HOTMART_USERNAME` e `HOTMART_PASSWORD` do ambiente, executa login em `https://app.hotmart.com/login` com Playwright e imprime a URL resultante após submissão.
+- Objetivo: facilitar teste operacional de autenticação sem acoplamento ao fluxo completo de coleta agendada.
+- Commit relacionado: `9195df7`.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/testes/HotmartAuthMain.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/testes/HotmartAuthMain.java
@@ -1,0 +1,48 @@
+package com.marketinghub.moishotmart.testes;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.WaitUntilState;
+
+public class HotmartAuthMain {
+
+    public static void main(String[] args) {
+        String username = System.getenv("HOTMART_USERNAME");
+        String password = System.getenv("HOTMART_PASSWORD");
+
+        if (isBlank(username) || isBlank(password)) {
+            System.err.println("Defina HOTMART_USERNAME e HOTMART_PASSWORD antes de executar.");
+            System.exit(1);
+        }
+
+        try (Playwright playwright = Playwright.create()) {
+            Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(false));
+            BrowserContext context = browser.newContext();
+            Page page = context.newPage();
+
+            page.navigate("https://app.hotmart.com/login", new Page.NavigateOptions()
+                    .setTimeout(60_000)
+                    .setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
+
+            page.locator("input[type='email'], input[name='email']").first().fill(username);
+            page.locator("input[type='password'], input[name='password']").first().fill(password);
+            page.locator("button[type='submit']").first().click();
+
+            page.waitForTimeout(5_000);
+            System.out.println("URL atual após login: " + page.url());
+
+            context.close();
+            browser.close();
+        } catch (Exception ex) {
+            System.err.println("Falha na autenticação Hotmart: " + ex.getMessage());
+            System.exit(1);
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an isolated, easy-to-run utility to validate Hotmart username/password authentication without running the full collector flow.
- Record the addition in the project changelog to document the operational test helper in `docs/mois/registros.md`.

### Description
- Added a new test helper class `HotmartAuthMain` at `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/testes/HotmartAuthMain.java` that performs a Playwright-driven login to `https://app.hotmart.com/login` and prints the resulting URL after submission.
- The class reads credentials from the environment variables `HOTMART_USERNAME` and `HOTMART_PASSWORD`, performs form fill and submit, waits briefly, and reports success or failure to stdout/stderr.
- Updated `docs/mois/registros.md` with a new entry describing the `testes` structure and the purpose of the `HotmartAuthMain` utility.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1613a37c83218211048e45b1931d)