### PR TITLE
Landing tab: preview experiment HTML and remove landing pipeline blocks

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -74,3 +74,16 @@
   - AGENTS.md
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+
+## 2026-05-17 04:08:17 UTC-3
+- solicitação para ajustar a aba Landing do experimento para usar o HTML salvo no próprio registro da tabela `experiment` e alinhar com a migração da geração para o Gera Landing.
+- raciocínio aplicado: remover dependência da listagem antiga de landings do pipeline e exibir diretamente a prévia do HTML final que agora pertence ao fluxo Gera Landing.
+- foi feito no frontend:
+  - atualização da aba Landing para renderizar o `landingPageHtml` do experimento em preview (`iframe` com `srcDoc`) e manter o botão de aprovação para campanha apontando o destino da campanha para `/landing/{id}`.
+  - remoção dos blocos de landing do conteúdo do pipeline na aba "Conteúdo" (mantidas apenas etapas de Campaign Angle e Ad Copy).
+- documentos/arquivos lidos:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/experiment/LandingTab.tsx
+  - frontend/src/pages/experiment/ExperimentDetailPage.tsx

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -238,54 +238,8 @@ export default function ExperimentDetailPage() {
         description: "Conteúdo bruto salvo na coluna ad_copy.",
         rawValue: data?.adCopy,
       },
-      {
-        key: "wireframe",
-        title: "Etapa 3 · Landing Wireframe",
-        description: "Conteúdo bruto salvo na coluna landing_page_wireframe.",
-        rawValue: data?.landingPageWireframe,
-      },
-      {
-        key: "copy",
-        title: "Etapa 4 · Landing Copy",
-        description: "Conteúdo bruto salvo na coluna landing_page_copy.",
-        rawValue: data?.landingPageCopy,
-      },
-      {
-        key: "image-planning",
-        title: "Etapa 5 · Planejamento de Imagens",
-        description:
-          "Conteúdo bruto salvo na coluna landing_page_image_planning.",
-        rawValue: data?.landingPageImagePlanning,
-      },
-      {
-        key: "design-preset",
-        title: "Etapa 6 · Preset Design",
-        description:
-          "Conteúdo bruto salvo na coluna landing_page_design_preset.",
-        rawValue: data?.landingPageDesignPreset,
-      },
-      {
-        key: "landing-page-deliverables",
-        title: "Etapa 8 · Landing Page Deliverables",
-        description: "JSON final dos entregáveis da amostra e do produto final.",
-        rawValue: data?.landingPageDeliverables,
-      },
-      {
-        key: "landing-html",
-        title: "Etapa 7 · Landing HTML",
-        description: "Conteúdo bruto salvo na coluna landing_page_html.",
-        rawValue: data?.landingPageHtml,
-      },
     ],
-    [
-      data?.adCopy,
-      data?.campaignAngle,
-      data?.landingPageCopy,
-      data?.landingPageDesignPreset,
-      data?.landingPageHtml,
-      data?.landingPageImagePlanning,
-      data?.landingPageWireframe,
-    ],
+    [data?.adCopy, data?.campaignAngle],
   );
   useBreadcrumbs([
     {

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import type { Experiment } from "../../api/experiment/useExperiments";
 import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
-import { useLandingPages } from "../../api/landing/useLandingPages";
 
 interface LandingTabProps {
   experiment: Experiment;
@@ -29,26 +28,16 @@ function normalizeUrl(url?: string | null) {
 }
 
 export default function LandingTab({ experiment }: LandingTabProps) {
-  const { data: landingPages, isLoading, isError } = useLandingPages(experiment.id);
   const updateExperiment = useUpdateExperiment(experiment.id);
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
-  const [selectedLandingId, setSelectedLandingId] = useState<number | null>(null);
-
-  const sortedLandingPages = useMemo(() => {
-    if (!Array.isArray(landingPages)) {
-      return [];
-    }
-
-    return [...landingPages].sort((a, b) => b.id - a.id);
-  }, [landingPages]);
+  const landingHtml = useMemo(() => {
+    const raw = experiment.landingPageHtml;
+    return typeof raw === "string" && raw.trim().length > 0 ? raw : null;
+  }, [experiment.landingPageHtml]);
 
   const selectedDestinationUrl = normalizeUrl(experiment.followUpActionUrl);
-  const resolvedSelectedLanding = useMemo(
-    () => sortedLandingPages.find((landing) => landing.id === selectedLandingId) ?? null,
-    [selectedLandingId, sortedLandingPages],
-  );
 
-  const handleApproveLanding = async (landingId: number, landingUrl: string) => {
+  const handleApproveLanding = async () => {
     const kpiTargetValue = experiment.kpiTarget ?? experiment.kpiTargetCpl;
     if (kpiTargetValue == null || experiment.metricPresetId == null) {
       setFeedback({
@@ -59,7 +48,7 @@ export default function LandingTab({ experiment }: LandingTabProps) {
       return;
     }
 
-    const destinationUrl = resolveStandaloneLandingUrl(landingUrl);
+    const destinationUrl = resolveStandaloneLandingUrl(`/landing/${experiment.id}`);
     setFeedback(null);
 
     try {
@@ -103,7 +92,7 @@ export default function LandingTab({ experiment }: LandingTabProps) {
       <div className="card border-0 shadow-sm">
         <div className="card-body">
           <h5 className="card-title mb-1">Landing do experimento</h5>
-          <p className="text-muted mb-0">Selecione uma landing e aprove no botão final da aba.</p>
+          <p className="text-muted mb-0">Pré-visualização do HTML salvo no experimento.</p>
         </div>
       </div>
 
@@ -116,64 +105,27 @@ export default function LandingTab({ experiment }: LandingTabProps) {
         </div>
       ) : null}
 
-      {isLoading ? (
-        <p className="text-muted">Carregando landings do experimento...</p>
-      ) : isError ? (
-        <p className="text-danger">Não foi possível carregar as landings deste experimento.</p>
-      ) : sortedLandingPages.length === 0 ? (
+      {!landingHtml ? (
         <p className="text-muted mb-0">
-          Nenhuma landing gerada ainda. Gere o HTML na aba Estrutura de conteúdo para publicar aqui.
+          Nenhum HTML de landing encontrado no registro do experimento.
         </p>
       ) : (
-        <div className="d-flex flex-column gap-3">
-          {sortedLandingPages.map((landing) => {
-            const standaloneUrl = resolveStandaloneLandingUrl(landing.url);
-            const isSelected = normalizeUrl(standaloneUrl) === selectedDestinationUrl;
-
-            return (
-              <div key={landing.id} className="card border-0 shadow-sm">
-                <div className="card-body d-flex flex-column gap-3">
-                  <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
-                    <div>
-                      <h6 className="mb-1 d-flex align-items-center gap-2">
-                        Landing #{landing.id}
-                        {isSelected ? (
-                          <span className="badge text-bg-success">Destino ativo</span>
-                        ) : null}
-                      </h6>
-                      <p className="text-muted small mb-1">Tipo: {landing.type}</p>
-                      <p className="text-muted small mb-0">Status: {landing.status}</p>
-                    </div>
-                    <div className="form-check">
-                      <input
-                        id={`landing-choice-${landing.id}`}
-                        className="form-check-input"
-                        type="radio"
-                        name="landing-choice"
-                        checked={selectedLandingId === landing.id}
-                        onChange={() => setSelectedLandingId(landing.id)}
-                      />
-                      <label className="form-check-label small" htmlFor={`landing-choice-${landing.id}`}>
-                        Selecionar para campanha
-                      </label>
-                    </div>
-                  </div>
-
-                  <div>
-                    <p className="text-muted small mb-1">URL standalone</p>
-                    <a
-                      href={standaloneUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="small text-break"
-                    >
-                      {standaloneUrl}
-                    </a>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
+        <div className="card border-0 shadow-sm">
+          <div className="card-body d-flex flex-column gap-3">
+            <div className="d-flex flex-wrap align-items-center gap-2">
+              <span className="fw-semibold">Destino atual:</span>
+              {selectedDestinationUrl ? (
+                <span className="badge text-bg-success">URL de campanha definida</span>
+              ) : (
+                <span className="badge text-bg-secondary">Sem URL aprovada</span>
+              )}
+            </div>
+            <iframe
+              title="Prévia da landing do experimento"
+              srcDoc={landingHtml}
+              style={{ width: "100%", minHeight: 560, border: "1px solid #dee2e6", borderRadius: 8 }}
+            />
+          </div>
         </div>
       )}
 
@@ -182,11 +134,9 @@ export default function LandingTab({ experiment }: LandingTabProps) {
           type="button"
           className="btn btn-success"
           onClick={() =>
-            resolvedSelectedLanding
-              ? handleApproveLanding(resolvedSelectedLanding.id, resolvedSelectedLanding.url)
-              : undefined
+            handleApproveLanding()
           }
-          disabled={updateExperiment.isPending || !resolvedSelectedLanding}
+          disabled={updateExperiment.isPending || !landingHtml}
         >
           {updateExperiment.isPending ? (
             <span className="d-inline-flex align-items-center gap-2">


### PR DESCRIPTION
### Motivation
- The landing-generation flow was moved from the experiment pipeline to the `Gera Landing` flow, so the Experiments UI must stop depending on the old pipeline landings list and instead preview the HTML stored on the experiment record. 
- This change avoids duplicated responsibility and keeps the approval UX consistent with the new `Gera Landing` flow.

### Description
- Updated `frontend/src/pages/experiment/LandingTab.tsx` to read `experiment.landingPageHtml` and render a preview using an `iframe` with `srcDoc`, and kept the approval button which now sets the experiment `followUpActionUrl` to `/landing/{experiment.id}` after KPI/preset validation. 
- Removed landing-related pipeline cards from `frontend/src/pages/experiment/ExperimentDetailPage.tsx` so `pipelineContentCards` now contains only `campaign-angle` and `ad-copy`. 
- Appended an entry to `docs/registros/experimentos.md` documenting the change following the repository's append-only experiment registry policy. 
- Adjusted memoization and button enablement logic so the Landing tab is enabled only when `landingPageHtml` is present.

### Testing
- Attempted to run frontend tests with `cd frontend && npm run test -- LandingTab --runInBand`, which failed because the `vitest` binary is not available in the current environment (`sh: 1: vitest: not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a096909e6dc832198646eace6ca0932)