### PR TITLE
Add Hotmart access token setting and admin UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/settings/GeneralSettingKeys.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/settings/GeneralSettingKeys.java
@@ -5,6 +5,7 @@ public final class GeneralSettingKeys {
     public static final String EMAIL_SERVICE_SMTP = "email_service_smtp";
     public static final String LEAD_PORTAL_EMAIL_TEMPLATE_HTML = "lead_portal_email_template_html";
     public static final String LEAD_PORTAL_EMAIL_TEMPLATE_SUBJECT = "lead_portal_email_template_subject";
+    public static final String HOTMART_ACCESS_TOKEN_JWT = "hotmart_access_token_jwt";
 
     private GeneralSettingKeys() {
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -131,6 +131,7 @@ import MdsWorkspacePage from "./pages/mds/MdsWorkspacePage";
 import MdsRequestDetailPage from "./pages/mds/MdsRequestDetailPage";
 import MdsArtifactsPage from "./pages/mds/MdsArtifactsPage";
 import MdsReportPage from "./pages/mds/MdsReportPage";
+import HotmartPage from "./pages/hotmart/HotmartPage";
 
 export default function App() {
   return (
@@ -292,6 +293,7 @@ export default function App() {
               <Route path="/mds/requests/:requestId" element={<MdsRequestDetailPage />} />
               <Route path="/mds/requests/:requestId/artifacts" element={<MdsArtifactsPage />} />
               <Route path="/mds/reports/:requestId" element={<MdsReportPage />} />
+              <Route path="/hotmart" element={<HotmartPage />} />
               <Route
                 path="/oprm/routine/:occupationSeedRef"
                 element={<OprmRoutinePage />}

--- a/frontend/src/api/settings/useHotmartAccessTokenSetting.ts
+++ b/frontend/src/api/settings/useHotmartAccessTokenSetting.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface GeneralSetting {
+  name: string;
+  value: string | null;
+  updatedAt: string | null;
+}
+
+export const HOTMART_ACCESS_TOKEN_SETTING_NAME = "hotmart_access_token_jwt";
+
+export function useHotmartAccessTokenSetting() {
+  return useQuery({
+    queryKey: ["general-setting", HOTMART_ACCESS_TOKEN_SETTING_NAME],
+    queryFn: async () => {
+      try {
+        const { data } = await axios.get<GeneralSetting>(
+          `/api/settings/${HOTMART_ACCESS_TOKEN_SETTING_NAME}`,
+        );
+        return data;
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          return {
+            name: HOTMART_ACCESS_TOKEN_SETTING_NAME,
+            value: null,
+            updatedAt: null,
+          } satisfies GeneralSetting;
+        }
+        throw error;
+      }
+    },
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useUpdateHotmartAccessTokenSetting() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (value: string) => {
+      const payload = { value };
+      const { data } = await axios.put<GeneralSetting>(
+        `/api/settings/${HOTMART_ACCESS_TOKEN_SETTING_NAME}`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(
+        ["general-setting", HOTMART_ACCESS_TOKEN_SETTING_NAME],
+        data,
+      );
+    },
+  });
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -108,6 +108,7 @@ const NAV_SECTIONS: NavSection[] = [
       { to: "/mois", label: "MOIS", icon: Workflow },
       { to: "/oprm", label: "OPRM", icon: Workflow },
       { to: "/mds", label: "MDS", icon: Microscope },
+      { to: "/hotmart", label: "Hotmart", icon: Workflow },
     ],
   },
   {

--- a/frontend/src/pages/hotmart/HotmartPage.tsx
+++ b/frontend/src/pages/hotmart/HotmartPage.tsx
@@ -1,0 +1,112 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import PageTitle from "../../components/PageTitle";
+import {
+  useHotmartAccessTokenSetting,
+  useUpdateHotmartAccessTokenSetting,
+} from "../../api/settings/useHotmartAccessTokenSetting";
+
+function formatUpdatedAt(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function HotmartPage() {
+  const { data, isLoading, isError } = useHotmartAccessTokenSetting();
+  const updateSetting = useUpdateHotmartAccessTokenSetting();
+  const [tokenValue, setTokenValue] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (data) {
+      setTokenValue(data.value ?? "");
+    }
+  }, [data?.value]);
+
+  const updatedAt = useMemo(() => formatUpdatedAt(data?.updatedAt), [data?.updatedAt]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFeedback(null);
+
+    const trimmed = tokenValue.trim();
+    if (!trimmed) {
+      setFeedback("Informe o token JWT de acesso da Hotmart.");
+      return;
+    }
+
+    try {
+      await updateSetting.mutateAsync(trimmed);
+      setFeedback("Token salvo com sucesso.");
+    } catch {
+      setFeedback("Não foi possível salvar o token. Tente novamente.");
+    }
+  };
+
+  return (
+    <div className="mt-3">
+      <PageTitle>Hotmart</PageTitle>
+
+      <section className="card mt-3 shadow-sm border-0">
+        <div className="card-header">
+          <h5 className="mb-1">Token de acesso</h5>
+          <p className="text-muted small mb-0">
+            Cole aqui o JWT obtido no login da Hotmart para uso nas integrações deste módulo.
+          </p>
+        </div>
+        <div className="card-body">
+          {isLoading ? <p className="mb-0">Carregando token...</p> : null}
+          {isError ? (
+            <p className="text-danger mb-0">Não foi possível carregar o token salvo.</p>
+          ) : null}
+
+          {!isLoading && !isError ? (
+            <form onSubmit={handleSubmit} className="d-flex flex-column gap-3" noValidate>
+              <div>
+                <label htmlFor="hotmartAccessToken" className="form-label fw-semibold">
+                  JWT Hotmart <span className="text-danger">*</span>
+                </label>
+                <textarea
+                  id="hotmartAccessToken"
+                  className="form-control"
+                  rows={6}
+                  value={tokenValue}
+                  onChange={(event) => setTokenValue(event.target.value)}
+                  placeholder="Cole aqui o token JWT"
+                  required
+                />
+                <div className="form-text">Última atualização: {updatedAt}</div>
+              </div>
+
+              <div className="d-flex gap-2">
+                <button
+                  type="submit"
+                  className="btn btn-primary"
+                  disabled={updateSetting.isPending}
+                >
+                  {updateSetting.isPending ? (
+                    <>
+                      <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
+                      Salvando...
+                    </>
+                  ) : (
+                    "Salvar"
+                  )}
+                </button>
+              </div>
+            </form>
+          ) : null}
+
+          {feedback ? <div className="alert alert-info mt-3 mb-0">{feedback}</div> : null}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a place to store and manage the Hotmart JWT access token used by Hotmart integrations. 
- Expose the token as a general setting so it can be read/updated by the UI and other services.

### Description
- Add a new general setting key `HOTMART_ACCESS_TOKEN_JWT` in `GeneralSettingKeys.java` to represent the `hotmart_access_token_jwt` setting. 
- Add a React query hook pair `useHotmartAccessTokenSetting` and `useUpdateHotmartAccessTokenSetting` in `frontend/src/api/settings/useHotmartAccessTokenSetting.ts` to GET and PUT the general setting via `/api/settings/hotmart_access_token_jwt`. 
- Implement a new admin page `HotmartPage` at `frontend/src/pages/hotmart/HotmartPage.tsx` that displays, edits, and saves the JWT with loading/error/feedback UI and formatted `updatedAt`. 
- Wire the page into the app by importing it in `App.tsx` and adding a route at `/hotmart`, and add a navigation item to `MainNavigation.tsx` linking to the new page.

### Testing
- Ran the frontend build/type-check and unit test suite via `yarn build` and `yarn test`, and they completed successfully. 
- Ran the backend ads-service tests via `./gradlew :ads-service:test` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0359e7876c8321a00c4db9c06474ba)