### PR TITLE
Implementa ciclo 2 do coletor ClickBank e alternância ímpar/par no scheduler

### DIFF
--- a/docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md
+++ b/docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md
@@ -80,3 +80,21 @@ No Ciclo Dois, recomenda-se:
 - DTO dedicado para produto ClickBank com campos semânticos explícitos (`nickname`, `category`);
 - validações automatizadas de consistência de URL;
 - testes de regressão com múltiplos formatos de HTML da página Top Offers.
+
+## 8. Definição canônica do Ciclo Dois (ativada)
+
+O Ciclo Dois do coletor ClickBank passa a operar com o seguinte fluxo obrigatório:
+
+1. Ler do backend MOIS (`/api/v1/mois/clickbase/products`) a lista de produtos já persistidos no ciclo 1.
+2. Para cada produto, acessar a `detailsUrl` do produto para resolver a URL final da página de vendas.
+3. Persistir novamente no backend MOIS via endpoint de persistência (`/api/v1/mois/persistence/collection-jobs/{jobId}`), garantindo armazenamento em base de páginas de venda para análises futuras.
+
+### 8.1 Regras de execução agendada
+
+- **Horas ímpares:** executar **Ciclo 1** (Top Offers).
+- **Horas pares:** executar **Ciclo 2** (resolução/persistência de páginas de venda).
+
+### 8.2 Responsabilidades por módulo
+
+- **Leitura e persistência:** backend pacote **MOIS**.
+- **Coleta e tratamentos:** módulo **mois-clickbank-collector**.

--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -146,3 +146,8 @@
 - Atendendo solicitação de registro, a tela `/hotmart` no frontend foi atualizada para exibir informação explícita de que o ciclo 2 captura `pageSalesLink`.
 - Registrado também na UI que a persistência ocorre em `mois_collected_reference.sales_page_url`, reduzindo ambiguidade operacional sobre origem/destino do link de página de vendas.
 - Mantido o comportamento já existente do botão **Ver página de vendas**, com orientação textual de que ele usa essa URL quando disponível.
+
+## 2026-05-14 18:08:32 UTC-3
+- Implementado o ciclo 2 no `mois-clickbank-collector`: leitura dos produtos base via backend MOIS (`/api/v1/mois/clickbase/products`), acesso da `detailsUrl` produto a produto e persistência do resultado no endpoint de coleta (`/api/v1/mois/persistence/collection-jobs/{jobId}`).
+- Scheduler do coletor ClickBank ajustado para alternância por hora: horas ímpares executam ciclo 1 (Top Offers) e horas pares executam ciclo 2 (página de vendas).
+- Atualizada a documentação canônica de coleta ClickBank com definição operacional do novo ciclo 2 e responsabilidades entre backend MOIS e módulo coletor.

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorScheduler.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorScheduler.java
@@ -2,6 +2,7 @@ package com.marketinghub.moisclickbank.service;
 
 import com.marketinghub.moisclickbank.dto.ClickbankDtos.ClickbankCollectionRequest;
 import com.marketinghub.moisclickbank.dto.ClickbankDtos.ClickbankCollectionResponse;
+import java.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,8 +38,17 @@ public class ClickbankCollectorScheduler {
             log.info("Clickbank scheduler desabilitado por configuração.");
             return;
         }
-        ClickbankCollectionResponse response = collectorService.collect(new ClickbankCollectionRequest(source, maxProducts));
-        log.info("Clickbank scheduler executado status={} produtos={} mensagem={}",
-                response.status(), response.products().size(), response.message());
+        int currentHour = LocalDateTime.now().getHour();
+        boolean isOddHour = currentHour % 2 != 0;
+        ClickbankCollectionRequest request = new ClickbankCollectionRequest(source, maxProducts);
+        ClickbankCollectionResponse response = isOddHour
+                ? collectorService.collectFirstCycle(request)
+                : collectorService.collectSecondCycleFromBackend(request);
+        log.info("Clickbank scheduler executado hora={} ciclo={} status={} produtos={} mensagem={}",
+                currentHour,
+                isOddHour ? "CICLO_1_TOP_OFFERS" : "CICLO_2_VENDAS_PAGE",
+                response.status(),
+                response.products().size(),
+                response.message());
     }
 }

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
@@ -87,6 +87,10 @@ public class ClickbankCollectorService {
     }
 
     public ClickbankCollectionResponse collect(ClickbankCollectionRequest request) {
+        return collectFirstCycle(request);
+    }
+
+    public ClickbankCollectionResponse collectFirstCycle(ClickbankCollectionRequest request) {
         int boundedMax = request.maxProducts() <= 0 ? 10 : Math.min(request.maxProducts(), 50);
 
         List<ClickbankProductSnapshot> products = new ArrayList<>();
@@ -114,6 +118,89 @@ public class ClickbankCollectorService {
         return new ClickbankCollectionResponse(status, message, products);
     }
 
+
+
+    public ClickbankCollectionResponse collectSecondCycleFromBackend(ClickbankCollectionRequest request) {
+        int boundedMax = request.maxProducts() <= 0 ? 10 : Math.min(request.maxProducts(), 50);
+        List<ClickbankProductSnapshot> products = new ArrayList<>();
+        String status = "COLLECTION_EXECUTED";
+        String message = "Ciclo 2 executado a partir dos produtos persistidos no backend.";
+
+        List<ClickbankProductSnapshot> baseProducts = fetchFirstCycleProductsFromBackend(boundedMax);
+        for (ClickbankProductSnapshot base : baseProducts) {
+            if (products.size() >= boundedMax) {
+                break;
+            }
+            products.add(collectSalesPageFromProduct(base));
+        }
+        persistCollectedProductsOnBackend(request, status, products);
+        return new ClickbankCollectionResponse(status, message, products);
+    }
+
+    private List<ClickbankProductSnapshot> fetchFirstCycleProductsFromBackend(int maxProducts) {
+        List<ClickbankProductSnapshot> products = new ArrayList<>();
+        String endpoint = backendBaseUrl + "/api/v1/mois/clickbase/products?workspaceId=" + workspaceId + "&limit=" + Math.max(1, Math.min(maxProducts, 100));
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .header("accept", "application/json")
+                    .GET()
+                    .build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                log.warn("Ciclo 2: falha ao obter produtos base do backend. status={}, endpoint={}", response.statusCode(), endpoint);
+                return products;
+            }
+            JsonNode root = objectMapper.readTree(response.body());
+            JsonNode items = firstArray(root, "items", "products", "content", "results");
+            if (items == null || !items.isArray()) {
+                return products;
+            }
+            for (JsonNode item : items) {
+                String title = pickFirstNonBlank(extractProductText(item, "title", "name", "productName"), "Produto sem título");
+                String detailsUrl = pickFirstNonBlank(extractProductText(item, "detailsUrl", "productUrl", "url"), clickbankTopOffersUrl);
+                String salesPageUrl = pickFirstNonBlank(extractProductText(item, "salesPageUrl", "pageUrl"), detailsUrl);
+                products.add(new ClickbankProductSnapshot(
+                        title,
+                        pickFirstNonBlank(extractProductText(item, "productNickname", "nickname", "rating"), "N/A"),
+                        pickFirstNonBlank(extractProductText(item, "productCategory", "category", "commission"), "N/A"),
+                        detailsUrl,
+                        extractProductNumber(item, "temperature", "clickbankTemperature"),
+                        salesPageUrl,
+                        Instant.now()));
+            }
+        } catch (Exception ex) {
+            log.warn("Ciclo 2: erro ao obter produtos do backend.", ex);
+        }
+        return products;
+    }
+
+    private ClickbankProductSnapshot collectSalesPageFromProduct(ClickbankProductSnapshot base) {
+        String normalizedDetailsUrl = coalesceNotBlank(base.detailsUrl(), clickbankTopOffersUrl);
+        String salesPageUrl = coalesceNotBlank(base.salesPageUrl(), normalizedDetailsUrl);
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(normalizedDetailsUrl))
+                    .header("accept", "text/html")
+                    .GET()
+                    .build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 200 && response.statusCode() < 400 && response.uri() != null) {
+                salesPageUrl = response.uri().toString();
+            }
+        } catch (Exception ex) {
+            log.warn("Ciclo 2: falha ao resolver página de vendas para detailsUrl={}", normalizedDetailsUrl);
+        }
+        return new ClickbankProductSnapshot(
+                base.title(),
+                base.rating(),
+                base.commission(),
+                normalizedDetailsUrl,
+                base.temperature(),
+                salesPageUrl,
+                Instant.now()
+        );
+    }
     private int collectProductsFromTopOffersPage(int boundedMax, List<ClickbankProductSnapshot> products) {
         try {
             HttpRequest request = HttpRequest.newBuilder()


### PR DESCRIPTION
### Motivation
- Implementar o Segundo Ciclo do coletor ClickBank para capturar e armazenar as páginas de venda (sales pages) a partir dos produtos já persistidos no backend MOIS. 
- Garantir que leitura e persistência fiquem no pacote `MOIS` e que o coletor (`mois-clickbank-collector`) faça o enriquecimento e resolução das URLs de vendas. 
- Agendar execuções em alternância por hora (hora ímpar = ciclo 1, hora par = ciclo 2) para reduzir carga e manter fluxo previsível.

### Description
- Adiciona `collectSecondCycleFromBackend`, `fetchFirstCycleProductsFromBackend` e `collectSalesPageFromProduct` em `ClickbankCollectorService` para ler produtos do endpoint do backend e resolver/persistir a `salesPageUrl`. 
- Altera `collect` para delegar a `collectFirstCycle` e mantém `collectFirstCycle` para a lógica existente de `Top Offers`. 
- Atualiza `ClickbankCollectorScheduler` para calcular a hora atual com `LocalDateTime.now().getHour()` e alternar entre `collectFirstCycle` e `collectSecondCycleFromBackend` conforme hora ímpar/par. 
- Atualiza documentação canônica `docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md` com a definição operacional do Ciclo Dois e registra a mudança em `docs/registros/coletor-mois1.md` com timestamp UTC-3.

### Testing
- Executei `mvn test -q` no módulo `mois-clickbank-collector` e os testes unitários do módulo foram executados com sucesso. 
- Os testes existentes de `ClickbankCollectorServiceTest` e `ClickbankCollectorControllerTest` foram mantidos e exercitados durante a validação. 
- Não foram introduzidos novos unit tests neste PR; o comportamento do ciclo 2 é coberto por chamadas reais ao backend simulado durante execução manual/local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a063971043c8321b9a432bd359f289a)