### PR TITLE
Fix MOIS controller test wiring (add MoisClickbaseProductService MockBean)

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
@@ -6,6 +6,7 @@ import com.marketinghub.mois.dto.MoisOfferDtos;
 import com.marketinghub.mois.dto.MoisWorkspaceDtos;
 import com.marketinghub.mois.dto.MoisCollectionPersistenceDtos;
 import com.marketinghub.mois.service.MoisCollectionPersistenceService;
+import com.marketinghub.mois.service.MoisClickbaseProductService;
 import com.marketinghub.mois.service.MoisHotmartProductService;
 import com.marketinghub.mois.service.MoisModuleGateway;
 import java.time.Instant;
@@ -45,6 +46,9 @@ class MoisControllerContractTest {
 
     @MockBean
     private MoisHotmartProductService moisHotmartProductService;
+
+    @MockBean
+    private MoisClickbaseProductService moisClickbaseProductService;
 
     @Test
     void shouldAcceptDiscoveryRequest() throws Exception {


### PR DESCRIPTION
### Motivation
- The `@WebMvcTest(MoisController.class)` slice failed to start because the controller gained a constructor dependency on `MoisClickbaseProductService` that was not mocked in the test, causing ApplicationContext bootstrap errors and aborting the test class.

### Description
- Added import and `@MockBean private MoisClickbaseProductService moisClickbaseProductService;` to `backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java` so the test slice has all constructor dependencies mocked.

### Testing
- Running the wrapper from the wrong directory with `./mvnw -q -Dtest=com.marketinghub.mois.web.MoisControllerContractTest test` failed due to missing wrapper in that path (expected environment error). 
- Ran the targeted test with `cd backend/ads-service && ../mvnw -q -Dtest=com.marketinghub.mois.web.MoisControllerContractTest test` and the test class executed successfully (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05d26ffb5c832183eb51e4c96244bb)