### PR TITLE
fix(frontend): declare openLandingActions before blockingChecklist to fix TS2448/TS2454

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -122,3 +122,15 @@
   - `frontend/src/pages/experiment/ExperimentDetailPage.tsx`
   - `docs/canonical/facebook-campaign-publication-canon.v1.md`
   - `docs/registros/experimentos.md`
+
+## 2026-05-17 14:40:45 UTC-3
+- correção de erro de typecheck no `ExperimentDetailPage` por uso de função antes da declaração.
+- o checklist bloqueante da aba Facebook referenciava `openLandingActions` antes da inicialização do `const`, causando TS2448/TS2454.
+- foi movida a declaração de `openLandingActions` para antes de `blockingChecklist`, mantendo o mesmo comportamento de navegação/scroll para a aba Landing.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+- arquivos alterados:
+  - frontend/src/pages/experiment/ExperimentDetailPage.tsx
+  - docs/registros/experimentos.md

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1087,6 +1087,16 @@ export default function ExperimentDetailPage() {
     readinessSummary?.hasCreatives ?? data.creativeApproved;
   const readinessCreativeCount = readinessSummary?.creativeCount ?? 0;
   const hasDailyBudget = data.dailyBudget != null && data.dailyBudget > 0;
+  const openLandingActions = () => {
+    setTab("landing");
+    window.requestAnimationFrame(() => {
+      tabsSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
+  };
+
   const blockingChecklist: ChecklistItem[] = [
     {
       id: "creatives",
@@ -1126,15 +1136,6 @@ export default function ExperimentDetailPage() {
     isReadyForFacebook && data.platform === "FACEBOOK";
   const releaseButtonDisabled =
     releaseInProgress || !canReleaseExperiment || isLoadingReadiness;
-  const openLandingActions = () => {
-    setTab("landing");
-    window.requestAnimationFrame(() => {
-      tabsSectionRef.current?.scrollIntoView({
-        behavior: "smooth",
-        block: "start",
-      });
-    });
-  };
 
   const configurationChecklist: ChecklistItem[] = [
     {


### PR DESCRIPTION
### Motivation
- Fix a TypeScript build error where a block-scoped `const` was referenced before its declaration causing `TS2448`/`TS2454` in the experiment detail page UI.
- Keep existing UI behavior (navigate + scroll to the Landing tab) while restoring correct declaration order to satisfy the typechecker.

### Description
- Move the `openLandingActions` function declaration to appear before the `blockingChecklist` so the checklist can reference it safely at construction time in `frontend/src/pages/experiment/ExperimentDetailPage.tsx`.
- No behavioral changes were introduced: the function still sets the tab to `"landing"` and performs the same `requestAnimationFrame` scroll into view.
- Add an entry to the canonical experiments log at `docs/registros/experimentos.md` documenting the fix and the reason (TypeScript use-before-declaration).

### Testing
- Ran `npm run typecheck` in `frontend`, which removed the original `openLandingActions`-related `TS2448/TS2454` failures but the typecheck command still fails due to environment/configuration issues unrelated to this change. 
- Remaining typecheck errors are missing type definitions for `@testing-library/jest-dom`, `vite/client`, and `vitest/globals`, and deprecation notices (`TS5107`/`TS5101`) from `tsconfig.json` with the TypeScript version in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09fd5cfa708321b16eebb464cf4fb9)