### PR TITLE
oprm-coletor-mei: fix scheduled ingestion to 23:00, enable by default and add diagnostics

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -19,3 +19,7 @@
 - 2026-05-12 13:40:00 (UTC-3): habilitado endpoint Actuator de arquivo de log no módulo `oprm-coletor-mei` com exposição `logfile` e configuração de `logging.file.name` (default `/tmp/oprm-coletor-mei.log`) para permitir consulta operacional via URL `/actuator/logfile`.
 
 - 2026-05-12 19:30:00 (UTC-3): reprogramado novamente o agendamento padrão da ingestão de CNAEs da Receita Federal no módulo `oprm-coletor-mei` para executar às 19:30 no fuso `America/Sao_Paulo` (`cron` padrão `0 30 19 * * *`), mantendo override por `OPRM_COLLECTOR_SCHEDULE_CRON`.
+
+- 2026-05-12 22:15:00 (UTC-3): adicionados logs explícitos nas primeiras linhas do método agendado `runScheduledIngestion` no `oprm-coletor-mei` (incluindo `enabled`, `cron`, `timezone`, `source` e `payloadFile`) para diagnosticar ausência de execução; também reprogramado o agendamento padrão para 23:00 no fuso `America/Sao_Paulo` (`cron` padrão `0 0 23 * * *`) e habilitado por padrão (`enabled=true`), mantendo overrides por variáveis de ambiente.
+
+- 2026-05-12 22:35:00 (UTC-3): ajuste solicitado: agendamento fixado diretamente no método `runScheduledIngestion` com `@Scheduled(cron = "0 0 23 * * *", zone = "America/Sao_Paulo")` para eliminar dependência de configuração externa do horário de execução.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/service/CnaeCatalogCollectorScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/catalog/service/CnaeCatalogCollectorScheduler.java
@@ -35,8 +35,14 @@ public class CnaeCatalogCollectorScheduler {
         this.objectMapper = objectMapper;
     }
 
-    @Scheduled(cron = "${oprm.collector.schedule.cron}", zone = "${oprm.collector.schedule.timezone}")
+    @Scheduled(cron = "0 0 23 * * *", zone = "America/Sao_Paulo")
     public void runScheduledIngestion() {
+        log.info("Disparo do agendador de ingestão CNAE: enabled={}, cron={}, timezone={}, source={}, payloadFile={}",
+                scheduleProperties.enabled(),
+                scheduleProperties.cron(),
+                scheduleProperties.timezone(),
+                scheduleProperties.source(),
+                scheduleProperties.payloadFile());
         if (!scheduleProperties.enabled()) {
             return;
         }

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -21,8 +21,8 @@ oprm:
     batch-size: ${OPRM_COLLECTOR_BATCH_SIZE:500}
 
     schedule:
-      enabled: ${OPRM_COLLECTOR_SCHEDULE_ENABLED:false}
-      cron: ${OPRM_COLLECTOR_SCHEDULE_CRON:0 30 19 * * *}
+      enabled: ${OPRM_COLLECTOR_SCHEDULE_ENABLED:true}
+      cron: ${OPRM_COLLECTOR_SCHEDULE_CRON:0 0 23 * * *}
       timezone: ${OPRM_COLLECTOR_SCHEDULE_TIMEZONE:America/Sao_Paulo}
       source: ${OPRM_COLLECTOR_SCHEDULE_SOURCE:RECEITA_FEDERAL}
       payload-file: ${OPRM_COLLECTOR_SCHEDULE_PAYLOAD_FILE:}


### PR DESCRIPTION
### Motivation
- Ensure the CNAE ingestion job reliably runs at a predictable time and expose runtime diagnostics to investigate missed executions.
- Move scheduling behavior to the scheduler code path to avoid relying on external config for the cron expression.
- Document operational changes and timeline for the OPRM collector deployment and troubleshooting steps.

### Description
- Hardcoded the schedule on the scheduler method by changing `@Scheduled(cron = "${oprm.collector.schedule.cron}", zone = "${oprm.collector.schedule.timezone}")` to `@Scheduled(cron = "0 0 23 * * *", zone = "America/Sao_Paulo")` in `CnaeCatalogCollectorScheduler`. 
- Added an informational log at the start of `runScheduledIngestion` to emit `enabled`, `cron`, `timezone`, `source` and `payloadFile` via `log.info(...)` for early diagnostics. 
- Kept the existing guard checks for `scheduleProperties.enabled()` and missing `payloadFile`, and ensured errors are recorded via `executionLogService.error(...)` as before. 
- Changed defaults in `application.yml` to enable the schedule by default (`enabled: true`) and set the default cron to `0 0 23 * * *`, and updated the docs `docs/registros/oprm1.md` with rollout notes about scheduling, logging and observability changes. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03cebac6648321bf247823d7ab872e)