### PR TITLE
Fix landing-page-wireframe JSON schema recursion for OpenAI structured outputs

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -26,20 +26,7 @@
               "type": "array",
               "minItems": 1,
               "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "nome": {
-                    "type": "string"
-                  },
-                  "valor": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "nome",
-                  "valor"
-                ]
+                "$ref": "#/$defs/estilo"
               }
             },
             "secoes": {
@@ -65,93 +52,14 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "nome": {
-                          "type": "string"
-                        },
-                        "valor": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "nome",
-                        "valor"
-                      ]
+                      "$ref": "#/$defs/estilo"
                     }
                   },
                   "elementosSeccao": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "tag": {
-                          "type": "string"
-                        },
-                        "texto": {
-                          "type": "object",
-                          "additionalProperties": false,
-                          "properties": {
-                            "tamMaximo": {
-                              "type": "integer",
-                              "minimum": 1
-                            },
-                            "tamMinimo": {
-                              "type": "integer",
-                              "minimum": 1
-                            },
-                            "conteudo": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "tamMaximo",
-                            "tamMinimo",
-                            "conteudo"
-                          ]
-                        },
-                        "estilos": {
-                          "type": "array",
-                          "minItems": 1,
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                              "nome": {
-                                "type": "string"
-                              },
-                              "valor": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "nome",
-                              "valor"
-                            ]
-                          }
-                        },
-                        "elementosInternos": {
-                          "type": "array",
-                          "description": "Lista recursiva de elementos internos com a mesma estrutura do elemento pai.",
-                          "minItems": 0,
-                          "items": {
-                            "$ref": "#/properties/pagina/properties/corpo/properties/secoes/items/properties/elementosSeccao/items"
-                          }
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "tag",
-                        "texto",
-                        "estilos",
-                        "elementosInternos"
-                      ]
+                      "$ref": "#/$defs/elementoSecao"
                     }
                   }
                 },
@@ -180,5 +88,82 @@
   },
   "required": [
     "pagina"
-  ]
+  ],
+  "$defs": {
+    "estilo": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nome": {
+          "type": "string"
+        },
+        "valor": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "nome",
+        "valor"
+      ]
+    },
+    "textoElemento": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tamMaximo": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "tamMinimo": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "conteudo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tamMaximo",
+        "tamMinimo",
+        "conteudo"
+      ]
+    },
+    "elementoSecao": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "texto": {
+          "$ref": "#/$defs/textoElemento"
+        },
+        "estilos": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/estilo"
+          }
+        },
+        "elementosInternos": {
+          "type": "array",
+          "description": "Lista recursiva de elementos internos com a mesma estrutura do elemento pai.",
+          "minItems": 0,
+          "items": {
+            "$ref": "#/$defs/elementoSecao"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "tag",
+        "texto",
+        "estilos",
+        "elementosInternos"
+      ]
+    }
+  }
 }

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -6,3 +6,4 @@
 - 2026-05-12 09:25:00 UTC-3 — Atualizado o contrato da etapa landing-page-wireframe para formato JSON simplificado com raiz `pagina` (head/corpo/secoes/elementos), incluindo novo schema e regras de prompt alinhadas ao novo payload.
 
 - 2026-05-12 09:40:00 UTC-3 — Ajustado o contrato para explicitar que `elementosInternos` em `elementosSeccao` é recursivo (filhos, netos e níveis seguintes com o mesmo schema), alinhando regra de composição de seção.
+- 2026-05-12 10:05:00 UTC-3 — Corrigido o schema da etapa landing-page-wireframe para compatibilidade com OpenAI Structured Outputs: a recursão de `elementosInternos` passou a referenciar `#/$defs/elementoSecao` definido no topo do schema, evitando erro 400 `invalid_json_schema` por referência fora de definições top-level.


### PR DESCRIPTION
### Motivation
- Prevent OpenAI Responses API `400 invalid_json_schema` errors by making recursive references point only to top-level definitions, ensuring compatibility with `response_format` in `strict: true` mode.

### Description
- Add a top-level `$defs` containing reusable definitions `estilo`, `textoElemento` and `elementoSecao` in `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json`.
- Replace inline object definitions with `$ref` to `#/$defs/*` and make `elementosInternos.items` reference `#/$defs/elementoSecao` to support recursion allowed by OpenAI structured-output validators.
- Update `docs/gera-landing/registros3.md` with an append-only note describing the fix and timestamp the change.
- Commit changes to the `ai-worker` prompt/schema assets so the `gera wireframe` step uses the revised schema.

### Testing
- Ran the module unit test command `mvn -f ai-worker/pom.xml -Dtest=ExperimentPipelineOpenAiClientTest test`, which failed due to an unresolved local dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT` returning a 401 from the configured package repository, so tests could not complete.
- No further automated tests were run in this environment; the schema change is targeted to address the OpenAI validation error observed in production (`invalid_json_schema`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033da405448321b9d0a67c7b3f808a)