### PR TITLE
Mock MoisHotmartProductService in MoisController WebMvc test

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
@@ -6,6 +6,7 @@ import com.marketinghub.mois.dto.MoisOfferDtos;
 import com.marketinghub.mois.dto.MoisWorkspaceDtos;
 import com.marketinghub.mois.dto.MoisCollectionPersistenceDtos;
 import com.marketinghub.mois.service.MoisCollectionPersistenceService;
+import com.marketinghub.mois.service.MoisHotmartProductService;
 import com.marketinghub.mois.service.MoisModuleGateway;
 import java.time.Instant;
 import java.util.List;
@@ -41,6 +42,9 @@ class MoisControllerContractTest {
 
     @MockBean
     private MoisCollectionPersistenceService collectionPersistenceService;
+
+    @MockBean
+    private MoisHotmartProductService moisHotmartProductService;
 
     @Test
     void shouldAcceptDiscoveryRequest() throws Exception {


### PR DESCRIPTION
### Motivation
- The `MoisController` constructor requires a `MoisHotmartProductService` bean which was not provided in the `@WebMvcTest` slice, causing ApplicationContext initialization to fail for the controller contract tests.

### Description
- Added an import and a `@MockBean private MoisHotmartProductService moisHotmartProductService;` to `backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java` so the MVC test can instantiate the controller.

### Testing
- Ran `mvn -Dtest=com.marketinghub.mois.web.MoisControllerContractTest test -q` and the test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a051d6788321a882580437b20838)