### PR TITLE
Fix MySQL key length for MOIS sales library ingest migration

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-15-mois-sales-library-url-ingest.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-15-mois-sales-library-url-ingest.yaml
@@ -28,7 +28,7 @@ databaseChangeLog:
                 created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                 PRIMARY KEY (id),
-                UNIQUE KEY uk_mois_sales_library_workspace_url (workspace_id, url_canonical),
+                UNIQUE KEY uk_mois_sales_library_workspace_url (workspace_id, url_canonical(512)),
                 KEY idx_mois_sales_library_updated_at (updated_at),
                 KEY idx_mois_sales_library_source (source)
               ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
### Motivation
- The Liquibase changeset for `mois_sales_library_url_ingest` created a composite unique index on `workspace_id VARCHAR(120)` + `url_canonical VARCHAR(1024)` which can exceed InnoDB's 3072-byte key limit under `utf8mb4`, causing migrations to fail at application startup.
- The change is intended to make the migration compatible with MySQL 5.7 / InnoDB using `utf8mb4` without losing practical uniqueness for `url_canonical`.

### Description
- Updated `backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-15-mois-sales-library-url-ingest.yaml` to change the unique index from `(workspace_id, url_canonical)` to `(workspace_id, url_canonical(512))` to limit index bytes. 
- Left table columns and other indexes unchanged and preserved `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`.

### Testing
- Ran `cd backend/ads-service && mvn test -DskipITs` and the module build completed successfully with tests passing. 
- Attempting `cd /workspace/marketing-hub && mvn -pl backend/ads-service test -DskipITs` from repo root failed because the multi-module invocation was not applicable, which did not affect the module-level validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0670e69dd88321bf96b45d75eeaf88)