### PR TITLE
docs: designate canonical registro for MOIS collectors and add required template

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -1,5 +1,8 @@
 # Registros — MOIS
 
+> ⚠️ Para alterações operacionais dos coletores MOIS (Hotmart/ClickBank), use como arquivo canônico principal: `docs/registros/coletor-mois1.md`.
+> Este arquivo `docs/mois/registros.md` permanece para registros gerais do módulo MOIS que não sejam do coletor.
+
 > Orientação: todos os registros deste documento devem sempre incluir **data e hora no fuso UTC-3**.
 > Neste documento segue política de **append-only** (não pode ter nenhuma linha apagada; apenas inserções).
 

--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -1,5 +1,18 @@
 # Registros — Coletor Mois
 
+> 🔴 **Arquivo canônico principal (atual)** para registro operacional dos módulos coletores do MOIS.
+> Toda alteração em `mois-hotmart-collector` e `mois-clickbank-collector` deve ser registrada neste arquivo.
+> Em caso de dúvida entre arquivos de registro, este é o ponto único de verdade.
+
+## Template obrigatório de novo registro
+
+```md
+## YYYY-MM-DD HH:mm:ss UTC-3
+- descrição breve do problema
+- descrição breve do raciocínio para a solução
+- registro do que foi feito
+```
+
 > Orientação: todos os registros deste documento devem sempre incluir **data e hora no fuso UTC-3**.
 > Neste documento segue política de **append-only** (não pode ter nenhuma linha apagada; apenas inserções).
 
@@ -214,3 +227,13 @@
 - Adicionados logs detalhados no método `publishSalesPagesToLibrary` do coletor Hotmart para diagnóstico da ingestão na biblioteca.
 - Incluído log de início do método, contagem de produtos elegíveis vs. sem URL e log do payload JSON enviado para `POST /api/mois/sales-library/urls:ingest` (com truncamento para segurança operacional).
 - Ajustado envio HTTP para reutilizar o mesmo `payloadJson` registrado em log, garantindo rastreabilidade exata entre payload logado e payload transmitido.
+
+## 2026-05-16 19:07:15 UTC-3
+- havia ambiguidade sobre o arquivo oficial de registro dos módulos coletores MOIS, causando dispersão de lançamentos entre documentos diferentes.
+- para eliminar a causa-raiz, foi definido um único ponto canônico explícito e um template obrigatório único no topo do arquivo.
+- atualizado  com bloco de governança de "arquivo canônico principal" e template obrigatório; atualizado  com aviso de redirecionamento para o arquivo canônico dos coletores.
+
+## 2026-05-16 19:07:23 UTC-3
+- havia ambiguidade sobre o arquivo oficial de registro dos módulos coletores MOIS, causando dispersão de lançamentos entre documentos diferentes.
+- para eliminar a causa-raiz, foi definido um único ponto canônico explícito e um template obrigatório único no topo do arquivo.
+- atualizado docs/registros/coletor-mois1.md com bloco de governança de "arquivo canônico principal" e template obrigatório; atualizado docs/mois/registros.md com aviso de redirecionamento para o arquivo canônico dos coletores.


### PR DESCRIPTION
### Motivation
- There was ambiguity about which file should contain operational records for MOIS collectors, causing dispersed and inconsistent entries across documents.
- The change centralizes collector operational records to eliminate divergence and enforce a single source of truth.
- A consistent template and guidance are required to ensure all collector records include the required UTC-3 timestamp and follow the append-only policy.

### Description
- Added a redirect/notice to `docs/mois/registros.md` pointing collectors' operational changes to the canonical file `docs/registros/coletor-mois1.md`.
- Updated `docs/registros/coletor-mois1.md` to declare it as the canonical file for collector modules, inserted a mandatory record template, and included governance text clarifying its authority.
- Appended two new timestamped entries to `docs/registros/coletor-mois1.md` documenting the resolution of the ambiguity and the redirection change.

### Testing
- Documentation-only change; no automated unit tests were modified or required to validate these edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e95712d08321ab72fa24eda2d0b2)