### PR TITLE
feat(clickbank): add GraphQL-based ClickBank fetch (gravity/category/title) with Top Offers fallback

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -186,3 +186,10 @@
 - Token de autenticação foi sanitizado no documento para `Bearer <CLICKBANK_JWT_TOKEN>`, evitando credencial sensível em texto plano.
 
 - 2026-05-15: Documento de referência do fetch JWT do Clickbase movido de `mois-clickbank-collector/docs/clickbase-fetch-ciclo-consulta.md` para `docs/mois/clickbase-fetch-ciclo-consulta.md` para centralização na documentação MOIS.
+
+## 2026-05-15 18:00:03 UTC-3
+- Implementado novo fluxo de coleta ClickBank com prioridade para consulta GraphQL autenticada em `POST /graphql` (accounts.clickbank.com), usando JWT salvo em `/api/settings/clickbank_access_token_jwt`.
+- Novo mapeamento de importação prioriza os campos comerciais solicitados: nome do produto (`title`), categoria (`marketplaceStats.category`), gravity (`marketplaceStats.gravity`) e URL da página de vendas (fallback para `url` do hit).
+- Mantido fallback resiliente para Top Offers público quando o JWT não estiver disponível ou quando a consulta GraphQL falhar.
+- Incluído log obrigatório de ingestão com payload bruto retornado pela fonte (`CLICKBANK_GRAPHQL_PAYLOAD_CRU`) antes de qualquer transformação.
+- Ajustados os testes unitários do coletor para o novo contrato do construtor com a configuração `collector.clickbank.graphql-url`.

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
@@ -38,6 +38,22 @@ public class ClickbankCollectorService {
     private static final int LOGIN_SUBMIT_RETRIES = 3;
     private static final int COOKIE_RETRY_ATTEMPTS = 3;
     private static final String CLICKBANK_MARKET_API_URL = "https://api.clickbank.com/v2/marketplace";
+    private static final String CLICKBANK_GRAPHQL_QUERY = """
+            query ($parameters: MarketplaceSearchParameters!) {
+              marketplaceSearch(parameters: $parameters) {
+                hits {
+                  title
+                  url
+                  marketplaceStats {
+                    category
+                    gravity
+                    rank
+                    sellerVolume
+                  }
+                }
+              }
+            }
+            """;
 
     private final boolean headless;
     private final String chromiumExecutablePath;
@@ -49,6 +65,7 @@ public class ClickbankCollectorService {
     private final boolean logFullToken;
     private final String backendBaseUrl;
     private final String clickbankJwtSettingKey;
+    private final String clickbankGraphqlUrl;
     private final String workspaceId;
     private final String defaultNiche;
     private final String defaultMarketTheme;
@@ -67,6 +84,7 @@ public class ClickbankCollectorService {
             @Value("${collector.clickbank.log-full-token:false}") boolean logFullToken,
             @Value("${collector.backend.base-url:http://191.252.181.168:8000}") String backendBaseUrl,
             @Value("${collector.clickbank.jwt-setting-key:clickbank_access_token_jwt}") String clickbankJwtSettingKey,
+            @Value("${collector.clickbank.graphql-url:https://accounts.clickbank.com/graphql}") String clickbankGraphqlUrl,
             @Value("${collector.backend.workspace-id:workspace-001}") String workspaceId,
             @Value("${collector.backend.niche:marketing-digital}") String defaultNiche,
             @Value("${collector.backend.market-theme:ofertas-clickbank}") String defaultMarketTheme
@@ -81,6 +99,7 @@ public class ClickbankCollectorService {
         this.logFullToken = logFullToken;
         this.backendBaseUrl = backendBaseUrl;
         this.clickbankJwtSettingKey = clickbankJwtSettingKey;
+        this.clickbankGraphqlUrl = clickbankGraphqlUrl;
         this.workspaceId = workspaceId;
         this.defaultNiche = defaultNiche;
         this.defaultMarketTheme = defaultMarketTheme;
@@ -105,8 +124,14 @@ public class ClickbankCollectorService {
         );
 
         try {
-            int apiCollected = collectProductsFromTopOffersPage(boundedMax, products);
-            log.info("Coleta página Top Offers finalizada. produtosColetados={}", apiCollected);
+            String accessToken = fetchClickbankJwtFromGeneralSettings();
+            int apiCollected = collectProductsFromGraphql(accessToken, boundedMax, products);
+            if (apiCollected == 0) {
+                apiCollected = collectProductsFromTopOffersPage(boundedMax, products);
+                log.info("Coleta fallback Top Offers finalizada. produtosColetados={}", apiCollected);
+            } else {
+                log.info("Coleta GraphQL Clickbank finalizada. produtosColetados={}", apiCollected);
+            }
             status = "COLLECTION_EXECUTED";
             message = "Coleta executada via página pública Top Offers da ClickBank.";
         } catch (Exception ex) {
@@ -116,6 +141,60 @@ public class ClickbankCollectorService {
         }
         persistCollectedProductsOnBackend(request, status, products);
         return new ClickbankCollectionResponse(status, message, products);
+    }
+
+    private int collectProductsFromGraphql(String accessToken, int boundedMax, List<ClickbankProductSnapshot> products) {
+        if (accessToken == null || accessToken.isBlank()) {
+            log.warn("JWT Clickbank ausente para consulta GraphQL; ativando fallback de coleta pública.");
+            return 0;
+        }
+        try {
+            Map<String, Object> parameters = new HashMap<>();
+            parameters.put("sortField", "rank");
+            parameters.put("sortDescending", false);
+            parameters.put("productAttributes", List.of("shippable"));
+            parameters.put("resultsPerPage", boundedMax);
+            parameters.put("offset", 0);
+            parameters.put("nicknameMasq", null);
+            Map<String, Object> body = Map.of("query", CLICKBANK_GRAPHQL_QUERY, "variables", Map.of("parameters", parameters));
+            String payload = objectMapper.writeValueAsString(body);
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(clickbankGraphqlUrl))
+                    .header("accept", "application/json")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer " + accessToken)
+                    .POST(HttpRequest.BodyPublishers.ofString(payload))
+                    .build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+            log.info("CLICKBANK_GRAPHQL_PAYLOAD_CRU status={} bodyRaw='{}'", response.statusCode(), truncateForLog(response.body(), 10_000));
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                return 0;
+            }
+            JsonNode hits = objectMapper.readTree(response.body()).path("data").path("marketplaceSearch").path("hits");
+            if (!hits.isArray()) {
+                return 0;
+            }
+            LinkedHashSet<String> dedupe = new LinkedHashSet<>();
+            for (JsonNode hit : hits) {
+                if (products.size() >= boundedMax) {
+                    break;
+                }
+                String title = pickFirstNonBlank(extractProductText(hit, "title", "name"), "Produto sem título");
+                String detailsUrl = normalizeClickbankUrl(extractProductText(hit, "url", "productUrl"));
+                JsonNode stats = hit.path("marketplaceStats");
+                String category = pickFirstNonBlank(extractProductText(stats, "category"), "N/A");
+                Double gravity = extractProductNumber(stats, "gravity");
+                String dedupeKey = (title + "|" + category + "|" + detailsUrl).toLowerCase();
+                if (!dedupe.add(dedupeKey)) {
+                    continue;
+                }
+                products.add(new ClickbankProductSnapshot(title, "N/A", category, detailsUrl, gravity, detailsUrl, Instant.now()));
+            }
+            return products.size();
+        } catch (Exception ex) {
+            log.warn("Falha na coleta GraphQL Clickbank.", ex);
+            return 0;
+        }
     }
 
 

--- a/mois-clickbank-collector/src/main/resources/application.properties
+++ b/mois-clickbank-collector/src/main/resources/application.properties
@@ -20,6 +20,7 @@ collector.clickbank.username=${COLLECTOR_CLICKBANK_USERNAME:}
 collector.clickbank.password=${COLLECTOR_CLICKBANK_PASSWORD:}
 collector.clickbank.username-fallback=${COLLECTOR_CLICKBANK_USERNAME_FALLBACK:}
 collector.clickbank.password-fallback=${COLLECTOR_CLICKBANK_PASSWORD_FALLBACK:}
+collector.clickbank.graphql-url=${COLLECTOR_CLICKBANK_GRAPHQL_URL:https://accounts.clickbank.com/graphql}
 
 # Automatic hourly execution
 collector.scheduler.enabled=${COLLECTOR_SCHEDULER_ENABLED:true}

--- a/mois-clickbank-collector/src/test/java/com/marketinghub/moisclickbank/service/ClickbankCollectorServiceTest.java
+++ b/mois-clickbank-collector/src/test/java/com/marketinghub/moisclickbank/service/ClickbankCollectorServiceTest.java
@@ -27,6 +27,7 @@ class ClickbankCollectorServiceTest {
                 false,
                 "http://localhost:8000",
                 "clickbank_access_token_jwt",
+                "https://accounts.clickbank.com/graphql",
                 "workspace-001",
                 "marketing-digital",
                 "ofertas-clickbank"
@@ -62,7 +63,8 @@ class ClickbankCollectorServiceTest {
             ClickbankCollectorService service = new ClickbankCollectorService(
                     true, "", "https://app.clickbank.com/market/search", "", "", "",
                     topOffersUrl, "", "", false, "http://127.0.0.1:1",
-                    "clickbank_access_token_jwt", "workspace-001", "marketing-digital", "ofertas-clickbank"
+                    "clickbank_access_token_jwt", "https://accounts.clickbank.com/graphql",
+                    "workspace-001", "marketing-digital", "ofertas-clickbank"
             );
             var response = service.collect(new ClickbankCollectionRequest("clickbank-market", 10));
 


### PR DESCRIPTION
### Motivation
- Implementar um novo ciclo de consulta ClickBank que importe os melhores vendedores com campos comerciais (nome, categoria, gravity e página de vendas) conforme o documento de referência `docs/mois/clickbase-fetch-ciclo-consulta.md`.
- Usar a API GraphQL autenticada quando houver JWT disponível para melhorar qualidade e cobertura dos dados, mantendo robustez caso o token falte.

### Description
- Adicionada consulta GraphQL padrão `CLIKBANK_GRAPHQL_QUERY` e novo método `collectProductsFromGraphql(...)` que busca `title`, `marketplaceStats.category`, `marketplaceStats.gravity` e `url` e popula `ClickbankProductSnapshot` (gravity mapeado em `temperature` por compatibilidade com o DTO atual).
- Prioridade de execução: buscar JWT via `fetchClickbankJwtFromGeneralSettings()` e executar GraphQL em `collector.clickbank.graphql-url`, com fallback automático para o parser da página pública Top Offers quando o JWT estiver ausente ou a consulta falhar.
- Incluído log bruto obrigatório do payload retornado pela fonte com a tag `CLICKBANK_GRAPHQL_PAYLOAD_CRU` antes de qualquer transformação e adicionada a configuração `collector.clickbank.graphql-url` em `application.properties`.
- Atualizados testes unitários para o novo construtor/configuração e registrada a operação em `docs/registros/coletor-mois1.md` com timestamp UTC-3.

### Testing
- Executado `mvn -q test` no módulo `mois-clickbank-collector` e os testes automatizados do módulo passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0788ea738c8321a6b1ef6b30887cc0)