### PR TITLE
Simplifica contrato JSON da etapa landing-page-wireframe (raiz `pagina`)

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -138,6 +138,8 @@
                         },
                         "elementosInternos": {
                           "type": "array",
+                          "description": "Lista recursiva de elementos internos com a mesma estrutura do elemento pai.",
+                          "minItems": 0,
                           "items": {
                             "$ref": "#/properties/pagina/properties/corpo/properties/secoes/items/properties/elementosSeccao/items"
                           }

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -2,221 +2,181 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "pageGoal": {
-      "type": "string"
-    },
-    "variantLayoutId": {
-      "type": "string",
-      "enum": [
-        "form-first",
-        "proof-first",
-        "story-first"
-      ]
-    },
-    "messageMatchSummary": {
-      "type": "string"
-    },
-    "mobilePriorityNotes": {
-      "type": "string"
-    },
-    "ctaPlacementNotes": {
-      "type": "string"
-    },
-    "formPlacementNotes": {
-      "type": "string"
-    },
-    "sectionOrder": {
-      "type": "array",
-      "minItems": 4,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "sectionId": {
-            "type": "string"
-          },
-          "sectionName": {
-            "type": "string"
-          },
-          "objective": {
-            "type": "string"
-          },
-          "contentType": {
-            "type": "string",
-            "enum": [
-              "hero",
-              "form",
-              "split",
-              "proof",
-              "timeline",
-              "faq",
-              "cta"
-            ]
-          },
-          "copySource": {
-            "type": "string"
-          },
-          "uiNotes": {
-            "type": "string"
-          },
-          "uiTags": {
-            "type": "string"
-          },
-          "uiSizeTexts": {
-            "type": "string"
-          },
-          "uiSizes": {
-            "type": "string"
-          },
-          "messageMatchDependency": {
-            "type": "string"
-          },
-          "sectionDependsOn": {
-            "type": "array",
-            "items": {
+    "pagina": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "head": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "texto": {
               "type": "string"
             }
           },
-          "mobilePriorityScore": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 10
-          },
-          "dropOffRisk": {
-            "type": "string",
-            "enum": [
-              "baixo",
-              "medio",
-              "alto"
-            ]
-          },
-          "surfaceSpec": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "surfaceToken": {
-                "type": "string"
-              },
-              "notes": {
-                "type": "string"
+          "required": [
+            "texto"
+          ]
+        },
+        "corpo": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "estilos": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "nome": {
+                    "type": "string"
+                  },
+                  "valor": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "nome",
+                  "valor"
+                ]
               }
             },
-            "required": [
-              "surfaceToken",
-              "notes"
-            ]
-          },
-          "ctaSlot": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "hasCta": {
-                "type": "boolean"
-              },
-              "ctaLabel": {
-                "type": "string"
-              },
-              "ctaVariant": {
-                "type": "string"
-              },
-              "matchAdCta": {
-                "type": "string"
-              },
-              "notes": {
-                "type": "string"
+            "secoes": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "nome": {
+                    "type": "string"
+                  },
+                  "objetivo": {
+                    "type": "string"
+                  },
+                  "oQueQuerProvocarNoUsuario": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "estilos": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "nome": {
+                          "type": "string"
+                        },
+                        "valor": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "nome",
+                        "valor"
+                      ]
+                    }
+                  },
+                  "elementosSeccao": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "tag": {
+                          "type": "string"
+                        },
+                        "texto": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "tamMaximo": {
+                              "type": "integer",
+                              "minimum": 1
+                            },
+                            "tamMinimo": {
+                              "type": "integer",
+                              "minimum": 1
+                            },
+                            "conteudo": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "tamMaximo",
+                            "tamMinimo",
+                            "conteudo"
+                          ]
+                        },
+                        "estilos": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "nome": {
+                                "type": "string"
+                              },
+                              "valor": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "nome",
+                              "valor"
+                            ]
+                          }
+                        },
+                        "elementosInternos": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/properties/pagina/properties/corpo/properties/secoes/items/properties/elementosSeccao/items"
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "tag",
+                        "texto",
+                        "estilos",
+                        "elementosInternos"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "nome",
+                  "objetivo",
+                  "oQueQuerProvocarNoUsuario",
+                  "id",
+                  "estilos",
+                  "elementosSeccao"
+                ]
               }
-            },
-            "required": [
-              "hasCta",
-              "ctaLabel",
-              "ctaVariant",
-              "matchAdCta",
-              "notes"
-            ]
-          }
-        },
-        "required": [
-          "sectionId",
-          "sectionName",
-          "objective",
-          "contentType",
-          "copySource",
-          "uiNotes",
-          "uiTags",
-          "uiSizeTexts",
-          "uiSizes",
-          "messageMatchDependency",
-          "sectionDependsOn",
-          "mobilePriorityScore",
-          "dropOffRisk",
-          "surfaceSpec",
-          "ctaSlot"
-        ]
-      }
-    },
-    "consistencyChecks": {
-      "type": "array",
-      "minItems": 2,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "check": {
-            "type": "string"
+            }
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PASS",
-              "WARN",
-              "FAIL"
-            ]
-          },
-          "details": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "check",
-          "status",
-          "details"
-        ]
-      }
-    },
-    "bodyAttributes": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "attribute": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
-          },
-          "notes": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "attribute",
-          "value",
-          "notes"
-        ]
-      }
+          "required": [
+            "estilos",
+            "secoes"
+          ]
+        }
+      },
+      "required": [
+        "head",
+        "corpo"
+      ]
     }
   },
   "required": [
-    "pageGoal",
-    "variantLayoutId",
-    "messageMatchSummary",
-    "mobilePriorityNotes",
-    "ctaPlacementNotes",
-    "formPlacementNotes",
-    "bodyAttributes",
-    "sectionOrder",
-    "consistencyChecks"
+    "pagina"
   ]
 }

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -52,6 +52,7 @@ Regras fixas da etapa (formato simplificado):
 - Cada item de `estilos[]` deve ter apenas `nome` e `valor`.
 - Cada seção deve conter: `nome`, `objetivo`, `oQueQuerProvocarNoUsuario`, `id`, `estilos[]`, `elementosSeccao[]`.
 - Cada item de `elementosSeccao[]` deve conter: `id`, `tag`, `texto`, `estilos[]`, `elementosInternos[]`.
+- `elementosInternos[]` representa hierarquia de filhos e deve suportar recursão (filho pode conter netos e assim por diante), sempre com o mesmo contrato do elemento pai.
 - Campo `texto` de cada elemento deve conter exatamente: `tamMaximo`, `tamMinimo`, `conteudo`.
 - `elementosInternos` pode ser lista vazia, mas sempre deve existir.
 - Não invente campos fora do schema.

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -43,90 +43,33 @@ Briefing das Imagens dos Anuncios:
 
 
 template_id: landing-wireframe
-template_version: v1
+template_version: v2
 artifact_target: landingPageWireframe
 
-Modelo conceitual interno obrigatório (não expor no output final):
-- `entryAsset`
-- `coreOffer`
-- `activationLayer`
-- `continuityLayer`
-- `proofDevice`
-
-Regras fixas da etapa:
-- `pageGoal` deve explicitar a ação principal esperada da página.
-- `variantLayoutId` deve ser um entre: form-first, proof-first, story-first.
-- `sectionOrder` deve mapear ordem, objetivo, dependências de message match e variação intencional de seção via `surfaceSpec` (âncora estrutural) + `uiNotes`.
-- Em uiTags você vai definir as tags html que vão compor a seção esccreve em html cada tag com seu id. Somente da seção atual.
-- Quando definir um elemento `<ul>` em `uiTags`, nunca use placeholder vazio nem atributo auxiliar (ex.: `<ul id='s1-bullets' data-li-count='2'></ul>`). Declare os `<li>` explicitamente dentro do `<ul>`, cada um com id próprio (ex.: `<ul id="s1-bullets"><li id="s1-bullets-1"></li><li id="s1-bullets-2"></li></ul>`).
-- Todos os elmentos mais externos devem manter a mesma distancia da margem esquerda para manter uma visualização esteticamente harmoniosa na pagina. 
-- Em uiSizes você vai definir o tamanho de cada tag ( uiTags ) definindo como fica a apresentação na tela use codificação css.
-- **Lista permitida (fechada) de atributos CSS em `uiSizes`**: use exclusivamente os atributos abaixo, sem criar sinônimos, atalhos extras ou propriedades fora da lista:
-  `position`, `top`, `right`, `bottom`, `left`, `z-index`, `display`, `float`, `clear`, `visibility`, `overflow`, `overflow-x`, `overflow-y`, `width`, `height`, `min-width`, `min-height`, `max-width`, `max-height`, `box-sizing`, `margin`, `margin-top`, `margin-right`, `margin-bottom`, `margin-left`, `padding`, `padding-top`, `padding-right`, `padding-bottom`, `padding-left`, `flex`, `flex-direction`, `flex-wrap`, `flex-flow`, `justify-content`, `align-items`, `align-content`, `align-self`, `gap`, `row-gap`, `column-gap`, `order`, `flex-grow`, `flex-shrink`, `flex-basis`, `grid`, `grid-template`, `grid-template-columns`, `grid-template-rows`, `grid-template-areas`, `grid-column`, `grid-column-start`, `grid-column-end`, `grid-row`, `grid-row-start`, `grid-row-end`, `grid-area`, `justify-items`, `place-items`, `place-content`, `transform`, `translate`, `scale`, `rotate`, `transform-origin`.
-- Em uiSizes, para cada `<img>` definido em `uiTags`, especifique obrigatoriamente largura, altura, proporção e comportamento responsivo (desktop/mobile), para manter a composição estaticamente atraente.
-- Em uiSizeTexts você vai definir para cada tag de texto de ( uiTags ) o tamanho do texto em caracteres: máximo e mínimo.
-- Defina obrigatoriamente `bodyAttributes[]` para declarar os atributos do elemento `<body>` (um item por atributo), sempre com `attribute`, `value` e `notes` explicando o objetivo do atributo no layout/conversão.
-- Cada seção deve incluir todos os campos canônicos de `sectionOrder`, incluindo `surfaceSpec` e `ctaSlot`.
-- Se houver CTA na seção, preencher `ctaSlot` com `hasCta`, `ctaLabel`, `ctaVariant`, `matchAdCta` e `notes`.
-- `formPlacementNotes` deve informar momento de exposição do formulário e estratégia sticky quando aplicável.
-- Não exija nem produza campos fora do schema canônico atual (ex.: `mediaSlot`, `compositionNotes`, `messageMatchSummary`, `backgroundColorStrategy`, `textImageBalanceNotes`).
-- `consistencyChecks` deve validar continuidade comercial e aderência estrutural sem exigir campos fora do canônico.
-- Defina `formSpec` como contrato funcional do formulário (campos, consentimento e successState).
+Regras fixas da etapa (formato simplificado):
+- Entregar somente JSON válido no formato raiz `pagina`.
+- Estrutura obrigatória: `pagina.head.texto`, `pagina.corpo.estilos[]`, `pagina.corpo.secoes[]`.
+- Cada item de `estilos[]` deve ter apenas `nome` e `valor`.
+- Cada seção deve conter: `nome`, `objetivo`, `oQueQuerProvocarNoUsuario`, `id`, `estilos[]`, `elementosSeccao[]`.
+- Cada item de `elementosSeccao[]` deve conter: `id`, `tag`, `texto`, `estilos[]`, `elementosInternos[]`.
+- Campo `texto` de cada elemento deve conter exatamente: `tamMaximo`, `tamMinimo`, `conteudo`.
+- `elementosInternos` pode ser lista vazia, mas sempre deve existir.
+- Não invente campos fora do schema.
 - Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
-- Manter hero compacto e alta densidade útil acima da dobra no mobile.
-- Permitir respiros visuais entre blocos para legibilidade, porém evitar grandes áreas vazias; distribua conteúdo e elementos para não criar “buracos” extensos no layout (especialmente no mobile).
-- Reduzir distância entre promessa, prova, CTA e entendimento da oferta nas primeiras seções.
-- Mobile-first obrigatório (prioridade total): projetar cada seção primeiro para viewport entre 320px e 430px; desktop é adaptação posterior.
-- Em mobile, **proibir layout de duas colunas simultâneas para conteúdo principal** (texto + imagem lado a lado no mesmo nível). Empilhar sempre em coluna única, com ordem narrativa: promessa → explicação curta → prova/lista → CTA.
-- Cada seção deve nascer com sequência vertical explícita em `uiNotes` (ordem de leitura mobile), evitando alternância confusa esquerda/direita entre blocos consecutivos.
-- Limitar blocos de texto no mobile: no máximo 1 título + 1 parágrafo curto + 1 lista curta por seção (quando aplicável). Quebrar conteúdo longo em novas seções ao invés de condensar.
-- Para listas (`<ul>`), usar itens curtos e escaneáveis no mobile (frases objetivas), evitando listas extensas que empurrem o CTA para muito abaixo.
-- Toda seção com imagem deve definir em `uiSizes` comportamento mobile sem “vazios”: imagem com largura fluida (`width: 100%`), altura proporcional e alinhamento consistente com o bloco de texto da seção.
-- Em mobile, evitar espaços verticais excessivos: definir espaçamentos progressivos e compactos entre título, texto, lista, imagem e CTA, sem áreas mortas grandes entre seções.
-- Reforçar densidade de conversão no mobile: o primeiro CTA principal deve aparecer até o final da segunda seção e se repetir em pontos de prova/oferta sem quebrar fluidez.
-- Em `mobilePriorityScore`, seções críticas de conversão (hero, prova principal, oferta e CTA) devem receber prioridade alta e tratamento de layout compacto orientado a ação.
-- A seção de oferta deve acomodar `entryAsset` e `coreOffer` quando ambos existirem, sem assumir nomes fixos.
-- Se não houver distinção clara entre ativo inicial e oferta principal, projetar seção única coerente (sem forçar duas camadas artificiais).
-- Não usar nomenclaturas internas (`entryAsset`, `coreOffer` etc.) como rótulo visível do wireframe; usar linguagem comercial apropriada ao caso.
-- Preencher obrigatoriamente `readingFlowSpec`, `conversionPathSpec`, `proofPlan`, `trustSignalsSpec` e `accessibilitySpec` (ausência bloqueia aprovação no backend).
-- Em `readingFlowSpec`, garantir `maxParagraphLinesMobile <= 4` e `bulletDensityPerSection >= 3` (especialmente em argumento/prova).
-- Em `conversionPathSpec`, manter continuidade com CTA principal da copy (`primaryAction` + `ctaLabelCanonical`) e listar variações apenas em `ctaLabelVariantsAllowed`.
-- Em `proofPlan`, incluir pelo menos 2 tipos distintos de prova e mapear `proofSectionIds` apenas para seções existentes em `sectionOrder`.
-- Para evitar erro 422, monte `proofPlan.proofSectionIds` somente após finalizar `sectionOrder`: copie os `sectionId` literalmente de `sectionOrder` (sem renomear, traduzir, resumir ou inventar IDs).
-- Antes de responder, faça checklist final obrigatório: para cada item em `proofPlan.proofSectionIds`, confirme correspondência exata (match 1:1) com algum `sectionOrder[*].sectionId`; se não existir correspondência exata, corrija/remova o item.
-- Em `trustSignalsSpec`, para páginas com formulário: `brandIdentityRequired=true`, `privacyNoticeNearForm=true`, `privacyPolicyUrl` preenchida e `legalFooterItems` com empresa/contato/política.
-- Em `accessibilitySpec`, respeitar mínimos canônicos: `minTextContrast` >= 4.5:1, `minTouchTargetPx` >= 44 e `formFieldMinHeightPx` >= 44.
+- Evite JSON dentro de strings; mantenha cada informação no seu campo próprio.
+- Mobile-first obrigatório: priorize leitura vertical e CTA claro nas primeiras seções.
+- Para tags de lista (`ul`), sempre declarar os `li` internos explicitamente.
 
 OUTPUT_CONTRACT
-Responda em JSON válido e estritamente aderente ao artefato `landingPageWireframe`.
+Responda em JSON válido e estritamente aderente ao artefato `landingPageWireframe` simplificado.
 
-### Responsabilidade canônica de imagem nesta etapa
-
-- Defina no wireframe todos os itens estruturais de imagem por seção (ex.: `sectionId`, `imageBindingKey`, objetivo visual e restrições de composição/layout).
-- A página deve ser visualmente rica: planeje imagens em alta cobertura de seções, priorizando hero, dor, mecanismo, prova, oferta e CTA com contexto visual claro (evitar blocos longos sem apoio visual).
-- Cada seção com potencial de conversão deve explicitar imagem conectada ao eixo **Dor → Resultado** do nicho (mostrar problema real, transformação esperada e evidência prática da melhora).
-- Em cada objetivo visual, descreva a cena de forma concreta para refletir a dor principal do nicho e o resultado desejado (antes/depois, contraste de estado, ganho percebido, redução de esforço).
-- Variar o tipo de imagem entre seções (ex.: contexto da dor, demonstração de mecanismo, prova social/documental, visual da oferta) para evitar repetição e aumentar percepção de valor.
-- O estágio `landing-page-image-planning` **não pode redefinir** esses campos estruturais; ele apenas consome o que veio do wireframe e gera o prompt final para o modelo de imagem.
 Campos obrigatórios:
-- pageGoal
-- variantLayoutId
-- bodyAttributes[] com attribute, value, notes (lista obrigatória de atributos definidos para o `<body>`).
-- sectionOrder[] com sectionId, sectionName, objective, contentType, copySource, uiNotes, uiTags, uiSizes, messageMatchDependency, sectionDependsOn, mobilePriorityScore, dropOffRisk, surfaceSpec, ctaSlot
-- mobilePriorityNotes
-- ctaPlacementNotes
-- formPlacementNotes
-- readingFlowSpec
-- conversionPathSpec
-- proofPlan
-- trustSignalsSpec
-- accessibilitySpec
-- consistencyChecks[]
-- formSpec
-
-Observação canônica:
-- Em `surfaceSpec` do wireframe, trate `surfaceToken` + `notes` como núcleo obrigatório estrutural.
-- `style` e `contrastMode` são responsabilidade da etapa `landingPageDesignPreset.sectionPresets`.
+- pagina
+- pagina.head.texto
+- pagina.corpo.estilos[] com nome, valor
+- pagina.corpo.secoes[] com nome, objetivo, oQueQuerProvocarNoUsuario, id, estilos, elementosSeccao
+- pagina.corpo.secoes[].elementosSeccao[] com id, tag, texto, estilos, elementosInternos
+- pagina.corpo.secoes[].elementosSeccao[].texto com tamMaximo, tamMinimo, conteudo
 
 Formato de resposta:
 - Precisamos da resposta em Json-Schema.

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -4,3 +4,5 @@
 > Neste documento segue política de **append-only** (não pode ter nenhuma linha apagada; apenas inserções).
 
 - 2026-05-12 09:25:00 UTC-3 — Atualizado o contrato da etapa landing-page-wireframe para formato JSON simplificado com raiz `pagina` (head/corpo/secoes/elementos), incluindo novo schema e regras de prompt alinhadas ao novo payload.
+
+- 2026-05-12 09:40:00 UTC-3 — Ajustado o contrato para explicitar que `elementosInternos` em `elementosSeccao` é recursivo (filhos, netos e níveis seguintes com o mesmo schema), alinhando regra de composição de seção.

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -2,3 +2,5 @@
 
 > Orientação: todos os registros deste documento devem sempre incluir **data e hora no fuso UTC-3**.
 > Neste documento segue política de **append-only** (não pode ter nenhuma linha apagada; apenas inserções).
+
+- 2026-05-12 09:25:00 UTC-3 — Atualizado o contrato da etapa landing-page-wireframe para formato JSON simplificado com raiz `pagina` (head/corpo/secoes/elementos), incluindo novo schema e regras de prompt alinhadas ao novo payload.


### PR DESCRIPTION
### Motivation
- Reduzir a complexidade do artefato gerado pela etapa de `gera wireframe` para um JSON mais simples e previsível com raiz `pagina` para facilitar consumo por etapas subsequentes.
- Evitar JSON embutido em strings e limitar o contrato a campos claramente tipados para reduzir erros de validação e necessidade de pós-processamento manual.

### Description
- Substitui o schema canônico de wireframe por um formato simplificado com raiz `pagina` em `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` que define `pagina.head.texto`, `pagina.corpo.estilos[]` e `pagina.corpo.secoes[]` com `elementosSeccao` e `texto` (`tamMaximo`, `tamMinimo`, `conteudo`).
- Atualiza o prompt da etapa em `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` para `template_version: v2` e regras que exigem estrita conformidade ao novo contrato simplificado (proibição de campos fora do schema, itens obrigatórios e orientações mobile-first e para listas). 
- Remove/omite do contrato simplificado os blocos avançados do formato anterior (ex.: `sectionOrder`, `consistencyChecks`, `proofPlan`, `trustSignalsSpec`, `readingFlowSpec` etc.) para enfocar um payload mínimo e bem-estruturado.
- Registra a mudança no log append-only de Gera Landing em `docs/gera-landing/registros3.md` com data/hora UTC-3 e descrição da alteração.

### Testing
- Executei os testes direcionados com `mvn -f ai-worker/pom.xml -Dtest=GeraLandingServiceTest,GeraLandingExecutionServiceTest test` para validar integração do prompt/schema com o fluxo de execução do módulo `ai-worker`.
- A execução do build/testes falhou por resolução de dependência privada ausente (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`) retornando `401 Unauthorized` do repositório GitHub Packages, portanto os testes não puderam ser concluídos com sucesso.
- Não foram alteradas classes Java de produção além dos recursos de prompt/schema, e os testes de unidade locais foram preparados para rodar assim que a dependência privada for disponibilizada ou instalada localmente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0333e7e1d083219080f47f3fc5f6ee)