### PR TITLE
feat(hotmart): exibe contagem de jobs e produtos por ciclo

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -96,3 +96,10 @@
   - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
   - mois-hotmart-collector/AGENTS.md
 
+
+## 2026-05-17 15:10:00 UTC
+- atualização da tela /hotmart para exibir métricas de execução por ciclo: quantidade de jobs executados, total geral de produtos e total de produtos por ciclo (job).
+- adicionada seção "Resumo de ciclos Hotmart" com cards de indicadores e tabela por ciclo.
+- documentos/códigos consultados:
+  - frontend/src/pages/hotmart/HotmartPage.tsx
+  - frontend/src/api/settings/useHotmartCollectedProducts.ts

--- a/frontend/src/pages/hotmart/HotmartPage.tsx
+++ b/frontend/src/pages/hotmart/HotmartPage.tsx
@@ -48,6 +48,27 @@ export default function HotmartPage() {
 
   const latestHotmartExecution = useMemo(() => hotmartJobsQuery.data?.[0], [hotmartJobsQuery.data]);
 
+  const hotmartCycleStats = useMemo(() => {
+    const products = hotmartProductsQuery.data ?? [];
+    const jobs = hotmartJobsQuery.data ?? [];
+
+    const productsByCycle = new Map<string, number>();
+    for (const product of products) {
+      productsByCycle.set(product.jobId, (productsByCycle.get(product.jobId) ?? 0) + 1);
+    }
+
+    return {
+      totalExecutedJobs: jobs.length,
+      totalProducts: products.length,
+      cycles: jobs.map((job) => ({
+        jobId: job.jobId,
+        status: job.status,
+        createdAt: formatUpdatedAt(job.createdAt),
+        productsCount: productsByCycle.get(job.jobId) ?? 0,
+      })),
+    };
+  }, [hotmartJobsQuery.data, hotmartProductsQuery.data]);
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setFeedback(null);
@@ -127,6 +148,74 @@ export default function HotmartPage() {
             </div>
           ) : null}
 
+        </div>
+      </section>
+
+
+      <section className="card mt-3 shadow-sm border-0">
+        <div className="card-header">
+          <h5 className="mb-1">Resumo de ciclos Hotmart</h5>
+          <p className="text-muted small mb-0">
+            Mostra a quantidade de jobs executados e o total de produtos coletados no período carregado.
+          </p>
+        </div>
+        <div className="card-body">
+          {hotmartJobsQuery.isLoading || hotmartProductsQuery.isLoading ? (
+            <p className="mb-0">Carregando resumo...</p>
+          ) : null}
+
+          {hotmartJobsQuery.isError || hotmartProductsQuery.isError ? (
+            <p className="text-danger mb-0">Não foi possível carregar o resumo de ciclos.</p>
+          ) : null}
+
+          {!hotmartJobsQuery.isLoading &&
+          !hotmartProductsQuery.isLoading &&
+          !hotmartJobsQuery.isError &&
+          !hotmartProductsQuery.isError ? (
+            <>
+              <div className="row g-3 mb-3">
+                <div className="col-12 col-md-6">
+                  <div className="border rounded p-3 h-100">
+                    <div className="text-muted small">Jobs executados</div>
+                    <div className="fs-4 fw-semibold">{hotmartCycleStats.totalExecutedJobs}</div>
+                  </div>
+                </div>
+                <div className="col-12 col-md-6">
+                  <div className="border rounded p-3 h-100">
+                    <div className="text-muted small">Total de produtos (geral)</div>
+                    <div className="fs-4 fw-semibold">{hotmartCycleStats.totalProducts}</div>
+                  </div>
+                </div>
+              </div>
+
+              {hotmartCycleStats.cycles.length > 0 ? (
+                <div className="table-responsive">
+                  <table className="table table-sm align-middle mb-0">
+                    <thead>
+                      <tr>
+                        <th>Ciclo (job)</th>
+                        <th>Status</th>
+                        <th>Executado em</th>
+                        <th className="text-end">Produtos no ciclo</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {hotmartCycleStats.cycles.map((cycle) => (
+                        <tr key={cycle.jobId}>
+                          <td className="small">{cycle.jobId}</td>
+                          <td>{cycle.status}</td>
+                          <td>{cycle.createdAt}</td>
+                          <td className="text-end fw-semibold">{cycle.productsCount}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <p className="mb-0 text-secondary">Nenhum ciclo encontrado para o workspace.</p>
+              )}
+            </>
+          ) : null}
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Dar visibilidade operacional das coletas Hotmart exibindo quantos jobs foram executados e quantos produtos foram coletados por ciclo para facilitar monitoramento e troubleshooting.

### Description
- Adicionei um `useMemo` chamado `hotmartCycleStats` em `frontend/src/pages/hotmart/HotmartPage.tsx` que agrupa produtos por `jobId` e combina os dados retornados por `useHotmartCollectionJobs` e `useHotmartCollectedProducts` para calcular totais e contagens por ciclo.
- Implementei uma nova seção de interface "Resumo de ciclos Hotmart" com cards de indicadores (jobs executados e total de produtos) e uma tabela listando `jobId`, `status`, data de execução e quantidade de produtos por ciclo em `frontend/src/pages/hotmart/HotmartPage.tsx`.
- Registrei a alteração no log operacional do módulo MOIS em `docs/registros/mois1.md` conforme rotina do projeto.
- Não houve alterações no backend; o frontend reutiliza os hooks existentes `useHotmartCollectionJobs` e `useHotmartCollectedProducts`.

### Testing
- Executado `npm run build` no diretório `frontend`, que falhou no ambiente de CI/local por ausência do binário `vite`, então o bundle final não pôde ser validado aqui.
- Nenhum teste unitário automatizado foi executado contra as mudanças neste ambiente de execução; a alteração é principalmente de UI/combinação de queries e deve ser verificada em ambiente com dependências instaladas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a176ac8f08321934f4b0c6cf758e4)