### PR TITLE
fix(frontend): correct obsolete journey assignment type import

### DIFF
--- a/frontend/src/obsoleto/jornada/useExperimentJourneyAssignments.ts
+++ b/frontend/src/obsoleto/jornada/useExperimentJourneyAssignments.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
-import type { JourneyAssignment } from "../journey/types";
+import type { JourneyAssignment } from "../../api/journey/types";
 
 export interface ExperimentJourneyAssignments {
   journeyId?: number | null;


### PR DESCRIPTION
### Motivation
- Fix a `TS2307` module resolution error caused by an incorrect import path in an obsolete frontend hook so the file can be type-checked.

### Description
- Updated the import in `frontend/src/obsoleto/jornada/useExperimentJourneyAssignments.ts` from `../journey/types` to `../../api/journey/types` to reference the correct type declaration.

### Testing
- Ran `cd frontend && npm run typecheck`; the original `TS2307` missing-module error for that file is resolved, but type checking still fails due to missing type definition packages (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) and TypeScript 6 deprecation/config errors in `tsconfig.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a2ced20c8321a86208e87a6c9007)