### PR TITLE
Add framework image generation summary endpoint and frontend integration

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/dto/FrameworkImageGenerationSummaryDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/dto/FrameworkImageGenerationSummaryDto.java
@@ -1,0 +1,13 @@
+package com.marketinghub.experiment.frameworkimage.dto;
+
+import java.time.Instant;
+
+public record FrameworkImageGenerationSummaryDto(
+        int totalItems,
+        int plannedCount,
+        int processingCount,
+        int waitingOpenAiBatchCount,
+        int completedCount,
+        int failedCount,
+        Instant updatedAt) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationService.java
@@ -7,6 +7,7 @@ import com.marketinghub.experiment.frameworkimage.FrameworkImageGenerationJob;
 import com.marketinghub.experiment.frameworkimage.FrameworkImageGenerationJobStage;
 import com.marketinghub.experiment.frameworkimage.FrameworkImageGenerationJobStatus;
 import com.marketinghub.experiment.frameworkimage.dto.FrameworkImageGenerationItemStatusDto;
+import com.marketinghub.experiment.frameworkimage.dto.FrameworkImageGenerationSummaryDto;
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageGenerationJobCompletionRequest;
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageGenerationJobDto;
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageWebnizationPendingAssetDto;
@@ -306,6 +307,49 @@ public class FrameworkImageGenerationService {
         }
 
         return response;
+    }
+
+    @Transactional(readOnly = true)
+    public FrameworkImageGenerationSummaryDto summarizeJobsByExperiment(Long experimentId) {
+        List<FrameworkImageGenerationItemStatusDto> items = listJobsByExperiment(experimentId);
+        int planned = 0;
+        int processing = 0;
+        int waitingOpenAiBatch = 0;
+        int completed = 0;
+        int failed = 0;
+        Instant updatedAt = null;
+
+        for (FrameworkImageGenerationItemStatusDto item : items) {
+            String status = item.status() == null ? "" : item.status().trim().toUpperCase();
+            String stage = item.stage() == null ? "" : item.stage().trim().toUpperCase();
+            if ("PLANNED".equals(status) || "PENDING".equals(status)) {
+                planned++;
+            }
+            if ("PROCESSING".equals(status)) {
+                processing++;
+            }
+            if ("WAITING_OPENAI_BATCH".equals(stage)) {
+                waitingOpenAiBatch++;
+            }
+            if ("COMPLETED".equals(status)) {
+                completed++;
+            }
+            if ("FAILED".equals(status)) {
+                failed++;
+            }
+            if (item.updatedAt() != null && (updatedAt == null || item.updatedAt().isAfter(updatedAt))) {
+                updatedAt = item.updatedAt();
+            }
+        }
+
+        return new FrameworkImageGenerationSummaryDto(
+                items.size(),
+                planned,
+                processing,
+                waitingOpenAiBatch,
+                completed,
+                failed,
+                updatedAt);
     }
 
     private FrameworkImageGenerationJob findJob(UUID jobId) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/web/FrameworkImageGenerationController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/web/FrameworkImageGenerationController.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment.frameworkimage.web;
 
 import com.marketinghub.experiment.frameworkimage.dto.FrameworkImageGenerationItemStatusDto;
+import com.marketinghub.experiment.frameworkimage.dto.FrameworkImageGenerationSummaryDto;
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageGenerationJobDto;
 import com.marketinghub.experiment.frameworkimage.service.FrameworkImageGenerationService;
 import java.util.List;
@@ -30,5 +31,10 @@ public class FrameworkImageGenerationController {
     @GetMapping
     public List<FrameworkImageGenerationItemStatusDto> list(@PathVariable Long experimentId) {
         return service.listJobsByExperiment(experimentId);
+    }
+
+    @GetMapping("/summary")
+    public FrameworkImageGenerationSummaryDto summary(@PathVariable Long experimentId) {
+        return service.summarizeJobsByExperiment(experimentId);
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/frameworkimage/web/FrameworkImageGenerationControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/frameworkimage/web/FrameworkImageGenerationControllerTest.java
@@ -6,10 +6,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.marketinghub.experiment.frameworkimage.dto.FrameworkImageGenerationItemStatusDto;
+import com.marketinghub.experiment.frameworkimage.dto.FrameworkImageGenerationSummaryDto;
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageGenerationJobDto;
 import com.marketinghub.experiment.frameworkimage.service.FrameworkImageGenerationService;
 import java.util.List;
 import java.util.UUID;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -84,5 +86,19 @@ class FrameworkImageGenerationControllerTest {
                 .andExpect(jsonPath("$[1].status").value("PLANNED"));
 
         verify(service).listJobsByExperiment(8L);
+    }
+
+    @Test
+    void summaryReturnsAggregatedCounters() throws Exception {
+        when(service.summarizeJobsByExperiment(20L)).thenReturn(
+                new FrameworkImageGenerationSummaryDto(8, 0, 8, 8, 0, 0, Instant.parse("2026-05-13T20:09:00Z")));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/experiments/20/framework-images/summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalItems").value(8))
+                .andExpect(jsonPath("$.processingCount").value(8))
+                .andExpect(jsonPath("$.waitingOpenAiBatchCount").value(8));
+
+        verify(service).summarizeJobsByExperiment(20L);
     }
 }

--- a/frontend/src/api/experiment/useFrameworkImageSummary.ts
+++ b/frontend/src/api/experiment/useFrameworkImageSummary.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface FrameworkImageSummary {
+  totalItems: number;
+  plannedCount: number;
+  processingCount: number;
+  waitingOpenAiBatchCount: number;
+  completedCount: number;
+  failedCount: number;
+  updatedAt?: string;
+}
+
+export function useFrameworkImageSummary(experimentId?: string) {
+  return useQuery({
+    queryKey: ["framework-image-summary", experimentId],
+    enabled: Boolean(experimentId),
+    queryFn: async () => {
+      if (!experimentId) return null;
+      const { data } = await axios.get<FrameworkImageSummary>(
+        `/api/experiments/${experimentId}/framework-images/summary`,
+      );
+      return data;
+    },
+    refetchInterval: 5000,
+  });
+}

--- a/frontend/src/api/experiment/useGenerateFrameworkImages.ts
+++ b/frontend/src/api/experiment/useGenerateFrameworkImages.ts
@@ -20,6 +20,9 @@ export function useGenerateFrameworkImages(experimentId?: string) {
           queryKey: ["framework-image-statuses", experimentId],
         }),
         queryClient.invalidateQueries({
+          queryKey: ["framework-image-summary", experimentId],
+        }),
+        queryClient.invalidateQueries({
           queryKey: ["experiment-pipeline-jobs", experimentId],
         }),
       ]);

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -45,6 +45,7 @@ import {
   type GeraLandingStageExecutionItem,
 } from "../../api/experiment/useGeraLandingStageExecutions";
 import { useFrameworkImageStatuses } from "../../api/experiment/useFrameworkImageStatuses";
+import { useFrameworkImageSummary } from "../../api/experiment/useFrameworkImageSummary";
 import { useGenerateFrameworkImages } from "../../api/experiment/useGenerateFrameworkImages";
 
 type ChecklistItem = {
@@ -185,6 +186,7 @@ export default function ExperimentDetailPage() {
   } = useGeraLandingStageExecutions(expId, "landing-page-image-planning", true);
   const { data: frameworkImageStatuses, isLoading: isLoadingFrameworkImageStatuses } =
     useFrameworkImageStatuses(expId);
+  const { data: frameworkImageSummary } = useFrameworkImageSummary(expId);
   const generateFrameworkImages = useGenerateFrameworkImages(expId);
   const { data: readinessSummary, isLoading: isLoadingReadiness } =
     useExperimentReadiness(expId);
@@ -2130,6 +2132,25 @@ const runningGeraLandingJobId = mergedPendingGeraLandingExecutions.find((executi
                     bloco <strong>Gerar imagens em lote (AI Worker)</strong>.
                   </span>
                 </div>
+                {frameworkImageSummary ? (
+                  <div className="row g-2">
+                    <div className="col-6 col-md-4">
+                      <div className="small border rounded p-2 bg-light">Em processamento: <strong>{frameworkImageSummary.processingCount}</strong></div>
+                    </div>
+                    <div className="col-6 col-md-4">
+                      <div className="small border rounded p-2 bg-light">Aguardando OpenAI batch: <strong>{frameworkImageSummary.waitingOpenAiBatchCount}</strong></div>
+                    </div>
+                    <div className="col-6 col-md-4">
+                      <div className="small border rounded p-2 bg-light">Concluídas: <strong>{frameworkImageSummary.completedCount}</strong></div>
+                    </div>
+                    <div className="col-6 col-md-4">
+                      <div className="small border rounded p-2 bg-light">Falhas: <strong>{frameworkImageSummary.failedCount}</strong></div>
+                    </div>
+                    <div className="col-6 col-md-4">
+                      <div className="small border rounded p-2 bg-light">Total de itens: <strong>{frameworkImageSummary.totalItems}</strong></div>
+                    </div>
+                  </div>
+                ) : null}
                 {isLoadingFrameworkImageStatuses ? (
                   <p className="text-muted mb-0">Carregando status do Gera Imagem...</p>
                 ) : null}


### PR DESCRIPTION
### Motivation
- Provide an aggregated view of framework image generation progress so the UI can show counters (processing, waiting for OpenAI batch, completed, failed, total) and poll for updates.

### Description
- Add `FrameworkImageGenerationSummaryDto` to represent aggregated counters and latest update time.
- Implement `summarizeJobsByExperiment` in `FrameworkImageGenerationService` which aggregates statuses from `listJobsByExperiment` into the summary DTO.
- Expose a new controller endpoint `GET /api/experiments/{experimentId}/framework-images/summary` via `FrameworkImageGenerationController`.
- Add a frontend hook `useFrameworkImageSummary` to poll the new endpoint and integrate the summary into `ExperimentDetailPage`, plus invalidate the summary query after triggering generation in `useGenerateFrameworkImages`.
- Add `summaryReturnsAggregatedCounters` unit test in `FrameworkImageGenerationControllerTest` to assert the controller returns the expected JSON shape.

### Testing
- Ran backend unit tests for `FrameworkImageGenerationControllerTest`, including the new `summaryReturnsAggregatedCounters` test, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04da99f28c83218c5d6c76ddfad788)