### PR TITLE
Remove aba de E-mails de amostra do detalhe de Experimento e marcar como obsoleto

### DIFF
--- a/docs/obsoletos/itens-obsoletos.md
+++ b/docs/obsoletos/itens-obsoletos.md
@@ -34,3 +34,18 @@ Este documento centraliza itens que foram marcados como obsoletos no Marketing H
 
 ### Observação de dependência de dados
 Apesar da remoção no frontend, ainda existem dependências de jornada no backend/banco (FKs e modelo), então a remoção total deve ser planejada de forma incremental.
+
+## Frontend — E-mails de amostra no Experimento (obsoleto)
+
+### Status
+- **Obsoleto**
+- **Data do registro:** 2026-05-16
+- **Motivo:** aba de e-mails de amostra aposentada por decisão de produto; fluxo não deve mais ser acessível na tela de experimento.
+
+### Itens removidos da superfície da aplicação
+- A tela de detalhe de experimento (`/experiments/:id`) não exibe mais:
+  - Aba **E-mails de amostra**.
+  - Conteúdo da tab `sample-emails` com o componente `SampleEmailsTab`.
+
+### Sinalização de obsolescência mantida na UI
+- No overview do experimento, o campo **E-mail de amostra** permanece visível com valor fixo **Obsoleto** para registrar a descontinuação.

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -14,7 +14,6 @@ import { getExperimentStageLabel } from "./stageLabels";
 import nicheIcon from "../../assets/icons/niche-icon.svg";
 import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import CriativosTab from "./CriativosTab";
-import SampleEmailsTab from "./SampleEmailsTab";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 import * as Tabs from "@radix-ui/react-tabs";
 import { useFacebookConfigurationStatus } from "../../api/useFacebookConfigurationStatus";
@@ -1352,32 +1351,6 @@ export default function ExperimentDetailPage() {
     FAILED: "Com erro",
   };
 
-  const selectedEmailOverview = data.selectedSampleEmailSubject ? (
-    <div className="d-flex flex-column">
-      <span>{data.selectedSampleEmailSubject}</span>
-      {data.selectedSampleEmailUpdatedAt ? (
-        <span className="text-muted small">
-          Atualizado em {formatDateTimeValue(data.selectedSampleEmailUpdatedAt)}
-        </span>
-      ) : null}
-      <button
-        type="button"
-        className="btn btn-link btn-sm p-0 mt-1 align-self-start"
-        onClick={() => setTab("sample-emails")}
-      >
-        Ver e-mails
-      </button>
-    </div>
-  ) : (
-    <button
-      type="button"
-      className="btn btn-link btn-sm p-0"
-      onClick={() => setTab("sample-emails")}
-    >
-      Escolher e-mail
-    </button>
-  );
-
   const rows = [
     {
       label: "Nicho",
@@ -1427,8 +1400,8 @@ export default function ExperimentDetailPage() {
       value: data.sampleEmailsToGenerate ?? "—",
     },
     {
-      label: "E-mail de amostra selecionado",
-      value: selectedEmailOverview,
+      label: "E-mail de amostra",
+      value: "Obsoleto",
     },
     {
       label: "Fluxo de portal do lead",
@@ -1923,9 +1896,6 @@ export default function ExperimentDetailPage() {
             </Tabs.Trigger>
             <Tabs.Trigger value="gera-landing" className="nav-link">
               Gera landing
-            </Tabs.Trigger>
-            <Tabs.Trigger value="sample-emails" className="nav-link">
-              E-mails de amostra
             </Tabs.Trigger>
             <Tabs.Trigger value="lead-portal" className="nav-link">
               Portal do Lead
@@ -2710,15 +2680,6 @@ export default function ExperimentDetailPage() {
                 </div>
               </div>
             </div>
-          </Tabs.Content>
-          <Tabs.Content value="sample-emails" asChild>
-            <SampleEmailsTab
-              experimentId={expId}
-              requestedSampleEmails={data.sampleEmailsToGenerate}
-              selectedSampleEmailId={data.selectedSampleEmailId}
-              selectedSampleEmailSubject={data.selectedSampleEmailSubject}
-              selectedSampleEmailUpdatedAt={data.selectedSampleEmailUpdatedAt}
-            />
           </Tabs.Content>
           <Tabs.Content value="lead-portal" asChild>
             <LeadPortalFlowTab experiment={data} />


### PR DESCRIPTION
### Motivation
- Remover o fluxo de e-mails de amostra da UI porque a aba foi aposentada por decisão de produto e não deve mais ser acessível na tela de experimento.

### Description
- Atualiza `frontend/src/pages/experiment/ExperimentDetailPage.tsx` removendo a importação e o componente `SampleEmailsTab`, eliminando o gatilho de tab `sample-emails` e seu conteúdo associado, e substituindo o resumo do e-mail selecionado por um valor fixo `"Obsoleto"` no overview.
- Remove o bloco `selectedEmailOverview` que exibía detalhes e ações para os e-mails de amostra e quaisquer botões que navegavam para a aba `sample-emails`.
- Atualiza `docs/obsoletos/itens-obsoletos.md` adicionando a seção "Frontend — E-mails de amostra no Experimento (obsoleto)" com status, motivo e itens removidos para registrar formalmente a descontinuação.

### Testing
- Executed TypeScript typecheck (`yarn tsc`) and the frontend build (`yarn build`) which completed successfully. 
- Ran unit tests (`yarn test`) and lint (`yarn lint`) for the frontend and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f62c73088321bd47c055cdd93a28)