### PR TITLE
mois-clickbank-collector: scrape ClickBank Top Offers page, remove hardcoded credentials, add config

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -122,3 +122,9 @@
 - Ajustado o ciclo 2 do `mois-hotmart-collector` para extrair explicitamente `pageSalesLink` na resposta de detalhe da Hotmart (`v1/market/product/{id}/details`), além de `salesPageUrl`.
 - Persistência enviada ao backend agora inclui ambos os metadados (`salesPageUrl` e `pageSalesLink`) no `rawMetadata` da referência, mantendo fallback para URL de detalhes.
 - Backend (`ads-service`) reforçado para preencher `sales_page_url` também a partir de `rawMetadata.pageSalesLink` quando `rawMetadata.salesPageUrl` não vier preenchido.
+
+## 2026-05-14 10:20 UTC
+- Coletor `mois-clickbank-collector` ajustado para usar a página pública de Top Offers da ClickBank (`https://www.clickbank.com/blog/clickbank-top-offers/`) como fonte primária, sem dependência de sessão/token por enquanto.
+- Serviço passou a coletar links e títulos diretamente do HTML da página pública e normalizar para `ClickbankProductSnapshot`.
+- `application.properties` corrigido para remover credenciais hardcoded, passando a usar variáveis de ambiente para usuário/senha e incluindo variável dedicada `COLLECTOR_CLICKBANK_TOP_OFFERS_URL`.
+- Teste unitário atualizado para validar comportamento de erro quando a URL pública estiver indisponível.

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,6 +45,7 @@ public class ClickbankCollectorService {
     private final String clickbankSessionCookie;
     private final String clickbankUsername;
     private final String clickbankPassword;
+    private final String clickbankTopOffersUrl;
     private final boolean logFullToken;
     private final String backendBaseUrl;
     private final String clickbankJwtSettingKey;
@@ -59,6 +61,7 @@ public class ClickbankCollectorService {
             @Value("${collector.clickbank.session-cookie:}") String clickbankSessionCookie,
             @Value("${collector.clickbank.username:}") String clickbankUsername,
             @Value("${collector.clickbank.password:}") String clickbankPassword,
+            @Value("${collector.clickbank.top-offers-url:https://www.clickbank.com/blog/clickbank-top-offers/}") String clickbankTopOffersUrl,
             @Value("${collector.clickbank.username-fallback:}") String clickbankUsernameFallback,
             @Value("${collector.clickbank.password-fallback:}") String clickbankPasswordFallback,
             @Value("${collector.clickbank.log-full-token:false}") boolean logFullToken,
@@ -74,6 +77,7 @@ public class ClickbankCollectorService {
         this.clickbankSessionCookie = clickbankSessionCookie;
         this.clickbankUsername = pickFirstNonBlank(clickbankUsername, clickbankUsernameFallback);
         this.clickbankPassword = pickFirstNonBlank(clickbankPassword, clickbankPasswordFallback);
+        this.clickbankTopOffersUrl = clickbankTopOffersUrl;
         this.logFullToken = logFullToken;
         this.backendBaseUrl = backendBaseUrl;
         this.clickbankJwtSettingKey = clickbankJwtSettingKey;
@@ -87,43 +91,64 @@ public class ClickbankCollectorService {
 
         List<ClickbankProductSnapshot> products = new ArrayList<>();
         String status = "COLLECTION_EXECUTED";
-        String message = "Coleta executada com token JWT da configuração geral.";
-        boolean hasSessionCookie = clickbankSessionCookie != null && !clickbankSessionCookie.isBlank();
-        boolean hasCredentials = clickbankUsername != null && !clickbankUsername.isBlank()
-                && clickbankPassword != null && !clickbankPassword.isBlank();
-
-        String clickbankAccessToken = fetchClickbankJwtFromGeneralSettings();
-        if (clickbankAccessToken.isBlank()) {
-            log.warn("Coleta Clickbank ignorada: token JWT não encontrado em configurações gerais.");
-            return new ClickbankCollectionResponse(
-                    "COLLECTION_SKIPPED",
-                    "Token JWT da Clickbank ausente. Configure a chave '" + clickbankJwtSettingKey + "' em /api/settings/{name}.",
-                    products
-            );
-        }
+        String message = "Coleta executada a partir da página pública de Top Offers da ClickBank.";
 
         log.info(
-                "Iniciando coleta Clickbank com Playwright. headless={}, maxProductsSolicitado={}, maxProductsAplicado={}, hasSessionCookie={}, hasCredentials={}",
-                headless,
+                "Iniciando coleta Clickbank por página pública. maxProductsSolicitado={}, maxProductsAplicado={}, topOffersUrl={}",
                 request.maxProducts(),
                 boundedMax,
-                hasSessionCookie,
-                hasCredentials
+                clickbankTopOffersUrl
         );
-        logTokenDiagnostics(clickbankAccessToken);
 
-        try (Playwright ignored = Playwright.create()) {
-            int apiCollected = collectProductsViaMarketApi(clickbankAccessToken, boundedMax, products);
-            log.info("Coleta API Clickbank finalizada. produtosColetadosViaApi={}", apiCollected);
+        try {
+            int apiCollected = collectProductsFromTopOffersPage(boundedMax, products);
+            log.info("Coleta página Top Offers finalizada. produtosColetados={}", apiCollected);
             status = "COLLECTION_EXECUTED";
-            message = "Coleta executada via API da Clickbank usando JWT salvo em configurações gerais.";
+            message = "Coleta executada via página pública Top Offers da ClickBank.";
         } catch (Exception ex) {
             status = "COLLECTION_ERROR";
-            message = "Falha na coleta API: " + ex.getMessage();
-            log.error("Erro na coleta Clickbank via API JWT.", ex);
+            message = "Falha na coleta da página Top Offers: " + ex.getMessage();
+            log.error("Erro na coleta Clickbank da página Top Offers.", ex);
         }
         persistCollectedProductsOnBackend(request, status, products);
         return new ClickbankCollectionResponse(status, message, products);
+    }
+
+    private int collectProductsFromTopOffersPage(int boundedMax, List<ClickbankProductSnapshot> products) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(clickbankTopOffersUrl))
+                    .header("accept", "text/html")
+                    .GET()
+                    .build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IllegalStateException("Top Offers retornou status " + response.statusCode());
+            }
+            String html = response.body();
+            java.util.regex.Pattern anchorPattern = java.util.regex.Pattern.compile(
+                    "<a[^>]+href\\s*=\\s*\"([^\"]+)\"[^>]*>(.*?)</a>",
+                    java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
+            );
+            java.util.regex.Matcher matcher = anchorPattern.matcher(html);
+            LinkedHashSet<String> dedupe = new LinkedHashSet<>();
+            while (matcher.find() && products.size() < boundedMax) {
+                String href = matcher.group(1).trim();
+                String title = matcher.group(2).replaceAll("<[^>]*>", "").replaceAll("\\s+", " ").trim();
+                if (title.isBlank() || href.isBlank()) {
+                    continue;
+                }
+                String normalizedUrl = href.startsWith("http") ? href : "https://www.clickbank.com" + href;
+                String dedupeKey = title.toLowerCase() + "|" + normalizedUrl.toLowerCase();
+                if (!dedupe.add(dedupeKey)) {
+                    continue;
+                }
+                products.add(new ClickbankProductSnapshot(title, "N/A", "N/A", normalizedUrl, null, normalizedUrl, Instant.now()));
+            }
+            return products.size();
+        } catch (Exception ex) {
+            throw new RuntimeException("Não foi possível coletar top offers públicos.", ex);
+        }
     }
 
     private void persistCollectedProductsOnBackend(

--- a/mois-clickbank-collector/src/main/resources/application.properties
+++ b/mois-clickbank-collector/src/main/resources/application.properties
@@ -14,11 +14,12 @@ management.endpoint.health.show-details=always
 collector.playwright.headless=${COLLECTOR_PLAYWRIGHT_HEADLESS:true}
 collector.playwright.chromium-executable-path=${COLLECTOR_PLAYWRIGHT_EXECUTABLE_PATH:}
 collector.clickbank.search-url=${COLLECTOR_HOTMART_SEARCH_URL:https://app.clickbank.com/market/search}
+collector.clickbank.top-offers-url=${COLLECTOR_CLICKBANK_TOP_OFFERS_URL:https://www.clickbank.com/blog/clickbank-top-offers/}
 collector.clickbank.session-cookie=${COLLECTOR_HOTMART_SESSION_COOKIE:}
-collector.clickbank.username=paulofore@gmail.com
-collector.clickbank.password=FQ3nW5*c.KnrdLY
-collector.clickbank.username-fallback=paulofore@gmail.com
-collector.clickbank.password-fallback=FQ3nW5*c.KnrdLY
+collector.clickbank.username=${COLLECTOR_HOTMART_USERNAME:}
+collector.clickbank.password=${COLLECTOR_HOTMART_PASSWORD:}
+collector.clickbank.username-fallback=${COLLECTOR_HOTMART_USERNAME_FALLBACK:}
+collector.clickbank.password-fallback=${COLLECTOR_HOTMART_PASSWORD_FALLBACK:}
 
 # Automatic hourly execution
 collector.scheduler.enabled=${COLLECTOR_SCHEDULER_ENABLED:true}

--- a/mois-clickbank-collector/src/test/java/com/marketinghub/moisclickbank/service/ClickbankCollectorServiceTest.java
+++ b/mois-clickbank-collector/src/test/java/com/marketinghub/moisclickbank/service/ClickbankCollectorServiceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 class ClickbankCollectorServiceTest {
 
     @Test
-    void shouldSkipWhenSessionAndCredentialsAreMissing() {
+    void shouldReturnCollectionErrorWhenPublicPageIsUnavailable() {
         ClickbankCollectorService service = new ClickbankCollectorService(
                 true,
                 "",
@@ -16,6 +16,7 @@ class ClickbankCollectorServiceTest {
                 "",
                 "",
                 "",
+                "http://127.0.0.1:1/unreachable-top-offers",
                 "",
                 "",
                 false,
@@ -28,6 +29,6 @@ class ClickbankCollectorServiceTest {
 
         var response = service.collect(new ClickbankCollectionRequest("clickbank-market", 10));
 
-        assertEquals("COLLECTION_SKIPPED", response.status());
+        assertEquals("COLLECTION_ERROR", response.status());
     }
 }


### PR DESCRIPTION
### Motivation
- Replace dependency on ClickBank session/JWT and hardcoded credentials by using the public "Top Offers" page as primary data source to simplify collection and avoid session management.
- Improve configurability by moving sensitive values to environment-backed properties and adding a dedicated `collector.clickbank.top-offers-url` property.
- Make the collector resilient to public-page unavailability with clearer error semantics and logging.

### Description
- Added a new configuration property `collector.clickbank.top-offers-url` (env var `COLLECTOR_CLICKBANK_TOP_OFFERS_URL`) and wired it into the service constructor.
- Implemented `collectProductsFromTopOffersPage(...)` which fetches the public HTML using `HttpClient`, extracts anchor links/titles with a regex, deduplicates results with `LinkedHashSet`, normalizes URLs and populates `ClickbankProductSnapshot` entries.
- Reworked `collect(...)` to use the public-page collector path and updated logging/messages accordingly; removed the previous JWT/playwright API-path gating logic.
- Removed hardcoded credentials from `application.properties` and switched to environment-backed placeholders for username/password fallbacks, and updated test `ClickbankCollectorServiceTest` to reflect the new behavior and failure mode when the public page is unreachable.

### Testing
- Ran unit tests with `mvn test`; the updated `ClickbankCollectorServiceTest.shouldReturnCollectionErrorWhenPublicPageIsUnavailable` was executed and passed.
- No additional automated integration tests were added in this change and existing module-level tests passed under the CI `mvn test` step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a052adc0540832195fd8ae16a867132)