### PR TITLE
Add processing job table and job endpoints for sales-library ingest

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/dto/MoisSalesLibraryDtos.java
@@ -34,6 +34,30 @@ public final class MoisSalesLibraryDtos {
     }
 
 
+
+    public record SalesLibraryJobResponse(
+            long id,
+            long urlIngestId,
+            String status,
+            int attempts,
+            String errorCategory,
+            String errorMessage,
+            Instant nextRetryAt,
+            Instant createdAt,
+            Instant updatedAt,
+            Instant startedAt,
+            Instant finishedAt
+    ) {
+    }
+
+    public record SalesLibraryJobPageResponse(
+            int page,
+            int pageSize,
+            long total,
+            List<SalesLibraryJobResponse> items
+    ) {
+    }
+
     public record SalesLibraryEntryResponse(
             long id,
             String workspaceId,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibraryService.java
@@ -11,13 +11,17 @@ import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MoisSalesLibraryService {
 
+    private static final String JOB_STATUS_PENDING = "PENDING";
+
     private final JdbcTemplate jdbcTemplate;
 
+    @Transactional
     public MoisSalesLibraryDtos.SalesLibraryIngestResponse ingestUrls(MoisSalesLibraryDtos.SalesLibraryIngestRequest request) {
         int persisted = 0;
         String normalizedSource = request.source().trim().toUpperCase(Locale.ROOT);
@@ -49,6 +53,28 @@ public class MoisSalesLibraryService {
                     capturedAtUtc,
                     capturedAtUtc
             );
+
+            Long urlIngestId = jdbcTemplate.queryForObject(
+                    """
+                            SELECT id
+                            FROM mois_sales_library_url_ingest
+                            WHERE url_canonical = ?
+                            LIMIT 1
+                            """,
+                    Long.class,
+                    canonical
+            );
+            if (urlIngestId != null) {
+                jdbcTemplate.update(
+                        """
+                                INSERT INTO mois_sales_library_processing_job
+                                (url_ingest_id, status, attempts, created_at, updated_at)
+                                VALUES (?, ?, 0, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                                """,
+                        urlIngestId,
+                        JOB_STATUS_PENDING
+                );
+            }
             persisted++;
         }
 
@@ -60,7 +86,88 @@ public class MoisSalesLibraryService {
         );
     }
 
+    public MoisSalesLibraryDtos.SalesLibraryJobResponse getJob(long jobId) {
+        List<MoisSalesLibraryDtos.SalesLibraryJobResponse> rows = jdbcTemplate.query(
+                """
+                        SELECT id, url_ingest_id, status, attempts, error_category, error_message,
+                               next_retry_at, created_at, updated_at, started_at, finished_at
+                        FROM mois_sales_library_processing_job
+                        WHERE id = ?
+                        LIMIT 1
+                        """,
+                (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryJobResponse(
+                        rs.getLong("id"),
+                        rs.getLong("url_ingest_id"),
+                        rs.getString("status"),
+                        rs.getInt("attempts"),
+                        rs.getString("error_category"),
+                        rs.getString("error_message"),
+                        toInstant(rs.getTimestamp("next_retry_at")),
+                        toInstant(rs.getTimestamp("created_at")),
+                        toInstant(rs.getTimestamp("updated_at")),
+                        toInstant(rs.getTimestamp("started_at")),
+                        toInstant(rs.getTimestamp("finished_at"))
+                ),
+                jobId
+        );
+        if (rows.isEmpty()) {
+            throw new IllegalArgumentException("Job not found: " + jobId);
+        }
+        return rows.get(0);
+    }
 
+    public MoisSalesLibraryDtos.SalesLibraryJobPageResponse listJobs(String workspaceId, String status, int page, int pageSize) {
+        int normalizedPage = Math.max(1, page);
+        int normalizedPageSize = Math.max(1, Math.min(pageSize, 100));
+        int offset = (normalizedPage - 1) * normalizedPageSize;
+
+        String normalizedStatus = status == null || status.isBlank() ? null : status.trim().toUpperCase(Locale.ROOT);
+        String statusClause = normalizedStatus == null ? "" : " AND j.status = ?";
+
+        Long total = jdbcTemplate.queryForObject(
+                """
+                        SELECT COUNT(*)
+                        FROM mois_sales_library_processing_job j
+                        JOIN mois_sales_library_url_ingest i ON i.id = j.url_ingest_id
+                        WHERE i.workspace_id = ?
+                        """ + statusClause,
+                Long.class,
+                normalizedStatus == null ? new Object[]{workspaceId} : new Object[]{workspaceId, normalizedStatus}
+        );
+
+        List<MoisSalesLibraryDtos.SalesLibraryJobResponse> items = jdbcTemplate.query(
+                """
+                        SELECT j.id, j.url_ingest_id, j.status, j.attempts, j.error_category, j.error_message,
+                               j.next_retry_at, j.created_at, j.updated_at, j.started_at, j.finished_at
+                        FROM mois_sales_library_processing_job j
+                        JOIN mois_sales_library_url_ingest i ON i.id = j.url_ingest_id
+                        WHERE i.workspace_id = ?
+                        """ + statusClause + " ORDER BY j.updated_at DESC LIMIT ? OFFSET ?",
+                (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryJobResponse(
+                        rs.getLong("id"),
+                        rs.getLong("url_ingest_id"),
+                        rs.getString("status"),
+                        rs.getInt("attempts"),
+                        rs.getString("error_category"),
+                        rs.getString("error_message"),
+                        toInstant(rs.getTimestamp("next_retry_at")),
+                        toInstant(rs.getTimestamp("created_at")),
+                        toInstant(rs.getTimestamp("updated_at")),
+                        toInstant(rs.getTimestamp("started_at")),
+                        toInstant(rs.getTimestamp("finished_at"))
+                ),
+                normalizedStatus == null
+                        ? new Object[]{workspaceId, normalizedPageSize, offset}
+                        : new Object[]{workspaceId, normalizedStatus, normalizedPageSize, offset}
+        );
+
+        return new MoisSalesLibraryDtos.SalesLibraryJobPageResponse(
+                normalizedPage,
+                normalizedPageSize,
+                total == null ? 0 : total,
+                items
+        );
+    }
 
     public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(String workspaceId, int page, int pageSize) {
         int normalizedPage = Math.max(1, page);
@@ -134,4 +241,3 @@ public class MoisSalesLibraryService {
         return timestamp == null ? null : timestamp.toInstant();
     }
 }
-

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
@@ -3,16 +3,18 @@ package com.marketinghub.mois.biblioteca.web;
 import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
 import com.marketinghub.mois.biblioteca.service.MoisSalesLibraryService;
 import jakarta.validation.Valid;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.GetMapping;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/mois/sales-library")
@@ -22,8 +24,6 @@ public class MoisSalesLibraryController {
 
     private final MoisSalesLibraryService service;
 
-
-
     @GetMapping("/entries")
     public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(
             @RequestParam String workspaceId,
@@ -31,6 +31,25 @@ public class MoisSalesLibraryController {
             @RequestParam(defaultValue = "20") int pageSize
     ) {
         return service.listEntries(workspaceId, page, pageSize);
+    }
+
+    @GetMapping("/jobs")
+    public MoisSalesLibraryDtos.SalesLibraryJobPageResponse listJobs(
+            @RequestParam String workspaceId,
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize
+    ) {
+        return service.listJobs(workspaceId, status, page, pageSize);
+    }
+
+    @GetMapping("/jobs/{jobId}")
+    public MoisSalesLibraryDtos.SalesLibraryJobResponse getJob(@PathVariable long jobId) {
+        try {
+            return service.getJob(jobId);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        }
     }
 
     @PostMapping("/urls:ingest")

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-16-mois-sales-library-processing-job.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-16-mois-sales-library-processing-job.yaml
@@ -1,0 +1,36 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-16-mois-sales-library-processing-job-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: mois_sales_library_processing_job
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_library_processing_job (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                url_ingest_id BIGINT NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                attempts INT NOT NULL DEFAULT 0,
+                error_category VARCHAR(80) NULL,
+                error_message VARCHAR(1000) NULL,
+                next_retry_at DATETIME NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                started_at DATETIME NULL,
+                finished_at DATETIME NULL,
+                PRIMARY KEY (id),
+                KEY idx_mois_sales_library_job_status_updated (status, updated_at),
+                KEY idx_mois_sales_library_job_url_ingest (url_ingest_id),
+                CONSTRAINT fk_mois_sales_library_job_url_ingest
+                  FOREIGN KEY (url_ingest_id) REFERENCES mois_sales_library_url_ingest(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,9 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-05-16-mois-sales-library-processing-job.yaml
+      relativeToChangelogFile: true
+
+  - include:
       file: changesets/2026-05-15-experiment-landing-deliverables.yaml
       relativeToChangelogFile: true
 

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -653,3 +653,16 @@ Para suportar o gerenciamento administrativo de ocupações no módulo OPRM (cad
 - Endpoint backend de ingestão: `POST /api/mois/sales-library/urls:ingest`.
 - Regra de unicidade: `url_canonical` (URL canônica única na biblioteca, independente de `workspace_id` e `source`).
 - Regra operacional: o coletor envia URL para o backend principal; somente o backend persiste no banco.
+
+## MOIS — Biblioteca de páginas de vendas (jobs de processamento, 2026-05-16)
+
+- Nova tabela backend: `mois_sales_library_processing_job`.
+- Objetivo: registrar a fila de processamento assíncrono por URL ingerida da biblioteca de sales pages.
+- Relacionamento: `mois_sales_library_processing_job.url_ingest_id -> mois_sales_library_url_ingest.id`.
+- Estados operacionais iniciais suportados: `PENDING` (com evolução prevista para `FETCHING`, `FETCHED`, `ANALYZING`, `DONE`, `FAILED`, `RETRY_SCHEDULED`).
+- Colunas operacionais: `status`, `attempts`, `error_category`, `error_message`, `next_retry_at`, `started_at`, `finished_at`, `created_at`, `updated_at`.
+- Índices operacionais: `(status, updated_at)` para observabilidade de fila e `url_ingest_id` para correlação por URL.
+- Endpoints backend adicionados para observabilidade:
+  - `GET /api/mois/sales-library/jobs/{jobId}`
+  - `GET /api/mois/sales-library/jobs?workspaceId=...&status=...`
+- Regra operacional: cada ingestão válida em `POST /api/mois/sales-library/urls:ingest` também cria um job inicial `PENDING`.


### PR DESCRIPTION
### Motivation

- Support asynchronous processing of ingested sales-library URLs by recording per-URL processing jobs and exposing observability endpoints.

### Description

- Added new Liquibase changeset to create `mois_sales_library_processing_job` with FK to `mois_sales_library_url_ingest`, operational columns, and indexes, and included it in the master changelog.
- Extended DTOs with `SalesLibraryJobResponse` and `SalesLibraryJobPageResponse` to model job details and paged responses.
- Updated `MoisSalesLibraryService` to mark `ingestUrls` as transactional and to enqueue a `PENDING` job for each persisted URL, and added `getJob` and `listJobs` methods to fetch single job details and paginated job lists filtered by `workspaceId` and optional `status`.
- Added controller endpoints `GET /api/mois/sales-library/jobs` and `GET /api/mois/sales-library/jobs/{jobId}` with 404 mapping for missing jobs and preserved the existing ingest endpoint behavior.
- Documented the new processing-job model and endpoints in `docs/modelo-dados-experimento.md`.

### Testing

- No new automated tests were added for the feature, and the existing automated backend test suite was executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e3515f6883219cec0bb7ff0edf39)