### PR TITLE
Docs: replace deprecated "Portal do Lead" with "Gera Landing" and clarify Facebook Ads release checklist

### DIFF
--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -15,7 +15,7 @@ Este documento complementa o `system-governance-canon.v2.md` e passa a ser a fon
 
 - Garantir que a decisão de publicar campanhas de experimento siga invariantes únicos e rastreáveis no backend.
 - Amarrar UI, worker e integrações ao mesmo contrato para evitar drift entre checklist, botões de liberação e funil.
-- Explicitar dependências externas (Marketing API e domínio do Lead Portal) que condicionam a execução.
+- Explicitar dependências externas (Marketing API e domínio de publicação da landing) que condicionam a execução.
 
 ## 2. Escopo e exclusões
 
@@ -50,8 +50,8 @@ Implementação: `ExperimentReadinessService` (backend) expõe os mesmos critér
    - `experiment.creative_approved = true` e pelo menos um registro em `creative` do experimento com `status = 'READY'`.
    - O botão **Gerar anúncios do pipeline** pode produzir até 3 anúncios (texto + prompt) via Worker AI (`gpt-image-1.5`). Eles entram como `DRAFT` e precisam ser aprovados antes da liberação.
    - Quando múltiplos criativos `READY` existem, o worker publica todos no mesmo ad set para preservar as variações aprovadas.
-2. **Fluxo do Portal do Lead**
-   - O experimento precisa ter um `lead_portal_flow` associado e ativo, servindo páginas pelo domínio `oportunidadebrasil.shop`.
+2. **Landing/formulário do experimento (Gera Landing)**
+   - O experimento precisa ter a landing/formulário do experimento gerada e publicada pelo fluxo do **Gera Landing** no domínio `oportunidadebrasil.shop`.
    - O link de campanha deve apontar para `https://oportunidadebrasil.shop/api/flows/{slug}/page` (exemplo atual do experimento 11: `https://oportunidadebrasil.shop/api/flows/exp-11-landing/page`).
    - A página de formulário precisa carregar o pixel do Facebook do nicho (`market_niche.facebook_pixel_id`) antes da publicação.
 3. **Público completo**
@@ -68,7 +68,7 @@ O cartão também lista itens operacionais que não travam o worker, mas devem s
 - **Página do Facebook** e **Conta do Instagram** – precisam existir no hub e permanecer válidas para evitar erros de publicação.
 - **Orçamento diário** – `experiment.daily_budget` deve estar preenchido para refletir a automação de mídia.
 - **Formulário de captação** – quando existir link válido de formulário no fluxo do experimento, ele é tratado como publicado para operação do Marketing Hub.
-- **Importante**: o formulário usado neste checklist é o formulário interno do fluxo do Marketing Hub (Lead Portal/fluxo), **não** o Instant Form nativo do Facebook Ads.
+- **Importante**: o formulário usado neste checklist é o formulário interno publicado pelo **Gera Landing** no Marketing Hub, **não** o Instant Form nativo do Facebook Ads.
 
 ## 7. Contrato de liberação para o Facebook Ads Worker
 

--- a/docs/manual-usuario/aihub/liberar-facebook-ads-worker.md
+++ b/docs/manual-usuario/aihub/liberar-facebook-ads-worker.md
@@ -6,7 +6,7 @@ e está pronto para ser enviado ao Facebook Ads Worker.
 ## Pré-requisitos
 
 - Criativos aprovados e prontos para uso.
-- Ao menos um fluxo do Portal do Lead associado ao experimento.
+- Landing/formulário do experimento gerado e aplicado pelo fluxo do Gera Landing.
 - Segmentação completa (interesses, cargos e comportamentos aprovados).
 - Configurações operacionais feitas: conta/página do Facebook, Instagram e
   orçamento diário.

--- a/docs/pipeline-landing-experimento.md
+++ b/docs/pipeline-landing-experimento.md
@@ -6,7 +6,7 @@ Este guia descreve a sequência obrigatória de ações para gerar, aplicar e ap
 >
 > - Estrutura do pipeline (`CAMPAIGN_ANGLE` → `LANDING_PAGE_HTML`) em `docs/experiment-pipeline-artifacts-visual.md` e na tela **Experimentos › Conteúdo › Geração** (`frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx`).
 > - Planejamento e geração de imagens do framework em `useFrameworkImageStatuses`/`useGenerateFrameworkImages`.
-> - Seleção/aprovação do fluxo do portal em `frontend/src/pages/experiment/LeadPortalFlowTab.tsx`.
+> - Aplicação/aprovação do formulário diretamente no fluxo do Gera Landing (sem aba Portal do Lead).
 > - Service de deploy automático do formulário via `ExperimentLeadPortalFlowScheduler` (AI Worker).
 
 Consulta ao MySQL confirmou o contexto do experimento monitorado:
@@ -30,7 +30,7 @@ Os logs em produção reforçam que o fluxo `exp-10-landing` está ativo (`FlowE
 | 4 | **Gerar as imagens** do framework | Painel "Geração das imagens planejadas" (mesma tela) | Planejamento aprovado | Status `WEB_READY` com `webUrl` por item | 
 | 5 | **Solicitar o HTML da Landing** (`LANDING_PAGE_HTML`) e revisar | aba HTML da Landing | Steps 1–4 concluídos | HTML final com imagens reais (sem placeholder) | 
 | 6 | **Aplicar HTML ao formulário** | Botão "Usar como formulário do experimento" | HTML validado | `customFormHtml` atualizado no fluxo vinculado | 
-| 7 | **Selecionar e aprovar o formulário** | Experimento › aba Portal do Lead | HTML aplicado | `lead_portal_flow_id` apontando para o slug correto + `approved=true` |
+| 7 | **Aplicar e publicar o formulário via Gera Landing** | Experimento › Conteúdo › Geração | HTML aplicado | fluxo aplicado/publicado sem depender da aba Portal do Lead |
 
 ## Passo a passo detalhado
 
@@ -62,13 +62,12 @@ Os logs em produção reforçam que o fluxo `exp-10-landing` está ativo (`FlowE
 
 ### 6. Aplicar ao formulário do experimento
 1. Ainda no preview, clique em **Usar como formulário do experimento**. A chamada `POST /api/experiments/:id/pipeline/landing-page-html/apply-to-form` atualiza o `customFormHtml` do fluxo vinculado.
-2. Volte para o card "Portal do Lead" da página do experimento e confirme que o slug correto aparece em "Fluxo atribuído".
+2. Confirme no próprio fluxo do Gera Landing que a aplicação/publicação foi concluída para o slug correto.
 
-### 7. Selecionar e aprovar o formulário
-1. Na aba **Portal do Lead**, use o seletor para vincular o fluxo desejado ao experimento (campo `lead_portal_flow_id`).
-2. Ative a aprovação com o toggle **Aprovar/Revogar** (chamada `PATCH /api/lead-portal-flows/:id/approval`).
-3. Se já estava aprovado e o HTML foi substituído, clique em **Revogar** e depois **Aprovar** para propagar o novo artefato.
-4. Esta etapa dispara automaticamente o deploy para `https://oportunidadebrasil.shop/flows/{slug}`; não há passos manuais adicionais.
+### 7. Aplicar e publicar o formulário via Gera Landing
+1. Com o HTML final revisado, execute a aplicação/publicação no próprio fluxo do **Gera Landing**.
+2. Confirme que o deploy foi propagado para `https://oportunidadebrasil.shop/flows/{slug}`.
+3. Não use mais a antiga aba **Portal do Lead**; ela foi descontinuada.
 
 ## Evitando o placeholder do hero
 - **Causa raiz:** HTML gerado antes das imagens chegarem em `WEB_READY`. O worker injeta `https://placehold.co/...` apenas para manter layout válido.
@@ -85,7 +84,7 @@ Os logs em produção reforçam que o fluxo `exp-10-landing` está ativo (`FlowE
 - [ ] `LANDING_PAGE_COPY`, `LANDING_PAGE_WIREFRAME`, `LANDING_PAGE_IMAGE_PLANNING` e `LANDING_PAGE_HTML` em `COMPLETED` no histórico do pipeline.
 - [ ] Painel de imagens sem registros `PENDING/FAILED` e todas com `webUrl` válido.
 - [ ] HTML aplicado ao experimento (`Última aplicação` exibida no card do preview).
-- [ ] Fluxo correto selecionado no experimento e aprovado novamente após ajustes.
+- [ ] Aplicação/publicação concluída no fluxo do Gera Landing após ajustes finais.
 - [ ] Acesso público (`/flows/{slug}`) renderizando hero real (sem `placehold`).
 - [ ] Logs do Portal confirmando `render-complete` após a última aprovação.
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -45,3 +45,13 @@
 > Em caso de timestamp incorreto já registrado, não apague nem edite o registro antigo; adicione um novo registro de correção explicando o erro.
 > Neste documento segue política de **append-only** (não pode ter nenhuma linha apagada; apenas inserções).
 >
+
+## 2026-05-17 03:38:52 UTC-3
+- Atualização documental para remover referências à aba descontinuada "Portal do Lead" no fluxo de liberação para Facebook Ads.
+- Raciocínio: a operação atual é centralizada no Gera Landing; manter instruções antigas induzia erro operacional e bloqueio indevido na liberação do experimento.
+- Foi feito: revisão e ajuste dos documentos operacionais/canônicos para substituir instruções de aprovação em aba por aplicação/publicação via Gera Landing.
+- documentos lidos para tratar a situação:
+  - docs/manual-usuario/aihub/liberar-facebook-ads-worker.md
+  - docs/pipeline-landing-experimento.md
+  - docs/canonical/facebook-campaign-publication-canon.v1.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Align operational and canonical documentation with the current landing deployment flow to avoid accidental use of the deprecated "Portal do Lead" tab and reduce release/blocking errors for Facebook Ads experiments.
- Make explicit that the experiment form is published via the `Gera Landing` flow and not the Meta Instant Form, and ensure the release/checklist language matches backend invariants for publishing.

### Description
- Updated `docs/canonical/facebook-campaign-publication-canon.v1.md` to reference the landing/form published by `Gera Landing`, to clarify the form source and tweak wording around external dependencies and the internal form note.
- Updated `docs/manual-usuario/aihub/liberar-facebook-ads-worker.md` to replace references to the Portal do Lead with the `Gera Landing` publishing step in the prerequisites and guidance text.
- Updated `docs/pipeline-landing-experimento.md` to remove the old Portal tab workflow, document applying/publishing the form via `Gera Landing`, adjust step ordering and the final checklist, and mark the Portal tab as discontinued.
- Appended an entry to `docs/registros/experimentos.md` documenting the change and listing the files reviewed/updated.

### Testing
- Documentation-only change; ran `markdownlint` and a local `mkdocs build` to validate formatting and site build, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a095e3fe6508321baa05cce58589351)