### PR TITLE
Reagenda ingestão automática de CNAEs para 19:30 (America/Sao_Paulo)

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -17,3 +17,5 @@
 - 2026-05-12 09:00:00 (UTC-3): reprogramado o agendamento padrão da busca/ingestão de CNAEs da Receita Federal no módulo `oprm-coletor-mei` para executar ao meio-dia (12:00) no fuso `America/Sao_Paulo` (`cron` padrão `0 0 12 * * *`), mantendo possibilidade de override por variável `OPRM_COLLECTOR_SCHEDULE_CRON`.
 
 - 2026-05-12 13:40:00 (UTC-3): habilitado endpoint Actuator de arquivo de log no módulo `oprm-coletor-mei` com exposição `logfile` e configuração de `logging.file.name` (default `/tmp/oprm-coletor-mei.log`) para permitir consulta operacional via URL `/actuator/logfile`.
+
+- 2026-05-12 19:30:00 (UTC-3): reprogramado novamente o agendamento padrão da ingestão de CNAEs da Receita Federal no módulo `oprm-coletor-mei` para executar às 19:30 no fuso `America/Sao_Paulo` (`cron` padrão `0 30 19 * * *`), mantendo override por `OPRM_COLLECTOR_SCHEDULE_CRON`.

--- a/oprm-coletor-mei/README.md
+++ b/oprm-coletor-mei/README.md
@@ -43,11 +43,11 @@ docker build -t oprm-coletor-mei:local .
 
 
 ## Agendamento da ingestão (Receita Federal)
-Para agendar a ingestão automática no OPRM Coletor às **15:10** (horário de Brasília), configure:
+Para agendar a ingestão automática no OPRM Coletor às **19:30** (horário de Brasília), configure:
 
 ```bash
 export OPRM_COLLECTOR_SCHEDULE_ENABLED=true
-export OPRM_COLLECTOR_SCHEDULE_CRON="0 10 15 * * *"
+export OPRM_COLLECTOR_SCHEDULE_CRON="0 30 19 * * *"
 export OPRM_COLLECTOR_SCHEDULE_TIMEZONE="America/Sao_Paulo"
 export OPRM_COLLECTOR_SCHEDULE_SOURCE="RECEITA_FEDERAL"
 export OPRM_COLLECTOR_SCHEDULE_PAYLOAD_FILE="/caminho/receita-cnaes.json"

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -22,7 +22,7 @@ oprm:
 
     schedule:
       enabled: ${OPRM_COLLECTOR_SCHEDULE_ENABLED:false}
-      cron: ${OPRM_COLLECTOR_SCHEDULE_CRON:0 0 12 * * *}
+      cron: ${OPRM_COLLECTOR_SCHEDULE_CRON:0 30 19 * * *}
       timezone: ${OPRM_COLLECTOR_SCHEDULE_TIMEZONE:America/Sao_Paulo}
       source: ${OPRM_COLLECTOR_SCHEDULE_SOURCE:RECEITA_FEDERAL}
       payload-file: ${OPRM_COLLECTOR_SCHEDULE_PAYLOAD_FILE:}


### PR DESCRIPTION
### Motivation
- Ajustar o agendamento padrão da ingestão de CNAEs para executar às 19:30 (horário de Brasília) conforme necessidade operacional de execução no período solicitado.
- Atualizar documentação e registros operacionais para refletir o novo cron padrão e manter a possibilidade de override por variável de ambiente.

### Description
- Altera o default em `oprm-coletor-mei/src/main/resources/application.yml` trocando o `OPRM_COLLECTOR_SCHEDULE_CRON` de `0 0 12 * * *` para `0 30 19 * * *` e preservando `OPRM_COLLECTOR_SCHEDULE_TIMEZONE=America/Sao_Paulo`.
- Atualiza `oprm-coletor-mei/README.md` para documentar o novo horário `19:30` e o exemplo de variável de ambiente `export OPRM_COLLECTOR_SCHEDULE_CRON="0 30 19 * * *"`.
- Acrescenta registro operacional em `docs/registros/oprm1.md` com a entrada de reprogramação para `2026-05-12 19:30:00 (UTC-3)`.

### Testing
- Tentativa de executar `./mvnw test -q` no módulo `oprm-coletor-mei` falhou por ausência do wrapper (`mvnw` não presente). 
- Executado `mvn test -q` dentro de `oprm-coletor-mei` e os testes unitários do módulo passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a3da8d8483218a14bf624a117256)