### PR TITLE
Add direct sidebar navigation item for OPRM CNAEs

### DIFF
--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -33,6 +33,14 @@ describe("OPRM navigation", () => {
     expect(link.getAttribute("href")).toBe("/oprm");
   });
 
+
+  it("has menu link to /oprm/cnaes-volume", () => {
+    setup(<App />, ["/"]);
+    const link = screen.getByRole("link", { name: /^cnaes$/i });
+    expect(link).toBeTruthy();
+    expect(link.getAttribute("href")).toBe("/oprm/cnaes-volume");
+  });
+
   it("renders loading state on /oprm/operations route", async () => {
     setup(<App />, ["/oprm/operations"]);
     expect(await screen.findByText(/carregando jobs do oprm/i)).toBeTruthy();

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -107,7 +107,18 @@ const NAV_SECTIONS: NavSection[] = [
       { to: "/hypotheses", label: "Hipóteses", icon: hypothesisIcon },
       { to: "/mois", label: "MOIS", icon: Workflow },
       { to: "/mois/sales-pages-library", label: "Biblioteca Sales Pages", icon: Workflow },
-      { to: "/oprm", label: "OPRM", icon: Workflow },
+      {
+        to: "/oprm",
+        label: "OPRM",
+        icon: Workflow,
+        children: [
+          {
+            to: "/oprm/cnaes-volume",
+            label: "CNAEs",
+            icon: Workflow,
+          },
+        ],
+      },
       { to: "/mds", label: "MDS", icon: Microscope },
       { to: "/hotmart", label: "Hotmart", icon: Workflow },
       { to: "/clickbase", label: "Clickbase", icon: Workflow },


### PR DESCRIPTION
### Motivation
- The CNAEs screen lived at `/oprm/cnaes-volume` but was not discoverable from the main sidebar, forcing users to open the OPRM workspace first; this change exposes the CNAEs link directly to improve navigation.

### Description
- Added a nested `CNAEs` menu item under the existing `OPRM` entry in `frontend/src/components/MainNavigation.tsx` pointing to `/oprm/cnaes-volume`.
- Added a unit test in `frontend/src/__tests__/OprmNavigation.test.tsx` that asserts the sidebar contains a link to `/oprm/cnaes-volume`.
- This is a frontend-only change and does not alter backend contracts.

### Testing
- Installed frontend dependencies with `cd frontend && npm ci`.
- Executed the navigation tests with `cd frontend && npm test -- --run src/__tests__/OprmNavigation.test.tsx`.
- The test run completed successfully (`Test Files 1 passed`, `Tests 5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d03537c083218bc0c9bbd93527cc)