### PR TITLE
Add Clickbase product listing: backend service, API endpoint, frontend page and hook

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisClickbaseProductDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisClickbaseProductDtos.java
@@ -1,0 +1,24 @@
+package com.marketinghub.mois.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class MoisClickbaseProductDtos {
+
+    private MoisClickbaseProductDtos() {}
+
+    public record ClickbaseCollectedProductResponse(
+            String jobId,
+            String referenceId,
+            String title,
+            String productUrl,
+            String producerName,
+            Integer successScore,
+            Instant collectedAt
+    ) {}
+
+    public record ClickbaseCollectedProductListResponse(
+            String workspaceId,
+            List<ClickbaseCollectedProductResponse> items
+    ) {}
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisClickbaseProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisClickbaseProductService.java
@@ -1,0 +1,66 @@
+package com.marketinghub.mois.service;
+
+import com.marketinghub.mois.dto.MoisClickbaseProductDtos;
+import java.sql.Timestamp;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MoisClickbaseProductService {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public MoisClickbaseProductDtos.ClickbaseCollectedProductListResponse listLatestByWorkspace(String workspaceId, int limit) {
+        String latestJobId = jdbcTemplate.query(
+                        """
+                                SELECT job_id
+                                FROM mois_collected_reference
+                                WHERE workspace_id = ?
+                                  AND source = 'CLICKBANK'
+                                ORDER BY updated_at DESC
+                                LIMIT 1
+                                """,
+                        (rs, rowNum) -> rs.getString("job_id"),
+                        workspaceId)
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        if (latestJobId == null) {
+            return new MoisClickbaseProductDtos.ClickbaseCollectedProductListResponse(workspaceId, List.of());
+        }
+
+        List<MoisClickbaseProductDtos.ClickbaseCollectedProductResponse> items = jdbcTemplate.query(
+                """
+                        SELECT job_id, reference_id, title, product_name, product_url, producer_name, success_score, collected_at
+                        FROM mois_collected_reference
+                        WHERE workspace_id = ?
+                          AND source = 'CLICKBANK'
+                          AND job_id = ?
+                        ORDER BY success_score DESC, collected_at DESC
+                        LIMIT ?
+                        """,
+                (rs, rowNum) -> {
+                    Timestamp collectedAt = rs.getTimestamp("collected_at");
+                    String title = rs.getString("product_name");
+                    if (title == null || title.isBlank()) {
+                        title = rs.getString("title");
+                    }
+                    return new MoisClickbaseProductDtos.ClickbaseCollectedProductResponse(
+                            rs.getString("job_id"),
+                            rs.getString("reference_id"),
+                            title,
+                            rs.getString("product_url"),
+                            rs.getString("producer_name"),
+                            rs.getObject("success_score", Integer.class),
+                            collectedAt == null ? null : collectedAt.toInstant());
+                },
+                workspaceId, latestJobId, limit
+        );
+
+        return new MoisClickbaseProductDtos.ClickbaseCollectedProductListResponse(workspaceId, items);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
@@ -1,11 +1,13 @@
 package com.marketinghub.mois.web;
 
 import com.marketinghub.mois.dto.MoisArtifactDtos;
+import com.marketinghub.mois.dto.MoisClickbaseProductDtos;
 import com.marketinghub.mois.dto.MoisDiscoveryDtos;
 import com.marketinghub.mois.dto.MoisInsightDtos;
 import com.marketinghub.mois.dto.MoisOfferDtos;
 import com.marketinghub.mois.dto.MoisHotmartProductDtos;
 import com.marketinghub.mois.dto.MoisWorkspaceDtos;
+import com.marketinghub.mois.service.MoisClickbaseProductService;
 import com.marketinghub.mois.service.MoisCollectionPersistenceService;
 import com.marketinghub.mois.service.MoisHotmartProductService;
 import com.marketinghub.mois.service.MoisModuleGateway;
@@ -32,6 +34,7 @@ public class MoisController {
     private final MoisModuleGateway gateway;
     private final MoisCollectionPersistenceService collectionPersistenceService;
     private final MoisHotmartProductService moisHotmartProductService;
+    private final MoisClickbaseProductService moisClickbaseProductService;
 
     @PostMapping("/discovery-requests")
     @ResponseStatus(HttpStatus.ACCEPTED)
@@ -264,4 +267,17 @@ public class MoisController {
         int normalizedLimit = Math.max(1, Math.min(limit == null ? 24 : limit, 100));
         return moisHotmartProductService.listLatestByWorkspace(workspaceId, normalizedLimit);
     }
+
+    @GetMapping("/clickbase/products")
+    public MoisClickbaseProductDtos.ClickbaseCollectedProductListResponse listClickbaseProducts(
+            @RequestParam(defaultValue = "workspace-001") String workspaceId,
+            @RequestParam(defaultValue = "24") Integer limit
+    ) {
+        if (!StringUtils.hasText(workspaceId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "workspaceId is required");
+        }
+        int normalizedLimit = Math.max(1, Math.min(limit == null ? 24 : limit, 100));
+        return moisClickbaseProductService.listLatestByWorkspace(workspaceId, normalizedLimit);
+    }
+
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -133,6 +133,7 @@ import MdsRequestDetailPage from "./pages/mds/MdsRequestDetailPage";
 import MdsArtifactsPage from "./pages/mds/MdsArtifactsPage";
 import MdsReportPage from "./pages/mds/MdsReportPage";
 import HotmartPage from "./pages/hotmart/HotmartPage";
+import ClickbasePage from "./pages/clickbase/ClickbasePage";
 
 export default function App() {
   return (
@@ -296,6 +297,7 @@ export default function App() {
               <Route path="/mds/requests/:requestId/artifacts" element={<MdsArtifactsPage />} />
               <Route path="/mds/reports/:requestId" element={<MdsReportPage />} />
               <Route path="/hotmart" element={<HotmartPage />} />
+              <Route path="/clickbase" element={<ClickbasePage />} />
               <Route
                 path="/oprm/routine/:occupationSeedRef"
                 element={<OprmRoutinePage />}

--- a/frontend/src/api/settings/useClickbaseCollectedProducts.ts
+++ b/frontend/src/api/settings/useClickbaseCollectedProducts.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface ClickbaseCollectedProduct {
+  jobId: string;
+  referenceId: string;
+  title: string;
+  productUrl?: string | null;
+  producerName?: string | null;
+  successScore?: number | null;
+  collectedAt?: string | null;
+}
+
+interface ClickbaseCollectedProductListResponse {
+  workspaceId: string;
+  items: ClickbaseCollectedProduct[];
+}
+
+export function useClickbaseCollectedProducts(workspaceId: string, limit = 24) {
+  return useQuery({
+    queryKey: ["settings", "clickbase", "products", workspaceId, limit],
+    enabled: workspaceId.trim().length > 0,
+    queryFn: async () => {
+      const { data } = await axios.get<ClickbaseCollectedProductListResponse>("/api/v1/mois/clickbase/products", {
+        params: { workspaceId, limit },
+      });
+      return data.items;
+    },
+  });
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -109,6 +109,7 @@ const NAV_SECTIONS: NavSection[] = [
       { to: "/oprm", label: "OPRM", icon: Workflow },
       { to: "/mds", label: "MDS", icon: Microscope },
       { to: "/hotmart", label: "Hotmart", icon: Workflow },
+      { to: "/clickbase", label: "Clickbase", icon: Workflow },
     ],
   },
   {

--- a/frontend/src/pages/clickbase/ClickbasePage.tsx
+++ b/frontend/src/pages/clickbase/ClickbasePage.tsx
@@ -1,0 +1,64 @@
+import { useMemo } from "react";
+import PageTitle from "../../components/PageTitle";
+import { useClickbaseCollectedProducts } from "../../api/settings/useClickbaseCollectedProducts";
+
+export default function ClickbasePage() {
+  const workspaceId = "workspace-001";
+  const clickbaseProductsQuery = useClickbaseCollectedProducts(workspaceId, 24);
+  const latestJobId = useMemo(() => clickbaseProductsQuery.data?.[0]?.jobId, [clickbaseProductsQuery.data]);
+
+  return (
+    <div className="mt-3">
+      <PageTitle>Clickbase</PageTitle>
+
+      <section className="card mt-3 shadow-sm border-0">
+        <div className="card-header">
+          <h5 className="mb-1">Produtos coletados</h5>
+          <p className="text-muted small mb-0">Exibe os produtos da última coleta automática registrada para o workspace.</p>
+        </div>
+        <div className="card-body">
+          {clickbaseProductsQuery.isLoading ? <p className="mb-0">Carregando produtos...</p> : null}
+          {clickbaseProductsQuery.isError ? (
+            <p className="text-danger mb-0">Não foi possível carregar os produtos coletados.</p>
+          ) : null}
+          {!clickbaseProductsQuery.isLoading &&
+          !clickbaseProductsQuery.isError &&
+          clickbaseProductsQuery.data &&
+          clickbaseProductsQuery.data.length === 0 ? (
+            <p className="mb-0 text-secondary">Nenhuma coleta Clickbase encontrada até o momento.</p>
+          ) : null}
+
+          {clickbaseProductsQuery.data && clickbaseProductsQuery.data.length > 0 ? (
+            <>
+              <p className="small text-muted mb-3">
+                Job mais recente: <strong>{latestJobId}</strong>
+              </p>
+              <div className="row g-3">
+                {clickbaseProductsQuery.data.map((item) => (
+                  <article key={item.referenceId} className="col-12 col-md-6 col-lg-4">
+                    <div className="card h-100 border">
+                      <div className="card-body d-flex flex-column">
+                        <h6 className="card-title">{item.title || "Produto sem título"}</h6>
+                        <p className="small text-muted mb-2">Produtor: {item.producerName || "Não informado"}</p>
+                        <p className="small mb-3">
+                          Score de sucesso: <strong>{item.successScore ?? "—"}</strong>
+                        </p>
+                        {item.productUrl ? (
+                          <a href={item.productUrl} target="_blank" rel="noreferrer" className="btn btn-outline-primary btn-sm mt-auto">
+                            Ver produto
+                          </a>
+                        ) : (
+                          <span className="small text-muted mt-auto">URL do produto não disponível.</span>
+                        )}
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a way to surface Clickbank/Clickbase collected products from the most recent automatic collection per workspace.

### Description

- Add DTOs in `MoisClickbaseProductDtos` to model collected product responses and lists.
- Implement `MoisClickbaseProductService` which queries `mois_collected_reference` for the latest `CLICKBANK` job and returns top products ordered by `success_score` and `collected_at`.
- Expose a new API endpoint `GET /api/v1/mois/clickbase/products` in `MoisController` that delegates to `MoisClickbaseProductService` and enforces `workspaceId`/`limit` validation.
- Add frontend support including a React page `ClickbasePage`, a data hook `useClickbaseCollectedProducts`, a route at `/clickbase`, and a navigation entry so users can view collected products.

### Testing

- No automated tests were added or modified for this change and no automated test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c82c26d48321b38b0da6d1e32086)