### PR TITLE
test: adicionar regras ArchUnit de isolamento para MOIS e OPRM

### DIFF
--- a/backend/ads-service/pom.xml
+++ b/backend/ads-service/pom.xml
@@ -74,6 +74,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
@@ -1,0 +1,39 @@
+package com.marketinghub.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeClasses(packages = "com.marketinghub")
+class ModuleIsolationArchitectureTest {
+
+    @ArchTest
+    static final ArchRule moisMustNotDependOnOtherMarketingHubPackages = noClasses()
+            .that()
+            .resideInAPackage("com.marketinghub.mois..")
+            .should()
+            .dependOnClassesThat(otherMarketingHubPackagesExcept("com.marketinghub.mois"))
+            .because("o módulo MOIS não deve depender de outros pacotes internos do sistema");
+
+    @ArchTest
+    static final ArchRule oprmMustNotDependOnOtherMarketingHubPackages = noClasses()
+            .that()
+            .resideInAPackage("com.marketinghub.oprm..")
+            .should()
+            .dependOnClassesThat(otherMarketingHubPackagesExcept("com.marketinghub.oprm"))
+            .because("o módulo OPRM não deve depender de outros pacotes internos do sistema");
+
+    private static DescribedPredicate<JavaClass> otherMarketingHubPackagesExcept(String allowedPackagePrefix) {
+        return new DescribedPredicate<>("other com.marketinghub packages except " + allowedPackagePrefix) {
+            @Override
+            public boolean test(JavaClass input) {
+                String packageName = input.getPackageName();
+                return packageName.startsWith("com.marketinghub") && !packageName.startsWith(allowedPackagePrefix);
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Motivation
- Garantir a isolação de módulos no backend de acordo com as convenções do projeto, impedindo que os pacotes `com.marketinghub.mois..` e `com.marketinghub.oprm..` dependam de outros pacotes internos.

### Description
- Adicionada a dependência de teste `com.tngtech.archunit:archunit-junit5` em `backend/ads-service/pom.xml` para habilitar regras arquiteturais via JUnit5.
- Criado o teste `ModuleIsolationArchitectureTest` em `backend/ads-service/src/test/java/com/marketinghub/architecture/` com duas regras que verificam isolamento de `com.marketinghub.mois..` e `com.marketinghub.oprm..`.
- Implementado um `DescribedPredicate<JavaClass>` reutilizável chamado `otherMarketingHubPackagesExcept` para detectar dependências em outros pacotes internos `com.marketinghub` exceto o pacote permitido do módulo.
- As regras falham se classes dos módulos MOIS/OPRM dependerem de qualquer outro pacote `com.marketinghub` fora do próprio módulo.

### Testing
- Executado `mvn -Dtest=ModuleIsolationArchitectureTest test` no módulo `backend/ads-service`, cujo resultado foi: `Tests run: 2, Failures: 0, Errors: 0` (passou).
- A compilação e execução do teste completaram com `BUILD SUCCESS` no contexto do módulo testado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a079a0dcc288321991111ceabc3a505)