### PR TITLE
Add GitHub Actions run logs tool (`github_actions_get_run_logs`)

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -24,6 +24,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `github_actions_list_workflows`: lista workflows do repositório configurado no GitHub Actions.
 - `github_actions_list_runs`: lista execuções (runs) de workflows do repositório configurado no GitHub Actions.
 - `github_actions_get_run_summary`: verifica se uma execução terminou com sucesso e detalha jobs/steps com falha.
+- `github_actions_get_run_logs`: baixa os logs compactados de uma execução e retorna um trecho em texto.
 
 ## Executar localmente
 

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -209,6 +209,17 @@ public class McpController {
                                                     "description", "ID do workflow run no GitHub Actions.")),
                                     "required", List.of("run_id"),
                                     "additionalProperties", false)
+                    ),
+                    Map.of(
+                            "name", "github_actions_get_run_logs",
+                            "description", "Baixa e retorna trecho dos logs de uma execução de workflow no GitHub Actions.",
+                            "inputSchema", Map.of(
+                                    "type", "object",
+                                    "properties", Map.of(
+                                            "run_id", Map.of("type", "integer", "minimum", 1,
+                                                    "description", "ID do workflow run no GitHub Actions.")),
+                                    "required", List.of("run_id"),
+                                    "additionalProperties", false)
                     )))));
             case "tools/call" -> ResponseEntity.ok(callTool(id, request));
             default -> ResponseEntity.ok(error(id, -32601, "Method not found: " + method));
@@ -252,6 +263,7 @@ public class McpController {
                 case "github_actions_list_workflows" -> callGithubActionsListWorkflows(id, arguments);
                 case "github_actions_list_runs" -> callGithubActionsListRuns(id, arguments);
                 case "github_actions_get_run_summary" -> callGithubActionsGetRunSummary(id, arguments);
+                case "github_actions_get_run_logs" -> callGithubActionsGetRunLogs(id, arguments);
                 default -> error(id, -32602, "Unknown tool: " + toolName);
             };
         } catch (IllegalArgumentException ex) {
@@ -425,6 +437,22 @@ public class McpController {
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
             return error(id, -32603, "Failed to fetch workflow run summary: " + ex.getMessage());
+        }
+    }
+
+
+
+    private Map<String, Object> callGithubActionsGetRunLogs(Object id, Map<String, Object> arguments) {
+        Integer runIdArg = intArgument(arguments, "run_id");
+        Long runId = runIdArg == null ? null : runIdArg.longValue();
+
+        try {
+            Map<String, Object> result = githubActionsService.getRunLogs(runId);
+            return successToolResult(id, result, "GitHub workflow run logs fetched");
+        } catch (IllegalArgumentException ex) {
+            return error(id, -32602, ex.getMessage());
+        } catch (Exception ex) {
+            return error(id, -32603, "Failed to fetch workflow run logs: " + ex.getMessage());
         }
     }
 

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/GithubActionsService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/GithubActionsService.java
@@ -14,10 +14,13 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 @Service
 public class GithubActionsService {
@@ -96,6 +99,56 @@ public class GithubActionsService {
                 : Map.of();
 
         return buildSummary(runId, runPayload, jobsPayload, runUri.toString(), jobsUri.toString());
+    }
+
+    public Map<String, Object> getRunLogs(Long runId) {
+        ensureEnabled();
+        if (runId == null || runId <= 0) {
+            throw new IllegalArgumentException("run_id must be a positive integer");
+        }
+
+        URI logsUri = UriComponentsBuilder.fromHttpUrl(properties.github().apiBaseUrl())
+                .pathSegment("repos", properties.github().owner(), properties.github().repo(), "actions", "runs",
+                        String.valueOf(runId), "logs")
+                .build(true)
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(requiredText(properties.github().token(), "mcp.github.token"));
+        headers.set("Accept", "application/vnd.github+json");
+        headers.set("X-GitHub-Api-Version", "2022-11-28");
+
+        ResponseEntity<byte[]> response = restTemplate.exchange(logsUri, HttpMethod.GET, new HttpEntity<>(headers), byte[].class);
+        byte[] body = response.getBody() == null ? new byte[0] : response.getBody();
+
+        String logs = extractZipText(body);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("run_id", runId);
+        result.put("logs_api_url", logsUri.toString());
+        result.put("statusCode", response.getStatusCode().value());
+        result.put("log_excerpt", logs.length() > 12000 ? logs.substring(0, 12000) : logs);
+        result.put("truncated", logs.length() > 12000);
+        result.put("log_length", logs.length());
+        return result;
+    }
+
+    private String extractZipText(byte[] zippedContent) {
+        try (ZipInputStream zipInputStream = new ZipInputStream(new java.io.ByteArrayInputStream(zippedContent), StandardCharsets.UTF_8)) {
+            StringBuilder logs = new StringBuilder();
+            ZipEntry entry;
+            while ((entry = zipInputStream.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                byte[] content = zipInputStream.readAllBytes();
+                logs.append("===== ").append(entry.getName()).append(" =====\n");
+                logs.append(new String(content, StandardCharsets.UTF_8)).append("\n");
+            }
+            return logs.toString().trim();
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("failed to unzip workflow logs: " + ex.getMessage());
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -216,7 +216,8 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.result.tools[7].name").value("meta_graph_debug_token"))
                 .andExpect(jsonPath("$.result.tools[8].name").value("github_actions_list_workflows"))
                 .andExpect(jsonPath("$.result.tools[9].name").value("github_actions_list_runs"))
-                .andExpect(jsonPath("$.result.tools[10].name").value("github_actions_get_run_summary"));
+                .andExpect(jsonPath("$.result.tools[10].name").value("github_actions_get_run_summary"))
+                .andExpect(jsonPath("$.result.tools[11].name").value("github_actions_get_run_logs"));
     }
 
 
@@ -225,7 +226,7 @@ class McpControllerTest {
         mockMvc.perform(post("/mcp")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                {"jsonrpc":"2.0","id":14,"method":"tools/call","params":{"name":"github_actions_get_run_summary","arguments":{"run_id":123}}}
+                                {"jsonrpc":"2.0","id":14,"method":"tools/call","params":{"name":"github_actions_get_run_logs","arguments":{"run_id":123}}}
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.error.code").value(-32602))


### PR DESCRIPTION
### Motivation

- Provide a tool to download and inspect compressed GitHub Actions run logs and return a text excerpt for diagnostics.

### Description

- Document the new tool in `mcp-server/README.md` as `github_actions_get_run_logs`.
- Register `github_actions_get_run_logs` in the MCP tool list and route calls to a new handler in `McpController` via `callGithubActionsGetRunLogs` and `callTool` dispatching.
- Implement `GithubActionsService.getRunLogs` to fetch the workflow run logs archive from the GitHub API, unzip the contents with `ZipInputStream`, concatenate files into a single text blob, and return metadata plus a truncated `log_excerpt` when large.
- Update `McpControllerTest` expectations to include the new tool and adapt the disabled-github-tools test to call `github_actions_get_run_logs`.

### Testing

- Ran the module unit tests for the MCP server, including `McpControllerTest`, and the suite completed successfully.
- Verified the new controller and service code paths by exercising `tools/list` and the disabled-github-tools test assertions in the updated test class.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a039db1bd9083219b4282cb396c1945)