### PR TITLE
docs: atualizar cânone do Gera Landing com `error_detail`

### DIFF
--- a/docs/gera-landing/modelo-canonico-gera-landing.md
+++ b/docs/gera-landing/modelo-canonico-gera-landing.md
@@ -75,7 +75,8 @@ Registrar o ciclo de vida completo de uma execução, incluindo:
 | `openai_job_id` | `VARCHAR(120)` | Não | ID técnico da resposta/job OpenAI quando disponível. |
 | `model_response` | `LONGTEXT` | Não | Conteúdo final retornado pelo modelo. |
 | `provisional_html` | `LONGTEXT` | Não | HTML provisório (informado ou derivado do model response). |
-| `error_message` | `LONGTEXT` | Não | Motivo textual de falha quando houver. |
+| `error_message` | `LONGTEXT` | Não | Motivo textual resumido de falha quando houver. |
+| `error_detail` | `LONGTEXT` | Não | Detalhe técnico complementar da falha (stack, contexto, payload rejeitado etc.). |
 | `input_tokens` | `INT` | Não | Tokens de entrada efetivos. |
 | `output_tokens` | `INT` | Não | Tokens de saída efetivos. |
 | `cost_usd` | `DECIMAL(12,6)` | Não | Custo estimado em USD. |
@@ -90,6 +91,14 @@ Registrar o ciclo de vida completo de uma execução, incluindo:
   - detalhe por `experimentId + idJob`.
 
 ---
+
+
+## 2.4 Evolução recente de schema (erro detalhado)
+
+- ChangeSet Liquibase: `2026-05-09-add-gera-landing-error-detail`.
+- Tabela afetada: `gera_landing_stage_execution`.
+- Coluna adicionada: `error_detail` (`LONGTEXT`).
+- Objetivo: separar mensagem resumida de falha (`error_message`) do detalhe técnico completo (`error_detail`) no fechamento de execução (`receive-result`).
 
 ## 3) Contratos HTTP canônicos
 
@@ -246,6 +255,7 @@ Backend em `receiveResult`:
 - persiste `model_response`;
 - calcula `provisional_html` (usa payload se veio, senão monta via assembler);
 - persiste `error_message` (quando houver);
+- persiste `error_detail` (quando houver);
 - persiste `openai_job_id` (quando informado);
 - persiste `openai_model` (quando informado no handoff do prompt);
 - persiste `input_tokens`, `output_tokens`, `cost_usd`;
@@ -278,7 +288,7 @@ Além disso, para etapa `landing-page-wireframe`, sem erro e com `modelResponse`
    - resposta final persistida sem `errorMessage`.
 
 5. **FALHA**
-   - erro final persistido em `error_message`.
+   - erro final persistido em `error_message` (resumo) e opcionalmente `error_detail` (detalhe técnico).
 
 ---
 
@@ -293,7 +303,7 @@ Cada execução pode ser reconstituída de ponta a ponta com:
 - `openAiJobId` + resposta final;
 - métricas de custo/tokens;
 - timestamps de início/fim;
-- `error_message` quando aplicável.
+- `error_message` e `error_detail` quando aplicável.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Alinhar o documento canônico do módulo Gera Landing ao comportamento real do backend que passou a persistir detalhe técnico de erro além da mensagem resumida.

### Description
- Atualiza o dicionário de dados adicionando a coluna `error_detail` (`LONGTEXT`) e diferencia `error_message` (resumo) de `error_detail` (detalhe técnico). 
- Insere seção de evolução de schema referenciando o ChangeSet Liquibase `2026-05-09-add-gera-landing-error-detail` que adiciona a coluna `error_detail` na tabela `gera_landing_stage_execution`.
- Atualiza a documentação do fluxo `receive-result` para indicar a persistência explícita de `error_detail` e ajusta a descrição do estado `FALHA` e das regras de rastreabilidade para incluir ambos os campos.
- Fonte usada: código em `backend/ads-service/src/main/java/com/marketinghub/geralanding` e changeset em `backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-09-gera-landing-error-detail-column.yaml`.

### Testing
- Executed `git status --short` to verify file changes and then committed the update with `git add` + `git commit`, both commands succeeded. 
- No automated unit tests were run as part of this change (documentation-only update).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9e4880108321ad5738acac7afa6a)