### PR TITLE
Normalize item IDs for copy application and render body section items by element tags

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/lhm/LandingHtmlModule.java
@@ -634,7 +634,7 @@ public class LandingHtmlModule {
                     if (!slotId.equalsIgnoreCase(asTrimmedString(bodySection.get("slotId")))) {
                         continue;
                     }
-                    appendBodySectionBlock(slotted, bodySection);
+                    appendBodySectionBlock(slotted, section, bodySection);
                 }
             }
             if (slotted.length() > 0) {
@@ -647,7 +647,7 @@ public class LandingHtmlModule {
                 continue;
             }
             StringBuilder sb = new StringBuilder();
-            appendBodySectionBlock(sb, bodySection);
+            appendBodySectionBlock(sb, section, bodySection);
             return sb.toString();
         }
         return "";
@@ -680,7 +680,42 @@ public class LandingHtmlModule {
                 .toList();
     }
 
-    private void appendBodySectionBlock(StringBuilder sb, Map<String, Object> bodySection) {
+    @SuppressWarnings("unchecked")
+    private void appendBodySectionBlock(StringBuilder sb, Map<String, Object> section, Map<String, Object> bodySection) {
+        if (bodySection.get("items") instanceof List<?> rawItems) {
+            Map<String, String> tagsById = buildTagsById(section);
+            StringBuilder pendingListItems = new StringBuilder();
+            for (Object rawItem : rawItems) {
+                if (!(rawItem instanceof Map<?, ?> itemMap)) {
+                    continue;
+                }
+                String itemId = asTrimmedString(((Map<String, Object>) itemMap).get("id"));
+                String text = asTrimmedString(((Map<String, Object>) itemMap).get("texto"));
+                if (!StringUtils.hasText(text)) {
+                    continue;
+                }
+                String tag = firstNonBlank(tagsById.get(itemId), "p");
+                if ("li".equalsIgnoreCase(tag)) {
+                    pendingListItems.append("<li>").append(escapeHtml(text)).append("</li>");
+                    continue;
+                }
+                if (pendingListItems.length() > 0) {
+                    sb.append("<ul>").append(pendingListItems).append("</ul>");
+                    pendingListItems.setLength(0);
+                }
+                if ("h1".equalsIgnoreCase(tag) || "h2".equalsIgnoreCase(tag) || "h3".equalsIgnoreCase(tag)) {
+                    sb.append("<").append(tag.toLowerCase(Locale.ROOT)).append(">")
+                            .append(escapeHtml(text))
+                            .append("</").append(tag.toLowerCase(Locale.ROOT)).append(">");
+                } else {
+                    appendParagraph(sb, text);
+                }
+            }
+            if (pendingListItems.length() > 0) {
+                sb.append("<ul>").append(pendingListItems).append("</ul>");
+            }
+            return;
+        }
         appendRichText(sb, asTrimmedString(bodySection.get("summary")));
         appendRichText(sb, asTrimmedString(bodySection.get("copy")));
         if (bodySection.get("bullets") instanceof List<?> rawBullets) {
@@ -697,6 +732,36 @@ public class LandingHtmlModule {
             }
         }
         appendParagraph(sb, asTrimmedString(bodySection.get("ctaSupport")));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> buildTagsById(Map<String, Object> section) {
+        if (section == null || !(section.get("elementosSeccao") instanceof List<?> rawElements)) {
+            return Map.of();
+        }
+        java.util.LinkedHashMap<String, String> tagsById = new java.util.LinkedHashMap<>();
+        for (Object rawElement : rawElements) {
+            collectTagsById(rawElement, tagsById);
+        }
+        return tagsById;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void collectTagsById(Object node, Map<String, String> target) {
+        if (!(node instanceof Map<?, ?> rawMap)) {
+            return;
+        }
+        Map<String, Object> map = (Map<String, Object>) rawMap;
+        String id = asTrimmedString(map.get("id"));
+        String tag = asTrimmedString(map.get("tag"));
+        if (StringUtils.hasText(id) && StringUtils.hasText(tag)) {
+            target.put(id, tag);
+        }
+        if (map.get("elementosInternos") instanceof List<?> internals) {
+            for (Object child : internals) {
+                collectTagsById(child, target);
+            }
+        }
     }
     private String buildFaqMarkup(String sectionId, List<Map<String, Object>> faqCopy) {
         if (!StringUtils.hasText(sectionId) || faqCopy == null || faqCopy.isEmpty()) {

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessor.java
@@ -10,9 +10,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Locale;
 
 @Component
 public class CopyProvisionalHtmlProcessor {
@@ -53,8 +55,9 @@ public class CopyProvisionalHtmlProcessor {
                 .prettyPrint(false)
                 .charset("utf-8")
                 .syntax(Document.OutputSettings.Syntax.html);
+        Map<String, Element> elementByNormalizedId = indexElementsByNormalizedId(document);
         for (Map.Entry<String, String> entry : copyByItemId.entrySet()) {
-            Element element = document.getElementById(entry.getKey());
+            Element element = resolveElementByItemId(document, elementByNormalizedId, entry.getKey());
             if (element != null && StringUtils.hasText(entry.getValue())) {
                 applyCopyToElement(element, entry.getValue().trim());
             }
@@ -66,6 +69,40 @@ public class CopyProvisionalHtmlProcessor {
         }
 
         return normalizeSerializedHtml(document.outerHtml());
+    }
+
+    private Element resolveElementByItemId(Document document, Map<String, Element> elementByNormalizedId, String itemId) {
+        if (!StringUtils.hasText(itemId)) {
+            return null;
+        }
+        Element directElement = document.getElementById(itemId);
+        if (directElement != null) {
+            return directElement;
+        }
+        return elementByNormalizedId.get(normalizeId(itemId));
+    }
+
+    private Map<String, Element> indexElementsByNormalizedId(Document document) {
+        Map<String, Element> result = new HashMap<>();
+        for (Element element : document.getAllElements()) {
+            String id = element.id();
+            if (!StringUtils.hasText(id)) {
+                continue;
+            }
+            result.putIfAbsent(normalizeId(id), element);
+        }
+        return result;
+    }
+
+    private String normalizeId(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "";
+        }
+        return value.trim()
+                .replace('–', '-')
+                .replace('—', '-')
+                .replaceAll("\\s+", "")
+                .toLowerCase(Locale.ROOT);
     }
 
 
@@ -200,7 +237,7 @@ public class CopyProvisionalHtmlProcessor {
                         asString(itemMap.get("texto"))
                 );
                 if (StringUtils.hasText(id) && StringUtils.hasText(copy)) {
-                    result.put(id.trim(), copy.trim());
+                    result.put(normalizeId(id), copy.trim());
                 }
             }
         }

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -42,3 +42,5 @@
 - 2026-05-12 22:50:00 UTC-3 — Ajustado o gerador de HTML provisório da etapa `landing-page-copy` para suportar o novo wireframe com raiz `pagina` quando `sectionOrder` não estiver presente, reutilizando `WireframeHtmlGenerator` para montar o HTML base antes de aplicar os textos por id; mantida compatibilidade com o formato legado.
 
 - 2026-05-12 23:10:00 UTC-3 — Ajustado o merge de HTML provisório da etapa `landing-page-copy` para os JSONs novos do experimento 20: o processador passou a ler `bodySections[].items[].texto` na extração da copy por id e a aplicar conteúdo em `input`/`textarea` via `placeholder`, garantindo composição correta entre wireframe e copy no preview.
+
+- 2026-05-13 00:25:00 UTC-3 — Registrada correção no gerador de HTML provisório da etapa `landing-page-copy` (pacote `geralanding`): aplicação de copy por `id` com resolução resiliente (match exato + fallback por id normalizado com remoção de espaços, normalização de traços unicode e case-insensitive) para evitar perda de texto em elementos `<li>` e demais tags quando houver variação de formatação entre wireframe e copy.


### PR DESCRIPTION
### Motivation
- Make copy application robust to ID formatting differences (unicode dashes, whitespace, case) and improve body-section HTML generation by honoring element tags defined in the wireframe.

### Description
- Add `normalizeId`, `indexElementsByNormalizedId`, and `resolveElementByItemId` to `CopyProvisionalHtmlProcessor` so `applyCopyByItemId` can find elements by a normalized ID fallback when `document.getElementById` fails.
- Normalize keys in `collectCopyByItemId` so collected copy entries use `normalizeId(id)` for tolerant lookups.
- Change `appendBodySectionBlock` in `LandingHtmlModule` to accept the parent `section` and render `items` using tags mapped by `buildTagsById`, with `collectTagsById` recursively collecting `id`->`tag` mappings from `elementosSeccao`.`elementosInternos` and producing proper list, heading, and paragraph markup with escaping.
- Preserve existing rich text, bullets and CTA handling while adding pending-list aggregation and tag-aware rendering, plus small import/utility adjustments (`Locale`, `HashMap`).

### Testing
- Ran the project unit tests with `./gradlew test` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03e8682f88832184e25329866bee1a)