### PR TITLE
Fix undefined image prompt variable in CriativosTab

### DIFF
--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -494,7 +494,8 @@ export default function CriativosTab({ experimentId }: Props) {
     const isProcessing = processingCreativeId === c.id;
     const hasImagePrompt = Boolean(c.imagePrompt?.trim());
     const isPromptExpanded = Boolean(expandedPromptByCreativeId[c.id]);
-    const hasPreviousImagePrompt = Boolean(imagePrompt.trim());
+    const previousImagePrompt = experiment?.creativeImagePrompt?.trim() ?? "";
+    const hasPreviousImagePrompt = Boolean(previousImagePrompt);
     const isPreviousPromptExpanded = Boolean(
       expandedPreviousPromptByCreativeId[c.id],
     );
@@ -685,7 +686,7 @@ export default function CriativosTab({ experimentId }: Props) {
               </button>
               {isPreviousPromptExpanded && (
                 <p className="creative-card-prompt-text mb-0 mt-2">
-                  {imagePrompt.trim()}
+                  {previousImagePrompt}
                 </p>
               )}
             </div>


### PR DESCRIPTION
### Motivation
- The UI referenced an undefined `imagePrompt` variable when rendering the "prompt anterior da imagem" section, causing TypeScript build errors and breaking the frontend typecheck.

### Description
- Use a safe local `previousImagePrompt` derived from `experiment?.creativeImagePrompt?.trim() ?? ""` to provide the previous image prompt value. 
- Replace the undefined `imagePrompt.trim()` usage with `previousImagePrompt` and gate visibility with `hasPreviousImagePrompt = Boolean(previousImagePrompt)`.
- No change in UX or toggle behavior, only a defensive fix to avoid the undefined variable.

### Testing
- Ran `npm run typecheck` in `frontend/` and confirmed the original `TS2552` undefined-name errors were resolved by this change. 
- The typecheck command still fails in this environment due to unrelated issues: missing type definitions for `@testing-library/jest-dom`, `vite/client`, and `vitest/globals`, and TypeScript deprecation warnings in `tsconfig.json`. These remaining failures are configuration/environmental and not caused by the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ee034db88321a45a3f1a087e9b17)