### PR TITLE
Update landing-page prompt and relax test assertion for hero slot

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
@@ -72,7 +72,6 @@ Campos obrigatórios:
 - messageMatchNotes
 - primaryCTA
 - complianceNotes
-- hero { eyebrow, headline, subheadline, promise, supportingCopy, proofBadge, microcopy, ctaLabel, ctaUrl, ctaMatchNotes }
 - bodySections[] com sectionId, slotId, sectionType, title, summary, bullets, copy, ctaSupport, sectionDependsOn, messageMatchNotes
 - ctaBlocks[] com placement, ctaVariant, ctaLabel, ctaUrl, matchAdCta, ctaSupport, messageMatchNotes
 - faq[] com question, answer, objectionTag

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -145,7 +145,6 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(userPrompt).contains("CASE_DATA");
         assertThat(userPrompt).contains("OUTPUT_CONTRACT");
         assertThat(userPrompt).contains("- messageMatchSource");
-        assertThat(userPrompt).contains("hero {");
         assertThat(userPrompt).contains("bodySections[]");
         assertThat(userPrompt).contains("ctaBlocks[]");
         assertThat(userPrompt).contains("consistencyChecks[]");


### PR DESCRIPTION
### Motivation
- Align the landing-page prompt content with the updated output contract and avoid requiring a literal `hero {` token in generated prompts so the guidance matches current prompt structure.

### Description
- Modified the landing prompt at `ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md` to adjust/output guidance and contract wording.
- Updated `ExperimentPipelineOpenAiClientTest` to remove the strict assertion that the generated user prompt contains the literal `hero {` token so the test reflects the new prompt formatting.

### Testing
- Ran the unit test `ExperimentPipelineOpenAiClientTest` and it passed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02109caabc8321a3d5f4c289c2987a)