### PR TITLE
Fix GeraLandingExecutionServiceTest to match new constructor signature

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -36,7 +36,8 @@ class GeraLandingExecutionServiceTest {
                         objectMapper,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
-                        new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"));
+                        new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"));
         service.processPendingExecutions();
 
         verify(openAiClient).generate(any());
@@ -67,7 +68,8 @@ class GeraLandingExecutionServiceTest {
                         objectMapper,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
-                        new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"));
+                        new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"));
         service.processPendingExecutions();
 
         verify(backendClient).receiveFailure(any(), any(), any(), any(), any());


### PR DESCRIPTION
### Motivation
- The production class `GeraLandingExecutionService` was changed to require an additional `Resource` (image planning schema), so the unit tests needed to be updated to match the new constructor and restore compilation.

### Description
- Updated `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` to pass a third `ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json")` in both `GeraLandingExecutionService` instantiations used by the tests.

### Testing
- Ran `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test`; execution failed before tests due to Maven dependency resolution error for `com.marketinghub:ads-service:0.0.1-SNAPSHOT` returning `401 Unauthorized` from GitHub Packages, so tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ad861248832184c8d9e1048b9d52)