### PR TITLE
Docs: require creatives to be `READY` for Facebook campaign publication (remove `IN_PRODUCTION` allowance)

### DIFF
--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -47,7 +47,7 @@ Este documento complementa o `system-governance-canon.v2.md` e passa a ser a fon
 Implementação: `ExperimentReadinessService` (backend) expõe os mesmos critérios usados pelo cartão **Campanha de Facebook Ads** e pelo `facebook-ads-worker`. **Todos os itens abaixo precisam estar resolvidos** para que o worker gere conjuntos de anúncios.
 
 1. **Criativos aprovados**
-   - `experiment.creative_approved = true` e pelo menos um registro em `creative` do experimento com `status IN ('READY','IN_PRODUCTION')`.
+   - `experiment.creative_approved = true` e pelo menos um registro em `creative` do experimento com `status = 'READY'`.
    - O botão **Gerar anúncios do pipeline** pode produzir até 3 anúncios (texto + prompt) via Worker AI (`gpt-image-1.5`). Eles entram como `DRAFT` e precisam ser aprovados antes da liberação.
    - Quando múltiplos criativos `READY` existem, o worker publica todos no mesmo ad set para preservar as variações aprovadas.
 2. **Fluxo do Portal do Lead**


### PR DESCRIPTION
### Motivation
- Narrow the canonical readiness rule so that only creatives with `status = 'READY'` count as approved for automated publication by the Facebook Ads worker.

### Description
- Update `docs/canonical/facebook-campaign-publication-canon.v1.md` to change the creatives invariant from "`status IN ('READY','IN_PRODUCTION')`" to "`status = 'READY'`" under the "Criativos aprovados" checklist item.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a079d80a4e483218d87b149c277044a)