### PR TITLE
Publica landing aprovada no Lead Portal e expõe URLs iframe/standalone

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -564,11 +564,14 @@ public class ExperimentPipelineGenerationService {
                 throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, message, ex);
             }
         }
+        LandingPageVariantLinksDto primaryLinks = toVariantLinks("Gera Landing", iaFlow);
+
         experiment.setLeadPortalFlow(iaFlow);
         experiment.setSchemaFirstLeadPortalEnabled(true);
+        experiment.setFollowUpActionUrl(primaryLinks.standaloneUrl());
         experimentRepository.save(experiment);
 
-        List<LandingPageVariantLinksDto> variantLinks = List.of(toVariantLinks("Gera Landing", iaFlow));
+        List<LandingPageVariantLinksDto> variantLinks = List.of(primaryLinks);
 
         String pixelId = iaFlow.getMarketNiche() != null ? iaFlow.getMarketNiche().getFacebookPixelId() : null;
         return new LandingPagePublicationResultDto(

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -158,3 +158,16 @@
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/ExperimentDetailPage.tsx
   - backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+
+## 2026-05-17 20:35:00 UTC
+- ajuste na aprovação da landing para campanha para publicar automaticamente no Lead Portal e expor as duas URLs esperadas na aba Landing.
+- backend (`approve-and-publish`) agora também persiste no experimento a URL standalone publicada (destino oficial de campanha) ao concluir a aprovação.
+- frontend da aba Landing passou a chamar o endpoint de aprovação/publicação (`/pipeline/landing-page-html/approve-and-publish`) e a exibir:
+  - URL do iframe (Lead Portal)
+  - URL standalone (para uso na campanha)
+- criada nova API client no frontend para o fluxo de aprovação/publicação de landing.
+- arquivos alterados:
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`
+  - `frontend/src/api/experiment/useApproveAndPublishLanding.ts`
+  - `frontend/src/pages/experiment/LandingTab.tsx`
+  - `docs/registros/experimentos.md`

--- a/frontend/src/api/experiment/useApproveAndPublishLanding.ts
+++ b/frontend/src/api/experiment/useApproveAndPublishLanding.ts
@@ -1,0 +1,32 @@
+import { useMutation } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface LandingVariantLinks {
+  variant: string;
+  flowId: number;
+  iframeUrl: string | null;
+  standaloneUrl: string | null;
+}
+
+export interface LandingPublicationResult {
+  experimentId: number;
+  flowId: number;
+  approved: boolean;
+  published: boolean;
+  publicUrl: string | null;
+  variantLinks: LandingVariantLinks[];
+  facebookPixelId: string | null;
+  pixelAppliedAutomatically: boolean;
+  message: string;
+}
+
+export function useApproveAndPublishLanding(experimentId: number) {
+  return useMutation({
+    mutationFn: async () => {
+      const { data } = await axios.post<LandingPublicationResult>(
+        `/api/experiments/${experimentId}/pipeline/landing-page-html/approve-and-publish`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import type { Experiment } from "../../api/experiment/useExperiments";
-import { useUpdateExperiment } from "../../api/experiment/useUpdateExperiment";
+import { useApproveAndPublishLanding } from "../../api/experiment/useApproveAndPublishLanding";
 
 interface LandingTabProps {
   experiment: Experiment;
@@ -28,14 +28,15 @@ function normalizeUrl(url?: string | null) {
 }
 
 export default function LandingTab({ experiment }: LandingTabProps) {
-  const updateExperiment = useUpdateExperiment(experiment.id);
+  const approveAndPublishLanding = useApproveAndPublishLanding(experiment.id);
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const landingHtml = useMemo(() => {
     const raw = experiment.landingPageHtml;
     return typeof raw === "string" && raw.trim().length > 0 ? raw : null;
   }, [experiment.landingPageHtml]);
 
-  const selectedDestinationUrl = normalizeUrl(experiment.followUpActionUrl);
+  const [publishedUrls, setPublishedUrls] = useState<{ iframeUrl: string | null; standaloneUrl: string | null } | null>(null);
+  const selectedDestinationUrl = normalizeUrl(publishedUrls?.standaloneUrl ?? experiment.followUpActionUrl);
   const campaignDestinationUrl = resolveStandaloneLandingUrl(`/landing/${experiment.id}`);
 
   const handleApproveLanding = async () => {
@@ -49,35 +50,18 @@ export default function LandingTab({ experiment }: LandingTabProps) {
       return;
     }
 
-    const destinationUrl = resolveStandaloneLandingUrl(`/landing/${experiment.id}`);
     setFeedback(null);
 
     try {
-      await updateExperiment.mutateAsync({
-        name: experiment.name,
-        hypothesis: experiment.hypothesis,
-        kpiTarget: Number(kpiTargetValue),
-        metricPresetId: experiment.metricPresetId ?? undefined,
-        sampleSize: experiment.sampleSize ?? undefined,
-        mde: experiment.mdePercent ?? undefined,
-        startDate: experiment.startDate ?? undefined,
-        endDate: experiment.endDate ?? undefined,
-        creativesToGenerate: experiment.creativesToGenerate ?? undefined,
-        instantFormsToGenerate: experiment.instantFormsToGenerate ?? undefined,
-        emailsToGenerate: experiment.emailsToGenerate ?? undefined,
-        deliverablesToGenerate: experiment.deliverablesToGenerate ?? undefined,
-        leadPortalFlowsToGenerate: experiment.leadPortalFlowsToGenerate ?? undefined,
-        journeyTemplateId: experiment.journeyTemplateId ?? undefined,
-        facebookPageId: experiment.facebookPage?.id ?? null,
-        facebookInstantFormId: experiment.facebookInstantForm?.id ?? null,
-        instagramAccountId: experiment.instagramAccount?.id ?? null,
-        leadPortalFlowId: experiment.leadPortalFlowId ?? null,
-        followUpActionUrl: destinationUrl,
+      const publication = await approveAndPublishLanding.mutateAsync();
+      const primaryVariant = publication.variantLinks?.[0] ?? null;
+      setPublishedUrls({
+        iframeUrl: primaryVariant?.iframeUrl ?? publication.publicUrl ?? null,
+        standaloneUrl: primaryVariant?.standaloneUrl ?? null,
       });
-
       setFeedback({
         variant: "success",
-        message: "Landing aprovada e definida como URL de destino da campanha.",
+        message: publication.message || "Landing aprovada e publicada no Lead Portal.",
       });
     } catch {
       setFeedback({
@@ -128,9 +112,17 @@ export default function LandingTab({ experiment }: LandingTabProps) {
                   {campaignDestinationUrl}
                 </a>
               </div>
+              {publishedUrls?.iframeUrl ? (
+                <div>
+                  <strong>URL do iframe (Lead Portal):</strong>{" "}
+                  <a href={publishedUrls.iframeUrl} target="_blank" rel="noreferrer">
+                    {publishedUrls.iframeUrl}
+                  </a>
+                </div>
+              ) : null}
               {selectedDestinationUrl ? (
                 <div>
-                  <strong>URL atualmente aprovada:</strong>{" "}
+                  <strong>URL standalone (usar na campanha):</strong>{" "}
                   <a href={selectedDestinationUrl} target="_blank" rel="noreferrer">
                     {selectedDestinationUrl}
                   </a>
@@ -153,9 +145,9 @@ export default function LandingTab({ experiment }: LandingTabProps) {
           onClick={() =>
             handleApproveLanding()
           }
-          disabled={updateExperiment.isPending || !landingHtml}
+          disabled={approveAndPublishLanding.isPending || !landingHtml}
         >
-          {updateExperiment.isPending ? (
+          {approveAndPublishLanding.isPending ? (
             <span className="d-inline-flex align-items-center gap-2">
               <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true" />
               Aprovando...


### PR DESCRIPTION
### Motivation
- Garantir que, quando o usuário aprova a landing para campanha, o sistema publique o HTML no Lead Portal e gere as duas URLs necessárias (iframe e standalone), usando a standalone como destino oficial da campanha.

### Description
- Backend: `ExperimentPipelineGenerationService.approveAndPublishLandingPage` agora calcula os links da variação publicada (`toVariantLinks`), persiste a `standaloneUrl` em `experiment.followUpActionUrl` e devolve `variantLinks` no `LandingPagePublicationResultDto`.
- Frontend: criado o client `useApproveAndPublishLanding` para chamar `POST /api/experiments/{id}/pipeline/landing-page-html/approve-and-publish` e tipar o resultado com `iframeUrl` e `standaloneUrl`.
- Frontend UI: a aba Landing (`LandingTab.tsx`) passou a usar o novo endpoint, captura e exibe a `URL do iframe (Lead Portal)` e a `URL standalone (usar na campanha)`, e desabilita o botão enquanto a operação assíncrona está em andamento.
- Documentação: registro da mudança adicionado em `docs/registros/experimentos.md`.

### Testing
- Executei a suíte de testes do backend com `cd backend/ads-service && ../mvnw -q test`, que rodou a bateria de testes; a maioria dos testes passou mas existe uma falha em teste pré-existente `FacebookAdsCampaignControllerTest.listExperimentsByStatus` (falha não introduzida por este PR). 
- Tentei `cd backend && ./mvnw -q -pl ads-service test` e `cd backend/ads-service && ./mvnw -q test` com variações de invocação do wrapper, encontrando diferenças de ambiente/paths (algumas execuções locais do wrapper não disponíveis no ambiente). 
- Executei `cd frontend && npm run -s typecheck`, que falhou por dependências/arquivos de tipos ausentes e flags de depreciação do TypeScript no ambiente de CI local; isso é um problema de ambiente e não bloqueia a funcionalidade implementada.

Files changed: `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java`, `frontend/src/api/experiment/useApproveAndPublishLanding.ts`, `frontend/src/pages/experiment/LandingTab.tsx`, `docs/registros/experimentos.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a23a4dfac8321832c34f2490cff1a)