### PR TITLE
Install Chromium deps and set container flags to fix Playwright driver errors

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -192,3 +192,10 @@
 - Ajustado `HotmartCollectorService` para usar fallback explícito de credenciais quando `collector.hotmart.username/password` chegarem em branco via ambiente, priorizando os valores definidos em properties.
 - Adicionadas propriedades `collector.hotmart.username-fallback` e `collector.hotmart.password-fallback` no `application.properties` para garantir uso das credenciais do arquivo quando necessário.
 - Registro criado por solicitação explícita: "Ao final registre o trabalho em /docs/mois/registros.md".
+
+## 2026-05-08 22:30:00 UTC
+- Analisada recorrência de `COLLECTION_ERROR` no `mois-hotmart-collector` com mensagem `Falha na coleta Playwright: Failed to create driver` observada nos logs recentes via MCP.
+- Corrigido o runtime Docker do coletor para incluir dependências de sistema exigidas pelo Chromium/Playwright (`libnss3`, `libatk-bridge2.0-0`, `libxkbcommon0`, `libgbm1`, `libasound2`, `libxcomposite1`, `libxdamage1`, `libxfixes3`, `libxrandr2`, `libcups2`, `libpangocairo-1.0-0`, `libgtk-3-0`, `libdrm2`, `fonts-liberation`, `ca-certificates`).
+- Ajustado o launch do Chromium no `HotmartCollectorService` com argumentos `--no-sandbox` e `--disable-dev-shm-usage` para maior estabilidade em container.
+- Validação executada no módulo com `mvn test -q` concluída com sucesso.
+- Registro criado por solicitação explícita: "agora registre o trabalho em /docs/mois/registros.md".

--- a/mois-hotmart-collector/Dockerfile
+++ b/mois-hotmart-collector/Dockerfile
@@ -6,6 +6,25 @@ RUN mvn -q -DskipTests package
 
 FROM eclipse-temurin:21-jre
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libxkbcommon0 \
+    libgbm1 \
+    libasound2 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libcups2 \
+    libpangocairo-1.0-0 \
+    libgtk-3-0 \
+    libdrm2 \
+    fonts-liberation \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/target/mois-hotmart-collector.jar app.jar
 EXPOSE 8096
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -61,7 +61,9 @@ public class HotmartCollectorService {
         }
 
         try (Playwright playwright = Playwright.create()) {
-            Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(headless));
+            Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions()
+                    .setHeadless(headless)
+                    .setArgs(List.of("--no-sandbox", "--disable-dev-shm-usage")));
             BrowserContext context = browser.newContext();
             Page page = context.newPage();
 


### PR DESCRIPTION
### Motivation
- Resolve recurring `COLLECTION_ERROR` caused by Playwright failing to create a Chromium driver in the collector container by providing required system libraries.
- Improve Chromium stability in Docker by disabling sandboxing and shared memory usage for headless runs.
- Record the operational changes in the module changelog under `/docs/mois/registros.md`.

### Description
- Updated `mois-hotmart-collector/Dockerfile` to install required system packages for Chromium/Playwright (for example `libnss3`, `libgtk-3-0`, `libgbm1`, `fonts-liberation`, and `ca-certificates`) and to clean apt lists afterwards.
- Adjusted `HotmartCollectorService` to launch Chromium with additional args `--no-sandbox` and `--disable-dev-shm-usage` when calling Playwright (`.setArgs(List.of("--no-sandbox", "--disable-dev-shm-usage"))`).
- Appended a new registry entry to `docs/mois/registros.md` documenting the diagnosis and the fixes applied on `2026-05-08 22:30:00 UTC`.

### Testing
- Ran `mvn test -q` in the `mois-hotmart-collector` module and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5f525a748321a1a86ea45df578f5)