### PR TITLE
Restrict module controller scope in AGENTS documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Toda decisão de arquitetura, dados, prompts, automações, integrações e arte
 - **URL do BACKEND** : http://191.252.181.168:8000
 - **Modelo único**: entidades residem no backend. Os demais módulos acessam o banco de dados pelo backend.
 - **Fluxo entre containers**: nada de chamadas diretas entre serviços (frontend, workers, lead-portal etc). Todo tráfego passa pelo backend principal; apenas o backend fala com o banco.
+- **Escopo de controllers por módulo**: cada módulo só pode acessar os controllers do próprio módulo (ex.: MOIS usa apenas controllers do pacote MOIS; OPRM usa apenas controllers do pacote OPRM; e assim sucessivamente). É proibido um módulo consumir controllers de outro módulo diretamente.
 - **Novos endpoints**: verifique se o contrato já existe; caso contrário, defina-o no backend, atualize a documentação e adicione testes.
 - **Manual do usuário**: todos os links devem usar `target="_blank"`.
 - **Frontend**: sempre que alterar o frontend crie os métodos do backend para suportar. Tanto back quanto o front estão sendo executados no mesmo host.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -9,4 +9,5 @@
 - Liquibase (YAML): em `preConditions`, nunca misture mapeamento e lista no mesmo nível de indentação (ex.: `onFail:` seguido de `- dbms:`). Use sempre lista explícita (`- onFail: ...`, `- onError: ...`, `- dbms:`) para evitar `ParserException` de YAML.
 - Os endpoints de contas do Facebook não podem descartar valores que não aparecem na UI (por exemplo, tokens de acesso ou IDs padrão). Ao atualizar um registro existente, preserve qualquer campo que não tenha sido enviado explicitamente na requisição.
 - JDBC + MySQL: ao ler colunas `UUID`, nunca use `ResultSet#getObject` com `UUID.class`. Faça a conversão explícita de acordo com o tipo da coluna (`CHAR(36)`/`VARCHAR`: `UUID.fromString(rs.getString(...))`; `BINARY(16)`: converta o `byte[]` para `UUID` com utilitário dedicado ou `UUID.nameUUIDFromBytes`).
+- Escopo de controllers por módulo: cada módulo só pode acessar os controllers do próprio módulo/pacote (ex.: MOIS -> controllers de MOIS; OPRM -> controllers de OPRM). É proibido consumir controllers de outro módulo diretamente.
 - Depois de uma alteração execute os testes unitários antes da criação do PR.


### PR DESCRIPTION
### Motivation
- Clarify architecture rules by preventing modules from consuming controllers from other modules directly to enforce module boundaries and reduce tight coupling.

### Description
- Add the `Escopo de controllers por módulo` rule to `AGENTS.md` and `backend/AGENTS.md`, stating that each module may only access controllers in its own module/package and must not call controllers from other modules directly.

### Testing
- Documentation-only change; no automated tests were modified or required to validate this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0536c7d90c832196d08b3efe9bb798)