### PR TITLE
Support new 'pagina' wireframe format and add unit test

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessor.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public class CopyProvisionalHtmlProcessor {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private final WireframeHtmlGenerator wireframeHtmlGenerator = new WireframeHtmlGenerator();
 
     public String process(String wireframeJson, String copyJson) {
         if (!StringUtils.hasText(wireframeJson)) {
@@ -86,7 +87,7 @@ public class CopyProvisionalHtmlProcessor {
     private String buildHtmlFromWireframe(Map<String, Object> wireframe) {
         Object rawSections = wireframe.get("sectionOrder");
         if (!(rawSections instanceof List<?> sections) || sections.isEmpty()) {
-            throw new IllegalArgumentException("Wireframe sem sectionOrder para montar HTML base");
+            return buildHtmlFromWireframePaginaModel(wireframe);
         }
 
         List<String> sectionBlocks = new ArrayList<>();
@@ -123,6 +124,18 @@ public class CopyProvisionalHtmlProcessor {
                 + "\n  </style>\n</head>\n<body" + buildBodyAttributes(wireframe) + ">"
                 + String.join("\n", sectionBlocks)
                 + "\n</body>\n</html>";
+    }
+
+    private String buildHtmlFromWireframePaginaModel(Map<String, Object> wireframe) {
+        if (!wireframe.containsKey("pagina")) {
+            throw new IllegalArgumentException("Wireframe sem sectionOrder para montar HTML base");
+        }
+        try {
+            String wireframeJson = OBJECT_MAPPER.writeValueAsString(wireframe);
+            return wireframeHtmlGenerator.generateFromJson(wireframeJson);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Falha ao montar HTML base para o novo formato de wireframe", e);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessorNewWireframeFormatTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessorNewWireframeFormatTest.java
@@ -1,0 +1,54 @@
+package com.marketinghub.geralanding;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CopyProvisionalHtmlProcessorNewWireframeFormatTest {
+
+    private final CopyProvisionalHtmlProcessor processor = new CopyProvisionalHtmlProcessor();
+
+    @Test
+    void shouldGenerateHtmlFromPaginaWireframeAndApplyCopyItems() {
+        String wireframeJson = """
+                {
+                  "pagina": {
+                    "head": { "texto": "Wireframe novo" },
+                    "corpo": {
+                      "estilos": [{ "nome": "max-width", "valor": "680px" }],
+                      "secoes": [
+                        {
+                          "id": "s1-hero",
+                          "tag": "section",
+                          "estilos": [{ "nome": "padding", "valor": "16px" }],
+                          "elementosSeccao": [
+                            {"id":"headline","tag":"h1","texto":{"conteudo":""},"estilos":[{"nome":"margin","valor":"0"}]},
+                            {"id":"subheadline","tag":"p","texto":{"conteudo":""},"estilos":[{"nome":"margin","valor":"8px 0 0"}]}
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        String copyJson = """
+                {
+                  "bodySections": [
+                    {
+                      "items": [
+                        {"item":"headline","copy":"Transforme sua captação"},
+                        {"item":"subheadline","copy":"Receba uma prévia em poucos minutos"}
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        String html = processor.process(wireframeJson, copyJson);
+
+        assertTrue(html.contains("Transforme sua captação"));
+        assertTrue(html.contains("Receba uma prévia em poucos minutos"));
+        assertTrue(html.contains("headline"));
+    }
+}

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -39,3 +39,4 @@
 - 2026-05-13 09:55:00 UTC-3 — Corrigido o schema da etapa `landing-page-wireframe` para compatibilidade rígida com OpenAI Structured Outputs exigindo `briefingVisual` no `required` de `elementoSecao`; para preservar a regra de uso exclusivo em imagens, o campo passou a aceitar `null` e o prompt/contrato foram alinhados para usar `briefingVisual: null` quando `tag` for diferente de `img`.
 
 - 2026-05-13 — Ajustada a fase `geralanding` do `landingPageCopy` para saída por seção com `items` contendo apenas `id` e `texto`, mantendo os mesmos ids do wireframe (sem aliases). Arquivos: `landing-page-copy.md` e `landing-page-copy-schema.json`.
+- 2026-05-12 22:50:00 UTC-3 — Ajustado o gerador de HTML provisório da etapa `landing-page-copy` para suportar o novo wireframe com raiz `pagina` quando `sectionOrder` não estiver presente, reutilizando `WireframeHtmlGenerator` para montar o HTML base antes de aplicar os textos por id; mantida compatibilidade com o formato legado.


### PR DESCRIPTION
### Motivation

- Add support for a new wireframe JSON shape that uses a top-level `pagina` model instead of `sectionOrder` so provisional HTML can be generated from the new format.

### Description

- Use a `WireframeHtmlGenerator` instance to produce HTML when the incoming wireframe lacks `sectionOrder` and contains a `pagina` key by adding `buildHtmlFromWireframePaginaModel` and calling it from `buildHtmlFromWireframe`.
- Change `buildHtmlFromWireframe` to fallback to the new `pagina`-based builder instead of throwing when `sectionOrder` is missing.
- Add a new unit test `CopyProvisionalHtmlProcessorNewWireframeFormatTest` to verify HTML generation from the `pagina` wireframe and that copy items are applied to elements.
- Keep existing behavior for legacy `sectionOrder` wireframes unchanged and reuse the existing JSON parsing and copy application logic.

### Testing

- Added `CopyProvisionalHtmlProcessorNewWireframeFormatTest` that asserts generated HTML contains the supplied copy and element ids, and the test passed when running the test suite.
- Ran the module unit tests with `mvn test` and the new test succeeded alongside existing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03d373b7988321affc065e9272b131)