### PR TITLE
Update tests to pass new FrameworkImageService constructor parameter

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/frameworkimage/FrameworkImageServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/frameworkimage/FrameworkImageServiceTest.java
@@ -44,7 +44,8 @@ class FrameworkImageServiceTest {
                 java.time.Duration.ofMillis(10),
                 "worker-test",
                 true,
-                100);
+                100,
+                0d);
         UUID jobId = UUID.randomUUID();
         FrameworkImageJobDto job = new FrameworkImageJobDto(
                 jobId,
@@ -102,7 +103,8 @@ class FrameworkImageServiceTest {
                 java.time.Duration.ofMillis(10),
                 "worker-test",
                 true,
-                100);
+                100,
+                0d);
         UUID jobId = UUID.randomUUID();
         FrameworkImageJobDto job = new FrameworkImageJobDto(
                 jobId,
@@ -145,7 +147,8 @@ class FrameworkImageServiceTest {
                 java.time.Duration.ofMillis(10),
                 "worker-test",
                 true,
-                100);
+                100,
+                0d);
         UUID jobId = UUID.randomUUID();
         FrameworkImageJobDto job = new FrameworkImageJobDto(
                 jobId,


### PR DESCRIPTION
### Motivation

- The `FrameworkImageService` constructor signature was extended with a new `double` parameter and the tests needed to be updated so they compile and reflect the new API.

### Description

- Updated three instantiations in `FrameworkImageServiceTest` to include the new `double` argument by adding `0d` after the existing `100` argument. 
- No behavioral changes to the tests themselves beyond matching the new constructor signature.

### Testing

- Ran the `FrameworkImageServiceTest` unit tests (`processPendingClaimsRunsBatchAndCompletesWithOpenAiReadyStage`, `processPendingFailsAllClaimedJobsWhenBatchThrows`, and `processPendingSkipsWhenJobCannotBeClaimed`), and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04be9ab45c83218ec5b79b34d03a30)