### PR TITLE
fix(frontend): correct Audience tab ids on Experiment detail

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -2689,7 +2689,7 @@ export default function ExperimentDetailPage() {
             />
           </Tabs.Content>
           <Tabs.Content value="publico" asChild>
-            <ExperimentAudienceTab experimentId={expId} nicheId={data?.marketNicheId} />
+            <ExperimentAudienceTab experimentId={Number(expId)} nicheId={data?.nicheId} />
           </Tabs.Content>
           <Tabs.Content value="conteudo" asChild>
             <div className="d-flex flex-column gap-3">


### PR DESCRIPTION
### Motivation
- Fix TypeScript type errors when rendering the Audience tab by aligning props passed from `ExperimentDetailPage` with the `ExperimentAudienceTab` prop types and the `Experiment` DTO.

### Description
- Replace `experimentId={expId}` with `experimentId={Number(expId)}` and `nicheId={data?.marketNicheId}` with `nicheId={data?.nicheId}` in `frontend/src/pages/experiment/ExperimentDetailPage.tsx` to match the expected numeric `experimentId` and the actual `Experiment` field names.

### Testing
- Ran `npm run typecheck` in `frontend/` and verified the original errors (`TS2322: string not assignable to number` and `TS2339: Property 'marketNicheId' does not exist on type 'Experiment'`) are resolved; the typecheck still fails due to unrelated environment/tooling issues (missing type definitions for `@testing-library/jest-dom`, `vite/client`, `vitest/globals` and TypeScript deprecation warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e8cefd388321ab5d0206180a19e6)