### PR TITLE
Fix OpenAI schema rejection for gera-landing landing-page-copy (add 'type' to not clauses)

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json
@@ -22,12 +22,14 @@
         "eyebrow": {
           "type": "string",
           "not": {
+            "type": "string",
             "pattern": "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-)"
           }
         },
         "headline": {
           "type": "string",
           "not": {
+            "type": "string",
             "pattern": "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-)"
           },
           "minLength": 8
@@ -35,6 +37,7 @@
         "subheadline": {
           "type": "string",
           "not": {
+            "type": "string",
             "pattern": "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-)"
           },
           "minLength": 12
@@ -42,12 +45,14 @@
         "promise": {
           "type": "string",
           "not": {
+            "type": "string",
             "pattern": "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-)"
           }
         },
         "supportingCopy": {
           "type": "string",
           "not": {
+            "type": "string",
             "pattern": "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-)"
           },
           "minLength": 24
@@ -55,18 +60,21 @@
         "proofBadge": {
           "type": "string",
           "not": {
+            "type": "string",
             "pattern": "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-)"
           }
         },
         "microcopy": {
           "type": "string",
           "not": {
+            "type": "string",
             "pattern": "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-)"
           }
         },
         "ctaLabel": {
           "type": "string",
           "not": {
+            "type": "string",
             "pattern": "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-)"
           }
         },
@@ -76,6 +84,7 @@
         "ctaMatchNotes": {
           "type": "string",
           "not": {
+            "type": "string",
             "pattern": "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-)"
           }
         }


### PR DESCRIPTION
### Motivation
- The OpenAI response formatter rejected `experiment_pipeline_landing_page_copy` because several `not` subschemas under the `hero` fields lacked a required `type` key, causing `invalid_json_schema` errors when sending the prompt schema to the API.

### Description
- Added `"type": "string"` to each `not` subschema for the `hero` string properties in `ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json`.
- Left the existing `pattern` blacklist intact so the original constraints against internal tokens/uis remain enforced.

### Testing
- Validated JSON syntax with `python -m json.tool ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json` and it succeeded.
- Confirmed all affected `not` entries include `type` using `rg -n '"not"|"type"' ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json` and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0129a15ef483219af224938b6b24a4)