### PR TITLE
Add landingPageWireframe to AI worker prompt payload for gera-landing copy

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingBackendClient.java
@@ -64,6 +64,7 @@ public class GeraLandingBackendClient {
         payload.put("campaignAngle", parseJsonField(experiment.get("campaignAngle")));
         payload.put("adCopy", parseJsonField(experiment.get("adCopy")));
         payload.put("adImageBriefing", parseJsonField(experiment.get("adImageBriefing")));
+        payload.put("landingPageWireframe", parseJsonField(experiment.get("landingPageWireframe")));
         payload.put("NICHE_NAME", resolveNicheName(experiment.get("nicheId")));
         populateHypothesisFields(payload, experiment.get("nicheId"), experiment.get("hypothesisId"));
         return payload;


### PR DESCRIPTION
### Motivation
- The `landing-page-copy` prompt contains the section "Wireframe da Landing: IMPORTANTE !!" which was left empty because the AI worker payload did not include the experiment's `landingPageWireframe`, causing the `{dados-landingPageWireframe}` placeholder to remain unfilled.

### Description
- Populate `landingPageWireframe` in the prompt context returned by `GeraLandingBackendClient.loadPromptData` in `ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingBackendClient.java` so the worker receives the wireframe when assembling the `landing-page-copy` prompt.

### Testing
- Attempted to run targeted unit tests with `mvn -f ai-worker/pom.xml -Dtest=GeraLandingServiceTest,GeraLandingExecutionServiceTest test`, but the build could not complete due to a private dependency resolution failure (`com.marketinghub:ads-service:0.0.1-SNAPSHOT` returning HTTP 401), so tests could not be fully executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00880112a88321876e5b9fbc6a5b69)