### PR TITLE
feat(frontend): incluir etapa Preset Design no ExperimentDetailPage

### DIFF
--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -76,6 +76,7 @@ export interface Experiment {
   landingPageCopy?: string | null;
   landingPageWireframe?: string | null;
   landingPageImagePlanning?: string | null;
+  landingPageDesignPreset?: string | null;
   landingPageHtml?: string | null;
   creativeImagePrompt?: string | null;
   instagramAccount?: InstagramAccountSummary | null;

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -262,8 +262,15 @@ export default function ExperimentDetailPage() {
         rawValue: data?.landingPageImagePlanning,
       },
       {
+        key: "design-preset",
+        title: "Etapa 6 · Preset Design",
+        description:
+          "Conteúdo bruto salvo na coluna landing_page_design_preset.",
+        rawValue: data?.landingPageDesignPreset,
+      },
+      {
         key: "landing-html",
-        title: "Etapa 6 · Landing HTML",
+        title: "Etapa 7 · Landing HTML",
         description: "Conteúdo bruto salvo na coluna landing_page_html.",
         rawValue: data?.landingPageHtml,
       },
@@ -272,6 +279,7 @@ export default function ExperimentDetailPage() {
       data?.adCopy,
       data?.campaignAngle,
       data?.landingPageCopy,
+      data?.landingPageDesignPreset,
       data?.landingPageHtml,
       data?.landingPageImagePlanning,
       data?.landingPageWireframe,


### PR DESCRIPTION
### Motivation
- Corrigir ausência da etapa de `landingPageDesignPreset` na sequência de cards do pipeline do experimento para refletir o fluxo canônico entre planejamento de imagens e HTML.
- Garantir tipagem no frontend para o campo exposto pela API (`landingPageDesignPreset`).

### Description
- Atualiza a interface `Experiment` em `frontend/src/api/experiment/useExperiments.ts` adicionando `landingPageDesignPreset?: string | null;` para suportar o novo artefato.
- Insere um novo card `design-preset` em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` com `title: "Etapa 6 · Preset Design"`, `description: "Conteúdo bruto salvo na coluna landing_page_design_preset."` e `rawValue: data?.landingPageDesignPreset`.
- Renumera o card de `Landing HTML` para `Etapa 7 · Landing HTML` e atualiza o array de dependências do `useMemo` para incluir `data?.landingPageDesignPreset` para evitar inconsistências de renderização.

### Testing
- Executado `npm run -s typecheck` em `frontend/`, que falhou por problemas do ambiente local com tipos ausentes (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) e avisos/deprecações do `tsconfig`; nenhuma outra suíte automática foi executada neste rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a067e8383c483219a1c45676bac3bbf)