### PR TITLE
feat(frontend): adiciona aba Público para marcar cargos/comportamentos aprovados do nicho

### DIFF
--- a/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useState } from "react";
+import { useExperimentTargetingSelections, useSaveExperimentTargetingSelections } from "../../api/experiment/useExperimentTargetingSelections";
+import { useTargetingElementsByNiche } from "../../api/targeting/useTargetingElementsByNiche";
+import type { TargetingCandidateType, TargetingElement } from "../../api/targeting/types";
+
+interface ExperimentAudienceTabProps {
+  experimentId: number;
+  nicheId?: number | null;
+}
+
+const TYPE_LABEL: Record<TargetingElement["type"], string> = {
+  INTEREST: "Interesse",
+  JOB_TITLE: "Cargo",
+  BEHAVIOR: "Comportamento",
+};
+
+function toCandidateType(type: TargetingElement["type"]): TargetingCandidateType {
+  return type === "JOB_TITLE" ? "WORK_POSITION" : type;
+}
+
+function buildKey(element: TargetingElement) {
+  return `${element.type}::${element.id}`;
+}
+
+export function ExperimentAudienceTab({ experimentId, nicheId }: ExperimentAudienceTabProps) {
+  const nicheIdAsString = nicheId != null ? String(nicheId) : undefined;
+  const { data: elements, isLoading } = useTargetingElementsByNiche(nicheIdAsString, { status: "APPROVED" });
+  const { data: savedSelections } = useExperimentTargetingSelections(experimentId);
+  const saveSelections = useSaveExperimentTargetingSelections(experimentId);
+
+  const availableOptions = useMemo(
+    () => (elements ?? []).filter((item) => item.type === "JOB_TITLE" || item.type === "BEHAVIOR"),
+    [elements],
+  );
+
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!savedSelections || availableOptions.length === 0) {
+      return;
+    }
+    const byId = new Set<number>();
+    savedSelections.forEach((entry) => {
+      if (typeof entry.targetingElementId === "number") {
+        byId.add(entry.targetingElementId);
+      }
+    });
+    const next = new Set<string>();
+    availableOptions.forEach((item) => {
+      if (byId.has(item.id)) next.add(buildKey(item));
+    });
+    setSelected(next);
+  }, [savedSelections, availableOptions]);
+
+  const grouped = useMemo(() => {
+    return {
+      JOB_TITLE: availableOptions.filter((item) => item.type === "JOB_TITLE"),
+      BEHAVIOR: availableOptions.filter((item) => item.type === "BEHAVIOR"),
+    };
+  }, [availableOptions]);
+
+  const toggleSelection = (item: TargetingElement) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      const key = buildKey(item);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    const selectedItems = availableOptions.filter((item) => selected.has(buildKey(item)));
+    await saveSelections.mutateAsync({
+      items: selectedItems.map((item) => ({
+        candidateType: toCandidateType(item.type),
+        term: item.term,
+        targetingElementId: item.id,
+      })),
+    });
+  };
+
+  if (nicheId == null) {
+    return <div className="alert alert-warning mt-3 mb-0">Experimento sem nicho vinculado.</div>;
+  }
+
+  return (
+    <div className="card mt-3">
+      <div className="card-body d-flex flex-column gap-3">
+        <div>
+          <h5 className="card-title mb-1">Público</h5>
+          <p className="text-muted mb-0 small">Marque somente cargos e comportamentos já aprovados para o nicho.</p>
+        </div>
+
+        {isLoading ? (
+          <div className="text-muted small">Carregando opções do nicho...</div>
+        ) : availableOptions.length === 0 ? (
+          <div className="text-muted small">Nenhum cargo/comportamento aprovado foi encontrado para este nicho.</div>
+        ) : (
+          <div className="row g-3">
+            {(["JOB_TITLE", "BEHAVIOR"] as const).map((type) => (
+              <div key={type} className="col-12 col-lg-6">
+                <div className="border rounded p-3 h-100">
+                  <h6 className="mb-2">{TYPE_LABEL[type]}</h6>
+                  <div className="d-flex flex-column gap-2">
+                    {grouped[type].map((item) => {
+                      const key = buildKey(item);
+                      return (
+                        <div className="form-check" key={key}>
+                          <input
+                            id={key}
+                            className="form-check-input"
+                            type="checkbox"
+                            checked={selected.has(key)}
+                            onChange={() => toggleSelection(item)}
+                            disabled={saveSelections.isPending}
+                          />
+                          <label htmlFor={key} className="form-check-label">
+                            {item.term}
+                          </label>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="d-flex justify-content-end">
+          <button className="btn btn-primary" onClick={handleSave} disabled={saveSelections.isPending || isLoading}>
+            {saveSelections.isPending ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+                Salvando...
+              </span>
+            ) : (
+              "Salvar público"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -29,6 +29,7 @@ import ExperimentFunnelTab from "./ExperimentFunnelTab";
 import ExperimentReportPanel from "./ExperimentReportPanel";
 import ExperimentLearningPanel from "./ExperimentLearningPanel";
 import ExperimentContentGenerationTab from "./ExperimentContentGenerationTab";
+import { ExperimentAudienceTab } from "./ExperimentAudienceTab";
 import LandingTab from "./LandingTab";
 import CollapsibleJsonViewer from "../../components/CollapsibleJsonViewer";
 import { useExperimentFacebookRelease } from "../../api/experiment/useExperimentFacebookRelease";
@@ -1904,6 +1905,9 @@ export default function ExperimentDetailPage() {
             <Tabs.Trigger value="conteudo" className="nav-link">
               Conteúdo
             </Tabs.Trigger>
+            <Tabs.Trigger value="publico" className="nav-link">
+              Público
+            </Tabs.Trigger>
           </Tabs.List>
           <Tabs.Content value="overview" asChild>
             <div className="d-flex flex-column gap-3">
@@ -2690,6 +2694,9 @@ export default function ExperimentDetailPage() {
               campaignAngle={data?.campaignAngle}
               adCopy={data?.adCopy}
             />
+          </Tabs.Content>
+          <Tabs.Content value="publico" asChild>
+            <ExperimentAudienceTab experimentId={expId} nicheId={data?.marketNicheId} />
           </Tabs.Content>
           <Tabs.Content value="conteudo" asChild>
             <div className="d-flex flex-column gap-3">


### PR DESCRIPTION
### Motivation
- Permitir que o time marque, a partir da tela do experimento, quais cargos e comportamentos aprovados no nicho devem compor o público da campanha sem criar novos termos. 

### Description
- Adicionada nova aba `Público` na tela de detalhe do experimento em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` que renderiza o componente `ExperimentAudienceTab`.
- Criado `frontend/src/pages/experiment/ExperimentAudienceTab.tsx` que lista apenas segmentações do nicho com `status: "APPROVED"` e filtra pelos tipos `JOB_TITLE` e `BEHAVIOR`.
- Seleção por checkbox com persistência usando os hooks/contratos existentes `useExperimentTargetingSelections` e `useSaveExperimentTargetingSelections`, e leitura via `useTargetingElementsByNiche` (sem novos endpoints); ao salvar `JOB_TITLE` é convertido para `WORK_POSITION` como esperado pelo backend.
- UX: botão `Salvar público` com estado de carregamento e bloqueio durante requisição assíncrona, e mensagens de aviso quando não há nicho ou não existem itens aprovados.

### Testing
- Executado `cd frontend && npm run -s build`, que falhou no ambiente de CI local com erro `vite: not found`; portanto o build não pôde ser validado aqui.
- Não foram executados outros testes automatizados nesta rodada (nenhum teste unitário/end-to-end rodado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e30d6cd88321a22b18ff541262c1)