### PR TITLE
Clickbase: surface JWT auth failures in UI and add collection-jobs hook; update MOIS docs

### DIFF
--- a/docs/registros/coletor-mois1.md
+++ b/docs/registros/coletor-mois1.md
@@ -245,3 +245,14 @@
 - Criado workflow dedicado `CI - MOIS Sales Library Worker` para o novo projeto `mois-sales-library-worker`, com esteiras de teste (`mvn test`), build/push de imagem no GHCR e deploy automático em `main`.
 - Deploy configurado no mesmo host dos demais módulos MOIS (`177.153.62.107`), com sincronização para `/opt/marketinghub/mois-sales-library-worker` e subida via `docker compose` com project name isolado (`marketinghub-mois-sales-library-worker`).
 - Adicionado arquivo `mois-sales-library-worker/docker-compose.deploy.yml` para fixar a imagem publicada (`MOIS_SALES_LIBRARY_WORKER_IMAGE`) no ambiente de produção, mantendo padrão operacional já usado nos outros coletores MOIS.
+
+## 2026-05-17 16:05 UTC
+- Análise operacional dos logs de ingestão do `clickbank-coletor-mois` via MCP (`java_module_logs`) focada no envio de token para a consulta GraphQL da ClickBank.
+- Evidência confirmada de envio do token no request: `hasAuthorizationHeader=true` e `tokenLength=1005` em múltiplas execuções do Ciclo 3 (08h, 11h, 14h UTC).
+- Em todas as tentativas do Ciclo 3 observadas, a resposta da origem foi `status=403` com corpo HTML do CloudFront (`Request blocked`), seguida de classificação interna `motivo=JWT_EXPIRED_OR_INVALID` e coleta zerada.
+- Conclusão de causa-raiz desta rodada: o coletor está enviando o token, porém a origem está bloqueando a requisição no edge (CloudFront) antes de qualquer payload útil de negócio; portanto o problema atual é de aceitação/autorização na origem e não de ausência de header no coletor.
+
+## 2026-05-17 16:35 UTC
+- Ajustada tela Clickbase no frontend para exibir alerta operacional quando a última execução de coleta apontar indício de falha de autenticação/token (ex.: `JWT_EXPIRED_OR_INVALID`, `403`, `REQUEST BLOCKED`, `UNAUTHORIZED`).
+- O alerta é exibido ao lado do textarea de JWT orientando o usuário a atualizar o token e salvar, reduzindo ambiguidade no tratamento do erro observado no GraphQL da ClickBank.
+- Implementada leitura de jobs em `useClickbaseCollectionJobs` via endpoint já existente `GET /api/v1/mois/collection-jobs` para suportar a lógica da mensagem sem criar novo contrato.

--- a/frontend/src/api/settings/useClickbaseCollectedProducts.ts
+++ b/frontend/src/api/settings/useClickbaseCollectedProducts.ts
@@ -28,3 +28,29 @@ export function useClickbaseCollectedProducts(workspaceId: string, limit = 24) {
     },
   });
 }
+
+
+export interface ClickbaseCollectionJob {
+  jobId: string;
+  workspaceId: string;
+  status: string;
+  createdAt?: string | null;
+  message?: string | null;
+}
+
+interface ClickbaseCollectionJobListResponse {
+  items: ClickbaseCollectionJob[];
+}
+
+export function useClickbaseCollectionJobs(workspaceId: string) {
+  return useQuery({
+    queryKey: ["settings", "clickbase", "jobs", workspaceId],
+    enabled: workspaceId.trim().length > 0,
+    queryFn: async () => {
+      const { data } = await axios.get<ClickbaseCollectionJobListResponse>("/api/v1/mois/collection-jobs", {
+        params: { workspaceId },
+      });
+      return data.items;
+    },
+  });
+}

--- a/frontend/src/pages/clickbase/ClickbasePage.tsx
+++ b/frontend/src/pages/clickbase/ClickbasePage.tsx
@@ -1,6 +1,9 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import PageTitle from "../../components/PageTitle";
-import { useClickbaseCollectedProducts } from "../../api/settings/useClickbaseCollectedProducts";
+import {
+  useClickbaseCollectedProducts,
+  useClickbaseCollectionJobs,
+} from "../../api/settings/useClickbaseCollectedProducts";
 import {
   useClickbankAccessTokenSetting,
   useUpdateClickbankAccessTokenSetting,
@@ -22,6 +25,7 @@ function formatUpdatedAt(value?: string | null) {
 export default function ClickbasePage() {
   const workspaceId = "workspace-001";
   const clickbaseProductsQuery = useClickbaseCollectedProducts(workspaceId, 24);
+  const clickbaseJobsQuery = useClickbaseCollectionJobs(workspaceId);
   const { data: clickbankSetting, isLoading: isLoadingSetting, isError: isErrorSetting } =
     useClickbankAccessTokenSetting();
   const updateClickbankSetting = useUpdateClickbankAccessTokenSetting();
@@ -36,6 +40,24 @@ export default function ClickbasePage() {
 
   const updatedAt = useMemo(() => formatUpdatedAt(clickbankSetting?.updatedAt), [clickbankSetting?.updatedAt]);
   const latestJobId = useMemo(() => clickbaseProductsQuery.data?.[0]?.jobId, [clickbaseProductsQuery.data]);
+
+  const latestClickbaseExecution = useMemo(() => clickbaseJobsQuery.data?.[0], [clickbaseJobsQuery.data]);
+  const shouldShowTokenRefreshAlert = useMemo(() => {
+    if (!latestClickbaseExecution) {
+      return false;
+    }
+
+    const message = (latestClickbaseExecution.message ?? "").toUpperCase();
+    const hasTokenHint =
+      message.includes("JWT_EXPIRED_OR_INVALID") ||
+      message.includes("TOKEN") ||
+      message.includes("403") ||
+      message.includes("UNAUTHORIZED") ||
+      message.includes("REQUEST BLOCKED");
+
+    return (latestClickbaseExecution.status === "COLLECTION_ERROR" || latestClickbaseExecution.status === "COLLECTION_SKIPPED") && hasTokenHint;
+  }, [latestClickbaseExecution]);
+
   const latestJobDate = useMemo(() => {
     const collectedAt = clickbaseProductsQuery.data?.[0]?.collectedAt;
     if (!collectedAt) {
@@ -118,6 +140,13 @@ export default function ClickbasePage() {
           ) : null}
 
           {feedback ? <div className="alert alert-info mt-3 mb-0">{feedback}</div> : null}
+
+          {shouldShowTokenRefreshAlert ? (
+            <div className="alert alert-warning mt-3 mb-0" role="alert">
+              <strong>Atenção:</strong> a última coleta indicou falha de autenticação no Graph da ClickBank.
+              Atualize o token JWT no campo acima e salve para liberar as próximas coletas.
+            </div>
+          ) : null}
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Surface authentication-related failures observed during ClickBank collections to reduce operator confusion and prompt JWT refresh when the origin blocks requests at the edge. 
- Provide a way for the frontend to read recent collection job metadata so UI logic can detect token-related errors without adding new endpoints. 
- Consolidate MOIS collector governance into a single canonical registro and document the operational analysis and new worker deployment decisions.

### Description
- Added `useClickbaseCollectionJobs` hook in `frontend/src/api/settings/useClickbaseCollectedProducts.ts` to call `GET /api/v1/mois/collection-jobs` and expose `ClickbaseCollectionJob` items. 
- Updated `frontend/src/pages/clickbase/ClickbasePage.tsx` to consume the new hook, compute `shouldShowTokenRefreshAlert` from the latest job `status` and `message`, and render a warning alert next to the JWT textarea instructing operators to update the token. 
- Kept existing product listing behavior and token save flow intact and added the necessary imports and memoized selectors for the new job data. 
- Updated `docs/registros/coletor-mois1.md` with canonical-file governance, an operational analysis of ClickBank GraphQL/CloudFront `403`/`JWT_EXPIRED_OR_INVALID` observations, and notes about the new `mois-sales-library-worker` CI/deploy configuration.

### Testing
- No automated tests were executed as part of this PR. 
- A GitHub Actions workflow was added/configured to run `mvn test` and build/push the `mois-sales-library-worker` image as part of CI for that project, but no workflow run result is included in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e47aa3bc83218a29065fdcf4582b)