### PR TITLE
Remover aba "Portal do Lead" da tela de detalhes do experimento

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -24,7 +24,6 @@ import {
   useExperimentCampaignResetPreview,
   type ExperimentCampaignResetSummary,
 } from "../../api/experiment/useExperimentCampaignReset";
-import LeadPortalFlowTab from "./LeadPortalFlowTab";
 import ExperimentFunnelTab from "./ExperimentFunnelTab";
 import ExperimentReportPanel from "./ExperimentReportPanel";
 import ExperimentLearningPanel from "./ExperimentLearningPanel";
@@ -1167,9 +1166,9 @@ export default function ExperimentDetailPage() {
         ? leadPortalFlowLabel
           ? `Fluxo ${leadPortalFlowLabel} vinculado ao experimento.`
           : "Já existe um fluxo do Portal do Lead vinculado."
-        : "Solicite ou vincule um fluxo aprovado na aba Portal do Lead.",
-      action: hasLeadPortalFlow ? undefined : () => setTab("lead-portal"),
-      actionLabel: hasLeadPortalFlow ? undefined : "Ir para Portal do Lead",
+        : "Solicite ou vincule um fluxo aprovado para o experimento.",
+      action: undefined,
+      actionLabel: undefined,
     },
   ];
 
@@ -1895,9 +1894,6 @@ export default function ExperimentDetailPage() {
             </Tabs.Trigger>
             <Tabs.Trigger value="gera-landing" className="nav-link">
               Gera landing
-            </Tabs.Trigger>
-            <Tabs.Trigger value="lead-portal" className="nav-link">
-              Portal do Lead
             </Tabs.Trigger>
             <Tabs.Trigger value="content-structure" className="nav-link">
               Estrutura de conteúdo
@@ -2682,9 +2678,6 @@ export default function ExperimentDetailPage() {
                 </div>
               </div>
             </div>
-          </Tabs.Content>
-          <Tabs.Content value="lead-portal" asChild>
-            <LeadPortalFlowTab experiment={data} />
           </Tabs.Content>
           <Tabs.Content value="content-structure" asChild>
             <ExperimentContentGenerationTab


### PR DESCRIPTION
### Motivation
- Atender à solicitação de ocultar a aba do Portal do Lead na tela de detalhe do experimento (`/experiments/:id`).
- Evitar navegação ou ações que apontem para uma aba removida, mantendo a consistência do checklist de pré-condições.

### Description
- Removi a importação e a renderização do componente `LeadPortalFlowTab` em `frontend/src/pages/experiment/ExperimentDetailPage.tsx`.
- Removi o `Tabs.Trigger` com `value="lead-portal"` da lista de abas para que a aba não seja mais exibida.
- Removi o `Tabs.Content` com `value="lead-portal"` para evitar qualquer renderização do conteúdo associado.
- Ajustei o item `lead-portal-flow` do `blockingChecklist` para remover as ações de navegação (`setTab("lead-portal")`) e atualizei a mensagem de hint.

### Testing
- Executei `npm run lint` no diretório `frontend`, que falhou por não existir o script `lint` no `package.json` (falha de configuração do ambiente, não relacionada à alteração).
- Executei `npm run typecheck` (`tsc --noEmit`) no `frontend`, que falhou por problemas de tipagens/ambiente (erros: falta de definições de tipo para `@testing-library/jest-dom`, `vite/client`, `vitest/globals` e avisos de opções de `tsconfig.json` depreciadas), sem relação direta com a modificação do código.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e5d24ec48321818da4f43a5552ed)