### PR TITLE
docs: exigir log de payload bruto em fluxos de ingestão

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Toda decisão de arquitetura, dados, prompts, automações, integrações e arte
 - **Frontend → Backend (validação de endpoint)**: sempre que criar no frontend uma chamada para o backend, verifique primeiro se o endpoint já existe. Se não existir, crie o endpoint no pacote/backend referente ao assunto da tela (ex.: MOIS, OPRM, etc.), respeitando o escopo do módulo.
 - **Qualidade**: sempre que alterar um módulo Java realizar os testes unitários antes de publicar o PR.
 - **Logs**: os logs dos modulos Java Spring Boot podem ser acessados pelo MCP Server.  Chame o endpoint MCP https://mcpserverdigi.shop/mcp via JSON-RPC.
+- **Logs de ingestão (obrigatório)**: sempre que for construído um fluxo de ingestão de dados, registrar em log o dado bruto recebido da fonte (payload original), antes de qualquer transformação/normalização.
 - **GitHub Actions (logs e execuções)**: também podem ser consultados via MCP Server usando as tools `github_actions_list_workflows`, `github_actions_list_runs`, `github_actions_get_run_summary` e `github_actions_get_run_logs` no endpoint https://mcpserverdigi.shop/mcp (JSON-RPC).
 - **Testes Unitários**: os testes unitários precisam sempre estar em concordancia com as regras dos documentos canonicos.
 - **Regra Geral (cânone x testes)**: sempre que houver alteração de regra em documento canônico, revisar e atualizar os testes unitários relacionados para manter aderência entre documentação, regras de domínio e validações automatizadas.


### PR DESCRIPTION
### Motivation
- Garantir rastreabilidade e acelerar diagnóstico de incidentes em pipelines de ingestão ao preservar o payload bruto recebido da fonte antes de qualquer transformação.

### Description
- Atualiza o `AGENTS.md` raiz para adicionar a diretriz obrigatória `Logs de ingestão (obrigatório)`: sempre registrar em log o dado bruto (payload original) vindo da fonte antes de qualquer transformação/normalização.

### Testing
- Executados `git status`, `git add AGENTS.md` e `git commit -m "docs: exigir log de payload bruto em fluxos de ingestão"` e verificado que o arquivo `AGENTS.md` foi modificado e o commit criado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0763e658f08321a2aa95845b2855cb)