### PR TITLE
Consider approved targeting packages in ExperimentReadinessService and tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -9,6 +9,7 @@ import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.experiment.repository.ExperimentTargetingSelectionRepository;
+import com.marketinghub.targeting.repository.TargetingElementRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,13 +24,16 @@ public class ExperimentReadinessService {
     private final ExperimentService experimentService;
     private final CreativeRepository creativeRepository;
     private final ExperimentTargetingSelectionRepository targetingSelectionRepository;
+    private final TargetingElementRepository targetingElementRepository;
 
     public ExperimentReadinessService(ExperimentService experimentService,
                                       CreativeRepository creativeRepository,
-                                      ExperimentTargetingSelectionRepository targetingSelectionRepository) {
+                                      ExperimentTargetingSelectionRepository targetingSelectionRepository,
+                                      TargetingElementRepository targetingElementRepository) {
         this.experimentService = experimentService;
         this.creativeRepository = creativeRepository;
         this.targetingSelectionRepository = targetingSelectionRepository;
+        this.targetingElementRepository = targetingElementRepository;
     }
 
     @Transactional(readOnly = true)
@@ -98,13 +102,13 @@ public class ExperimentReadinessService {
             missing.add("leadPortalFlow");
         }
         if (!hasConfiguredTargeting(experiment)) {
-            missing.add("targetingSelections");
+            missing.add("approvedTargetingPackage");
         }
         return List.copyOf(missing);
     }
 
     private List<TargetingElementType> mapMissingTargetingTypes(List<String> missingConfiguration) {
-        if (!missingConfiguration.contains("targetingSelections")) {
+        if (!missingConfiguration.contains("approvedTargetingPackage")) {
             return List.of();
         }
         return List.of(
@@ -117,7 +121,20 @@ public class ExperimentReadinessService {
         if (experiment == null) {
             return false;
         }
+        if (hasApprovedTargetingPackage(experiment)) {
+            return true;
+        }
         return hasSelectedTargeting(experiment.getId());
+    }
+
+    private boolean hasApprovedTargetingPackage(Experiment experiment) {
+        if (experiment.getNiche() == null || experiment.getNiche().getId() == null) {
+            return false;
+        }
+        return !targetingElementRepository.findApprovedForExperiment(
+                experiment.getNiche().getId(),
+                TargetingElementType.JOB_TITLE,
+                experiment.getHypothesisRef() != null ? experiment.getHypothesisRef().getId() : null).isEmpty();
     }
 
     private boolean hasApprovedCreative(Experiment experiment) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -10,8 +10,10 @@ import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.targeting.TargetingCandidateType;
+import com.marketinghub.targeting.TargetingElement;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.experiment.repository.ExperimentTargetingSelectionRepository;
+import com.marketinghub.targeting.repository.TargetingElementRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -33,6 +35,8 @@ class ExperimentReadinessServiceTest {
     private CreativeRepository creativeRepository;
     @Mock
     private ExperimentTargetingSelectionRepository targetingSelectionRepository;
+    @Mock
+    private TargetingElementRepository targetingElementRepository;
 
     @InjectMocks
     private ExperimentReadinessService service;
@@ -47,6 +51,8 @@ class ExperimentReadinessServiceTest {
         when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(false);
         when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
                 .thenReturn(0L);
+        when(targetingElementRepository.findApprovedForExperiment(experiment.getNiche().getId(),
+                TargetingElementType.JOB_TITLE, experiment.getHypothesisRef().getId())).thenReturn(List.of());
 
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
@@ -76,6 +82,8 @@ class ExperimentReadinessServiceTest {
         when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
         when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
                 .thenReturn(1L);
+        when(targetingElementRepository.findApprovedForExperiment(experiment.getNiche().getId(),
+                TargetingElementType.JOB_TITLE, experiment.getHypothesisRef().getId())).thenReturn(List.of());
 
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
@@ -99,6 +107,8 @@ class ExperimentReadinessServiceTest {
         when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
         when(targetingSelectionRepository.countByExperimentIdAndCandidateType(experimentId, TargetingCandidateType.WORK_POSITION))
                 .thenReturn(0L);
+        when(targetingElementRepository.findApprovedForExperiment(experiment.getNiche().getId(),
+                TargetingElementType.JOB_TITLE, experiment.getHypothesisRef().getId())).thenReturn(List.of());
 
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
@@ -106,6 +116,29 @@ class ExperimentReadinessServiceTest {
         assertThat(summary.missingTargetingTypes()).containsExactly(TargetingElementType.JOB_TITLE);
         assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
                 .contains(ExperimentReadinessIssueType.TARGETING);
+    }
+
+    @Test
+    void shouldTreatApprovedTargetingPackageAsReadyEvenWithoutSelection() {
+        Long experimentId = 15L;
+        Experiment experiment = buildExperiment(experimentId, 21L);
+        LeadPortalFlow flow = new LeadPortalFlow();
+        flow.setApproved(true);
+        experiment.setLeadPortalFlow(flow);
+
+        when(experimentService.get(experimentId)).thenReturn(experiment);
+        when(creativeRepository.countByExperimentId(experimentId)).thenReturn(1L);
+        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
+        when(targetingElementRepository.findApprovedForExperiment(experiment.getNiche().getId(),
+                TargetingElementType.JOB_TITLE, experiment.getHypothesisRef().getId()))
+                .thenReturn(List.of(new TargetingElement()));
+
+        ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
+
+        assertThat(summary.hasCompleteTargeting()).isTrue();
+        assertThat(summary.missingTargetingTypes()).isEmpty();
+        assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
+                .doesNotContain(ExperimentReadinessIssueType.TARGETING);
     }
 
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -134,3 +134,15 @@
 - arquivos alterados:
   - frontend/src/pages/experiment/ExperimentDetailPage.tsx
   - docs/registros/experimentos.md
+
+## 2026-05-17 18:10:00 UTC
+- investigação da inconsistência entre a tela `/facebook-campaigns` e o comportamento do facebook-ads worker para o experimento 20.
+- causa-raiz identificada: `ExperimentReadinessService` exigia apenas seleção local de público (`experiment_targeting_selection`), enquanto o worker bloqueia por ausência de pacote aprovado de targeting (job titles aprovados por nicho/hipótese em `targeting_element`).
+- correção aplicada no backend:
+  - `ExperimentReadinessService` passou a considerar o experimento pronto em targeting quando houver **pacote aprovado de targeting** (JOB_TITLE aprovado para nicho/hipótese), mantendo fallback para seleção local para compatibilidade.
+  - atualização dos testes unitários para cobrir o novo critério de prontidão e evitar regressão.
+- resultado esperado: a tela de campanhas e a elegibilidade real do worker passam a refletir a mesma regra de prontidão de público.
+- arquivos alterados:
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java`
+  - `backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java`
+  - `docs/registros/experimentos.md`


### PR DESCRIPTION
### Motivation

- Align experiment readiness checks with the worker behavior by treating an approved targeting package (approved job titles for niche/hypothesis) as satisfying targeting readiness instead of only local selections.
- Fix an inconsistency that caused the UI `/facebook-campaigns` checklist to diverge from backend worker eligibility rules.

### Description

- Injected `TargetingElementRepository` into `ExperimentReadinessService` and added a new `hasApprovedTargetingPackage` method that queries `findApprovedForExperiment` for `TargetingElementType.JOB_TITLE`.  
- Updated `hasConfiguredTargeting` to return true when an approved targeting package exists, keeping the previous local selection check as a fallback.  
- Changed the missing configuration marker from `targetingSelections` to `approvedTargetingPackage` and adjusted `mapMissingTargetingTypes` accordingly.  
- Updated unit tests in `ExperimentReadinessServiceTest` to mock `TargetingElementRepository`, added a new test `shouldTreatApprovedTargetingPackageAsReadyEvenWithoutSelection`, and updated expectations; also updated documentation `docs/registros/experimentos.md` with the change rationale.

### Testing

- Ran the module unit tests for the ads service with `mvn -pl backend/ads-service test` and the `ExperimentReadinessServiceTest` suite, and they passed successfully.  
- The new test `shouldTreatApprovedTargetingPackageAsReadyEvenWithoutSelection` was executed and passed.  
- No automated test failures observed in the modified module after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a01a58134832186f2d25c89dbd69e)