### PR TITLE
Report detailed GraphQL skip reasons and add unit tests

### DIFF
--- a/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
+++ b/mois-clickbank-collector/src/main/java/com/marketinghub/moisclickbank/service/ClickbankCollectorService.java
@@ -54,6 +54,13 @@ public class ClickbankCollectorService {
               }
             }
             """;
+    private enum GraphqlSkipReason {
+        JWT_ABSENT,
+        JWT_EXPIRED_OR_INVALID,
+        GRAPHQL_EMPTY_RESULT,
+        HTTP_ERROR,
+        REQUEST_ERROR
+    }
 
     private final boolean headless;
     private final String chromiumExecutablePath;
@@ -151,11 +158,12 @@ public class ClickbankCollectorService {
 
         try {
             String accessToken = fetchClickbankJwtFromGeneralSettings();
-            int apiCollected = collectProductsFromGraphql(accessToken, boundedMax, products);
+            GraphqlCollectionOutcome outcome = collectProductsFromGraphql(accessToken, boundedMax, products);
+            int apiCollected = outcome.collectedProducts();
             if (apiCollected == 0) {
                 status = "COLLECTION_SKIPPED";
-                message = "Ciclo 3 não coletou produtos via GraphQL (JWT ausente/inválido ou retorno vazio).";
-                log.warn("Ciclo 3 GraphQL sem dados coletados. produtosColetados={}", apiCollected);
+                message = "Ciclo 3 não coletou produtos via GraphQL. motivo=" + outcome.skipReason();
+                log.warn("Ciclo 3 GraphQL sem dados coletados. produtosColetados={} motivo={}", apiCollected, outcome.skipReason());
             } else {
                 log.info("Ciclo 3 GraphQL finalizado. produtosColetados={}", apiCollected);
             }
@@ -169,10 +177,10 @@ public class ClickbankCollectorService {
         return new ClickbankCollectionResponse(status, message, products);
     }
 
-    private int collectProductsFromGraphql(String accessToken, int boundedMax, List<ClickbankProductSnapshot> products) {
+    private GraphqlCollectionOutcome collectProductsFromGraphql(String accessToken, int boundedMax, List<ClickbankProductSnapshot> products) {
         if (accessToken == null || accessToken.isBlank()) {
-            log.warn("JWT Clickbank ausente para consulta GraphQL; ativando fallback de coleta pública.");
-            return 0;
+            log.warn("JWT Clickbank ausente para consulta GraphQL.");
+            return new GraphqlCollectionOutcome(0, GraphqlSkipReason.JWT_ABSENT);
         }
         try {
             Map<String, Object> parameters = new HashMap<>();
@@ -202,11 +210,15 @@ public class ClickbankCollectorService {
             HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
             log.info("CLICKBANK_GRAPHQL_PAYLOAD_CRU status={} bodyRaw='{}'", response.statusCode(), truncateForLog(response.body(), 10_000));
             if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                return 0;
+                GraphqlSkipReason reason = response.statusCode() == 401 || response.statusCode() == 403
+                        ? GraphqlSkipReason.JWT_EXPIRED_OR_INVALID
+                        : GraphqlSkipReason.HTTP_ERROR;
+                log.warn("Ciclo 3 GraphQL retornou status não 2xx. status={} motivo={}", response.statusCode(), reason);
+                return new GraphqlCollectionOutcome(0, reason);
             }
             JsonNode hits = objectMapper.readTree(response.body()).path("data").path("marketplaceSearch").path("hits");
             if (!hits.isArray()) {
-                return 0;
+                return new GraphqlCollectionOutcome(0, GraphqlSkipReason.GRAPHQL_EMPTY_RESULT);
             }
             LinkedHashSet<String> dedupe = new LinkedHashSet<>();
             for (JsonNode hit : hits) {
@@ -224,12 +236,17 @@ public class ClickbankCollectorService {
                 }
                 products.add(new ClickbankProductSnapshot(title, "N/A", category, detailsUrl, gravity, detailsUrl, Instant.now()));
             }
-            return products.size();
+            if (products.isEmpty()) {
+                return new GraphqlCollectionOutcome(0, GraphqlSkipReason.GRAPHQL_EMPTY_RESULT);
+            }
+            return new GraphqlCollectionOutcome(products.size(), null);
         } catch (Exception ex) {
             log.warn("Falha na coleta GraphQL Clickbank.", ex);
-            return 0;
+            return new GraphqlCollectionOutcome(0, GraphqlSkipReason.REQUEST_ERROR);
         }
     }
+
+    private record GraphqlCollectionOutcome(int collectedProducts, GraphqlSkipReason skipReason) {}
 
 
 

--- a/mois-clickbank-collector/src/test/java/com/marketinghub/moisclickbank/service/ClickbankCollectorServiceTest.java
+++ b/mois-clickbank-collector/src/test/java/com/marketinghub/moisclickbank/service/ClickbankCollectorServiceTest.java
@@ -81,4 +81,59 @@ class ClickbankCollectorServiceTest {
             server.stop(0);
         }
     }
+
+    @Test
+    void shouldReturnSkippedWithJwtAbsentReasonOnThirdCycle() {
+        ClickbankCollectorService service = new ClickbankCollectorService(
+                true, "", "https://app.clickbank.com/market/search", "", "", "",
+                "http://127.0.0.1:1", "", "", false, "http://127.0.0.1:1",
+                "clickbank_access_token_jwt", "https://accounts.clickbank.com/graphql",
+                "workspace-001", "marketing-digital", "ofertas-clickbank"
+        );
+
+        var response = service.collectThirdCycleGraphql(new ClickbankCollectionRequest("clickbank-market", 10));
+
+        assertEquals("COLLECTION_SKIPPED", response.status());
+        assertTrue(response.message().contains("motivo=JWT_ABSENT"));
+    }
+
+    @Test
+    void shouldReturnSkippedWithJwtExpiredReasonWhenGraphqlReturns401() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/api/settings/clickbank_access_token_jwt", exchange -> {
+            String body = "{\"name\":\"clickbank_access_token_jwt\",\"value\":\"valid-looking-token\"}";
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        server.createContext("/graphql", exchange -> {
+            String body = "{\"errors\":[{\"message\":\"token expired\"}]}";
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(401, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        server.start();
+        String base = "http://127.0.0.1:" + server.getAddress().getPort();
+        try {
+            ClickbankCollectorService service = new ClickbankCollectorService(
+                    true, "", "https://app.clickbank.com/market/search", "", "", "",
+                    "http://127.0.0.1:1", "", "", false, base,
+                    "clickbank_access_token_jwt", base + "/graphql",
+                    "workspace-001", "marketing-digital", "ofertas-clickbank"
+            );
+
+            var response = service.collectThirdCycleGraphql(new ClickbankCollectionRequest("clickbank-market", 10));
+
+            assertEquals("COLLECTION_SKIPPED", response.status());
+            assertTrue(response.message().contains("motivo=JWT_EXPIRED_OR_INVALID"));
+        } finally {
+            server.stop(0);
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Improve observability and control flow for the GraphQL collection path by returning explicit skip reasons when no products are collected.

### Description
- Add `GraphqlSkipReason` enum and `GraphqlCollectionOutcome` record to represent why GraphQL collection was skipped or how many products were collected.
- Change `collectProductsFromGraphql` to return a `GraphqlCollectionOutcome` instead of an `int`, mapping absent token, non-2xx HTTP, empty results, and request errors to distinct `GraphqlSkipReason` values and enhancing logging.
- Update `collectThirdCycleGraphql` to use the outcome to set the `message` and logs with the skip reason when zero products are collected.
- Add two unit tests (`shouldReturnSkippedWithJwtAbsentReasonOnThirdCycle` and `shouldReturnSkippedWithJwtExpiredReasonWhenGraphqlReturns401`) to validate skip behavior for missing JWT and 401 responses.

### Testing
- Ran unit tests in `ClickbankCollectorServiceTest`, including the new tests `shouldReturnSkippedWithJwtAbsentReasonOnThirdCycle` and `shouldReturnSkippedWithJwtExpiredReasonWhenGraphqlReturns401`, and existing first-cycle test; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a095e9018908321a711db62da6cd8ad)