### PR TITLE
MOIS: add sales-pages library listing (backend DTOs/endpoints + frontend UI)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/dto/MoisSalesLibraryDtos.java
@@ -1,4 +1,4 @@
-package com.marketinghub.mois.dto;
+package com.marketinghub.mois.biblioteca.dto;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -32,4 +32,28 @@ public final class MoisSalesLibraryDtos {
             int persisted
     ) {
     }
+
+
+    public record SalesLibraryEntryResponse(
+            long id,
+            String workspaceId,
+            String source,
+            String urlOriginal,
+            String urlCanonical,
+            String title,
+            int ingestCount,
+            Instant firstCapturedAt,
+            Instant lastCapturedAt,
+            Instant updatedAt
+    ) {
+    }
+
+    public record SalesLibraryEntryPageResponse(
+            int page,
+            int pageSize,
+            long total,
+            List<SalesLibraryEntryResponse> items
+    ) {
+    }
+
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibraryService.java
@@ -1,10 +1,12 @@
-package com.marketinghub.mois.service;
+package com.marketinghub.mois.biblioteca.service;
 
-import com.marketinghub.mois.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
 import java.net.URI;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -58,6 +60,57 @@ public class MoisSalesLibraryService {
         );
     }
 
+
+
+    public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(String workspaceId, int page, int pageSize) {
+        int normalizedPage = Math.max(1, page);
+        int normalizedPageSize = Math.max(1, Math.min(pageSize, 100));
+        int offset = (normalizedPage - 1) * normalizedPageSize;
+
+        Long total = jdbcTemplate.queryForObject(
+                """
+                        SELECT COUNT(*)
+                        FROM mois_sales_library_url_ingest
+                        WHERE workspace_id = ?
+                        """,
+                Long.class,
+                workspaceId
+        );
+
+        List<MoisSalesLibraryDtos.SalesLibraryEntryResponse> items = jdbcTemplate.query(
+                """
+                        SELECT id, workspace_id, source, url_original, url_canonical, title, ingest_count,
+                               first_captured_at, last_captured_at, updated_at
+                        FROM mois_sales_library_url_ingest
+                        WHERE workspace_id = ?
+                        ORDER BY updated_at DESC
+                        LIMIT ? OFFSET ?
+                        """,
+                (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryEntryResponse(
+                        rs.getLong("id"),
+                        rs.getString("workspace_id"),
+                        rs.getString("source"),
+                        rs.getString("url_original"),
+                        rs.getString("url_canonical"),
+                        rs.getString("title"),
+                        rs.getInt("ingest_count"),
+                        toInstant(rs.getTimestamp("first_captured_at")),
+                        toInstant(rs.getTimestamp("last_captured_at")),
+                        toInstant(rs.getTimestamp("updated_at"))
+                ),
+                workspaceId,
+                normalizedPageSize,
+                offset
+        );
+
+        return new MoisSalesLibraryDtos.SalesLibraryEntryPageResponse(
+                normalizedPage,
+                normalizedPageSize,
+                total == null ? 0 : total,
+                items
+        );
+    }
+
     private String canonicalize(String rawUrl) {
         if (rawUrl == null || rawUrl.isBlank()) {
             return null;
@@ -76,4 +129,9 @@ public class MoisSalesLibraryService {
             return rawUrl.trim();
         }
     }
+
+    private Instant toInstant(Timestamp timestamp) {
+        return timestamp == null ? null : timestamp.toInstant();
+    }
 }
+

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
@@ -1,8 +1,10 @@
-package com.marketinghub.mois.web;
+package com.marketinghub.mois.biblioteca.web;
 
-import com.marketinghub.mois.dto.MoisSalesLibraryDtos;
-import com.marketinghub.mois.service.MoisSalesLibraryService;
+import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.biblioteca.service.MoisSalesLibraryService;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.GetMapping;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -19,6 +21,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class MoisSalesLibraryController {
 
     private final MoisSalesLibraryService service;
+
+
+
+    @GetMapping("/entries")
+    public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(
+            @RequestParam String workspaceId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize
+    ) {
+        return service.listEntries(workspaceId, page, pageSize);
+    }
 
     @PostMapping("/urls:ingest")
     @ResponseStatus(HttpStatus.ACCEPTED)

--- a/docs/novos-modulos/mois/especificacao-biblioteca-sales-pages.md
+++ b/docs/novos-modulos/mois/especificacao-biblioteca-sales-pages.md
@@ -190,6 +190,22 @@ Essa taxonomia é obrigatória para comparabilidade entre páginas.
 - `POST /api/mois/sales-library/pages/{pageId}:reanalyze`
   - reexecuta análise a partir do snapshot persistido.
 
+
+### 8.4 Consulta paginada de entradas ingeridas (implementado)
+
+- `GET /api/mois/sales-library/entries`
+  - parâmetros: `workspaceId` (obrigatório), `page` (default `1`), `pageSize` (default `20`, máx `100`);
+  - ordenação: `updated_at desc`;
+  - retorno: `page`, `pageSize`, `total`, `items[]` com URL original/canônica, origem, título e contadores de ingestão.
+
+### 8.5 Organização de código no backend (implementado)
+
+Para manter o domínio da biblioteca isolado dentro do contexto MOIS no backend principal, os componentes da biblioteca ficam no pacote:
+
+- `com.marketinghub.mois.biblioteca.dto`
+- `com.marketinghub.mois.biblioteca.service`
+- `com.marketinghub.mois.biblioteca.web`
+
 ---
 
 ## 9. Regras de qualidade

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -122,6 +122,7 @@ import MoisWorkspacePage from "./pages/mois/MoisWorkspacePage";
 import MoisReferenceIntakePage from "./pages/mois/MoisReferenceIntakePage";
 import MoisExtractionPage from "./pages/mois/MoisExtractionPage";
 import MoisLibraryPage from "./pages/mois/MoisLibraryPage";
+import MoisSalesPagesLibraryPage from "./pages/mois/MoisSalesPagesLibraryPage";
 import MoisComparisonPage from "./pages/mois/MoisComparisonPage";
 import MoisOfferBuilderPage from "./pages/mois/MoisOfferBuilderPage";
 import MoisResearchSourcesPage from "./pages/mois/MoisResearchSourcesPage";
@@ -290,6 +291,7 @@ export default function App() {
               <Route path="/mois/automatic-collections/:jobId" element={<MoisCollectionJobDetailPage />} />
               <Route path="/mois/extraction" element={<MoisExtractionPage />} />
               <Route path="/mois/library" element={<MoisLibraryPage />} />
+              <Route path="/mois/sales-pages-library" element={<MoisSalesPagesLibraryPage />} />
               <Route path="/mois/comparison" element={<MoisComparisonPage />} />
               <Route path="/mois/builder" element={<MoisOfferBuilderPage />} />
               <Route path="/mds" element={<MdsWorkspacePage />} />

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -212,3 +212,24 @@ export interface MoisCollectedReferenceLineageResponse {
   generatedLibraryBlockIds: string[];
   updatedAt: string;
 }
+
+
+export interface MoisSalesLibraryEntry {
+  id: number;
+  workspaceId: string;
+  source: string;
+  urlOriginal: string;
+  urlCanonical: string;
+  title?: string;
+  ingestCount: number;
+  firstCapturedAt?: string;
+  lastCapturedAt?: string;
+  updatedAt: string;
+}
+
+export interface MoisSalesLibraryEntryPageResponse {
+  page: number;
+  pageSize: number;
+  total: number;
+  items: MoisSalesLibraryEntry[];
+}

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { MoisSalesLibraryEntryPageResponse } from "./types";
+
+export function useMoisSalesLibraryEntries(workspaceId: string, page: number, pageSize: number) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", workspaceId, page, pageSize],
+    queryFn: async () => {
+      const { data } = await axios.get<MoisSalesLibraryEntryPageResponse>("/api/mois/sales-library/entries", {
+        params: { workspaceId, page, pageSize },
+      });
+      return data;
+    },
+  });
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -106,6 +106,7 @@ const NAV_SECTIONS: NavSection[] = [
           },
       { to: "/hypotheses", label: "Hipóteses", icon: hypothesisIcon },
       { to: "/mois", label: "MOIS", icon: Workflow },
+      { to: "/mois/sales-pages-library", label: "Biblioteca Sales Pages", icon: Workflow },
       { to: "/oprm", label: "OPRM", icon: Workflow },
       { to: "/mds", label: "MDS", icon: Microscope },
       { to: "/hotmart", label: "Hotmart", icon: Workflow },

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useMoisSalesLibraryEntries } from "../../api/mois/useMoisSalesLibrary";
+
+const WORKSPACE_ID = "workspace-default";
+const PAGE_SIZE = 20;
+
+export default function MoisSalesPagesLibraryPage() {
+  const [page, setPage] = useState(1);
+  const query = useMoisSalesLibraryEntries(WORKSPACE_ID, page, PAGE_SIZE);
+
+  const totalPages = query.data ? Math.max(1, Math.ceil(query.data.total / query.data.pageSize)) : 1;
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-wrap justify-content-between gap-3">
+        <div>
+          <PageTitle>Biblioteca de Páginas de Vendas</PageTitle>
+          <p className="text-secondary mb-0">Entradas ingeridas da biblioteca (com paginação).</p>
+        </div>
+        <Link className="btn btn-outline-secondary" to="/mois">
+          Voltar ao workspace
+        </Link>
+      </header>
+
+      {query.isLoading ? <p className="text-secondary">Carregando entradas...</p> : null}
+      {query.isError ? <div className="alert alert-danger">Falha ao carregar entradas da biblioteca.</div> : null}
+
+      {query.data ? (
+        <section className="card border-0 shadow-sm">
+          <div className="card-body table-responsive">
+            <table className="table table-sm align-middle">
+              <thead>
+                <tr>
+                  <th>URL canônica</th>
+                  <th>Origem</th>
+                  <th>Título</th>
+                  <th>Ingestões</th>
+                  <th>Última captura</th>
+                </tr>
+              </thead>
+              <tbody>
+                {query.data.items.length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="text-secondary">
+                      Nenhuma entrada encontrada.
+                    </td>
+                  </tr>
+                ) : (
+                  query.data.items.map((item) => (
+                    <tr key={item.id}>
+                      <td className="text-break">{item.urlCanonical}</td>
+                      <td>{item.source}</td>
+                      <td>{item.title || "—"}</td>
+                      <td>{item.ingestCount}</td>
+                      <td>{item.lastCapturedAt || "—"}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+
+            <div className="d-flex justify-content-between align-items-center mt-3">
+              <span className="text-secondary small">
+                Página {query.data.page} de {totalPages} • Total: {query.data.total}
+              </span>
+              <div className="btn-group">
+                <button type="button" className="btn btn-outline-secondary btn-sm" disabled={query.data.page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>
+                  Anterior
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary btn-sm"
+                  disabled={query.data.page >= totalPages}
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                >
+                  Próxima
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a paginated read API and UI for ingested sales pages so workspaces can browse persisted entries. 
- Scope the library domain under a dedicated package to keep MOIS library code isolated as `com.marketinghub.mois.biblioteca`.
- Expose a simple frontend view and client hook to consume the new paginated endpoint. 

### Description

- Moved sales-library backend classes into `com.marketinghub.mois.biblioteca.*` and added new DTOs `SalesLibraryEntryResponse` and `SalesLibraryEntryPageResponse` in `MoisSalesLibraryDtos`.
- Implemented `listEntries` in `MoisSalesLibraryService` which queries `mois_sales_library_url_ingest` with pagination, ordering by `updated_at DESC`, and converts SQL `Timestamp` to `Instant` via a helper `toInstant` method.
- Added controller endpoint `GET /api/mois/sales-library/entries` with request params `workspaceId`, `page`, and `pageSize` and preserved the existing ingest endpoint `POST /api/mois/sales-library/urls:ingest`.
- Updated docs (`especificacao-biblioteca-sales-pages.md`) to document the paginated entries endpoint and the backend package organization.
- Frontend changes include new types for entries, a React Query hook `useMoisSalesLibraryEntries`, a new page component `MoisSalesPagesLibraryPage`, a route at `/mois/sales-pages-library`, and a navigation link to the new page.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07334637d483219d055fc1755cd0a0)