### PR TITLE
Refactor CopyProvisionalHtmlAssembler by extracting payload resolver and HTML processor

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlAssembler.java
@@ -1,129 +1,43 @@
 package com.marketinghub.geralanding;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.parser.Parser;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
-import java.util.List;
-import java.util.Map;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
 
 @Component
 public class CopyProvisionalHtmlAssembler {
 
+    private final CopyProvisionalHtmlPayloadResolver payloadResolver;
+    private final CopyProvisionalHtmlProcessor processor;
     private final ObjectMapper objectMapper;
 
-    public CopyProvisionalHtmlAssembler(ObjectMapper objectMapper) {
+    public CopyProvisionalHtmlAssembler(CopyProvisionalHtmlPayloadResolver payloadResolver,
+                                        CopyProvisionalHtmlProcessor processor,
+                                        ObjectMapper objectMapper) {
+        this.payloadResolver = payloadResolver;
+        this.processor = processor;
         this.objectMapper = objectMapper;
     }
 
-    @SuppressWarnings("unchecked")
     public String assemble(String copyModelResponse, String wireframeModelResponse, String jobId) {
         if (!StringUtils.hasText(copyModelResponse) || !StringUtils.hasText(wireframeModelResponse)) {
             return null;
         }
         try {
-            Map<String, Object> wireframeRoot = objectMapper.readValue(wireframeModelResponse, Map.class);
-            Map<String, Object> wireframe = wireframeRoot.get("landingPageWireframe") instanceof Map<?, ?> nested
-                    ? (Map<String, Object>) nested
-                    : wireframeRoot;
+            CopyProvisionalHtmlPayloadResolver.CopyProvisionalHtmlPayload payload =
+                    payloadResolver.resolve(copyModelResponse, wireframeModelResponse);
 
             WireframeHtmlGenerator generator = new WireframeHtmlGenerator();
-            String html = generator.generateFromJson(objectMapper.writeValueAsString(wireframe));
-
-            Map<String, Object> copyRoot = objectMapper.readValue(copyModelResponse, Map.class);
-            Map<String, Object> copy = copyRoot.get("landingPageCopy") instanceof Map<?, ?> nested
-                    ? (Map<String, Object>) nested
-                    : copyRoot;
-
-            Deque<String> copyTexts = collectCopyTexts(copy);
-            html = applyCopyToAllTextNodes(html, copyTexts);
-            if (StringUtils.hasText(copyTexts.peekFirst())) {
-                html = html.replaceFirst("(?is)<title>.*?</title>", "<title>" + escapeHtml(copyTexts.peekFirst()) + "</title>");
-            }
+            String html = generator.generateFromJson(payloadResolverToJson(payload));
+            html = processor.process(html, payload.copy());
             return appendJobIdCommentBeforeHead(html, jobId);
         } catch (Exception e) {
             return null;
         }
     }
 
-    private String applyCopyToAllTextNodes(String html, Deque<String> copyTexts) {
-        if (!StringUtils.hasText(html)) {
-            throw new IllegalArgumentException("HTML provisório ausente para aplicar a copy");
-        }
-        if (copyTexts.isEmpty()) {
-            throw new IllegalArgumentException("Copy da etapa Gera Copy sem textos para preencher a página");
-        }
-
-        Document document = Jsoup.parse(html, "", Parser.htmlParser());
-        List<Element> textElements = document.select("h1, h2, h3, p, li, span, summary, a, button");
-        for (Element element : textElements) {
-            String text = copyTexts.pollFirst();
-            if (!StringUtils.hasText(text)) {
-                throw new IllegalArgumentException("Copy insuficiente para preencher todos os campos de texto do HTML");
-            }
-            element.text(text);
-        }
-        return document.outerHtml();
-    }
-
-    private Deque<String> collectCopyTexts(Map<String, Object> copy) {
-        List<String> values = new ArrayList<>();
-        collectTextsRecursive(copy, null, values);
-        Deque<String> queue = new ArrayDeque<>();
-        for (String value : values) {
-            if (StringUtils.hasText(value)) {
-                queue.addLast(value.trim());
-            }
-        }
-        return queue;
-    }
-
-    @SuppressWarnings("unchecked")
-    private void collectTextsRecursive(Object node, String key, List<String> out) {
-        if (node == null) {
-            return;
-        }
-        if (node instanceof Map<?, ?> map) {
-            for (Map.Entry<?, ?> entry : map.entrySet()) {
-                collectTextsRecursive(entry.getValue(), String.valueOf(entry.getKey()), out);
-            }
-            return;
-        }
-        if (node instanceof List<?> list) {
-            for (Object item : list) {
-                collectTextsRecursive(item, key, out);
-            }
-            return;
-        }
-        if (node instanceof String text && shouldUseAsCopyText(key, text)) {
-            out.add(text);
-        }
-    }
-    private boolean shouldUseAsCopyText(String key, String value) {
-        if (!StringUtils.hasText(value)) {
-            return false;
-        }
-        if (key == null) {
-            return true;
-        }
-        String normalized = key.toLowerCase();
-        if (normalized.contains("id")
-                || normalized.contains("slot")
-                || normalized.contains("section")
-                || normalized.contains("url")
-                || normalized.contains("placement")
-                || normalized.contains("code")
-                || normalized.contains("status")) {
-            return false;
-        }
-        return true;
+    private String payloadResolverToJson(CopyProvisionalHtmlPayloadResolver.CopyProvisionalHtmlPayload payload) throws Exception {
+        return objectMapper.writeValueAsString(payload.wireframe());
     }
 
     private String appendJobIdCommentBeforeHead(String html, String jobId) {
@@ -138,12 +52,4 @@ public class CopyProvisionalHtmlAssembler {
         return html.substring(0, headIndex) + comment + html.substring(headIndex);
     }
 
-    private String escapeHtml(String value) {
-        return value
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace("\"", "&quot;")
-                .replace("'", "&#39;");
-    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlPayloadResolver.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlPayloadResolver.java
@@ -1,0 +1,34 @@
+package com.marketinghub.geralanding;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class CopyProvisionalHtmlPayloadResolver {
+
+    private final ObjectMapper objectMapper;
+
+    public CopyProvisionalHtmlPayloadResolver(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @SuppressWarnings("unchecked")
+    public CopyProvisionalHtmlPayload resolve(String copyModelResponse, String wireframeModelResponse) throws Exception {
+        Map<String, Object> wireframeRoot = objectMapper.readValue(wireframeModelResponse, Map.class);
+        Map<String, Object> wireframe = wireframeRoot.get("landingPageWireframe") instanceof Map<?, ?> nested
+                ? (Map<String, Object>) nested
+                : wireframeRoot;
+
+        Map<String, Object> copyRoot = objectMapper.readValue(copyModelResponse, Map.class);
+        Map<String, Object> copy = copyRoot.get("landingPageCopy") instanceof Map<?, ?> nested
+                ? (Map<String, Object>) nested
+                : copyRoot;
+
+        return new CopyProvisionalHtmlPayload(wireframe, copy);
+    }
+
+    public record CopyProvisionalHtmlPayload(Map<String, Object> wireframe, Map<String, Object> copy) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessor.java
@@ -1,0 +1,110 @@
+package com.marketinghub.geralanding;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CopyProvisionalHtmlProcessor {
+
+    public String process(String html, Map<String, Object> copy) {
+        Deque<String> copyTexts = collectCopyTexts(copy);
+        String output = applyCopyToAllTextNodes(html, copyTexts);
+        if (StringUtils.hasText(copyTexts.peekFirst())) {
+            output = output.replaceFirst("(?is)<title>.*?</title>", "<title>" + escapeHtml(copyTexts.peekFirst()) + "</title>");
+        }
+        return output;
+    }
+
+    private String applyCopyToAllTextNodes(String html, Deque<String> copyTexts) {
+        if (!StringUtils.hasText(html)) {
+            throw new IllegalArgumentException("HTML provisório ausente para aplicar a copy");
+        }
+        if (copyTexts.isEmpty()) {
+            throw new IllegalArgumentException("Copy da etapa Gera Copy sem textos para preencher a página");
+        }
+
+        Document document = Jsoup.parse(html, "", Parser.htmlParser());
+        List<Element> textElements = document.select("h1, h2, h3, p, li, span, summary, a, button");
+        for (Element element : textElements) {
+            String text = copyTexts.pollFirst();
+            if (!StringUtils.hasText(text)) {
+                throw new IllegalArgumentException("Copy insuficiente para preencher todos os campos de texto do HTML");
+            }
+            element.text(text);
+        }
+        return document.outerHtml();
+    }
+
+    private Deque<String> collectCopyTexts(Map<String, Object> copy) {
+        List<String> values = new ArrayList<>();
+        collectTextsRecursive(copy, null, values);
+        Deque<String> queue = new ArrayDeque<>();
+        for (String value : values) {
+            if (StringUtils.hasText(value)) {
+                queue.addLast(value.trim());
+            }
+        }
+        return queue;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void collectTextsRecursive(Object node, String key, List<String> out) {
+        if (node == null) {
+            return;
+        }
+        if (node instanceof Map<?, ?> map) {
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                collectTextsRecursive(entry.getValue(), String.valueOf(entry.getKey()), out);
+            }
+            return;
+        }
+        if (node instanceof List<?> list) {
+            for (Object item : list) {
+                collectTextsRecursive(item, key, out);
+            }
+            return;
+        }
+        if (node instanceof String text && shouldUseAsCopyText(key, text)) {
+            out.add(text);
+        }
+    }
+
+    private boolean shouldUseAsCopyText(String key, String value) {
+        if (!StringUtils.hasText(value)) {
+            return false;
+        }
+        if (key == null) {
+            return true;
+        }
+        String normalized = key.toLowerCase();
+        if (normalized.contains("id")
+                || normalized.contains("slot")
+                || normalized.contains("section")
+                || normalized.contains("url")
+                || normalized.contains("placement")
+                || normalized.contains("code")
+                || normalized.contains("status")) {
+            return false;
+        }
+        return true;
+    }
+
+    private String escapeHtml(String value) {
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlAssemblerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlAssemblerTest.java
@@ -8,7 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CopyProvisionalHtmlAssemblerTest {
 
-    private final CopyProvisionalHtmlAssembler assembler = new CopyProvisionalHtmlAssembler(new ObjectMapper());
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final CopyProvisionalHtmlAssembler assembler = new CopyProvisionalHtmlAssembler(
+            new CopyProvisionalHtmlPayloadResolver(objectMapper),
+            new CopyProvisionalHtmlProcessor(),
+            objectMapper);
 
     @Test
     void assembleAppliesCopyInDomOrderWithoutGroupingByTag() {


### PR DESCRIPTION
### Motivation
- Separate concerns so the assembler only coordinates work while parsing and DOM manipulation are handled by dedicated components for improved testability and maintainability.
- Make HTML copy application and JSON payload resolution reusable and injectable via Spring components.

### Description
- Introduced `CopyProvisionalHtmlPayloadResolver` which parses `copyModelResponse` and `wireframeModelResponse` into a `CopyProvisionalHtmlPayload` record.
- Introduced `CopyProvisionalHtmlProcessor` which applies copy texts to generated HTML using Jsoup and handles title escaping and validation.
- Updated `CopyProvisionalHtmlAssembler` to accept `CopyProvisionalHtmlPayloadResolver` and `CopyProvisionalHtmlProcessor`, delegate payload resolution and HTML processing, and simplify JSON-to-wireframe conversion via `objectMapper`.
- Adjusted `CopyProvisionalHtmlAssemblerTest` to construct the assembler with the new resolver and processor dependencies.

### Testing
- Ran the unit test `CopyProvisionalHtmlAssemblerTest` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0244294688832184953e186ad4cfd2)