### PR TITLE
Support pageSalesLink for Hotmart products (DTO, persistence, and UI)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisHotmartProductDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisHotmartProductDtos.java
@@ -17,6 +17,7 @@ public final class MoisHotmartProductDtos {
             String price,
             String currency,
             String salesPageUrl,
+            String pageSalesLink,
             Double temperature,
             Instant collectedAt
     ) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisCollectionPersistenceService.java
@@ -151,9 +151,9 @@ public class MoisCollectionPersistenceService {
                     ps.setString(24, coalesceNotBlank(metadataValue(item, "hotmartProducer"), metadataValue(item, "producerName"), metadataValue(item, "producer")));
                     ps.setString(25, coalesceNotBlank(
                             metadataValue(item, "salesPageUrl"),
+                            metadataValue(item, "salesPageUrls"),
                             metadataValue(item, "pageSalesLink"),
-                            metadataValue(item, "checkoutUrl"),
-                            item.url()));
+                            metadataValue(item, "checkoutUrl")));
                     ps.setBigDecimal(26, parseDecimal(metadataValue(item, "hotmartTemperature")));
                     ps.setString(27, coalesceNotBlank(metadataValue(item, "priceValue"), metadataValue(item, "price")));
                     ps.setTimestamp(28, item.collectedAt() == null ? null : Timestamp.from(item.collectedAt()));

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartProductService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisHotmartProductService.java
@@ -56,6 +56,7 @@ public class MoisHotmartProductService {
                             rs.getString("hotmart_price"),
                             "BRL",
                             rs.getString("sales_page_url"),
+                            rs.getString("sales_page_url"),
                             rs.getObject("hotmart_temperature") == null ? null : rs.getDouble("hotmart_temperature"),
                             collectedAt == null ? null : collectedAt.toInstant());
                 },

--- a/frontend/src/api/settings/useHotmartCollectedProducts.ts
+++ b/frontend/src/api/settings/useHotmartCollectedProducts.ts
@@ -11,6 +11,7 @@ export interface HotmartCollectedProduct {
   price?: string | null;
   currency?: string | null;
   salesPageUrl?: string | null;
+  pageSalesLink?: string | null;
   temperature?: number | null;
   collectedAt?: string | null;
 }

--- a/frontend/src/pages/hotmart/HotmartPage.tsx
+++ b/frontend/src/pages/hotmart/HotmartPage.tsx
@@ -150,7 +150,7 @@ export default function HotmartPage() {
                     const producer = item.producerName;
                     const price = item.price;
                     const currency = item.currency ?? "BRL";
-                    const salesPageUrl = item.salesPageUrl;
+                    const salesPageUrl = item.pageSalesLink?.trim() || item.salesPageUrl?.trim() || null;
 
                     return (
                       <article key={item.referenceId} className="col-12 col-md-6 col-lg-4">
@@ -170,7 +170,7 @@ export default function HotmartPage() {
                               Temperatura: <strong>{item.temperature ?? "—"}</strong>
                             </p>
                             <p className="small mb-2">
-                              Página de vendas:{" "}
+                              pageSalesLink:{" "}
                               {salesPageUrl ? (
                                 <a href={salesPageUrl} target="_blank" rel="noreferrer">
                                   {salesPageUrl}


### PR DESCRIPTION
### Motivation
- Add support for an alternative sales-page metadata key (`pageSalesLink`) so collected Hotmart products can surface the correct sales page link in the UI.
- Ensure persistence prefers multiple possible metadata keys for sales page links and keeps stored values consistent.

### Description
- Added `pageSalesLink` field to `MoisHotmartProductDtos.HotmartCollectedProductResponse` and to the frontend `HotmartCollectedProduct` interface.
- Updated `MoisCollectionPersistenceService` to coalesce sales-page metadata in the order `salesPageUrl`, `salesPageUrls`, `pageSalesLink`, `checkoutUrl` when persisting, and removed the previous fallback to `item.url()` for that column.
- When reading from the DB in `MoisHotmartProductService` the code now populates both `salesPageUrl` and `pageSalesLink` from the `sales_page_url` column so the new DTO field is filled.
- Adjusted the Hotmart page component to prefer `pageSalesLink` over `salesPageUrl` when rendering product cards and updated the displayed label accordingly.

### Testing
- Ran backend unit tests with `./gradlew test` and all tests passed.
- Ran frontend type-check and build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a062f7bf150832199d0e493812e6d38)