### PR TITLE
Add MOIS sales-library job endpoints and JSoup-based worker for async processing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/dto/MoisSalesLibraryDtos.java
@@ -9,6 +9,48 @@ import java.util.List;
 
 public final class MoisSalesLibraryDtos {
 
+
+    public record SalesLibraryClaimRequest(
+            @NotBlank String workspaceId,
+            @NotBlank String source
+    ) {
+    }
+
+    public record SalesLibraryClaimedJob(
+            long jobId,
+            long pageId,
+            String urlCanonical,
+            String title
+    ) {
+    }
+
+    public record SalesLibraryClaimResponse(
+            boolean claimed,
+            SalesLibraryClaimedJob job
+    ) {
+    }
+
+    public record SalesLibraryCompleteRequest(
+            BigDecimal scoreTotal,
+            String sectionsJson,
+            String copyJson,
+            String visualJson,
+            String imageJson,
+            String analysisNotes,
+            String parserVersion,
+            String promptVersion,
+            String modelName,
+            Instant analyzedAt
+    ) {
+    }
+
+    public record SalesLibraryFailRequest(
+            String errorCategory,
+            String errorMessage
+    ) {
+    }
+
+
     private MoisSalesLibraryDtos() {
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibraryService.java
@@ -22,6 +22,45 @@ public class MoisSalesLibraryService {
 
     private final JdbcTemplate jdbcTemplate;
 
+
+
+    @Transactional
+    public MoisSalesLibraryDtos.SalesLibraryClaimResponse claimJob(MoisSalesLibraryDtos.SalesLibraryClaimRequest request) {
+        List<MoisSalesLibraryDtos.SalesLibraryClaimedJob> rows = jdbcTemplate.query("""
+                SELECT j.id AS job_id, i.id AS page_id, i.url_canonical, i.title
+                FROM mois_sales_library_processing_job j
+                JOIN mois_sales_library_url_ingest i ON i.id = j.url_ingest_id
+                WHERE j.status = 'PENDING' AND i.workspace_id = ? AND i.source = ?
+                ORDER BY j.created_at ASC
+                LIMIT 1
+                """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryClaimedJob(
+                rs.getLong("job_id"), rs.getLong("page_id"), rs.getString("url_canonical"), rs.getString("title")),
+                request.workspaceId(), request.source().trim().toUpperCase(Locale.ROOT));
+        if (rows.isEmpty()) {
+            return new MoisSalesLibraryDtos.SalesLibraryClaimResponse(false, null);
+        }
+        MoisSalesLibraryDtos.SalesLibraryClaimedJob job = rows.get(0);
+        jdbcTemplate.update("UPDATE mois_sales_library_processing_job SET status='FETCHING', started_at=UTC_TIMESTAMP(), updated_at=UTC_TIMESTAMP() WHERE id=? AND status='PENDING'", job.jobId());
+        return new MoisSalesLibraryDtos.SalesLibraryClaimResponse(true, job);
+    }
+
+    @Transactional
+    public void completeJob(long jobId, MoisSalesLibraryDtos.SalesLibraryCompleteRequest request) {
+        Long pageId = jdbcTemplate.queryForObject("SELECT url_ingest_id FROM mois_sales_library_processing_job WHERE id = ? LIMIT 1", Long.class, jobId);
+        if (pageId == null) throw new IllegalArgumentException("Job not found: " + jobId);
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_page_analysis
+                (url_ingest_id, job_id, status, score_total, parser_version, prompt_version, model_name, sections_json, copy_json, visual_json, image_json, analysis_notes, analyzed_at, created_at, updated_at)
+                VALUES (?, ?, 'DONE', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                """, pageId, jobId, request.scoreTotal(), request.parserVersion(), request.promptVersion(), request.modelName(), request.sectionsJson(), request.copyJson(), request.visualJson(), request.imageJson(), request.analysisNotes(), request.analyzedAt() == null ? Instant.now() : request.analyzedAt());
+        jdbcTemplate.update("UPDATE mois_sales_library_processing_job SET status='DONE', finished_at=UTC_TIMESTAMP(), updated_at=UTC_TIMESTAMP() WHERE id=?", jobId);
+    }
+
+    @Transactional
+    public void failJob(long jobId, MoisSalesLibraryDtos.SalesLibraryFailRequest request) {
+        jdbcTemplate.update("UPDATE mois_sales_library_processing_job SET status='FAILED', error_category=?, error_message=?, finished_at=UTC_TIMESTAMP(), updated_at=UTC_TIMESTAMP() WHERE id=?", request.errorCategory(), request.errorMessage(), jobId);
+    }
+
     @Transactional
     public MoisSalesLibraryDtos.SalesLibraryIngestResponse ingestUrls(MoisSalesLibraryDtos.SalesLibraryIngestRequest request) {
         int persisted = 0;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
@@ -89,6 +89,32 @@ public class MoisSalesLibraryController {
         }
     }
 
+
+    @PostMapping("/jobs:claim")
+    public MoisSalesLibraryDtos.SalesLibraryClaimResponse claimJob(
+            @Valid @RequestBody MoisSalesLibraryDtos.SalesLibraryClaimRequest request
+    ) {
+        return service.claimJob(request);
+    }
+
+    @PostMapping("/jobs/{jobId}:complete")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void completeJob(
+            @PathVariable long jobId,
+            @RequestBody MoisSalesLibraryDtos.SalesLibraryCompleteRequest request
+    ) {
+        service.completeJob(jobId, request);
+    }
+
+    @PostMapping("/jobs/{jobId}:fail")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void failJob(
+            @PathVariable long jobId,
+            @RequestBody MoisSalesLibraryDtos.SalesLibraryFailRequest request
+    ) {
+        service.failJob(jobId, request);
+    }
+
     @PostMapping("/urls:ingest")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public MoisSalesLibraryDtos.SalesLibraryIngestResponse ingestUrls(

--- a/docs/canonical/mois-sales-library-worker-canon.v1.md
+++ b/docs/canonical/mois-sales-library-worker-canon.v1.md
@@ -1,0 +1,25 @@
+# Cânone — MOIS Sales Library Worker (v1)
+
+## Objetivo
+Processar de forma assíncrona os jobs `PENDING` da biblioteca de páginas de vendas do MOIS, executar extração básica da página e gravar análise estruturada para uso comercial.
+
+## Fluxo operacional
+1. Worker chama `POST /api/mois/sales-library/jobs:claim`.
+2. Backend retorna um job `PENDING` e o promove para `FETCHING`.
+3. Worker busca a URL da página e executa análise estruturada inicial.
+4. Em sucesso, worker chama `POST /api/mois/sales-library/jobs/{jobId}:complete` com score e JSONs (`sections_json`, `copy_json`, `visual_json`, `image_json`).
+5. Em falha, worker chama `POST /api/mois/sales-library/jobs/{jobId}:fail` com categoria/mensagem.
+
+## Contrato mínimo de saída da análise
+- `score_total`: pontuação comercial agregada.
+- `sections_json`: presença de headline/CTA/provas.
+- `copy_json`: estrutura de copy extraída.
+- `visual_json`: sinais visuais detectados.
+- `image_json`: metadados de imagens relevantes.
+- `analysis_notes`: observações do processamento.
+- `parser_version`, `prompt_version`, `model_name`: rastreabilidade técnica.
+
+## Regras
+- O worker não acessa banco diretamente; usa apenas API do backend principal.
+- Toda transição de estado deve ocorrer por endpoint do backend MOIS.
+- Falhas de parsing/fetch devem marcar job como `FAILED` com causa explícita.

--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -268,3 +268,8 @@
 - Definido como orientação canônica do módulo MOIS o documento **Biblioteca de Sales Pages**: `docs/novos-modulos/mois/especificacao-biblioteca-sales-pages.md`.
 - Registro explícito para o time: a execução do **Ciclo 2 do coletor Clickbase/ClickBank** passa a ser tratada como etapa inicial de construção da biblioteca de páginas de vendas, em aderência ao direcionamento do módulo.
 - Objetivo operacional consolidado: usar os links resolvidos/persistidos no ciclo 2 como base para evolução da biblioteca e análises estruturadas de sales pages no MOIS.
+
+## 2026-05-17 00:00 UTC
+- Criado módulo `mois-sales-library-worker` (Java 21 + Maven + Spring Boot + Docker) para processar jobs PENDING da biblioteca de sales pages via backend MOIS.
+- Criados endpoints backend para claim/complete/fail do job da pipeline assíncrona.
+- Criado cânone: `docs/canonical/mois-sales-library-worker-canon.v1.md`.

--- a/mois-sales-library-worker/Dockerfile
+++ b/mois-sales-library-worker/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/target/mois-sales-library-worker-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/mois-sales-library-worker/docker-compose.yml
+++ b/mois-sales-library-worker/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  mois-sales-library-worker:
+    build: .
+    container_name: mois-sales-library-worker
+    restart: unless-stopped
+    environment:
+      BACKEND_BASE_URL: http://191.252.181.168:8000
+      MOIS_WORKSPACE_ID: workspace-001
+      MOIS_SOURCE: CLICKBANK
+      MOIS_POLL_INTERVAL_MS: 15000

--- a/mois-sales-library-worker/pom.xml
+++ b/mois-sales-library-worker/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.marketinghub</groupId>
+  <artifactId>mois-sales-library-worker</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>mois-sales-library-worker</name>
+  <properties><java.version>21</java.version><spring.boot.version>3.3.5</spring.boot.version></properties>
+  <dependencyManagement><dependencies><dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-dependencies</artifactId><version>${spring.boot.version}</version><type>pom</type><scope>import</scope></dependency></dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-validation</artifactId></dependency>
+    <dependency><groupId>org.jsoup</groupId><artifactId>jsoup</artifactId><version>1.18.1</version></dependency>
+    <dependency><groupId>org.projectlombok</groupId><artifactId>lombok</artifactId><optional>true</optional></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+  </dependencies>
+  <build><plugins><plugin><groupId>org.springframework.boot</groupId><artifactId>spring-boot-maven-plugin</artifactId></plugin><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><configuration><release>21</release></configuration></plugin></plugins></build>
+</project>

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/MoisSalesLibraryWorkerApplication.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/MoisSalesLibraryWorkerApplication.java
@@ -1,0 +1,11 @@
+package com.marketinghub.mois.libraryworker;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class MoisSalesLibraryWorkerApplication {
+    public static void main(String[] args) { SpringApplication.run(MoisSalesLibraryWorkerApplication.class, args); }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/client/BackendClient.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/client/BackendClient.java
@@ -1,0 +1,22 @@
+package com.marketinghub.mois.libraryworker.client;
+
+import com.marketinghub.mois.libraryworker.model.WorkerDtos.*;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class BackendClient {
+    private final RestClient restClient;
+    public BackendClient(RestClient restClient) { this.restClient = restClient; }
+
+    public ClaimResponse claim(ClaimRequest request) {
+        return restClient.post().uri("/api/mois/sales-library/jobs:claim").contentType(MediaType.APPLICATION_JSON).body(request).retrieve().body(ClaimResponse.class);
+    }
+    public void complete(long jobId, CompleteRequest request) {
+        restClient.post().uri("/api/mois/sales-library/jobs/{jobId}:complete", jobId).contentType(MediaType.APPLICATION_JSON).body(request).retrieve().toBodilessEntity();
+    }
+    public void fail(long jobId, FailRequest request) {
+        restClient.post().uri("/api/mois/sales-library/jobs/{jobId}:fail", jobId).contentType(MediaType.APPLICATION_JSON).body(request).retrieve().toBodilessEntity();
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/config/WorkerConfig.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/config/WorkerConfig.java
@@ -1,0 +1,15 @@
+package com.marketinghub.mois.libraryworker.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(WorkerProperties.class)
+public class WorkerConfig {
+    @Bean
+    RestClient restClient(WorkerProperties properties) {
+        return RestClient.builder().baseUrl(properties.backendBaseUrl()).build();
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/config/WorkerProperties.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/config/WorkerProperties.java
@@ -1,0 +1,6 @@
+package com.marketinghub.mois.libraryworker.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "worker")
+public record WorkerProperties(String backendBaseUrl, String workspaceId, String source, long pollIntervalMs, int requestTimeoutMs) {}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/model/WorkerDtos.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/model/WorkerDtos.java
@@ -1,0 +1,14 @@
+package com.marketinghub.mois.libraryworker.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Map;
+
+public final class WorkerDtos {
+    private WorkerDtos() {}
+    public record ClaimRequest(String workspaceId, String source) {}
+    public record ClaimedJob(Long jobId, Long pageId, String urlCanonical, String title) {}
+    public record ClaimResponse(boolean claimed, ClaimedJob job) {}
+    public record CompleteRequest(BigDecimal scoreTotal, String sectionsJson, String copyJson, String visualJson, String imageJson, String analysisNotes, String parserVersion, String promptVersion, String modelName, Instant analyzedAt) {}
+    public record FailRequest(String errorCategory, String errorMessage) {}
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/service/PipelineRunner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/service/PipelineRunner.java
@@ -1,0 +1,44 @@
+package com.marketinghub.mois.libraryworker.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.mois.libraryworker.client.BackendClient;
+import com.marketinghub.mois.libraryworker.config.WorkerProperties;
+import com.marketinghub.mois.libraryworker.model.WorkerDtos.*;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service @Slf4j @RequiredArgsConstructor
+public class PipelineRunner {
+    private final BackendClient backendClient;
+    private final WorkerProperties properties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Scheduled(fixedDelayString = "${worker.poll-interval-ms:15000}")
+    public void runCycle() {
+        ClaimResponse claim = backendClient.claim(new ClaimRequest(properties.workspaceId(), properties.source()));
+        if (claim == null || !claim.claimed() || claim.job() == null) return;
+        long jobId = claim.job().jobId();
+        try {
+            var doc = Jsoup.connect(claim.job().urlCanonical()).timeout(properties.requestTimeoutMs()).get();
+            String text = doc.body() != null ? doc.body().text() : "";
+            Map<String, Object> sections = new HashMap<>();
+            sections.put("hasHeadline", doc.select("h1,h2").size() > 0);
+            sections.put("hasCta", text.toLowerCase().contains("comprar") || text.toLowerCase().contains("quero") || text.toLowerCase().contains("inscreva"));
+            sections.put("hasProof", text.toLowerCase().contains("depoimento") || text.toLowerCase().contains("prova") || text.toLowerCase().contains("resultado"));
+            BigDecimal score = BigDecimal.valueOf((Boolean.TRUE.equals(sections.get("hasHeadline")) ? 33 : 0) + (Boolean.TRUE.equals(sections.get("hasCta")) ? 33 : 0) + (Boolean.TRUE.equals(sections.get("hasProof")) ? 34 : 0));
+            String sectionsJson = objectMapper.writeValueAsString(sections);
+            backendClient.complete(jobId, new CompleteRequest(score, sectionsJson, "{}", "{}", "{}", "Análise inicial automatizada", "html-v1", "heuristic-v1", "local-jsoup", Instant.now()));
+            log.info("MOIS library job {} completed for page {}", jobId, claim.job().pageId());
+        } catch (Exception ex) {
+            backendClient.fail(jobId, new FailRequest("PIPELINE_ERROR", ex.getMessage()));
+            log.warn("MOIS library job {} failed: {}", jobId, ex.getMessage());
+        }
+    }
+}

--- a/mois-sales-library-worker/src/main/resources/application.yml
+++ b/mois-sales-library-worker/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  application:
+    name: mois-sales-library-worker
+worker:
+  backend-base-url: ${BACKEND_BASE_URL:http://191.252.181.168:8000}
+  workspace-id: ${MOIS_WORKSPACE_ID:workspace-001}
+  source: ${MOIS_SOURCE:CLICKBANK}
+  poll-interval-ms: ${MOIS_POLL_INTERVAL_MS:15000}
+  request-timeout-ms: ${MOIS_REQUEST_TIMEOUT_MS:30000}


### PR DESCRIPTION
### Motivation
- Provide an API for an asynchronous processing pipeline to claim, complete and fail `PENDING` jobs for the MOIS sales-library. 
- Allow an external worker to fetch a job, perform page analysis, and report results back to the backend without direct DB access. 
- Ship a lightweight reference worker implementation that performs an initial heuristic extraction and can be run via Docker. 

### Description
- Added DTOs for job operations: `SalesLibraryClaimRequest/Response`, `SalesLibraryClaimedJob`, `SalesLibraryCompleteRequest`, and `SalesLibraryFailRequest` in `MoisSalesLibraryDtos`. 
- Implemented service methods `claimJob`, `completeJob` and `failJob` in `MoisSalesLibraryService` to select a pending job, transition its state, insert analysis rows and mark jobs done/failed. 
- Exposed controller endpoints `POST /api/mois/sales-library/jobs:claim`, `POST /api/mois/sales-library/jobs/{jobId}:complete` and `POST /api/mois/sales-library/jobs/{jobId}:fail` in `MoisSalesLibraryController`. 
- Added a new `mois-sales-library-worker` module including a Spring Boot scheduled `PipelineRunner` that claims jobs, fetches pages with `Jsoup`, computes simple heuristics (`hasHeadline`, `hasCta`, `hasProof`), and posts `complete` or `fail` back to the backend; plus supporting `BackendClient`, configuration, DTOs, `pom.xml`, `Dockerfile` and `docker-compose.yml`. 
- Added canonical worker doc `docs/canonical/mois-sales-library-worker-canon.v1.md` and updated `docs/mois/registros.md` with the change record. 

### Testing
- Built the worker artifact using `mvn -q -DskipTests package` in the worker module, which completed successfully. 
- Executed backend module unit tests with `mvn -q test`, which passed for the modules run during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a095e67ed38832193cb9252dd697d8e)