### PR TITLE
Make landing-page-wireframe schema compatible with OpenAI Structured Outputs and update docs

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -235,7 +235,8 @@
           "type": "string"
         },
         "tag": {
-          "type": "string"
+          "type": "string",
+          "description": "Tag HTML do elemento. Regra contratual: `briefingVisual` só pode existir quando `tag` for exatamente `img`."
         },
         "texto": {
           "$ref": "#/$defs/textoElemento"
@@ -257,7 +258,7 @@
         },
         "briefingVisual": {
           "type": "object",
-          "description": "Campo exclusivo para elementos de imagem (`tag = img`). Não usar em outras tags.",
+          "description": "Campo exclusivo para elementos de imagem (`tag = img`). Não usar em outras tags. Se `tag` for diferente de `img`, omita `briefingVisual`.",
           "additionalProperties": false,
           "properties": {
             "ondeEntraNoVisual": {
@@ -302,32 +303,6 @@
         "texto",
         "estilos",
         "elementosInternos"
-      ],
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "tag": {
-                "const": "img"
-              }
-            },
-            "required": [
-              "tag"
-            ]
-          },
-          "then": {
-            "required": [
-              "briefingVisual"
-            ]
-          },
-          "else": {
-            "not": {
-              "required": [
-                "briefingVisual"
-              ]
-            }
-          }
-        }
       ]
     }
   }

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -31,3 +31,7 @@
 - 2026-05-12 21:05:00 UTC-3 — Definido no schema da etapa `landing-page-wireframe` o contrato obrigatório de `briefingVisual` para elementos com `tag="img"` (onde entra, tipo esperado, função comercial, objeção removida e classificação), mantendo a regra como exigência estrutural validável além da instrução de prompt.
 
 - 2026-05-12 21:22:00 UTC-3 — Refinado o contrato do `landing-page-wireframe` para deixar explícito que `briefingVisual` é campo exclusivo de elementos `img`: obrigatório quando `tag="img"` e proibido para outras tags (validação `if/then/else` no schema + reforço no prompt).
+
+- 2026-05-13 09:10:00 UTC-3 — Ajustado o schema da etapa `landing-page-wireframe` para compatibilidade com OpenAI Structured Outputs removendo o uso de `allOf` (com `if/then/else`), que é rejeitado pela API com erro `invalid_json_schema`; a regra de uso exclusivo de `briefingVisual` para `img` permanece reforçada no prompt.
+
+- 2026-05-13 09:32:00 UTC-3 — Reforçada a regra contratual no schema `landing-page-wireframe`: o campo `tag` agora explicita literalmente que `briefingVisual` só é permitido quando `tag = "img"`, e o próprio `briefingVisual` passou a repetir a instrução de omissão para demais tags.


### PR DESCRIPTION
### Motivation

- Remove use of `allOf` with `if/then/else` in the `landing-page-wireframe` schema because OpenAI Structured Outputs rejects that pattern with `invalid_json_schema` errors. 
- Preserve the contractual requirement that `briefingVisual` is exclusive to image elements while shifting enforcement to prompt/instructions and property descriptions.

### Description

- Removed the `allOf` conditional block that enforced `briefingVisual` when `tag = "img"` and prohibited it for other tags from `landing-page-wireframe-schema.json`.
- Added explanatory `description` text to the `tag` and `briefingVisual` properties to explicitly state that `briefingVisual` must only appear when `tag` is exactly `img` and must be omitted otherwise.
- Updated `docs/gera-landing/registros3.md` changelog to record the schema compatibility fix and the reinforced contractual wording added to the schema descriptions.

### Testing

- Validated the updated JSON schema against OpenAI Structured Outputs requirements and confirmed the previous `invalid_json_schema` rejection is avoided. 
- Ran CI checks including JSON schema linting and documentation build, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c3342154832181fafa96367397f0)