### PR TITLE
Add ExperimentLandingPhasesMain utility to produce combined wireframe/copy test output

### DIFF
--- a/testes/ExperimentLandingPhasesMain.java
+++ b/testes/ExperimentLandingPhasesMain.java
@@ -1,0 +1,32 @@
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class ExperimentLandingPhasesMain {
+    private static final Path INPUT_DIR = Path.of("entrada");
+    private static final Path WIREFRAME_FILE = INPUT_DIR.resolve("gera-wireframe.json");
+    private static final Path COPY_FILE = INPUT_DIR.resolve("gera-copy.json");
+    private static final Path OUTPUT_FILE = Path.of("testes/saídas/gera-wireframe-copy.txt");
+
+    public static void main(String[] args) throws Exception {
+        String wireframeJson = Files.readString(WIREFRAME_FILE, StandardCharsets.UTF_8);
+        String copyJson = Files.readString(COPY_FILE, StandardCharsets.UTF_8);
+
+        ExperimentLandingPhasesDto dto = new ExperimentLandingPhasesDto(wireframeJson, copyJson);
+
+        Files.createDirectories(OUTPUT_FILE.getParent());
+        String content = "=== Gera Wireframe ===\n"
+                + dto.geraWireframeJson() + "\n\n"
+                + "=== Gera Copy ===\n"
+                + dto.geraCopyJson() + "\n";
+
+        Files.writeString(OUTPUT_FILE, content, StandardCharsets.UTF_8);
+        System.out.println("Arquivo gerado em: " + OUTPUT_FILE);
+    }
+
+    public record ExperimentLandingPhasesDto(
+            String geraWireframeJson,
+            String geraCopyJson
+    ) {
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a small local runner to read input JSON files and produce a combined test output for the landing phases experiment.
- Make it easier to generate and inspect `gera-wireframe` and `gera-copy` content together for test verification and debugging.

### Description
- Add `ExperimentLandingPhasesMain` in `testes` which reads `entrada/gera-wireframe.json` and `entrada/gera-copy.json` and writes a combined output to `testes/saídas/gera-wireframe-copy.txt`.
- Use `Files` and `StandardCharsets.UTF_8` to read/write files and ensure the output directory is created with `Files.createDirectories`.
- Introduce an immutable record `ExperimentLandingPhasesDto` holding the two JSON strings and use it to build the output content.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024be405fc8321b817db69090d228f)