### PR TITLE
Add CNAE niche catalog ingestion endpoint and OPRM collector for normalization and batching

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/niche/OprmNicheCatalogItem.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/niche/OprmNicheCatalogItem.java
@@ -1,0 +1,52 @@
+package com.marketinghub.oprm.niche;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.*;
+
+@Entity
+@Table(name = "oprm_niche_catalog", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_oprm_niche_catalog_code", columnNames = "cnae_code")
+})
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OprmNicheCatalogItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "cnae_code", nullable = false, length = 16)
+    private String cnaeCode;
+
+    @Column(name = "cnae_label", nullable = false, length = 255)
+    private String cnaeLabel;
+
+    @Column(name = "source", nullable = false, length = 64)
+    private String source;
+
+    @Column(name = "active", nullable = false)
+    @Builder.Default
+    private boolean active = true;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/niche/dto/OprmNicheCatalogIngestRequestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/niche/dto/OprmNicheCatalogIngestRequestDto.java
@@ -1,0 +1,18 @@
+package com.marketinghub.oprm.niche.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record OprmNicheCatalogIngestRequestDto(
+        @NotBlank String source,
+        @NotEmpty List<@Valid RecordDto> records
+) {
+    public record RecordDto(
+            @NotBlank String cnaeCode,
+            @NotBlank String cnaeLabel,
+            Boolean active
+    ) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/niche/repository/OprmNicheCatalogItemRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/niche/repository/OprmNicheCatalogItemRepository.java
@@ -1,0 +1,7 @@
+package com.marketinghub.oprm.niche.repository;
+
+import com.marketinghub.oprm.niche.OprmNicheCatalogItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OprmNicheCatalogItemRepository extends JpaRepository<OprmNicheCatalogItem, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/niche/service/OprmNicheCatalogIngestionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/niche/service/OprmNicheCatalogIngestionService.java
@@ -1,0 +1,42 @@
+package com.marketinghub.oprm.niche.service;
+
+import com.marketinghub.oprm.niche.OprmNicheCatalogItem;
+import com.marketinghub.oprm.niche.dto.OprmNicheCatalogIngestRequestDto;
+import com.marketinghub.oprm.niche.dto.OprmNicheSnapshotIngestResponseDto;
+import com.marketinghub.oprm.niche.repository.OprmNicheCatalogItemRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OprmNicheCatalogIngestionService {
+
+    private final OprmNicheCatalogItemRepository repository;
+
+    @Transactional
+    public OprmNicheSnapshotIngestResponseDto ingest(OprmNicheCatalogIngestRequestDto request) {
+        List<OprmNicheCatalogItem> items = request.records().stream()
+                .map(record -> OprmNicheCatalogItem.builder()
+                        .cnaeCode(record.cnaeCode().trim())
+                        .cnaeLabel(record.cnaeLabel().trim())
+                        .source(request.source().trim())
+                        .active(record.active() == null || record.active())
+                        .build())
+                .toList();
+
+        List<OprmNicheCatalogItem> persisted = repository.saveAll(items);
+        int received = request.records().size();
+
+        return new OprmNicheSnapshotIngestResponseDto(
+                "ACCEPTED",
+                received,
+                received,
+                persisted.size(),
+                0,
+                "OK",
+                "catálogo CNAE persistido com sucesso"
+        );
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/niche/web/OprmNicheCatalogIngestionController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/niche/web/OprmNicheCatalogIngestionController.java
@@ -1,0 +1,25 @@
+package com.marketinghub.oprm.niche.web;
+
+import com.marketinghub.oprm.niche.dto.OprmNicheCatalogIngestRequestDto;
+import com.marketinghub.oprm.niche.dto.OprmNicheSnapshotIngestResponseDto;
+import com.marketinghub.oprm.niche.service.OprmNicheCatalogIngestionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/niches")
+@RequiredArgsConstructor
+public class OprmNicheCatalogIngestionController {
+
+    private final OprmNicheCatalogIngestionService service;
+
+    @PostMapping("/catalog:ingest")
+    public ResponseEntity<OprmNicheSnapshotIngestResponseDto> ingest(@Valid @RequestBody OprmNicheCatalogIngestRequestDto request) {
+        return ResponseEntity.accepted().body(service.ingest(request));
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmApiExceptionHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/web/OprmApiExceptionHandler.java
@@ -23,7 +23,8 @@ import org.springframework.web.server.ResponseStatusException;
         OprmWorkspaceController.class,
         OprmFeedbackController.class,
         OprmHeartbeatController.class,
-        com.marketinghub.oprm.niche.web.OprmNicheIngestionController.class
+        com.marketinghub.oprm.niche.web.OprmNicheIngestionController.class,
+        com.marketinghub.oprm.niche.web.OprmNicheCatalogIngestionController.class
 })
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class OprmApiExceptionHandler {

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-11-oprm-niche-catalog-ingestion.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-11-oprm-niche-catalog-ingestion.yaml
@@ -1,0 +1,66 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-11-01-oprm-niche-catalog-ingestion
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_niche_catalog
+      changes:
+        - createTable:
+            tableName: oprm_niche_catalog
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: cnae_code
+                  type: VARCHAR(16)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: cnae_label
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: source
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: active
+                  type: BIT(1)
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: oprm_niche_catalog
+            columnNames: cnae_code
+            constraintName: uk_oprm_niche_catalog_code
+        - createIndex:
+            tableName: oprm_niche_catalog
+            indexName: idx_oprm_niche_catalog_active
+            columns:
+              - column:
+                  name: active

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,9 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-05-11-oprm-niche-catalog-ingestion.yaml
+      relativeToChangelogFile: true
+
+  - include:
       file: changesets/2026-05-10-oprm-niche-snapshot-ingestion.yaml
       relativeToChangelogFile: true
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,0 +1,8 @@
+# Registros — OPRM
+
+> Orientação: todos os registros deste documento devem sempre incluir **data e hora no fuso UTC-3**.
+> Este documento segue política de **append-only** (não pode ter nenhuma linha apagada; apenas inserções).
+
+- 2026-05-11 14:25:00 (UTC-3): implementação inicial do plano de importação de CNAEs no backend: criado catálogo `oprm_niche_catalog` via Liquibase, endpoint `POST /api/niches/catalog:ingest` com validações de payload e regra de idempotência por `cnaeCode` normalizado, mantendo backend como único ponto de persistência. Resultado esperado: habilitar carga inicial de todos os CNAEs para suportar mapeamento ocupação↔CNAE e ranking de nichos.
+- 2026-05-11 15:05:00 (UTC-3): ajuste de arquitetura solicitado: removida regra de negócio de normalização/deduplicação/upsert do backend na ingestão de catálogo CNAE. O backend passou a atuar apenas como camada de persistência do lote recebido (saveAll), mantendo validações de contrato no DTO e constraints de banco. A lógica de negócio deve permanecer no módulo OPRM/coletor.
+- 2026-05-11 15:35:00 (UTC-3): implementação do coletor OPRM para ingestão de catálogo CNAE. Criado endpoint `POST /api/oprm-mei/catalog/collect` no módulo `oprm-coletor-mei`, com lógica de negócio de normalização de `cnaeCode`, deduplicação e envio em lotes para `POST /api/niches/catalog:ingest` no backend. Mantida diretriz: negócio no coletor/OPRM e backend apenas persistência.

--- a/oprm-coletor-mei/README.md
+++ b/oprm-coletor-mei/README.md
@@ -17,6 +17,21 @@ mvn spring-boot:run
 Health check:
 - `GET http://localhost:8094/api/oprm-mei/health`
 
+Coleta + ingestão de catálogo CNAE (OPRM):
+- `POST http://localhost:8094/api/oprm-mei/catalog/collect`
+- O coletor aplica normalização de `cnaeCode`, deduplicação e envio em lotes para o backend (`/api/niches/catalog:ingest`).
+
+Exemplo de payload:
+```json
+{
+  "source": "RECEITA_CNPJ_PUBLIC",
+  "records": [
+    { "cnaeCode": "62.01-5-01", "cnaeLabel": "Desenvolvimento de programas de computador sob encomenda", "active": true },
+    { "cnaeCode": "6201501", "cnaeLabel": "Desenvolvimento de programas de computador sob encomenda", "active": true }
+  ]
+}
+```
+
 ## Build Docker
 ```bash
 docker build -t oprm-coletor-mei:local .

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/config/CnaeCatalogCollectorConfig.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/config/CnaeCatalogCollectorConfig.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprmcoletormei.catalog.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(CnaeCatalogCollectorProperties.class)
+public class CnaeCatalogCollectorConfig {
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/config/CnaeCatalogCollectorProperties.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/config/CnaeCatalogCollectorProperties.java
@@ -1,0 +1,14 @@
+package com.marketinghub.oprmcoletormei.catalog.config;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "oprm.collector")
+public record CnaeCatalogCollectorProperties(
+        @NotBlank String backendBaseUrl,
+        @Min(1) int batchSize
+) {
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/dto/CnaeCatalogCollectRequest.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/dto/CnaeCatalogCollectRequest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprmcoletormei.catalog.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record CnaeCatalogCollectRequest(
+        @NotBlank String source,
+        @NotEmpty List<@Valid RawRecord> records
+) {
+    public record RawRecord(
+            @NotBlank String cnaeCode,
+            @NotBlank String cnaeLabel,
+            Boolean active
+    ) {}
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/dto/CnaeCatalogCollectResponse.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/dto/CnaeCatalogCollectResponse.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprmcoletormei.catalog.dto;
+
+public record CnaeCatalogCollectResponse(
+        int received,
+        int normalized,
+        int deduplicated,
+        int batchesSent,
+        int persisted
+) {
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/dto/CnaeCatalogIngestPayload.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/dto/CnaeCatalogIngestPayload.java
@@ -1,0 +1,14 @@
+package com.marketinghub.oprmcoletormei.catalog.dto;
+
+import java.util.List;
+
+public record CnaeCatalogIngestPayload(
+        String source,
+        List<Record> records
+) {
+    public record Record(
+            String cnaeCode,
+            String cnaeLabel,
+            Boolean active
+    ) {}
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/service/CnaeCatalogCollectorService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/service/CnaeCatalogCollectorService.java
@@ -1,0 +1,85 @@
+package com.marketinghub.oprmcoletormei.catalog.service;
+
+import com.marketinghub.oprmcoletormei.catalog.config.CnaeCatalogCollectorProperties;
+import com.marketinghub.oprmcoletormei.catalog.dto.CnaeCatalogCollectRequest;
+import com.marketinghub.oprmcoletormei.catalog.dto.CnaeCatalogCollectResponse;
+import com.marketinghub.oprmcoletormei.catalog.dto.CnaeCatalogIngestPayload;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class CnaeCatalogCollectorService {
+
+    private final RestClient.Builder restClientBuilder;
+    private final CnaeCatalogCollectorProperties properties;
+
+    public CnaeCatalogCollectorService(RestClient.Builder restClientBuilder, CnaeCatalogCollectorProperties properties) {
+        this.restClientBuilder = restClientBuilder;
+        this.properties = properties;
+    }
+
+    public CnaeCatalogCollectResponse collectAndIngest(CnaeCatalogCollectRequest request) {
+        List<CnaeCatalogIngestPayload.Record> normalized = normalizeAndDeduplicate(request.records());
+        List<List<CnaeCatalogIngestPayload.Record>> batches = partition(normalized, properties.batchSize());
+
+        int persisted = 0;
+        for (List<CnaeCatalogIngestPayload.Record> batch : batches) {
+            CnaeCatalogIngestPayload payload = new CnaeCatalogIngestPayload(request.source().trim(), batch);
+            IngestResponse response = sendBatch(payload);
+            persisted += response.persisted();
+        }
+
+        return new CnaeCatalogCollectResponse(
+                request.records().size(),
+                normalized.size(),
+                request.records().size() - normalized.size(),
+                batches.size(),
+                persisted
+        );
+    }
+
+    private IngestResponse sendBatch(CnaeCatalogIngestPayload payload) {
+        return restClientBuilder.build()
+                .post()
+                .uri(properties.backendBaseUrl() + "/api/niches/catalog:ingest")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload)
+                .retrieve()
+                .body(IngestResponse.class);
+    }
+
+    private List<CnaeCatalogIngestPayload.Record> normalizeAndDeduplicate(List<CnaeCatalogCollectRequest.RawRecord> records) {
+        Map<String, CnaeCatalogIngestPayload.Record> dedup = new LinkedHashMap<>();
+        for (CnaeCatalogCollectRequest.RawRecord record : records) {
+            String normalizedCode = record.cnaeCode().replaceAll("[^0-9]", "").trim();
+            if (normalizedCode.isBlank()) {
+                continue;
+            }
+            dedup.putIfAbsent(
+                    normalizedCode,
+                    new CnaeCatalogIngestPayload.Record(
+                            normalizedCode,
+                            record.cnaeLabel().trim(),
+                            record.active() == null || record.active()
+                    )
+            );
+        }
+        return new ArrayList<>(dedup.values());
+    }
+
+    private List<List<CnaeCatalogIngestPayload.Record>> partition(List<CnaeCatalogIngestPayload.Record> records, int batchSize) {
+        List<List<CnaeCatalogIngestPayload.Record>> batches = new ArrayList<>();
+        for (int i = 0; i < records.size(); i += batchSize) {
+            batches.add(records.subList(i, Math.min(i + batchSize, records.size())));
+        }
+        return batches;
+    }
+
+    private record IngestResponse(int persisted) {
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/web/CnaeCatalogCollectorController.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/web/CnaeCatalogCollectorController.java
@@ -1,0 +1,27 @@
+package com.marketinghub.oprmcoletormei.catalog.web;
+
+import com.marketinghub.oprmcoletormei.catalog.dto.CnaeCatalogCollectRequest;
+import com.marketinghub.oprmcoletormei.catalog.dto.CnaeCatalogCollectResponse;
+import com.marketinghub.oprmcoletormei.catalog.service.CnaeCatalogCollectorService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/oprm-mei/catalog")
+public class CnaeCatalogCollectorController {
+
+    private final CnaeCatalogCollectorService service;
+
+    public CnaeCatalogCollectorController(CnaeCatalogCollectorService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/collect")
+    public ResponseEntity<CnaeCatalogCollectResponse> collect(@Valid @RequestBody CnaeCatalogCollectRequest request) {
+        return ResponseEntity.accepted().body(service.collectAndIngest(request));
+    }
+}

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -14,3 +14,8 @@ management:
     health:
       probes:
         enabled: true
+
+oprm:
+  collector:
+    backend-base-url: ${OPRM_COLLECTOR_BACKEND_BASE_URL:http://191.252.181.168:8000}
+    batch-size: ${OPRM_COLLECTOR_BATCH_SIZE:500}


### PR DESCRIPTION
### Motivation

- Provide a way to persist a canonical CNAE niche catalog in the backend via an ingestion endpoint (`POST /api/niches/catalog:ingest`).
- Keep business rules for normalization, deduplication and batching in the collector component and make the backend act primarily as a persistence layer. 
- Enable initial mass-load of CNAE data and maintain database constraints to ensure uniqueness and queryability of active entries.

### Description

- Introduced JPA entity `OprmNicheCatalogItem`, repository `OprmNicheCatalogItemRepository`, DTO `OprmNicheCatalogIngestRequestDto`, service `OprmNicheCatalogIngestionService` and controller `OprmNicheCatalogIngestionController` to accept and persist catalog batches using `saveAll`.
- Added Liquibase changelog `changesets/2026-05-11-oprm-niche-catalog-ingestion.yaml` and included it in `db.changelog-master.yaml` to create the `oprm_niche_catalog` table with a unique constraint on `cnae_code` and an index on `active`.
- Updated global exception handler to include the new controller (`OprmNicheCatalogIngestionController`) in its advice registration.
- Added a new `oprm-coletor-mei` module with configuration `CnaeCatalogCollectorProperties`, collector service `CnaeCatalogCollectorService` that performs `cnaeCode` normalization, deduplication, partitioning into batches and HTTP posting to the backend, controller `POST /api/oprm-mei/catalog/collect`, DTOs for collect/ingest payloads, README updates, and application properties for backend URL and `batch-size`.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e817eba88321aaf554e9513d1e71)