### PR TITLE
Use system Chromium in Docker image and remove Playwright browser install

### DIFF
--- a/mois-hotmart-collector/Dockerfile
+++ b/mois-hotmart-collector/Dockerfile
@@ -8,6 +8,7 @@ FROM eclipse-temurin:21-jre
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    chromium \
     libnss3 \
     libatk-bridge2.0-0 \
     libxkbcommon0 \
@@ -27,12 +28,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=build /app/target/mois-hotmart-collector.jar app.jar
 
-# Pre-instala Chromium do Playwright no build para evitar download em runtime
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN mkdir -p /ms-playwright \
-    && java -cp /app/app.jar com.microsoft.playwright.CLI install chromium \
-    && test -d /ms-playwright \
-    && find /ms-playwright -maxdepth 4 -type f \( -name chrome -o -name chromium \)
+# Força uso de Chromium do sistema para ambiente Linux headless sem GUI
+ENV COLLECTOR_PLAYWRIGHT_EXECUTABLE_PATH=/usr/bin/chromium
 
 EXPOSE 8096
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
### Motivation
- Prevent runtime Playwright browser downloads and simplify headless Chromium usage by relying on the system-provided Chromium binary in the runtime image.

### Description
- Install `chromium` and required native libraries in the runtime image, remove the pre-installation of Playwright browsers (removing `PLAYWRIGHT_BROWSERS_PATH` and the `java -cp /app/app.jar com.microsoft.playwright.CLI install chromium` step), and set `COLLECTOR_PLAYWRIGHT_EXECUTABLE_PATH=/usr/bin/chromium` to force use of the system Chromium executable.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3ab11f908321ab8329fc07632d46)