### PR TITLE
feat(frontend): adicionar botão de copiar com ícone ao Job ID (Gera Landing)

### DIFF
--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -221,8 +221,24 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
               ) : null}
 
               <div className="row g-3 small">
-                <div className="col-md-6">
-                  <strong>Job ID:</strong> {detailQuery.data.idJob}
+                <div className="col-md-6 d-flex align-items-center gap-2 flex-wrap">
+                  <strong className="mb-0">Job ID:</strong>
+                  <span>{detailQuery.data.idJob}</span>
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-secondary"
+                    onClick={() =>
+                      handleCopyJson("idJob", detailQuery.data.idJob)
+                    }
+                    aria-label="Copiar Job ID"
+                    title="Copiar Job ID"
+                  >
+                    {copiedField === "idJob" ? (
+                      "Copiado!"
+                    ) : (
+                      <i className="bi bi-copy" aria-hidden="true" />
+                    )}
+                  </button>
                 </div>
                 <div className="col-md-6">
                   <strong>Status:</strong> {detailQuery.data.status}
@@ -338,7 +354,10 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                     );
                   })()}
                 </div>
-                <CollapsibleJsonViewer content={detailQuery.data.prompt} parseAsJson={false} />
+                <CollapsibleJsonViewer
+                  content={detailQuery.data.prompt}
+                  parseAsJson={false}
+                />
               </div>
               <div>
                 <div className="d-flex align-items-center gap-2 mb-2">


### PR DESCRIPTION
### Motivation
- Melhorar a usabilidade da tela de detalhe da execução Gera Landing permitindo copiar rapidamente o Job ID para uso em diagnósticos e investigações.

### Description
- Alterado `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx` para exibir o `Job ID` em um container `d-flex gap-2 flex-wrap` e adicionar um botão inline de cópia com o ícone `bi bi-copy`.
- Reaproveitado o handler existente `handleCopyJson` para executar a cópia e exibir feedback temporário `Copiado!` quando a ação for bem-sucedida.
- Adicionados atributos de acessibilidade `aria-label` e `title` ao botão e mantido comportamento responsivo do layout.
- Formatação aplicada com `npx prettier --write` antes do commit.

### Testing
- Executado `npx prettier --check src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx`, que falhou inicialmente por formatação e depois foi corrigido com `npx prettier --write` e verificado com `npx prettier --check` (agora passou).
- Não foram necessárias alterações backend nem testes unitários automatizados para esta melhoria de UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a062ab9e1ac8321a7d61e8852263f98)