### PR TITLE
Enforce unique `url_canonical` for mois_sales_library_url_ingest and update docs

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-15-mois-sales-library-url-unique-canonical.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-15-mois-sales-library-url-unique-canonical.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-15-mois-sales-library-url-unique-canonical-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_library_url_ingest
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              DELETE t1
+              FROM mois_sales_library_url_ingest t1
+              JOIN mois_sales_library_url_ingest t2
+                ON t1.url_canonical = t2.url_canonical
+               AND t1.id > t2.id;
+
+              ALTER TABLE mois_sales_library_url_ingest
+                DROP INDEX uk_mois_sales_library_workspace_url;
+
+              ALTER TABLE mois_sales_library_url_ingest
+                ADD UNIQUE KEY uk_mois_sales_library_url_canonical (url_canonical(512));

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -758,3 +758,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-05-15-mois-sales-library-url-ingest.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-05-15-mois-sales-library-url-unique-canonical.yaml
+      relativeToChangelogFile: true

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -639,7 +639,8 @@ Para suportar o gerenciamento administrativo de ocupações no módulo OPRM (cad
 
 - Nova tabela backend: `mois_sales_library_url_ingest`.
 - Objetivo: receber e persistir relacionalmente as URLs canônicas de páginas de venda enviadas pelos coletores (início: ciclo 2 do ClickBank).
-- Chave única: (`workspace_id`, `url_canonical`) para garantir idempotência de ingestão por workspace.
+- Chave única: `url_canonical` para garantir item único por URL canônica na biblioteca.
 - Colunas operacionais: `url_original`, `url_canonical`, `source`, `title`, `first_captured_at`, `last_captured_at`, `ingest_count`, `created_at`, `updated_at`.
 - Endpoint backend de ingestão: `POST /api/mois/sales-library/urls:ingest`.
+- Regra de unicidade: `url_canonical` (URL canônica única na biblioteca, independente de `workspace_id` e `source`).
 - Regra operacional: o coletor envia URL para o backend principal; somente o backend persiste no banco.

--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -157,3 +157,10 @@
 - O `ClickbankCollectorService.collectSecondCycleFromBackend` passou a, além de persistir no endpoint MOIS já existente, enviar as URLs resolvidas de página de vendas para o endpoint de ingestão da biblioteca: `POST /api/mois/sales-library/urls:ingest`.
 - Payload enviado inclui `workspaceId`, `source=CLICKBANK` e lista `urls` com `url`, `title` e `capturedAt`.
 - Comportamento resiliente: falhas na ingestão da biblioteca são registradas em log (warn), sem interromper a persistência padrão do ciclo 2.
+
+## 2026-05-15 03:20 UTC
+- Aplicada a regra de negócio de não duplicação por URL na biblioteca de sales pages: a unicidade passa a ser por `url_canonical`.
+- Criado changelog incremental no backend para:
+  - remover duplicidades legadas mantendo o menor `id` por `url_canonical`;
+  - trocar índice único de `(workspace_id, url_canonical)` para índice único em `url_canonical`.
+- Atualizado o modelo de dados para documentar explicitamente a regra canônica: URL única na biblioteca independentemente de workspace/source.


### PR DESCRIPTION
### Motivation

- Ensure the sales-pages library stores each canonical URL only once across workspaces to enforce global deduplication and simplify lookup semantics.

### Description

- Added a new Liquibase changeset `changesets/2026-05-15-mois-sales-library-url-unique-canonical.yaml` that deletes legacy duplicate rows keeping the lowest `id`, drops the old unique index `uk_mois_sales_library_workspace_url`, and adds a unique key on `url_canonical(512)` for `mois_sales_library_url_ingest` using MySQL-specific SQL. 
- Registered the new changeset in `db.changelog-master.yaml` by including the new file. 
- Updated documentation in `docs/modelo-dados-experimento.md` to change the uniqueness rule from `(workspace_id, url_canonical)` to a single `url_canonical` uniqueness invariant and to state the rule is independent of `workspace_id`/`source`. 
- Updated `docs/registros/coletor-mois1.md` to record the business-rule change and the migration actions applied.

### Testing

- Ran Liquibase changelog validation with `liquibase validate` against the changeset, which completed without validation errors. 
- Executed the backend service test suite with `./gradlew :backend:ads-service:test`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0680a7dbec83219bf38cf6205c37fc)