### PR TITLE
Improve OpenAI Batch error diagnostics for gera-landing (capture error_file and batch error details)

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
@@ -71,7 +71,9 @@ public class GeraLandingOpenAiBatchClient {
             BatchResponse batch = createBatch(inputFileId);
             BatchResponse completed = pollUntilCompleted(batch.id());
             if (!StringUtils.hasText(completed.outputFileId())) {
-                throw new IllegalStateException("Batch finalizado sem output_file_id");
+                String rawErrorOutput = downloadOptionalFileContent(completed.errorFileId());
+                throw new IllegalStateException("Batch finalizado sem output_file_id"
+                        + (StringUtils.hasText(rawErrorOutput) ? ". error_file=" + rawErrorOutput : ""));
             }
             String rawOutput = downloadFileContent(completed.outputFileId());
             OpenAiResponse response = parseFirstResponse(rawOutput);
@@ -161,6 +163,24 @@ public class GeraLandingOpenAiBatchClient {
         return new String(bytes, StandardCharsets.UTF_8);
     }
 
+    private String downloadOptionalFileContent(String fileId) {
+        if (!StringUtils.hasText(fileId)) {
+            return null;
+        }
+        try {
+            byte[] bytes = webClient.get().uri("/files/{id}/content", fileId)
+                    .retrieve().bodyToMono(byte[].class)
+                    .block();
+            if (bytes == null || bytes.length == 0) {
+                return null;
+            }
+            return new String(bytes, StandardCharsets.UTF_8);
+        } catch (Exception ex) {
+            log.warn("Falha ao baixar error_file_id={} do batch", fileId, ex);
+            return null;
+        }
+    }
+
     private OpenAiResponse parseFirstResponse(String jsonlOutput) throws Exception {
         String firstLine = jsonlOutput.lines().filter(StringUtils::hasText).findFirst()
                 .orElseThrow(() -> new IllegalStateException("Saída do batch sem linhas"));
@@ -169,7 +189,8 @@ public class GeraLandingOpenAiBatchClient {
             String rawErrorBody = line.response() != null ? line.response().rawBody() : null;
             throw new IllegalStateException("OpenAI retornou erro no batch. status=" + line.status_code()
                     + ", custom_id=" + line.custom_id()
-                    + ", body=" + rawErrorBody);
+                    + ", body=" + rawErrorBody
+                    + ", error=" + (line.error() != null ? line.error().toJson() : null));
         }
         if (line.response() == null || line.response().body() == null || line.response().body().isNull()) {
             throw new IllegalStateException("Linha de saída do batch sem response.body");
@@ -181,15 +202,26 @@ public class GeraLandingOpenAiBatchClient {
     private record FileResponse(String id) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record BatchResponse(String id, String status, @com.fasterxml.jackson.annotation.JsonProperty("output_file_id") String outputFileId) {}
+    private record BatchResponse(String id,
+                                 String status,
+                                 @com.fasterxml.jackson.annotation.JsonProperty("output_file_id") String outputFileId,
+                                 @com.fasterxml.jackson.annotation.JsonProperty("error_file_id") String errorFileId) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record BatchOutputLine(String custom_id, Integer status_code, BatchHttpResponse response) {}
+    private record BatchOutputLine(String custom_id, Integer status_code, BatchHttpResponse response, BatchError error) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record BatchHttpResponse(JsonNode body) {
         String rawBody() {
             return body != null ? body.toString() : null;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record BatchError(String code, String message, String param, String type) {
+        String toJson() {
+            return "{\"code\":\"" + code + "\",\"message\":\"" + message
+                    + "\",\"param\":\"" + param + "\",\"type\":\"" + type + "\"}";
         }
     }
 }

--- a/docs/gera-landing/registros1.md
+++ b/docs/gera-landing/registros1.md
@@ -1,0 +1,6 @@
+# Registros — Gera Landing
+
+> Orientação: todos os registros deste documento devem sempre incluir **data e hora no fuso UTC-3**.
+> Neste documento que o arquivo `docs/gera-landing/registros1.md` segue política de **append-only** (não pode ter nenhuma linha apagada; apenas inserções).
+
+- 2026-05-09 14:40:00 (UTC-3): registro pós-review solicitado para melhoria de diagnóstico de falhas OpenAI Batch no fluxo Gera Landing (`ai-worker`). No `GeraLandingOpenAiBatchClient`, o retorno de `/batches/{id}` passou a mapear também `error_file_id`; quando um batch conclui sem `output_file_id`, o worker agora tenta baixar o conteúdo do arquivo de erro (`/files/{error_file_id}/content`) e anexa o JSONL literal na mensagem de exceção para persistência no backend via `receive-result` com `errorMessage`. Também foi ampliado o parse da linha de saída (`BatchOutputLine`) para incluir o objeto `error` da OpenAI (`code`, `message`, `param`, `type`) em erros `status_code >= 400`, permitindo que a tela de detalhe da execução exiba causa raiz com maior precisão.


### PR DESCRIPTION
### Motivation
- Increase observability when OpenAI batch jobs finish without an `output_file_id` by surfacing any available error file contents and richer error details. 
- Allow the execution detail UI/backend to display root-cause information from the OpenAI batch `error` object when a per-line response has an HTTP error.

### Description
- Added `error_file_id` mapping to `BatchResponse` and created `downloadOptionalFileContent` to safely fetch and return error file contents when present. 
- When a batch completes without `output_file_id`, the client now attempts to download the `error_file_id` content and appends it to the thrown exception message. 
- Extended `BatchOutputLine` to include a `BatchError` object and updated `parseFirstResponse` to include `error` JSON in error messages, plus added a simple `toJson()` on `BatchError`. 
- Added `docs/gera-landing/registros1.md` documenting the change and the append-only UTC-3 logging requirement.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6f2d4e348321a45b447e975e8a17)