### PR TITLE
Display latest Clickbase job date on Clickbase page

### DIFF
--- a/frontend/src/pages/clickbase/ClickbasePage.tsx
+++ b/frontend/src/pages/clickbase/ClickbasePage.tsx
@@ -6,6 +6,20 @@ export default function ClickbasePage() {
   const workspaceId = "workspace-001";
   const clickbaseProductsQuery = useClickbaseCollectedProducts(workspaceId, 24);
   const latestJobId = useMemo(() => clickbaseProductsQuery.data?.[0]?.jobId, [clickbaseProductsQuery.data]);
+  const latestJobDate = useMemo(() => {
+    const collectedAt = clickbaseProductsQuery.data?.[0]?.collectedAt;
+    if (!collectedAt) {
+      return null;
+    }
+    const parsed = new Date(collectedAt);
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+    return new Intl.DateTimeFormat("pt-BR", {
+      dateStyle: "short",
+      timeStyle: "short",
+    }).format(parsed);
+  }, [clickbaseProductsQuery.data]);
 
   return (
     <div className="mt-3">
@@ -32,6 +46,9 @@ export default function ClickbasePage() {
             <>
               <p className="small text-muted mb-3">
                 Job mais recente: <strong>{latestJobId}</strong>
+              </p>
+              <p className="small text-muted mb-3">
+                Data do job: <strong>{latestJobDate ?? "Não informada"}</strong>
               </p>
               <div className="row g-3">
                 {clickbaseProductsQuery.data.map((item) => (


### PR DESCRIPTION
### Motivation

- Surface the date/time of the most recent Clickbase collection on the Clickbase page so operators can quickly see when the last job ran.
- Avoid runtime errors and show a sensible fallback when the `collectedAt` value is missing or invalid.

### Description

- Added a `latestJobDate` computed value using `useMemo` that parses `collectedAt`, validates it, and formats it with `Intl.DateTimeFormat` using the `pt-BR` locale and short date/time styles. 
- Rendered the formatted date in the UI with a fallback of `Não informada` when the date is missing or invalid. 
- Kept existing job id display and preserved existing product listing and fallbacks for missing product fields.

### Testing

- Ran TypeScript typecheck and linting (`tsc`/`eslint`) which completed successfully. 
- No new unit or integration tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061eda8e308321b505c640a65c7176)