### PR TITLE
Hide "Nenhuma inconsistência detectada" diagnostics banner on experiment page

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1107,6 +1107,10 @@ export default function ExperimentDetailPage() {
     diagnosticsUpdatedAt > 0
       ? formatDateTimeValue(new Date(diagnosticsUpdatedAt).toISOString())
       : null;
+  const shouldShowDiagnostics =
+    !!diagnostics &&
+    diagnostics.headline.trim().toLowerCase() !==
+      "nenhuma inconsistência detectada";
   const baseKpi = data.kpiTarget ?? data.kpiTargetCpl;
   const stopLossFactor = preset?.stopLossFactor;
   const stopLossCpl =
@@ -1499,7 +1503,7 @@ export default function ExperimentDetailPage() {
           />
           <span>Carregando diagnóstico da publicação...</span>
         </div>
-      ) : diagnostics ? (
+      ) : shouldShowDiagnostics ? (
         <div
           className={`alert alert-${diagnosticsVariant[diagnostics.severity] ?? "secondary"} mt-3`}
           role="alert"


### PR DESCRIPTION
### Motivation
- Avoid showing a non-actionable positive diagnostics banner that occupies space on the experiment detail UI by default.

### Description
- In `frontend/src/pages/experiment/ExperimentDetailPage.tsx` add a `shouldShowDiagnostics` flag that checks `diagnostics.headline` and suppresses the diagnostics alert when it equals `"Nenhuma inconsistência detectada"`, and update the render condition to use this flag instead of rendering for any `diagnostics` value.

### Testing
- Executed `cd frontend && npm run typecheck`, which failed due to missing type definitions and deprecated `tsconfig` options unrelated to this change, so no typecheck success was recorded for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ffb788f483219f46a08376a21a4f)