### PR TITLE
Fix MCP server boot failure when GitHub Actions env vars are absent

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -88,7 +88,7 @@ Quando `MCP_META_ENABLED=false`, as tools `meta_*` continuam aparecendo em `tool
 
 As tools GitHub podem ser ativadas/desativadas por configuração:
 
-- `MCP_GITHUB_ENABLED` (default `true`);
+- `MCP_GITHUB_ENABLED` (default `false`);
 - `MCP_GITHUB_API_BASE_URL` (default `https://api.github.com`);
 - `MCP_GITHUB_OWNER` (owner do repositório, obrigatório quando habilitado);
 - `MCP_GITHUB_REPO` (nome do repositório, obrigatório quando habilitado);

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -66,7 +66,7 @@ mcp:
     debug-access-token: ${MCP_META_GRAPH_DEBUG_ACCESS_TOKEN:${MCP_META_GRAPH_ACCESS_TOKEN:}}
     docs-allowed-hosts: ${MCP_META_DOCS_ALLOWED_HOSTS:developers.facebook.com,business.facebook.com,www.facebook.com}
   github:
-    enabled: ${MCP_GITHUB_ENABLED:true}
+    enabled: ${MCP_GITHUB_ENABLED:false}
     api-base-url: ${MCP_GITHUB_API_BASE_URL:https://api.github.com}
     owner: ${MCP_GITHUB_OWNER:}
     repo: ${MCP_GITHUB_REPO:}


### PR DESCRIPTION
### Motivation
- Prevent the `mcp-server` from failing startup when GitHub-related environment variables (`MCP_GITHUB_OWNER`/`MCP_GITHUB_REPO`) are not set while the GitHub tools are enabled, by avoiding a validation error that requires non-blank owner/repo when `mcp.github.enabled=true`.

### Description
- Change the default for GitHub integration to disabled by setting `mcp.github.enabled` / `MCP_GITHUB_ENABLED` to `false` in `mcp-server/src/main/resources/application.yml` and update `mcp-server/README.md` to document the new default behavior.

### Testing
- Ran the module test suite with `mvn test -q` in `mcp-server` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060cdc71f48321b864ec84ee812940)