### PR TITLE
Add stricter typography requirements to landing design prompt and remove embedded frontend template

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
@@ -12,6 +12,13 @@ Regras obrigatórias:
 5. Todo item de `attributes[].name` deve vir exatamente da whitelist abaixo.
 6. Não usar json em string. Campos estruturados devem ser objetos/arrays JSON reais.
 7. Manter consistência com objetivo comercial de conversão (clareza visual, contraste, hierarquia e foco no CTA).
+8. `theme.typography` é obrigatório e detalhado por tokens semânticos: `display`, `h1`, `h2`, `h3`, `body`, `lead`, `caption`, `overline`, `button`, `legal`.
+9. Para cada token tipográfico, declarar explicitamente todos os atributos CSS abaixo (sem omissões): `font`, `font-family`, `font-size`, `font-weight`, `font-style`, `font-variant`, `line-height`, `letter-spacing`, `word-spacing`, `text-align`, `text-decoration`, `text-decoration-line`, `text-decoration-color`, `text-decoration-style`, `text-transform`, `text-shadow`, `white-space`.
+10. Cada atributo tipográfico deve ter valor CSS concreto e válido; não usar vazio/null e evitar valores genéricos (`inherit`, `unset`, `initial`, `revert`) quando não houver intenção explícita.
+11. Reforçar hierarquia tipográfica: diferença perceptível entre títulos, subtítulos, corpo, apoio e CTA (escala, peso, espaçamento e contraste), mantendo legibilidade em desktop e mobile.
+12. Gerar variações `desktop` e `mobile` para cada token tipográfico, preservando a mesma hierarquia visual entre breakpoints.
+13. Em `consistencyChecks`, validar explicitamente: presença de todos os atributos tipográficos obrigatórios, legibilidade, contraste e força tipográfica de `display/h1/button`.
+14. Se faltar qualquer atributo obrigatório em qualquer token, registrar `FAIL` em `consistencyChecks` com detalhes objetivos; não omitir erro silenciosamente.
 
 Whitelist de atributos CSS permitidos (`attributes[].name`):
 - color
@@ -116,6 +123,13 @@ Formato de saída:
         "tokenBindings": [
           { "attributeName": "font-size", "tokenPath": "theme.typography.baseSize" }
         ]
+      }
+    ],
+    "consistencyChecks": [
+      {
+        "check": "TYPOGRAPHY_REQUIRED_ATTRIBUTES",
+        "status": "PASS|WARN|FAIL",
+        "details": "string"
       }
     ]
   }

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -620,60 +620,6 @@ artifact {
   }
 }`;
 
-const LANDING_DESIGN_PRESET_PROMPT_TEMPLATE = `${COMMON_PIPELINE_PROMPT}
-
-Criar o Preset de Design da Landing antes do HTML final, mantendo alinhamento com o plano de imagens da landing.
-
-Objetivo:
-Estruturar tema visual reutilizável (paleta, estilos e presets por seção) mantendo coerência com copy, wireframe e planejamento de imagens.
-
-Regras:
-1. Entregar objeto landingPageDesignPreset com:
-   - presetId
-   - theme.palette
-   - theme.typography (obrigatório e detalhado)
-   - sectionPresets[]
-   - componentPresets
-   - motion
-   - consistencyChecks[]
-2. sectionPresets deve cobrir as sectionId existentes no wireframe atual.
-3. surfaceStyle permitido: band | solid | gradient-soft | image-tint.
-4. contrastMode permitido: normal | high | soft.
-5. Não gerar HTML/CSS/JS nesta etapa.
-6. Typography é obrigatório no theme e em cada sectionPreset/componentPreset com tokens semânticos (display, h1, h2, h3, body, lead, caption, overline, button, legal).
-7. Para cada token tipográfico, declarar explicitamente os atributos CSS abaixo:
-   - font
-   - font-family
-   - font-size
-   - font-weight
-   - font-style
-   - font-variant
-   - line-height
-   - letter-spacing
-   - word-spacing
-   - text-align
-   - text-decoration
-   - text-decoration-line
-   - text-decoration-color
-   - text-decoration-style
-   - text-transform
-   - text-shadow
-   - white-space
-8. Exigir hierarquia tipográfica forte: diferença clara entre títulos, subtítulos, corpo, apoio e CTA (escala, peso e espaçamento), preservando legibilidade em desktop e mobile.
-9. consistencyChecks deve validar contraste, legibilidade, coerência da hierarquia e presença de todos os atributos tipográficos obrigatórios.
-
-Formato esperado:
-JSON com envelope canônico:
-{
-  landingPageDesignPreset: {
-    presetId,
-    theme,
-    sectionPresets,
-    componentPresets,
-    motion,
-    consistencyChecks
-  }
-}`;
 
 const SECTION_PROMPT_DEFAULTS: Partial<
   Record<ContentGenerationSectionKey, string>
@@ -682,7 +628,6 @@ const SECTION_PROMPT_DEFAULTS: Partial<
   "landing-copy": LANDING_COPY_PROMPT_TEMPLATE,
   "landing-layout": LANDING_LAYOUT_PROMPT_TEMPLATE,
   "landing-image-planning": LANDING_IMAGE_PLANNING_PROMPT_TEMPLATE,
-  "landing-design-preset": LANDING_DESIGN_PRESET_PROMPT_TEMPLATE,
   "landing-html": LANDING_HTML_PROMPT_TEMPLATE,
 };
 


### PR DESCRIPTION
### Motivation
- Centralize and strengthen the landing page design preset prompt to ensure strict, machine-parseable typography tokens and consistency checks for the design pipeline.
- Remove duplicated prompt text from the frontend to rely on the canonical prompt maintained in the backend resources.

### Description
- Updated `ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md` to require `theme.typography` with semantic tokens (`display`, `h1`, `h2`, `h3`, `body`, `lead`, `caption`, `overline`, `button`, `legal`) and to mandate a full set of CSS attributes per token, desktop/mobile variations, and explicit `consistencyChecks` including `TYPOGRAPHY_REQUIRED_ATTRIBUTES`.
- Added whitelist and explicit rules mandating concrete CSS values (no empty/null or generic `inherit|unset|initial|revert`), and introduced rules to fail when required typographic attributes are missing.
- Removed the embedded `LANDING_DESIGN_PRESET_PROMPT_TEMPLATE` constant from `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx` and deleted its entry in `SECTION_PROMPT_DEFAULTS` so the frontend no longer contains the duplicated prompt text.

### Testing
- Ran frontend type-check and unit tests with `yarn build` and `yarn test`, and they completed successfully.
- Built backend with `./gradlew build` to ensure resources are bundled and compilation succeeds, and the build completed successfully.
- Verified no runtime TypeScript errors in the modified `ExperimentContentGenerationTab.tsx` file via the CI type checks, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0732976c0c8321a010060482601aae)