### PR TITLE
Restore landing-copy prompt guidance for sectionId/slotId mapping

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/landing-copy.md
@@ -72,6 +72,8 @@ Critérios mínimos de aceite no próprio output:
 - `bodySections.length >= 4`
 - Se `landingPageWireframe` existir, `bodySections` deve conter exatamente as mesmas seções do wireframe, na mesma ordem de `sections`.
 - Cada `bodySections[i].items[j]` deve conter somente os campos `item` e `copy`.
+- cada item de `bodySections` deve informar `sectionId` + `slotId` exatamente como definidos no wireframe
+- não usar `purpose` como `slotId` (ex.: `headline`, `subheadline`, `promise`)
 - Se existir `uiTextTags`, os textos devem respeitar os limites sugeridos de caracteres por elemento/slot.
 - `faq.length >= 3`
 - `ctaBlocks.length >= 2`


### PR DESCRIPTION
### Motivation
- A unit test expecting explicit wireframe guidance in the landing-copy prompt (`ExperimentPipelineOpenAiClientTest.prependsLandingCopyGuidanceForLandingCopySection`) was failing because two acceptance-criteria lines were missing from the template.

### Description
- Restored the two missing acceptance-criteria lines in `ai-worker/src/main/resources/prompts/experiment/landing-copy.md` to require that each `bodySections` item includes `sectionId` + `slotId` exactly as in the wireframe and to forbid using `purpose` as `slotId` (ex.: `headline`, `subheadline`, `promise`).

### Testing
- Attempted to run the targeted unit test with `mvn -f ai-worker/pom.xml -Dtest=ExperimentPipelineOpenAiClientTest#prependsLandingCopyGuidanceForLandingCopySection test`, but Maven failed to resolve `com.marketinghub:ads-service:0.0.1-SNAPSHOT` due to an HTTP 401 from GitHub Packages, so the test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0214b2f4948321ae22ea98b77bfee4)