### PR TITLE
fix(liquibase): restaura raiz YAML em db.changelog-master do ads-service

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,8 +1,8 @@
+databaseChangeLog:
   - include:
       file: changesets/2026-05-13-mois-collected-reference-temperature.yaml
       relativeToChangelogFile: true
 
-databaseChangeLog:
   - include:
       file: changesets/2026-05-11-oprm-niche-catalog-ingestion.yaml
       relativeToChangelogFile: true


### PR DESCRIPTION
### Motivation
- Corrigir falha do Liquibase causada por um item de lista no topo do arquivo que impedia o parser YAML de encontrar a chave raiz `databaseChangeLog`.

### Description
- Ajustei `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` para garantir que `databaseChangeLog` seja a raiz do documento YAML.
- Reposicionei o include `changesets/2026-05-13-mois-collected-reference-temperature.yaml` para dentro da lista de `databaseChangeLog`, removendo a estrutura inválida que gerava `ParserException`.

### Testing
- Executei `mvn -q liquibase:validate` em `backend/ads-service`, que não reportou mais o erro de parsing YAML e falhou apenas por falta de `database URL` no ambiente local.
- Nenhum teste unitário adicional foi executado neste PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03f01383c083218ef3d4e8e4c44961)