### PR TITLE
CollapsibleJsonViewer: add `parseAsJson` flag and decode escaped newlines/tabs

### DIFF
--- a/frontend/src/components/CollapsibleJsonViewer.tsx
+++ b/frontend/src/components/CollapsibleJsonViewer.tsx
@@ -12,6 +12,7 @@ type CollapsibleJsonViewerProps = {
   content?: string | null;
   emptyMessage?: string;
   initiallyCollapsed?: boolean;
+  parseAsJson?: boolean;
 };
 
 function parseJson(content?: string | null): JsonValue | null {
@@ -21,6 +22,18 @@ function parseJson(content?: string | null): JsonValue | null {
   } catch {
     return null;
   }
+}
+
+function decodeEscapedText(value: string): string {
+  if (!value.includes("\\n") && !value.includes("\\r") && !value.includes("\\t")) {
+    return value;
+  }
+
+  return value
+    .replace(/\\r\\n/g, "\n")
+    .replace(/\\n/g, "\n")
+    .replace(/\\r/g, "\n")
+    .replace(/\\t/g, "\t");
 }
 
 function JsonNode({
@@ -47,7 +60,7 @@ function JsonNode({
             className="mb-0 d-inline"
             style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}
           >
-            {value}
+            {decodeEscapedText(value)}
           </pre>
         ) : (
           <code>{JSON.stringify(value)}</code>
@@ -94,8 +107,9 @@ export default function CollapsibleJsonViewer({
   content,
   emptyMessage = "Sem conteúdo registrado.",
   initiallyCollapsed = false,
+  parseAsJson = true,
 }: CollapsibleJsonViewerProps) {
-  const parsed = useMemo(() => parseJson(content), [content]);
+  const parsed = useMemo(() => (parseAsJson ? parseJson(content) : null), [content, parseAsJson]);
 
   if (!content) {
     return <p className="text-muted small mb-0">{emptyMessage}</p>;
@@ -104,7 +118,7 @@ export default function CollapsibleJsonViewer({
   if (!parsed) {
     return (
       <pre className="bg-body-tertiary p-3 rounded small mb-0 text-wrap">
-        {content}
+        {decodeEscapedText(content)}
       </pre>
     );
   }

--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -306,6 +306,7 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                 </div>
                 <CollapsibleJsonViewer
                   content={detailQuery.data.promptContent}
+                  parseAsJson={false}
                 />
               </div>
               <div>
@@ -337,7 +338,7 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                     );
                   })()}
                 </div>
-                <CollapsibleJsonViewer content={detailQuery.data.prompt} />
+                <CollapsibleJsonViewer content={detailQuery.data.prompt} parseAsJson={false} />
               </div>
               <div>
                 <div className="d-flex align-items-center gap-2 mb-2">


### PR DESCRIPTION
### Motivation

- Allow rendering raw text values without forcing JSON parsing and improve readability of strings that contain escaped newlines/tabs.

### Description

- Add an optional `parseAsJson?: boolean` prop to `CollapsibleJsonViewer` with a default of `true` and use it to skip JSON parsing when set to `false`.
- Introduce `decodeEscapedText` to replace `\r\n`, `\n`, `\r`, and `\t` with real newline and tab characters and apply it when rendering string nodes and non-parsed content.
- Update `ExperimentGeraLandingExecutionDetailPage.tsx` to pass `parseAsJson={false}` for `promptContent` and `prompt` so those fields display as raw, decoded text.

### Testing

- Ran the frontend TypeScript typecheck and `yarn build`, and ran the frontend test suite with `yarn test`, and the checks/tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd1413dfc8321a5e2232efcdd6fed)