### PR TITLE
Fix Hotmart cards not loading by selecting latest Hotmart job

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartProductService.java
@@ -17,8 +17,9 @@ public class MoisHotmartProductService {
         String latestJobId = jdbcTemplate.query(
                         """
                                 SELECT job_id
-                                FROM mois_collection_job_state
+                                FROM mois_collected_reference
                                 WHERE workspace_id = ?
+                                  AND source = 'HOTMART'
                                 ORDER BY updated_at DESC
                                 LIMIT 1
                                 """,


### PR DESCRIPTION
### Motivation
- The `/hotmart` UI showed no product cards when the system chose a latest MOIS job from a different source, causing the Hotmart product lookup to return empty results.

### Description
- Changed latest job lookup in `MoisHotmartProductService.listLatestByWorkspace` to query `mois_collected_reference` and filter by `source = 'HOTMART'` so the service picks the most recent Hotmart collection for the workspace.
- Kept the subsequent product query constrained by `workspace_id`, `source = 'HOTMART'` and the resolved `job_id` so returned items match the Hotmart job.
- Modified file: `backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartProductService.java`.

### Testing
- Ran the targeted unit test with `../../backend/mvnw -q -Dtest=MoisHotmartProductServiceTest test`, which passed.
- Verified the service now returns Hotmart items when a Hotmart collection exists for the workspace (via code inspection and test coverage).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a38ee31883218ad023c147f7dc3b)