### PR TITLE
Hotmart collector: add cycle 2 (product details), hour-based scheduler, and docs

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -94,3 +94,13 @@
 - Coletor Hotmart ajustado para mapear e persistir, além do título/URL, os campos solicitados do produto: `ucode`, `image`, `temperature`, `reviewRating`, `totalAnswers`, `blueprint`, `price.value`, `category`, `format` e `producer.name`.
 - `HotmartProductSnapshot` expandido para carregar esses atributos de forma estruturada durante a coleta via API.
 - `rawMetadata` enviado ao backend passou a incluir todos os novos campos para disponibilização na camada administrativa sem depender de parsing textual.
+
+## 2026-05-13 17:16 UTC
+- Estruturado o 2º ciclo do coletor Hotmart no módulo `mois-hotmart-collector`: após listar produtos no endpoint `v2/market/search`, o serviço agora percorre produto a produto e consulta `v1/market/product/{id}/details`.
+- Implementado enriquecimento por produto com foco em `salesPageUrl` (página de vendas), preservando fallback para dados do 1º ciclo quando o detalhe falhar.
+- Adicionados logs de causa-raiz para falhas no ciclo 2 por produto (`status` HTTP e `productId`) sem interromper a coleta completa.
+
+## 2026-05-13 17:35 UTC
+- Scheduler do coletor Hotmart ajustado para alternar ciclos por hora: horas ímpares executam ciclo 1 (listagem) e horas pares executam ciclo 2 (detalhes por produto).
+- Implementado no serviço o fluxo de ciclo 2 que lê produtos do backend (`/api/v1/mois/hotmart/products`) e consulta detalhes item a item na Hotmart, priorizando `salesPageUrl`.
+- Criado documento técnico do projeto descrevendo os dois ciclos e regras de execução em `mois-hotmart-collector/docs/ciclos-coleta-hotmart.md`.

--- a/mois-hotmart-collector/docs/ciclos-coleta-hotmart.md
+++ b/mois-hotmart-collector/docs/ciclos-coleta-hotmart.md
@@ -1,0 +1,37 @@
+# Coletor Hotmart — Ciclo 1 e Ciclo 2
+
+Este documento descreve a estratégia operacional de coleta em dois ciclos para o coletor Hotmart.
+
+## Visão geral
+
+- **Ciclo 1 (horas ímpares):** busca a listagem de produtos na Hotmart (`v2/market/search`) e persiste snapshots base no backend.
+- **Ciclo 2 (horas pares):** lê os produtos já persistidos no backend (resultado do ciclo 1), consulta detalhes produto a produto em `v1/market/product/{id}/details` e atualiza os dados com foco em `salesPageUrl`.
+
+## Regras de agendamento
+
+O scheduler executa de hora em hora e decide o ciclo com base na hora atual:
+
+- Hora ímpar (`hour % 2 != 0`) → executa `collectFirstCycle(...)`.
+- Hora par (`hour % 2 == 0`) → executa `collectSecondCycleFromBackend(...)`.
+
+## Ciclo 1 — Listagem
+
+1. Buscar token JWT da Hotmart em configuração geral do backend.
+2. Chamar `POST https://api-affiliation-market.hotmart.com/v2/market/search`.
+3. Mapear snapshots base dos produtos.
+4. Persistir no backend em `/api/v1/mois/persistence/collection-jobs/{jobId}`.
+
+## Ciclo 2 — Detalhes por produto
+
+1. Buscar token JWT da Hotmart em configuração geral do backend.
+2. Buscar produtos persistidos no backend via `/api/v1/mois/hotmart/products`.
+3. Para cada produto, chamar:
+   - `GET https://api-affiliation-market.hotmart.com/v1/market/product/{id}/details?userSessionId={session}`
+4. Enriquecer snapshot priorizando `salesPageUrl` e demais campos vindos do detalhe.
+5. Persistir novamente no backend para atualização das referências.
+
+## Tratamento de falhas
+
+- Se falhar obtenção do token: ciclo é marcado como `COLLECTION_SKIPPED`.
+- Se falhar detalhe de um produto específico no ciclo 2: mantém dados do ciclo 1 para aquele item e continua o processamento dos demais.
+- Logs registram `status` HTTP e `productId` para diagnóstico de causa-raiz.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -2,6 +2,7 @@ package com.marketinghub.moishotmart.service;
 
 import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionRequest;
 import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionResponse;
+import java.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,8 +37,17 @@ public class HotmartCollectorScheduler {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
         }
-        HotmartCollectionResponse response = collectorService.collect(new HotmartCollectionRequest(source, maxProducts));
-        log.info("Hotmart scheduler executado status={} produtos={} mensagem={}",
-                response.status(), response.products().size(), response.message());
+        int currentHour = LocalDateTime.now().getHour();
+        boolean isOddHour = currentHour % 2 != 0;
+        HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
+        HotmartCollectionResponse response = isOddHour
+                ? collectorService.collectFirstCycle(request)
+                : collectorService.collectSecondCycleFromBackend(request);
+        log.info("Hotmart scheduler executado hora={} ciclo={} status={} produtos={} mensagem={}",
+                currentHour,
+                isOddHour ? "CICLO_1_LISTAGEM" : "CICLO_2_DETALHES",
+                response.status(),
+                response.products().size(),
+                response.message());
     }
 }

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -37,6 +37,7 @@ public class HotmartCollectorService {
     private static final int LOGIN_SUBMIT_RETRIES = 3;
     private static final int COOKIE_RETRY_ATTEMPTS = 3;
     private static final String HOTMART_MARKET_API_URL = "https://api-affiliation-market.hotmart.com/v2/market/search";
+    private static final String HOTMART_PRODUCT_DETAILS_API_URL = "https://api-affiliation-market.hotmart.com/v1/market/product/%s/details?userSessionId=%s";
 
     private final boolean headless;
     private final String chromiumExecutablePath;
@@ -83,6 +84,10 @@ public class HotmartCollectorService {
     }
 
     public HotmartCollectionResponse collect(HotmartCollectionRequest request) {
+        return collectFirstCycle(request);
+    }
+
+    public HotmartCollectionResponse collectFirstCycle(HotmartCollectionRequest request) {
         int boundedMax = request.maxProducts() <= 0 ? 10 : Math.min(request.maxProducts(), 50);
 
         List<HotmartProductSnapshot> products = new ArrayList<>();
@@ -124,6 +129,78 @@ public class HotmartCollectorService {
         }
         persistCollectedProductsOnBackend(request, status, products);
         return new HotmartCollectionResponse(status, message, products);
+    }
+
+    public HotmartCollectionResponse collectSecondCycleFromBackend(HotmartCollectionRequest request) {
+        List<HotmartProductSnapshot> enrichedProducts = new ArrayList<>();
+        String status = "COLLECTION_EXECUTED";
+        String message = "Ciclo 2 executado a partir dos produtos persistidos no backend.";
+        String hotmartAccessToken = fetchHotmartJwtFromGeneralSettings();
+        if (hotmartAccessToken.isBlank()) {
+            return new HotmartCollectionResponse(
+                    "COLLECTION_SKIPPED",
+                    "Token JWT da Hotmart ausente para execução do ciclo 2.",
+                    enrichedProducts
+            );
+        }
+        List<HotmartProductSnapshot> baseProducts = fetchFirstCycleProductsFromBackend(request.maxProducts());
+        for (HotmartProductSnapshot base : baseProducts) {
+            if (enrichedProducts.size() >= request.maxProducts() && request.maxProducts() > 0) {
+                break;
+            }
+            JsonNode listItem = objectMapper.createObjectNode()
+                    .put("id", pickFirstNonBlank(base.ucode(), ""))
+                    .put("ucode", pickFirstNonBlank(base.ucode(), ""))
+                    .put("userSessionId", "");
+            enrichedProducts.add(enrichProductWithDetails(hotmartAccessToken, listItem, base));
+        }
+        persistCollectedProductsOnBackend(request, status, enrichedProducts);
+        return new HotmartCollectionResponse(status, message, enrichedProducts);
+    }
+
+    private List<HotmartProductSnapshot> fetchFirstCycleProductsFromBackend(int maxProducts) {
+        List<HotmartProductSnapshot> products = new ArrayList<>();
+        int boundedMax = maxProducts <= 0 ? 25 : Math.min(maxProducts, 100);
+        String endpoint = backendBaseUrl + "/api/v1/mois/hotmart/products?limit=" + boundedMax;
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .header("accept", "application/json")
+                    .GET()
+                    .build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                log.warn("Ciclo 2: falha ao obter produtos base do backend. status={}, endpoint={}", response.statusCode(), endpoint);
+                return products;
+            }
+            JsonNode root = objectMapper.readTree(response.body());
+            JsonNode items = firstArray(root, "items", "products", "content", "results");
+            if (items == null || !items.isArray()) {
+                return products;
+            }
+            for (JsonNode item : items) {
+                products.add(new HotmartProductSnapshot(
+                        extractProductText(item, "ucode", "productUcode"),
+                        pickFirstNonBlank(extractProductText(item, "title", "name", "productName"), "Produto sem título"),
+                        extractProductText(item, "image", "productImage"),
+                        pickFirstNonBlank(extractProductText(item, "reviewRating", "rating"), "N/A"),
+                        extractProductInteger(item, "totalAnswers"),
+                        extractProductNumber(item, "blueprint"),
+                        "N/A",
+                        extractProductNumber(item, "priceValue", "value"),
+                        extractProductText(item, "category"),
+                        extractProductText(item, "format"),
+                        extractProductText(item, "producerName"),
+                        pickFirstNonBlank(extractProductText(item, "detailsUrl", "productUrl", "url"), hotmartMarketUrl),
+                        extractProductNumber(item, "temperature", "hotmartTemperature"),
+                        extractProductText(item, "salesPageUrl", "pageUrl"),
+                        Instant.now()
+                ));
+            }
+        } catch (Exception ex) {
+            log.warn("Ciclo 2: erro ao obter produtos do backend.", ex);
+        }
+        return products;
     }
 
     private void persistCollectedProductsOnBackend(
@@ -285,7 +362,7 @@ public class HotmartCollectorService {
                             truncateForLog(item.toString(), 600));
                 }
                 Double temperature = extractProductNumber(item, "temperature", "temp", "hotness");
-                products.add(new HotmartProductSnapshot(
+                HotmartProductSnapshot baseSnapshot = new HotmartProductSnapshot(
                         extractProductText(item, "ucode"),
                         title == null || title.isBlank() ? "Produto sem título" : title,
                         extractProductText(item, "image"),
@@ -300,12 +377,67 @@ public class HotmartCollectorService {
                         url,
                         temperature,
                         salesPageUrl,
-                        Instant.now()));
+                        Instant.now());
+                products.add(enrichProductWithDetails(accessToken, item, baseSnapshot));
             }
             return products.size();
         } catch (Exception ex) {
             log.warn("Falha na coleta de produtos via API Hotmart.", ex);
             return 0;
+        }
+    }
+
+    private HotmartProductSnapshot enrichProductWithDetails(String accessToken, JsonNode listItem, HotmartProductSnapshot baseSnapshot) {
+        String productId = pickFirstNonBlank(
+                extractProductText(listItem, "id", "productId", "uuid"),
+                baseSnapshot.ucode()
+        );
+        if (productId == null || productId.isBlank()) {
+            return baseSnapshot;
+        }
+        String userSessionId = pickFirstNonBlank(
+                extractProductText(listItem, "userSessionId", "sessionId"),
+                "collector-" + UUID.randomUUID()
+        );
+        String detailsUrl = HOTMART_PRODUCT_DETAILS_API_URL.formatted(productId, userSessionId);
+        try {
+            HttpRequest detailsRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(detailsUrl))
+                    .header("accept", "application/json, text/plain, */*")
+                    .header("authorization", "Bearer " + accessToken)
+                    .GET()
+                    .build();
+            HttpResponse<String> detailsResponse = HttpClient.newHttpClient().send(detailsRequest, HttpResponse.BodyHandlers.ofString());
+            if (detailsResponse.statusCode() < 200 || detailsResponse.statusCode() >= 300) {
+                log.warn("Ciclo 2 Hotmart: falha ao buscar detalhe do produto. status={}, productId={}", detailsResponse.statusCode(), productId);
+                return baseSnapshot;
+            }
+            JsonNode detailsNode = objectMapper.readTree(detailsResponse.body());
+            String salesPageFromDetails = extractProductText(detailsNode, "salesPageUrl", "salesPage", "pageUrl", "url");
+            String detailPageUrl = pickFirstNonBlank(
+                    extractProductText(detailsNode, "detailsUrl", "productUrl", "checkoutUrl"),
+                    baseSnapshot.detailsUrl()
+            );
+            return new HotmartProductSnapshot(
+                    baseSnapshot.ucode(),
+                    pickFirstNonBlank(extractProductText(detailsNode, "name", "title"), baseSnapshot.title()),
+                    pickFirstNonBlank(extractProductText(detailsNode, "image"), baseSnapshot.image()),
+                    baseSnapshot.rating(),
+                    baseSnapshot.totalAnswers(),
+                    baseSnapshot.blueprint(),
+                    baseSnapshot.commission(),
+                    baseSnapshot.priceValue(),
+                    baseSnapshot.category(),
+                    baseSnapshot.format(),
+                    pickFirstNonBlank(firstText(detailsNode.path("producer"), "name"), baseSnapshot.producerName()),
+                    detailPageUrl,
+                    baseSnapshot.temperature(),
+                    pickFirstNonBlank(pickFirstNonBlank(salesPageFromDetails, baseSnapshot.salesPageUrl()), detailPageUrl),
+                    baseSnapshot.collectedAt()
+            );
+        } catch (Exception ex) {
+            log.warn("Ciclo 2 Hotmart: erro ao enriquecer produto com detalhes. productId={}", productId, ex);
+            return baseSnapshot;
         }
     }
 


### PR DESCRIPTION
### Motivation

- Introduce a second enrichment cycle to improve collected product data (notably `salesPageUrl`) by calling the Hotmart product details endpoint per item. 
- Run different collection behaviors on alternate hours to spread load and separate list vs detail work. 

### Description

- Implemented hour-based scheduling in `HotmartCollectorScheduler` that chooses `collectFirstCycle(...)` on odd hours and `collectSecondCycleFromBackend(...)` on even hours and added logging of `hora` and `ciclo` in the scheduler. 
- Added `collectFirstCycle(...)` and `collectSecondCycleFromBackend(...)` to `HotmartCollectorService`, and made `collect(...)` delegate to `collectFirstCycle(...)` for backward compatibility. 
- Implemented `fetchFirstCycleProductsFromBackend(...)` to read products from the backend and `enrichProductWithDetails(...)` to call `v1/market/product/{id}/details` per product, prioritizing `salesPageUrl` with fallback to cycle-1 data and preserving non-blocking per-item failure handling with logs. 
- Added a new technical document `mois-hotmart-collector/docs/ciclos-coleta-hotmart.md` describing the two-cycle strategy, scheduling rules and failure handling. 

### Testing

- Module tests were executed with `mvn test -q` and completed successfully. 
- The collector flow was exercised via the new scheduler paths (cycle 1 and cycle 2) and produced normal logging for successful and failed detail fetches during local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b10d73948321b5ecced80344e2dd)