### PR TITLE
Fix 400 on PUT /api/experiments/{id} when clearing lead portal flow

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -569,9 +569,10 @@ public class ExperimentService {
         }
         if (request.isLeadPortalFlowIdPresent()) {
             if (request.getLeadPortalFlowId() == null) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "leadPortalFlowId required");
+                exp.setLeadPortalFlow(null);
+            } else {
+                exp.setLeadPortalFlow(attachLeadPortalFlow(request.getLeadPortalFlowId(), exp.getNiche().getId()));
             }
-            exp.setLeadPortalFlow(attachLeadPortalFlow(request.getLeadPortalFlowId(), exp.getNiche().getId()));
         }
         if (request.isImageModelIdPresent() || request.isImageModelQualityIdPresent()) {
             Long currentModelId = request.isImageModelIdPresent()

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -875,6 +875,56 @@ class ExperimentServiceTest {
     }
 
     @Test
+    void updateClearsLeadPortalFlowWhenNullIsProvided() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste").build());
+        var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
+        var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
+                .marketNiche(niche)
+                .title("T")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(com.marketinghub.hypothesis.OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .build());
+        metricPresetRepository.save(MetricPreset.builder()
+                .id("LEAN_150")
+                .name("Lean-Startup 150")
+                .sampleSize(150)
+                .stopLossFactor(new BigDecimal("2"))
+                .defaultMdePp(new BigDecimal("12"))
+                .build());
+        Long flowId = createLeadPortalFlow(niche);
+        JourneyTemplate template = journeyTemplateRepository.save(JourneyTemplate.builder().name("Lifecycle").build());
+        CreateExperimentRequest req = new CreateExperimentRequest();
+        applyStageDefaults(req);
+        req.setMarketNicheId(niche.getId());
+        req.setHypothesisId(hyp.getId());
+        req.setName("Exp1");
+        req.setHypothesis("Teste");
+        req.setKpiTargetCpl(new BigDecimal("45"));
+        req.setMetricPresetId("LEAN_150");
+        req.setJourneyTemplateId(template.getId());
+        req.setInstagramAccountId(createInstagramAccount().getId());
+        req.setLeadPortalFlowId(flowId);
+        Experiment exp = service.create(req);
+
+        UpdateExperimentRequest updateReq = new UpdateExperimentRequest();
+        applyStageDefaults(updateReq);
+        updateReq.setName("Exp1");
+        updateReq.setHypothesis("Teste");
+        updateReq.setKpiTargetCpl(new BigDecimal("45"));
+        updateReq.setMetricPresetId("LEAN_150");
+        updateReq.setJourneyTemplateId(template.getId());
+        updateReq.setLeadPortalFlowId(null);
+
+        Experiment updated = service.update(exp.getId(), updateReq);
+
+        assertThat(updated.getLeadPortalFlow()).isNull();
+    }
+
+    @Test
     void updateChangesLeadPortalFlowWhenProvided() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste").build());
         var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -87,3 +87,15 @@
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/LandingTab.tsx
   - frontend/src/pages/experiment/ExperimentDetailPage.tsx
+
+## 2026-05-17 00:00:00 UTC
+- solicitação para investigar e corrigir `400 Bad Request` no `PUT /api/experiments/20`.
+- causa-raiz identificada: ao enviar `leadPortalFlowId: null` no payload de atualização, o backend tratava o campo como obrigatório quando presente e lançava erro `leadPortalFlowId required`.
+- correção aplicada: ajuste no `ExperimentService.update` para permitir `leadPortalFlowId` nulo quando informado explicitamente (limpando o vínculo do fluxo), mantendo validação normal quando um ID é enviado.
+- validação automatizada adicionada com teste unitário cobrindo o cenário de limpeza do `leadPortalFlowId` via update.
+- documentos/arquivos lidos:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+  - backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java


### PR DESCRIPTION
### Motivation
- Users received `400 Bad Request` when updating an experiment with `leadPortalFlowId: null`, because the update path treated the presence of the field as requiring a non-null value. 
- The intent is to allow clients to explicitly clear the `leadPortalFlow` association by sending `leadPortalFlowId: null` without triggering a validation error.

### Description
- Updated `ExperimentService.update` to accept an explicit `null` for `leadPortalFlowId` and clear the association with `exp.setLeadPortalFlow(null)` while preserving existing validation for non-null IDs (`backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java`).
- Added a unit test `updateClearsLeadPortalFlowWhenNullIsProvided` that creates an experiment with a lead portal flow then updates it with `leadPortalFlowId = null` and asserts the association is cleared (`backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java`).
- Recorded the investigation, root cause and the fix in the experiments registry file (`docs/registros/experimentos.md`).

### Testing
- Ran the targeted experiment service test suite with `cd backend/ads-service && ../mvnw -Dtest=ExperimentServiceTest test` and obtained `BUILD SUCCESS` with `Tests run: 19, Failures: 0, Errors: 0, Skipped: 0` indicating the new test passes.
- The change is covered by the added unit test `updateClearsLeadPortalFlowWhenNullIsProvided` which verifies the `leadPortalFlow` is removed when `leadPortalFlowId` is explicitly set to `null` in an update request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e1eddf088321931c369d74368214)