### PR TITLE
Remover card 'Prompts personalizados' na aba de Criativos

### DIFF
--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -236,7 +236,6 @@ export default function CriativosTab({ experimentId }: Props) {
   const pipelineInProgress = experiment?.creativeGenerationMode === "PIPELINE_ADS" && pendingCreativeRequests > 0;
   const pipelineButtonDisabled = pipelineRequest.isPending || pipelineInProgress || pendingCreativeRequests > 0 || !pipelineAvailable;
   const updateExperimentMutation = useUpdateExperiment(experimentId);
-  const updatePromptsMutation = useUpdateExperiment(experimentId);
   const [editing, setEditing] = useState<Creative | null>(null);
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const [experimentPageId, setExperimentPageId] = useState("");
@@ -258,8 +257,6 @@ export default function CriativosTab({ experimentId }: Props) {
     useState<Record<number, boolean>>({});
   const [expandedIntermediatePromptByCreativeId, setExpandedIntermediatePromptByCreativeId] =
     useState<Record<number, boolean>>({});
-  const [textPrompt, setTextPrompt] = useState("");
-  const [imagePrompt, setImagePrompt] = useState("");
   const { data: facebookPages, isLoading: isLoadingFacebookPages } =
     useAllFacebookPages();
   const { data: instagramAccounts, isLoading: isLoadingInstagramAccounts } =
@@ -294,14 +291,6 @@ export default function CriativosTab({ experimentId }: Props) {
         : "",
     );
   }, [experiment?.instagramAccount?.id]);
-
-  useEffect(() => {
-    setTextPrompt(experiment?.creativeTextPrompt ?? "");
-  }, [experiment?.creativeTextPrompt]);
-
-  useEffect(() => {
-    setImagePrompt(experiment?.creativeImagePrompt ?? "");
-  }, [experiment?.creativeImagePrompt]);
 
   const buildBaseExperimentUpdate = (): UpdateExperiment => {
     if (!experiment) {
@@ -411,56 +400,7 @@ export default function CriativosTab({ experimentId }: Props) {
     }
   };
 
-  const handleResetPrompts = () => {
-    setTextPrompt("");
-    setImagePrompt("");
-  };
-
-  const handleSavePrompts = async () => {
-    if (!experiment) {
-      return;
-    }
-    let basePayload: UpdateExperiment;
-    try {
-      basePayload = buildBaseExperimentUpdate();
-    } catch (error) {
-      setFeedback({
-        variant: "error",
-        title: "Não foi possível salvar os prompts",
-        description:
-          error instanceof Error && error.message === "missing-metrics"
-            ? "Defina a meta de KPI e o preset de métricas antes de personalizar os prompts."
-            : "Tente novamente em instantes.",
-      });
-      return;
-    }
-    const trimmedText = textPrompt.trim();
-    const trimmedImage = imagePrompt.trim();
-    try {
-      await updatePromptsMutation.mutateAsync({
-        ...basePayload,
-        creativeTextPrompt: trimmedText.length > 0 ? trimmedText : null,
-        creativeImagePrompt: trimmedImage.length > 0 ? trimmedImage : null,
-      });
-      const restoredToDefault = trimmedText.length === 0 && trimmedImage.length === 0;
-      setFeedback({
-        variant: "success",
-        title: "Prompts atualizados",
-        description: restoredToDefault
-          ? "Voltamos a usar os prompts padrão do worker."
-          : "Os próximos criativos seguirão as instruções personalizadas.",
-      });
-    } catch {
-      setFeedback({
-        variant: "error",
-        title: "Não foi possível salvar os prompts",
-        description: "Tente novamente em instantes.",
-      });
-    }
-  };
-
   const isSavingPageId = updateExperimentMutation.isPending;
-  const isSavingPrompts = updatePromptsMutation.isPending;
 
   const openEdit = (c: Creative) => {
     setEditing(c);
@@ -899,71 +839,6 @@ export default function CriativosTab({ experimentId }: Props) {
           em branco para usar a página padrão configurada no worker.
         </div>
       </div>
-      <section className="card mb-4">
-        <div className="card-body">
-          <div className="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-3">
-            <div>
-              <h2 className="h6 mb-1">Prompts personalizados</h2>
-              <p className="text-muted mb-0">Defina o tom das cópias e das imagens geradas pelo worker. Campos vazios restauram o comportamento padrão.</p>
-            </div>
-            <div className="d-flex flex-wrap gap-2">
-              <button
-                type="button"
-                className="btn btn-outline-secondary btn-sm"
-                onClick={handleResetPrompts}
-                disabled={isSavingPrompts}
-              >
-                Limpar campos
-              </button>
-              <button
-                type="button"
-                className="btn btn-primary btn-sm d-flex align-items-center gap-2"
-                onClick={handleSavePrompts}
-                disabled={isSavingPrompts}
-              >
-                {isSavingPrompts ? (
-                  <>
-                    <span
-                      className="spinner-border spinner-border-sm"
-                      role="status"
-                      aria-hidden
-                    />
-                    <span>Salvando...</span>
-                  </>
-                ) : (
-                  <span>Salvar prompts</span>
-                )}
-              </button>
-            </div>
-          </div>
-          <div className="row g-3">
-            <div className="col-12 col-lg-6">
-              <label className="form-label" htmlFor="creative-text-prompt">Prompt dos textos</label>
-              <textarea
-                id="creative-text-prompt"
-                className="form-control"
-                rows={8}
-                value={textPrompt}
-                onChange={(event) => setTextPrompt(event.target.value)}
-                placeholder="Explique como a IA deve escrever os anúncios"
-              />
-              <div className="form-text">Inclua contexto, persona, prova social ou call-to-actions desejados. Exemplos de variáveis: <code>{`{{quantity}}`}</code>, <code>{`{{hypothesisTitle}}`}</code>, <code>{`{{persona}}`}</code>, <code>{`{{problem}}`}</code>, <code>{`{{promise}}`}</code>.</div>
-            </div>
-            <div className="col-12 col-lg-6">
-              <label className="form-label" htmlFor="creative-image-prompt">Prompt das imagens</label>
-              <textarea
-                id="creative-image-prompt"
-                className="form-control"
-                rows={8}
-                value={imagePrompt}
-                onChange={(event) => setImagePrompt(event.target.value)}
-                placeholder="Descreva o visual desejado para os criativos"
-              />
-              <div className="form-text">Você pode usar <code>{`{{headline}}`}</code>, <code>{`{{primaryText}}`}</code>, <code>{`{{experimentName}}`}</code> e os mesmos campos da hipótese para alinhar as ilustrações.</div>
-            </div>
-          </div>
-        </div>
-      </section>
       {pipelineAvailable ? (
         <div className="alert alert-primary d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mt-3">
           <div>


### PR DESCRIPTION
### Motivation
- Simplificar a interface da aba de criativos removendo o card de "Prompts personalizados" que não deve mais ser exibido ao usuário.
- Eliminar lógica associada que se tornou código morto após a remoção da UI para reduzir superfície de manutenção.

### Description
- Remove o bloco JSX do card "Prompts personalizados" de `frontend/src/pages/experiment/CriativosTab.tsx` para que a tela siga diretamente para o bloco de pipeline e a galeria de criativos.
- Remove estados locais `textPrompt` e `imagePrompt`, seus `useEffect` de sincronização e os handlers `handleSavePrompts` e `handleResetPrompts` do componente.
- Remove a mutation duplicada `updatePromptsMutation` e as referências relacionadas ao estado `isSavingPrompts`.
- Mantém intactos os fluxos de configuração da página/Instagram, pipeline de anúncios e a renderização da galeria de criativos.

### Testing
- Executei `npm run -s typecheck` dentro de `frontend` e a checagem TypeScript falhou por ausência de definições de tipos e opções de `tsconfig` depreciadas no ambiente, sem relação direta com esta alteração.
- Tentei `npm run -s lint` mas não há script `lint` no `frontend/package.json`, então não foi possível executar linting automático aqui.
- Nenhum teste unitário específico foi executado devido a limitações do ambiente de dependências de tipos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e8c8f1d883219caa208d618e195b)