### PR TITLE
Hotmart: normalize salesPageUrl, prefer salesPageUrl field, expose productDetails in extractor and update UI label

### DIFF
--- a/frontend/src/pages/hotmart/HotmartPage.tsx
+++ b/frontend/src/pages/hotmart/HotmartPage.tsx
@@ -162,7 +162,7 @@ export default function HotmartPage() {
                     const producer = item.producerName;
                     const price = item.price;
                     const currency = item.currency ?? "BRL";
-                    const salesPageUrl = item.pageSalesLink?.trim() || item.salesPageUrl?.trim() || null;
+                    const salesPageUrl = item.salesPageUrl?.trim() || null;
 
                     return (
                       <article key={item.referenceId} className="col-12 col-md-6 col-lg-4">
@@ -182,7 +182,7 @@ export default function HotmartPage() {
                               Temperatura: <strong>{item.temperature ?? "—"}</strong>
                             </p>
                             <p className="small mb-2">
-                              pageSalesLink:{" "}
+                              Página de vendas:{" "}
                               {salesPageUrl ? (
                                 <a href={salesPageUrl} target="_blank" rel="noreferrer">
                                   {salesPageUrl}

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -257,9 +257,8 @@ public class HotmartCollectorService {
             rawMetadata.put("productName", product.title());
             rawMetadata.put("productImage", product.image());
             rawMetadata.put("productUrl", product.detailsUrl());
-            String resolvedSalesPageUrl = pickFirstNonBlank(product.salesPageUrl(), product.detailsUrl());
+            String resolvedSalesPageUrl = normalizeBlankToNull(product.salesPageUrl());
             rawMetadata.put("salesPageUrl", resolvedSalesPageUrl);
-            rawMetadata.put("pageSalesLink", resolvedSalesPageUrl);
             if (product.temperature() != null) {
                 rawMetadata.put("hotmartTemperature", String.valueOf(product.temperature()));
             }
@@ -276,7 +275,7 @@ public class HotmartCollectorService {
             reference.put("jobId", jobId);
             reference.put("source", "HOTMART");
             reference.put("title", product.title());
-            reference.put("url", pickFirstNonBlank(product.salesPageUrl(), product.detailsUrl()));
+            reference.put("url", resolvedSalesPageUrl);
             reference.put("niche", defaultNiche);
             reference.put("status", "COLLECTED");
             reference.put("favorite", false);
@@ -437,7 +436,7 @@ public class HotmartCollectorService {
                     pickFirstNonBlank(firstText(detailsNode.path("producer"), "name"), baseSnapshot.producerName()),
                     detailPageUrl,
                     baseSnapshot.temperature(),
-                    pickFirstNonBlank(pickFirstNonBlank(salesPageFromDetails, baseSnapshot.salesPageUrl()), detailPageUrl),
+                    pickFirstNonBlank(salesPageFromDetails, baseSnapshot.salesPageUrl()),
                     baseSnapshot.collectedAt()
             );
         } catch (Exception ex) {
@@ -771,6 +770,13 @@ public class HotmartCollectorService {
                 return nested;
             }
         }
+        JsonNode productDetailsNode = item.path("productDetails");
+        if (!productDetailsNode.isMissingNode() && !productDetailsNode.isNull()) {
+            String detailsText = firstText(productDetailsNode, keys);
+            if (detailsText != null && !detailsText.isBlank()) {
+                return detailsText;
+            }
+        }
         JsonNode sourceObjectNode = item.path("sourceObject");
         if (!sourceObjectNode.isMissingNode() && !sourceObjectNode.isNull()) {
             String sourceObject = firstText(sourceObjectNode, keys);
@@ -808,6 +814,13 @@ public class HotmartCollectorService {
             return fallback;
         }
         return "";
+    }
+
+    private String normalizeBlankToNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
     }
 
     private void logPlaywrightRuntimeDiagnostics() {


### PR DESCRIPTION
### Motivation
- Ensure the collected Hotmart product sales URL is normalized and consistently propagated to backend references and UI instead of falling back to other fields. 
- Remove legacy/ambiguous `pageSalesLink` usage and improve extraction coverage by checking an additional `productDetails` node in product payloads. 
- Improve the frontend presentation by using the canonical `salesPageUrl` and a clearer label for the sales page link.

### Description
- Added `normalizeBlankToNull` helper and used it to set `rawMetadata.salesPageUrl` so blank strings become `null` and are no longer treated as valid URLs. 
- Removed `pageSalesLink` from the persisted metadata and set the `reference.url` to the normalized `salesPageUrl` instead of falling back to the details URL. 
- Adjusted the product details enrichment to stop falling back to `detailPageUrl` when setting the sales page field and to prefer `salesPageFromDetails` or the original sales page. 
- Extended `extractProductText` to also inspect a `productDetails` JSON node when searching for keys. 
- Updated the frontend `HotmartPage` to only use `salesPageUrl` (no more `pageSalesLink`) and changed the displayed label to "Página de vendas" while keeping the link/button behavior intact.

### Testing
- Ran backend automated unit tests with `mvn test`, and the test suite passed. 
- Built and ran frontend checks with `yarn build` and `yarn test`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a079565a3bc83219856ba83a5ad5221)