### PR TITLE
Ajusta ciclo GraphQL do Clickbank para horas pares

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -193,3 +193,5 @@
 - Mantido fallback resiliente para Top Offers público quando o JWT não estiver disponível ou quando a consulta GraphQL falhar.
 - Incluído log obrigatório de ingestão com payload bruto retornado pela fonte (`CLICKBANK_GRAPHQL_PAYLOAD_CRU`) antes de qualquer transformação.
 - Ajustados os testes unitários do coletor para o novo contrato do construtor com a configuração `collector.clickbank.graphql-url`.
+
+- 2026-05-15 21:14 UTC — Ajustado agendamento padrão do coletor Clickbank GraphQL para horas pares (`0 0 */2 * * *`) em `application.properties`, `ClickbankCollectorScheduler` e README do módulo.

--- a/mois-clickbank-collector/README.md
+++ b/mois-clickbank-collector/README.md
@@ -85,7 +85,7 @@ O script `run-local-jar.sh` executa via `java -jar`, evitando dependência de pe
   - `collector.clickbank.username` + `collector.clickbank.password` (opção 2 para login automático)
 - Agendamento automático:
   - `collector.scheduler.enabled=true`
-  - `collector.scheduler.cron=0 0 * * * *` (**executa de hora em hora**)
+  - `collector.scheduler.cron=0 0 */2 * * *` (**executa em horas pares**)
   - `collector.scheduler.max-products=25`
 
 ## Variáveis de ambiente suportadas
@@ -98,7 +98,7 @@ O script `run-local-jar.sh` executa via `java -jar`, evitando dependência de pe
 | `COLLECTOR_CLICKBANK_USERNAME` | Usuário Clickbank para login automatizado | vazio |
 | `COLLECTOR_CLICKBANK_PASSWORD` | Senha Clickbank para login automatizado | vazio |
 | `COLLECTOR_SCHEDULER_ENABLED` | Habilita/desabilita execução automática | `true` |
-| `COLLECTOR_SCHEDULER_CRON` | Expressão cron da execução automática | `0 0 * * * *` |
+| `COLLECTOR_SCHEDULER_CRON` | Expressão cron da execução automática | `0 0 */2 * * *` |
 | `COLLECTOR_SCHEDULER_SOURCE` | Identificador da fonte usada no job agendado | `clickbank-market` |
 | `COLLECTOR_SCHEDULER_MAX_PRODUCTS` | Limite de produtos por execução agendada | `25` |
 

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorScheduler.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorScheduler.java
@@ -31,8 +31,8 @@ public class ClickbankCollectorScheduler {
         this.maxProducts = maxProducts;
     }
 
-    @Scheduled(cron = "${collector.scheduler.cron:0 0 * * * *}")
-    public void collectHourly() {
+    @Scheduled(cron = "${collector.scheduler.cron:0 0 */2 * * *}")
+    public void collectEvenHours() {
         log.info("Iniciando execução agendada do Clickbank Collector source={} maxProducts={}", source, maxProducts);
         if (!enabled) {
             log.info("Clickbank scheduler desabilitado por configuração.");

--- a/mois-clickbank-collector/src/main/resources/application.properties
+++ b/mois-clickbank-collector/src/main/resources/application.properties
@@ -22,8 +22,8 @@ collector.clickbank.username-fallback=${COLLECTOR_CLICKBANK_USERNAME_FALLBACK:}
 collector.clickbank.password-fallback=${COLLECTOR_CLICKBANK_PASSWORD_FALLBACK:}
 collector.clickbank.graphql-url=${COLLECTOR_CLICKBANK_GRAPHQL_URL:https://accounts.clickbank.com/graphql}
 
-# Automatic hourly execution
+# Automatic execution on even hours
 collector.scheduler.enabled=${COLLECTOR_SCHEDULER_ENABLED:true}
-collector.scheduler.cron=${COLLECTOR_SCHEDULER_CRON:0 0 * * * *}
+collector.scheduler.cron=${COLLECTOR_SCHEDULER_CRON:0 0 */2 * * *}
 collector.scheduler.source=${COLLECTOR_SCHEDULER_SOURCE:clickbank-market}
 collector.scheduler.max-products=${COLLECTOR_SCHEDULER_MAX_PRODUCTS:25}


### PR DESCRIPTION
### Motivation
- O agendamento padrão do coletor Clickbank estava configurado para execução a cada hora e precisa rodar apenas em horas pares para reduzir carga e alinhar com janela operacional. 

### Description
- Altera o cron default para `0 0 */2 * * *` em `mois-clickbank-collector/src/main/resources/application.properties`. 
- Atualiza a anotação `@Scheduled` e renomeia o método `collectHourly()` para `collectEvenHours()` em `mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorScheduler.java`. 
- Atualiza o `README` do módulo (`mois-clickbank-collector/README.md`) para documentar o novo cron padrão e a descrição de execução em horas pares. 
- Registra a alteração operacional em `docs/registros/coletor-mois1.md` conforme política de registros do coletor MOIS. 

### Testing
- Executei `mvn -q test` no diretório `mois-clickbank-collector` e os testes unitários do módulo foram executados com sucesso (sem erros de compilação ou falhas de teste).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078ca9e3b48321a83f9dc350271fcd)