### PR TITLE
Add Playwright-managed Chromium to mois-hotmart-collector Docker image

### DIFF
--- a/mois-hotmart-collector/Dockerfile
+++ b/mois-hotmart-collector/Dockerfile
@@ -2,7 +2,9 @@ FROM maven:3.9.9-eclipse-temurin-21 AS build
 WORKDIR /app
 COPY pom.xml .
 COPY src ./src
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN mvn -q -DskipTests package
+RUN mvn -q -DskipTests exec:java -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install chromium"
 
 FROM eclipse-temurin:21-jre
 WORKDIR /app
@@ -27,9 +29,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/target/mois-hotmart-collector.jar app.jar
+COPY --from=build /ms-playwright /ms-playwright
 
 # Não forçar executablePath: usar Chromium gerenciado pelo Playwright no runtime
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 EXPOSE 8096


### PR DESCRIPTION
### Motivation

- Ensure Chromium is installed and managed by Playwright inside the Docker image so the application can use Playwright-managed browsers at runtime.

### Description

- Install Playwright browsers during the Maven build by setting `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` and running the Playwright CLI to install Chromium in the build stage.
- Copy the Playwright browser artifacts from the build stage into the final runtime image with `COPY --from=build /ms-playwright /ms-playwright`.
- Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0` and `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` in the final image so the application uses the preinstalled Playwright-managed browser instead of forcing an `executablePath`.
- Keep the runtime base image and required system libraries for Chromium installed via `apt-get` to satisfy Playwright/Chromium dependencies.

### Testing

- No automated unit tests were executed because the build uses `-DskipTests` during `mvn package`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00855bc5ac832180af55e0f0faec89)