### PR TITLE
Remove redundant readiness success alert from Experiment Detail page

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1636,13 +1636,7 @@ export default function ExperimentDetailPage() {
                 ))}
               </ul>
             </div>
-          ) : (
-            <div className="alert alert-secondary mt-3" role="status">
-              Nenhuma inconsistência detectada pelo worker. Este experimento
-              pode ser publicado quando você liberar o status e demais
-              automações.
-            </div>
-          )}
+          ) : null}
           <div className="mt-3 d-flex flex-column flex-lg-row align-items-start gap-3">
             <button
               type="button"


### PR DESCRIPTION
### Motivation
- Remove the gray informational alert shown when no readiness issues exist because it is redundant on the experiment detail page and provides no actionable value to users.

### Description
- Deleted the success alert rendering in the Facebook Ads readiness section by updating `frontend/src/pages/experiment/ExperimentDetailPage.tsx` so that when there are no readiness issues the component renders nothing while preserving the loading and warning states.

### Testing
- Ran the frontend typecheck with `npm run typecheck` in `frontend/`, which failed due to existing environment/dependency/config issues unrelated to this UI-only change (missing type definitions and deprecated TypeScript config options).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07fadf5cec8321aca99b258fb13524)