### PR TITLE
Fix ai-worker GeraLanding test constructor mismatch (add deliverables schema)

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -38,7 +38,8 @@ class GeraLandingExecutionServiceTest {
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"),
-                        new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json"));
+                        new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-deliverables-schema.json"));
         service.processPendingExecutions();
 
         verify(openAiClient).generate(any());
@@ -71,7 +72,8 @@ class GeraLandingExecutionServiceTest {
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"),
-                        new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json"));
+                        new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-deliverables-schema.json"));
         service.processPendingExecutions();
 
         verify(backendClient).receiveFailure(any(), any(), any(), any(), any());

--- a/docs/gera-landing/registros3.md
+++ b/docs/gera-landing/registros3.md
@@ -82,3 +82,5 @@
 - 2026-05-15 10:30:00 UTC-3 — Criada a nova etapa final canônica `landing-page-deliverables` no fluxo Gera Landing para geração de JSON de entregáveis da **amostra** e do **produto final**, com endpoint de start no backend (`/deliverables/start`) e prompt/schema dedicados no AI Worker (`prompts/geralanding/landing-page-deliverables.*`).
 
 - 2026-05-15 11:25:00 UTC-3 — Persistência final habilitada para a etapa `landing-page-deliverables`: adicionado o campo `experiment.landing_page_deliverables` (artefato JSON final de entregáveis da amostra e do produto completo), com gravação automática no fechamento com sucesso da etapa.
+
+- 2026-05-15 17:55:00 UTC — Corrigida falha de compilação nos testes do AI Worker (pacote `geralanding`): `GeraLandingExecutionServiceTest` foi atualizado para refletir a nova assinatura do construtor de `GeraLandingExecutionService`, incluindo o quinto recurso de schema (`landing-page-deliverables-schema.json`) exigido pela etapa canônica `landing-page-deliverables`.


### PR DESCRIPTION
### Motivation
- Fix compilation failure in `ai-worker` tests caused by `GeraLandingExecutionService` gaining a fifth `Resource` constructor parameter for `landing-page-deliverables-schema.json` while the unit test still supplied only four schema resources.

### Description
- Updated `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` to pass the additional `ClassPathResource("prompts/geralanding/landing-page-deliverables-schema.json")` in both test scenarios to match the service constructor signature.
- Recorded the change in `docs/gera-landing/registros3.md` to document the fix and the new canonical `landing-page-deliverables` stage.

### Testing
- Ran `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test`, which advanced past the previous constructor compilation error but failed during dependency resolution due to `com.marketinghub:ads-service:0.0.1-SNAPSHOT` returning `401 Unauthorized` from GitHub Packages, an environment/dependency issue unrelated to this test fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075cc2fa90832191f2888bb9ff3172)