### PR TITLE
Add sales-library page analysis table, DTOs, APIs and reanalyze job support

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/dto/MoisSalesLibraryDtos.java
@@ -3,6 +3,7 @@ package com.marketinghub.mois.biblioteca.dto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 
@@ -32,8 +33,6 @@ public final class MoisSalesLibraryDtos {
             int persisted
     ) {
     }
-
-
 
     public record SalesLibraryJobResponse(
             long id,
@@ -80,4 +79,51 @@ public final class MoisSalesLibraryDtos {
     ) {
     }
 
+    public record SalesLibraryPageResponse(
+            long pageId,
+            String workspaceId,
+            String source,
+            String urlCanonical,
+            String title,
+            String analysisStatus,
+            BigDecimal scoreTotal,
+            Instant analyzedAt,
+            Instant updatedAt
+    ) {
+    }
+
+    public record SalesLibraryPageListResponse(
+            int page,
+            int pageSize,
+            long total,
+            List<SalesLibraryPageResponse> items
+    ) {
+    }
+
+    public record SalesLibraryPageAnalysisResponse(
+            long analysisId,
+            long pageId,
+            Long jobId,
+            String status,
+            BigDecimal scoreTotal,
+            String parserVersion,
+            String promptVersion,
+            String modelName,
+            String sectionsJson,
+            String copyJson,
+            String visualJson,
+            String imageJson,
+            String analysisNotes,
+            Instant analyzedAt,
+            Instant updatedAt
+    ) {
+    }
+
+    public record SalesLibraryReanalyzeResponse(
+            long pageId,
+            long jobId,
+            String status,
+            Instant createdAt
+    ) {
+    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibraryService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.mois.biblioteca.service;
 
 import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
+import java.math.BigDecimal;
 import java.net.URI;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -65,15 +66,7 @@ public class MoisSalesLibraryService {
                     canonical
             );
             if (urlIngestId != null) {
-                jdbcTemplate.update(
-                        """
-                                INSERT INTO mois_sales_library_processing_job
-                                (url_ingest_id, status, attempts, created_at, updated_at)
-                                VALUES (?, ?, 0, UTC_TIMESTAMP(), UTC_TIMESTAMP())
-                                """,
-                        urlIngestId,
-                        JOB_STATUS_PENDING
-                );
+                createPendingJob(urlIngestId);
             }
             persisted++;
         }
@@ -86,30 +79,19 @@ public class MoisSalesLibraryService {
         );
     }
 
-    public MoisSalesLibraryDtos.SalesLibraryJobResponse getJob(long jobId) {
-        List<MoisSalesLibraryDtos.SalesLibraryJobResponse> rows = jdbcTemplate.query(
-                """
+    public MoisSalesLibraryDtos.SalesLibraryJobResponse getJob(long jobId) { /* unchanged simplified */
+        List<MoisSalesLibraryDtos.SalesLibraryJobResponse> rows = jdbcTemplate.query("""
                         SELECT id, url_ingest_id, status, attempts, error_category, error_message,
                                next_retry_at, created_at, updated_at, started_at, finished_at
                         FROM mois_sales_library_processing_job
                         WHERE id = ?
                         LIMIT 1
-                        """,
-                (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryJobResponse(
-                        rs.getLong("id"),
-                        rs.getLong("url_ingest_id"),
-                        rs.getString("status"),
-                        rs.getInt("attempts"),
-                        rs.getString("error_category"),
-                        rs.getString("error_message"),
-                        toInstant(rs.getTimestamp("next_retry_at")),
-                        toInstant(rs.getTimestamp("created_at")),
-                        toInstant(rs.getTimestamp("updated_at")),
-                        toInstant(rs.getTimestamp("started_at")),
-                        toInstant(rs.getTimestamp("finished_at"))
-                ),
-                jobId
-        );
+                        """, (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryJobResponse(
+                        rs.getLong("id"), rs.getLong("url_ingest_id"), rs.getString("status"),
+                        rs.getInt("attempts"), rs.getString("error_category"), rs.getString("error_message"),
+                        toInstant(rs.getTimestamp("next_retry_at")), toInstant(rs.getTimestamp("created_at")),
+                        toInstant(rs.getTimestamp("updated_at")), toInstant(rs.getTimestamp("started_at")),
+                        toInstant(rs.getTimestamp("finished_at"))), jobId);
         if (rows.isEmpty()) {
             throw new IllegalArgumentException("Job not found: " + jobId);
         }
@@ -120,124 +102,120 @@ public class MoisSalesLibraryService {
         int normalizedPage = Math.max(1, page);
         int normalizedPageSize = Math.max(1, Math.min(pageSize, 100));
         int offset = (normalizedPage - 1) * normalizedPageSize;
-
         String normalizedStatus = status == null || status.isBlank() ? null : status.trim().toUpperCase(Locale.ROOT);
         String statusClause = normalizedStatus == null ? "" : " AND j.status = ?";
-
-        Long total = jdbcTemplate.queryForObject(
-                """
-                        SELECT COUNT(*)
-                        FROM mois_sales_library_processing_job j
+        Long total = jdbcTemplate.queryForObject("""
+                        SELECT COUNT(*) FROM mois_sales_library_processing_job j
                         JOIN mois_sales_library_url_ingest i ON i.id = j.url_ingest_id
                         WHERE i.workspace_id = ?
                         """ + statusClause,
-                Long.class,
-                normalizedStatus == null ? new Object[]{workspaceId} : new Object[]{workspaceId, normalizedStatus}
-        );
-
-        List<MoisSalesLibraryDtos.SalesLibraryJobResponse> items = jdbcTemplate.query(
-                """
+                Long.class, normalizedStatus == null ? new Object[]{workspaceId} : new Object[]{workspaceId, normalizedStatus});
+        List<MoisSalesLibraryDtos.SalesLibraryJobResponse> items = jdbcTemplate.query("""
                         SELECT j.id, j.url_ingest_id, j.status, j.attempts, j.error_category, j.error_message,
                                j.next_retry_at, j.created_at, j.updated_at, j.started_at, j.finished_at
                         FROM mois_sales_library_processing_job j
                         JOIN mois_sales_library_url_ingest i ON i.id = j.url_ingest_id
                         WHERE i.workspace_id = ?
                         """ + statusClause + " ORDER BY j.updated_at DESC LIMIT ? OFFSET ?",
-                (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryJobResponse(
-                        rs.getLong("id"),
-                        rs.getLong("url_ingest_id"),
-                        rs.getString("status"),
-                        rs.getInt("attempts"),
-                        rs.getString("error_category"),
-                        rs.getString("error_message"),
-                        toInstant(rs.getTimestamp("next_retry_at")),
-                        toInstant(rs.getTimestamp("created_at")),
-                        toInstant(rs.getTimestamp("updated_at")),
-                        toInstant(rs.getTimestamp("started_at")),
-                        toInstant(rs.getTimestamp("finished_at"))
-                ),
-                normalizedStatus == null
-                        ? new Object[]{workspaceId, normalizedPageSize, offset}
-                        : new Object[]{workspaceId, normalizedStatus, normalizedPageSize, offset}
-        );
-
-        return new MoisSalesLibraryDtos.SalesLibraryJobPageResponse(
-                normalizedPage,
-                normalizedPageSize,
-                total == null ? 0 : total,
-                items
-        );
+                (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryJobResponse(rs.getLong("id"), rs.getLong("url_ingest_id"),
+                        rs.getString("status"), rs.getInt("attempts"), rs.getString("error_category"), rs.getString("error_message"),
+                        toInstant(rs.getTimestamp("next_retry_at")), toInstant(rs.getTimestamp("created_at")),
+                        toInstant(rs.getTimestamp("updated_at")), toInstant(rs.getTimestamp("started_at")),
+                        toInstant(rs.getTimestamp("finished_at"))),
+                normalizedStatus == null ? new Object[]{workspaceId, normalizedPageSize, offset} : new Object[]{workspaceId, normalizedStatus, normalizedPageSize, offset});
+        return new MoisSalesLibraryDtos.SalesLibraryJobPageResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }
 
-    public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(String workspaceId, int page, int pageSize) {
-        int normalizedPage = Math.max(1, page);
-        int normalizedPageSize = Math.max(1, Math.min(pageSize, 100));
-        int offset = (normalizedPage - 1) * normalizedPageSize;
-
-        Long total = jdbcTemplate.queryForObject(
-                """
-                        SELECT COUNT(*)
-                        FROM mois_sales_library_url_ingest
-                        WHERE workspace_id = ?
-                        """,
-                Long.class,
-                workspaceId
-        );
-
-        List<MoisSalesLibraryDtos.SalesLibraryEntryResponse> items = jdbcTemplate.query(
-                """
+    public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(String workspaceId, int page, int pageSize) { /* keep */
+        int normalizedPage = Math.max(1, page); int normalizedPageSize = Math.max(1, Math.min(pageSize, 100)); int offset = (normalizedPage - 1) * normalizedPageSize;
+        Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE workspace_id = ?", Long.class, workspaceId);
+        List<MoisSalesLibraryDtos.SalesLibraryEntryResponse> items = jdbcTemplate.query("""
                         SELECT id, workspace_id, source, url_original, url_canonical, title, ingest_count,
                                first_captured_at, last_captured_at, updated_at
                         FROM mois_sales_library_url_ingest
-                        WHERE workspace_id = ?
-                        ORDER BY updated_at DESC
-                        LIMIT ? OFFSET ?
-                        """,
-                (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryEntryResponse(
-                        rs.getLong("id"),
-                        rs.getString("workspace_id"),
-                        rs.getString("source"),
-                        rs.getString("url_original"),
-                        rs.getString("url_canonical"),
-                        rs.getString("title"),
-                        rs.getInt("ingest_count"),
-                        toInstant(rs.getTimestamp("first_captured_at")),
-                        toInstant(rs.getTimestamp("last_captured_at")),
-                        toInstant(rs.getTimestamp("updated_at"))
-                ),
-                workspaceId,
-                normalizedPageSize,
-                offset
-        );
-
-        return new MoisSalesLibraryDtos.SalesLibraryEntryPageResponse(
-                normalizedPage,
-                normalizedPageSize,
-                total == null ? 0 : total,
-                items
-        );
+                        WHERE workspace_id = ? ORDER BY updated_at DESC LIMIT ? OFFSET ?
+                        """, (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryEntryResponse(
+                        rs.getLong("id"), rs.getString("workspace_id"), rs.getString("source"), rs.getString("url_original"),
+                        rs.getString("url_canonical"), rs.getString("title"), rs.getInt("ingest_count"),
+                        toInstant(rs.getTimestamp("first_captured_at")), toInstant(rs.getTimestamp("last_captured_at")),
+                        toInstant(rs.getTimestamp("updated_at"))), workspaceId, normalizedPageSize, offset);
+        return new MoisSalesLibraryDtos.SalesLibraryEntryPageResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }
 
-    private String canonicalize(String rawUrl) {
-        if (rawUrl == null || rawUrl.isBlank()) {
-            return null;
-        }
-        try {
-            URI uri = URI.create(rawUrl.trim());
-            String scheme = uri.getScheme() == null ? "https" : uri.getScheme().toLowerCase(Locale.ROOT);
-            String host = uri.getHost();
-            if (host == null || host.isBlank()) {
-                return rawUrl.trim();
-            }
-            String normalizedHost = host.toLowerCase(Locale.ROOT);
-            String path = (uri.getPath() == null || uri.getPath().isBlank()) ? "/" : uri.getPath();
-            return scheme + "://" + normalizedHost + path;
-        } catch (Exception ignored) {
-            return rawUrl.trim();
-        }
+    public MoisSalesLibraryDtos.SalesLibraryPageListResponse listPages(String workspaceId, int page, int pageSize) {
+        int normalizedPage = Math.max(1, page); int normalizedPageSize = Math.max(1, Math.min(pageSize, 100)); int offset = (normalizedPage - 1) * normalizedPageSize;
+        Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE workspace_id = ?", Long.class, workspaceId);
+        List<MoisSalesLibraryDtos.SalesLibraryPageResponse> items = jdbcTemplate.query("""
+                SELECT i.id, i.workspace_id, i.source, i.url_canonical, i.title, i.updated_at,
+                       a.status AS analysis_status, a.score_total, a.analyzed_at
+                FROM mois_sales_library_url_ingest i
+                LEFT JOIN mois_sales_library_page_analysis a ON a.id = (
+                    SELECT a2.id FROM mois_sales_library_page_analysis a2
+                    WHERE a2.url_ingest_id = i.id ORDER BY a2.updated_at DESC LIMIT 1
+                )
+                WHERE i.workspace_id = ?
+                ORDER BY i.updated_at DESC LIMIT ? OFFSET ?
+                """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageResponse(
+                rs.getLong("id"), rs.getString("workspace_id"), rs.getString("source"), rs.getString("url_canonical"),
+                rs.getString("title"), rs.getString("analysis_status"), rs.getBigDecimal("score_total"),
+                toInstant(rs.getTimestamp("analyzed_at")), toInstant(rs.getTimestamp("updated_at"))), workspaceId, normalizedPageSize, offset);
+        return new MoisSalesLibraryDtos.SalesLibraryPageListResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }
 
-    private Instant toInstant(Timestamp timestamp) {
-        return timestamp == null ? null : timestamp.toInstant();
+    public MoisSalesLibraryDtos.SalesLibraryPageResponse getPage(long pageId) {
+        List<MoisSalesLibraryDtos.SalesLibraryPageResponse> rows = jdbcTemplate.query("""
+                SELECT i.id, i.workspace_id, i.source, i.url_canonical, i.title, i.updated_at,
+                       a.status AS analysis_status, a.score_total, a.analyzed_at
+                FROM mois_sales_library_url_ingest i
+                LEFT JOIN mois_sales_library_page_analysis a ON a.id = (
+                    SELECT a2.id FROM mois_sales_library_page_analysis a2
+                    WHERE a2.url_ingest_id = i.id ORDER BY a2.updated_at DESC LIMIT 1
+                )
+                WHERE i.id = ? LIMIT 1
+                """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageResponse(
+                rs.getLong("id"), rs.getString("workspace_id"), rs.getString("source"), rs.getString("url_canonical"),
+                rs.getString("title"), rs.getString("analysis_status"), rs.getBigDecimal("score_total"),
+                toInstant(rs.getTimestamp("analyzed_at")), toInstant(rs.getTimestamp("updated_at"))), pageId);
+        if (rows.isEmpty()) throw new IllegalArgumentException("Page not found: " + pageId);
+        return rows.get(0);
     }
+
+    public MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse getPageAnalysis(long pageId) {
+        List<MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse> rows = jdbcTemplate.query("""
+                SELECT a.id, a.url_ingest_id, a.job_id, a.status, a.score_total, a.parser_version,
+                       a.prompt_version, a.model_name, a.sections_json, a.copy_json, a.visual_json,
+                       a.image_json, a.analysis_notes, a.analyzed_at, a.updated_at
+                FROM mois_sales_library_page_analysis a
+                WHERE a.url_ingest_id = ? ORDER BY a.updated_at DESC LIMIT 1
+                """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse(
+                rs.getLong("id"), rs.getLong("url_ingest_id"), rs.getObject("job_id", Long.class),
+                rs.getString("status"), rs.getBigDecimal("score_total"), rs.getString("parser_version"),
+                rs.getString("prompt_version"), rs.getString("model_name"), rs.getString("sections_json"),
+                rs.getString("copy_json"), rs.getString("visual_json"), rs.getString("image_json"),
+                rs.getString("analysis_notes"), toInstant(rs.getTimestamp("analyzed_at")), toInstant(rs.getTimestamp("updated_at"))), pageId);
+        if (rows.isEmpty()) throw new IllegalArgumentException("Analysis not found for page: " + pageId);
+        return rows.get(0);
+    }
+
+    @Transactional
+    public MoisSalesLibraryDtos.SalesLibraryReanalyzeResponse reanalyzePage(long pageId) {
+        Long exists = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE id = ?", Long.class, pageId);
+        if (exists == null || exists == 0) throw new IllegalArgumentException("Page not found: " + pageId);
+        long jobId = createPendingJob(pageId);
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_page_analysis
+                (url_ingest_id, job_id, status, analysis_notes, created_at, updated_at)
+                VALUES (?, ?, 'PENDING', 'Reanálise solicitada via API', UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                """, pageId, jobId);
+        return new MoisSalesLibraryDtos.SalesLibraryReanalyzeResponse(pageId, jobId, JOB_STATUS_PENDING, Instant.now());
+    }
+
+    private long createPendingJob(long urlIngestId) {
+        jdbcTemplate.update("INSERT INTO mois_sales_library_processing_job (url_ingest_id, status, attempts, created_at, updated_at) VALUES (?, ?, 0, UTC_TIMESTAMP(), UTC_TIMESTAMP())", urlIngestId, JOB_STATUS_PENDING);
+        Long id = jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+        return id == null ? 0L : id;
+    }
+
+    private String canonicalize(String rawUrl) { if (rawUrl == null || rawUrl.isBlank()) return null; try { URI uri = URI.create(rawUrl.trim()); String scheme = uri.getScheme() == null ? "https" : uri.getScheme().toLowerCase(Locale.ROOT); String host = uri.getHost(); if (host == null || host.isBlank()) return rawUrl.trim(); String path = (uri.getPath() == null || uri.getPath().isBlank()) ? "/" : uri.getPath(); return scheme + "://" + host.toLowerCase(Locale.ROOT) + path; } catch (Exception ignored) { return rawUrl.trim(); } }
+    private Instant toInstant(Timestamp timestamp) { return timestamp == null ? null : timestamp.toInstant(); }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
@@ -52,6 +52,43 @@ public class MoisSalesLibraryController {
         }
     }
 
+    @GetMapping("/pages")
+    public MoisSalesLibraryDtos.SalesLibraryPageListResponse listPages(
+            @RequestParam String workspaceId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize
+    ) {
+        return service.listPages(workspaceId, page, pageSize);
+    }
+
+    @GetMapping("/pages/{pageId}")
+    public MoisSalesLibraryDtos.SalesLibraryPageResponse getPage(@PathVariable long pageId) {
+        try {
+            return service.getPage(pageId);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        }
+    }
+
+    @GetMapping("/pages/{pageId}/analysis")
+    public MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse getPageAnalysis(@PathVariable long pageId) {
+        try {
+            return service.getPageAnalysis(pageId);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        }
+    }
+
+    @PostMapping("/pages/{pageId}:reanalyze")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public MoisSalesLibraryDtos.SalesLibraryReanalyzeResponse reanalyzePage(@PathVariable long pageId) {
+        try {
+            return service.reanalyzePage(pageId);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        }
+    }
+
     @PostMapping("/urls:ingest")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public MoisSalesLibraryDtos.SalesLibraryIngestResponse ingestUrls(

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-17-mois-sales-library-analysis.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-17-mois-sales-library-analysis.yaml
@@ -1,0 +1,47 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-17-mois-sales-library-analysis-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_library_url_ingest
+        - not:
+            tableExists:
+              tableName: mois_sales_library_page_analysis
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_library_page_analysis (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                url_ingest_id BIGINT NOT NULL,
+                job_id BIGINT NULL,
+                snapshot_hash VARCHAR(128) NULL,
+                parser_version VARCHAR(64) NULL,
+                prompt_version VARCHAR(64) NULL,
+                model_name VARCHAR(120) NULL,
+                status VARCHAR(32) NOT NULL,
+                score_total DECIMAL(6,2) NULL,
+                sections_json LONGTEXT NULL,
+                copy_json LONGTEXT NULL,
+                visual_json LONGTEXT NULL,
+                image_json LONGTEXT NULL,
+                analysis_notes VARCHAR(1000) NULL,
+                analyzed_at DATETIME NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY idx_mois_sales_library_analysis_url_updated (url_ingest_id, updated_at),
+                KEY idx_mois_sales_library_analysis_status_updated (status, updated_at),
+                CONSTRAINT fk_mois_sales_library_analysis_url_ingest
+                  FOREIGN KEY (url_ingest_id) REFERENCES mois_sales_library_url_ingest(id)
+                  ON DELETE CASCADE,
+                CONSTRAINT fk_mois_sales_library_analysis_job
+                  FOREIGN KEY (job_id) REFERENCES mois_sales_library_processing_job(id)
+                  ON DELETE SET NULL
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -769,3 +769,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-05-15-mois-sales-library-url-unique-canonical.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-05-17-mois-sales-library-analysis.yaml
+      relativeToChangelogFile: true

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -666,3 +666,18 @@ Para suportar o gerenciamento administrativo de ocupações no módulo OPRM (cad
   - `GET /api/mois/sales-library/jobs/{jobId}`
   - `GET /api/mois/sales-library/jobs?workspaceId=...&status=...`
 - Regra operacional: cada ingestão válida em `POST /api/mois/sales-library/urls:ingest` também cria um job inicial `PENDING`.
+
+## MOIS — Biblioteca de páginas de vendas (camada de análise, 2026-05-17)
+
+- Nova tabela backend: `mois_sales_library_page_analysis`.
+- Objetivo: persistir versões de análise estruturada por página ingerida, com rastreabilidade de parser/prompt/modelo e status operacional.
+- Relacionamentos:
+  - `mois_sales_library_page_analysis.url_ingest_id -> mois_sales_library_url_ingest.id`.
+  - `mois_sales_library_page_analysis.job_id -> mois_sales_library_processing_job.id` (opcional, `ON DELETE SET NULL`).
+- Colunas operacionais: `status`, `score_total`, `sections_json`, `copy_json`, `visual_json`, `image_json`, `analysis_notes`, `analyzed_at`, `created_at`, `updated_at`.
+- Índices operacionais: `(url_ingest_id, updated_at)` para recuperar a versão mais recente por página e `(status, updated_at)` para observabilidade de backlog de análise.
+- Endpoints backend adicionados para consulta e acionamento:
+  - `GET /api/mois/sales-library/pages`
+  - `GET /api/mois/sales-library/pages/{pageId}`
+  - `GET /api/mois/sales-library/pages/{pageId}/analysis`
+  - `POST /api/mois/sales-library/pages/{pageId}:reanalyze`


### PR DESCRIPTION
### Motivation
- Introduce a versioned analysis layer for sales-library pages to persist structured analysis results, scores and metadata and enable reanalysis workflows. 
- Expose listing and inspection endpoints for pages and their latest analysis and provide an API to trigger reanalysis tied to the existing processing job queue. 

### Description
- Add a Liquibase changeset `changesets/2026-05-17-mois-sales-library-analysis.yaml` that creates `mois_sales_library_page_analysis` with appropriate FKs, indices and columns for parser/prompt/model, status, score and JSON payloads. 
- Add DTOs: `SalesLibraryPageResponse`, `SalesLibraryPageListResponse`, `SalesLibraryPageAnalysisResponse` and `SalesLibraryReanalyzeResponse` in `MoisSalesLibraryDtos`. 
- Implement service methods in `MoisSalesLibraryService`: `listPages`, `getPage`, `getPageAnalysis`, `reanalyzePage` and a helper `createPendingJob`, plus small refactors of `canonicalize` and `toInstant` and SQL/pagination query cleanup. 
- Expose new controller endpoints in `MoisSalesLibraryController`: `GET /api/mois/sales-library/pages`, `GET /api/mois/sales-library/pages/{pageId}`, `GET /api/mois/sales-library/pages/{pageId}/analysis` and `POST /api/mois/sales-library/pages/{pageId}:reanalyze`, and update `db.changelog-master.yaml` and docs `modelo-dados-experimento.md`. 

### Testing
- Ran unit test suite with `./gradlew test` and observed all tests passing. 
- Executed service-level integration checks including migrations and endpoint exercises via the ads-service build `./gradlew :ads-service:integrationTest` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0942a6bda483219ce1acfcc64c9149)