### PR TITLE
Add optional allowlisted `shell_exec` tool and Minecraft Bedrock texture diagnostic doc

### DIFF
--- a/docs/minecraft-bedrock-texture-diagnostico.md
+++ b/docs/minecraft-bedrock-texture-diagnostico.md
@@ -1,0 +1,124 @@
+# Diagnóstico: item/textura preto e rosa (magenta) no Minecraft Bedrock
+
+## Sintoma observado
+
+O padrão preto e rosa/magenta indica **textura ausente** (missing texture) no cliente Bedrock.
+
+No print enviado, o item aparece como `item:digicom:goo`, o que sugere addon/resource pack customizado com referência inválida para textura.
+
+## O que foi verificado no MCP do projeto
+
+No endpoint MCP do projeto (`https://mcpserverdigi.shop/mcp`), a lista de tools disponível hoje inclui:
+
+- `db_health`, `db_list_tables`, `db_read_table`, `db_query`
+- `java_module_logs`
+- `meta_docs_get`, `meta_graph_get`, `meta_graph_debug_token`
+- ferramentas de GitHub Actions
+
+Não há tool específica para Minecraft/resource pack. Então a causa precisa ser tratada no pacote Bedrock (manifest, paths, cache, compatibilidade de versão), não em configuração do MCP deste projeto.
+
+## Sobre “executar comandos Linux pelo MCP Server”
+
+Você está correto: **em alguns MCP servers existe tool de shell/exec para rodar comandos Linux remotamente**.
+
+No MCP deste projeto, durante esta investigação, essa capability **não apareceu no `tools/list`**. Se essa tool for habilitada depois (ex.: `shell_exec`, `run_command`, `terminal_exec`), ela pode ser usada para auditoria do host com foco em causa-raiz.
+
+### Comandos Linux que valem ouro quando shell remoto estiver disponível
+
+1. **Localizar packs e nomes suspeitos (`digicom`, `goo`)**
+   - `find / -type f \( -name '*.mcpack' -o -name 'manifest.json' -o -name '*.png' \) 2>/dev/null | rg -i 'digicom|goo|resource_packs|behavior_packs'`
+
+2. **Validar estrutura de pastas (evitar `pack/pack/...`)**
+   - `find <PASTA_DO_PACK> -maxdepth 3 -type d | sort`
+
+3. **Conferir manifesto e UUID/version**
+   - `cat <PASTA_DO_PACK>/manifest.json`
+
+4. **Checar se PNG referenciado realmente existe**
+   - `rg -n 'digicom|goo|texture' <PASTA_DO_PACK>`
+
+5. **Permissões e dono dos arquivos**
+   - `find <PASTA_DO_PACK> -type f -print0 | xargs -0 ls -l`
+
+6. **Hashes para detectar deploy antigo/cacheado**
+   - `find <PASTA_DO_PACK> -type f -name '*.png' -print0 | xargs -0 sha256sum | sort`
+
+> Mesmo com shell remoto, o diagnóstico mais comum continua sendo erro no pack (manifest/path/cache), e não `server.properties`.
+
+## Tentativa real de execução de comandos no host via MCP
+
+Foi feita tentativa prática de executar comando Linux no host pelo MCP (`tools/call`), com os nomes de tool mais comuns:
+
+- `shell_exec` → retorno JSON-RPC: `Unknown tool: shell_exec`.
+- `run_command` / `execute_command` → tentativas com timeout de upstream no endpoint.
+
+Interpretação técnica:
+
+1. No momento da análise, **não há evidência de tool de shell exposta de forma estável** neste MCP.
+2. Sem tool de execução remota disponível, não é possível rodar `find`, `cat`, `sha256sum` diretamente no host via MCP nesta sessão.
+3. A investigação viável ficou limitada às tools funcionais de dados/logs já descritas.
+
+## Pesquisa no MCP Server (servidor do projeto)
+
+Foi feita investigação direta no MCP remoto para verificar se o problema poderia estar em dados/serviços do servidor:
+
+- `tools/list`: confirmou que não existe tool específica para Minecraft packs/textures.
+- `db_list_tables`: banco com 176 tabelas do ecossistema Marketing Hub.
+- `db_query` em `information_schema.tables` para padrões `minecraft`, `texture`, `pack`, `digicom`: retornou apenas tabelas internas de pacotes/entregáveis de imagem (`deliverable_package`, `image_deliverable_package` etc.), sem domínio de assets de Minecraft.
+- `java_module_logs` (backend e ai-worker): logs com stacktrace de persistência Hibernate, sem referência a `minecraft`, `digicom:goo` ou erro de carregamento de textura.
+
+**Conclusão da busca no servidor:** não há evidência de que a causa esteja no servidor MCP/Marketing Hub. O defeito permanece caracterizado como problema de addon/resource pack Bedrock no cliente/mundo.
+
+## Evidências técnicas (Microsoft + Minecraft docs)
+
+De acordo com a documentação oficial do ecossistema Bedrock:
+
+1. Todo resource/behavior pack precisa de `manifest.json` válido, com UUIDs e versões consistentes.
+2. O Minecraft usa UUID + version para decidir se substitui pack já importado (se versão igual/menor, pode ignorar atualização).
+3. A recomendação atual de plataforma é alinhar `min_engine_version` com versões recentes e manter `format_version` de manifest em `2` para packs.
+4. Estrutura e tipos de arquivo da pasta do pack precisam estar corretos para o Bedrock carregar os assets (`.png`, `.json`, caminhos esperados).
+
+## Causa-raiz mais provável para o seu caso
+
+Como **nenhuma textura funciona** e até item de orientação ficou preto/rosa, a chance maior é uma destas:
+
+1. `manifest.json` inválido/incompatível (UUID repetido, módulo errado, versão não atualizada).
+2. Caminho/nome de textura divergente do identifier do item (`item:digicom:goo`).
+3. Pack antigo em cache (mesmo UUID/versão), impedindo recarga correta.
+4. Addon convertido de Java para Bedrock com estrutura de pastas/nomes não compatível.
+
+## Resposta direta à sua dúvida
+
+> "Será que falta configuração no `server.properties` para aceitar texturas?"
+
+**Na maioria dos casos, não.** O preto/rosa geralmente é problema do **pack no cliente/world pack**, não permissão do servidor para “aceitar textura”.
+
+## Checklist de correção (ordem recomendada)
+
+1. **Validar `manifest.json` do resource pack**
+   - `format_version: 2`
+   - `header.uuid` único
+   - `modules[].uuid` diferente do `header.uuid`
+   - `version` incrementada (ex.: de `[1,0,0]` para `[1,0,1]`)
+   - `min_engine_version` compatível com sua versão Bedrock
+
+2. **Conferir tipo de módulo**
+   - no resource pack, módulo deve ser `"type": "resources"`.
+
+3. **Revisar o item com erro (`digicom:goo`)**
+   - conferir o arquivo JSON do item e a referência literal da textura.
+   - conferir se o PNG existe no caminho exato (incluindo maiúsculas/minúsculas).
+
+4. **Forçar refresh de cache de pack**
+   - mudar UUIDs (header e module) + subir versão.
+   - remover/importar novamente o `.mcpack`/addon.
+
+5. **Testar sem conflito**
+   - ativar **só** esse pack no mundo (desativar outros temporariamente).
+
+6. **Reinstalar apenas o pack**
+   - baixar/exportar novamente do original, evitando zip com pasta duplicada (`pack/pack/...`).
+
+## Resultado esperado
+
+Após corrigir manifest + path da textura e forçar nova identidade (UUID/version), o item deixa de renderizar em preto/rosa e passa a usar o PNG definido.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -24,6 +24,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `github_actions_list_workflows`: lista workflows do repositório configurado no GitHub Actions.
 - `github_actions_list_runs`: lista execuções (runs) de workflows do repositório configurado no GitHub Actions.
 - `github_actions_get_run_summary`: verifica se uma execução terminou com sucesso e detalha jobs/steps com falha.
+- `shell_exec`: executa comando Linux no host com allowlist e timeout de segurança (desabilitado por padrão).
 
 ## Executar localmente
 
@@ -65,6 +66,27 @@ O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou
 Timeout de leitura HTTP por módulo: `MCP_LOG_FETCH_TIMEOUT_SECONDS` (default `45`).
 
 Limite máximo por chamada: `MCP_LOG_MAX_LINES` (default `500`).
+
+
+## Ferramenta de shell remoto (Linux)
+
+A tool de execução de comandos Linux pode ser habilitada por configuração:
+
+- `MCP_SHELL_ENABLED` (default `false`);
+- `MCP_SHELL_TIMEOUT_SECONDS` (default `20`);
+- `MCP_SHELL_MAX_OUTPUT_CHARS` (default `12000`);
+- `MCP_SHELL_ALLOWED_COMMANDS` (CSV, default `find,cat,rg,ls,sha256sum,head,tail,pwd,uname`).
+
+Quando `MCP_SHELL_ENABLED=false`, a chamada `tools/call` para `shell_exec` retorna:
+`shell tools are disabled (set mcp.shell.enabled=true)`.
+
+Exemplo de chamada:
+
+```bash
+curl -sS https://mcpserverdigi.shop/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"shell_exec","arguments":{"command":"uname -a"}}}'
+```
 
 ## Ferramentas de diagnóstico Meta
 

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -18,7 +18,8 @@ public record McpProperties(
         String apiKey,
         @NotNull @Valid Logs logs,
         @NotNull @Valid Meta meta,
-        @NotNull @Valid Github github
+        @NotNull @Valid Github github,
+        @NotNull @Valid Shell shell
 ) {
     public record Logs(
             @NotBlank String backendPath,
@@ -35,6 +36,15 @@ public record McpProperties(
             @Positive int fetchRetryDelayMillis,
             @Positive int maxLines,
             @Positive int httpTailRangeBytes
+    ) {
+    }
+
+
+    public record Shell(
+            boolean enabled,
+            @Positive int timeoutSeconds,
+            @Positive int maxOutputChars,
+            @NotEmpty List<@NotBlank String> allowedCommands
     ) {
     }
 

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -5,6 +5,7 @@ import com.marketinghub.mcpserver.service.DatabaseDiagnosticsService;
 import com.marketinghub.mcpserver.service.MetaDiagnosticsService;
 import com.marketinghub.mcpserver.service.GithubActionsService;
 import com.marketinghub.mcpserver.service.ModuleLogService;
+import com.marketinghub.mcpserver.service.ShellCommandService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,17 +40,20 @@ public class McpController {
     private final ModuleLogService moduleLogService;
     private final MetaDiagnosticsService metaDiagnosticsService;
     private final GithubActionsService githubActionsService;
+    private final ShellCommandService shellCommandService;
 
     public McpController(McpProperties properties,
                          DatabaseDiagnosticsService databaseDiagnosticsService,
                          ModuleLogService moduleLogService,
                          MetaDiagnosticsService metaDiagnosticsService,
-                         GithubActionsService githubActionsService) {
+                         GithubActionsService githubActionsService,
+                         ShellCommandService shellCommandService) {
         this.properties = properties;
         this.databaseDiagnosticsService = databaseDiagnosticsService;
         this.moduleLogService = moduleLogService;
         this.metaDiagnosticsService = metaDiagnosticsService;
         this.githubActionsService = githubActionsService;
+        this.shellCommandService = shellCommandService;
     }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
@@ -209,6 +213,17 @@ public class McpController {
                                                     "description", "ID do workflow run no GitHub Actions.")),
                                     "required", List.of("run_id"),
                                     "additionalProperties", false)
+                                        ),
+                    Map.of(
+                            "name", "shell_exec",
+                            "description", "Executa comando Linux no host com allowlist e timeout de segurança.",
+                            "inputSchema", Map.of(
+                                    "type", "object",
+                                    "properties", Map.of(
+                                            "command", Map.of("type", "string",
+                                                    "description", "Comando Linux permitido pela allowlist.")),
+                                    "required", List.of("command"),
+                                    "additionalProperties", false)
                     )))));
             case "tools/call" -> ResponseEntity.ok(callTool(id, request));
             default -> ResponseEntity.ok(error(id, -32601, "Method not found: " + method));
@@ -252,6 +267,7 @@ public class McpController {
                 case "github_actions_list_workflows" -> callGithubActionsListWorkflows(id, arguments);
                 case "github_actions_list_runs" -> callGithubActionsListRuns(id, arguments);
                 case "github_actions_get_run_summary" -> callGithubActionsGetRunSummary(id, arguments);
+                case "shell_exec" -> callShellExecTool(id, arguments);
                 default -> error(id, -32602, "Unknown tool: " + toolName);
             };
         } catch (IllegalArgumentException ex) {
@@ -476,6 +492,13 @@ public class McpController {
             return (Map<String, Object>) map;
         }
         throw new IllegalArgumentException(name + " must be an object");
+    }
+
+
+    private Map<String, Object> callShellExecTool(Object id, Map<String, Object> arguments) {
+        String command = stringArgument(arguments, "command");
+        Map<String, Object> result = shellCommandService.execute(command);
+        return successToolResult(id, result, "Shell command executed");
     }
 
     private Map<String, Object> successToolResult(Object id, Map<String, Object> data, String text) {

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ShellCommandService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ShellCommandService.java
@@ -1,0 +1,64 @@
+package com.marketinghub.mcpserver.service;
+
+import com.marketinghub.mcpserver.config.McpProperties;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class ShellCommandService {
+
+    private final McpProperties properties;
+
+    public ShellCommandService(McpProperties properties) {
+        this.properties = properties;
+    }
+
+    public Map<String, Object> execute(String command) {
+        if (!properties.shell().enabled()) {
+            throw new IllegalArgumentException("shell tools are disabled (set mcp.shell.enabled=true)");
+        }
+        String trimmed = command == null ? "" : command.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("command is required");
+        }
+
+        String firstToken = trimmed.split("\\s+")[0].toLowerCase(Locale.ROOT);
+        if (properties.shell().allowedCommands().stream().noneMatch(cmd -> cmd.equalsIgnoreCase(firstToken))) {
+            throw new IllegalArgumentException("command not allowed: " + firstToken);
+        }
+
+        ProcessBuilder pb = new ProcessBuilder("bash", "-lc", trimmed);
+        pb.redirectErrorStream(true);
+
+        try {
+            Process process = pb.start();
+            boolean finished = process.waitFor(properties.shell().timeoutSeconds(), TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                throw new IllegalArgumentException("command timed out after " + properties.shell().timeoutSeconds() + "s");
+            }
+            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            if (output.length() > properties.shell().maxOutputChars()) {
+                output = output.substring(0, properties.shell().maxOutputChars()) + "\n... [truncated]";
+            }
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("command", trimmed);
+            result.put("exitCode", process.exitValue());
+            result.put("output", output);
+            result.put("timeoutSeconds", properties.shell().timeoutSeconds());
+            return result;
+        } catch (IOException e) {
+            throw new IllegalArgumentException("failed to execute command: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalArgumentException("command interrupted", e);
+        }
+    }
+}

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -63,6 +63,11 @@ mcp:
     access-token: ${MCP_META_GRAPH_ACCESS_TOKEN:}
     debug-access-token: ${MCP_META_GRAPH_DEBUG_ACCESS_TOKEN:${MCP_META_GRAPH_ACCESS_TOKEN:}}
     docs-allowed-hosts: ${MCP_META_DOCS_ALLOWED_HOSTS:developers.facebook.com,business.facebook.com,www.facebook.com}
+  shell:
+    enabled: ${MCP_SHELL_ENABLED:false}
+    timeout-seconds: ${MCP_SHELL_TIMEOUT_SECONDS:20}
+    max-output-chars: ${MCP_SHELL_MAX_OUTPUT_CHARS:12000}
+    allowed-commands: ${MCP_SHELL_ALLOWED_COMMANDS:find,cat,rg,ls,sha256sum,head,tail,pwd,uname}
   github:
     enabled: ${MCP_GITHUB_ENABLED:false}
     api-base-url: ${MCP_GITHUB_API_BASE_URL:https://api.github.com}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -47,7 +47,8 @@ class MetaToolsServiceTest {
                         "owner",
                         "repo",
                         "token"
-                )
+                ),
+                new McpProperties.Shell(false, 20, 12000, List.of("find"))
         );
         service = new MetaToolsService(properties, restTemplate, new ObjectMapper());
     }

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
@@ -89,6 +89,7 @@ class ModuleLogServiceTest {
                 ""
         );
 
-        return new McpProperties("marketing-hub-mcp", "1.0.0", "", logs, meta, github);
+        return new McpProperties("marketing-hub-mcp", "1.0.0", "", logs, meta, github,
+                new McpProperties.Shell(false, 20, 12000, List.of("find")));
     }
 }


### PR DESCRIPTION
### Motivation

- Provide an optional, controlled way to run a small set of allowlisted Linux commands via the MCP to aid remote troubleshooting and forensic diagnosis of issues on the host using `shell_exec`.
- Document a common client-side issue for Minecraft Bedrock (black/magenta missing texture) and clarify that the MCP server was not the root cause in typical cases.

### Description

- Added a new `Shell` configuration record to `McpProperties` and wired defaults into `application.yml` under `mcp.shell` with `enabled`, `timeout-seconds`, `max-output-chars`, and `allowed-commands` keys.
- Implemented `ShellCommandService` that validates allowlisted commands, enforces timeout and output limits, executes commands via `bash -lc`, and returns `command`, `exitCode`, `output`, and `timeoutSeconds` in the result.
- Integrated the shell tool into the API by registering `shell_exec` in the tools list, adding handling in `McpController` to call `ShellCommandService`, and injecting the service into the controller.
- Updated `README.md` to document the `shell_exec` tool and its configuration and added a new `docs/minecraft-bedrock-texture-diagnostico.md` file with a diagnostic checklist for Bedrock texture issues.
- Adjusted unit test setup code to include the new `Shell` properties in `MetaToolsServiceTest` and `ModuleLogServiceTest` constructors.

### Testing

- Ran unit tests including `MetaToolsServiceTest` and `ModuleLogServiceTest` after updating test fixtures to include `McpProperties.Shell`, and the tests completed successfully.
- Performed a local run of the service (`mvn -s settings.xml spring-boot:run`) to validate that configuration binding and `tools/list`/`tools/call` behavior expose the `shell_exec` tool when `mcp.shell.enabled=true` and that calls are rejected when disabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035e11f6d88321a0791b3e7ec66906)