### PR TITLE
Add start endpoint for Gera Landing design preset stage

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContoller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContoller.java
@@ -50,6 +50,12 @@ public class GeraLandingContoller {
     return ResponseEntity.accepted().body(response);
   }
 
+
+  @PostMapping("/design-preset/start")
+  public ResponseEntity<GeraLandingStartResponse> startDesignPreset(@PathVariable Long experimentId) {
+    GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, "landing-page-design-preset");
+    return ResponseEntity.accepted().body(response);
+  }
   @PostMapping("/image-prompts/start")
   public ResponseEntity<GeraLandingStartResponse> startImagePrompts(@PathVariable Long experimentId) {
     GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, "landing-page-image-planning");

--- a/docs/gera-landing/modelo-canonico-gera-landing.md
+++ b/docs/gera-landing/modelo-canonico-gera-landing.md
@@ -107,7 +107,19 @@ Registrar o ciclo de vida completo de uma execução, incluindo:
 ## 3.1 Endpoints públicos (admin)
 
 - `POST /api/experiments/{experimentId}/geralanding/wireframe/start`
-  - cria execução inicial;
+  - cria execução inicial da etapa `landing-page-wireframe`;
+  - retorna `202 Accepted` com `{ idJob, status }`.
+
+- `POST /api/experiments/{experimentId}/geralanding/copy/start`
+  - cria execução inicial da etapa `landing-page-copy`;
+  - retorna `202 Accepted` com `{ idJob, status }`.
+
+- `POST /api/experiments/{experimentId}/geralanding/design-preset/start`
+  - cria execução inicial da etapa `landing-page-design-preset`;
+  - retorna `202 Accepted` com `{ idJob, status }`.
+
+- `POST /api/experiments/{experimentId}/geralanding/image-prompts/start`
+  - cria execução inicial da etapa `landing-page-image-planning`;
   - retorna `202 Accepted` com `{ idJob, status }`.
 
 - `GET /api/experiments/{experimentId}/geralanding/stage-executions`

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -65,3 +65,4 @@
 
 - 2026-05-14 12:00:00 UTC-3 — Nova etapa canônica **landing-page-design-preset** habilitada no fluxo Gera Landing do AI Worker, com prompt e schema dedicados em `prompts/geralanding` e whitelist explícita de atributos CSS por seção/elemento para geração estruturada de presets visuais.
 - 2026-05-14 13:55:00 UTC — Frontend do experimento atualizado com o card **Gera Preset Design** (botão iniciar, jobs em execução, histórico e custo total), alinhado ao mesmo padrão visual/funcional de Gera Copy e Gera WireFrame.
+- 2026-05-14 17:25:00 UTC — Corrigida a causa-raiz de erro 404 no card **Gera Preset Design**: adicionado no backend (`com.marketinghub.geralanding`) o endpoint canônico `POST /api/experiments/{experimentId}/geralanding/design-preset/start`, registrando execução inicial com `stageCode=landing-page-design-preset` e retorno `202 Accepted` (idJob/status), em paridade com wireframe/copy/image-prompts.


### PR DESCRIPTION
### Motivation
- The frontend calls the design preset start route but the backend did not expose `POST /api/experiments/{experimentId}/geralanding/design-preset/start`, causing `404` when users press the Gera Preset Design button.
- Update the canonical Gera Landing docs and operational changelog to reflect the new supported start endpoint so contracts and UI remain in sync.

### Description
- Added a new `@PostMapping("/design-preset/start")` handler in `backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContoller.java` that registers an initial execution with `stageCode = "landing-page-design-preset"` and returns `202 Accepted` with the start response.
- Updated `docs/gera-landing/modelo-canonico-gera-landing.md` to list the `design-preset/start` endpoint alongside existing start endpoints for wireframe, copy and image prompts.
- Appended an entry to `docs/gera-landing/registros3.md` documenting the fix and the root-cause correction for the frontend 404.

### Testing
- Ran the Gera Landing test suite for the backend module with `../mvnw -Dtest='*GeraLanding*' test` inside `backend/ads-service`, which completed successfully: `BUILD SUCCESS` (19 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06052a6dbc8321a0feffe6653e1193)