### PR TITLE
fix(liquibase): corrigir parse YAML no changelog OPRM (quote DECIMAL)

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-13-oprm-cnpj-market-import-phase-c-d.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-13-oprm-cnpj-market-import-phase-c-d.yaml
@@ -17,6 +17,6 @@ databaseChangeLog:
               - column: { name: total_empresas, type: BIGINT, defaultValueNumeric: 0, constraints: { nullable: false } }
               - column: { name: total_empresas_mei, type: BIGINT, defaultValueNumeric: 0, constraints: { nullable: false } }
               - column: { name: total_empresas_simples, type: BIGINT, defaultValueNumeric: 0, constraints: { nullable: false } }
-              - column: { name: avg_socios_por_empresa, type: DECIMAL(10,2) }
+              - column: { name: avg_socios_por_empresa, type: "DECIMAL(10,2)" }
               - column: { name: updated_at, type: DATETIME, constraints: { nullable: false } }
         - createIndex: { tableName: oprm_market_size_by_cnae, indexName: idx_market_size_total_ativos, columns: [ { column: { name: total_estabelecimentos_ativos } } ] }


### PR DESCRIPTION
### Motivation
- Corrigir erro de parsing do Liquibase (`Unexpected node: 2)`) causado pelo valor `DECIMAL(10,2)` não entre aspas em um mapeamento YAML.

### Description
- Ajustado o changelog `backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-13-oprm-cnpj-market-import-phase-c-d.yaml` trocando `type: DECIMAL(10,2)` por `type: "DECIMAL(10,2)"` para produzir YAML válido para o parser do Liquibase.

### Testing
- Executado `mvn -q liquibase:validate` em `backend/ads-service`, o comando não apresentou novo erro de parse após o ajuste, porém a execução foi interrompida por ausência de configuração de URL do banco (`The database URL has not been specified either as a parameter or in a properties file`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e3ad3528832199dc56248a78b9d1)