### PR TITLE
Add Clickbank Coletor Mois runtime log source to MCP server

### DIFF
--- a/mcp-server/AGENTS.md
+++ b/mcp-server/AGENTS.md
@@ -11,6 +11,7 @@ Manter os seguintes endpoints como defaults de origem de logs no módulo `mcp-se
 - Lead Portal: `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`
 - Portal Pagamentos (Lead Portal): `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`
 - Mois Coletor Hotmart: `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`
+- Clickbank Coletor Mois: `http://177.153.62.107:9096/internal/ops-monitor/logfile`
 - OPRM Coletor Receita: `http://177.153.62.107:8094/actuator/logfile`
 
 Sempre que houver alteração desses endpoints, atualizar em conjunto:

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -17,7 +17,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `db_list_tables`: lista todas as tabelas disponíveis no schema atual.
 - `db_read_table`: lê dados de uma tabela com paginação (`table`, `limit`, `offset`).
 - `db_query`: executa SQL de leitura (`SELECT`/`WITH`) com limite de linhas.
-- `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-hotmart`, `oprm-coletor-receita`).
+- `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-hotmart`, `clickbank-coletor-mois`, `oprm-coletor-receita`).
 - `meta_docs_get`: busca páginas de documentação da Meta em hosts aprovados.
 - `meta_graph_get`: executa leitura (`GET`) da Graph API com token configurado no MCP.
 - `meta_graph_debug_token`: executa `debug_token` para validar tokens.
@@ -56,6 +56,7 @@ O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou
 - `MCP_LOG_MDS_PATH` (default `http://177.153.62.107:8091/actuator/logfile`);
 - `MCP_LOG_MOIS_PATH` (default `http://177.153.62.107:8094/manage/logfile`);
 - `MCP_LOG_MOIS_HOTMART_PATH` (default `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`);
+- `MCP_LOG_CLICKBANK_COLETOR_MOIS_PATH` (default `http://177.153.62.107:9096/internal/ops-monitor/logfile`);
 - `MCP_LOG_OPRM_COLETOR_RECEITA_PATH` (default `http://177.153.62.107:8094/actuator/logfile`).
 - `MCP_LOG_FETCH_TIMEOUT_SECONDS` (default `45`);
 - `MCP_LOG_FETCH_ATTEMPTS` (default `3`), número de tentativas para leitura HTTP de logs;

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -30,6 +30,7 @@ public record McpProperties(
             @NotBlank String mdsPath,
             @NotBlank String moisPath,
             @NotBlank String moisHotmartPath,
+            @NotBlank String clickbankColetorMoisPath,
             @NotBlank String oprmColetorReceitaPath,
             @Positive int fetchTimeoutSeconds,
             @Positive int fetchAttempts,

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -128,13 +128,13 @@ public class McpController {
                     ),
                     Map.of(
                             "name", "java_module_logs",
-                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, oprm-coletor-receita).",
+                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita).",
                             "inputSchema", Map.of(
                                     "type", "object",
                                     "properties", Map.of(
                                             "module", Map.of("type", "string",
                                                     "enum", List.of("backend", "ai-worker", "lead-portal", "facebook-ads",
-                                                            "email-service", "lead-portal-payment", "mds", "mois", "mois-hotmart", "oprm-coletor-receita"),
+                                                            "email-service", "lead-portal-payment", "mds", "mois", "mois-hotmart", "clickbank-coletor-mois", "oprm-coletor-receita"),
                                                     "description", "Módulo Java para consultar logs."),
                                             "lines", Map.of("type", "integer", "minimum", 1,
                                                     "maximum", moduleLogService.maxLines(),

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -197,6 +197,7 @@ public class ModuleLogService {
             case "mds" -> properties.logs().mdsPath();
             case "mois" -> properties.logs().moisPath();
             case "mois-hotmart" -> properties.logs().moisHotmartPath();
+            case "clickbank-coletor-mois" -> properties.logs().clickbankColetorMoisPath();
             case "oprm-coletor-receita" -> properties.logs().oprmColetorReceitaPath();
             default -> throw new IllegalArgumentException("Unknown module: " + module);
         };
@@ -210,10 +211,10 @@ public class ModuleLogService {
         String normalized = module.trim().toLowerCase();
         return switch (normalized) {
             case "backend", "ai-worker", "lead-portal", "facebook-ads", "email-service", "lead-portal-payment",
-                 "mds", "mois", "mois-hotmart", "oprm-coletor-receita" -> normalized;
+                 "mds", "mois", "mois-hotmart", "clickbank-coletor-mois", "oprm-coletor-receita" -> normalized;
             default -> throw new IllegalArgumentException(
                     "module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, " +
-                            "lead-portal-payment, mds, mois, mois-hotmart, oprm-coletor-receita");
+                            "lead-portal-payment, mds, mois, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita");
         };
     }
 

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -51,6 +51,7 @@ mcp:
     mds-path: ${MCP_LOG_MDS_PATH:http://177.153.62.107:8091/actuator/logfile}
     mois-path: ${MCP_LOG_MOIS_PATH:http://177.153.62.107:8094/manage/logfile}
     mois-hotmart-path: ${MCP_LOG_MOIS_HOTMART_PATH:http://177.153.62.107:8096/ops-monitor/mois-hotmart-log}
+    clickbank-coletor-mois-path: ${MCP_LOG_CLICKBANK_COLETOR_MOIS_PATH:http://177.153.62.107:9096/internal/ops-monitor/logfile}
     oprm-coletor-receita-path: ${MCP_LOG_OPRM_COLETOR_RECEITA_PATH:http://177.153.62.107:8094/actuator/logfile}
     fetch-timeout-seconds: ${MCP_LOG_FETCH_TIMEOUT_SECONDS:45}
     fetch-attempts: ${MCP_LOG_FETCH_ATTEMPTS:3}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -189,7 +189,7 @@ class McpControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.error.code").value(-32602))
                 .andExpect(jsonPath("$.error.message")
-                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, oprm-coletor-receita"));
+                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita"));
     }
 
     @Test

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -32,7 +32,7 @@ class MetaToolsServiceTest {
                 "marketing-hub-mcp",
                 "1.0.0",
                 null,
-                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", 45, 3, 400, 500, 262144),
+                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", 45, 3, 400, 500, 262144),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
@@ -66,6 +66,7 @@ class ModuleLogServiceTest {
                 logUrl,
                 logUrl,
                 logUrl,
+                logUrl,
                 2,
                 3,
                 1,


### PR DESCRIPTION
### Motivation
- Add the Clickbank Coletor Mois Spring Boot runtime log endpoint to the MCP server so the `java_module_logs` tool can fetch and tail logs for that module.
- Keep MCP configuration, runtime resolution and documentation in sync so operators can enable the new log source via environment variables.

### Description
- Added `clickbank-coletor-mois-path` to `src/main/resources/application.yml` with env var `MCP_LOG_CLICKBANK_COLETOR_MOIS_PATH` and default `http://177.153.62.107:9096/internal/ops-monitor/logfile`.
- Extended `McpProperties.Logs` to include `clickbankColetorMoisPath` so configuration binding supports the new key.
- Updated `ModuleLogService` to resolve `clickbank-coletor-mois` in `modulePath(...)` and accept it in `normalizeModule(...)` and its validation message.
- Updated `McpController` tool metadata (`tools/list` / `java_module_logs`) to expose the new module option and enum in the input schema.
- Updated documentation files `mcp-server/README.md` and `mcp-server/AGENTS.md` to list the new default endpoint and the corresponding `MCP_LOG_*` variable.
- Adjusted unit tests that construct `McpProperties.Logs` and that assert the module validation message (tests changed: `ModuleLogServiceTest`, `MetaToolsServiceTest`, `McpControllerTest`).

### Testing
- Ran `mvn test -q` in `mcp-server` and resolved compilation/test failures introduced by the new `Logs` field by updating test constructors and expected messages, after which the test suite passed (`mvn test -q` succeeded).
- Note: an initial run of `./mvnw test -q` failed because the project does not include the wrapper, so `mvn` was used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a054e44b1e48321b3a2a299aa9b4310)