### PR TITLE
fix(frontend): restore creative card edit action symbols and handler

### DIFF
--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -12,6 +12,7 @@ import { resolveAssetUrl } from "../../utils/resolveAssetUrl";
 import {
   AlertTriangle,
   CheckCircle2,
+  Edit3,
   Eye,
   Sparkles,
   Trash2,
@@ -460,6 +461,11 @@ export default function CriativosTab({ experimentId }: Props) {
 
   const isSavingPageId = updateExperimentMutation.isPending;
   const isSavingPrompts = updatePromptsMutation.isPending;
+
+  const openEdit = (c: Creative) => {
+    setEditing(c);
+    setShowPreview(true);
+  };
 
   const startPreview = (c: Creative) => {
     setEditing(c);


### PR DESCRIPTION
### Motivation
- Fix TypeScript errors caused by missing `Edit3` symbol and undefined `openEdit` handler so the creative card "Editar" button compiles and opens the preview/edit modal.

### Description
- Added `Edit3` to the `lucide-react` imports in `frontend/src/pages/experiment/CriativosTab.tsx` and restored the `openEdit` handler which sets `editing` and `showPreview` to reuse the existing modal flow.

### Testing
- Ran `cd frontend && npm run typecheck`; the `openEdit`/`Edit3` errors are resolved but the typecheck still fails due to unrelated environment/dependency/type-definition issues (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) and TypeScript deprecation warnings in `tsconfig.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d75232f88321b74864ea8dd6a4e6)