### PR TITLE
Hotmart: publish sales page URLs to MOIS sales-library at end of Cycle 2 with detailed logging

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -202,3 +202,13 @@
 - Ciclo 2 mantido para resolução e persistência de páginas de venda a partir dos produtos salvos no backend MOIS.
 - Implementado Ciclo 3 independente para coleta via GraphQL ClickBank com status explícito `COLLECTION_SKIPPED` quando JWT estiver ausente/inválido ou sem hits.
 - Atualizado cânone MOIS (`docs/mois/mois-canonico-coleta-clickbank-ciclo-um.md`) para oficializar o Ciclo 3 e as regras de execução em 3 slots.
+
+## 2026-05-16 00:00 UTC
+- Hotmart (MOIS) alinhado ao fluxo já existente do ClickBank para publicar URLs na biblioteca de páginas de vendas ao final do Ciclo 2.
+- Adicionado envio para `POST /api/mois/sales-library/urls:ingest` com payload contendo `workspaceId`, `source=HOTMART` e lista de URLs resolvidas (`salesPageUrl` com fallback para `detailsUrl`).
+- Incluídos logs de sucesso, rejeição de contrato e erro de transporte para rastreabilidade da ingestão da biblioteca.
+
+## 2026-05-16 00:20 UTC
+- Adicionados logs detalhados no método `publishSalesPagesToLibrary` do coletor Hotmart para diagnóstico da ingestão na biblioteca.
+- Incluído log de início do método, contagem de produtos elegíveis vs. sem URL e log do payload JSON enviado para `POST /api/mois/sales-library/urls:ingest` (com truncamento para segurança operacional).
+- Ajustado envio HTTP para reutilizar o mesmo `payloadJson` registrado em log, garantindo rastreabilidade exata entre payload logado e payload transmitido.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -155,7 +155,64 @@ public class HotmartCollectorService {
             enrichedProducts.add(enrichProductWithDetails(hotmartAccessToken, listItem, base));
         }
         persistCollectedProductsOnBackend(request, status, enrichedProducts);
+        publishSalesPagesToLibrary(enrichedProducts);
         return new HotmartCollectionResponse(status, message, enrichedProducts);
+    }
+
+    private void publishSalesPagesToLibrary(List<HotmartProductSnapshot> products) {
+        if (products == null || products.isEmpty()) {
+            log.info("Ciclo 2: publishSalesPagesToLibrary ignorado porque lista de produtos está vazia.");
+            return;
+        }
+        log.info("Ciclo 2: iniciando publishSalesPagesToLibrary. totalProdutosRecebidos={}", products.size());
+        List<Map<String, Object>> urls = new ArrayList<>();
+        int skippedWithoutUrl = 0;
+        for (HotmartProductSnapshot product : products) {
+            String salesPageUrl = pickFirstNonBlank(product.salesPageUrl(), product.detailsUrl());
+            if (salesPageUrl == null || salesPageUrl.isBlank()) {
+                skippedWithoutUrl++;
+                continue;
+            }
+            Map<String, Object> item = new HashMap<>();
+            item.put("url", salesPageUrl);
+            item.put("source", "HOTMART");
+            item.put("workspaceId", workspaceId);
+            item.put("title", product.title());
+            item.put("capturedAt", Instant.now().toString());
+            urls.add(item);
+        }
+        log.info("Ciclo 2: preparo de URLs concluído. totalElegiveis={}, totalSemUrl={}", urls.size(), skippedWithoutUrl);
+        if (urls.isEmpty()) {
+            log.info("Ciclo 2: nenhuma URL elegível para ingestão na biblioteca de sales pages.");
+            return;
+        }
+        String endpoint = backendBaseUrl + "/api/mois/sales-library/urls:ingest";
+        try {
+            Map<String, Object> body = new HashMap<>();
+            body.put("workspaceId", workspaceId);
+            body.put("source", "HOTMART");
+            body.put("urls", urls);
+            String payloadJson = objectMapper.writeValueAsString(body);
+            log.info("Ciclo 2: payload de ingestão para biblioteca de sales pages. endpoint={}, payload={}",
+                    endpoint,
+                    truncateForLog(payloadJson, 4000));
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(payloadJson))
+                    .build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                log.info("Ciclo 2: ingestão de sales pages enviada com sucesso. endpoint={}, totalUrls={}", endpoint, urls.size());
+            } else {
+                log.warn("Ciclo 2: backend rejeitou ingestão de sales pages. endpoint={}, status={}, body={}",
+                        endpoint,
+                        response.statusCode(),
+                        truncateForLog(response.body(), 500));
+            }
+        } catch (Exception ex) {
+            log.warn("Ciclo 2: falha ao enviar URLs para biblioteca de sales pages. endpoint={}", endpoint, ex);
+        }
     }
 
     private List<HotmartProductSnapshot> fetchFirstCycleProductsFromBackend(int maxProducts) {


### PR DESCRIPTION
### Motivation
- Align Hotmart collector to the ClickBank flow by publishing resolved sales page URLs into the centralized MOIS sales-library at the end of Cycle 2.
- Improve observability and traceability of the ingest operation by adding start/summary/payload and transport result logs.
- Provide a resilient, auditable path to register sales pages in the backend so downstream consumers can index/use them.

### Description
- Added a call to `publishSalesPagesToLibrary` from `collectSecondCycleFromBackend` in `HotmartCollectorService` to trigger ingestion after Cycle 2 persistence.  
- Implemented `publishSalesPagesToLibrary` which builds a list of URL entries (`workspaceId`, `source=HOTMART`, `url`, `title`, `capturedAt`), counts skipped items without URLs, and logs summary information.  
- The method serializes a JSON payload (`workspaceId`, `source`, `urls`), logs a truncated `payloadJson` for diagnostics, and sends it via `HttpClient` to `POST /api/mois/sales-library/urls:ingest`, logging success, backend rejections, and transport exceptions.  
- Documentation `docs/registros/coletor-mois1.md` was updated to record the Hotmart alignment and the added logging details for the library ingestion flow.

### Testing
- No new automated tests were added for this change.  
- The existing unit/integration test suite was executed locally and completed successfully.  
- Manual inspection of logs was used during development to validate payload composition and error handling behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d71d605083219f7d14d627ca738e)