### PR TITLE
Align GeraLandingExecutionServiceTest with updated constructor signature

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -35,7 +35,8 @@ class GeraLandingExecutionServiceTest {
                         openAiClient,
                         objectMapper,
                         20,
-                        new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"));
+                        new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"));
         service.processPendingExecutions();
 
         verify(openAiClient).generate(any());
@@ -65,7 +66,8 @@ class GeraLandingExecutionServiceTest {
                         openAiClient,
                         objectMapper,
                         20,
-                        new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"));
+                        new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"));
         service.processPendingExecutions();
 
         verify(backendClient).receiveFailure(any(), any(), any(), any());


### PR DESCRIPTION
### Motivation
- Fix a compilation error caused by a changed `GeraLandingExecutionService` constructor that now requires two `Resource` parameters (wireframe and copy schema) while the test passed only one.

### Description
- Updated `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` to pass both `ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json")` and `ClassPathResource("prompts/geralanding/landing-page-copy-schema.json")` to the `GeraLandingExecutionService` constructor in both test cases, aligning the test with the service signature.

### Testing
- Attempted to run `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test`, but execution was blocked by dependency resolution: `com.marketinghub:ads-service:0.0.1-SNAPSHOT` could not be fetched from GitHub Packages (HTTP 401 Unauthorized), so tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff431b8d288321be4791fff9da015c)