### PR TITLE
Add CI/CD workflow and deploy config for MOIS Sales Library Worker

### DIFF
--- a/.github/workflows/mois-sales-library-worker-ci.yml
+++ b/.github/workflows/mois-sales-library-worker-ci.yml
@@ -1,0 +1,122 @@
+name: CI - MOIS Sales Library Worker
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "mois-sales-library-worker/**"
+      - ".github/workflows/mois-sales-library-worker-ci.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "mois-sales-library-worker/**"
+      - ".github/workflows/mois-sales-library-worker-ci.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/mois-sales-library-worker
+
+jobs:
+  test:
+    name: Test (MOIS Sales Library Worker)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Maven test
+        working-directory: mois-sales-library-worker
+        run: mvn -B test
+
+  build-and-push:
+    name: Build and Push Image (MOIS Sales Library Worker)
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=sha-${{ github.sha }}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mois-sales-library-worker
+          file: ./mois-sales-library-worker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    name: Deploy (MOIS Sales Library Worker)
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: github.ref == 'refs/heads/main'
+    environment: production
+    env:
+      DEPLOY_HOST: 177.153.62.107
+      DEPLOY_USER: root
+      REMOTE_PATH: /opt/marketinghub/mois-sales-library-worker
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare SSH
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_CHAVE != '' && secrets.VPS_SSH_CHAVE || secrets.VPS_SSH_KEY != '' && secrets.VPS_SSH_KEY || secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -z "${VPS_SSH_KEY}" ]; then
+            echo "Erro: nenhuma chave SSH foi encontrada nos secrets esperados." >&2
+            exit 1
+          fi
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          printf '%s\n' "SSH_COMMON_ARGS=-i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=yes -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -o ConnectTimeout=60" >> "$GITHUB_ENV"
+
+      - name: Sync project files
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p ${REMOTE_PATH}"
+          rsync -az --delete -e "ssh ${SSH_COMMON_ARGS}" --exclude '.git' --exclude 'target' --exclude '.idea' --exclude '.vscode' --exclude '.DS_Store' \
+            mois-sales-library-worker/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_PATH}"
+
+      - name: Deploy with Docker Compose
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "set -euo pipefail \
+            && cd ${REMOTE_PATH} \
+            && export MOIS_SALES_LIBRARY_WORKER_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA} \
+            && export COMPOSE_PROJECT_NAME=marketinghub-mois-sales-library-worker \
+            && docker login ${{ env.REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml pull \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml up -d --remove-orphans \
+            && docker image prune -af"

--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -240,3 +240,8 @@
 - havia ambiguidade sobre o arquivo oficial de registro dos módulos coletores MOIS, causando dispersão de lançamentos entre documentos diferentes.
 - para eliminar a causa-raiz, foi definido um único ponto canônico explícito e um template obrigatório único no topo do arquivo.
 - atualizado docs/registros/coletor-mois1.md com bloco de governança de "arquivo canônico principal" e template obrigatório; atualizado docs/mois/registros.md com aviso de redirecionamento para o arquivo canônico dos coletores.
+
+## 2026-05-17 12:10 UTC-3
+- Criado workflow dedicado `CI - MOIS Sales Library Worker` para o novo projeto `mois-sales-library-worker`, com esteiras de teste (`mvn test`), build/push de imagem no GHCR e deploy automático em `main`.
+- Deploy configurado no mesmo host dos demais módulos MOIS (`177.153.62.107`), com sincronização para `/opt/marketinghub/mois-sales-library-worker` e subida via `docker compose` com project name isolado (`marketinghub-mois-sales-library-worker`).
+- Adicionado arquivo `mois-sales-library-worker/docker-compose.deploy.yml` para fixar a imagem publicada (`MOIS_SALES_LIBRARY_WORKER_IMAGE`) no ambiente de produção, mantendo padrão operacional já usado nos outros coletores MOIS.

--- a/mois-sales-library-worker/docker-compose.deploy.yml
+++ b/mois-sales-library-worker/docker-compose.deploy.yml
@@ -1,0 +1,3 @@
+services:
+  mois-sales-library-worker:
+    image: ${MOIS_SALES_LIBRARY_WORKER_IMAGE:-ghcr.io/marketing-hub-org/marketing-hub/mois-sales-library-worker:latest}


### PR DESCRIPTION
### Motivation
- Provide CI/CD for the new `mois-sales-library-worker` service that ingests sales-page URLs into the sales-library and deploy it alongside existing MOIS modules on the same host. 
- Keep operations consistent with other MOIS collectors by reusing the established GHCR build/push and `docker compose` deployment pattern.

### Description
- Add GitHub Actions workflow `.github/workflows/mois-sales-library-worker-ci.yml` implementing `test`, `build-and-push` to GHCR and `deploy` stages with deployment targeting host `177.153.62.107` and remote path `/opt/marketinghub/mois-sales-library-worker`.
- Add `mois-sales-library-worker/docker-compose.deploy.yml` that pins the production image via `MOIS_SALES_LIBRARY_WORKER_IMAGE` and provides a `latest` fallback.
- Record the delivery in the canonical registry `docs/registros/coletor-mois1.md` with a timestamped entry describing the workflow and deployment configuration.

### Testing
- Ran `cd mois-sales-library-worker && mvn -B test`, which completed with `BUILD SUCCESS` and no tests discovered in the module. 
- The workflow is configured to run the same `mvn -B test` step, build/push to GHCR and deploy automatically on `main` when executed by GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09653f06348321bc92c8d9cd5ced54)