### PR TITLE
Add OPRM CNPJ market import domain, service, controller and DB migrations

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/OprmCnpjCnaeDim.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/OprmCnpjCnaeDim.java
@@ -1,0 +1,21 @@
+package com.marketinghub.oprm.market;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import lombok.Data;
+
+@Entity
+@Data
+public class OprmCnpjCnaeDim {
+    @Id
+    @Column(length = 7)
+    private String cnaeCode;
+    @Column(nullable = false)
+    private String description;
+    @Column(nullable = false)
+    private boolean active = true;
+    @Column(nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/OprmCnpjImportFile.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/OprmCnpjImportFile.java
@@ -1,0 +1,25 @@
+package com.marketinghub.oprm.market;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.Data;
+
+@Entity
+@Data
+public class OprmCnpjImportFile {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "run_id")
+    private OprmCnpjImportRun run;
+    @Column(nullable = false, length = 120) private String fileName;
+    @Column(nullable = false) private String fileUrl;
+    @Column(nullable = false, length = 30) private String datasetType;
+    @Column(nullable = false, length = 20) private String status;
+    @Column(nullable = false) private long rowsRead;
+    @Column(nullable = false) private long rowsValid;
+    @Column(nullable = false) private long rowsRejected;
+    @Column(nullable = false) private Instant startedAt;
+    private Instant finishedAt;
+    @Column(length = 1000) private String errorMessage;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/OprmCnpjImportRun.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/OprmCnpjImportRun.java
@@ -1,0 +1,29 @@
+package com.marketinghub.oprm.market;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import lombok.Data;
+
+@Entity
+@Data
+public class OprmCnpjImportRun {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private LocalDate snapshotDate;
+    @Column(nullable = false)
+    private String sourceUrl;
+    @Column(nullable = false, length = 20)
+    private String status;
+    @Column(nullable = false)
+    private Instant startedAt;
+    private Instant finishedAt;
+    @Column(nullable = false) private int filesTotal;
+    @Column(nullable = false) private int filesProcessed;
+    @Column(nullable = false) private long rowsRead;
+    @Column(nullable = false) private long rowsValid;
+    @Column(nullable = false) private long rowsRejected;
+    @Column(length = 1000)
+    private String errorMessage;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmCnaeUpsertDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmCnaeUpsertDto.java
@@ -1,0 +1,5 @@
+package com.marketinghub.oprm.market.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record OprmCnaeUpsertDto(@NotBlank String cnaeCode, @NotBlank String description, boolean active) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmCreateImportRunRequestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmCreateImportRunRequestDto.java
@@ -1,0 +1,23 @@
+package com.marketinghub.oprm.market.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+public record OprmCreateImportRunRequestDto(
+        @NotNull LocalDate snapshotDate,
+        @NotBlank String sourceUrl,
+        @NotBlank String status,
+        @NotNull Instant startedAt,
+        Instant finishedAt,
+        Integer filesTotal,
+        Integer filesProcessed,
+        Long rowsRead,
+        Long rowsValid,
+        Long rowsRejected,
+        String errorMessage,
+        @NotEmpty List<OprmImportFileSeedDto> files
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmImportFileEventRequestDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmImportFileEventRequestDto.java
@@ -1,0 +1,8 @@
+package com.marketinghub.oprm.market.dto;
+
+import java.util.List;
+import java.time.Instant;
+
+public record OprmImportFileEventRequestDto(String status, Long rowsRead, Long rowsValid, Long rowsRejected, String errorMessage,
+                                            Instant finishedAt,
+                                            List<OprmCnaeUpsertDto> cnaes) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmImportFileSeedDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmImportFileSeedDto.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.market.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+
+public record OprmImportFileSeedDto(
+        @NotBlank String fileName,
+        @NotBlank String fileUrl,
+        @NotBlank String datasetType,
+        String status,
+        Long rowsRead,
+        Long rowsValid,
+        Long rowsRejected,
+        String errorMessage,
+        Instant startedAt,
+        Instant finishedAt
+) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmImportRunCreatedResponseDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmImportRunCreatedResponseDto.java
@@ -1,0 +1,5 @@
+package com.marketinghub.oprm.market.dto;
+
+import java.util.List;
+
+public record OprmImportRunCreatedResponseDto(Long runId, List<Long> fileIds) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/repository/OprmCnpjCnaeDimRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/repository/OprmCnpjCnaeDimRepository.java
@@ -1,0 +1,6 @@
+package com.marketinghub.oprm.market.repository;
+
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OprmCnpjCnaeDimRepository extends JpaRepository<OprmCnpjCnaeDim, String> {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/repository/OprmCnpjImportFileRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/repository/OprmCnpjImportFileRepository.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.market.repository;
+
+import com.marketinghub.oprm.market.OprmCnpjImportFile;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OprmCnpjImportFileRepository extends JpaRepository<OprmCnpjImportFile, Long> {
+    List<OprmCnpjImportFile> findByRunId(Long runId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/repository/OprmCnpjImportRunRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/repository/OprmCnpjImportRunRepository.java
@@ -1,0 +1,6 @@
+package com.marketinghub.oprm.market.repository;
+
+import com.marketinghub.oprm.market.OprmCnpjImportRun;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OprmCnpjImportRunRepository extends JpaRepository<OprmCnpjImportRun, Long> {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/service/OprmMarketImportService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/service/OprmMarketImportService.java
@@ -1,0 +1,97 @@
+package com.marketinghub.oprm.market.service;
+
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
+import com.marketinghub.oprm.market.OprmCnpjImportFile;
+import com.marketinghub.oprm.market.OprmCnpjImportRun;
+import com.marketinghub.oprm.market.dto.*;
+import com.marketinghub.oprm.market.repository.OprmCnpjCnaeDimRepository;
+import com.marketinghub.oprm.market.repository.OprmCnpjImportFileRepository;
+import com.marketinghub.oprm.market.repository.OprmCnpjImportRunRepository;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OprmMarketImportService {
+    private final OprmCnpjImportRunRepository runRepository;
+    private final OprmCnpjImportFileRepository fileRepository;
+    private final OprmCnpjCnaeDimRepository cnaeDimRepository;
+
+    @Transactional
+    public OprmImportRunCreatedResponseDto startRun(OprmCreateImportRunRequestDto request) {
+        OprmCnpjImportRun run = new OprmCnpjImportRun();
+        run.setSnapshotDate(request.snapshotDate());
+        run.setSourceUrl(request.sourceUrl());
+        run.setStatus(request.status());
+        run.setStartedAt(request.startedAt());
+        run.setFinishedAt(request.finishedAt());
+        run.setFilesTotal(request.filesTotal() != null ? request.filesTotal() : request.files().size());
+        run.setFilesProcessed(request.filesProcessed() != null ? request.filesProcessed() : 0);
+        run.setRowsRead(request.rowsRead() != null ? request.rowsRead() : 0L);
+        run.setRowsValid(request.rowsValid() != null ? request.rowsValid() : 0L);
+        run.setRowsRejected(request.rowsRejected() != null ? request.rowsRejected() : 0L);
+        run.setErrorMessage(request.errorMessage());
+        run = runRepository.save(run);
+        final OprmCnpjImportRun persistedRun = run;
+
+        List<Long> fileIds = request.files().stream().map(seed -> {
+            OprmCnpjImportFile file = new OprmCnpjImportFile();
+            file.setRun(persistedRun);
+            file.setFileName(seed.fileName());
+            file.setFileUrl(seed.fileUrl());
+            file.setDatasetType(seed.datasetType());
+            file.setStatus(seed.status() != null ? seed.status() : "STARTED");
+            file.setRowsRead(seed.rowsRead() != null ? seed.rowsRead() : 0L);
+            file.setRowsValid(seed.rowsValid() != null ? seed.rowsValid() : 0L);
+            file.setRowsRejected(seed.rowsRejected() != null ? seed.rowsRejected() : 0L);
+            file.setErrorMessage(seed.errorMessage());
+            file.setStartedAt(seed.startedAt() != null ? seed.startedAt() : request.startedAt());
+            file.setFinishedAt(seed.finishedAt());
+            return fileRepository.save(file).getId();
+        }).toList();
+
+        return new OprmImportRunCreatedResponseDto(run.getId(), fileIds);
+    }
+
+    @Transactional
+    public void registerFileEvent(Long runId, Long fileId, OprmImportFileEventRequestDto request) {
+        OprmCnpjImportFile file = fileRepository.findById(fileId).orElseThrow();
+
+        if (request.status() != null) file.setStatus(request.status());
+        if (request.rowsRead() != null) file.setRowsRead(request.rowsRead());
+        if (request.rowsValid() != null) file.setRowsValid(request.rowsValid());
+        if (request.rowsRejected() != null) file.setRowsRejected(request.rowsRejected());
+        if (request.errorMessage() != null) file.setErrorMessage(request.errorMessage());
+        if (request.finishedAt() != null) file.setFinishedAt(request.finishedAt());
+        fileRepository.save(file);
+
+        if (request.cnaes() != null && !request.cnaes().isEmpty()) {
+            for (OprmCnaeUpsertDto row : request.cnaes()) {
+                OprmCnpjCnaeDim item = cnaeDimRepository.findById(row.cnaeCode()).orElseGet(OprmCnpjCnaeDim::new);
+                item.setCnaeCode(row.cnaeCode());
+                item.setDescription(row.description());
+                item.setActive(row.active());
+                item.setUpdatedAt(Instant.now());
+                cnaeDimRepository.save(item);
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<OprmCnpjImportRun> listRuns() {
+        return runRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public List<OprmCnpjImportFile> listRunFiles(Long runId) {
+        return fileRepository.findByRunId(runId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OprmCnpjCnaeDim> listCnaes() {
+        return cnaeDimRepository.findAll();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/web/OprmMarketImportController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/web/OprmMarketImportController.java
@@ -1,0 +1,49 @@
+package com.marketinghub.oprm.market.web;
+
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
+import com.marketinghub.oprm.market.OprmCnpjImportFile;
+import com.marketinghub.oprm.market.OprmCnpjImportRun;
+import com.marketinghub.oprm.market.dto.OprmCreateImportRunRequestDto;
+import com.marketinghub.oprm.market.dto.OprmImportFileEventRequestDto;
+import com.marketinghub.oprm.market.dto.OprmImportRunCreatedResponseDto;
+import com.marketinghub.oprm.market.service.OprmMarketImportService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/oprm/market/import-runs")
+@RequiredArgsConstructor
+public class OprmMarketImportController {
+    private final OprmMarketImportService service;
+
+    @PostMapping
+    public OprmImportRunCreatedResponseDto createRun(@Valid @RequestBody OprmCreateImportRunRequestDto request) {
+        return service.startRun(request);
+    }
+
+    @PostMapping("/{runId}/files/{fileId}/events")
+    public ResponseEntity<Void> fileEvent(@PathVariable Long runId,
+                                          @PathVariable Long fileId,
+                                          @RequestBody OprmImportFileEventRequestDto request) {
+        service.registerFileEvent(runId, fileId, request);
+        return ResponseEntity.accepted().build();
+    }
+
+    @GetMapping
+    public List<OprmCnpjImportRun> listRuns() {
+        return service.listRuns();
+    }
+
+    @GetMapping("/{runId}/files")
+    public List<OprmCnpjImportFile> listRunFiles(@PathVariable Long runId) {
+        return service.listRunFiles(runId);
+    }
+
+    @GetMapping("/cnaes")
+    public List<OprmCnpjCnaeDim> listCnaes() {
+        return service.listCnaes();
+    }
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-13-oprm-cnpj-market-import-phase-a-b.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-13-oprm-cnpj-market-import-phase-a-b.yaml
@@ -1,0 +1,58 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-13-oprm-cnpj-market-import-phase-a-b
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+      changes:
+        - createTable:
+            tableName: oprm_cnpj_import_run
+            columns:
+              - column: { name: id, type: BIGINT, autoIncrement: true, constraints: { primaryKey: true, nullable: false } }
+              - column: { name: snapshot_date, type: DATE, constraints: { nullable: false } }
+              - column: { name: source_url, type: VARCHAR(255), constraints: { nullable: false } }
+              - column: { name: status, type: VARCHAR(20), constraints: { nullable: false } }
+              - column: { name: started_at, type: DATETIME, constraints: { nullable: false } }
+              - column: { name: finished_at, type: DATETIME }
+              - column: { name: files_total, type: INT, defaultValueNumeric: 0, constraints: { nullable: false } }
+              - column: { name: files_processed, type: INT, defaultValueNumeric: 0, constraints: { nullable: false } }
+              - column: { name: rows_read, type: BIGINT, defaultValueNumeric: 0, constraints: { nullable: false } }
+              - column: { name: rows_valid, type: BIGINT, defaultValueNumeric: 0, constraints: { nullable: false } }
+              - column: { name: rows_rejected, type: BIGINT, defaultValueNumeric: 0, constraints: { nullable: false } }
+              - column: { name: error_message, type: VARCHAR(1000) }
+        - createIndex: { tableName: oprm_cnpj_import_run, indexName: idx_import_run_snapshot, columns: [ { column: { name: snapshot_date } } ] }
+        - createIndex: { tableName: oprm_cnpj_import_run, indexName: idx_import_run_status, columns: [ { column: { name: status } } ] }
+
+        - createTable:
+            tableName: oprm_cnpj_import_file
+            columns:
+              - column: { name: id, type: BIGINT, autoIncrement: true, constraints: { primaryKey: true, nullable: false } }
+              - column: { name: run_id, type: BIGINT, constraints: { nullable: false } }
+              - column: { name: file_name, type: VARCHAR(120), constraints: { nullable: false } }
+              - column: { name: file_url, type: VARCHAR(255), constraints: { nullable: false } }
+              - column: { name: dataset_type, type: VARCHAR(30), constraints: { nullable: false } }
+              - column: { name: status, type: VARCHAR(20), constraints: { nullable: false } }
+              - column: { name: rows_read, type: BIGINT, defaultValueNumeric: 0, constraints: { nullable: false } }
+              - column: { name: rows_valid, type: BIGINT, defaultValueNumeric: 0, constraints: { nullable: false } }
+              - column: { name: rows_rejected, type: BIGINT, defaultValueNumeric: 0, constraints: { nullable: false } }
+              - column: { name: started_at, type: DATETIME, constraints: { nullable: false } }
+              - column: { name: finished_at, type: DATETIME }
+              - column: { name: error_message, type: VARCHAR(1000) }
+        - addForeignKeyConstraint:
+            baseTableName: oprm_cnpj_import_file
+            baseColumnNames: run_id
+            referencedTableName: oprm_cnpj_import_run
+            referencedColumnNames: id
+            constraintName: fk_oprm_cnpj_import_file_run
+        - createIndex: { tableName: oprm_cnpj_import_file, indexName: idx_import_file_run, columns: [ { column: { name: run_id } } ] }
+        - createIndex: { tableName: oprm_cnpj_import_file, indexName: idx_import_file_dataset, columns: [ { column: { name: dataset_type } } ] }
+
+        - createTable:
+            tableName: oprm_cnpj_cnae_dim
+            columns:
+              - column: { name: cnae_code, type: VARCHAR(7), constraints: { primaryKey: true, nullable: false } }
+              - column: { name: description, type: VARCHAR(255), constraints: { nullable: false } }
+              - column: { name: active, type: TINYINT(1), defaultValueNumeric: 1, constraints: { nullable: false } }
+              - column: { name: updated_at, type: DATETIME, constraints: { nullable: false } }

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,9 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-05-13-oprm-cnpj-market-import-phase-a-b.yaml
+      relativeToChangelogFile: true
+
+  - include:
       file: changesets/2026-05-13-mois-collected-reference-temperature.yaml
       relativeToChangelogFile: true
 


### PR DESCRIPTION
### Motivation
- Introduce domain model and APIs to support importing CNPJ market data (import runs, files and CNAE dimension) so import jobs can be tracked and CNAE rows upserted.
- Persist import metadata and CNAE dimension rows to the database and expose simple endpoints for run creation and file event reporting.

### Description
- Added JPA entities `OprmCnpjImportRun`, `OprmCnpjImportFile` and `OprmCnpjCnaeDim` to represent runs, files and CNAE dimension rows respectively.
- Added DTOs for API payloads: `OprmCreateImportRunRequestDto`, `OprmImportFileSeedDto`, `OprmImportFileEventRequestDto`, `OprmCnaeUpsertDto` and `OprmImportRunCreatedResponseDto`.
- Implemented `OprmMarketImportService` with `startRun`, `registerFileEvent`, `listRuns`, `listRunFiles` and `listCnaes` behaviors and repositories `OprmCnpjImportRunRepository`, `OprmCnpjImportFileRepository`, `OprmCnpjCnaeDimRepository` for persistence.
- Exposed REST endpoints in `OprmMarketImportController` to create runs, report file events and list runs/files/CNAEs, and added Liquibase changelog `2026-05-13-oprm-cnpj-market-import-phase-a-b.yaml` with table/index/fk creations and included it in `db.changelog-master.yaml`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c666b9008321ad38d4f764010b81)