### PR TITLE
fix(clickbank): align ClickBank deploy SSH user with Hotmart workflow

### DIFF
--- a/.github/workflows/mois-clickbank-collector-ci.yml
+++ b/.github/workflows/mois-clickbank-collector-ci.yml
@@ -83,7 +83,7 @@ jobs:
     environment: production
     env:
       DEPLOY_HOST: 177.153.62.107
-      DEPLOY_USER: ubuntu
+      DEPLOY_USER: root
       REMOTE_PATH: /opt/marketinghub/mois-clickbank-collector
 
     steps:

--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -133,3 +133,8 @@
 - Workflow `.github/workflows/mois-clickbank-collector-ci.yml` atualizado para publicar/deploy no host `177.153.62.107`.
 - Limpeza de nomenclaturas legadas de Hotmart no módulo `mois-clickbank-collector` (workflow, compose, README, properties, utilitário de autenticação e logs), padronizando para ClickBank.
 - Variáveis de ambiente e imagem de deploy renomeadas para prefixo `CLICKBANK`/`MOIS_CLICKBANK`.
+
+
+## 2026-05-14 00:00 UTC
+- Corrigido o workflow do `mois-clickbank-collector` para autenticar no deploy com o mesmo usuário do `mois-hotmart-collector` (`DEPLOY_USER=root`) no host `177.153.62.107`, eliminando falha `Permission denied (publickey,password)` ao executar o SSH.
+- Mantido o mesmo fluxo de chave/known_hosts e compose do Hotmart, alterando apenas o usuário remoto para alinhar ao ambiente já funcional.


### PR DESCRIPTION
### Motivation
- Eliminar falha de autenticação `Permission denied (publickey,password)` no deploy do coletor ClickBank alinhando o usuário SSH ao workflow do Hotmart no mesmo host.

### Description
- Atualizado `DEPLOY_USER` de `ubuntu` para `root` em `.github/workflows/mois-clickbank-collector-ci.yml` e registrado a correção em `docs/registros/coletor-mois1.md`.

### Testing
- Validado o diff e a presença de `DEPLOY_USER: root` com `git diff` e inspeção do arquivo ` .github/workflows/mois-clickbank-collector-ci.yml`, sem erro de sintaxe; não houve necessidade de executar testes unitários pois a mudança é apenas de workflow/docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a054afa4fc883218ecd9ed7b889542b)