### PR TITLE
Use CollapsibleJsonViewer for errorDetail and update copy button label

### DIFF
--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -127,12 +127,12 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                       className="btn btn-sm btn-outline-secondary"
                       onClick={() => handleCopyJson("errorDetail", detailQuery.data.errorDetail)}
                     >
-                      {copiedField === "errorDetail" ? "Copiado!" : "Copiar"}
+                      {copiedField === "errorDetail" ? "Copiado!" : "Copiar JSON"}
                     </button>
                   </div>
-                  <pre className="mb-0 mt-2 small overflow-auto">
-                    <code>{detailQuery.data.errorDetail}</code>
-                  </pre>
+                  <div className="mt-2">
+                    <CollapsibleJsonViewer content={detailQuery.data.errorDetail} />
+                  </div>
                 </div>
               ) : null}
 


### PR DESCRIPTION
### Motivation
- Melhorar a legibilidade de payloads de erro grandes/aninhados ao exibir `errorDetail` em formato JSON colapsável em vez de um bloco `pre` longo.

### Description
- Substitui o bloco `<pre>` por `CollapsibleJsonViewer` e atualiza o rótulo do botão de cópia para `Copiar JSON` em `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx`.

### Testing
- Executei `npm run typecheck` no diretório `frontend`, que falhou devido a problemas pré-existentes de configuração/definições de tipos (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) e opções de `tsconfig` deprecadas, sendo essas falhas não relacionadas à alteração de UI feita.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffafe8034083218d64cdb2c11069c1)