### PR TITLE
Add provisional HTML generation endpoint and service logic

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContoller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContoller.java
@@ -55,4 +55,10 @@ public class GeraLandingContoller {
     GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, "landing-page-image-planning");
     return ResponseEntity.accepted().body(response);
   }
+
+  @PostMapping("/html/provisional/generate")
+  public ResponseEntity<GeraLandingProvisionalHtmlResponse> generateProvisionalHtml(@PathVariable Long experimentId) {
+    String provisionalHtml = executionService.generateAndPersistProvisionalHtmlFromExperiment(experimentId);
+    return ResponseEntity.ok(new GeraLandingProvisionalHtmlResponse(provisionalHtml));
+  }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingProvisionalHtmlResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingProvisionalHtmlResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.geralanding;
+
+public record GeraLandingProvisionalHtmlResponse(String provisionalHtml) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -68,6 +68,33 @@ public class GeraLandingStageExecutionService {
     }
 
     @Transactional
+    public String generateAndPersistProvisionalHtmlFromExperiment(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+
+        if (!StringUtils.hasText(experiment.getLandingPageWireframe())) {
+            throw new IllegalStateException("Não foi possível montar HTML provisório: experiment.landingPageWireframe ausente");
+        }
+        if (!StringUtils.hasText(experiment.getLandingPageCopy())) {
+            throw new IllegalStateException("Não foi possível montar HTML provisório: experiment.landingPageCopy ausente");
+        }
+
+        String baseHtml = copyProvisionalHtmlAssembler.assemble(
+                experiment.getLandingPageCopy(),
+                experiment.getLandingPageWireframe(),
+                "manual-generate-provisional-html");
+        String htmlWithGeneratedImages = landingPageImageInjector.injectImages(experimentId, baseHtml);
+        String provisionalHtml = """
+                <!-- AUTO: provisional html generated manually by /geralanding/html/provisional/generate -->
+                %s
+                """.formatted(htmlWithGeneratedImages);
+
+        experiment.setLandingPageHtml(provisionalHtml);
+        experimentRepository.save(experiment);
+        return provisionalHtml;
+    }
+
+    @Transactional
     public void registerWorkerPromptExecution(GeraLandingWorkerPromptRequest request) {
         Instant now = Instant.now();
         Experiment experiment = experimentRepository.findById(request.experimentId())

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingContollerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingContollerTest.java
@@ -67,6 +67,18 @@ class GeraLandingContollerTest {
 
         verify(executionService).registerInitialExecution(eq(99L), eq("landing-page-image-planning"));
     }
+
+    @Test
+    void shouldGenerateAndPersistProvisionalHtml() throws Exception {
+        when(executionService.generateAndPersistProvisionalHtmlFromExperiment(99L))
+                .thenReturn("<html>preview</html>");
+
+        mockMvc.perform(post("/api/experiments/{experimentId}/geralanding/html/provisional/generate", 99L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.provisionalHtml").value("<html>preview</html>"));
+
+        verify(executionService).generateAndPersistProvisionalHtmlFromExperiment(eq(99L));
+    }
     @Test
     void shouldListStageExecutionsOrderedByMostRecentFirst() throws Exception {
         when(executionService.listExperimentStageExecutions(99L, "landing-page-wireframe", true))

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -304,4 +304,26 @@ class GeraLandingStageExecutionServiceTest {
         assertEquals(execution.getProvisionalHtml(), experiment.getLandingPageHtml());
         verify(experimentRepository).save(experiment);
     }
+
+    @Test
+    void shouldGenerateAndPersistProvisionalHtmlFromExperimentData() {
+        Experiment experiment = new Experiment();
+        experiment.setId(88L);
+        experiment.setLandingPageWireframe("{\"landingPageWireframe\":{}}");
+        experiment.setLandingPageCopy("{\"landingPageCopy\":{}}");
+
+        when(experimentRepository.findById(88L)).thenReturn(Optional.of(experiment));
+        when(copyProvisionalHtmlAssembler.assemble(
+                experiment.getLandingPageCopy(),
+                experiment.getLandingPageWireframe(),
+                "manual-generate-provisional-html")).thenReturn("<html>base</html>");
+        when(landingPageImageInjector.injectImages(88L, "<html>base</html>"))
+                .thenReturn("<html>with-images</html>");
+
+        String html = service.generateAndPersistProvisionalHtmlFromExperiment(88L);
+
+        assertTrue(html.contains("with-images"));
+        assertEquals(html, experiment.getLandingPageHtml());
+        verify(experimentRepository).save(experiment);
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide a way to manually generate and persist a provisional landing-page HTML from an experiment's wireframe and copy for preview and quick manual workflows.

### Description
- Add a new controller endpoint `POST /api/experiments/{experimentId}/geralanding/html/provisional/generate` in `GeraLandingContoller` that returns a `GeraLandingProvisionalHtmlResponse` with the generated HTML.
- Add `GeraLandingProvisionalHtmlResponse` record to carry the `provisionalHtml` payload.
- Implement `generateAndPersistProvisionalHtmlFromExperiment` in `GeraLandingStageExecutionService` to validate experiment data, assemble base HTML with `copyProvisionalHtmlAssembler`, inject images with `landingPageImageInjector`, prefix an auto-generation comment, persist into `experiment.landingPageHtml`, and return the generated HTML.

### Testing
- Added controller test `GeraLandingContollerTest.shouldGenerateAndPersistProvisionalHtml` which mocks the service and verifies the endpoint returns the provisional HTML, and the test passed.
- Added service test `GeraLandingStageExecutionServiceTest.shouldGenerateAndPersistProvisionalHtmlFromExperimentData` which exercises assembling, image injection, persistence and return value, and the test passed.
- Ran the affected unit test classes including `GeraLandingContollerTest` and `GeraLandingStageExecutionServiceTest` and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a054358e1308321b71d6822ebe4d9ba)