### PR TITLE
Centralize landing approval: remove in-preview approve buttons and add experiment registro entry

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -45,3 +45,12 @@
 > Em caso de timestamp incorreto já registrado, não apague nem edite o registro antigo; adicione um novo registro de correção explicando o erro.
 > Neste documento segue política de **append-only** (não pode ter nenhuma linha apagada; apenas inserções).
 >
+## 2026-05-17 03:30:43 UTC-3
+- solicitação para registrar formalmente o tema experimento no local canônico após ajuste de fluxo de aprovação de landing.
+- o raciocínio foi garantir rastreabilidade operacional no arquivo obrigatório de registros do domínio de experimentos, mantendo aderência ao contrato append-only.
+- registro realizado neste documento informando a centralização da aprovação final de landing apenas na aba "Landing" e a remoção dos demais pontos de aprovação na visualização de conteúdo.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -3885,7 +3885,6 @@ function LandingHtmlPreview({
   content: LandingHtmlContent;
   experimentId?: string;
 }) {
-  const [isApplying, setIsApplying] = useState(false);
   const canRender = Boolean(content.htmlDocument?.trim());
   const frameworkImageStatusQuery = useFrameworkImageStatuses(experimentId);
   const resolvedGeneratedImages = useMemo(
@@ -3905,34 +3904,6 @@ function LandingHtmlPreview({
   );
   const deterministicUrl = content.deterministic?.publicUrl?.trim();
   const aiUrl = content.ai?.publicUrl?.trim();
-
-  const handleApplyToForm = async () => {
-    if (!experimentId) return;
-    try {
-      setIsApplying(true);
-      const { data } = await axios.post<{
-        publicUrl?: string | null;
-        facebookPixelId?: string | null;
-        pixelAppliedAutomatically?: boolean;
-      }>(
-        `/api/experiments/${experimentId}/pipeline/landing-page-html/approve-and-publish`,
-      );
-      const publicationUrl = data?.publicUrl;
-      const pixelFeedback =
-        data?.pixelAppliedAutomatically && data.facebookPixelId
-          ? ` Pixel do nicho aplicado automaticamente (${data.facebookPixelId}).`
-          : " Pixel do nicho será aplicado automaticamente ao ficar disponível.";
-      toast.success(
-        publicationUrl
-          ? `Landing aprovada e publicada automaticamente em ${publicationUrl}.${pixelFeedback}`
-          : `Landing aprovada e publicação automática iniciada.${pixelFeedback}`,
-      );
-    } catch (error) {
-      toast.error(getErrorMessage(error));
-    } finally {
-      setIsApplying(false);
-    }
-  };
 
   return (
     <div className="d-flex flex-column gap-3 mt-3">
@@ -3976,26 +3947,9 @@ function LandingHtmlPreview({
           </div>
         </div>
       ) : null}
-      <div className="d-flex flex-wrap gap-2">
-        <button
-          type="button"
-          className="btn btn-outline-primary"
-          disabled={isApplying || !experimentId || !canRender}
-          onClick={handleApplyToForm}
-        >
-          {isApplying ? (
-            <span className="d-inline-flex align-items-center gap-1">
-              <span
-                className="spinner-border spinner-border-sm"
-                role="status"
-                aria-hidden="true"
-              />
-              Aplicando...
-            </span>
-          ) : (
-            "Aprovar e publicar landing"
-          )}
-        </button>
+      <div className="alert alert-info py-2 mb-0 small" role="status">
+        A aprovação final da landing para campanha acontece exclusivamente na aba
+        <strong> Landing</strong> deste experimento.
       </div>
       {canRender ? (
         <div className="border rounded overflow-hidden">
@@ -4122,27 +4076,6 @@ function LandingHtmlPreview({
             </div>
           </div>
         </div>
-      </div>
-      <div className="d-flex justify-content-end">
-        <button
-          type="button"
-          className="btn btn-primary"
-          disabled={isApplying || !experimentId || !canRender}
-          onClick={handleApplyToForm}
-        >
-          {isApplying ? (
-            <span className="d-inline-flex align-items-center gap-1">
-              <span
-                className="spinner-border spinner-border-sm"
-                role="status"
-                aria-hidden="true"
-              />
-              Publicando...
-            </span>
-          ) : (
-            "Aprovar landing e liberar para campanha"
-          )}
-        </button>
       </div>
       {content.htmlDocument ? (
         <details>


### PR DESCRIPTION
### Motivation

- Centralize the final approval flow so that landing pages are approved only from the dedicated "Landing" tab and avoid scattered approval points in the content preview UI. 
- Record the operational change in the canonical experiments register while keeping the document `append-only` and traceable. 

### Description

- Appended a new timestamped entry to `docs/registros/experimentos.md` documenting the change and listing related files consulted. 
- Removed the `isApplying` state and the `handleApplyToForm` function and eliminated the approve/publish buttons and their `axios.post` call from `LandingHtmlPreview` in `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx`. 
- Replaced the interactive approve controls with an informational alert that states final approval happens exclusively in the experiment's `Landing` tab, while preserving the landing iframe preview and image listings. 

### Testing

- Ran the frontend type check and build via the usual commands (e.g. `yarn build`) and the build completed successfully. 
- Executed the frontend unit test suite (e.g. `yarn test`) and tests passed. 
- Ran linting (e.g. `yarn lint`) to ensure formatting and static checks; lint passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a095e2203c08321affa10f14bd3a01a)