### PR TITLE
OPRM: CNPJ import plan — quantitativo-first (minimize persisted facts)

### DIFF
--- a/docs/novos-modulos/OPRM/oprm-plano-importacao-cnpj-market-size.md
+++ b/docs/novos-modulos/OPRM/oprm-plano-importacao-cnpj-market-size.md
@@ -1,8 +1,8 @@
-# Plano de importação CNPJ para OPRM (fase 1: tamanho de mercado sem geografia)
+# Plano de importação CNPJ para OPRM (fase 1: quantitativo-first sem geografia)
 
 ## Objetivo
 
-Definir como implementar a importação da base CNPJ aberta para suportar métricas quantitativas de tamanho de mercado no OPRM, com persistência no backend (MySQL 5.7) e consumo via API.
+Definir como implementar a importação da base CNPJ aberta para suportar métricas quantitativas de tamanho de mercado no OPRM, **com mínima persistência necessária no backend (MySQL 5.7)** e consumo via API.
 
 ## Princípios de arquitetura
 
@@ -10,6 +10,15 @@ Definir como implementar a importação da base CNPJ aberta para suportar métri
 - OPRM/coletor executa lógica de coleta, parsing e envio em lotes para endpoints do backend.
 - Fase 1 sem recorte geográfico obrigatório (município/UF opcional).
 - Evitar JSON dentro de JSON nos contratos.
+- **Priorizar agregação quantitativa e evitar carga de armazenamento detalhado sem necessidade comprovada.**
+
+## Diretriz desta fase
+
+Como o foco atual é **dados quantitativos**, a fase 1 adota estratégia **quantitativo-first**:
+
+- Persistir somente tabelas operacionais e agregadas necessárias para consulta de market size.
+- Evitar, nesta fase, tabelas fato detalhadas por CNPJ (empresa/estabelecimento/sócio/simples).
+- Evoluir para detalhamento apenas quando houver caso de uso validado (auditoria, drill-down, segmentação avançada).
 
 ## Tabelas propostas (backend)
 
@@ -57,7 +66,7 @@ Campos sugeridos:
 - `idx_import_file_run` (`run_id`)
 - `idx_import_file_dataset` (`dataset_type`)
 
-## 2) Dimensões (fase 1)
+## 2) Dimensão essencial (fase 1)
 
 ### `oprm_cnpj_cnae_dim`
 - `cnae_code` VARCHAR(7) PK
@@ -65,91 +74,9 @@ Campos sugeridos:
 - `active` TINYINT(1) NOT NULL DEFAULT 1
 - `updated_at` DATETIME NOT NULL
 
-### `oprm_cnpj_natureza_dim`
-- `natureza_code` VARCHAR(4) PK
-- `description` VARCHAR(255) NOT NULL
-- `updated_at` DATETIME NOT NULL
+> Nota: `natureza`, `motivo` e `qualificacao` podem entrar em fase posterior, somente se exigidos por novos indicadores.
 
-### `oprm_cnpj_motivo_dim`
-- `motivo_code` VARCHAR(2) PK
-- `description` VARCHAR(255) NOT NULL
-- `updated_at` DATETIME NOT NULL
-
-### `oprm_cnpj_qualificacao_dim`
-- `qualificacao_code` VARCHAR(2) PK
-- `description` VARCHAR(255) NOT NULL
-- `updated_at` DATETIME NOT NULL
-
-## 3) Fatos de mercado (fase 1)
-
-### `oprm_cnpj_empresa_fact`
-Chave no nível CNPJ básico (8 dígitos).
-
-- `cnpj_basico` VARCHAR(8) PK
-- `razao_social` VARCHAR(255) NOT NULL
-- `natureza_code` VARCHAR(4) NULL
-- `porte_code` VARCHAR(2) NULL
-- `capital_social` DECIMAL(18,2) NULL
-- `ente_federativo` VARCHAR(255) NULL
-- `snapshot_date` DATE NOT NULL
-- `updated_at` DATETIME NOT NULL
-
-Índices:
-- `idx_empresa_natureza` (`natureza_code`)
-- `idx_empresa_porte` (`porte_code`)
-
-### `oprm_cnpj_estabelecimento_fact`
-Chave no nível CNPJ completo (8+4+2).
-
-- `cnpj_basico` VARCHAR(8) NOT NULL
-- `cnpj_ordem` VARCHAR(4) NOT NULL
-- `cnpj_dv` VARCHAR(2) NOT NULL
-- `cnpj_completo` VARCHAR(14) NOT NULL
-- `matriz_filial` VARCHAR(1) NULL
-- `nome_fantasia` VARCHAR(255) NULL
-- `situacao_cadastral` VARCHAR(2) NULL
-- `motivo_code` VARCHAR(2) NULL
-- `data_situacao_cadastral` DATE NULL
-- `data_inicio_atividade` DATE NULL
-- `cnae_principal` VARCHAR(7) NULL
-- `cnaes_secundarios` TEXT NULL
-- `snapshot_date` DATE NOT NULL
-- `updated_at` DATETIME NOT NULL
-
-PK e índices:
-- PK (`cnpj_completo`)
-- `idx_estab_cnpj_basico` (`cnpj_basico`)
-- `idx_estab_cnae_principal` (`cnae_principal`)
-- `idx_estab_situacao` (`situacao_cadastral`)
-- `idx_estab_motivo` (`motivo_code`)
-
-### `oprm_cnpj_simples_fact`
-- `cnpj_basico` VARCHAR(8) PK
-- `optante_simples` CHAR(1) NULL
-- `data_opcao_simples` DATE NULL
-- `data_exclusao_simples` DATE NULL
-- `optante_mei` CHAR(1) NULL
-- `data_opcao_mei` DATE NULL
-- `data_exclusao_mei` DATE NULL
-- `snapshot_date` DATE NOT NULL
-- `updated_at` DATETIME NOT NULL
-
-### `oprm_cnpj_socio_fact`
-- `id` BIGINT PK AUTO_INCREMENT
-- `cnpj_basico` VARCHAR(8) NOT NULL
-- `tipo_socio` VARCHAR(1) NULL
-- `nome_socio` VARCHAR(255) NULL
-- `documento_socio_ofuscado` VARCHAR(20) NULL
-- `qualificacao_code` VARCHAR(2) NULL
-- `data_entrada_sociedade` DATE NULL
-- `snapshot_date` DATE NOT NULL
-- `updated_at` DATETIME NOT NULL
-
-Índices:
-- `idx_socio_cnpj_basico` (`cnpj_basico`)
-- `idx_socio_qualificacao` (`qualificacao_code`)
-
-## 4) Tabela agregada de mercado (API pronta para OPRM)
+## 3) Tabela agregada de mercado (API pronta para OPRM)
 
 ### `oprm_market_size_by_cnae`
 Agregado materializado para consultas rápidas.
@@ -161,12 +88,26 @@ Agregado materializado para consultas rápidas.
 - `total_empresas` BIGINT NOT NULL
 - `total_empresas_mei` BIGINT NOT NULL
 - `total_empresas_simples` BIGINT NOT NULL
-- `avg_socios_por_empresa` DECIMAL(10,2) NOT NULL
+- `avg_socios_por_empresa` DECIMAL(10,2) NULL
 - `updated_at` DATETIME NOT NULL
 
 PK e índices:
 - PK (`snapshot_date`, `cnae_code`)
 - `idx_market_size_total_ativos` (`total_estabelecimentos_ativos`)
+
+## 4) Fatos detalhados (postergados)
+
+As tabelas abaixo **não fazem parte da fase 1** para evitar sobrecarga de banco:
+
+- `oprm_cnpj_empresa_fact`
+- `oprm_cnpj_estabelecimento_fact`
+- `oprm_cnpj_simples_fact`
+- `oprm_cnpj_socio_fact`
+
+Critério para ativação futura:
+- necessidade formal de drill-down por CNPJ;
+- auditoria detalhada com retenção histórica;
+- novos produtos que dependam desses dados granulares.
 
 ## Fluxo de importação a implementar
 
@@ -175,29 +116,21 @@ PK e índices:
 2. Gerar lista de arquivos da snapshot.
 3. Criar registros em `oprm_cnpj_import_file` (status `STARTED`).
 
-## Etapa B — Importação de dimensões
-1. Importar `Cnaes.zip`, `Naturezas.zip`, `Motivos.zip`, `Qualificacoes.zip`.
+## Etapa B — Importação de dimensão
+1. Importar `Cnaes.zip`.
 2. Upsert por chave de domínio.
 3. Marcar arquivo como `COMPLETED` e atualizar contadores.
 
-## Etapa C — Importação dos fatos
-1. Importar `Empresas*.zip` em lotes (batch 5k–20k linhas).
-2. Importar `Estabelecimentos*.zip` em lotes.
-3. Importar `Simples.zip` e `Socios*.zip`.
-4. Regras de parsing:
+## Etapa C — Agregação quantitativa direta (sem persistir fatos)
+1. Processar `Empresas*.zip`, `Estabelecimentos*.zip`, `Simples.zip` e `Socios*.zip` em lotes (batch 5k–20k linhas).
+2. Agregar em memória/stream por `snapshot_date + cnae_code`.
+3. Regras de parsing:
    - datas `00000000` -> `NULL`;
    - decimal com vírgula -> `DECIMAL(18,2)`;
    - campos fora do layout -> rejeição com contagem + log de erro.
+4. Persistir somente resultado consolidado em `oprm_market_size_by_cnae`.
 
-## Etapa D — Agregação quantitativa
-1. Recalcular `oprm_market_size_by_cnae` para `snapshot_date` da execução.
-2. Métricas mínimas:
-   - estabelecimentos totais e ativos por CNAE;
-   - empresas totais por CNAE;
-   - optantes Simples/MEI por CNAE;
-   - média de sócios por empresa por CNAE.
-
-## Etapa E — Finalização
+## Etapa D — Finalização
 1. Fechar `oprm_cnpj_import_file` pendentes.
 2. Atualizar `oprm_cnpj_import_run` com `COMPLETED` ou `PARTIAL/FAILED`.
 3. Expor resumo em endpoint de execuções do OPRM.
@@ -212,11 +145,11 @@ PK e índices:
 
 ## Estratégia de rollout
 
-1. **PR 1**: Liquibase (tabelas de run/file + dimensões + fatos).
-2. **PR 2**: Serviço backend de upsert e validações de contrato.
-3. **PR 3**: Implementação do coletor OPRM para download/parse/envio em batch.
-4. **PR 4**: Agregação `oprm_market_size_by_cnae` + endpoint de consulta.
-5. **PR 5**: Observabilidade (métricas, logs, retentativas e alertas).
+1. **PR 1**: Liquibase (tabelas `run/file` + `cnae_dim` + `market_size_by_cnae`).
+2. **PR 2**: Serviço backend de consolidação quantitativa e validações de contrato.
+3. **PR 3**: Implementação do coletor OPRM para download/parse/agregação/envio em batch.
+4. **PR 4**: Endpoint de consulta + observabilidade (métricas, logs, retentativas e alertas).
+5. **PR 5 (opcional)**: Introdução de fatos detalhados, se justificado por caso de uso.
 
 ## Critérios de aceite (fase 1)
 
@@ -224,3 +157,4 @@ PK e índices:
 - Contagem consistente entre linhas lidas, válidas e rejeitadas.
 - Consulta de tamanho de mercado por CNAE com tempo de resposta aceitável.
 - Nenhuma dependência de recorte geográfico para entregar valor na fase inicial.
+- Persistência limitada ao mínimo necessário para o objetivo quantitativo atual.


### PR DESCRIPTION
### Motivation
- Reframe the phase 1 import plan to prioritize quantitative aggregation over granular persistence to reduce storage and complexity. 
- Clarify scope so only essential operational tables are persisted initially and detailed fact tables are postponed until required by validated use cases.

### Description
- Updated the document title and introduction to adopt a `quantitativo-first` approach and emphasize minimal persistence in MySQL 5.7. 
- Removed several detailed dimension and fact table definitions from phase 1 and kept only `oprm_cnpj_cnae_dim`, while postponing `empresa/estabelecimento/simples/socio` facts to a later phase. 
- Changed the import flow to aggregate in-memory/stream by `snapshot_date + cnae_code` and persist only the consolidated `oprm_market_size_by_cnae`, and relaxed `avg_socios_por_empresa` to allow `NULL`. 
- Adjusted staging tables, favored `oprm_cnpj_import_run` and `oprm_cnpj_import_file` for execution tracking, and updated the rollout/PR plan to reflect the reduced initial schema (`run/file`, `cnae_dim`, `market_size_by_cnae`).

### Testing
- Documentation CI checks (`markdown` lint and static site build) were executed and completed successfully. 
- No production code or unit tests were modified in this change set, so no unit/integration tests were run against application code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c194d49483218b3b1be0487bbfbd)