### PR TITLE
Alinha saída geralanding para `items` por seção com ids do wireframe

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json
@@ -36,19 +36,19 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "item": {
+                "id": {
                   "type": "string",
-                  "description": "Id técnico literal vindo de uiTextTags."
+                  "description": "Id técnico literal vindo do wireframe (elementosSeccao e elementosInternos)."
                 },
-                "copy": {
+                "texto": {
                   "type": "string",
                   "minLength": 1,
                   "pattern": "^(?!.*(?i:(adCopy\\\\.|campaignAngle\\\\.|landingMatchLine|mechanismSummary|primaryCTA|messageMatchNotes|ctaMatchNotes|matchAdCta|usa literalmente|id[eê]ntic[oa] ao an[úu]ncio|[âa]ncora para o formul[áa]rio|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\\\bV[1-3]-|lorem ipsum|como funciona \\\\(passo)))).+"
                 }
               },
               "required": [
-                "item",
-                "copy"
+                "id",
+                "texto"
               ]
             }
           }
@@ -58,7 +58,7 @@
           "items"
         ]
       },
-      "description": "Cada bodySection deve seguir exatamente a lista/ordem de seções do wireframe e conter items com pares item/copy baseados em uiTextTags, respeitando o tamanho sugerido em caracteres."
+      "description": "Cada bodySection deve seguir exatamente a lista/ordem de seções do wireframe e conter items com pares id/texto baseados em uiTextTags, respeitando o tamanho sugerido em caracteres."
     },
     "ctaBlocks": {
       "type": "array",

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
@@ -28,13 +28,13 @@ Wireframe da Landing: IMPORTANTE !!
 {dados-landingPageWireframe}
 
 template_id: landing-copy
-template_version: v2
+template_version: v3
 artifact_target: landingPageCopy
 
 SYSTEM_INSTRUCTIONS
 Objetivo principal desta etapa:
 - Ler o JSON que vem logo após "Wireframe da Landing: IMPORTANTE !!".
-- Para cada seção/slot do wireframe, gerar os textos finais para os campos do contrato de `landingPageCopy`.
+- Para cada seção do wireframe, gerar uma lista de itens contendo somente `id` e `texto`, preservando exatamente os ids originais do wireframe.
 - Respeitar obrigatoriamente os sinais de `uiTags` e os limites sugeridos em `uiSizeTexts`.
 
 Elementos de contexto (usar para direcionar a argumentação, sem mudar a estrutura do wireframe):
@@ -72,15 +72,15 @@ Campos obrigatórios:
 - messageMatchNotes
 - primaryCTA
 - complianceNotes
-- bodySections[] com sectionId, slotId, sectionType, title, summary, bullets, copy, ctaSupport, sectionDependsOn, messageMatchNotes
+- bodySections[] com sectionId e items[] (cada item contendo apenas id e texto)
 - ctaBlocks[] com placement, ctaVariant, ctaLabel, ctaUrl, matchAdCta, ctaSupport, messageMatchNotes
 - faq[] com question, answer, objectionTag
 - consistencyChecks[] com check, status (PASS/WARN/FAIL), details
 
 Critérios mínimos de aceite no próprio output:
 - `bodySections.length >= 4`
-- Se `landingPageWireframe.copySlots` existir, `bodySections[i].slotId` deve pertencer aos copySlots da `sectionId` correspondente.
-- cada `bodySections[i].bullets.length >= 3`
+- Cada `bodySections[i].items[j].id` deve existir na seção correspondente do wireframe (`elementosSeccao` e filhos), sem renomear ids.
+- cada `bodySections[i].items.length >= 3`
 - `faq.length >= 3`
 - `ctaBlocks.length >= 2`
 - incluir em `consistencyChecks` os checks: CTA_MATCH, PROMISE_MATCH, GOOGLE_LANDING_BEST_PRACTICES

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -37,3 +37,5 @@
 - 2026-05-13 09:32:00 UTC-3 — Reforçada a regra contratual no schema `landing-page-wireframe`: o campo `tag` agora explicita literalmente que `briefingVisual` só é permitido quando `tag = "img"`, e o próprio `briefingVisual` passou a repetir a instrução de omissão para demais tags.
 
 - 2026-05-13 09:55:00 UTC-3 — Corrigido o schema da etapa `landing-page-wireframe` para compatibilidade rígida com OpenAI Structured Outputs exigindo `briefingVisual` no `required` de `elementoSecao`; para preservar a regra de uso exclusivo em imagens, o campo passou a aceitar `null` e o prompt/contrato foram alinhados para usar `briefingVisual: null` quando `tag` for diferente de `img`.
+
+- 2026-05-13 — Ajustada a fase `geralanding` do `landingPageCopy` para saída por seção com `items` contendo apenas `id` e `texto`, mantendo os mesmos ids do wireframe (sem aliases). Arquivos: `landing-page-copy.md` e `landing-page-copy-schema.json`.


### PR DESCRIPTION
### Motivation
- Tornar a fase `geralanding` compatível com saída estruturada por seção e garantir mapeamento direto entre os elementos do wireframe e a copy final usando os mesmos `id` técnicos.
- Evitar remapeamentos e ambiguidades no pipeline de montagem de landing, facilitando validação automática e integração com o artefato de wireframe publicado.

### Description
- Atualizado o prompt `ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md` para `template_version: v3` e para exigir saída por seção com `items` contendo apenas `id` e `texto`, além de ajustar os critérios mínimos de aceite para refletir o novo formato.
- Alinhado o `OUTPUT_CONTRACT` no prompt para pedir `bodySections[]` com `sectionId` e `items[]` (cada item: `id` + `texto`).
- Modificado o schema JSON `ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json` substituindo `item/copy` por `id/texto`, atualizando descrições e `required` correspondentes, e ajustando a descrição do `bodySections` para o novo contrato.
- Registrado o ajuste em `docs/gera-landing/registros3.md` com a mudança de comportamento e referência aos arquivos alterados.

### Testing
- Validado o JSON do schema com `python -m json.tool ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json`, que retornou `OK` sem erros de sintaxe.
- Não houve erros de parsing do schema e a nova especificação está pronta para ser usada em execuções de geração estruturada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03cf5318088321b093ef573b6c37b5)