### PR TITLE
Add JWT extraction and token-authenticated Hotmart API fallback with masked logging

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -51,3 +51,9 @@
 - Implementado fallback de coleta via API oficial `https://api-affiliation-market.hotmart.com/v2/market/search` quando a página de market não retorna cards no DOM (`cardsEncontrados=0`).
 - O fallback executa `fetch` no contexto autenticado da página (`credentials: include`) e mapeia produtos retornados da API para `HotmartProductSnapshot`.
 - Adicionado log técnico do status HTTP e `bodyPreview` truncado da resposta da API para diagnóstico de contrato/autenticação sem depender apenas do scraper visual.
+
+## 2026-05-11 15:30:35 UTC-3
+- Adicionado diagnóstico pós-login no `HotmartCollectorService` para extração de token JWT (tentativa em `localStorage`, `sessionStorage` e `document.cookie`) com logs de cada passo.
+- Adicionado logging de token com proteção por padrão (`masked`) e opção explícita `collector.hotmart.log-full-token=true` para modo diagnóstico completo.
+- Fallback da API Hotmart agora tenta enviar `Authorization: Bearer <token>` quando token estiver disponível, mantendo também `credentials: include`.
+- Incluídos logs detalhados no início do fallback da API informando presença de token e pré-visualização mascarada para rastrear causa-raiz de falhas de autenticação/coleta.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -36,6 +36,7 @@ public class HotmartCollectorService {
     private final String hotmartSessionCookie;
     private final String hotmartUsername;
     private final String hotmartPassword;
+    private final boolean logFullToken;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public HotmartCollectorService(
@@ -46,7 +47,8 @@ public class HotmartCollectorService {
             @Value("${collector.hotmart.username:}") String hotmartUsername,
             @Value("${collector.hotmart.password:}") String hotmartPassword,
             @Value("${collector.hotmart.username-fallback:}") String hotmartUsernameFallback,
-            @Value("${collector.hotmart.password-fallback:}") String hotmartPasswordFallback
+            @Value("${collector.hotmart.password-fallback:}") String hotmartPasswordFallback,
+            @Value("${collector.hotmart.log-full-token:false}") boolean logFullToken
     ) {
         this.headless = headless;
         this.chromiumExecutablePath = chromiumExecutablePath;
@@ -54,6 +56,7 @@ public class HotmartCollectorService {
         this.hotmartSessionCookie = hotmartSessionCookie;
         this.hotmartUsername = pickFirstNonBlank(hotmartUsername, hotmartUsernameFallback);
         this.hotmartPassword = pickFirstNonBlank(hotmartPassword, hotmartPasswordFallback);
+        this.logFullToken = logFullToken;
     }
 
     public HotmartCollectionResponse collect(HotmartCollectionRequest request) {
@@ -104,6 +107,8 @@ public class HotmartCollectorService {
             Page page = context.newPage();
 
             authenticateHotmart(context, page, hasSessionCookie, hasCredentials);
+            String hotmartAccessToken = tryExtractAccessToken(page);
+            logTokenDiagnostics(hotmartAccessToken);
 
             log.info("Navegando para URL de mercado Hotmart: {}", hotmartMarketUrl);
             page.navigate(hotmartMarketUrl, new Page.NavigateOptions()
@@ -122,7 +127,7 @@ public class HotmartCollectorService {
                 log.warn("Nenhum card de produto encontrado na página de mercado. url='{}', htmlSnapshot='{}'",
                         page.url(),
                         captureHtmlSnapshot(page));
-                int apiCollected = collectProductsViaMarketApi(page, boundedMax, products);
+                int apiCollected = collectProductsViaMarketApi(page, hotmartAccessToken, boundedMax, products);
                 log.info("Fallback API Hotmart finalizado. produtosColetadosViaApi={}", apiCollected);
             }
             if (products.isEmpty()) {
@@ -176,10 +181,13 @@ public class HotmartCollectorService {
     }
 
 
-    private int collectProductsViaMarketApi(Page page, int boundedMax, List<HotmartProductSnapshot> products) {
+    private int collectProductsViaMarketApi(Page page, String accessToken, int boundedMax, List<HotmartProductSnapshot> products) {
         try {
+            log.info("Fallback API Hotmart: iniciando chamada. hasAccessToken={}, tokenPreview='{}'",
+                    accessToken != null && !accessToken.isBlank(),
+                    maskToken(accessToken));
             String response = page.evaluate("""
-                    async ({ apiUrl, rows }) => {
+                    async ({ apiUrl, rows, accessToken }) => {
                       const payload = {
                         page: 1,
                         rows,
@@ -191,6 +199,7 @@ public class HotmartCollectorService {
                         credentials: 'include',
                         headers: {
                           'accept': 'application/json, text/plain, */*',
+                          ...(accessToken ? { 'authorization': `Bearer ${accessToken}` } : {}),
                           'content-type': 'application/json'
                         },
                         body: JSON.stringify(payload)
@@ -198,7 +207,7 @@ public class HotmartCollectorService {
                       const text = await res.text();
                       return JSON.stringify({ status: res.status, body: text });
                     }
-                    """, java.util.Map.of("apiUrl", HOTMART_MARKET_API_URL, "rows", boundedMax)).toString();
+                    """, java.util.Map.of("apiUrl", HOTMART_MARKET_API_URL, "rows", boundedMax, "accessToken", accessToken == null ? "" : accessToken)).toString();
 
             JsonNode root = objectMapper.readTree(response);
             int status = root.path("status").asInt();
@@ -234,6 +243,61 @@ public class HotmartCollectorService {
             log.warn("Falha no fallback de coleta via API Hotmart.", ex);
             return 0;
         }
+    }
+
+    private String tryExtractAccessToken(Page page) {
+        log.info("Token Hotmart: iniciando extração pós-login (localStorage/sessionStorage/cookies).");
+        try {
+            Object tokenObj = page.evaluate("""
+                    () => {
+                      const jwtRegex = /eyJ[A-Za-z0-9_-]*\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+/;
+                      const stores = [window.localStorage, window.sessionStorage];
+                      for (const storage of stores) {
+                        for (let i = 0; i < storage.length; i++) {
+                          const key = storage.key(i);
+                          const value = storage.getItem(key);
+                          if (!value) continue;
+                          if (jwtRegex.test(value)) return value.match(jwtRegex)[0];
+                        }
+                      }
+                      const cookieMatch = document.cookie.match(jwtRegex);
+                      return cookieMatch ? cookieMatch[0] : '';
+                    }
+                    """);
+            String token = tokenObj == null ? "" : tokenObj.toString();
+            if (token.isBlank()) {
+                log.warn("Token Hotmart: nenhum token JWT encontrado no contexto da página. url='{}'", page.url());
+                return "";
+            }
+            log.info("Token Hotmart: token capturado com sucesso.");
+            return token;
+        } catch (Exception ex) {
+            log.warn("Token Hotmart: falha ao extrair token pós-login. url='{}'", page.url(), ex);
+            return "";
+        }
+    }
+
+    private void logTokenDiagnostics(String token) {
+        boolean hasToken = token != null && !token.isBlank();
+        log.info("Token Hotmart: hasToken={}, length={}", hasToken, hasToken ? token.length() : 0);
+        if (!hasToken) {
+            return;
+        }
+        if (logFullToken) {
+            log.warn("Token Hotmart (FULL - modo diagnóstico): {}", token);
+        } else {
+            log.info("Token Hotmart (masked): {}", maskToken(token));
+        }
+    }
+
+    private String maskToken(String token) {
+        if (token == null || token.isBlank()) {
+            return "";
+        }
+        if (token.length() <= 20) {
+            return "***";
+        }
+        return token.substring(0, 12) + "...<masked>..." + token.substring(token.length() - 8);
     }
 
     private JsonNode firstArray(JsonNode node, String... keys) {

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java
@@ -17,7 +17,8 @@ class HotmartCollectorServiceTest {
                 "",
                 "",
                 "",
-                ""
+                "",
+                false
         );
 
         var response = service.collect(new HotmartCollectionRequest("hotmart-market", 10));


### PR DESCRIPTION
### Motivation
- Improve reliability of product collection when the Hotmart market page returns no product cards by attempting an authenticated API fallback. 
- Collect deterministic diagnostics (HTML snapshot, API status/body and token presence) to aid root-cause analysis of collection/authentication failures. 
- Avoid accidental leak of sensitive tokens by default while providing an opt-in diagnostic mode for full-token logging.

### Description
- Added a new config property `collector.hotmart.log-full-token` and constructor wiring to control verbose token logging via `logFullToken` in `HotmartCollectorService`. 
- Implemented `tryExtractAccessToken(Page)` to attempt JWT extraction from `localStorage`, `sessionStorage` and `document.cookie`, and `logTokenDiagnostics(String)` plus `maskToken(String)` to safely log token presence/preview. 
- Changed the API fallback to accept and optionally send an `Authorization: Bearer <token>` header, updated the in-page `fetch` call and the Java-side `collectProductsViaMarketApi` signature to pass the token, and added diagnostic logs for API status and body previews. 
- Updated documentation entry `docs/registros/coletor-mois1.md` describing the changes and added a unit test adjustment to accommodate the new constructor parameter. 

### Testing
- Updated unit test `HotmartCollectorServiceTest.shouldSkipWhenSessionAndCredentialsAreMissing` to supply the new `logFullToken` boolean parameter. 
- Ran unit tests (`mvn -DskipTests=false test`) including the modified test and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021da4b89883219d9c491b165507c7)