### PR TITLE
Preinstall Chromium, add executable-path support and enhance Playwright logging for mois-hotmart-collector

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -211,3 +211,10 @@
 - Fluxo de login também passou a registrar início e URL resultante após submissão, para facilitar triagem de falhas de autenticação.
 - Validação executada: `mvn -q test` no módulo `mois-hotmart-collector` com sucesso.
 - Registro criado por solicitação explícita: "registre em /docs/mois/registros.md".
+
+## 2026-05-09 05:55:33 UTC-3
+- Revisado o ajuste de estabilidade do `mois-hotmart-collector` para execução em ambiente sem UI com Playwright.
+- No `Dockerfile`, a etapa de pré-instalação do Chromium foi endurecida para validação explícita do diretório de browsers e busca correta do binário (com expressão `find` parentetizada), evitando falso-positivo silencioso.
+- Mantida a estratégia de uso de browser com `collector.playwright.chromium-executable-path` no serviço, permitindo apontamento explícito do executável quando necessário em produção.
+- Testes unitários do módulo Java reexecutados com sucesso após os ajustes.
+- Registro criado por solicitação explícita: "registre o trabalho em /docs/mois/registros.md".

--- a/mois-hotmart-collector/Dockerfile
+++ b/mois-hotmart-collector/Dockerfile
@@ -26,5 +26,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/target/mois-hotmart-collector.jar app.jar
+
+# Pre-instala Chromium do Playwright no build para evitar download em runtime
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN mkdir -p /ms-playwright \
+    && java -cp /app/app.jar com.microsoft.playwright.CLI install chromium \
+    && test -d /ms-playwright \
+    && find /ms-playwright -maxdepth 4 -type f \( -name chrome -o -name chromium \)
+
 EXPOSE 8096
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -13,6 +13,7 @@ import com.microsoft.playwright.options.WaitUntilState;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,6 +24,7 @@ public class HotmartCollectorService {
     private static final Logger log = LoggerFactory.getLogger(HotmartCollectorService.class);
 
     private final boolean headless;
+    private final String chromiumExecutablePath;
     private final String hotmartMarketUrl;
     private final String hotmartSessionCookie;
     private final String hotmartUsername;
@@ -30,6 +32,7 @@ public class HotmartCollectorService {
 
     public HotmartCollectorService(
             @Value("${collector.playwright.headless:true}") boolean headless,
+            @Value("${collector.playwright.chromium-executable-path:}") String chromiumExecutablePath,
             @Value("${collector.hotmart.search-url:https://app.hotmart.com/market/search}") String hotmartMarketUrl,
             @Value("${collector.hotmart.session-cookie:}") String hotmartSessionCookie,
             @Value("${collector.hotmart.username:}") String hotmartUsername,
@@ -38,6 +41,7 @@ public class HotmartCollectorService {
             @Value("${collector.hotmart.password-fallback:}") String hotmartPasswordFallback
     ) {
         this.headless = headless;
+        this.chromiumExecutablePath = chromiumExecutablePath;
         this.hotmartMarketUrl = hotmartMarketUrl;
         this.hotmartSessionCookie = hotmartSessionCookie;
         this.hotmartUsername = pickFirstNonBlank(hotmartUsername, hotmartUsernameFallback);
@@ -78,9 +82,15 @@ public class HotmartCollectorService {
             List<String> launchArgs = List.of("--no-sandbox", "--disable-dev-shm-usage");
             log.info("Playwright inicializado. Chromium executablePath='{}', launchArgs={}", browserPath, launchArgs);
 
-            Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions()
+            BrowserType.LaunchOptions launchOptions = new BrowserType.LaunchOptions()
                     .setHeadless(headless)
-                    .setArgs(launchArgs));
+                    .setArgs(launchArgs);
+            if (chromiumExecutablePath != null && !chromiumExecutablePath.isBlank()) {
+                launchOptions.setExecutablePath(Path.of(chromiumExecutablePath));
+                log.info("Usando Chromium com executablePath explícito: '{}'", chromiumExecutablePath);
+            }
+
+            Browser browser = playwright.chromium().launch(launchOptions);
             BrowserContext context = browser.newContext();
             Page page = context.newPage();
 

--- a/mois-hotmart-collector/src/main/resources/application.properties
+++ b/mois-hotmart-collector/src/main/resources/application.properties
@@ -12,6 +12,7 @@ management.endpoint.health.show-details=always
 
 # Hotmart authenticated collection
 collector.playwright.headless=${COLLECTOR_PLAYWRIGHT_HEADLESS:true}
+collector.playwright.chromium-executable-path=${COLLECTOR_PLAYWRIGHT_EXECUTABLE_PATH:}
 collector.hotmart.search-url=${COLLECTOR_HOTMART_SEARCH_URL:https://app.hotmart.com/market/search}
 collector.hotmart.session-cookie=${COLLECTOR_HOTMART_SESSION_COOKIE:}
 collector.hotmart.username=paulofore@gmail.com

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java
@@ -11,6 +11,7 @@ class HotmartCollectorServiceTest {
     void shouldSkipWhenSessionAndCredentialsAreMissing() {
         HotmartCollectorService service = new HotmartCollectorService(
                 true,
+                "",
                 "https://app.hotmart.com/market/search",
                 "",
                 "",


### PR DESCRIPTION
### Motivation
- Fix intermittent `Failed to create driver` runtime errors when running Playwright/Chromium in headless container environments by ensuring required system libraries and a preinstalled browser binary are available and detectable.
- Provide an explicit override for the Chromium executable via configuration to make production deployments more deterministic when the auto-discovered binary cannot be used.
- Improve diagnostics around Playwright bootstrap, authentication strategy, navigation and errors to speed triage of collection failures.

### Description
- Hardened the `Dockerfile` to pre-install Playwright Chromium into `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` and validate the presence of browser binaries using `find`, and added `PLAYWRIGHT_BROWSERS_PATH` environment handling.
- Installed required system libraries in the runtime image to support Chromium in container (`libnss3`, `libatk-bridge2.0-0`, `libxkbcommon0`, `libgbm1`, `libxcomposite1`, `libxdamage1`, `libxfixes3`, `libxrandr2`, `libcups2`, `libpangocairo-1.0-0`, `libgtk-3-0`, `libdrm2`, `fonts-liberation`, `ca-certificates`).
- Added `collector.playwright.chromium-executable-path` configuration in `application.properties` and a constructor parameter in `HotmartCollectorService` to allow explicit executable path injection.
- Updated `HotmartCollectorService` to log Playwright bootstrap details, report the chosen authentication strategy, and use the configured Chromium `executablePath` when provided before launching the browser.
- Adjusted unit test `HotmartCollectorServiceTest` to match the new constructor signature.

### Testing
- Ran module unit tests with `mvn -q test` in the `mois-hotmart-collector` module and they completed successfully.
- The updated `HotmartCollectorServiceTest` passed under the same test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea06657b48321830925e47eaf091f)