### PR TITLE
feat(frontend): adiciona gráfico e indicadores de outcomes no backtest

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -64,3 +64,13 @@
   - frontend/AGENTS.md
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+
+
+## 2026-05-17 00:00:00 UTC
+- solicitação para evoluir o frontend na aba de backtest com visualização das quantidades por outcome e indicadores de progresso.
+- implementação realizada na aba de funil/backtest com gráfico de barras por outcome (quantidade por etapa), destaque do total atual e percentual em relação à referência ideal de 500.
+- também foi adicionado cálculo explícito da meta (500) para facilitar leitura operacional durante acompanhamento de performance.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/experiment/ExperimentFunnelTab.tsx

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -12,6 +12,12 @@ const currencyFormatter = new Intl.NumberFormat("pt-BR", {
   minimumFractionDigits: 2,
 });
 
+const BACKTEST_TARGET_TOTAL = 500;
+
+function formatPercentage(value: number) {
+  return `${value.toFixed(1)}%`;
+}
+
 interface ExperimentFunnelTabProps {
   experimentId: string;
   totalSpend?: number | null;
@@ -139,6 +145,21 @@ export default function ExperimentFunnelTab({
     },
   ];
   const selectableStages = stages.length > 0 ? stages : fallbackStages;
+  const outcomeQuantities = selectableStages.map((stage) => ({
+    label: stage.label,
+    quantity: stage.totalCount,
+  }));
+  const maxOutcomeQuantity = outcomeQuantities.reduce((max, item) =>
+    Math.max(max, item.quantity), 0,
+  );
+  const totalOutcomes = outcomeQuantities.reduce(
+    (accumulator, item) => accumulator + item.quantity,
+    0,
+  );
+  const outcomeTargetPercent =
+    BACKTEST_TARGET_TOTAL > 0
+      ? (totalOutcomes / BACKTEST_TARGET_TOTAL) * 100
+      : 0;
   const registerEvent = useRegisterExperimentFunnelEvent(experimentId);
   const resetFunnel = useResetExperimentFunnel(experimentId);
   const [form, setForm] = useState({
@@ -224,6 +245,44 @@ export default function ExperimentFunnelTab({
           Cada custo por conversão abaixo divide o total gasto pela quantidade
           de conversões registradas em cada etapa.
         </p>
+
+        <div className="rounded-3 border p-3 mb-4">
+          <div className="d-flex flex-wrap justify-content-between align-items-end gap-3 mb-3">
+            <div>
+              <div className="text-uppercase text-muted small fw-semibold">
+                Backtest · total atual de outcomes
+              </div>
+              <div className="fs-2 fw-bold">{totalOutcomes}</div>
+            </div>
+            <div className="text-end">
+              <div className="text-muted small">Meta ideal: {BACKTEST_TARGET_TOTAL}</div>
+              <div className="fs-5 fw-semibold">
+                {formatPercentage(outcomeTargetPercent)} da meta
+              </div>
+            </div>
+          </div>
+          <div className="d-flex flex-column gap-2">
+            {outcomeQuantities.map((item) => {
+              const widthPercent = maxOutcomeQuantity > 0
+                ? (item.quantity / maxOutcomeQuantity) * 100
+                : 0;
+              return (
+                <div key={item.label}>
+                  <div className="d-flex justify-content-between small">
+                    <span>{item.label}</span>
+                    <strong>{item.quantity}</strong>
+                  </div>
+                  <div className="progress" role="img" aria-label={`Quantidade do outcome ${item.label}: ${item.quantity}`}>
+                    <div
+                      className="progress-bar"
+                      style={{ width: `${Math.max(widthPercent, item.quantity > 0 ? 4 : 0)}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
 
         {isLoading ? (
           <div className="text-muted">Carregando funil...</div>


### PR DESCRIPTION
### Motivation
- Tornar a aba de backtest mais útil exibindo a distribuição atual de outcomes por etapa para facilitar decisões operacionais. 
- Destacar o total geral atual e comparar com uma referência operacional (meta de 500) para acompanhamento rápido do progresso. 
- Registrar a alteração no arquivo canônico de experimentos para rastreabilidade operacional.

### Description
- Adiciona a constante `BACKTEST_TARGET_TOTAL` e a função `formatPercentage` em `ExperimentFunnelTab.tsx` para suportar cálculo e formatação do percentual da meta. 
- Calcula `outcomeQuantities`, `maxOutcomeQuantity`, `totalOutcomes` e `outcomeTargetPercent` a partir das etapas do funil e usa esses valores para a visualização. 
- Insere um bloco UI que mostra o `totalOutcomes` em destaque, a `Meta ideal: 500` com percentual calculado e um gráfico de barras por outcome implementado com `progress-bar`. 
- Registra a atividade adicionando uma entrada no `docs/registros/experimentos.md` apontando os arquivos e a razão da mudança.

### Testing
- Executado `cd frontend && npm run typecheck`, que falhou por falta de definições de tipo (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) e flags deprecadas no `tsconfig.json`, portanto o typecheck não pôde ser concluído com o ambiente local atual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964757d308321a4a2bd2ed83f8368)