### PR TITLE
Add landing-page-design-preset schema resource to GeraLandingExecutionService tests

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -37,7 +37,8 @@ class GeraLandingExecutionServiceTest {
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
-                        new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"));
+                        new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json"));
         service.processPendingExecutions();
 
         verify(openAiClient).generate(any());
@@ -69,7 +70,8 @@ class GeraLandingExecutionServiceTest {
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
-                        new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"));
+                        new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json"));
         service.processPendingExecutions();
 
         verify(backendClient).receiveFailure(any(), any(), any(), any(), any());


### PR DESCRIPTION
### Motivation
- Align tests with an updated `GeraLandingExecutionService` constructor by providing the new `landing-page-design-preset` schema so the service can load all expected prompt schemas during execution.

### Description
- Update `GeraLandingExecutionServiceTest` to pass `new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json")` as an additional schema argument in both `processPendingExecutionsShouldSendPromptToOpenAiAndRegisterResult` and `processPendingExecutionsShouldRegisterFailureWhenOpenAiFails` test setups.

### Testing
- Executed the unit tests for `GeraLandingExecutionServiceTest`; the updated tests ran and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ce345a308321a35461d5598f701a)