### PR TITLE
Add oprm-coletor-mei Spring Boot service with CI/CD and Docker support

### DIFF
--- a/.github/workflows/oprm-coletor-mei-ci.yml
+++ b/.github/workflows/oprm-coletor-mei-ci.yml
@@ -1,0 +1,126 @@
+name: CI – OPRM Coletor MEI
+
+on:
+  push:
+    branches: ["main", "master"]
+    paths:
+      - 'oprm-coletor-mei/**'
+      - '.github/workflows/oprm-coletor-mei-ci.yml'
+  pull_request:
+    paths:
+      - 'oprm-coletor-mei/**'
+      - '.github/workflows/oprm-coletor-mei-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: oprm-coletor-mei
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Run tests
+        run: mvn -B test
+
+  docker:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
+      IMAGE_TAG: latest
+      IMAGE_SHA_TAG: ${{ github.sha }}
+    outputs:
+      image-tag: ${{ steps.image_tag.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAMESPACE }}/oprm-coletor-mei
+          tags: |
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=${{ env.IMAGE_SHA_TAG }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: oprm-coletor-mei
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/oprm-coletor-mei:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAMESPACE }}/oprm-coletor-mei:buildcache,mode=max
+      - name: Expose image tag
+        id: image_tag
+        run: echo "value=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - test
+      - docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      DEPLOY_HOST: 177.153.62.107
+      DEPLOY_USER: root
+      REMOTE_PATH: ${{ secrets.OPRM_COLETOR_MEI_REMOTE_PATH || '/root/oprm-coletor-mei' }}
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_NAMESPACE: ghcr.io/${{ github.repository_owner }}
+      IMAGE_TAG: ${{ needs.docker.outputs['image-tag'] }}
+      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME != '' && secrets.GHCR_USERNAME || github.repository_owner }}
+      GHCR_TOKEN: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure SSH
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_CHAVE != '' && secrets.VPS_SSH_CHAVE || secrets.VPS_SSH_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "SSH_COMMON_ARGS=-i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -o ConnectTimeout=60" >> "$GITHUB_ENV"
+      - name: Prepare remote directory
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p ${REMOTE_PATH}"
+      - name: Sync service to VPS
+        run: |
+          rsync -az --delete \
+            -e "ssh ${SSH_COMMON_ARGS}" \
+            --exclude '.git/' \
+            --exclude 'target/' \
+            oprm-coletor-mei/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_PATH}"
+      - name: Publish service
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "set -euo pipefail \
+            && cd ${REMOTE_PATH} \
+            && if [ -n '${GHCR_TOKEN}' ]; then echo '${GHCR_TOKEN}' | docker login ${IMAGE_REGISTRY} -u '${GHCR_USERNAME}' --password-stdin; fi \
+            && export OPRM_COLETOR_MEI_IMAGE='${IMAGE_NAMESPACE}/oprm-coletor-mei:${IMAGE_TAG}' \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml pull \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml up -d --remove-orphans \
+            && docker image prune -af"
+      - name: Clean build artifacts from repository
+        if: always()
+        run: |
+          git clean -ffdx -- oprm-coletor-mei/target

--- a/oprm-coletor-mei/Dockerfile
+++ b/oprm-coletor-mei/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/target/oprm-coletor-mei-0.1.0-SNAPSHOT.jar app.jar
+EXPOSE 8094
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/oprm-coletor-mei/README.md
+++ b/oprm-coletor-mei/README.md
@@ -1,0 +1,23 @@
+# OPRM Coletor MEI
+
+Serviço Spring Boot para coleta e normalização de dados MEI (fonte Receita Federal) para integração com o backend do Marketing Hub.
+
+## Stack
+- Java 21
+- Spring Boot 3
+- Maven
+- Docker
+
+## Execução local
+```bash
+cd oprm-coletor-mei
+mvn spring-boot:run
+```
+
+Health check:
+- `GET http://localhost:8094/api/oprm-mei/health`
+
+## Build Docker
+```bash
+docker build -t oprm-coletor-mei:local .
+```

--- a/oprm-coletor-mei/docker-compose.deploy.yml
+++ b/oprm-coletor-mei/docker-compose.deploy.yml
@@ -1,0 +1,4 @@
+services:
+  oprm-coletor-mei:
+    image: ${OPRM_COLETOR_MEI_IMAGE}
+    build: null

--- a/oprm-coletor-mei/docker-compose.yml
+++ b/oprm-coletor-mei/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  oprm-coletor-mei:
+    build: .
+    container_name: oprm-coletor-mei
+    ports:
+      - "8094:8094"
+    environment:
+      - SPRING_PROFILES_ACTIVE=default

--- a/oprm-coletor-mei/pom.xml
+++ b/oprm-coletor-mei/pom.xml
@@ -1,0 +1,78 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.marketinghub</groupId>
+    <artifactId>oprm-coletor-mei</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>oprm-coletor-mei</name>
+    <description>Coletor MEI para integração OPRM</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <spring.boot.version>3.4.5</spring.boot.version>
+        <start-class>com.marketinghub.oprmcoletormei.OprmColetorMeiApplication</start-class>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <configuration>
+                    <mainClass>${start-class}</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/OprmColetorMeiApplication.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/OprmColetorMeiApplication.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprmcoletormei;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OprmColetorMeiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OprmColetorMeiApplication.class, args);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/web/HealthController.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/web/HealthController.java
@@ -1,0 +1,20 @@
+package com.marketinghub.oprmcoletormei.web;
+
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/oprm-mei")
+public class HealthController {
+
+    @GetMapping("/health")
+    public Map<String, Object> health() {
+        return Map.of(
+                "status", "UP",
+                "service", "oprm-coletor-mei",
+                "timestamp", Instant.now().toString());
+    }
+}

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+server:
+  port: 8094
+
+spring:
+  application:
+    name: oprm-coletor-mei
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/oprmcoletormei/OprmColetorMeiApplicationTests.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/oprmcoletormei/OprmColetorMeiApplicationTests.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprmcoletormei;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class OprmColetorMeiApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce a new Spring Boot service `oprm-coletor-mei` to collect and normalize MEI data for the Marketing Hub backend.
- Provide containerization and deployment artifacts so the service can be built, run locally, and deployed to a VPS or GitHub Container Registry.
- Add automated CI to validate the build and run tests before publishing Docker images and deploying from the `main` branch.

### Description

- Add a new Maven-based Spring Boot project under `oprm-coletor-mei` including `pom.xml`, application entrypoint `OprmColetorMeiApplication.java`, a simple `HealthController`, and `application.yml` configuration.
- Provide a `Dockerfile`, `docker-compose.yml`, and `docker-compose.deploy.yml` to build and run the service locally and in deployments, exposing port `8094` and setting `SPRING_PROFILES_ACTIVE=default`.
- Add a minimal unit test `OprmColetorMeiApplicationTests` with `contextLoads()` to validate Spring context startup.
- Add a GitHub Actions workflow `/.github/workflows/oprm-coletor-mei-ci.yml` that runs `mvn -B test`, builds and pushes Docker images to GHCR, and deploys to a VPS when changes land on `main` with SSH/rsync and `docker compose` pull/up steps.

### Testing

- The project includes an automated unit test `OprmColetorMeiApplicationTests#contextLoads` intended to be executed by `mvn -B test` in CI.
- No automated test results are included in this PR; the added CI job `CI – OPRM Coletor MEI` will run `mvn -B test` as part of the pipeline and publish Docker images when successful.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01292ca4b08321abe43ea93d0cd03c)