### PR TITLE
feat(frontend): adicionar campo JWT Clickbank na tela Clickbase

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -166,3 +166,8 @@
 - Atualizado o modelo de dados para documentar explicitamente a regra canônica: URL única na biblioteca independentemente de workspace/source.
 
 - Exposta sinalização de falha da última coleta Hotmart na tela `/hotmart` via `status/message` do último `collection-job` para orientar quando ocorrer JWT expirado (`invalid_token`).
+
+## 2026-05-15 10:30 UTC
+- Frontend da tela `/clickbase` atualizado para incluir formulário de token JWT do Clickbank, seguindo o padrão da tela Hotmart.
+- Adicionado hook de configuração (`useClickbankAccessTokenSetting`) usando `/api/settings/clickbank_access_token_jwt` para carregar/salvar token persistido no backend (banco de dados).
+- Botão de salvar com estado assíncrono (desabilitado + spinner) e campo obrigatório com asterisco para garantir consistência de UX.

--- a/frontend/src/api/settings/useClickbankAccessTokenSetting.ts
+++ b/frontend/src/api/settings/useClickbankAccessTokenSetting.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface GeneralSetting {
+  name: string;
+  value: string | null;
+  updatedAt: string | null;
+}
+
+export const CLICKBANK_ACCESS_TOKEN_SETTING_NAME = "clickbank_access_token_jwt";
+
+export function useClickbankAccessTokenSetting() {
+  return useQuery({
+    queryKey: ["general-setting", CLICKBANK_ACCESS_TOKEN_SETTING_NAME],
+    queryFn: async () => {
+      try {
+        const { data } = await axios.get<GeneralSetting>(
+          `/api/settings/${CLICKBANK_ACCESS_TOKEN_SETTING_NAME}`,
+        );
+        return data;
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          return {
+            name: CLICKBANK_ACCESS_TOKEN_SETTING_NAME,
+            value: null,
+            updatedAt: null,
+          } satisfies GeneralSetting;
+        }
+        throw error;
+      }
+    },
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useUpdateClickbankAccessTokenSetting() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (value: string) => {
+      const payload = { value };
+      const { data } = await axios.put<GeneralSetting>(
+        `/api/settings/${CLICKBANK_ACCESS_TOKEN_SETTING_NAME}`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(
+        ["general-setting", CLICKBANK_ACCESS_TOKEN_SETTING_NAME],
+        data,
+      );
+    },
+  });
+}

--- a/frontend/src/pages/clickbase/ClickbasePage.tsx
+++ b/frontend/src/pages/clickbase/ClickbasePage.tsx
@@ -1,10 +1,40 @@
-import { useMemo } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import PageTitle from "../../components/PageTitle";
 import { useClickbaseCollectedProducts } from "../../api/settings/useClickbaseCollectedProducts";
+import {
+  useClickbankAccessTokenSetting,
+  useUpdateClickbankAccessTokenSetting,
+} from "../../api/settings/useClickbankAccessTokenSetting";
+
+function formatUpdatedAt(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
 
 export default function ClickbasePage() {
   const workspaceId = "workspace-001";
   const clickbaseProductsQuery = useClickbaseCollectedProducts(workspaceId, 24);
+  const { data: clickbankSetting, isLoading: isLoadingSetting, isError: isErrorSetting } =
+    useClickbankAccessTokenSetting();
+  const updateClickbankSetting = useUpdateClickbankAccessTokenSetting();
+  const [tokenValue, setTokenValue] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (clickbankSetting) {
+      setTokenValue(clickbankSetting.value ?? "");
+    }
+  }, [clickbankSetting?.value]);
+
+  const updatedAt = useMemo(() => formatUpdatedAt(clickbankSetting?.updatedAt), [clickbankSetting?.updatedAt]);
   const latestJobId = useMemo(() => clickbaseProductsQuery.data?.[0]?.jobId, [clickbaseProductsQuery.data]);
   const latestJobDate = useMemo(() => {
     const collectedAt = clickbaseProductsQuery.data?.[0]?.collectedAt;
@@ -21,9 +51,75 @@ export default function ClickbasePage() {
     }).format(parsed);
   }, [clickbaseProductsQuery.data]);
 
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFeedback(null);
+
+    const trimmed = tokenValue.trim();
+    if (!trimmed) {
+      setFeedback("Informe o token JWT de acesso do Clickbank.");
+      return;
+    }
+
+    try {
+      await updateClickbankSetting.mutateAsync(trimmed);
+      setFeedback("Token salvo com sucesso.");
+    } catch {
+      setFeedback("Não foi possível salvar o token. Tente novamente.");
+    }
+  };
+
   return (
     <div className="mt-3">
       <PageTitle>Clickbase</PageTitle>
+
+      <section className="card mt-3 shadow-sm border-0">
+        <div className="card-header">
+          <h5 className="mb-1">Token de acesso</h5>
+          <p className="text-muted small mb-0">Cole aqui o JWT do Clickbank para uso nas próximas coletas automáticas.</p>
+        </div>
+        <div className="card-body">
+          {isLoadingSetting ? <p className="mb-0">Carregando token...</p> : null}
+          {isErrorSetting ? (
+            <p className="text-danger mb-0">Não foi possível carregar o token salvo.</p>
+          ) : null}
+
+          {!isLoadingSetting && !isErrorSetting ? (
+            <form onSubmit={handleSubmit} className="d-flex flex-column gap-3" noValidate>
+              <div>
+                <label htmlFor="clickbankAccessToken" className="form-label fw-semibold">
+                  JWT Clickbank <span className="text-danger">*</span>
+                </label>
+                <textarea
+                  id="clickbankAccessToken"
+                  className="form-control"
+                  rows={6}
+                  value={tokenValue}
+                  onChange={(event) => setTokenValue(event.target.value)}
+                  placeholder="Cole aqui o token JWT"
+                  required
+                />
+                <div className="form-text">Última atualização: {updatedAt}</div>
+              </div>
+
+              <div className="d-flex gap-2">
+                <button type="submit" className="btn btn-primary" disabled={updateClickbankSetting.isPending}>
+                  {updateClickbankSetting.isPending ? (
+                    <>
+                      <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
+                      Salvando...
+                    </>
+                  ) : (
+                    "Salvar"
+                  )}
+                </button>
+              </div>
+            </form>
+          ) : null}
+
+          {feedback ? <div className="alert alert-info mt-3 mb-0">{feedback}</div> : null}
+        </div>
+      </section>
 
       <section className="card mt-3 shadow-sm border-0">
         <div className="card-header">


### PR DESCRIPTION
### Motivation
- Alinhar a tela `/clickbase` com o padrão da `/hotmart` para permitir fornecer e persistir o JWT do Clickbank para usos futuros nas rotinas de coleta.
- Evitar dependência manual do coletor por credenciais temporárias mantendo o token salvo no backend para novos ciclos de consulta.

### Description
- Adicionado o hook `useClickbankAccessTokenSetting` em `frontend/src/api/settings/useClickbankAccessTokenSetting.ts` que lê/escreve a configuração em `/api/settings/clickbank_access_token_jwt` e trata `404` como ausência de configuração.
- Atualizada a página `frontend/src/pages/clickbase/ClickbasePage.tsx` para incluir a seção “Token de acesso” com `textarea` obrigatório, exibição de `Última atualização`, feedback de sucesso/erro e botão `Salvar` com estado assíncrono (desabilitado + spinner), mantendo a listagem de produtos coletados.
- Atualizado o registro operacional em `docs/registros/coletor-mois1.md` documentando a inclusão do formulário de token JWT do Clickbank.

### Testing
- Executado `npm run build` em `frontend`, que falhou no ambiente CI local devido a dependência de runtime ausente: `sh: 1: vite: not found`.
- Não foram executados testes unitários automatizados neste PR devido ao ambiente de build incompleto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0745133e60832196a393a2a47bc3fb)