### PR TITLE
ClickBank Top Offers: HTML parser, URL normalization, metadata mapping, docs and tests

### DIFF
--- a/docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md
+++ b/docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md
@@ -1,0 +1,82 @@
+# MOIS — Documento Canônico da Coleta ClickBank (Ciclo Um)
+
+## 1. Objetivo do ciclo
+
+Este documento define o **Ciclo Um** da coleta ClickBank no MOIS, com foco em:
+- coletar ofertas públicas da página Top Offers;
+- normalizar os dados coletados;
+- persistir no backend MOIS com rastreabilidade de origem;
+- manter mapeamento explícito **fonte → destino** dos dados.
+
+Referência de origem da coleta pública:
+- `https://www.clickbank.com/blog/clickbank-top-offers/`
+
+## 2. Escopo do Ciclo Um
+
+O Ciclo Um cobre exclusivamente:
+1. leitura da página pública de Top Offers;
+2. extração de bloco de produto (título, nickname, categoria e links);
+3. montagem de snapshots internos (`ClickbankProductSnapshot`);
+4. transformação para payload de persistência (`references` + `rawMetadata`);
+5. envio para endpoint de persistência MOIS.
+
+Não cobre neste ciclo:
+- enriquecimento por outras fontes externas;
+- classificação avançada por IA;
+- reconciliação cross-source.
+
+## 3. Mapeamento de dados (Fonte → Destino)
+
+### 3.1 Fonte primária (HTML ClickBank Top Offers)
+
+| Campo de origem (ClickBank Top Offers) | Regra de extração no ciclo um | Campo de destino interno (snapshot) | Campo de destino na persistência MOIS |
+|---|---|---|---|
+| Heading numerado com link do produto (`<h1-3>...<a href=...>Título</a>`) | Extrair texto do link e sanitizar HTML | `title` | `references[].title` |
+| `href` do link do título no heading | Normalizar URL relativa para absoluta | `detailsUrl` | `references[].rawMetadata.productUrl` |
+| Linha “Nickname: ...” no bloco do produto | Extrair texto após label | `rating` *(uso atual para nickname)* | `references[].rawMetadata.productNickname` |
+| Linha “Category: ...” no bloco do produto | Extrair texto após label | `commission` *(uso atual para categoria)* | `references[].rawMetadata.productCategory` |
+| Link “Check out their landing page here.” | Extrair `href` e normalizar | `salesPageUrl` | `references[].url` e `references[].rawMetadata.salesPageUrl` |
+| Momento da coleta | `Instant.now()` | `collectedAt` | `references[].collectedAt` |
+
+### 3.2 Fonte de contexto operacional (requisição do coletor)
+
+| Campo de origem | Destino na persistência MOIS |
+|---|---|
+| `request.source` | `references[].sourceContext` |
+| `request.maxProducts` | `job.limitPerSource` (com regra de limite aplicado no coletor) |
+| `workspaceId` configurado | `job.workspaceId` |
+| `defaultNiche` configurado | `job.niche` e `references[].niche` |
+| `defaultMarketTheme` configurado | `job.marketTheme` |
+
+## 4. Contrato de persistência no MOIS (Ciclo Um)
+
+No Ciclo Um, cada produto coletado deve gerar:
+- `references[].title` preenchido com nome do produto;
+- `references[].url` apontando para landing page quando existir;
+- `references[].rawMetadata` com campos mínimos:
+  - `productName`
+  - `productUrl`
+  - `salesPageUrl`
+  - `productNickname`
+  - `productCategory`
+  - `clickbankTemperature` *(opcional quando disponível)*
+
+## 5. Regras canônicas de qualidade do ciclo
+
+1. **Priorizar URL de landing page do produto** para `references[].url`.
+2. **Normalizar URLs relativas** para absolutas antes de persistir.
+3. **Evitar duplicidade** por chave composta (`title + nickname + detailsUrl`).
+4. Se nenhum produto for encontrado, registrar aviso operacional no log.
+5. Persistência deve manter rastreabilidade mínima no `rawMetadata` para auditoria.
+
+## 6. Observações de compatibilidade
+
+- No estado atual do DTO, o campo `rating` é utilizado para nickname e `commission` para categoria.
+- Esta adaptação é aceita no Ciclo Um por compatibilidade, mas deve evoluir em ciclo posterior para campos semânticos próprios.
+
+## 7. Evolução prevista (Ciclo Dois)
+
+No Ciclo Dois, recomenda-se:
+- DTO dedicado para produto ClickBank com campos semânticos explícitos (`nickname`, `category`);
+- validações automatizadas de consistência de URL;
+- testes de regressão com múltiplos formatos de HTML da página Top Offers.

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
@@ -126,29 +126,82 @@ public class ClickbankCollectorService {
                 throw new IllegalStateException("Top Offers retornou status " + response.statusCode());
             }
             String html = response.body();
-            java.util.regex.Pattern anchorPattern = java.util.regex.Pattern.compile(
-                    "<a[^>]+href\\s*=\\s*\"([^\"]+)\"[^>]*>(.*?)</a>",
+            java.util.regex.Pattern productPattern = java.util.regex.Pattern.compile(
+                    "<h[1-3][^>]*>\\s*(?:\\d+\\)\\s*)?<a[^>]+href\\s*=\\s*\"([^\"]+)\"[^>]*>(.*?)</a>\\s*</h[1-3]>(.*?)(?=<h[1-3][^>]*>\\s*(?:\\d+\\)\\s*)?<a|$)",
                     java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
             );
-            java.util.regex.Matcher matcher = anchorPattern.matcher(html);
+            java.util.regex.Pattern nicknamePattern = java.util.regex.Pattern.compile(
+                    "Nickname:\\s*(.*?)\\s*(?=Category:|$)",
+                    java.util.regex.Pattern.CASE_INSENSITIVE
+            );
+            java.util.regex.Pattern categoryPattern = java.util.regex.Pattern.compile(
+                    "Category:\\s*(.*?)\\s*(?=Check out their landing page here\\.?|$)",
+                    java.util.regex.Pattern.CASE_INSENSITIVE
+            );
+            java.util.regex.Pattern landingPagePattern = java.util.regex.Pattern.compile(
+                    "<a[^>]+href\\s*=\\s*\"([^\"]+)\"[^>]*>\\s*Check out their landing page here\\.?\\s*</a>",
+                    java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
+            );
+            java.util.regex.Matcher matcher = productPattern.matcher(html);
             LinkedHashSet<String> dedupe = new LinkedHashSet<>();
             while (matcher.find() && products.size() < boundedMax) {
                 String href = matcher.group(1).trim();
-                String title = matcher.group(2).replaceAll("<[^>]*>", "").replaceAll("\\s+", " ").trim();
+                String title = stripHtml(matcher.group(2));
+                String sectionHtml = matcher.group(3);
+                String sectionText = stripHtml(sectionHtml);
                 if (title.isBlank() || href.isBlank()) {
                     continue;
                 }
-                String normalizedUrl = href.startsWith("http") ? href : "https://www.clickbank.com" + href;
-                String dedupeKey = title.toLowerCase() + "|" + normalizedUrl.toLowerCase();
+
+                String nickname = "N/A";
+                java.util.regex.Matcher nicknameMatcher = nicknamePattern.matcher(sectionText);
+                if (nicknameMatcher.find()) {
+                    nickname = nicknameMatcher.group(1).trim();
+                }
+
+                String category = "N/A";
+                java.util.regex.Matcher categoryMatcher = categoryPattern.matcher(sectionText);
+                if (categoryMatcher.find()) {
+                    category = categoryMatcher.group(1).trim();
+                }
+
+                String detailsUrl = normalizeClickbankUrl(href);
+                String salesPageUrl = detailsUrl;
+                java.util.regex.Matcher landingPageMatcher = landingPagePattern.matcher(sectionHtml);
+                if (landingPageMatcher.find()) {
+                    salesPageUrl = normalizeClickbankUrl(landingPageMatcher.group(1));
+                }
+                String dedupeKey = title.toLowerCase() + "|" + nickname.toLowerCase() + "|" + detailsUrl.toLowerCase();
                 if (!dedupe.add(dedupeKey)) {
                     continue;
                 }
-                products.add(new ClickbankProductSnapshot(title, "N/A", "N/A", normalizedUrl, null, normalizedUrl, Instant.now()));
+                products.add(new ClickbankProductSnapshot(title, nickname, category, detailsUrl, null, salesPageUrl, Instant.now()));
+            }
+            if (products.isEmpty()) {
+                log.warn("Parser Top Offers não encontrou blocos de produtos. url={}", clickbankTopOffersUrl);
             }
             return products.size();
         } catch (Exception ex) {
             throw new RuntimeException("Não foi possível coletar top offers públicos.", ex);
         }
+    }
+
+    private String stripHtml(String htmlFragment) {
+        if (htmlFragment == null) {
+            return "";
+        }
+        return htmlFragment
+                .replaceAll("<[^>]*>", " ")
+                .replaceAll("&nbsp;", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+
+    private String normalizeClickbankUrl(String href) {
+        if (href == null || href.isBlank()) {
+            return clickbankTopOffersUrl;
+        }
+        return href.startsWith("http") ? href : "https://www.clickbank.com" + href;
     }
 
     private void persistCollectedProductsOnBackend(
@@ -204,6 +257,8 @@ public class ClickbankCollectorService {
             rawMetadata.put("productName", product.title());
             rawMetadata.put("productUrl", product.detailsUrl());
             rawMetadata.put("salesPageUrl", coalesceNotBlank(product.salesPageUrl(), product.detailsUrl()));
+            rawMetadata.put("productNickname", product.rating());
+            rawMetadata.put("productCategory", product.commission());
             if (product.temperature() != null) {
                 rawMetadata.put("clickbankTemperature", String.valueOf(product.temperature()));
             }

--- a/mois-clickbank-collector/src/test/java/com/marketinghub/moisclickbank/service/ClickbankCollectorServiceTest.java
+++ b/mois-clickbank-collector/src/test/java/com/marketinghub/moisclickbank/service/ClickbankCollectorServiceTest.java
@@ -1,8 +1,13 @@
 package com.marketinghub.moisclickbank.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.marketinghub.moisclickbank.dto.ClickbankDtos.ClickbankCollectionRequest;
+import com.sun.net.httpserver.HttpServer;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 class ClickbankCollectorServiceTest {
@@ -30,5 +35,48 @@ class ClickbankCollectorServiceTest {
         var response = service.collect(new ClickbankCollectionRequest("clickbank-market", 10));
 
         assertEquals("COLLECTION_ERROR", response.status());
+    }
+
+    @Test
+    void shouldExtractNicknameCategoryAndLandingPageFromTopOffersHtml() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/top-offers", exchange -> {
+            String html = """
+                    <html><body>
+                      <h2>1) <a href="/market/product/vin-checkup">VIN Checkup</a></h2>
+                      <p><strong>Nickname:</strong> vincheckup</p>
+                      <p><strong>Category:</strong> Software &amp; Services</p>
+                      <p><a href="https://get.vincheckup.com/">Check out their landing page here.</a></p>
+                    </body></html>
+                    """;
+            byte[] bytes = html.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "text/html; charset=utf-8");
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        server.start();
+        String topOffersUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/top-offers";
+        try {
+            ClickbankCollectorService service = new ClickbankCollectorService(
+                    true, "", "https://app.clickbank.com/market/search", "", "", "",
+                    topOffersUrl, "", "", false, "http://127.0.0.1:1",
+                    "clickbank_access_token_jwt", "workspace-001", "marketing-digital", "ofertas-clickbank"
+            );
+            var response = service.collect(new ClickbankCollectionRequest("clickbank-market", 10));
+
+            assertEquals("COLLECTION_EXECUTED", response.status());
+            assertEquals(1, response.products().size());
+            var product = response.products().getFirst();
+            assertEquals("VIN Checkup", product.title());
+            assertEquals("vincheckup", product.rating());
+            assertEquals("Software &amp; Services", product.commission());
+            assertEquals("https://www.clickbank.com/market/product/vin-checkup", product.detailsUrl());
+            assertEquals("https://get.vincheckup.com/", product.salesPageUrl());
+            assertTrue(product.collectedAt() != null);
+        } finally {
+            server.stop(0);
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Implement the Ciclo Um collection contract for ClickBank Top Offers by extracting product blocks, normalizing fields and preserving source traceability. 
- Improve robustness of the public Top Offers collector to extract nickname, category and landing page links and avoid duplicates.

### Description

- Add canonical specification document at `docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md` describing scope, source→destination mapping and quality rules for Cycle One. 
- Replace simple anchor parsing with a `productPattern` that extracts heading-linked product blocks and capture section content, and add `nicknamePattern`, `categoryPattern` and `landingPagePattern` to extract contextual fields. 
- Populate `ClickbankProductSnapshot` with `title`, `nickname` (stored in `rating`), `category` (stored in `commission`), `detailsUrl`, `salesPageUrl` and `collectedAt`, and deduplicate by `title|nickname|detailsUrl`. 
- Add helpers `stripHtml` and `normalizeClickbankUrl` for HTML sanitization and relative→absolute URL normalization, and log a warning when no products are found. 
- Include new `rawMetadata` entries `productNickname` and `productCategory` when building the persistence payload. 
- Add unit test `shouldExtractNicknameCategoryAndLandingPageFromTopOffersHtml` that runs an embedded `HttpServer` serving a sample Top Offers HTML and validates extraction, plus keep existing unreachable-page error test in `ClickbankCollectorServiceTest`.

### Testing

- Ran unit tests in `ClickbankCollectorServiceTest`, which include `shouldReturnCollectionErrorWhenPublicPageIsUnavailable` and the new `shouldExtractNicknameCategoryAndLandingPageFromTopOffersHtml`, and both tests passed. 
- Executed the project's test suite (`mvn test`), and the affected unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060ab5a78883219a2786db93744f44)