### PR TITLE
Add Cycle 3 GraphQL collection and hourly 3-slot scheduler for ClickBank collector

### DIFF
--- a/docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md
+++ b/docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md
@@ -91,8 +91,26 @@ O Ciclo Dois do coletor ClickBank passa a operar com o seguinte fluxo obrigatór
 
 ### 8.1 Regras de execução agendada
 
-- **Horas ímpares:** executar **Ciclo 1** (Top Offers).
-- **Horas pares:** executar **Ciclo 2** (resolução/persistência de páginas de venda).
+A execução passa a ocorrer **a cada hora**, com roteamento por `horaAtual % 3`:
+
+- **Resto 0:** executar **Ciclo 1** (Top Offers público).
+- **Resto 1:** executar **Ciclo 2** (resolução/persistência de páginas de venda).
+- **Resto 2:** executar **Ciclo 3** (coleta via GraphQL ClickBank).
+
+## 9. Definição canônica do Ciclo Três (ativada)
+
+O Ciclo Três do coletor ClickBank passa a operar com o seguinte fluxo obrigatório:
+
+1. Ler JWT ClickBank salvo no backend MOIS (`general-settings`).
+2. Executar consulta no endpoint GraphQL da ClickBank (`/graphql`) para retornar produtos ranqueados.
+3. Mapear os hits para o snapshot canônico do MOIS (`title`, `detailsUrl`, `category`, `temperature`, `salesPageUrl`).
+4. Persistir no backend MOIS via endpoint de persistência (`/api/v1/mois/persistence/collection-jobs/{jobId}`).
+
+### 9.1 Regras do Ciclo 3
+
+- O Ciclo 3 é **independente** do Ciclo 1 e não deve ser tratado apenas como fallback interno.
+- Sem JWT válido, o ciclo deve registrar status explícito de coleta sem dados (skipped), preservando rastreabilidade operacional.
+- Logs de ingestão devem registrar payload bruto retornado do GraphQL antes de normalização.
 
 ### 8.2 Responsabilidades por módulo
 

--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -195,3 +195,10 @@
 - Ajustados os testes unitários do coletor para o novo contrato do construtor com a configuração `collector.clickbank.graphql-url`.
 
 - 2026-05-15 21:14 UTC — Ajustado agendamento padrão do coletor Clickbank GraphQL para horas pares (`0 0 */2 * * *`) em `application.properties`, `ClickbankCollectorScheduler` e README do módulo.
+
+## 2026-05-15 22:10 UTC
+- Refatorado o agendamento do coletor ClickBank para modelo de 3 ciclos com execução horária (`0 0 * * * *`) e roteamento por `horaAtual % 3`.
+- Ciclo 1 consolidado como coleta exclusiva Top Offers público (sem fallback GraphQL embutido).
+- Ciclo 2 mantido para resolução e persistência de páginas de venda a partir dos produtos salvos no backend MOIS.
+- Implementado Ciclo 3 independente para coleta via GraphQL ClickBank com status explícito `COLLECTION_SKIPPED` quando JWT estiver ausente/inválido ou sem hits.
+- Atualizado cânone MOIS (`docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md`) para oficializar o Ciclo 3 e as regras de execução em 3 slots.

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorScheduler.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorScheduler.java
@@ -31,22 +31,31 @@ public class ClickbankCollectorScheduler {
         this.maxProducts = maxProducts;
     }
 
-    @Scheduled(cron = "${collector.scheduler.cron:0 0 */2 * * *}")
-    public void collectEvenHours() {
+    @Scheduled(cron = "${collector.scheduler.cron:0 0 * * * *}")
+    public void collectHourly() {
         log.info("Iniciando execução agendada do Clickbank Collector source={} maxProducts={}", source, maxProducts);
         if (!enabled) {
             log.info("Clickbank scheduler desabilitado por configuração.");
             return;
         }
         int currentHour = LocalDateTime.now().getHour();
-        boolean isOddHour = currentHour % 2 != 0;
+        int cycleSlot = currentHour % 3;
         ClickbankCollectionRequest request = new ClickbankCollectionRequest(source, maxProducts);
-        ClickbankCollectionResponse response = isOddHour
-                ? collectorService.collectFirstCycle(request)
-                : collectorService.collectSecondCycleFromBackend(request);
+        ClickbankCollectionResponse response;
+        String cycleName;
+        if (cycleSlot == 0) {
+            cycleName = "CICLO_1_TOP_OFFERS";
+            response = collectorService.collectFirstCycle(request);
+        } else if (cycleSlot == 1) {
+            cycleName = "CICLO_2_VENDAS_PAGE";
+            response = collectorService.collectSecondCycleFromBackend(request);
+        } else {
+            cycleName = "CICLO_3_GRAPHQL";
+            response = collectorService.collectThirdCycleGraphql(request);
+        }
         log.info("Clickbank scheduler executado hora={} ciclo={} status={} produtos={} mensagem={}",
                 currentHour,
-                isOddHour ? "CICLO_1_TOP_OFFERS" : "CICLO_2_VENDAS_PAGE",
+                cycleName,
                 response.status(),
                 response.products().size(),
                 response.message());

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
@@ -106,7 +106,7 @@ public class ClickbankCollectorService {
     }
 
     public ClickbankCollectionResponse collect(ClickbankCollectionRequest request) {
-        return collectFirstCycle(request);
+        return collectThirdCycleGraphql(request);
     }
 
     public ClickbankCollectionResponse collectFirstCycle(ClickbankCollectionRequest request) {
@@ -117,28 +117,54 @@ public class ClickbankCollectorService {
         String message = "Coleta executada a partir da página pública de Top Offers da ClickBank.";
 
         log.info(
-                "Iniciando coleta Clickbank por página pública. maxProductsSolicitado={}, maxProductsAplicado={}, topOffersUrl={}",
+                "Iniciando Ciclo 1 Clickbank (Top Offers público). maxProductsSolicitado={}, maxProductsAplicado={}, topOffersUrl={}",
                 request.maxProducts(),
                 boundedMax,
                 clickbankTopOffersUrl
         );
 
         try {
+            int collected = collectProductsFromTopOffersPage(boundedMax, products);
+            log.info("Ciclo 1 Top Offers finalizado. produtosColetados={}", collected);
+            status = "COLLECTION_EXECUTED";
+            message = "Ciclo 1 executado via página pública Top Offers da ClickBank.";
+        } catch (Exception ex) {
+            status = "COLLECTION_ERROR";
+            message = "Falha no Ciclo 1 (Top Offers): " + ex.getMessage();
+            log.error("Erro no Ciclo 1 Clickbank (Top Offers).", ex);
+        }
+        persistCollectedProductsOnBackend(request, status, products);
+        return new ClickbankCollectionResponse(status, message, products);
+    }
+
+
+    public ClickbankCollectionResponse collectThirdCycleGraphql(ClickbankCollectionRequest request) {
+        int boundedMax = request.maxProducts() <= 0 ? 10 : Math.min(request.maxProducts(), 50);
+        List<ClickbankProductSnapshot> products = new ArrayList<>();
+        String status = "COLLECTION_EXECUTED";
+        String message = "Ciclo 3 executado via GraphQL da ClickBank.";
+
+        log.info("Iniciando Ciclo 3 Clickbank (GraphQL). maxProductsSolicitado={}, maxProductsAplicado={}, graphqlUrl={}",
+                request.maxProducts(),
+                boundedMax,
+                clickbankGraphqlUrl);
+
+        try {
             String accessToken = fetchClickbankJwtFromGeneralSettings();
             int apiCollected = collectProductsFromGraphql(accessToken, boundedMax, products);
             if (apiCollected == 0) {
-                apiCollected = collectProductsFromTopOffersPage(boundedMax, products);
-                log.info("Coleta fallback Top Offers finalizada. produtosColetados={}", apiCollected);
+                status = "COLLECTION_SKIPPED";
+                message = "Ciclo 3 não coletou produtos via GraphQL (JWT ausente/inválido ou retorno vazio).";
+                log.warn("Ciclo 3 GraphQL sem dados coletados. produtosColetados={}", apiCollected);
             } else {
-                log.info("Coleta GraphQL Clickbank finalizada. produtosColetados={}", apiCollected);
+                log.info("Ciclo 3 GraphQL finalizado. produtosColetados={}", apiCollected);
             }
-            status = "COLLECTION_EXECUTED";
-            message = "Coleta executada via página pública Top Offers da ClickBank.";
         } catch (Exception ex) {
             status = "COLLECTION_ERROR";
-            message = "Falha na coleta da página Top Offers: " + ex.getMessage();
-            log.error("Erro na coleta Clickbank da página Top Offers.", ex);
+            message = "Falha no Ciclo 3 (GraphQL): " + ex.getMessage();
+            log.error("Erro no Ciclo 3 Clickbank (GraphQL).", ex);
         }
+
         persistCollectedProductsOnBackend(request, status, products);
         return new ClickbankCollectionResponse(status, message, products);
     }

--- a/mois-clickbank-collector/src/test/java/com/marketinghub/moisclickbank/service/ClickbankCollectorServiceTest.java
+++ b/mois-clickbank-collector/src/test/java/com/marketinghub/moisclickbank/service/ClickbankCollectorServiceTest.java
@@ -33,7 +33,7 @@ class ClickbankCollectorServiceTest {
                 "ofertas-clickbank"
         );
 
-        var response = service.collect(new ClickbankCollectionRequest("clickbank-market", 10));
+        var response = service.collectFirstCycle(new ClickbankCollectionRequest("clickbank-market", 10));
 
         assertEquals("COLLECTION_ERROR", response.status());
     }
@@ -66,7 +66,7 @@ class ClickbankCollectorServiceTest {
                     "clickbank_access_token_jwt", "https://accounts.clickbank.com/graphql",
                     "workspace-001", "marketing-digital", "ofertas-clickbank"
             );
-            var response = service.collect(new ClickbankCollectionRequest("clickbank-market", 10));
+            var response = service.collectFirstCycle(new ClickbankCollectionRequest("clickbank-market", 10));
 
             assertEquals("COLLECTION_EXECUTED", response.status());
             assertEquals(1, response.products().size());


### PR DESCRIPTION
### Motivation

- Centralize ClickBank collection into three distinct hourly cycles to separate public Top Offers, sales-page resolution and authenticated GraphQL collection. 
- Ensure better traceability and explicit status reporting when GraphQL JWT is absent or returns no hits. 

### Description

- Change scheduler to run hourly with cron default `0 0 * * * *` and route execution by `horaAtual % 3` to three slots, implemented in `ClickbankCollectorScheduler.collectHourly`. 
- Introduce an independent Cycle 3 GraphQL flow in `ClickbankCollectorService.collectThirdCycleGraphql` that reads JWT from settings, calls the ClickBank GraphQL endpoint and maps hits to the canonical snapshot, and log raw payloads before normalization. 
- Keep Cycle 1 (`collectFirstCycle`) for Top Offers public scraping and Cycle 2 for backend-driven sales-page resolution; update `collect` to default to the GraphQL cycle for direct calls. 
- Adjust error/status semantics so Cycle 3 returns `COLLECTION_SKIPPED` when JWT is missing/invalid or no hits are returned, and record `COLLECTION_ERROR` on exceptions; also persist collected products to backend after each cycle. 
- Update documentation files (`docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md`, `docs/registros/coletor-mois1.md`) to reflect the 3-cycle model and new GraphQL contract. 
- Update unit tests to target the explicit cycle methods (tests in `ClickbankCollectorServiceTest` now call `collectFirstCycle`). 

### Testing

- Updated unit tests in `mois-clickbank-collector` (`ClickbankCollectorServiceTest`) were executed and validate Top Offers parsing and error status handling, and they passed. 
- Ran the module unit test suite (`mvn test`), and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07954d6ee483219f80fd7c327eb46e)