### PR TITLE
Remove adset-workflow/spec checks from ExperimentReadinessService

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -6,18 +6,11 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
-import com.marketinghub.facebookads.playbook.ExperimentAdSetSpec;
-import com.marketinghub.facebookads.playbook.ExperimentAdSetSpecSlot;
-import com.marketinghub.facebookads.playbook.ExperimentAdSetWorkflow;
-import com.marketinghub.facebookads.playbook.ExperimentAdSetWorkflowStatus;
-import com.marketinghub.facebookads.playbook.repository.ExperimentAdSetSpecRepository;
-import com.marketinghub.facebookads.playbook.repository.ExperimentAdSetWorkflowRepository;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.experiment.repository.ExperimentTargetingSelectionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,19 +23,13 @@ public class ExperimentReadinessService {
     private final ExperimentService experimentService;
     private final CreativeRepository creativeRepository;
     private final ExperimentTargetingSelectionRepository targetingSelectionRepository;
-    private final ExperimentAdSetWorkflowRepository adSetWorkflowRepository;
-    private final ExperimentAdSetSpecRepository adSetSpecRepository;
 
     public ExperimentReadinessService(ExperimentService experimentService,
                                       CreativeRepository creativeRepository,
-                                      ExperimentTargetingSelectionRepository targetingSelectionRepository,
-                                      ExperimentAdSetWorkflowRepository adSetWorkflowRepository,
-                                      ExperimentAdSetSpecRepository adSetSpecRepository) {
+                                      ExperimentTargetingSelectionRepository targetingSelectionRepository) {
         this.experimentService = experimentService;
         this.creativeRepository = creativeRepository;
         this.targetingSelectionRepository = targetingSelectionRepository;
-        this.adSetWorkflowRepository = adSetWorkflowRepository;
-        this.adSetSpecRepository = adSetSpecRepository;
     }
 
     @Transactional(readOnly = true)
@@ -130,7 +117,7 @@ public class ExperimentReadinessService {
         if (experiment == null) {
             return false;
         }
-        return hasReadyAdSetSpecs(experiment.getId()) || hasSelectedTargeting(experiment.getId());
+        return hasSelectedTargeting(experiment.getId());
     }
 
     private boolean hasApprovedCreative(Experiment experiment) {
@@ -155,36 +142,5 @@ public class ExperimentReadinessService {
                 experimentId, TargetingCandidateType.WORK_POSITION) > 0;
     }
 
-    private boolean hasReadyAdSetSpecs(Long experimentId) {
-        if (experimentId == null) {
-            return false;
-        }
-        return adSetWorkflowRepository.findByExperimentId(experimentId)
-                .filter(workflow -> workflow.getStatus() == ExperimentAdSetWorkflowStatus.COMPLETED)
-                .filter(this::hasEnoughReadySpecs)
-                .isPresent();
-    }
-
-    private boolean hasEnoughReadySpecs(ExperimentAdSetWorkflow workflow) {
-        List<ExperimentAdSetSpec> specs = adSetSpecRepository.findByWorkflowId(workflow.getId());
-        if (specs.isEmpty()) {
-            return false;
-        }
-        long readyCount = specs.stream()
-                .filter(this::isSpecReady)
-                .count();
-        return readyCount >= ExperimentAdSetSpecSlot.values().length;
-    }
-
-    private boolean isSpecReady(ExperimentAdSetSpec spec) {
-        if (spec == null) {
-            return false;
-        }
-        if (!"READY".equalsIgnoreCase(spec.getReachStatus())) {
-            return false;
-        }
-        String validation = spec.getValidationStatus();
-        return !StringUtils.hasText(validation) || "VALID".equalsIgnoreCase(validation.trim());
-    }
 
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -6,12 +6,6 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
-import com.marketinghub.facebookads.playbook.ExperimentAdSetSpec;
-import com.marketinghub.facebookads.playbook.ExperimentAdSetSpecSlot;
-import com.marketinghub.facebookads.playbook.ExperimentAdSetWorkflow;
-import com.marketinghub.facebookads.playbook.ExperimentAdSetWorkflowStatus;
-import com.marketinghub.facebookads.playbook.repository.ExperimentAdSetSpecRepository;
-import com.marketinghub.facebookads.playbook.repository.ExperimentAdSetWorkflowRepository;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.niche.MarketNiche;
@@ -25,7 +19,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,10 +33,6 @@ class ExperimentReadinessServiceTest {
     private CreativeRepository creativeRepository;
     @Mock
     private ExperimentTargetingSelectionRepository targetingSelectionRepository;
-    @Mock
-    private ExperimentAdSetWorkflowRepository adSetWorkflowRepository;
-    @Mock
-    private ExperimentAdSetSpecRepository adSetSpecRepository;
 
     @InjectMocks
     private ExperimentReadinessService service;
@@ -56,7 +45,6 @@ class ExperimentReadinessServiceTest {
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentId(experimentId)).thenReturn(0L);
         when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(false);
-        when(adSetWorkflowRepository.findByExperimentId(experimentId)).thenReturn(Optional.empty());
         when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
                 .thenReturn(0L);
 
@@ -109,7 +97,6 @@ class ExperimentReadinessServiceTest {
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentId(experimentId)).thenReturn(1L);
         when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
-        when(adSetWorkflowRepository.findByExperimentId(experimentId)).thenReturn(Optional.empty());
         when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
                 .thenReturn(0L);
 
@@ -121,38 +108,7 @@ class ExperimentReadinessServiceTest {
                 .contains(ExperimentReadinessIssueType.TARGETING);
     }
 
-    @Test
-    void shouldTreatReadyAdSetSpecsAsCompleteTargeting() {
-        Long experimentId = 9L;
-        Experiment experiment = buildExperiment(experimentId, 20L);
-        LeadPortalFlow flow = new LeadPortalFlow();
-        flow.setApproved(true);
-        experiment.setLeadPortalFlow(flow);
 
-        when(experimentService.get(experimentId)).thenReturn(experiment);
-        when(creativeRepository.countByExperimentId(experimentId)).thenReturn(1L);
-        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
-
-        ExperimentAdSetWorkflow workflow = ExperimentAdSetWorkflow.builder()
-                .id(42L)
-                .status(ExperimentAdSetWorkflowStatus.COMPLETED)
-                .build();
-        when(adSetWorkflowRepository.findByExperimentId(experimentId)).thenReturn(Optional.of(workflow));
-
-        List<ExperimentAdSetSpec> specs = List.of(
-                buildSpec(ExperimentAdSetSpecSlot.DESIGNERS),
-                buildSpec(ExperimentAdSetSpecSlot.MARKETING),
-                buildSpec(ExperimentAdSetSpecSlot.SMB)
-        );
-        when(adSetSpecRepository.findByWorkflowId(workflow.getId())).thenReturn(specs);
-
-        ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
-
-        assertThat(summary.hasCompleteTargeting()).isTrue();
-        assertThat(summary.missingTargetingTypes()).isEmpty();
-        assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
-                .doesNotContain(ExperimentReadinessIssueType.TARGETING);
-    }
 
     private Experiment buildExperiment(Long experimentId, Long nicheId) {
         MarketNiche niche = new MarketNiche();
@@ -170,11 +126,4 @@ class ExperimentReadinessServiceTest {
         return experiment;
     }
 
-    private ExperimentAdSetSpec buildSpec(ExperimentAdSetSpecSlot slot) {
-        ExperimentAdSetSpec spec = new ExperimentAdSetSpec();
-        spec.setSlot(slot);
-        spec.setReachStatus("READY");
-        spec.setValidationStatus("VALID");
-        return spec;
-    }
 }

--- a/docs/obsoletos/itens-obsoletos.md
+++ b/docs/obsoletos/itens-obsoletos.md
@@ -49,3 +49,18 @@ Apesar da remoção no frontend, ainda existem dependências de jornada no backe
 
 ### Sinalização de obsolescência mantida na UI
 - No overview do experimento, o campo **E-mail de amostra** permanece visível com valor fixo **Obsoleto** para registrar a descontinuação.
+
+## Backend — Readiness por workflow de adset (obsoleto)
+
+### Status
+- **Obsoleto**
+- **Data do registro:** 2026-05-16
+- **Motivo:** o workflow automático de adset não deve mais ser considerado requisito de prontidão para publicação/criação de campanha.
+
+### Mudança aplicada
+- A validação de readiness do experimento **não** usa mais `experiment_adset_workflow`/`experiment_adset_spec` como critério para considerar público completo.
+- O requisito de público permanece baseado em seleção salva em `experiment_targeting_selection` (cargo/work position).
+
+### Impacto de dependência na criação de campanha
+- A criação/publicação de campanha **não depende** mais de workflow de adset concluído.
+- O bloqueio de público passa a depender apenas da existência de seleção de segmentação salva no experimento.


### PR DESCRIPTION
### Motivation
- The experiment readiness check should no longer depend on the automatic adset workflow/spec artifacts as a requirement for targeting completeness per product decision. 
- Simplify readiness logic to rely on explicit saved targeting selections and creative/lead-portal statuses. 
- Document the backend obsolescence of adset workflow-based readiness to keep architecture and docs aligned. 

### Description
- Removed imports, repository fields, constructor parameters and methods related to `ExperimentAdSetWorkflow` and `ExperimentAdSetSpec`, including `hasReadyAdSetSpecs`, `hasEnoughReadySpecs` and `isSpecReady`. 
- Changed `hasConfiguredTargeting` to depend only on saved targeting selection via `ExperimentTargetingSelectionRepository` and removed adset-spec checks. 
- Updated `ExperimentReadinessServiceTest` to remove mocks and tests tied to adset workflow/spec behavior and adjusted expectations accordingly. 
- Added documentation in `docs/obsoletos/itens-obsoletos.md` marking backend readiness-by-adset-workflow as obsoleted and describing the impact. 

### Testing
- Ran unit tests, including the updated `ExperimentReadinessServiceTest`, which were modified to remove adset workflow/spec scenarios; the test suite completed successfully. 
- Executed project build (`mvn test`), and the automated test run passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07fa243768832193badb19c9e5395a)