### PR TITLE
Add early error when SSH key secret is missing in deploy workflow

### DIFF
--- a/.github/workflows/mois-clickbank-collector-ci.yml
+++ b/.github/workflows/mois-clickbank-collector-ci.yml
@@ -94,6 +94,10 @@ jobs:
         env:
           VPS_SSH_KEY: ${{ secrets.VPS_SSH_CHAVE != '' && secrets.VPS_SSH_CHAVE || secrets.VPS_SSH_KEY != '' && secrets.VPS_SSH_KEY || secrets.SSH_PRIVATE_KEY }}
         run: |
+          if [ -z "${VPS_SSH_KEY}" ]; then
+            echo "Erro: nenhuma chave SSH foi encontrada nos secrets esperados." >&2
+            exit 1
+          fi
           install -m 700 -d ~/.ssh
           printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519


### PR DESCRIPTION
### Motivation
- Ensure the deploy job fails fast with a clear error when no SSH private key secret is provided so deployments don't hang or continue with an invalid SSH setup.

### Description
- Add a runtime check in the `Prepare SSH` step that prints an error and exits if `VPS_SSH_KEY` is empty, preventing subsequent SSH/rsync commands from running with a missing key.

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0547dc1b0083219c8c6850bcead9b0)