### PR TITLE
Fix Gera Wireframe schema invalid_json_schema for briefingVisual

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -257,8 +257,8 @@
           }
         },
         "briefingVisual": {
-          "type": "object",
-          "description": "Campo exclusivo para elementos de imagem (`tag = img`). Não usar em outras tags. Se `tag` for diferente de `img`, omita `briefingVisual`.",
+          "type": ["object", "null"],
+          "description": "Campo exclusivo para elementos de imagem (`tag = img`). Não usar em outras tags. Se `tag` for diferente de `img`, usar `briefingVisual: null`.",
           "additionalProperties": false,
           "properties": {
             "ondeEntraNoVisual": {
@@ -302,7 +302,8 @@
         "tag",
         "texto",
         "estilos",
-        "elementosInternos"
+        "elementosInternos",
+        "briefingVisual"
       ]
     }
   }

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -58,7 +58,7 @@ Regras fixas da etapa (formato simplificado):
   - `funcaoComercial`;
   - `objecaoQueRemove`;
   - `classificacaoVisual` em: `mockup`, `foto`, `ilustração`, `diagrama`, `print conceitual`.
-- `briefingVisual` é exclusivo de `img`: não declarar este campo em elementos com outras tags.
+- `briefingVisual` é exclusivo de `img`: para outras tags, manter `briefingVisual: null` (não preencher objeto).
 - `elementosInternos[]` representa hierarquia de filhos e deve suportar recursão (filho pode conter netos e assim por diante), sempre com o mesmo contrato do elemento pai.
 - Campo `texto` de cada elemento deve conter exatamente: `tamMaximo`, `tamMinimo`, `conteudo`.
 - `elementosInternos` pode ser lista vazia, mas sempre deve existir.
@@ -112,7 +112,7 @@ Campos obrigatórios:
 - pagina.corpo.secoes[] com nome, objetivo, oQueQuerProvocarNoUsuario, papelComercial, fasePersuasao, objeçãoQueRemove, prioridadeConversao, acaoEsperada, fonteContexto, id, estilos, elementosSeccao
 - pagina.corpo.secoes[].elementosSeccao[] com id, tag, texto, estilos, elementosInternos
 - Para `tag = "img"`, `pagina.corpo.secoes[].elementosSeccao[].briefingVisual` é obrigatório no contrato.
-- Para tags diferentes de `img`, `briefingVisual` não deve existir no JSON.
+- Para tags diferentes de `img`, `briefingVisual` deve existir com valor `null`.
 - pagina.corpo.secoes[].elementosSeccao[].texto com tamMaximo, tamMinimo, conteudo
 - Em wireframe, `conteudo` deve ser sempre `""` (sem texto final).
 

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -35,3 +35,5 @@
 - 2026-05-13 09:10:00 UTC-3 — Ajustado o schema da etapa `landing-page-wireframe` para compatibilidade com OpenAI Structured Outputs removendo o uso de `allOf` (com `if/then/else`), que é rejeitado pela API com erro `invalid_json_schema`; a regra de uso exclusivo de `briefingVisual` para `img` permanece reforçada no prompt.
 
 - 2026-05-13 09:32:00 UTC-3 — Reforçada a regra contratual no schema `landing-page-wireframe`: o campo `tag` agora explicita literalmente que `briefingVisual` só é permitido quando `tag = "img"`, e o próprio `briefingVisual` passou a repetir a instrução de omissão para demais tags.
+
+- 2026-05-13 09:55:00 UTC-3 — Corrigido o schema da etapa `landing-page-wireframe` para compatibilidade rígida com OpenAI Structured Outputs exigindo `briefingVisual` no `required` de `elementoSecao`; para preservar a regra de uso exclusivo em imagens, o campo passou a aceitar `null` e o prompt/contrato foram alinhados para usar `briefingVisual: null` quando `tag` for diferente de `img`.


### PR DESCRIPTION
### Motivation
- Fix the `invalid_json_schema` 400 returned by OpenAI Structured Outputs that complained about a missing `briefingVisual` in the schema `required` for the `landing-page-wireframe` artifact.
- Preserve the business rule that `briefingVisual` applies only to image elements while satisfying the strict Structured Outputs requirement that properties in `properties` must appear in `required`.

### Description
- Updated `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` to add `briefingVisual` to the `required` list of `elementoSecao` and changed its type to `["object","null"]` so non-image elements may set `briefingVisual: null`.
- Aligned the prompt/contract text in `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` to instruct producers to use `briefingVisual: null` when `tag != "img"` instead of omitting the field.
- Appended an audit entry to `docs/gera-landing/registros3.md` recording the change in the append-only log.

### Testing
- Validated the updated schema JSON syntax with `python -m json.tool ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` which succeeded (no errors).
- No additional automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c9cea7ec832188809b6ecd47c3cc)