### PR TITLE
Ajusta etapa 6 da aba Conteúdo para Preset de Design

### DIFF
--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -109,17 +109,17 @@ const CONTENT_GENERATION_SECTIONS: ContentGenerationSection[] = [
     defaultQuantity: 4,
   },
   {
-    key: "landing-image-planning",
-    label: "Planejamento de Imagens da Landing",
-    description:
-      "Planeje prompts, posicionamento e direção visual das imagens antes da geração final do HTML.",
-    defaultQuantity: 1,
-  },
-  {
     key: "landing-design-preset",
     label: "Preset de Design da Landing",
     description:
       "Defina tema visual, paleta e presets por seção antes da composição final do HTML.",
+    defaultQuantity: 1,
+  },
+  {
+    key: "landing-image-planning",
+    label: "Planejamento de Imagens da Landing",
+    description:
+      "Planeje prompts, posicionamento e direção visual das imagens antes da geração final do HTML.",
     defaultQuantity: 1,
   },
   {
@@ -622,7 +622,7 @@ artifact {
 
 const LANDING_DESIGN_PRESET_PROMPT_TEMPLATE = `${COMMON_PIPELINE_PROMPT}
 
-Criar o Preset de Design da Landing após o planejamento de imagens e antes do HTML final.
+Criar o Preset de Design da Landing antes do HTML final, mantendo alinhamento com o plano de imagens da landing.
 
 Objetivo:
 Estruturar tema visual reutilizável (paleta, estilos e presets por seção) mantendo coerência com copy, wireframe e planejamento de imagens.


### PR DESCRIPTION
### Motivation
- Colocar `landing-design-preset` como etapa 6 na aba "Conteúdo" do detalhe do experimento para que o preset de design seja gerado antes do HTML final e manter fluxo lógico entre planejamento de imagens e geração de HTML.

### Description
- Reordena `CONTENT_GENERATION_SECTIONS` em `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx` trocando `landing-design-preset` com `landing-image-planning` e ajusta a instrução em `LANDING_DESIGN_PRESET_PROMPT_TEMPLATE` para "Criar o Preset de Design da Landing antes do HTML final, mantendo alinhamento com o plano de imagens da landing.".

### Testing
- Executei `npm run typecheck` em `frontend` e a verificação falhou devido a tipos ausentes e deprecações em `tsconfig`, um problema de configuração/dependências do ambiente que não está relacionado a esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06787acd508321844aa0fb0b47a5ec)