### PR TITLE
Improve Hotmart collector diagnostics and nested JSON mapping

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -73,3 +73,9 @@
 - Mapeado snapshot de produto para `references` do payload de persistência, permitindo gravação em `mois_collected_reference` e exibição na tela `/hotmart`.
 - Adicionados parâmetros de configuração para `workspaceId`, `niche` e `marketTheme` no coletor.
 - Testes do módulo executados com sucesso (`mvn test -q`).
+
+## 2026-05-13 21:50 UTC
+- Adicionados logs de causa-raiz no `HotmartCollectorService` para diagnosticar porque a tela mostrava "Produto sem título" e campos "Não informado" mesmo com coleta concluída.
+- A coleta via API agora registra: chaves do objeto raiz quando não encontra array de produtos, quantidade de itens retornados e chaves do primeiro item para validar contrato real do JSON retornado pela Hotmart.
+- Incluído log por item quando título não for mapeável, com `itemPreview` truncado, para identificar exatamente quais campos vieram no payload e ajustar contrato/mapeamento sem suposições.
+- Melhorado o parser para ler campos também em objetos aninhados (`product` e `sourceObject`), reduzindo perda de dados quando a Hotmart muda o formato do JSON.

--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -79,3 +79,7 @@
 - A coleta via API agora registra: chaves do objeto raiz quando não encontra array de produtos, quantidade de itens retornados e chaves do primeiro item para validar contrato real do JSON retornado pela Hotmart.
 - Incluído log por item quando título não for mapeável, com `itemPreview` truncado, para identificar exatamente quais campos vieram no payload e ajustar contrato/mapeamento sem suposições.
 - Melhorado o parser para ler campos também em objetos aninhados (`product` e `sourceObject`), reduzindo perda de dados quando a Hotmart muda o formato do JSON.
+
+## 2026-05-13 22:05 UTC
+- Incluído log explícito da resposta crua do fetch da Hotmart no fluxo principal da API (`HOTMART_FETCH_RESPOSTA_CRUA`), com status HTTP e `bodyRaw` truncado em 10.000 caracteres.
+- Objetivo: deixar inequívoco no log exatamente o que o coletor conseguiu obter da Hotmart para diagnóstico de contrato/mapeamento.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -251,13 +251,24 @@ public class HotmartCollectorService {
             JsonNode data = objectMapper.readTree(body);
             JsonNode productsNode = firstArray(data, "products", "items", "content", "results");
             if (productsNode == null || !productsNode.isArray()) {
+                log.warn("Resposta API Hotmart sem array de produtos. keysRaiz={}", previewFieldNames(data));
                 return 0;
             }
+            log.info("Resposta API Hotmart: totalItensArray={}, chavesPrimeiroItem={}",
+                    productsNode.size(),
+                    productsNode.size() > 0 ? previewFieldNames(productsNode.get(0)) : "[]");
             for (JsonNode item : productsNode) {
                 if (products.size() >= boundedMax) break;
-                String title = firstText(item, "name", "productName", "title");
-                String url = firstText(item, "checkoutUrl", "productUrl", "url", "link");
-                if (url == null || url.isBlank()) url = hotmartMarketUrl;
+                String title = extractProductText(item, "name", "productName", "title");
+                String url = extractProductText(item, "checkoutUrl", "productUrl", "url", "link");
+                if (url == null || url.isBlank()) {
+                    url = hotmartMarketUrl;
+                }
+                if (title == null || title.isBlank()) {
+                    log.warn("Item Hotmart sem título mapeável. chavesItem={}, itemPreview={}",
+                            previewFieldNames(item),
+                            truncateForLog(item.toString(), 600));
+                }
                 products.add(new HotmartProductSnapshot(
                         title == null || title.isBlank() ? "Produto sem título" : title,
                         "N/A",
@@ -517,6 +528,40 @@ public class HotmartCollectorService {
             }
         }
         return null;
+    }
+
+    private String extractProductText(JsonNode item, String... keys) {
+        String direct = firstText(item, keys);
+        if (direct != null && !direct.isBlank()) {
+            return direct;
+        }
+        JsonNode productNode = item.path("product");
+        if (!productNode.isMissingNode() && !productNode.isNull()) {
+            String nested = firstText(productNode, keys);
+            if (nested != null && !nested.isBlank()) {
+                return nested;
+            }
+        }
+        JsonNode sourceObjectNode = item.path("sourceObject");
+        if (!sourceObjectNode.isMissingNode() && !sourceObjectNode.isNull()) {
+            String sourceObject = firstText(sourceObjectNode, keys);
+            if (sourceObject != null && !sourceObject.isBlank()) {
+                return sourceObject;
+            }
+        }
+        return null;
+    }
+
+    private String previewFieldNames(JsonNode node) {
+        if (node == null || !node.isObject()) {
+            return "[]";
+        }
+        List<String> keys = new ArrayList<>();
+        node.fieldNames().forEachRemaining(keys::add);
+        if (keys.size() > 12) {
+            return keys.subList(0, 12) + "...";
+        }
+        return keys.toString();
     }
 
     private String truncateForLog(String value, int maxLength) {

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -245,6 +245,9 @@ public class HotmartCollectorService {
             HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
             String body = response.body();
             log.info("Resposta API Hotmart recebida. status={}, bodyPreview='{}'", response.statusCode(), truncateForLog(body, 1200));
+            log.info("HOTMART_FETCH_RESPOSTA_CRUA status={} bodyRaw='{}'",
+                    response.statusCode(),
+                    truncateForLog(body, 10_000));
             if (response.statusCode() < 200 || response.statusCode() >= 300) {
                 return 0;
             }


### PR DESCRIPTION
### Motivation
- The `/hotmart` UI was showing placeholders like "Produto sem título" or "Não informado" because the collector lost product fields when Hotmart changed the JSON shape. 
- We need clearer runtime diagnostics and more resilient field extraction so root-cause can be identified and mapped without guessing.

### Description
- Added API-path diagnostics in `HotmartCollectorService` to log when no products array is found and to show root keys via `previewFieldNames`. 
- Log the returned array size and the first item keys, and emit a per-item `warn` with a truncated payload preview when title mapping fails. 
- Implemented `extractProductText(...)` to search for product fields at the top level and inside nested `product` and `sourceObject` objects, and switched API parsing to use it. 
- Documented the change in `docs/registros/coletor-mois1.md` and kept the legacy Playwright flow for rollback safety.

### Testing
- Ran module tests with `cd mois-hotmart-collector && mvn test -q`, which executed the unit tests including `HotmartCollectorServiceTest` and completed successfully. 
- Observed diagnostic logs during tests showing the JWT fetch path and the collector decision path (`COLLECTION_SKIPPED`) as expected under test conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c97b1cd48321996bf49ac193af53)