### PR TITLE
landing-page-wireframe: exigir briefingVisual para imagens e reforçar regras de prompt

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -254,6 +254,46 @@
           "items": {
             "$ref": "#/$defs/elementoSecao"
           }
+        },
+        "briefingVisual": {
+          "type": "object",
+          "description": "Campo exclusivo para elementos de imagem (`tag = img`). Não usar em outras tags.",
+          "additionalProperties": false,
+          "properties": {
+            "ondeEntraNoVisual": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tipoVisualEsperado": {
+              "type": "string",
+              "minLength": 1
+            },
+            "funcaoComercial": {
+              "type": "string",
+              "minLength": 1
+            },
+            "objecaoQueRemove": {
+              "type": "string",
+              "minLength": 1
+            },
+            "classificacaoVisual": {
+              "type": "string",
+              "enum": [
+                "mockup",
+                "foto",
+                "ilustração",
+                "diagrama",
+                "print conceitual"
+              ]
+            }
+          },
+          "required": [
+            "ondeEntraNoVisual",
+            "tipoVisualEsperado",
+            "funcaoComercial",
+            "objecaoQueRemove",
+            "classificacaoVisual"
+          ]
         }
       },
       "required": [
@@ -262,6 +302,32 @@
         "texto",
         "estilos",
         "elementosInternos"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "tag": {
+                "const": "img"
+              }
+            },
+            "required": [
+              "tag"
+            ]
+          },
+          "then": {
+            "required": [
+              "briefingVisual"
+            ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "briefingVisual"
+              ]
+            }
+          }
+        }
       ]
     }
   }

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -52,6 +52,13 @@ Regras fixas da etapa (formato simplificado):
 - Cada item de `estilos[]` deve ter apenas `nome` e `valor`.
 - Cada seção deve conter: `nome`, `objetivo`, `oQueQuerProvocarNoUsuario`, `papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada`, `fonteContexto[]`, `id`, `estilos[]`, `elementosSeccao[]`.
 - Cada item de `elementosSeccao[]` deve conter: `id`, `tag`, `texto`, `estilos[]`, `elementosInternos[]`.
+- Quando `tag = "img"`, o elemento deve conter também `briefingVisual` com:
+  - `ondeEntraNoVisual`;
+  - `tipoVisualEsperado`;
+  - `funcaoComercial`;
+  - `objecaoQueRemove`;
+  - `classificacaoVisual` em: `mockup`, `foto`, `ilustração`, `diagrama`, `print conceitual`.
+- `briefingVisual` é exclusivo de `img`: não declarar este campo em elementos com outras tags.
 - `elementosInternos[]` representa hierarquia de filhos e deve suportar recursão (filho pode conter netos e assim por diante), sempre com o mesmo contrato do elemento pai.
 - Campo `texto` de cada elemento deve conter exatamente: `tamMaximo`, `tamMinimo`, `conteudo`.
 - `elementosInternos` pode ser lista vazia, mas sempre deve existir.
@@ -62,6 +69,30 @@ Regras fixas da etapa (formato simplificado):
 - Objetivo comercial obrigatório: estruturar a página para venda com foco na coleta de informação para envio de amostra/prova do produto (ex.: formulário/CTA de captura).
 - Fase wireframe NÃO preenche copy: em TODOS os elementos, `texto.conteudo` deve ser string vazia (`""`) nesta etapa.
 - Para tags de lista (`ul`), sempre declarar os `li` internos explicitamente.
+- Formulário obrigatório da landing: incluir seção/formulário de captura contendo somente os campos `nome` e `email` (não incluir telefone, WhatsApp, CPF, empresa ou outros campos).
+- Hero obrigatório com âncora primária: na primeira dobra (hero), incluir CTA com link âncora direto para a seção do formulário.
+- Âncoras obrigatórias adicionais: incluir mais duas âncoras internas para pontos estratégicos distintos da página (ex.: mecanismo, prova social, oferta), além da âncora do hero para o formulário.
+- Balanceamento visual obrigatório: intercalar blocos de texto e imagem ao longo da página, inserindo elementos `img` em seções relevantes para reduzir paredes de texto e melhorar escaneabilidade.
+- Imagem de produto obrigatória: garantir que pelo menos uma `img` represente visualmente a ideia do produto/entrega que o cliente está comprando (ex.: mockup da solução, amostra do conteúdo, kit/resultado final esperado).
+- Para cada visual (`img`) planejado no wireframe, explicitar no `objetivo`/metadados da seção:
+  - onde o visual entra na narrativa da página (posição e contexto comercial);
+  - qual tipo de visual é esperado;
+  - qual função comercial o visual cumpre;
+  - qual objeção o visual ajuda a remover;
+  - classificar o visual como: `mockup`, `foto`, `ilustração`, `diagrama` ou `print conceitual`.
+- Heurística prática de composição (usar como inspiração, NÃO como regra rígida; adapte ao contexto do nicho/oferta):
+  - Hero bullets: preferir ~3 itens.
+  - Lista de entregáveis: preferir entre 3 e 5 itens.
+  - Antes/depois: preferir 3 itens de "antes" e 3 itens de "depois".
+  - Como funciona: preferir 3 passos.
+  - FAQ: preferir entre 4 e 6 perguntas.
+  - Formulário inicial: em cenários gerais, pode variar entre 3 e 4 campos; quando houver diretriz explícita desta execução, ela prevalece.
+- Heurística para listas longas no mobile (inspiração contextual, não regra absoluta):
+  - Evitar listas grandes no início da página.
+  - Evitar mais de 5 itens visíveis por bloco quando a pessoa ainda não entendeu a oferta.
+  - Evitar misturar no mesmo bloco: benefícios, recursos e explicações extensas.
+  - Evitar estruturas que aumentem sensação de esforço, prejudiquem foco no CTA ou alonguem demais o mobile sem avanço de persuasão.
+  - Listas grandes podem ser aceitáveis quando estiverem em FAQ recolhido, quebradas em cards, com hierarquia clara, posicionadas após entendimento da oferta ou quando necessárias para provar entrega concreta (ex.: mini-kit com 5 itens).
 
 - Ajuste de intenção por seção (referência do esboço):
   - `papelComercial`: descreva a função comercial da seção no funil da landing (ex.: primeira dobra de conversão, remoção de risco, fechamento).
@@ -80,6 +111,8 @@ Campos obrigatórios:
 - pagina.corpo.estilos[] com nome, valor
 - pagina.corpo.secoes[] com nome, objetivo, oQueQuerProvocarNoUsuario, papelComercial, fasePersuasao, objeçãoQueRemove, prioridadeConversao, acaoEsperada, fonteContexto, id, estilos, elementosSeccao
 - pagina.corpo.secoes[].elementosSeccao[] com id, tag, texto, estilos, elementosInternos
+- Para `tag = "img"`, `pagina.corpo.secoes[].elementosSeccao[].briefingVisual` é obrigatório no contrato.
+- Para tags diferentes de `img`, `briefingVisual` não deve existir no JSON.
 - pagina.corpo.secoes[].elementosSeccao[].texto com tamMaximo, tamMinimo, conteudo
 - Em wireframe, `conteudo` deve ser sempre `""` (sem texto final).
 

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -17,3 +17,17 @@
 - 2026-05-12 18:05:00 UTC-3 — Ajustado o montador HTML do wireframe para alternar fundo de seção em duas cores (claro/escuro) no payload `pagina/corpo/secoes` e para representar imagens (`img`) com placeholder visual exibindo dimensões definidas no wireframe.
 
 - 2026-05-12 19:15:00 UTC-3 — Ajustadas as solicitações da etapa `landing-page-wireframe` para exigir, em cada seção, metadados de intenção comercial no padrão do esboço (`papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada`, `fonteContexto`), com atualização sincronizada do prompt e do schema.
+
+- 2026-05-12 20:39:44 UTC-3 — Atualizada a criação da etapa `landing-page-wireframe` para exigir formulário com apenas `nome` e `email`, CTA no hero com âncora direta para o formulário, mais duas âncoras internas estratégicas e inserção obrigatória de imagens para alternância entre texto e imagem.
+
+- 2026-05-12 20:42:21 UTC-3 — Inserida no prompt da etapa `landing-page-wireframe` uma heurística prática de composição para landing mobile (quantidades sugeridas para bullets, entregáveis, antes/depois, passos, FAQ e campos de formulário), explicitamente tratada como inspiração flexível e não regra fixa.
+
+- 2026-05-12 20:44:18 UTC-3 — Adicionada no prompt da etapa `landing-page-wireframe` uma fonte extra de inspiração para uso de listas longas no mobile, definindo quando evitar e quando aceitar listas extensas (FAQ recolhido, cards, hierarquia clara, após entendimento da oferta e prova de entrega).
+
+- 2026-05-12 20:46:17 UTC-3 — Ajustado o prompt da etapa `landing-page-wireframe` para exigir ao menos uma imagem que comunique visualmente a ideia do produto/entrega comprada pelo cliente (mockup, amostra de conteúdo, kit ou resultado esperado).
+
+- 2026-05-12 20:48:15 UTC-3 — Incluída no prompt da etapa `landing-page-wireframe` a orientação para detalhar cada visual (`img`) com contexto de uso (onde entra), tipo esperado, função comercial, objeção removida e classificação do formato (mockup, foto, ilustração, diagrama ou print conceitual).
+
+- 2026-05-12 21:05:00 UTC-3 — Definido no schema da etapa `landing-page-wireframe` o contrato obrigatório de `briefingVisual` para elementos com `tag="img"` (onde entra, tipo esperado, função comercial, objeção removida e classificação), mantendo a regra como exigência estrutural validável além da instrução de prompt.
+
+- 2026-05-12 21:22:00 UTC-3 — Refinado o contrato do `landing-page-wireframe` para deixar explícito que `briefingVisual` é campo exclusivo de elementos `img`: obrigatório quando `tag="img"` e proibido para outras tags (validação `if/then/else` no schema + reforço no prompt).


### PR DESCRIPTION
### Motivation
- Garantir que elementos de imagem (`tag = img`) carreguem metadados comerciais e criativos obrigatórios para produção visual consistente. 
- Evitar campos indevidos, melhorar validação estrutural e compatibilidade com OpenAI Structured Outputs usando regras explícitas de schema. 
- Reforçar heurísticas e restrições de composição do wireframe (formulário, âncoras, balanceamento texto/imagem) para orientar entregas padronizadas. 

### Description
- Adicionado o objeto `briefingVisual` ao schema `landing-page-wireframe` com campos obrigatórios: `ondeEntraNoVisual`, `tipoVisualEsperado`, `funcaoComercial`, `objecaoQueRemove` e `classificacaoVisual` (enum com `mockup`, `foto`, `ilustração`, `diagrama`, `print conceitual`).
- Inserida validação condicional `if/then/else` para tornar `briefingVisual` obrigatório quando `tag == "img"` e proibir sua presença para outras tags. 
- Atualizado o prompt (`landing-page-wireframe.md`) para documentar as novas regras: briefingVisual exclusivo de `img`, obrigatoriedade de formulário com apenas `nome` e `email`, CTA no hero ancorando o formulário, mais duas âncoras internas, balanceamento texto/imagem e heurísticas de composição mobile. 
- Atualizados registros (`docs/gera-landing/registros3.md`) com histórico das alterações e justificativas de design/validação. 

### Testing
- Executada validação do JSON Schema contra ferramentas de linting e validação e o schema validou sem erros (passou). 
- Rodados testes automatizados de contrato de prompt/OUTPUT_CONTRACT para confirmar presença e exclusividade de `briefingVisual` em `img` e todos passaram. 
- Executados testes unitários do montador HTML provisório que consome o novo payload `pagina/corpo/secoes` e os testes unitários passaram. 
- Validado fluxo de saída estruturada (simulação de Structured Outputs) com payloads de exemplo para garantir compatibilidade com OpenAI Structured Outputs e a validação foi bem-sucedida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03ba1ab7608321bdaaf2229054e09c)