### PR TITLE
Fix gera-landing stage execution test stubs for provisional HTML paths

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -268,8 +268,10 @@ class GeraLandingStageExecutionServiceTest {
                 experiment.getLandingPageWireframe(),
                 request.modelResponse(),
                 experiment.getLandingPageDesignPreset(),
-                "id-image-planning")).thenReturn("<html>completo</html>");
-        when(landingPageImageInjector.injectImages(66L, "<html>completo</html>")).thenReturn("<html>com-imagens</html>");
+                "id-image-planning"))
+                .thenReturn("<html>com-imagens</html>");
+        when(landingPageImageInjector.injectImages(66L, "<html>com-imagens</html>"))
+                .thenReturn("<html>com-imagens</html>");
 
         service.receiveResult("id-image-planning", request);
 
@@ -424,9 +426,9 @@ class GeraLandingStageExecutionServiceTest {
         when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc("id-design".getBytes(StandardCharsets.UTF_8)))
                 .thenReturn(Optional.of(execution));
         when(experimentRepository.findById(79L)).thenReturn(Optional.of(experiment), Optional.of(experiment));
-        when(copyProvisionalHtmlAssembler.assembleComplete(
-                experiment.getLandingPageCopy(),
+        when(designPresetProvisionalHtmlAssembler.assemble(
                 experiment.getLandingPageWireframe(),
+                experiment.getLandingPageCopy(),
                 experiment.getLandingPageImagePlanning(),
                 request.modelResponse(),
                 "id-design"))


### PR DESCRIPTION
### Motivation
- Tests in `GeraLandingStageExecutionServiceTest` were failing with a NPE because mocks did not reflect the service behavior that assembles provisional HTML differently per stage (image-planning vs design-preset).
- The goal is to make the unit tests deterministic and aligned with the current `GeraLandingStageExecutionService` logic so provisional HTML is created and persisted in tests.

### Description
- Updated the design-preset test to mock `DesignPresetProvisionalHtmlAssembler.assemble(...)` instead of the copy assembler so the `landing-page-design-preset` stage returns provisional HTML.
- Restored and adjusted `copyProvisionalHtmlAssembler.assembleComplete(...)` expectations for image-planning scenarios to match arguments used by the service.
- Added explicit `landingPageImageInjector.injectImages(...)` mocks in image-planning tests to make image injection deterministic and avoid null `provisionalHtml` in assertions.
- Cleaned up related test stubs in `GeraLandingStageExecutionServiceTest.java` so the `generateAndPersistProvisionalHtmlFromExperiment` and stage result tests exercise the correct assembly paths.

### Testing
- Ran targeted unit tests with `mvn -Dtest=GeraLandingStageExecutionServiceTest test`; initially the suite exhibited errors (NPE) before the fixes, and after the changes the targeted tests were executed and validated locally as passing.
- The modifications were limited to the test file `backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java` and no production code was changed during this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06485a84d4832190f4d5398de13e62)