### PR TITLE
Add OPRM coletor receita log endpoint to MCP java_module_logs

### DIFF
--- a/mcp-server/AGENTS.md
+++ b/mcp-server/AGENTS.md
@@ -11,6 +11,7 @@ Manter os seguintes endpoints como defaults de origem de logs no módulo `mcp-se
 - Lead Portal: `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`
 - Portal Pagamentos (Lead Portal): `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`
 - Mois Coletor Hotmart: `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`
+- OPRM Coletor Receita: `http://177.153.62.107:8094/actuator/logfile`
 
 Sempre que houver alteração desses endpoints, atualizar em conjunto:
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -17,7 +17,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `db_list_tables`: lista todas as tabelas disponíveis no schema atual.
 - `db_read_table`: lê dados de uma tabela com paginação (`table`, `limit`, `offset`).
 - `db_query`: executa SQL de leitura (`SELECT`/`WITH`) com limite de linhas.
-- `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-hotmart`).
+- `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-hotmart`, `oprm-coletor-receita`).
 - `meta_docs_get`: busca páginas de documentação da Meta em hosts aprovados.
 - `meta_graph_get`: executa leitura (`GET`) da Graph API com token configurado no MCP.
 - `meta_graph_debug_token`: executa `debug_token` para validar tokens.
@@ -54,7 +54,8 @@ O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou
 - `MCP_LOG_LEAD_PORTAL_PAYMENT_PATH` (default `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`);
 - `MCP_LOG_MDS_PATH` (default `http://177.153.62.107:8091/actuator/logfile`);
 - `MCP_LOG_MOIS_PATH` (default `http://177.153.62.107:8094/manage/logfile`);
-- `MCP_LOG_MOIS_HOTMART_PATH` (default `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`).
+- `MCP_LOG_MOIS_HOTMART_PATH` (default `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`);
+- `MCP_LOG_OPRM_COLETOR_RECEITA_PATH` (default `http://177.153.62.107:8094/actuator/logfile`).
 - `MCP_LOG_FETCH_TIMEOUT_SECONDS` (default `45`);
 - `MCP_LOG_FETCH_ATTEMPTS` (default `3`), número de tentativas para leitura HTTP de logs;
 - `MCP_LOG_FETCH_RETRY_DELAY_MILLIS` (default `400`), intervalo entre tentativas de leitura HTTP;

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -30,6 +30,7 @@ public record McpProperties(
             @NotBlank String mdsPath,
             @NotBlank String moisPath,
             @NotBlank String moisHotmartPath,
+            @NotBlank String oprmColetorReceitaPath,
             @Positive int fetchTimeoutSeconds,
             @Positive int fetchAttempts,
             @Positive int fetchRetryDelayMillis,

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -128,13 +128,13 @@ public class McpController {
                     ),
                     Map.of(
                             "name", "java_module_logs",
-                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart).",
+                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, oprm-coletor-receita).",
                             "inputSchema", Map.of(
                                     "type", "object",
                                     "properties", Map.of(
                                             "module", Map.of("type", "string",
                                                     "enum", List.of("backend", "ai-worker", "lead-portal", "facebook-ads",
-                                                            "email-service", "lead-portal-payment", "mds", "mois", "mois-hotmart"),
+                                                            "email-service", "lead-portal-payment", "mds", "mois", "mois-hotmart", "oprm-coletor-receita"),
                                                     "description", "Módulo Java para consultar logs."),
                                             "lines", Map.of("type", "integer", "minimum", 1,
                                                     "maximum", moduleLogService.maxLines(),

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -197,6 +197,7 @@ public class ModuleLogService {
             case "mds" -> properties.logs().mdsPath();
             case "mois" -> properties.logs().moisPath();
             case "mois-hotmart" -> properties.logs().moisHotmartPath();
+            case "oprm-coletor-receita" -> properties.logs().oprmColetorReceitaPath();
             default -> throw new IllegalArgumentException("Unknown module: " + module);
         };
     }
@@ -209,10 +210,10 @@ public class ModuleLogService {
         String normalized = module.trim().toLowerCase();
         return switch (normalized) {
             case "backend", "ai-worker", "lead-portal", "facebook-ads", "email-service", "lead-portal-payment",
-                 "mds", "mois", "mois-hotmart" -> normalized;
+                 "mds", "mois", "mois-hotmart", "oprm-coletor-receita" -> normalized;
             default -> throw new IllegalArgumentException(
                     "module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, " +
-                            "lead-portal-payment, mds, mois, mois-hotmart");
+                            "lead-portal-payment, mds, mois, mois-hotmart, oprm-coletor-receita");
         };
     }
 

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -51,6 +51,7 @@ mcp:
     mds-path: ${MCP_LOG_MDS_PATH:http://177.153.62.107:8091/actuator/logfile}
     mois-path: ${MCP_LOG_MOIS_PATH:http://177.153.62.107:8094/manage/logfile}
     mois-hotmart-path: ${MCP_LOG_MOIS_HOTMART_PATH:http://177.153.62.107:8096/ops-monitor/mois-hotmart-log}
+    oprm-coletor-receita-path: ${MCP_LOG_OPRM_COLETOR_RECEITA_PATH:http://177.153.62.107:8094/actuator/logfile}
     fetch-timeout-seconds: ${MCP_LOG_FETCH_TIMEOUT_SECONDS:45}
     fetch-attempts: ${MCP_LOG_FETCH_ATTEMPTS:3}
     fetch-retry-delay-millis: ${MCP_LOG_FETCH_RETRY_DELAY_MILLIS:400}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -48,6 +48,7 @@ class McpControllerTest {
         registry.add("mcp.logs.mds-path", () -> TEST_LOG_DIR.resolve("mds.log").toString());
         registry.add("mcp.logs.mois-path", () -> TEST_LOG_DIR.resolve("mois.log").toString());
         registry.add("mcp.logs.mois-hotmart-path", () -> TEST_LOG_DIR.resolve("mois-hotmart.log").toString());
+        registry.add("mcp.logs.oprm-coletor-receita-path", () -> TEST_LOG_DIR.resolve("oprm-coletor-receita.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
         registry.add("mcp.meta.enabled", () -> "false");
         registry.add("mcp.meta.graph-base-url", () -> "https://graph.facebook.com");
@@ -188,7 +189,7 @@ class McpControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.error.code").value(-32602))
                 .andExpect(jsonPath("$.error.message")
-                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart"));
+                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, oprm-coletor-receita"));
     }
 
     @Test
@@ -269,6 +270,7 @@ class McpControllerApiKeyEnabledTest {
         registry.add("mcp.logs.mds-path", () -> TEST_LOG_DIR.resolve("mds.log").toString());
         registry.add("mcp.logs.mois-path", () -> TEST_LOG_DIR.resolve("mois.log").toString());
         registry.add("mcp.logs.mois-hotmart-path", () -> TEST_LOG_DIR.resolve("mois-hotmart.log").toString());
+        registry.add("mcp.logs.oprm-coletor-receita-path", () -> TEST_LOG_DIR.resolve("oprm-coletor-receita.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
         registry.add("mcp.meta.enabled", () -> "false");
         registry.add("mcp.meta.graph-base-url", () -> "https://graph.facebook.com");

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -32,7 +32,7 @@ class MetaToolsServiceTest {
                 "marketing-hub-mcp",
                 "1.0.0",
                 null,
-                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", 45, 3, 400, 500, 262144),
+                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", 45, 3, 400, 500, 262144),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
@@ -65,6 +65,7 @@ class ModuleLogServiceTest {
                 logUrl,
                 logUrl,
                 logUrl,
+                logUrl,
                 2,
                 3,
                 1,


### PR DESCRIPTION
### Motivation

- Expor o ponto de logs do coletor OPRM (Receita) ao MCP para permitir que a ferramenta `java_module_logs` recupere logs deste serviço específico. 
- Manter a lista de fontes de logs e a documentação sincronizadas com o contrato operacional do módulo `mcp-server`.

### Description

- Adicionei o novo property `oprm-coletor-receita-path` em `src/main/resources/application.yml` com default `http://177.153.62.107:8094/actuator/logfile`.
- Incluí `oprmColetorReceitaPath` no record `McpProperties.Logs` e atualizei o roteamento em `ModuleLogService.modulePath` para suportar o módulo `oprm-coletor-receita`.
- Atualizei a definição da tool `java_module_logs` em `McpController` para listar e validar o novo módulo na enum/schema e ajustar a descrição do tool.
- Sincronizei documentação e operação: atualizei `README.md` e `mcp-server/AGENTS.md` e adaptei os testes (`McpControllerTest`, `ModuleLogServiceTest`, `MetaToolsServiceTest`) para a nova propriedade e assinatura do record.

### Testing

- Executei `./mvnw -q -Dtest=McpControllerTest test` que falhou localmente porque o wrapper `./mvnw` não está presente in-repo.
- Executei `mvn -q -Dtest=McpControllerTest test` inicialmente, que falhou por incompatibilidade do construtor após a mudança (corrigido ajustando os testes e o uso do record `Logs`).
- Após correções executei `mvn -q -Dtest=McpControllerTest,ModuleLogServiceTest,MetaToolsServiceTest test` e os testes selecionados passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a039972aca08321ab2f9cf21fdb2c46)