### PR TITLE
OPRM: add CNPJ open-data snapshot inventory and import plan for market-size phase

### DIFF
--- a/docs/novos-modulos/OPRM/cnpj-open-data-2026-04-12.md
+++ b/docs/novos-modulos/OPRM/cnpj-open-data-2026-04-12.md
@@ -1,0 +1,130 @@
+# Base CNPJ aberta (snapshot 2026-04-12) para OPRM
+
+## Objetivo
+
+Documentar os arquivos ZIP publicados em `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/`, suas URLs diretas a importância de cada conjunto para o OPRM no Marketing Hub, com foco inicial em mensuração quantitativa de tamanho de mercado (sem recorte geográfico).
+
+## URL base
+
+- `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/`
+
+## Arquivos e importância para o projeto (foco quantitativo, sem geografia)
+
+### 1) Cnaes.zip
+- **URL**: `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Cnaes.zip`
+- **O que contém**: tabela de domínio CNAE (código e descrição da atividade econômica).
+- **Importância para o OPRM**:
+  - classificar nichos por atividade real de mercado;
+  - suportar filtros por segmento para análises de dor e oportunidade;
+  - base para agregações por setor no eixo Dor → Resultado → Mecanismo → Prova → Oferta.
+
+### 2) Empresas0.zip ... Empresas9.zip
+- **URLs**:
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Empresas0.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Empresas1.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Empresas2.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Empresas3.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Empresas4.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Empresas5.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Empresas6.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Empresas7.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Empresas8.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Empresas9.zip`
+- **O que contém**: dados da pessoa jurídica no nível da empresa (CNPJ básico), como razão social, natureza jurídica, porte e capital social.
+- **Importância para o OPRM**:
+  - permitir clusterização de mercado por porte e natureza jurídica;
+  - identificar perfil econômico predominante por nicho;
+  - apoiar critérios de priorização comercial por potencial de compra e maturidade do público.
+
+### 3) Estabelecimentos0.zip ... Estabelecimentos9.zip
+- **URLs**:
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Estabelecimentos0.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Estabelecimentos1.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Estabelecimentos2.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Estabelecimentos3.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Estabelecimentos4.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Estabelecimentos5.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Estabelecimentos6.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Estabelecimentos7.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Estabelecimentos8.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Estabelecimentos9.zip`
+- **O que contém**: dados do estabelecimento (matriz/filial), incluindo situação cadastral, CNAE principal/secundário, endereço, município, UF e contato.
+- **Importância para o OPRM**:
+  - principal base para **contagem de estabelecimentos ativos** por CNAE;
+  - suportar cálculo de tamanho de mercado por volume (total de CNPJs operacionais);
+  - permitir métricas quantitativas como participação relativa por segmento.
+
+### 4) Motivos.zip
+- **URL**: `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Motivos.zip`
+- **O que contém**: códigos e descrições dos motivos de situação cadastral.
+- **Importância para o OPRM**:
+  - explicar eventos de baixa/suspensão/inaptidão;
+  - gerar sinais de dor operacional e risco em determinados segmentos.
+
+### 5) Municipios.zip
+- **URL**: `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Municipios.zip`
+- **O que contém**: códigos e nomes de municípios.
+- **Importância para o OPRM (neste momento)**:
+  - **baixa prioridade** para o objetivo atual;
+  - manter apenas para compatibilidade futura, sem uso analítico obrigatório na fase quantitativa inicial.
+
+### 6) Naturezas.zip
+- **URL**: `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Naturezas.zip`
+- **O que contém**: tabela de natureza jurídica.
+- **Importância para o OPRM**:
+  - segmentar mercados por tipo de entidade jurídica;
+  - ajustar linguagem de oferta e expectativa de decisão por perfil empresarial.
+
+### 7) Paises.zip
+- **URL**: `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Paises.zip`
+- **O que contém**: códigos e nomes de países usados nos registros da base CNPJ.
+- **Importância para o OPRM**:
+  - suporte a casos com vínculo internacional;
+  - melhora consistência de dados em cenários com sócios/endereços no exterior.
+
+### 8) Qualificacoes.zip
+- **URL**: `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Qualificacoes.zip`
+- **O que contém**: tabela de qualificação de sócios e representantes.
+- **Importância para o OPRM**:
+  - enriquecer leitura de governança e perfil decisor;
+  - apoiar hipóteses comerciais sobre quem influencia compra dentro das empresas.
+
+### 9) Simples.zip
+- **URL**: `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Simples.zip`
+- **O que contém**: situação de opção/exclusão no Simples Nacional e MEI.
+- **Importância para o OPRM**:
+  - sinalizar maturidade tributária e porte operacional;
+  - ajudar na priorização de produtos por capacidade de investimento do público.
+
+### 10) Socios0.zip ... Socios9.zip
+- **URLs**:
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Socios0.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Socios1.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Socios2.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Socios3.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Socios4.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Socios5.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Socios6.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Socios7.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Socios8.zip`
+  - `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-04-12/Socios9.zip`
+- **O que contém**: quadro societário (identificação e qualificação dos sócios, datas e tipos de participação).
+- **Importância para o OPRM**:
+  - análise de perfil de decisão e estrutura societária;
+  - suporte para estratégias comerciais B2B orientadas a decisores reais.
+
+## Recomendação operacional para o projeto (fase 1: tamanho de mercado)
+
+1. Ingerir primeiro as tabelas de domínio essenciais para classificação quantitativa: CNAE, Naturezas, Motivos e Qualificações (Municípios/Países ficam opcionais nesta fase).
+2. Ingerir Empresas e Estabelecimentos para formar o núcleo de métricas de tamanho de mercado.
+3. Enriquecer com Simples e Sócios para cortes de maturidade e perfil societário.
+4. Publicar agregações via backend para consumo do OPRM, respeitando o modelo único (backend como ponto de acesso aos dados).
+
+## Métricas quantitativas recomendadas (sem geografia)
+
+- **TAM por segmento (CNAE)**: total de estabelecimentos ativos por CNAE principal.
+- **Mercado endereçável por porte**: distribuição por porte dentro de cada CNAE.
+- **Densidade empresarial por natureza jurídica**: volume por tipo de entidade.
+- **Taxa de atividade**: ativos / total por segmento.
+- **Penetração Simples/MEI**: proporção de optantes por segmento.
+- **Complexidade societária**: média de sócios por empresa e faixas de estrutura societária.

--- a/docs/novos-modulos/OPRM/oprm-plano-importacao-cnpj-market-size.md
+++ b/docs/novos-modulos/OPRM/oprm-plano-importacao-cnpj-market-size.md
@@ -1,0 +1,226 @@
+# Plano de importação CNPJ para OPRM (fase 1: tamanho de mercado sem geografia)
+
+## Objetivo
+
+Definir como implementar a importação da base CNPJ aberta para suportar métricas quantitativas de tamanho de mercado no OPRM, com persistência no backend (MySQL 5.7) e consumo via API.
+
+## Princípios de arquitetura
+
+- Somente o backend acessa o banco de dados.
+- OPRM/coletor executa lógica de coleta, parsing e envio em lotes para endpoints do backend.
+- Fase 1 sem recorte geográfico obrigatório (município/UF opcional).
+- Evitar JSON dentro de JSON nos contratos.
+
+## Tabelas propostas (backend)
+
+## 1) Staging de execução
+
+### `oprm_cnpj_import_run`
+Controle de cada execução de importação.
+
+Campos sugeridos:
+- `id` BIGINT PK AUTO_INCREMENT
+- `snapshot_date` DATE NOT NULL
+- `source_url` VARCHAR(255) NOT NULL
+- `status` VARCHAR(20) NOT NULL (`STARTED`, `COMPLETED`, `FAILED`, `PARTIAL`)
+- `started_at` DATETIME NOT NULL
+- `finished_at` DATETIME NULL
+- `files_total` INT NOT NULL DEFAULT 0
+- `files_processed` INT NOT NULL DEFAULT 0
+- `rows_read` BIGINT NOT NULL DEFAULT 0
+- `rows_valid` BIGINT NOT NULL DEFAULT 0
+- `rows_rejected` BIGINT NOT NULL DEFAULT 0
+- `error_message` VARCHAR(1000) NULL
+
+Índices:
+- `idx_import_run_snapshot` (`snapshot_date`)
+- `idx_import_run_status` (`status`)
+
+### `oprm_cnpj_import_file`
+Rastreia cada arquivo ZIP processado na execução.
+
+Campos sugeridos:
+- `id` BIGINT PK AUTO_INCREMENT
+- `run_id` BIGINT NOT NULL (FK lógica para `oprm_cnpj_import_run.id`)
+- `file_name` VARCHAR(120) NOT NULL
+- `file_url` VARCHAR(255) NOT NULL
+- `dataset_type` VARCHAR(30) NOT NULL (`CNAE`, `EMPRESA`, `ESTABELECIMENTO`, `SOCIO`, `SIMPLES`, `DOMINIO`)
+- `status` VARCHAR(20) NOT NULL
+- `rows_read` BIGINT NOT NULL DEFAULT 0
+- `rows_valid` BIGINT NOT NULL DEFAULT 0
+- `rows_rejected` BIGINT NOT NULL DEFAULT 0
+- `started_at` DATETIME NOT NULL
+- `finished_at` DATETIME NULL
+- `error_message` VARCHAR(1000) NULL
+
+Índices:
+- `idx_import_file_run` (`run_id`)
+- `idx_import_file_dataset` (`dataset_type`)
+
+## 2) Dimensões (fase 1)
+
+### `oprm_cnpj_cnae_dim`
+- `cnae_code` VARCHAR(7) PK
+- `description` VARCHAR(255) NOT NULL
+- `active` TINYINT(1) NOT NULL DEFAULT 1
+- `updated_at` DATETIME NOT NULL
+
+### `oprm_cnpj_natureza_dim`
+- `natureza_code` VARCHAR(4) PK
+- `description` VARCHAR(255) NOT NULL
+- `updated_at` DATETIME NOT NULL
+
+### `oprm_cnpj_motivo_dim`
+- `motivo_code` VARCHAR(2) PK
+- `description` VARCHAR(255) NOT NULL
+- `updated_at` DATETIME NOT NULL
+
+### `oprm_cnpj_qualificacao_dim`
+- `qualificacao_code` VARCHAR(2) PK
+- `description` VARCHAR(255) NOT NULL
+- `updated_at` DATETIME NOT NULL
+
+## 3) Fatos de mercado (fase 1)
+
+### `oprm_cnpj_empresa_fact`
+Chave no nível CNPJ básico (8 dígitos).
+
+- `cnpj_basico` VARCHAR(8) PK
+- `razao_social` VARCHAR(255) NOT NULL
+- `natureza_code` VARCHAR(4) NULL
+- `porte_code` VARCHAR(2) NULL
+- `capital_social` DECIMAL(18,2) NULL
+- `ente_federativo` VARCHAR(255) NULL
+- `snapshot_date` DATE NOT NULL
+- `updated_at` DATETIME NOT NULL
+
+Índices:
+- `idx_empresa_natureza` (`natureza_code`)
+- `idx_empresa_porte` (`porte_code`)
+
+### `oprm_cnpj_estabelecimento_fact`
+Chave no nível CNPJ completo (8+4+2).
+
+- `cnpj_basico` VARCHAR(8) NOT NULL
+- `cnpj_ordem` VARCHAR(4) NOT NULL
+- `cnpj_dv` VARCHAR(2) NOT NULL
+- `cnpj_completo` VARCHAR(14) NOT NULL
+- `matriz_filial` VARCHAR(1) NULL
+- `nome_fantasia` VARCHAR(255) NULL
+- `situacao_cadastral` VARCHAR(2) NULL
+- `motivo_code` VARCHAR(2) NULL
+- `data_situacao_cadastral` DATE NULL
+- `data_inicio_atividade` DATE NULL
+- `cnae_principal` VARCHAR(7) NULL
+- `cnaes_secundarios` TEXT NULL
+- `snapshot_date` DATE NOT NULL
+- `updated_at` DATETIME NOT NULL
+
+PK e índices:
+- PK (`cnpj_completo`)
+- `idx_estab_cnpj_basico` (`cnpj_basico`)
+- `idx_estab_cnae_principal` (`cnae_principal`)
+- `idx_estab_situacao` (`situacao_cadastral`)
+- `idx_estab_motivo` (`motivo_code`)
+
+### `oprm_cnpj_simples_fact`
+- `cnpj_basico` VARCHAR(8) PK
+- `optante_simples` CHAR(1) NULL
+- `data_opcao_simples` DATE NULL
+- `data_exclusao_simples` DATE NULL
+- `optante_mei` CHAR(1) NULL
+- `data_opcao_mei` DATE NULL
+- `data_exclusao_mei` DATE NULL
+- `snapshot_date` DATE NOT NULL
+- `updated_at` DATETIME NOT NULL
+
+### `oprm_cnpj_socio_fact`
+- `id` BIGINT PK AUTO_INCREMENT
+- `cnpj_basico` VARCHAR(8) NOT NULL
+- `tipo_socio` VARCHAR(1) NULL
+- `nome_socio` VARCHAR(255) NULL
+- `documento_socio_ofuscado` VARCHAR(20) NULL
+- `qualificacao_code` VARCHAR(2) NULL
+- `data_entrada_sociedade` DATE NULL
+- `snapshot_date` DATE NOT NULL
+- `updated_at` DATETIME NOT NULL
+
+Índices:
+- `idx_socio_cnpj_basico` (`cnpj_basico`)
+- `idx_socio_qualificacao` (`qualificacao_code`)
+
+## 4) Tabela agregada de mercado (API pronta para OPRM)
+
+### `oprm_market_size_by_cnae`
+Agregado materializado para consultas rápidas.
+
+- `snapshot_date` DATE NOT NULL
+- `cnae_code` VARCHAR(7) NOT NULL
+- `total_estabelecimentos` BIGINT NOT NULL
+- `total_estabelecimentos_ativos` BIGINT NOT NULL
+- `total_empresas` BIGINT NOT NULL
+- `total_empresas_mei` BIGINT NOT NULL
+- `total_empresas_simples` BIGINT NOT NULL
+- `avg_socios_por_empresa` DECIMAL(10,2) NOT NULL
+- `updated_at` DATETIME NOT NULL
+
+PK e índices:
+- PK (`snapshot_date`, `cnae_code`)
+- `idx_market_size_total_ativos` (`total_estabelecimentos_ativos`)
+
+## Fluxo de importação a implementar
+
+## Etapa A — Inicialização da execução
+1. Criar registro em `oprm_cnpj_import_run` com status `STARTED`.
+2. Gerar lista de arquivos da snapshot.
+3. Criar registros em `oprm_cnpj_import_file` (status `STARTED`).
+
+## Etapa B — Importação de dimensões
+1. Importar `Cnaes.zip`, `Naturezas.zip`, `Motivos.zip`, `Qualificacoes.zip`.
+2. Upsert por chave de domínio.
+3. Marcar arquivo como `COMPLETED` e atualizar contadores.
+
+## Etapa C — Importação dos fatos
+1. Importar `Empresas*.zip` em lotes (batch 5k–20k linhas).
+2. Importar `Estabelecimentos*.zip` em lotes.
+3. Importar `Simples.zip` e `Socios*.zip`.
+4. Regras de parsing:
+   - datas `00000000` -> `NULL`;
+   - decimal com vírgula -> `DECIMAL(18,2)`;
+   - campos fora do layout -> rejeição com contagem + log de erro.
+
+## Etapa D — Agregação quantitativa
+1. Recalcular `oprm_market_size_by_cnae` para `snapshot_date` da execução.
+2. Métricas mínimas:
+   - estabelecimentos totais e ativos por CNAE;
+   - empresas totais por CNAE;
+   - optantes Simples/MEI por CNAE;
+   - média de sócios por empresa por CNAE.
+
+## Etapa E — Finalização
+1. Fechar `oprm_cnpj_import_file` pendentes.
+2. Atualizar `oprm_cnpj_import_run` com `COMPLETED` ou `PARTIAL/FAILED`.
+3. Expor resumo em endpoint de execuções do OPRM.
+
+## Endpoints backend necessários
+
+- `POST /api/oprm/market/import-runs` (iniciar execução)
+- `POST /api/oprm/market/import-runs/{runId}/files/{fileId}/events` (progresso)
+- `POST /api/oprm/market/import-runs/{runId}/complete` (finalizar)
+- `GET /api/oprm/market/import-runs` (histórico)
+- `GET /api/oprm/market-size/cnaes?snapshotDate=YYYY-MM-DD&limit=...` (consulta agregada)
+
+## Estratégia de rollout
+
+1. **PR 1**: Liquibase (tabelas de run/file + dimensões + fatos).
+2. **PR 2**: Serviço backend de upsert e validações de contrato.
+3. **PR 3**: Implementação do coletor OPRM para download/parse/envio em batch.
+4. **PR 4**: Agregação `oprm_market_size_by_cnae` + endpoint de consulta.
+5. **PR 5**: Observabilidade (métricas, logs, retentativas e alertas).
+
+## Critérios de aceite (fase 1)
+
+- Importação completa de uma snapshot com rastreabilidade por arquivo.
+- Contagem consistente entre linhas lidas, válidas e rejeitadas.
+- Consulta de tamanho de mercado por CNAE com tempo de resposta aceitável.
+- Nenhuma dependência de recorte geográfico para entregar valor na fase inicial.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -25,3 +25,8 @@
 
 - 2026-05-12 22:35:00 (UTC-3): ajuste solicitado: agendamento fixado diretamente no método `runScheduledIngestion` com `@Scheduled(cron = "0 0 23 * * *", zone = "America/Sao_Paulo")` para eliminar dependência de configuração externa do horário de execução.
 - 2026-05-13 03:05:00 (UTC): agendamento da ingestão CNAE (Receita Federal) alterado para 01:00 no fuso `America/Sao_Paulo` (Brasília), com atualização do cron hardcoded no `@Scheduled` e do cron padrão configurável em `application.yml` para `0 0 1 * * *`.
+
+- 2026-05-13: Criado documento `docs/novos-modulos/OPRM/cnpj-open-data-2026-04-12.md` com descrição de cada ZIP da base CNPJ (snapshot 2026-04-12), URLs diretas e relevância para o OPRM/Marketing Hub.
+- 2026-05-13 16:10:00 (UTC-3): complemento do registro do dia 2026-05-13: documento `docs/novos-modulos/OPRM/cnpj-open-data-2026-04-12.md` criado com inventário dos ZIPs, URLs diretas e importância por dataset para uso no OPRM.
+- 2026-05-13 16:30:00 (UTC-3): refinado documento `docs/novos-modulos/OPRM/cnpj-open-data-2026-04-12.md` para foco inicial exclusivamente quantitativo de tamanho de mercado, removendo priorização geográfica e adicionando métricas recomendadas sem recorte territorial.
+- 2026-05-13 16:50:00 (UTC-3): criado `docs/novos-modulos/OPRM/oprm-plano-importacao-cnpj-market-size.md` com desenho de tabelas (staging, dimensões, fatos e agregado), fluxo de importação por etapas, endpoints backend necessários e estratégia de rollout para implementação da carga CNPJ com foco em tamanho de mercado.


### PR DESCRIPTION
### Motivation

- Document the CNPJ open-data snapshot (2026-04-12) and provide direct URLs and dataset relevance to support OPRM market-size metrics without geographic cut.
- Define a concrete import plan, target schema and API surface for ingesting CNPJ data into the backend (MySQL 5.7) to enable materialized market-size aggregates by CNAE.

### Description

- Added `docs/novos-modulos/OPRM/cnpj-open-data-2026-04-12.md` which inventories each ZIP in the snapshot, provides direct download URLs and explains the relevance of each dataset for OPRM analyses. 
- Added `docs/novos-modulos/OPRM/oprm-plano-importacao-cnpj-market-size.md` which defines import principles, proposed staging/dimension/fact table schemas (including `oprm_cnpj_import_run`, `oprm_cnpj_import_file`, dimension tables and facts), parsing rules, import flow (A–E), and required backend endpoints such as `POST /api/oprm/market/import-runs` and `GET /api/oprm/market-size/cnaes`. 
- Updated `docs/registros/oprm1.md` to record the creation and refinement of the new documentation and the import plan entries in the project log. 

### Testing

- No automated tests were executed for these documentation-only changes. 
- Changes are limited to markdown documentation and registry entries with no code or schema migration applied in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ae8f3cb88321b62b65e655b60fa3)