### PR TITLE
Show last 6 Clickbank collection jobs on /clickbase page

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -103,3 +103,13 @@
 - documentos/códigos consultados:
   - frontend/src/pages/hotmart/HotmartPage.tsx
   - frontend/src/api/settings/useHotmartCollectedProducts.ts
+
+## 2026-05-17 15:35:00 UTC
+- atualização da tela /clickbase para exibir as 6 últimas execuções de jobs da fonte Clickbank.
+- adicionada seção com tabela contendo job, status, nicho, data de criação e mensagem de execução.
+- ajuste de tipagem no frontend para incluir campos de `sources` e `niche` retornados pelo endpoint `/api/v1/mois/collection-jobs`.
+- documentos/códigos consultados:
+  - frontend/src/pages/clickbase/ClickbasePage.tsx
+  - frontend/src/api/settings/useClickbaseCollectedProducts.ts
+  - backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisWorkspaceDtos.java
+  - backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java

--- a/frontend/src/api/settings/useClickbaseCollectedProducts.ts
+++ b/frontend/src/api/settings/useClickbaseCollectedProducts.ts
@@ -33,7 +33,9 @@ export function useClickbaseCollectedProducts(workspaceId: string, limit = 24) {
 export interface ClickbaseCollectionJob {
   jobId: string;
   workspaceId: string;
+  niche?: string | null;
   status: string;
+  sources?: string[];
   createdAt?: string | null;
   message?: string | null;
 }

--- a/frontend/src/pages/clickbase/ClickbasePage.tsx
+++ b/frontend/src/pages/clickbase/ClickbasePage.tsx
@@ -41,7 +41,15 @@ export default function ClickbasePage() {
   const updatedAt = useMemo(() => formatUpdatedAt(clickbankSetting?.updatedAt), [clickbankSetting?.updatedAt]);
   const latestJobId = useMemo(() => clickbaseProductsQuery.data?.[0]?.jobId, [clickbaseProductsQuery.data]);
 
-  const latestClickbaseExecution = useMemo(() => clickbaseJobsQuery.data?.[0], [clickbaseJobsQuery.data]);
+  const clickbankJobs = useMemo(() => {
+    const jobs = clickbaseJobsQuery.data ?? [];
+    return jobs.filter((job) =>
+      (job.sources ?? []).some((source) => source.toUpperCase() === "CLICKBANK"),
+    );
+  }, [clickbaseJobsQuery.data]);
+
+  const latestClickbaseExecution = useMemo(() => clickbankJobs[0], [clickbankJobs]);
+  const latestSixClickbankJobs = useMemo(() => clickbankJobs.slice(0, 6), [clickbankJobs]);
   const shouldShowTokenRefreshAlert = useMemo(() => {
     if (!latestClickbaseExecution) {
       return false;
@@ -145,6 +153,47 @@ export default function ClickbasePage() {
             <div className="alert alert-warning mt-3 mb-0" role="alert">
               <strong>Atenção:</strong> a última coleta indicou falha de autenticação no Graph da ClickBank.
               Atualize o token JWT no campo acima e salve para liberar as próximas coletas.
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="card mt-3 shadow-sm border-0">
+        <div className="card-header">
+          <h5 className="mb-1">Últimas execuções de jobs Clickbank</h5>
+          <p className="text-muted small mb-0">Mostra as 6 execuções mais recentes com fonte Clickbank para este workspace.</p>
+        </div>
+        <div className="card-body">
+          {clickbaseJobsQuery.isLoading ? <p className="mb-0">Carregando execuções...</p> : null}
+          {clickbaseJobsQuery.isError ? <p className="text-danger mb-0">Não foi possível carregar os jobs de execução.</p> : null}
+          {!clickbaseJobsQuery.isLoading && !clickbaseJobsQuery.isError && latestSixClickbankJobs.length === 0 ? (
+            <p className="mb-0 text-secondary">Nenhuma execução Clickbank encontrada até o momento.</p>
+          ) : null}
+
+          {latestSixClickbankJobs.length > 0 ? (
+            <div className="table-responsive">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th scope="col">Job</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Nicho</th>
+                    <th scope="col">Criado em</th>
+                    <th scope="col">Mensagem</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {latestSixClickbankJobs.map((job) => (
+                    <tr key={job.jobId}>
+                      <td className="fw-semibold">{job.jobId}</td>
+                      <td>{job.status}</td>
+                      <td>{job.niche || "—"}</td>
+                      <td>{formatUpdatedAt(job.createdAt)}</td>
+                      <td className="small text-muted">{job.message || "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
### Motivation
- Provide operators a quick view of recent Clickbank collection activity directly on the `/clickbase` screen so authentication or collection issues can be detected faster.

### Description
- Added a new executions section to the Clickbase UI that displays the 6 most recent collection jobs whose `sources` include `CLICKBANK` with columns `Job`, `Status`, `Nicho`, `Criado em` and `Mensagem` in a responsive table; change live in `frontend/src/pages/clickbase/ClickbasePage.tsx`.
- Filtered the collection jobs client-side by `sources` and exposed `latestSixClickbankJobs` and `latestClickbaseExecution` via `useMemo` for UI use in `ClickbasePage.tsx`.
- Extended the frontend job type to include optional `sources` and `niche` fields so the filter and display match the backend payload in `frontend/src/api/settings/useClickbaseCollectedProducts.ts`.
- Appended an entry to the MOIS task log at `docs/registros/mois1.md` documenting the UI update and the typing adjustment.

### Testing
- Attempted a frontend build with `cd /workspace/marketing-hub/frontend && npm run -s build` to validate integration, but the build could not run in this environment due to missing `vite` (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a251992f48321ab42d4a7b4565a4c)