### PR TITLE
Publish ClickBank cycle-2 sales page URLs to MOIS sales-library and update operational docs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisSalesLibraryDtos.java
@@ -1,0 +1,35 @@
+package com.marketinghub.mois.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.time.Instant;
+import java.util.List;
+
+public final class MoisSalesLibraryDtos {
+
+    private MoisSalesLibraryDtos() {
+    }
+
+    public record SalesLibraryIngestRequest(
+            @NotBlank String workspaceId,
+            @NotBlank String source,
+            @NotEmpty List<@Valid SalesLibraryUrlItem> urls
+    ) {
+    }
+
+    public record SalesLibraryUrlItem(
+            @NotBlank String url,
+            String title,
+            Instant capturedAt
+    ) {
+    }
+
+    public record SalesLibraryIngestResponse(
+            String workspaceId,
+            String source,
+            int received,
+            int persisted
+    ) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/service/MoisSalesLibraryService.java
@@ -1,0 +1,79 @@
+package com.marketinghub.mois.service;
+
+import com.marketinghub.mois.dto.MoisSalesLibraryDtos;
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MoisSalesLibraryService {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public MoisSalesLibraryDtos.SalesLibraryIngestResponse ingestUrls(MoisSalesLibraryDtos.SalesLibraryIngestRequest request) {
+        int persisted = 0;
+        String normalizedSource = request.source().trim().toUpperCase(Locale.ROOT);
+        for (MoisSalesLibraryDtos.SalesLibraryUrlItem item : request.urls()) {
+            String canonical = canonicalize(item.url());
+            if (canonical == null || canonical.isBlank()) {
+                continue;
+            }
+            Instant capturedAt = item.capturedAt() == null ? Instant.now() : item.capturedAt();
+            LocalDateTime capturedAtUtc = LocalDateTime.ofInstant(capturedAt, ZoneOffset.UTC);
+            jdbcTemplate.update(
+                    """
+                            INSERT INTO mois_sales_library_url_ingest
+                            (workspace_id, source, url_original, url_canonical, title, first_captured_at, last_captured_at, ingest_count, created_at, updated_at)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, 1, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                            ON DUPLICATE KEY UPDATE
+                                source = VALUES(source),
+                                url_original = VALUES(url_original),
+                                title = COALESCE(NULLIF(VALUES(title), ''), title),
+                                last_captured_at = GREATEST(COALESCE(last_captured_at, VALUES(last_captured_at)), VALUES(last_captured_at)),
+                                ingest_count = ingest_count + 1,
+                                updated_at = UTC_TIMESTAMP()
+                            """,
+                    request.workspaceId(),
+                    normalizedSource,
+                    item.url(),
+                    canonical,
+                    item.title(),
+                    capturedAtUtc,
+                    capturedAtUtc
+            );
+            persisted++;
+        }
+
+        return new MoisSalesLibraryDtos.SalesLibraryIngestResponse(
+                request.workspaceId(),
+                normalizedSource,
+                request.urls().size(),
+                persisted
+        );
+    }
+
+    private String canonicalize(String rawUrl) {
+        if (rawUrl == null || rawUrl.isBlank()) {
+            return null;
+        }
+        try {
+            URI uri = URI.create(rawUrl.trim());
+            String scheme = uri.getScheme() == null ? "https" : uri.getScheme().toLowerCase(Locale.ROOT);
+            String host = uri.getHost();
+            if (host == null || host.isBlank()) {
+                return rawUrl.trim();
+            }
+            String normalizedHost = host.toLowerCase(Locale.ROOT);
+            String path = (uri.getPath() == null || uri.getPath().isBlank()) ? "/" : uri.getPath();
+            return scheme + "://" + normalizedHost + path;
+        } catch (Exception ignored) {
+            return rawUrl.trim();
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisSalesLibraryController.java
@@ -1,0 +1,30 @@
+package com.marketinghub.mois.web;
+
+import com.marketinghub.mois.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.service.MoisSalesLibraryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/mois/sales-library")
+@RequiredArgsConstructor
+@Validated
+public class MoisSalesLibraryController {
+
+    private final MoisSalesLibraryService service;
+
+    @PostMapping("/urls:ingest")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public MoisSalesLibraryDtos.SalesLibraryIngestResponse ingestUrls(
+            @Valid @RequestBody MoisSalesLibraryDtos.SalesLibraryIngestRequest request
+    ) {
+        return service.ingestUrls(request);
+    }
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-15-mois-sales-library-url-ingest.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-15-mois-sales-library-url-ingest.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-15-mois-sales-library-url-ingest-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: mois_sales_library_url_ingest
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_library_url_ingest (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                workspace_id VARCHAR(120) NOT NULL,
+                source VARCHAR(40) NOT NULL,
+                url_original VARCHAR(1024) NOT NULL,
+                url_canonical VARCHAR(1024) NOT NULL,
+                title VARCHAR(512) NULL,
+                first_captured_at DATETIME NULL,
+                last_captured_at DATETIME NULL,
+                ingest_count INT NOT NULL DEFAULT 1,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_mois_sales_library_workspace_url (workspace_id, url_canonical),
+                KEY idx_mois_sales_library_updated_at (updated_at),
+                KEY idx_mois_sales_library_source (source)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -755,3 +755,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-05-14-mois-collected-reference-hotmart-price.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-05-15-mois-sales-library-url-ingest.yaml
+      relativeToChangelogFile: true

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -634,3 +634,12 @@ Para suportar o gerenciamento administrativo de ocupações no módulo OPRM (cad
 - Chave única: (`snapshot_date`, `source`, `cnae_code`, `uf`, `municipio`).
 - Endpoint de ingestão no backend: `POST /api/niches/snapshots:ingest`.
 - Regra operacional: coletor como cliente da API backend; sem escrita direta no banco.
+
+## MOIS — Biblioteca de páginas de vendas (2026-05-15)
+
+- Nova tabela backend: `mois_sales_library_url_ingest`.
+- Objetivo: receber e persistir relacionalmente as URLs canônicas de páginas de venda enviadas pelos coletores (início: ciclo 2 do ClickBank).
+- Chave única: (`workspace_id`, `url_canonical`) para garantir idempotência de ingestão por workspace.
+- Colunas operacionais: `url_original`, `url_canonical`, `source`, `title`, `first_captured_at`, `last_captured_at`, `ingest_count`, `created_at`, `updated_at`.
+- Endpoint backend de ingestão: `POST /api/mois/sales-library/urls:ingest`.
+- Regra operacional: o coletor envia URL para o backend principal; somente o backend persiste no banco.

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -260,3 +260,8 @@
 - Mantidas as proteções anti-overlay já existentes, com foco em eliminar o bloqueio do cookie policy que impede a transição de estado autenticado.
 - Validação executada no módulo Java: `mvn -q test` com sucesso.
 - Registro criado por solicitação explícita: "registre as alterações".
+
+## 2026-05-14 22:30:00 UTC
+- Definido como orientação canônica do módulo MOIS o documento **Biblioteca de Sales Pages**: `docs/novos-modulos/mois/especificacao-biblioteca-sales-pages.md`.
+- Registro explícito para o time: a execução do **Ciclo 2 do coletor Clickbase/ClickBank** passa a ser tratada como etapa inicial de construção da biblioteca de páginas de vendas, em aderência ao direcionamento do módulo.
+- Objetivo operacional consolidado: usar os links resolvidos/persistidos no ciclo 2 como base para evolução da biblioteca e análises estruturadas de sales pages no MOIS.

--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -151,3 +151,9 @@
 - Implementado o ciclo 2 no `mois-clickbank-collector`: leitura dos produtos base via backend MOIS (`/api/v1/mois/clickbase/products`), acesso da `detailsUrl` produto a produto e persistência do resultado no endpoint de coleta (`/api/v1/mois/persistence/collection-jobs/{jobId}`).
 - Scheduler do coletor ClickBank ajustado para alternância por hora: horas ímpares executam ciclo 1 (Top Offers) e horas pares executam ciclo 2 (página de vendas).
 - Atualizada a documentação canônica de coleta ClickBank com definição operacional do novo ciclo 2 e responsabilidades entre backend MOIS e módulo coletor.
+
+## 2026-05-14 22:45:00 UTC
+- Iniciada implementação prática do objetivo da biblioteca de páginas de vendas no **Ciclo 2** do `mois-clickbank-collector`.
+- O `ClickbankCollectorService.collectSecondCycleFromBackend` passou a, além de persistir no endpoint MOIS já existente, enviar as URLs resolvidas de página de vendas para o endpoint de ingestão da biblioteca: `POST /api/mois/sales-library/urls:ingest`.
+- Payload enviado inclui `workspaceId`, `source=CLICKBANK` e lista `urls` com `url`, `title` e `capturedAt`.
+- Comportamento resiliente: falhas na ingestão da biblioteca são registradas em log (warn), sem interromper a persistência padrão do ciclo 2.

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
@@ -134,7 +134,55 @@ public class ClickbankCollectorService {
             products.add(collectSalesPageFromProduct(base));
         }
         persistCollectedProductsOnBackend(request, status, products);
+        publishSalesPagesToLibrary(products);
         return new ClickbankCollectionResponse(status, message, products);
+    }
+
+    private void publishSalesPagesToLibrary(List<ClickbankProductSnapshot> products) {
+        if (products == null || products.isEmpty()) {
+            return;
+        }
+        List<Map<String, Object>> urls = new ArrayList<>();
+        for (ClickbankProductSnapshot product : products) {
+            String salesPageUrl = coalesceNotBlank(product.salesPageUrl(), product.detailsUrl());
+            if (salesPageUrl == null || salesPageUrl.isBlank()) {
+                continue;
+            }
+            Map<String, Object> item = new HashMap<>();
+            item.put("url", salesPageUrl);
+            item.put("source", "CLICKBANK");
+            item.put("workspaceId", workspaceId);
+            item.put("title", product.title());
+            item.put("capturedAt", Instant.now().toString());
+            urls.add(item);
+        }
+        if (urls.isEmpty()) {
+            log.info("Ciclo 2: nenhuma URL elegível para ingestão na biblioteca de sales pages.");
+            return;
+        }
+        String endpoint = backendBaseUrl + "/api/mois/sales-library/urls:ingest";
+        try {
+            Map<String, Object> body = new HashMap<>();
+            body.put("workspaceId", workspaceId);
+            body.put("source", "CLICKBANK");
+            body.put("urls", urls);
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(body)))
+                    .build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                log.info("Ciclo 2: ingestão de sales pages enviada com sucesso. endpoint={}, totalUrls={}", endpoint, urls.size());
+            } else {
+                log.warn("Ciclo 2: backend rejeitou ingestão de sales pages. endpoint={}, status={}, body={}",
+                        endpoint,
+                        response.statusCode(),
+                        truncate(response.body(), 500));
+            }
+        } catch (Exception ex) {
+            log.warn("Ciclo 2: falha ao enviar URLs para biblioteca de sales pages. endpoint={}", endpoint, ex);
+        }
     }
 
     private List<ClickbankProductSnapshot> fetchFirstCycleProductsFromBackend(int maxProducts) {
@@ -1015,5 +1063,12 @@ public class ClickbankCollectorService {
         } catch (Exception ignored) {
             log.debug("Overlay '{}' ainda visível após timeout de espera.", selector);
         }
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength) + "...";
     }
 }


### PR DESCRIPTION
### Motivation
- Treat Cycle 2 of the ClickBank collector as the canonical source for building the MOIS sales-pages library and record that operational orientation in the project docs.
- Ensure resolved sales-page URLs discovered during Cycle 2 are ingested into the centralized `sales-library` service for downstream analysis and reuse.

### Description
- Added a call to `publishSalesPagesToLibrary` from `collectSecondCycleFromBackend` to send resolved sales-page URLs to `POST /api/mois/sales-library/urls:ingest` after persisting normal cycle results. 
- Implemented `publishSalesPagesToLibrary` to collect eligible URLs from `ClickbankProductSnapshot`, build a payload with `workspaceId`, `source=CLICKBANK`, `urls` (containing `url`, `title`, `capturedAt`) and send it via `HttpClient`, logging success or warnings on non-2xx responses and catching exceptions without failing the main flow.
- Added a small `truncate` helper for safely logging long response bodies.
- Updated documentation and operational registros (`docs/mois/registros.md` and `docs/registros/coletor-mois1.md`) to record the new library specification, the Cycle 2 ingestion behavior, and related CI/deploy and collector changes.

### Testing
- No new automated tests were added or executed as part of this change; please run `mvn -q test` on the `mois-clickbank-collector` module to validate build and unit tests before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06489e602c8321a325a81dedbab636)