### PR TITLE
Add diagnostic logging for Playwright failures in HotmartCollectorService

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -199,3 +199,15 @@
 - Ajustado o launch do Chromium no `HotmartCollectorService` com argumentos `--no-sandbox` e `--disable-dev-shm-usage` para maior estabilidade em container.
 - Validação executada no módulo com `mvn test -q` concluída com sucesso.
 - Registro criado por solicitação explícita: "agora registre o trabalho em /docs/mois/registros.md".
+
+## 2026-05-09 01:10:00 UTC
+- Atendendo à solicitação de aumentar observabilidade do erro `Falha na coleta Playwright: Failed to create driver` no `mois-hotmart-collector`, foram adicionados logs diagnósticos no `HotmartCollectorService`.
+- Novos logs cobrem:
+  - contexto de início da coleta (`headless`, limites solicitado/aplicado, presença de cookie/senha);
+  - bootstrap do Playwright com `chromium executablePath` e argumentos de launch;
+  - estratégia de autenticação usada (cookie de sessão vs login/senha);
+  - navegação para URL alvo, quantidade de cards encontrados/processados e total coletado;
+  - erro com contexto completo e stack trace no bloco de exceção.
+- Fluxo de login também passou a registrar início e URL resultante após submissão, para facilitar triagem de falhas de autenticação.
+- Validação executada: `mvn -q test` no módulo `mois-hotmart-collector` com sucesso.
+- Registro criado por solicitação explícita: "registre em /docs/mois/registros.md".

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -13,11 +13,14 @@ import com.microsoft.playwright.options.WaitUntilState;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 public class HotmartCollectorService {
+    private static final Logger log = LoggerFactory.getLogger(HotmartCollectorService.class);
 
     private final boolean headless;
     private final String hotmartMarketUrl;
@@ -52,6 +55,7 @@ public class HotmartCollectorService {
                 && hotmartPassword != null && !hotmartPassword.isBlank();
 
         if (!hasSessionCookie && !hasCredentials) {
+            log.warn("Coleta Hotmart ignorada: autenticação ausente (sem cookie de sessão e sem credenciais).");
             return new HotmartCollectionResponse(
                     "COLLECTION_SKIPPED",
                     "Autenticação Hotmart ausente. Configure collector.hotmart.session-cookie "
@@ -60,23 +64,39 @@ public class HotmartCollectorService {
             );
         }
 
+        log.info(
+                "Iniciando coleta Hotmart com Playwright. headless={}, maxProductsSolicitado={}, maxProductsAplicado={}, hasSessionCookie={}, hasCredentials={}",
+                headless,
+                request.maxProducts(),
+                boundedMax,
+                hasSessionCookie,
+                hasCredentials
+        );
+
         try (Playwright playwright = Playwright.create()) {
+            String browserPath = playwright.chromium().executablePath();
+            List<String> launchArgs = List.of("--no-sandbox", "--disable-dev-shm-usage");
+            log.info("Playwright inicializado. Chromium executablePath='{}', launchArgs={}", browserPath, launchArgs);
+
             Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions()
                     .setHeadless(headless)
-                    .setArgs(List.of("--no-sandbox", "--disable-dev-shm-usage")));
+                    .setArgs(launchArgs));
             BrowserContext context = browser.newContext();
             Page page = context.newPage();
 
             if (hasSessionCookie) {
+                log.info("Usando autenticação por cookie de sessão Hotmart.");
                 context.addCookies(List.of(new Cookie("hotmart_session", hotmartSessionCookie)
                         .setDomain(".hotmart.com")
                         .setPath("/")
                         .setHttpOnly(true)
                         .setSecure(true)));
             } else {
+                log.info("Usando autenticação por login/senha Hotmart.");
                 performLogin(page);
             }
 
+            log.info("Navegando para URL de mercado Hotmart: {}", hotmartMarketUrl);
             page.navigate(hotmartMarketUrl, new Page.NavigateOptions()
                     .setTimeout(60_000)
                     .setWaitUntil(WaitUntilState.NETWORKIDLE));
@@ -84,6 +104,7 @@ public class HotmartCollectorService {
 
             int cardsCount = page.locator("a[href*='/market/products/']").count();
             int maxToRead = Math.min(cardsCount, boundedMax);
+            log.info("Página carregada. cardsEncontrados={}, cardsProcessados={}", cardsCount, maxToRead);
             for (int i = 0; i < maxToRead; i++) {
                 String title = page.locator("a[href*='/market/products/']").nth(i).innerText();
                 String detailsUrl = page.locator("a[href*='/market/products/']").nth(i).getAttribute("href");
@@ -99,11 +120,20 @@ public class HotmartCollectorService {
                 ));
             }
 
+            log.info("Coleta Hotmart finalizada com sucesso. produtosColetados={}", products.size());
             context.close();
             browser.close();
         } catch (Exception ex) {
             status = "COLLECTION_ERROR";
             message = "Falha na coleta Playwright: " + ex.getMessage();
+            log.error(
+                    "Erro na coleta Hotmart via Playwright. headless={}, hasSessionCookie={}, hasCredentials={}, marketUrl='{}'",
+                    headless,
+                    hasSessionCookie,
+                    hasCredentials,
+                    hotmartMarketUrl,
+                    ex
+            );
         }
 
         return new HotmartCollectionResponse(status, message, products);
@@ -120,6 +150,8 @@ public class HotmartCollectorService {
     }
 
     private void performLogin(Page page) {
+        log.info("Iniciando login Hotmart por credenciais (username preenchido={}).",
+                hotmartUsername != null && !hotmartUsername.isBlank());
         page.navigate("https://app.hotmart.com/login", new Page.NavigateOptions()
                 .setTimeout(60_000)
                 .setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
@@ -128,5 +160,6 @@ public class HotmartCollectorService {
         page.locator("input[type='password'], input[name='password']").first().fill(hotmartPassword);
         page.locator("button[type='submit']").first().click();
         page.waitForTimeout(3_000);
+        log.info("Login Hotmart submetido. URL atual após espera='{}'.", page.url());
     }
 }


### PR DESCRIPTION
### Motivation
- Improve observability for recurring `Failed to create driver` Playwright errors during Hotmart collection. 
- Provide contextual diagnostic data to triage authentication and Chromium launch issues in containerized runtime. 
- Record changes in runtime behavior and maintenance work in the project registry `docs/mois/registros.md`.

### Description
- Added an SLF4J logger to `HotmartCollectorService` and inserted diagnostic logs for collection start, authentication presence, and strategy selection. 
- Log Playwright bootstrap details including `chromium executablePath` and launch arguments and centralized the launch args into a `launchArgs` list used at browser launch. 
- Instrumented navigation and scraping flow with logs for target URL, counts of product cards found/processed, and final product count, and augmented exception handling to log full context and stack trace. 
- Updated `docs/mois/registros.md` with entries describing the observability changes and previous runtime fixes.

### Testing
- Executed module unit/integration tests with `mvn -q test` in `mois-hotmart-collector`, which completed successfully. 
- No automated regressions or test failures were reported after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe86b91d048321a4e9f8a699976c07)