### PR TITLE
Update WORKSPACE_ID to workspace-001 in MoisSalesPagesLibraryPage

### DIFF
--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import { useMoisSalesLibraryEntries } from "../../api/mois/useMoisSalesLibrary";
 
-const WORKSPACE_ID = "workspace-default";
+const WORKSPACE_ID = "workspace-001";
 const PAGE_SIZE = 20;
 
 export default function MoisSalesPagesLibraryPage() {


### PR DESCRIPTION
### Motivation
- Point the Mois sales pages library to the correct workspace by changing the workspace identifier from `workspace-default` to `workspace-001`.

### Description
- Update the `WORKSPACE_ID` constant in `MoisSalesPagesLibraryPage.tsx` from `workspace-default` to `workspace-001`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07394671f483219d2a9fc9ba19d6eb)