### PR TITLE
Adapta montador HTML provisório ao novo JSON de wireframe (pagina/corpo/secoes)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/WireframeHtmlGenerator.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/WireframeHtmlGenerator.java
@@ -1,17 +1,26 @@
 package com.marketinghub.geralanding;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class WireframeHtmlGenerator {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     public String generateFromJson(String json) {
         if (!StringUtils.hasText(json)) {
             return null;
+        }
+
+        if (json.contains("\"pagina\"") && json.contains("\"corpo\"") && json.contains("\"secoes\"")) {
+            return generateFromPaginaJson(json);
         }
 
         String sectionOrder = extractSectionOrderArray(json);
@@ -52,6 +61,86 @@ public class WireframeHtmlGenerator {
         html.append("</html>\n");
 
         return html.toString();
+    }
+
+    private String generateFromPaginaJson(String json) {
+        try {
+            Map<String, Object> root = OBJECT_MAPPER.readValue(json, new TypeReference<>() {});
+            Map<String, Object> pagina = asMap(root.get("pagina"));
+            Map<String, Object> head = asMap(pagina.get("head"));
+            Map<String, Object> corpo = asMap(pagina.get("corpo"));
+
+            StringBuilder html = new StringBuilder();
+            html.append("<!doctype html>\n<html lang=\"pt-BR\">\n<head>\n<meta charset=\"UTF-8\">\n")
+                .append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n")
+                .append("<title>").append(escapeHtmlText(asText(head.get("texto"), "Wireframe provisório"))).append("</title>\n")
+                .append("<style>\n").append(baseCss());
+            html.append("\nbody{").append(renderInlineStyle(asList(corpo.get("estilos")))).append("}\n");
+            html.append("</style>\n</head>\n<body>\n");
+            for (Map<String, Object> secao : asList(corpo.get("secoes"))) {
+                html.append(renderElement(secao, "elementosSeccao", "section"));
+            }
+            html.append("</body>\n</html>\n");
+            return html.toString();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Falha ao renderizar novo JSON de wireframe", e);
+        }
+    }
+
+    private String renderElement(Map<String, Object> node, String childKey, String defaultTag) {
+        String tag = asText(node.get("tag"), defaultTag);
+        String id = asText(node.get("id"), "");
+        String style = renderInlineStyle(asList(node.get("estilos")));
+        StringBuilder out = new StringBuilder();
+        out.append("<").append(tag);
+        if (StringUtils.hasText(id)) out.append(" id=\"").append(escapeHtmlAttribute(id)).append("\"");
+        if (StringUtils.hasText(style)) out.append(" style=\"").append(escapeHtmlAttribute(style)).append("\"");
+        out.append(">");
+        out.append(resolveText(node));
+        for (Map<String, Object> child : asList(node.get("elementosInternos"))) {
+            out.append(renderElement(child, "elementosInternos", "div"));
+        }
+        for (Map<String, Object> child : asList(node.get(childKey))) {
+            out.append(renderElement(child, "elementosInternos", "div"));
+        }
+        out.append("</").append(tag).append(">\n");
+        return out.toString();
+    }
+
+    private String resolveText(Map<String, Object> node) {
+        Map<String, Object> texto = asMap(node.get("texto"));
+        String content = asText(texto.get("conteudo"), "").trim();
+        return escapeHtmlText(StringUtils.hasText(content) ? content : "Lorem ipsum dolor sit amet.");
+    }
+
+    private String renderInlineStyle(List<Map<String, Object>> estilos) {
+        StringBuilder out = new StringBuilder();
+        for (Map<String, Object> estilo : estilos) {
+            String nome = asText(estilo.get("nome"), "");
+            String valor = asText(estilo.get("valor"), "");
+            if (StringUtils.hasText(nome) && StringUtils.hasText(valor)) {
+                out.append(nome).append(":").append(valor).append(";");
+            }
+        }
+        return out.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> asMap(Object value) {
+        return value instanceof Map<?, ?> map ? (Map<String, Object>) map : Map.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> asList(Object value) {
+        return value instanceof List<?> list ? (List<Map<String, Object>>) list : List.of();
+    }
+
+    private String asText(Object value, String fallback) {
+        return value instanceof String text && StringUtils.hasText(text) ? text : fallback;
+    }
+
+    private static String escapeHtmlText(String value) {
+        return escapeHtmlAttribute(value);
     }
 
     private static String baseCss() {

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/WireframeHtmlGeneratorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/WireframeHtmlGeneratorTest.java
@@ -62,4 +62,37 @@ class WireframeHtmlGeneratorTest {
         assertTrue(html.contains("background:#111111;color:#ffffff"));
         assertTrue(html.contains("form id=\"f1\" style=\"background:#dcfce7;color:#14532d;border:1px solid #86efac;border-radius:12px;padding:16px;\""));
     }
+
+    @Test
+    void shouldRenderNewPaginaCorpoSecoesStructure() {
+        String json = """
+            {
+              "pagina": {
+                "head": {"texto": "Wireframe Novo"},
+                "corpo": {
+                  "estilos": [{"nome":"max-width","valor":"680px"}],
+                  "secoes": [
+                    {
+                      "id": "s1-hero",
+                      "estilos": [{"nome":"padding","valor":"20px"}],
+                      "elementosSeccao": [
+                        {"id":"el-1","tag":"h1","texto":{"conteudo":""},"estilos":[]},
+                        {"id":"el-2","tag":"p","texto":{"conteudo":"Texto real"},"estilos":[]}
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+            """;
+
+        WireframeHtmlGenerator generator = new WireframeHtmlGenerator();
+        String html = generator.generateFromJson(json);
+
+        assertNotNull(html);
+        assertTrue(html.contains("<section id=\"s1-hero\""));
+        assertTrue(html.contains("<h1 id=\"el-1\">Lorem ipsum dolor sit amet."));
+        assertTrue(html.contains("<p id=\"el-2\">Texto real</p>"));
+        assertTrue(html.contains("body{max-width:680px;}"));
+    }
 }

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -9,3 +9,5 @@
 - 2026-05-12 10:05:00 UTC-3 — Corrigido o schema da etapa landing-page-wireframe para compatibilidade com OpenAI Structured Outputs: a recursão de `elementosInternos` passou a referenciar `#/$defs/elementoSecao` definido no topo do schema, evitando erro 400 `invalid_json_schema` por referência fora de definições top-level.
 
 - 2026-05-12 10:20:00 UTC-3 — Restringido de forma rígida o campo `nome` de cada item de `estilos` no schema da etapa `landing-page-wireframe` para aceitar somente whitelist de atributos CSS estruturais permitidos (layout/posicionamento/flex/grid/transform), bloqueando nomes fora da lista.
+
+- 2026-05-12 14:40:00 UTC-3 — Atualizado o montador de HTML provisório da etapa landing-page-wireframe para suportar o novo payload com raiz `pagina`/`corpo`/`secoes`/`elementosSeccao`, renderização recursiva de elementos e fallback em Lorem Ipsum quando `texto.conteudo` vier vazio.


### PR DESCRIPTION
### Motivation

- O estágio `landing-page-wireframe` passou a gerar um JSON com raiz `pagina`/`corpo`/`secoes`, portanto o montador de HTML provisório precisava suportar o novo formato para não quebrar a etapa de geração de landing wireframes.
- É necessário preservar compatibilidade com o formato legado (`sectionOrder`) para evitar regressões em fluxos existentes.
- Quando o conteúdo de texto não estiver disponível no novo JSON, é obrigatório inserir um fallback em Lorem Ipsum para manter renderizações determinísticas e aprováveis.

### Description

- Atualiza `WireframeHtmlGenerator` para detectar o novo payload e delegar a `generateFromPaginaJson` quando o JSON contiver `"pagina"/"corpo"/"secoes"` e mantém o caminho legado baseado em `sectionOrder` para compatibilidade retroativa.
- Implementa renderização recursiva de elementos com `renderElement`, suportando `id`, `tag`, `estilos` (transformados em `style` inline) e `elementosInternos`/`elementosSeccao` aninhados.
- Adiciona fallback de texto: `texto.conteudo` vazio é substituído por `Lorem ipsum dolor sit amet.` e estilos inline são montados por `renderInlineStyle` para preservar a estética provisória.
- Inclui um teste unitário novo em `WireframeHtmlGeneratorTest` que valida a renderização do novo `pagina/corpo/secoes` e atualiza o registro de mudanças em `docs/gera-landing/registros3.md`.

### Testing

- Executei `cd backend/ads-service && ../mvnw -Dtest=WireframeHtmlGeneratorTest,WireframeProvisionalHtmlAssemblerTest test` e todos os testes relevantes passaram (6 testes, 0 falhas).
- Os testes cobrem tanto o comportamento legado (`sectionOrder`) quanto o novo formato (`pagina/corpo/secoes`) e valida o fallback de Lorem Ipsum e a aplicação de estilos inline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0363cb51488321b68225e8130d2a79)