### PR TITLE
Enable GitHub diagnostic tools by default (MCP_GITHUB_ENABLED=true)

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -88,7 +88,7 @@ Quando `MCP_META_ENABLED=false`, as tools `meta_*` continuam aparecendo em `tool
 
 As tools GitHub podem ser ativadas/desativadas por configuração:
 
-- `MCP_GITHUB_ENABLED` (default `false`);
+- `MCP_GITHUB_ENABLED` (default `true`);
 - `MCP_GITHUB_API_BASE_URL` (default `https://api.github.com`);
 - `MCP_GITHUB_OWNER` (owner do repositório, obrigatório quando habilitado);
 - `MCP_GITHUB_REPO` (nome do repositório, obrigatório quando habilitado);

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -66,7 +66,7 @@ mcp:
     debug-access-token: ${MCP_META_GRAPH_DEBUG_ACCESS_TOKEN:${MCP_META_GRAPH_ACCESS_TOKEN:}}
     docs-allowed-hosts: ${MCP_META_DOCS_ALLOWED_HOSTS:developers.facebook.com,business.facebook.com,www.facebook.com}
   github:
-    enabled: ${MCP_GITHUB_ENABLED:false}
+    enabled: ${MCP_GITHUB_ENABLED:true}
     api-base-url: ${MCP_GITHUB_API_BASE_URL:https://api.github.com}
     owner: ${MCP_GITHUB_OWNER:}
     repo: ${MCP_GITHUB_REPO:}


### PR DESCRIPTION
### Motivation

- Make the GitHub Actions diagnostic tools available by default by changing the `MCP_GITHUB_ENABLED` default to `true` so tools that rely on GitHub configuration are enabled out-of-the-box.

### Description

- Updated `mcp-server/README.md` and `mcp-server/src/main/resources/application.yml` to change the `MCP_GITHUB_ENABLED` default from `false` to `true`.

### Testing

- Ran the existing automated test suite with `mvn test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ce4976988321a14d0ecd3d2dc144)