### PR TITLE
fix(docker): use libasound2t64 in mois-hotmart-collector image

### DIFF
--- a/mois-hotmart-collector/Dockerfile
+++ b/mois-hotmart-collector/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libatk-bridge2.0-0 \
     libxkbcommon0 \
     libgbm1 \
-    libasound2 \
+    libasound2t64 \
     libxcomposite1 \
     libxdamage1 \
     libxfixes3 \


### PR DESCRIPTION
### Motivation
- Fix Docker image build failing with `E: Package 'libasound2' has no installation candidate` on Ubuntu "resolute" by using the concrete package available in the base image.

### Description
- Update `mois-hotmart-collector/Dockerfile` to replace `libasound2` with `libasound2t64` in the `apt-get install` list.

### Testing
- Attempted `docker build -f mois-hotmart-collector/Dockerfile mois-hotmart-collector -t mois-hotmart-collector:test` but local environment lacks Docker CLI (`docker: command not found`), so full build verification must be performed in CI or a Docker-enabled runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe62e7e0d08321887da26943ad1a54)