### PR TITLE
Remover duplicidade e ignorar status `planejado` nas pendências de publicação

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -99,3 +99,13 @@
   - docs/registros/experimentos.md
   - backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
   - backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+
+## 2026-05-17 13:20:14 UTC-3
+- solicitação para corrigir a lista de pendências de publicação no Facebook Ads exibindo item duplicado de Landing e removendo bloqueio indevido de status planejado.
+- raciocínio aplicado: padronizar a renderização da lista para evitar duplicidade por chave/label e filtrar explicitamente entradas de status que não devem bloquear publicação.
+- foi feito no frontend: atualização do componente `MissingConfigurationList` para deduplicar pendências por rótulo e ignorar entradas de status `planned/planejado`.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/facebook/MissingConfigurationList.tsx

--- a/frontend/src/pages/facebook/MissingConfigurationList.tsx
+++ b/frontend/src/pages/facebook/MissingConfigurationList.tsx
@@ -15,19 +15,40 @@ export function MissingConfigurationList({
     return null;
   }
 
+  const normalizedItems = items
+    .filter((item) => !isPlannedStatusEntry(item))
+    .filter((item, index, list) => list.indexOf(item) === index);
+
+  const uniqueEntriesByLabel = normalizedItems.reduce<
+    Array<{ key: string; label: string; helperText?: string }>
+  >((acc, item) => {
+    const info = getMissingConfigurationInfo(item);
+    const alreadyAdded = acc.some((entry) => entry.label === info.label);
+    if (!alreadyAdded) {
+      acc.push({ key: item, ...info });
+    }
+    return acc;
+  }, []);
+
+  if (uniqueEntriesByLabel.length === 0) {
+    return null;
+  }
+
   return (
     <ul className={className}>
-      {items.map((item) => {
-        const info = getMissingConfigurationInfo(item);
-        return (
-          <li key={item} className={itemClassName}>
-            <div>{info.label}</div>
-            {info.helperText ? (
-              <p className="text-body-secondary small mb-0">{info.helperText}</p>
-            ) : null}
-          </li>
-        );
-      })}
+      {uniqueEntriesByLabel.map((entry) => (
+        <li key={entry.key} className={itemClassName}>
+          <div>{entry.label}</div>
+          {entry.helperText ? (
+            <p className="text-body-secondary small mb-0">{entry.helperText}</p>
+          ) : null}
+        </li>
+      ))}
     </ul>
   );
+}
+
+function isPlannedStatusEntry(item: string): boolean {
+  const normalized = item.trim().toLowerCase();
+  return normalized === "planned" || normalized === "planejado";
 }


### PR DESCRIPTION
### Motivation
- Usuário relatou que a pendência “Landing” aparece duplicada na tela de experimentos prontos e que entradas com status marcado como planejado não devem bloquear publicação.  
- Objetivo: apresentar uma lista de pendências única por rótulo e excluir estados de status que não são bloqueios reais (`planned` / `planejado`).

### Description
- Atualiza o componente `frontend/src/pages/facebook/MissingConfigurationList.tsx` para filtrar entradas de status planejado usando a função `isPlannedStatusEntry` e remover essas entradas da lista de pendências.  
- Deduplica itens por `label` (não por chave) montando `uniqueEntriesByLabel` antes de renderizar para evitar repetição visual (ex.: “Landing” aparecendo duas vezes).  
- Ajusta a renderização para iterar sobre `uniqueEntriesByLabel` em vez da lista original e mantém `helperText` quando presente.  
- Adiciona entrada no log canônico `docs/registros/experimentos.md` com timestamp descrevendo a alteração operacional.

### Testing
- Tentativa de build do frontend com `npm --prefix frontend run build` foi executada e falhou no ambiente atual devido a `vite: not found`, portanto não houve build completo automatizado bem-sucedido.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ea84118c8321abf64dbc5db26842)