### PR TITLE
chore(oprm): remove obsolete docker-compose `version` and document CI pull failure

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -8,3 +8,5 @@
 - 2026-05-11 15:35:00 (UTC-3): implementação do coletor OPRM para ingestão de catálogo CNAE. Criado endpoint `POST /api/oprm-mei/catalog/collect` no módulo `oprm-coletor-mei`, com lógica de negócio de normalização de `cnaeCode`, deduplicação e envio em lotes para `POST /api/niches/catalog:ingest` no backend. Mantida diretriz: negócio no coletor/OPRM e backend apenas persistência.
 
 - 2026-05-11: Adicionado agendamento de ingestão no OPRM coletor (cron 15:10 America/Sao_Paulo) com payload externo configurável.
+
+- 2026-05-11 15:20:00 (UTC-3): diagnóstico de falha no `docker compose pull` do `oprm-coletor-mei` em CI: removido campo legado `version` do `docker-compose.yml` para eliminar warning de obsolescência e reduzir ruído operacional; identificado que erro final permanece de infraestrutura do runtime containerd (`failed commit on ref ... no such file or directory`), fora do escopo do compose do projeto.

--- a/oprm-coletor-mei/docker-compose.yml
+++ b/oprm-coletor-mei/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   oprm-coletor-mei:
     build: .


### PR DESCRIPTION
### Motivation
- Eliminar o aviso de obsolescência gerado pelo campo `version` no `docker-compose.yml` e registrar diagnóstico operacional do `docker compose pull` que falhou em CI para clarificar que o erro é de infraestrutura do runtime (`containerd`).

### Description
- Removido o campo `version` do arquivo `oprm-coletor-mei/docker-compose.yml` para alinhar ao esquema do Docker Compose v2 e reduzir ruído de warnings.
- Adicionada entrada operacional em `docs/registros/oprm1.md` documentando a análise da falha do `docker compose pull` e apontando que o erro `failed commit on ref ... no such file or directory` indica instabilidade/corrupção no armazenamento do `containerd`, fora do escopo do compose do projeto.

### Testing
- Tentativa de validação do compose com `docker compose config` falhou porque o binário `docker` não está disponível neste ambiente, então a validação local não pôde ser concluída (erro: `/bin/bash: docker: command not found`).
- Não foram executados testes unitários automáticos neste ambiente para as mudanças aplicadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021a5288148321b7259e02a5fe4338)