### PR TITLE
Add observability logs for Clickbank GraphQL requests and JWT retrieval

### DIFF
--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
@@ -184,6 +184,12 @@ public class ClickbankCollectorService {
             parameters.put("nicknameMasq", null);
             Map<String, Object> body = Map.of("query", CLICKBANK_GRAPHQL_QUERY, "variables", Map.of("parameters", parameters));
             String payload = objectMapper.writeValueAsString(body);
+            log.info(
+                    "CLICKBANK_GRAPHQL_REQUEST endpoint={} method=POST hasAuthorizationHeader={} payloadPreview='{}'",
+                    clickbankGraphqlUrl,
+                    true,
+                    truncateForLog(payload, 1200)
+            );
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(clickbankGraphqlUrl))
                     .header("accept", "application/json")
@@ -532,6 +538,7 @@ public class ClickbankCollectorService {
     private String fetchClickbankJwtFromGeneralSettings() {
         try {
             String endpoint = backendBaseUrl + "/api/settings/" + clickbankJwtSettingKey;
+            log.info("Buscando JWT Clickbank nas configurações gerais. endpoint={}, settingKey={}", endpoint, clickbankJwtSettingKey);
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(endpoint))
                     .GET()
@@ -543,7 +550,14 @@ public class ClickbankCollectorService {
                 return "";
             }
             JsonNode root = objectMapper.readTree(response.body());
-            return root.path("value").asText("");
+            String token = root.path("value").asText("");
+            log.info(
+                    "JWT Clickbank carregado das configurações gerais. endpoint={}, tokenPresente={}, tokenTamanho={}",
+                    endpoint,
+                    token != null && !token.isBlank(),
+                    token == null ? 0 : token.length()
+            );
+            return token;
         } catch (Exception ex) {
             log.warn("Erro ao buscar JWT da Clickbank em configurações gerais.", ex);
             return "";

--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
@@ -184,10 +184,12 @@ public class ClickbankCollectorService {
             parameters.put("nicknameMasq", null);
             Map<String, Object> body = Map.of("query", CLICKBANK_GRAPHQL_QUERY, "variables", Map.of("parameters", parameters));
             String payload = objectMapper.writeValueAsString(body);
+            boolean tokenPresent = accessToken != null && !accessToken.isBlank();
             log.info(
-                    "CLICKBANK_GRAPHQL_REQUEST endpoint={} method=POST hasAuthorizationHeader={} payloadPreview='{}'",
+                    "CLICKBANK_GRAPHQL_REQUEST endpoint={} method=POST hasAuthorizationHeader={} tokenLength={} payloadPreview='{}'",
                     clickbankGraphqlUrl,
-                    true,
+                    tokenPresent,
+                    tokenPresent ? accessToken.length() : 0,
                     truncateForLog(payload, 1200)
             );
             HttpRequest request = HttpRequest.newBuilder()


### PR DESCRIPTION
### Motivation
- Improve observability and debugging for the Clickbank collector by logging request/response metadata and configuration retrieval. 
- Make it easier to diagnose failures when calling Clickbank GraphQL and when loading the Clickbank JWT from backend settings.

### Description
- Added a log entry before sending the GraphQL request that records `clickbankGraphqlUrl`, HTTP method, presence of an authorization header, and a truncated payload preview via `truncateForLog`.
- Added logs in `fetchClickbankJwtFromGeneralSettings` to record the settings endpoint and the presence/length of the returned token.
- Kept response previews truncated for safety and continued using existing `truncateForLog` behavior for bodies.

### Testing
- Ran the project test suite with `mvn test` and the build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d73d489083218ce9769e3e6ec9ba)