### PR TITLE
docs: adicionar orientações sobre documentos canônicos no AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ Toda decisão de arquitetura, dados, prompts, automações, integrações e arte
 - **Artefatos**: docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md sempre leia e atualize se necessário.
 - **Modelo de dados**: `docs/modelo-dados-experimento.md`. Alterou entidades ou relacionamentos? Atualize o documento imediatamente.
 - **Liquibase / MySQL 5.7**: `docs/database/liquibase-mysql57.md`. Use sempre `databaseChangeLog` em YAML, `preConditions` com `dbms:mysql`, `splitStatements: true`, `stripComments: true` e valide mentalmente o SQL.
+- **Documentos canônicos básicos**: os documentos canônicos básicos do projeto ficam em `/docs/canonical` e devem ser consultados como referência primária.
+- **Decisão de mudança de regras (obrigatório)**: quando o usuário decidir mudar regras, altere imediatamente o documento correspondente em `/docs/canonical` referente ao tema.
 
 ## 2. Convenções de engenharia
 


### PR DESCRIPTION
### Motivation
- Reforçar governança documental e evitar divergência entre decisões de regra e a documentação canônica.
- Estabelecer uma localização única de referência para os documentos canônicos do projeto.

### Description
- Adiciona duas novas orientações em `AGENTS.md` na seção "1. Fontes de verdade": declara que os documentos canônicos ficam em `/docs/canonical`.
- Adiciona orientação obrigatória para atualizar imediatamente o documento correspondente em `/docs/canonical` sempre que houver decisão de mudança de regras; arquivo alterado: `AGENTS.md`.

### Testing
- Verificação de presença de `AGENTS.md` realizada com `pwd && rg --files -g 'AGENTS.md'` e retornou os arquivos esperados (sucesso).
- Alteração aplicada e inspeccionada com `nl -ba AGENTS.md | sed -n '18,40p'` para confirmar a inserção das linhas (sucesso).
- Mudança adicionada ao repositório e registrada com `git -C /workspace/marketing-hub add` e `git -C /workspace/marketing-hub commit -m "docs: add canonical update guidance to AGENTS"` e PR criado via `make_pr` (sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09fd1374f88321874fce3124afaf44)