### PR TITLE
Hotmart: add `pageSalesLink` metadata and use it as fallback when persisting sales page URL

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
@@ -149,7 +149,11 @@ public class MoisCollectionPersistenceService {
                     ps.setString(22, coalesceNotBlank(item.title(), metadataValue(item, "productName"), metadataValue(item, "hotmartProductName")));
                     ps.setString(23, coalesceNotBlank(item.url(), metadataValue(item, "productUrl")));
                     ps.setString(24, coalesceNotBlank(metadataValue(item, "hotmartProducer"), metadataValue(item, "producerName"), metadataValue(item, "producer")));
-                    ps.setString(25, coalesceNotBlank(metadataValue(item, "salesPageUrl"), metadataValue(item, "checkoutUrl"), item.url()));
+                    ps.setString(25, coalesceNotBlank(
+                            metadataValue(item, "salesPageUrl"),
+                            metadataValue(item, "pageSalesLink"),
+                            metadataValue(item, "checkoutUrl"),
+                            item.url()));
                     ps.setBigDecimal(26, parseDecimal(metadataValue(item, "hotmartTemperature")));
                     ps.setTimestamp(27, item.collectedAt() == null ? null : Timestamp.from(item.collectedAt()));
                     ps.setTimestamp(28, Timestamp.from(Instant.now()));

--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -117,3 +117,8 @@
 ## 2026-05-13 17:35:14 UTC-3
 - Registrada melhoria no `mois-hotmart-collector` para incluir log explícito da resposta crua do **ciclo 2** (`HOTMART_CICLO_2_DETALHE_RESPOSTA_CRUA`) durante o fetch de detalhes por produto.
 - O log agora registra `productId`, `status` HTTP e `bodyRaw` truncado (10.000 caracteres), mantendo padrão de observabilidade já adotado no ciclo 1 para análise de causa-raiz.
+
+## 2026-05-14 02:10 UTC
+- Ajustado o ciclo 2 do `mois-hotmart-collector` para extrair explicitamente `pageSalesLink` na resposta de detalhe da Hotmart (`v1/market/product/{id}/details`), além de `salesPageUrl`.
+- Persistência enviada ao backend agora inclui ambos os metadados (`salesPageUrl` e `pageSalesLink`) no `rawMetadata` da referência, mantendo fallback para URL de detalhes.
+- Backend (`ads-service`) reforçado para preencher `sales_page_url` também a partir de `rawMetadata.pageSalesLink` quando `rawMetadata.salesPageUrl` não vier preenchido.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -257,7 +257,9 @@ public class HotmartCollectorService {
             rawMetadata.put("productName", product.title());
             rawMetadata.put("productImage", product.image());
             rawMetadata.put("productUrl", product.detailsUrl());
-            rawMetadata.put("salesPageUrl", pickFirstNonBlank(product.salesPageUrl(), product.detailsUrl()));
+            String resolvedSalesPageUrl = pickFirstNonBlank(product.salesPageUrl(), product.detailsUrl());
+            rawMetadata.put("salesPageUrl", resolvedSalesPageUrl);
+            rawMetadata.put("pageSalesLink", resolvedSalesPageUrl);
             if (product.temperature() != null) {
                 rawMetadata.put("hotmartTemperature", String.valueOf(product.temperature()));
             }
@@ -417,7 +419,7 @@ public class HotmartCollectorService {
                 return baseSnapshot;
             }
             JsonNode detailsNode = objectMapper.readTree(detailsResponse.body());
-            String salesPageFromDetails = extractProductText(detailsNode, "salesPageUrl", "salesPage", "pageUrl", "url");
+            String salesPageFromDetails = extractProductText(detailsNode, "salesPageUrl", "pageSalesLink", "salesPage", "pageUrl", "url");
             String detailPageUrl = pickFirstNonBlank(
                     extractProductText(detailsNode, "detailsUrl", "productUrl", "checkoutUrl"),
                     baseSnapshot.detailsUrl()


### PR DESCRIPTION
### Motivation
- Improve Hotmart collection robustness by capturing an additional sales page field (`pageSalesLink`) from product details and ensuring the backend persists it when `salesPageUrl` is missing.
- Make collectors preserve the explicit detail-cycle URL so administrative UI and downstream logic can prefer the more specific link if available.

### Description
- Updated `mois-hotmart-collector` (`HotmartCollectorService`) to populate `rawMetadata.pageSalesLink` alongside `rawMetadata.salesPageUrl` and to set a resolved `salesPageUrl` into the reference payload. 
- Enhanced detail enrichment to include `pageSalesLink` as one of the keys checked during extraction (`extractProductText(...)`) so it can be picked from the Hotmart detail response.
- Updated backend persistence in `MoisCollectionPersistenceService` to include `pageSalesLink` in the `coalesceNotBlank(...)` chain used to populate the `sales_page_url` column (SQL parameter 25), preserving existing fallbacks.
- Documentation `docs/registros/coletor-mois1.md` updated to record the change in the Hotmart cycle 2 behavior and the backend fallback behavior.

### Testing
- Ran unit and integration tests via `mvn test` across the affected modules (`mois-hotmart-collector` and `ads-service`) and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0524b598c083219599274dcaec9ba7)