### PR TITLE
Log raw Hotmart product details response (truncated) for debugging

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -113,3 +113,7 @@
 ## 2026-05-13 15:01:39 UTC-3
 - Porta HTTP do módulo `mois-clickbank-collector` alterada de `8096` para `9096` (acima de 9000), ajustando `application.properties`, `docker-compose.yml`, `docker-compose.deploy.yml` e `Dockerfile`.
 - README do módulo atualizado para refletir a nova porta padrão (`MOIS_HOTMART_PORT=9096`) e a nova URL de logfile via Actuator (`http://191.252.120.96:9096/internal/ops-monitor/logfile`).
+
+## 2026-05-13 17:35:14 UTC-3
+- Registrada melhoria no `mois-hotmart-collector` para incluir log explícito da resposta crua do **ciclo 2** (`HOTMART_CICLO_2_DETALHE_RESPOSTA_CRUA`) durante o fetch de detalhes por produto.
+- O log agora registra `productId`, `status` HTTP e `bodyRaw` truncado (10.000 caracteres), mantendo padrão de observabilidade já adotado no ciclo 1 para análise de causa-raiz.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -408,6 +408,10 @@ public class HotmartCollectorService {
                     .GET()
                     .build();
             HttpResponse<String> detailsResponse = HttpClient.newHttpClient().send(detailsRequest, HttpResponse.BodyHandlers.ofString());
+            log.info("HOTMART_CICLO_2_DETALHE_RESPOSTA_CRUA productId={} status={} bodyRaw='{}'",
+                    productId,
+                    detailsResponse.statusCode(),
+                    truncateForLog(detailsResponse.body(), 10_000));
             if (detailsResponse.statusCode() < 200 || detailsResponse.statusCode() >= 300) {
                 log.warn("Ciclo 2 Hotmart: falha ao buscar detalhe do produto. status={}, productId={}", detailsResponse.statusCode(), productId);
                 return baseSnapshot;


### PR DESCRIPTION
### Motivation
- Improve observability when fetching product details from Hotmart by adding a debug-friendly log of the raw response to help diagnose failures and unexpected payloads.

### Description
- Add an `info`-level log call in `enrichProductWithDetails` that logs `productId`, the HTTP status, and a truncated response body using `truncateForLog` before the status check.

### Testing
- Ran the automated test suite with `mvn test` and the existing tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04dc1d9ed08321b0482389a6d8bfc5)