### PR TITLE
Fix Gera Copy provisional HTML merge with latest wireframe/copy JSONs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessor.java
@@ -56,7 +56,7 @@ public class CopyProvisionalHtmlProcessor {
         for (Map.Entry<String, String> entry : copyByItemId.entrySet()) {
             Element element = document.getElementById(entry.getKey());
             if (element != null && StringUtils.hasText(entry.getValue())) {
-                element.text(entry.getValue().trim());
+                applyCopyToElement(element, entry.getValue().trim());
             }
         }
 
@@ -66,6 +66,16 @@ public class CopyProvisionalHtmlProcessor {
         }
 
         return normalizeSerializedHtml(document.outerHtml());
+    }
+
+
+    private void applyCopyToElement(Element element, String value) {
+        String tagName = element.tagName();
+        if ("input".equalsIgnoreCase(tagName) || "textarea".equalsIgnoreCase(tagName)) {
+            element.attr("placeholder", value);
+            return;
+        }
+        element.text(value);
     }
 
     private String normalizeSerializedHtml(String html) {
@@ -186,7 +196,8 @@ public class CopyProvisionalHtmlProcessor {
                 String copy = firstNonBlank(
                         asString(itemMap.get("copy")),
                         asString(itemMap.get("value")),
-                        asString(itemMap.get("text"))
+                        asString(itemMap.get("text")),
+                        asString(itemMap.get("texto"))
                 );
                 if (StringUtils.hasText(id) && StringUtils.hasText(copy)) {
                     result.put(id.trim(), copy.trim());

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessorNewWireframeFormatTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessorNewWireframeFormatTest.java
@@ -51,4 +51,37 @@ class CopyProvisionalHtmlProcessorNewWireframeFormatTest {
         assertTrue(html.contains("Receba uma prévia em poucos minutos"));
         assertTrue(html.contains("headline"));
     }
+
+    @Test
+    void shouldApplyTextoFieldAndSetPlaceholderForInputElements() {
+        String wireframeJson = """
+                {
+                  "sectionOrder": [
+                    {
+                      "uiTags": "<section><h2 id=\\"title\\">Titulo</h2><input id=\\"email-input\\" type=\\"email\\" placeholder=\\"\\"/></section>",
+                      "uiSizes": ""
+                    }
+                  ]
+                }
+                """;
+
+        String copyJson = """
+                {
+                  "bodySections": [
+                    {
+                      "items": [
+                        {"id": "title", "texto": "Novo título"},
+                        {"id": "email-input", "texto": "seuemail@exemplo.com"}
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        String html = processor.process(wireframeJson, copyJson);
+
+        assertTrue(html.contains("Novo título"));
+        assertTrue(html.contains("id=\"email-input\""));
+        assertTrue(html.contains("placeholder=\"seuemail@exemplo.com\""));
+    }
 }

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -40,3 +40,5 @@
 
 - 2026-05-13 — Ajustada a fase `geralanding` do `landingPageCopy` para saída por seção com `items` contendo apenas `id` e `texto`, mantendo os mesmos ids do wireframe (sem aliases). Arquivos: `landing-page-copy.md` e `landing-page-copy-schema.json`.
 - 2026-05-12 22:50:00 UTC-3 — Ajustado o gerador de HTML provisório da etapa `landing-page-copy` para suportar o novo wireframe com raiz `pagina` quando `sectionOrder` não estiver presente, reutilizando `WireframeHtmlGenerator` para montar o HTML base antes de aplicar os textos por id; mantida compatibilidade com o formato legado.
+
+- 2026-05-12 23:10:00 UTC-3 — Ajustado o merge de HTML provisório da etapa `landing-page-copy` para os JSONs novos do experimento 20: o processador passou a ler `bodySections[].items[].texto` na extração da copy por id e a aplicar conteúdo em `input`/`textarea` via `placeholder`, garantindo composição correta entre wireframe e copy no preview.


### PR DESCRIPTION
### Motivation
- O processador de HTML provisório da etapa Gera Copy não estava alinhado com a nova forma dos JSONs encontrados em `experiment.id = 20`, onde o copy passou a usar `bodySections[].items[].texto` e o wireframe pode vir no modelo `pagina`/`corpo`/`secoes`.
- Campos de formulário (`input`/`textarea`) presentes no `uiTags` do wireframe não recebiam o conteúdo correto no preview porque o merge aplicava sempre `text()` em vez de popular `placeholder` quando apropriado.

### Description
- Adicionada extração do campo `texto` em `collectCopyByItemId` para suportar `bodySections[].items[].texto` além de `copy/value/text` (arquivo `CopyProvisionalHtmlProcessor.java`).
- Substituída escrita direta em texto por um método `applyCopyToElement` que seta `placeholder` para `input`/`textarea` e usa `text()` para elementos normais, e integrado ao fluxo de aplicação da copy.
- Atualizado o fluxo para continuar suportando ambos os formatos de wireframe (legado `sectionOrder` e novo `pagina`) mantendo a geração base via `WireframeHtmlGenerator` quando necessário.
- Adicionado um teste unitário em `CopyProvisionalHtmlProcessorNewWireframeFormatTest` cobrindo o uso de `texto` e a atribuição de `placeholder` em `input`.

### Testing
- Executado o teste unitário alvo com `mvn -Dtest=CopyProvisionalHtmlProcessorNewWireframeFormatTest test` e todos os testes desse caso passaram (2 tests, 0 failures, 0 errors).
- A validação local incluiu leitura do `experiment` id `20` via MCP `db_query` para confirmar os novos formatos de `landing_page_wireframe` e `landing_page_copy` antes das mudanças.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03dbed139c8321bc00d8aab936f25a)