### PR TITLE
Add `message` to collection job DTO and surface Hotmart collection errors in UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisWorkspaceDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisWorkspaceDtos.java
@@ -190,7 +190,8 @@ public final class MoisWorkspaceDtos {
             int limitPerSource,
             int minSuccessScore,
             List<String> sources,
-            Instant createdAt
+            Instant createdAt,
+            String message
     ) {
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisCollectionPersistenceServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/service/MoisCollectionPersistenceServiceTest.java
@@ -127,7 +127,8 @@ class MoisCollectionPersistenceServiceTest {
                 25,
                 80,
                 List.of("HOTMART"),
-                Instant.parse("2026-04-28T00:00:00Z")
+                Instant.parse("2026-04-28T00:00:00Z"),
+                null
         );
         return new MoisCollectionPersistenceDtos.CollectionJobStateResponse(job, List.of(), java.util.Map.of(), null, List.of());
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/web/MoisControllerContractTest.java
@@ -409,7 +409,8 @@ class MoisControllerContractTest {
                         50,
                         60,
                         List.of("META_AD_LIBRARY", "CLICKBANK"),
-                        Instant.parse("2026-04-25T12:00:00Z")
+                        Instant.parse("2026-04-25T12:00:00Z"),
+                        null
                 ));
 
         mockMvc.perform(post("/api/v1/mois/collection-jobs")
@@ -460,7 +461,8 @@ class MoisControllerContractTest {
                                         50,
                                         60,
                                         List.of("META_AD_LIBRARY"),
-                                        Instant.parse("2026-04-25T12:00:00Z")
+                                        Instant.parse("2026-04-25T12:00:00Z"),
+                                        null
                                 ),
                                 List.of(),
                                 java.util.Map.of(),

--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -164,3 +164,5 @@
   - remover duplicidades legadas mantendo o menor `id` por `url_canonical`;
   - trocar índice único de `(workspace_id, url_canonical)` para índice único em `url_canonical`.
 - Atualizado o modelo de dados para documentar explicitamente a regra canônica: URL única na biblioteca independentemente de workspace/source.
+
+- Exposta sinalização de falha da última coleta Hotmart na tela `/hotmart` via `status/message` do último `collection-job` para orientar quando ocorrer JWT expirado (`invalid_token`).

--- a/frontend/src/api/settings/useHotmartCollectedProducts.ts
+++ b/frontend/src/api/settings/useHotmartCollectedProducts.ts
@@ -33,3 +33,29 @@ export function useHotmartCollectedProducts(workspaceId: string, limit = 24) {
     },
   });
 }
+
+
+export interface HotmartCollectionJob {
+  jobId: string;
+  workspaceId: string;
+  status: string;
+  createdAt?: string | null;
+  message?: string | null;
+}
+
+interface HotmartCollectionJobListResponse {
+  items: HotmartCollectionJob[];
+}
+
+export function useHotmartCollectionJobs(workspaceId: string) {
+  return useQuery({
+    queryKey: ["settings", "hotmart", "jobs", workspaceId],
+    enabled: workspaceId.trim().length > 0,
+    queryFn: async () => {
+      const { data } = await axios.get<HotmartCollectionJobListResponse>("/api/v1/mois/collection-jobs", {
+        params: { workspaceId },
+      });
+      return data.items;
+    },
+  });
+}

--- a/frontend/src/pages/hotmart/HotmartPage.tsx
+++ b/frontend/src/pages/hotmart/HotmartPage.tsx
@@ -4,7 +4,10 @@ import {
   useHotmartAccessTokenSetting,
   useUpdateHotmartAccessTokenSetting,
 } from "../../api/settings/useHotmartAccessTokenSetting";
-import { useHotmartCollectedProducts } from "../../api/settings/useHotmartCollectedProducts";
+import {
+  useHotmartCollectedProducts,
+  useHotmartCollectionJobs,
+} from "../../api/settings/useHotmartCollectedProducts";
 
 function formatUpdatedAt(value?: string | null) {
   if (!value) return "—";
@@ -24,6 +27,7 @@ export default function HotmartPage() {
   const { data, isLoading, isError } = useHotmartAccessTokenSetting();
   const updateSetting = useUpdateHotmartAccessTokenSetting();
   const hotmartProductsQuery = useHotmartCollectedProducts(workspaceId, 24);
+  const hotmartJobsQuery = useHotmartCollectionJobs(workspaceId);
   const [tokenValue, setTokenValue] = useState("");
   const [feedback, setFeedback] = useState<string | null>(null);
 
@@ -41,6 +45,8 @@ export default function HotmartPage() {
       collectedAt: formatUpdatedAt(firstItem?.collectedAt),
     };
   }, [hotmartProductsQuery.data]);
+
+  const latestHotmartExecution = useMemo(() => hotmartJobsQuery.data?.[0], [hotmartJobsQuery.data]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -115,6 +121,12 @@ export default function HotmartPage() {
           ) : null}
 
           {feedback ? <div className="alert alert-info mt-3 mb-0">{feedback}</div> : null}
+          {latestHotmartExecution?.status === "COLLECTION_ERROR" ? (
+            <div className="alert alert-warning mt-3 mb-0" role="alert">
+              <strong>Falha na última coleta:</strong> {latestHotmartExecution.message || "Verifique o token JWT da Hotmart."}
+            </div>
+          ) : null}
+
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Surface the failure signal of the latest Hotmart collection job so the UI can inform operators when automatic collection fails (e.g. expired JWT). 
- Propagate a human-readable `message` from backend collection jobs to frontend consumers for diagnostic context.

### Description
- Added a `message` field to `MoisWorkspaceDtos.CollectionJobResponse` to carry an optional failure message from collection jobs. 
- Updated tests and constructors that create `CollectionJobResponse` instances to include the new `message` parameter. 
- Added frontend types and a new hook `useHotmartCollectionJobs` to fetch collection jobs from `GET /api/v1/mois/collection-jobs`. 
- Updated `HotmartPage` to consume `useHotmartCollectionJobs` and display a warning alert when the latest job has `status === "COLLECTION_ERROR"`, showing the `message` or a fallback text. 
- Documented the UI change in the collection changelog to note exposure of the last Hotmart collection failure via `status/message`.

### Testing
- Updated and ran `MoisCollectionPersistenceServiceTest`, which was adjusted to construct `CollectionJobResponse` with the new `message` field, and it succeeded. 
- Updated and ran `MoisControllerContractTest` which now mocks `CollectionJobResponse` with the `message` field, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0739cc5d648321bba057569e718d50)