### PR TITLE
test: validar CopyProvisionalHtmlAssembler com fixtures oficiais de wireframe+copy

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlAssemblerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlAssemblerTest.java
@@ -3,8 +3,11 @@ package com.marketinghub.geralanding;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CopyProvisionalHtmlAssemblerTest {
 
@@ -16,40 +19,28 @@ class CopyProvisionalHtmlAssemblerTest {
             objectMapper);
 
     @Test
-    void assembleAppliesCopyInDomOrderWithoutGroupingByTag() {
-        String wireframe = """
-                {
-                  "landingPageWireframe": {
-                    "sectionOrder": [
-                      {
-                        "uiTags": "<section><h1 id=\\"s1-title\\"></h1><p id=\\"s1-subtitle\\"></p><h2 id=\\"s2-title\\"></h2><p id=\\"s2-subtitle\\"></p></section>",
-                        "uiSizes": ""
-                      }
-                    ]
-                  }
-                }
-                """;
-        String copy = """
-                {
-                  "landingPageCopy": {
-                    "sections": [
-                      {"items": [
-                        {"id": "s1-title", "value": "Headline correta"},
-                        {"id": "s1-subtitle", "value": "Resumo correto"},
-                        {"id": "s2-title", "value": "Copy correta"},
-                        {"id": "s2-subtitle", "value": "Prova correta"}
-                      ]}
-                    ]
-                  }
-                }
-                """;
+    void assembleMustMatchExpectedHtmlExactlyForOfficialFixtures() throws IOException {
+        Path fixtureRoot = resolveFixtureRoot();
+        String wireframe = Files.readString(fixtureRoot.resolve("entradas/gera-wireframe.json"));
+        String copy = Files.readString(fixtureRoot.resolve("entradas/gera-copy.json"));
+        String expectedHtml = Files.readString(fixtureRoot.resolve("saidas/gera-wireframe-copy-exato.html"));
 
-        String html = assembler.assemble(copy, wireframe, "job-1");
+        String html = assembler.assemble(copy, wireframe, null);
 
-        assertNotNull(html);
-        assertTrue(html.contains("Headline correta"));
-        assertTrue(html.contains("Resumo correto"));
-        assertTrue(html.contains("Copy correta"));
-        assertTrue(html.contains("Prova correta"));
+        assertEquals(expectedHtml, html);
+    }
+
+    private Path resolveFixtureRoot() {
+        Path current = Path.of("").toAbsolutePath();
+        for (int i = 0; i < 8 && current != null; i++) {
+            Path candidate = current.resolve("testes");
+            if (Files.exists(candidate.resolve("entradas/gera-wireframe.json"))
+                    && Files.exists(candidate.resolve("entradas/gera-copy.json"))
+                    && Files.exists(candidate.resolve("saidas/gera-wireframe-copy-exato.html"))) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Não foi possível localizar pasta de fixtures em /testes");
     }
 }


### PR DESCRIPTION
### Motivation
- Garantir que a montagem do HTML provisório a partir de `gera-wireframe.json` + `gera-copy.json` produz exatamente o HTML canônico esperado (`gera-wireframe-copy-exato.html`) para prevenir previews parciais ou desalinhados com o contrato.

### Description
- Substituí o teste anterior por `CopyProvisionalHtmlAssemblerTest#assembleMustMatchExpectedHtmlExactlyForOfficialFixtures` que lê os artefatos reais em `testes/entradas` e compara igualdade exata com o fixture em `testes/saidas` usando `assertEquals`.
- Implementei `resolveFixtureRoot()` no teste para localizar de forma robusta a pasta `testes` subindo diretórios a partir do cwd do módulo, evitando dependência do working dir do runner.
- O teste agora instancia o assembler real (`CopyProvisionalHtmlAssembler` + `CopyProvisionalHtmlPayloadResolver` + `CopyProvisionalHtmlProcessor`) e compara a saída do `assemble` com o arquivo `gera-wireframe-copy-exato.html`.
- Ajustei imports e limpanças no arquivo de teste para refletir a nova estratégia de verificação por fixture.

### Testing
- Executei `mvn -Dtest=CopyProvisionalHtmlAssemblerTest test` no módulo `backend/ads-service` para rodar apenas o novo teste.
- O teste falhou com uma `AssertionFailedError` porque o HTML gerado difere do fixture exato, e o Maven reportou `BUILD FAILURE` (detalhes em `target/surefire-reports`).
- Esta falha evidencia divergência entre a implementação atual do assembler/processor e o HTML canônico do fixture, servindo como ponto objetivo para ajustar `CopyProvisionalHtmlProcessor` / `WireframeHtmlGenerator` até que o teste passe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02a4f741dc8321a952988944578a93)