### PR TITLE
Ajusta contrato do Gera Wireframe com intenção comercial por seção

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -45,6 +45,30 @@
                   "oQueQuerProvocarNoUsuario": {
                     "type": "string"
                   },
+                  "papelComercial": {
+                    "type": "string"
+                  },
+                  "fasePersuasao": {
+                    "type": "string"
+                  },
+                  "objeçãoQueRemove": {
+                    "type": "string"
+                  },
+                  "prioridadeConversao": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10
+                  },
+                  "acaoEsperada": {
+                    "type": "string"
+                  },
+                  "fonteContexto": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "id": {
                     "type": "string"
                   },
@@ -67,6 +91,12 @@
                   "nome",
                   "objetivo",
                   "oQueQuerProvocarNoUsuario",
+                  "papelComercial",
+                  "fasePersuasao",
+                  "objeçãoQueRemove",
+                  "prioridadeConversao",
+                  "acaoEsperada",
+                  "fonteContexto",
                   "id",
                   "estilos",
                   "elementosSeccao"

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -50,7 +50,7 @@ Regras fixas da etapa (formato simplificado):
 - Entregar somente JSON válido no formato raiz `pagina`.
 - Estrutura obrigatória: `pagina.head.texto`, `pagina.corpo.estilos[]`, `pagina.corpo.secoes[]`.
 - Cada item de `estilos[]` deve ter apenas `nome` e `valor`.
-- Cada seção deve conter: `nome`, `objetivo`, `oQueQuerProvocarNoUsuario`, `id`, `estilos[]`, `elementosSeccao[]`.
+- Cada seção deve conter: `nome`, `objetivo`, `oQueQuerProvocarNoUsuario`, `papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada`, `fonteContexto[]`, `id`, `estilos[]`, `elementosSeccao[]`.
 - Cada item de `elementosSeccao[]` deve conter: `id`, `tag`, `texto`, `estilos[]`, `elementosInternos[]`.
 - `elementosInternos[]` representa hierarquia de filhos e deve suportar recursão (filho pode conter netos e assim por diante), sempre com o mesmo contrato do elemento pai.
 - Campo `texto` de cada elemento deve conter exatamente: `tamMaximo`, `tamMinimo`, `conteudo`.
@@ -63,6 +63,14 @@ Regras fixas da etapa (formato simplificado):
 - Fase wireframe NÃO preenche copy: em TODOS os elementos, `texto.conteudo` deve ser string vazia (`""`) nesta etapa.
 - Para tags de lista (`ul`), sempre declarar os `li` internos explicitamente.
 
+- Ajuste de intenção por seção (referência do esboço):
+  - `papelComercial`: descreva a função comercial da seção no funil da landing (ex.: primeira dobra de conversão, remoção de risco, fechamento).
+  - `fasePersuasao`: explicite a fase predominante (ex.: dor-promessa-prova-acao).
+  - `objeçãoQueRemove`: declare a principal objeção que a seção resolve.
+  - `prioridadeConversao`: inteiro de 1 a 10 (10 = mais crítico para conversão).
+  - `acaoEsperada`: qual ação concreta o usuário deve tomar após consumir a seção.
+  - `fonteContexto[]`: liste de onde a seção foi derivada (ex.: `PAIN_JSON.surface`, `campaignAngle.primaryPromise`).
+
 OUTPUT_CONTRACT
 Responda em JSON válido e estritamente aderente ao artefato `landingPageWireframe` simplificado.
 
@@ -70,7 +78,7 @@ Campos obrigatórios:
 - pagina
 - pagina.head.texto
 - pagina.corpo.estilos[] com nome, valor
-- pagina.corpo.secoes[] com nome, objetivo, oQueQuerProvocarNoUsuario, id, estilos, elementosSeccao
+- pagina.corpo.secoes[] com nome, objetivo, oQueQuerProvocarNoUsuario, papelComercial, fasePersuasao, objeçãoQueRemove, prioridadeConversao, acaoEsperada, fonteContexto, id, estilos, elementosSeccao
 - pagina.corpo.secoes[].elementosSeccao[] com id, tag, texto, estilos, elementosInternos
 - pagina.corpo.secoes[].elementosSeccao[].texto com tamMaximo, tamMinimo, conteudo
 - Em wireframe, `conteudo` deve ser sempre `""` (sem texto final).

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -15,3 +15,5 @@
 - 2026-05-12 15:05:00 UTC-3 — Atualizada a etapa Gera Wireframe para reforçar objetivo comercial de venda com captura de dados para envio de amostra/prova, e bloqueado preenchimento de copy nesta fase (`texto.conteudo` obrigatório como string vazia no prompt e no schema).
 
 - 2026-05-12 18:05:00 UTC-3 — Ajustado o montador HTML do wireframe para alternar fundo de seção em duas cores (claro/escuro) no payload `pagina/corpo/secoes` e para representar imagens (`img`) com placeholder visual exibindo dimensões definidas no wireframe.
+
+- 2026-05-12 19:15:00 UTC-3 — Ajustadas as solicitações da etapa `landing-page-wireframe` para exigir, em cada seção, metadados de intenção comercial no padrão do esboço (`papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada`, `fonteContexto`), com atualização sincronizada do prompt e do schema.


### PR DESCRIPTION
### Motivation
- Alinhar a etapa `landing-page-wireframe` ao esboço fornecido, exigindo metadados de intenção comercial por seção para melhorar consistência entre wireframe, copy e imagem.
- Evitar divergências estruturais e rejeições de contrato (`422`) ao tornar explícitos campos de propósito e origem de contexto por seção.
- Facilitar que etapas subsequentes (`landing-page-copy`, `landing-page-image-planning`, `landing-page-html`) consumam sinais estruturais sem inventar campos fora do schema canônico.

### Description
- Atualiza o prompt/guia da etapa em `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` para exigir, em cada `pagina.corpo.secoes[]`, os campos `papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada` e `fonteContexto[]` e inclui instruções de preenchimento.
- Expande e altera o schema JSON em `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` para aceitar e obrigar os mesmos campos, com validação de `prioridadeConversao` (`integer` 1–10) e `fonteContexto` como array não vazio.
- Adiciona registro append-only da mudança em `docs/gera-landing/registros3.md` para rastreabilidade operacional do ajuste.

### Testing
- Validado o JSON do schema com `python -m json.tool ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json`, sem erros (schema é JSON válido).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a954f4e883218c50a99bc406d1f4)