### PR TITLE
Update tests to match new `receiveFailure` method signature

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -43,7 +43,7 @@ class GeraLandingExecutionServiceTest {
         verify(backendClient).receivePrompt(any(), any(), any(), any(), any(), any(), any(), any());
         verify(backendClient).receiveDispatch(any(), any(), any(), any());
         verify(backendClient).receiveResult(any(), any(), any(), any());
-        verify(backendClient, never()).receiveFailure(any(), any(), any(), any());
+        verify(backendClient, never()).receiveFailure(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -70,7 +70,7 @@ class GeraLandingExecutionServiceTest {
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"));
         service.processPendingExecutions();
 
-        verify(backendClient).receiveFailure(any(), any(), any(), any());
+        verify(backendClient).receiveFailure(any(), any(), any(), any(), any());
         verify(backendClient, never()).receiveResult(any(), any(), any(), any());
     }
 }


### PR DESCRIPTION
### Motivation
- The backend client's `receiveFailure` call gained an additional parameter, so tests needed to be updated to match the new method signature and avoid invocation-argument mismatches.

### Description
- Adjusted `GeraLandingExecutionServiceTest` verifications to expect five arguments for `receiveFailure` by changing both the success-path `never()` assertion and the failure-path assertion to use `any()` for the additional parameter.

### Testing
- Ran the `GeraLandingExecutionServiceTest` unit test and the module test suite after the change, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff7bcfcd2c8321a32974db6116cf45)