### PR TITLE
Document GitHub Actions access via MCP Server in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Toda decisão de arquitetura, dados, prompts, automações, integrações e arte
 - **Frontend**: sempre que alterar o frontend crie os métodos do backend para suportar. Tanto back quanto o front estão sendo executados no mesmo host.
 - **Qualidade**: sempre que alterar um módulo Java realizar os testes unitários antes de publicar o PR.
 - **Logs**: os logs dos modulos Java Spring Boot podem ser acessados pelo MCP Server.  Chame o endpoint MCP https://mcpserverdigi.shop/mcp via JSON-RPC.
+- **GitHub Actions (logs e execuções)**: também podem ser consultados via MCP Server usando as tools `github_actions_list_workflows`, `github_actions_list_runs`, `github_actions_get_run_summary` e `github_actions_get_run_logs` no endpoint https://mcpserverdigi.shop/mcp (JSON-RPC).
 - **Testes Unitários**: os testes unitários precisam sempre estar em concordancia com as regras dos documentos canonicos.
 - **Regra Geral (cânone x testes)**: sempre que houver alteração de regra em documento canônico, revisar e atualizar os testes unitários relacionados para manter aderência entre documentação, regras de domínio e validações automatizadas.
 - **Telas do Usuario**: as telas de usuario, ou frontend precisam sempre estar dando as informações mais importantes e precisas para  o usuario e ofereçendo so comandos necessários para o direcionamento dos fluxo de processos mantidos pelo sistema. Evite informações contraditórias, em excesso e desorganizadas. Mantenha sempre a conformidade com os documentos canonicos.


### PR DESCRIPTION
### Motivation
- Add guidance to AGENTS.md so engineers can consult GitHub Actions logs and runs through the MCP Server using the available tools.  

### Description
- Updated `AGENTS.md` to include a new rule documenting the `github_actions_list_workflows`, `github_actions_list_runs`, `github_actions_get_run_summary` and `github_actions_get_run_logs` tools and the MCP endpoint `https://mcpserverdigi.shop/mcp` (JSON-RPC).  

### Testing
- No automated tests were run because this is a documentation-only change and does not affect code or test artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b75745fc8321a02e5bbfe68d2336)