### PR TITLE
Harden mois-hotmart-collector Dockerfile for Playwright on Jammy and update runbook

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -237,3 +237,11 @@
 - Mantidas as variáveis `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` e `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` no Dockerfile para preservar estratégia atual de runtime.
 - Próximo passo operacional recomendado: rebuild/publish da imagem e redeploy do container para materializar a correção em produção.
 - Registro criado por solicitação explícita: "registre a pesquisa e o ajuste em /docs/mois/registros.md".
+
+## 2026-05-10 14:10:04 UTC-3
+- Endurecida a estratégia de container do `mois-hotmart-collector` para eliminar recorrência de falha do Playwright em ambiente Ubuntu 26.04.
+- `Dockerfile` atualizado para usar imagens base Jammy nas duas etapas (`maven:3.9.9-eclipse-temurin-21-jammy` e `eclipse-temurin:21-jre-jammy`), reduzindo risco de incompatibilidade de plataforma com Chromium gerenciado pelo Playwright.
+- Mantida instalação do Chromium no build (`install --with-deps chromium`) e forçado runtime a consumir somente browsers já empacotados (`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`, `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`), evitando tentativa de reinstalação dinâmica durante a coleta agendada.
+- Ajustado conjunto de libs de runtime para Jammy com `libasound2` (substituindo variante `t64`) e sem dependência do pacote de distro `chromium`.
+- Validação executada: `mvn -q test` no módulo `mois-hotmart-collector` com sucesso.
+- Registro criado por solicitação explícita: "registre o trabalho em /docs/mois/registros.md".

--- a/mois-hotmart-collector/Dockerfile
+++ b/mois-hotmart-collector/Dockerfile
@@ -1,21 +1,24 @@
-FROM maven:3.9.9-eclipse-temurin-21 AS build
+FROM maven:3.9.9-eclipse-temurin-21-jammy AS build
 WORKDIR /app
+
 COPY pom.xml .
 COPY src ./src
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN mvn -q -DskipTests package
-RUN mvn -q -DskipTests exec:java -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install chromium"
 
-FROM eclipse-temurin:21-jre
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
+
+RUN mvn -q -DskipTests package
+RUN mvn -q -DskipTests exec:java -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps chromium"
+
+FROM eclipse-temurin:21-jre-jammy
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    chromium \
     libnss3 \
     libatk-bridge2.0-0 \
     libxkbcommon0 \
     libgbm1 \
-    libasound2t64 \
+    libasound2 \
     libxcomposite1 \
     libxdamage1 \
     libxfixes3 \
@@ -28,12 +31,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /app/target/mois-hotmart-collector.jar app.jar
+COPY --from=build /app/target/mois-hotmart-collector.jar /app/app.jar
 COPY --from=build /ms-playwright /ms-playwright
 
-# Não forçar executablePath: usar Chromium gerenciado pelo Playwright no runtime
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
+# Usa browsers pré-instalados no build; evita tentativa de instalação no runtime
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 EXPOSE 8096
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
### Motivation

- Eliminate recurring Playwright bootstrap and Chromium executable resolution failures observed in Ubuntu 26.04 production containers by aligning build and runtime platforms and clarifying browser handling.

### Description

- Updated `mois-hotmart-collector/Dockerfile` to use Jammy-based images (`maven:3.9.9-eclipse-temurin-21-jammy` and `eclipse-temurin:21-jre-jammy`) to reduce platform incompatibility with Chromium used by Playwright.
- Changed Playwright install invocation in the build stage to `install --with-deps chromium` so Chromium and its dependencies are installed in the build image and copied into the runtime image at `/ms-playwright`.
- Adjusted runtime environment to consume prepackaged browsers by setting `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` and `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`, removed installing the distro `chromium` package, and normalized runtime libs replacing `libasound2t64` with `libasound2`.
- Added documentation entry in `docs/mois/registros.md` describing the diagnostic work, operational findings, and the applied container/Dockerfile adjustments.

### Testing

- Executed `mvn -q test` on the `mois-hotmart-collector` module and the test suite completed successfully.
- Performed a build run in the build stage with `mvn -q -DskipTests package` and the Playwright `install --with-deps chromium` step completed during image build validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b55a14148321ae567fe72e144b24)