### PR TITLE
Add observability/logging to mois-sales-library-worker (PipelineRunner & BackendClient)

### DIFF
--- a/docs/mois/registros.md
+++ b/docs/mois/registros.md
@@ -273,3 +273,13 @@
 - Criado módulo `mois-sales-library-worker` (Java 21 + Maven + Spring Boot + Docker) para processar jobs PENDING da biblioteca de sales pages via backend MOIS.
 - Criados endpoints backend para claim/complete/fail do job da pipeline assíncrona.
 - Criado cânone: `docs/canonical/mois-sales-library-worker-canon.v1.md`.
+
+## 2026-05-17 04:03:18 UTC-3
+- Adicionada observabilidade operacional no `mois-sales-library-worker` para validar execução de agendamento e integração com backend do MOIS.
+- O `PipelineRunner` agora registra no início de cada ciclo agendado (`@Scheduled`) os parâmetros principais (`workspaceId`, `source`, `pollIntervalMs`, `requestTimeoutMs`) e também loga explicitamente quando nenhum job foi reivindicado.
+- Ao reivindicar job com sucesso, o worker passa a registrar `jobId`, `pageId` e `urlCanonical` antes da coleta da página.
+- O `BackendClient` passou a logar chamadas e retornos dos endpoints do backend:
+  - `POST /api/mois/sales-library/jobs:claim` (entrada e saída com `claimed/hasJob`);
+  - `POST /api/mois/sales-library/jobs/{jobId}:complete` (entrada e status HTTP de retorno);
+  - `POST /api/mois/sales-library/jobs/{jobId}:fail` (entrada com categoria/erro e status HTTP de retorno).
+- Objetivo: permitir validação objetiva de que o agendamento está executando corretamente, que o backend está sendo chamado e qual foi o retorno de cada chamada.

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/client/BackendClient.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/client/BackendClient.java
@@ -1,22 +1,49 @@
 package com.marketinghub.mois.libraryworker.client;
 
 import com.marketinghub.mois.libraryworker.model.WorkerDtos.*;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 @Component
+@Slf4j
 public class BackendClient {
     private final RestClient restClient;
     public BackendClient(RestClient restClient) { this.restClient = restClient; }
 
     public ClaimResponse claim(ClaimRequest request) {
-        return restClient.post().uri("/api/mois/sales-library/jobs:claim").contentType(MediaType.APPLICATION_JSON).body(request).retrieve().body(ClaimResponse.class);
+        log.info("MOIS sales-library worker calling backend claim endpoint. workspaceId={}, source={}", request.workspaceId(), request.source());
+        ClaimResponse response = restClient.post()
+                .uri("/api/mois/sales-library/jobs:claim")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(ClaimResponse.class);
+        log.info("MOIS sales-library worker claim response received. claimed={}, hasJob={}",
+                response != null && response.claimed(),
+                response != null && response.job() != null);
+        return response;
     }
     public void complete(long jobId, CompleteRequest request) {
-        restClient.post().uri("/api/mois/sales-library/jobs/{jobId}:complete", jobId).contentType(MediaType.APPLICATION_JSON).body(request).retrieve().toBodilessEntity();
+        log.info("MOIS sales-library worker calling backend complete endpoint. jobId={}, scoreTotal={}", jobId, request.scoreTotal());
+        var entity = restClient.post()
+                .uri("/api/mois/sales-library/jobs/{jobId}:complete", jobId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .toBodilessEntity();
+        log.info("MOIS sales-library worker complete response received. jobId={}, status={}", jobId, entity.getStatusCode());
     }
     public void fail(long jobId, FailRequest request) {
-        restClient.post().uri("/api/mois/sales-library/jobs/{jobId}:fail", jobId).contentType(MediaType.APPLICATION_JSON).body(request).retrieve().toBodilessEntity();
+        log.warn("MOIS sales-library worker calling backend fail endpoint. jobId={}, errorCategory={}, errorMessage={}",
+                jobId, request.errorCategory(), request.errorMessage());
+        var entity = restClient.post()
+                .uri("/api/mois/sales-library/jobs/{jobId}:fail", jobId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .toBodilessEntity();
+        log.info("MOIS sales-library worker fail response received. jobId={}, status={}", jobId, entity.getStatusCode());
     }
 }

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/service/PipelineRunner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/service/PipelineRunner.java
@@ -22,10 +22,16 @@ public class PipelineRunner {
 
     @Scheduled(fixedDelayString = "${worker.poll-interval-ms:15000}")
     public void runCycle() {
+        log.info("MOIS sales-library worker cycle started. workspaceId={}, source={}, pollIntervalMs={}, requestTimeoutMs={}",
+                properties.workspaceId(), properties.source(), properties.pollIntervalMs(), properties.requestTimeoutMs());
         ClaimResponse claim = backendClient.claim(new ClaimRequest(properties.workspaceId(), properties.source()));
-        if (claim == null || !claim.claimed() || claim.job() == null) return;
+        if (claim == null || !claim.claimed() || claim.job() == null) {
+            log.info("MOIS sales-library worker cycle finished without claimed job.");
+            return;
+        }
         long jobId = claim.job().jobId();
         try {
+            log.info("MOIS sales-library worker claimed job. jobId={}, pageId={}, urlCanonical={}", jobId, claim.job().pageId(), claim.job().urlCanonical());
             var doc = Jsoup.connect(claim.job().urlCanonical()).timeout(properties.requestTimeoutMs()).get();
             String text = doc.body() != null ? doc.body().text() : "";
             Map<String, Object> sections = new HashMap<>();
@@ -38,7 +44,7 @@ public class PipelineRunner {
             log.info("MOIS library job {} completed for page {}", jobId, claim.job().pageId());
         } catch (Exception ex) {
             backendClient.fail(jobId, new FailRequest("PIPELINE_ERROR", ex.getMessage()));
-            log.warn("MOIS library job {} failed: {}", jobId, ex.getMessage());
+            log.warn("MOIS library job {} failed: {}", jobId, ex.getMessage(), ex);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Add operational observability to the `mois-sales-library-worker` to validate that the scheduled pipeline executes and to verify backend integration and responses.
- Make it easier to detect and diagnose why cycles finish without claimed jobs or why specific jobs succeed/fail by surfacing key request and response information.

### Description
- Updated `docs/mois/registros.md` with a new entry describing the observability additions for the worker.
- Enhanced `PipelineRunner` to log cycle start parameters (`workspaceId`, `source`, `pollIntervalMs`, `requestTimeoutMs`), to log when no job was claimed, and to log claimed job metadata (`jobId`, `pageId`, `urlCanonical`) before collection.
- Added `@Slf4j` to `BackendClient` and instrumented `claim`, `complete`, and `fail` calls to log request inputs and response results/status codes (including `claimed/hasJob` for claims).
- Improved error logging in `PipelineRunner` to include the exception stack trace when a job fails.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09678235548321b7897309238249e0)