### PR TITLE
Expand GeraLanding tests: assert prompt registration and include full pipeline data in prompt context

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -39,6 +39,7 @@ class GeraLandingExecutionServiceTest {
         service.processPendingExecutions();
 
         verify(openAiClient).generate(any());
+        verify(backendClient).receivePrompt(any(), any(), any(), any(), any(), any(), any(), any());
         verify(backendClient).receiveDispatch(any(), any(), any(), any());
         verify(backendClient).receiveResult(any(), any(), any(), any());
         verify(backendClient, never()).receiveFailure(any(), any(), any(), any());

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -50,27 +51,29 @@ class GeraLandingServiceTest {
 
     @Test
     void deveDisponibilizarTodosOsItensCanonicosDosPipelinesNoPromptFinal() throws Exception {
+        Map<String, Object> dadosPrompt = new LinkedHashMap<>();
+        dadosPrompt.put("NICHE_NAME", "E-commerce");
+        dadosPrompt.put("PAIN_JSON", Map.of("title", "Baixa conversão"));
+        dadosPrompt.put("RESULT_JSON", Map.of("title", "Mais vendas"));
+        dadosPrompt.put("MECHANISM_JSON", Map.of("title", "Mecanismo validado"));
+        dadosPrompt.put("PROOF_JSON", Map.of("title", "Prova objetiva"));
+        dadosPrompt.put("OFFER_JSON", Map.of("title", "Oferta principal"));
+        dadosPrompt.put("campaignAngle", Map.of("hook", "Ganhe tempo"));
+        dadosPrompt.put("adCopy", Map.of("headline", "Resultado claro"));
+        dadosPrompt.put("adImageBriefing", Map.of("scene", "Pessoa trabalhando"));
+        dadosPrompt.put("landingPageWireframe", Map.of("pageGoal", "capturar lead"));
+        dadosPrompt.put("landingCopy", Map.of("primaryCTA", "Quero começar"));
+        dadosPrompt.put("landingPromptImagem", "Prompt imagem");
+        dadosPrompt.put("listaImagem", Map.of("items", java.util.List.of("img1", "img2")));
+        dadosPrompt.put("landingPresetDesign", Map.of("palette", "neutral"));
+        dadosPrompt.put("landingHtml", "<html></html>");
+        dadosPrompt.put("experimentMetadata", Map.of("experimentId", 10));
+
         GeraLandingPromptContext context = new GeraLandingPromptContext(
                 10L,
                 "id-job-original",
                 "landing-page-wireframe",
-                Map.of(
-                        "NICHE_NAME", "E-commerce",
-                        "PAIN_JSON", Map.of("title", "Baixa conversão"),
-                        "RESULT_JSON", Map.of("title", "Mais vendas"),
-                        "MECHANISM_JSON", Map.of("title", "Mecanismo validado"),
-                        "PROOF_JSON", Map.of("title", "Prova objetiva"),
-                        "OFFER_JSON", Map.of("title", "Oferta principal"),
-                        "campaignAngle", Map.of("hook", "Ganhe tempo"),
-                        "adCopy", Map.of("headline", "Resultado claro"),
-                        "adImageBriefing", Map.of("scene", "Pessoa trabalhando"),
-                        "landingPageWireframe", Map.of("pageGoal", "capturar lead"),
-                        "landingCopy", Map.of("primaryCTA", "Quero começar"),
-                        "landingPromptImagem", "Prompt imagem",
-                        "listaImagem", Map.of("items", java.util.List.of("img1", "img2")),
-                        "landingPresetDesign", Map.of("palette", "neutral"),
-                        "landingHtml", "<html></html>",
-                        "experimentMetadata", Map.of("experimentId", 10)));
+                dadosPrompt);
 
         String prompt = service.montarPromptEtapa(context, "landing-page-wireframe");
 
@@ -108,6 +111,7 @@ class GeraLandingServiceTest {
                         Mockito.eq(10L),
                         Mockito.eq("test-placeholder"),
                         Mockito.eq(prompt),
+                        Mockito.isNull(),
                         Mockito.isNull(),
                         Mockito.isNull(),
                         Mockito.anyString());


### PR DESCRIPTION
### Motivation
- Ensure the execution flow registers the generated prompt with the backend when processing pending executions.
- Validate that the prompt builder exposes all canonical pipeline items in the final prompt output.
- Keep deterministic ordering of prompt data to avoid flakiness in assertions.

### Description
- Added a `verify(backendClient).receivePrompt(...)` assertion to `GeraLandingExecutionServiceTest` to confirm prompt registration when `processPendingExecutions()` runs.
- Expanded `GeraLandingServiceTest` to build a comprehensive `dadosPrompt` using `LinkedHashMap` and include all expected pipeline keys so the final prompt contains every canonical item.
- Updated the `receivePrompt` verification call in `GeraLandingServiceTest` to match the updated method signature by adding an extra `Mockito.isNull()` argument.
- Added the `LinkedHashMap` import and refactored the test to use the `dadosPrompt` variable instead of an inline `Map.of(...)` literal.

### Testing
- Ran unit tests for `GeraLandingExecutionServiceTest` and `GeraLandingServiceTest` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fefc574d9883218a4993f25d29d6fe)