### PR TITLE
docs: incluir lista de documentos lidos no template de registros do coletor MOIS

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -11,6 +11,9 @@
 - descrição breve do problema
 - descrição breve do raciocínio para a solução
 - registro do que foi feito
+- documentos lidos para tratar a situação:
+  - caminho/do/documento-1.md
+  - caminho/do/documento-2.md
 ```
 
 > Orientação: todos os registros deste documento devem sempre incluir **data e hora no fuso UTC-3**.


### PR DESCRIPTION
### Motivation
- Melhorar rastreabilidade operacional ao exigir que cada registro inclua explicitamente quais documentos foram consultados na análise.

### Description
- Atualiza o template de novo registro em `docs/registros/coletor-mois1.md` adicionando a seção `documentos lidos para tratar a situação` com itens de exemplo para preenchimento dos caminhos consultados.

### Testing
- Executado o script de edição (`python - <<'PY' ...`) que substituiu o template, e validado o resultado com `nl -ba docs/registros/coletor-mois1.md | sed -n '1,40p'`, ambos concluindo com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a094a9fd8dc8321a2d97ba5914f86e8)