### PR TITLE
Log start of scheduled ClickBank collector and update changelog

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -138,3 +138,6 @@
 ## 2026-05-14 00:00 UTC
 - Corrigido o workflow do `mois-clickbank-collector` para autenticar no deploy com o mesmo usuário do `mois-hotmart-collector` (`DEPLOY_USER=root`) no host `177.153.62.107`, eliminando falha `Permission denied (publickey,password)` ao executar o SSH.
 - Mantido o mesmo fluxo de chave/known_hosts e compose do Hotmart, alterando apenas o usuário remoto para alinhar ao ambiente já funcional.
+
+## 2026-05-14 04:45 UTC
+- Adicionado log no início do método agendado `collectHourly` do módulo `mois-clickbank-collector` para registrar início da execução automática com `source` e `maxProducts`, facilitando rastreamento operacional do scheduler.

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorScheduler.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorScheduler.java
@@ -32,6 +32,7 @@ public class ClickbankCollectorScheduler {
 
     @Scheduled(cron = "${collector.scheduler.cron:0 0 * * * *}")
     public void collectHourly() {
+        log.info("Iniciando execução agendada do Clickbank Collector source={} maxProducts={}", source, maxProducts);
         if (!enabled) {
             log.info("Clickbank scheduler desabilitado por configuração.");
             return;


### PR DESCRIPTION
### Motivation
- Improve observability of the scheduled ClickBank collector by explicitly logging the start of each automatic run with its `source` and `maxProducts` parameters.

### Description
- Added a startup log line to the scheduled method `collectHourly` in `ClickbankCollectorScheduler` to emit `Iniciando execução agendada do Clickbank Collector source={} maxProducts={}` at the beginning of the run.
- Updated the rollout/changelog file `docs/registros/coletor-mois1.md` to record the new scheduler log entry and related ClickBank collector changes.

### Testing
- Ran the project's unit test suite with `mvn test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0551b962908321bda542700ce35b40)