### PR TITLE
Fix TS2345 in LandingTab approve/publish hook call

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -171,3 +171,15 @@
   - `frontend/src/api/experiment/useApproveAndPublishLanding.ts`
   - `frontend/src/pages/experiment/LandingTab.tsx`
   - `docs/registros/experimentos.md`
+
+## 2026-05-17 17:34:07 UTC-3
+- correção de erro de typecheck na aba Landing do experimento ao aprovar/publicar landing.
+- causa-raiz: `experiment.id` é tipado como `string` no frontend, mas o hook `useApproveAndPublishLanding` exige `number` para compor a rota do endpoint.
+- foi feito: conversão explícita para número na chamada do hook (`Number(experiment.id)`), eliminando o conflito de tipos TS2345.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+- arquivos alterados:
+  - frontend/src/pages/experiment/LandingTab.tsx
+  - docs/registros/experimentos.md

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -28,7 +28,7 @@ function normalizeUrl(url?: string | null) {
 }
 
 export default function LandingTab({ experiment }: LandingTabProps) {
-  const approveAndPublishLanding = useApproveAndPublishLanding(experiment.id);
+  const approveAndPublishLanding = useApproveAndPublishLanding(Number(experiment.id));
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const landingHtml = useMemo(() => {
     const raw = experiment.landingPageHtml;


### PR DESCRIPTION
### Motivation
- Fix a TypeScript mismatch where `useApproveAndPublishLanding` expects a numeric `experimentId` but `experiment.id` is typed as `string`, causing `TS2345` during typecheck.

### Description
- Convert `experiment.id` to a number at the hook call site by changing the call to `useApproveAndPublishLanding(Number(experiment.id))` in `frontend/src/pages/experiment/LandingTab.tsx`.
- Add an append-only operational log entry documenting the root cause and fix in `docs/registros/experimentos.md` with the required UTC-3 timestamp.

### Testing
- Ran the frontend typecheck with `cd frontend && npm run typecheck` and confirmed the original `TS2345` no longer appears in the output. 
- The overall `tsc` run still exits non-zero due to unrelated environment/dependency TypeScript issues (missing type definition packages `@testing-library/jest-dom`, `vite/client`, `vitest/globals` and deprecation warnings in `tsconfig.json`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a261ebce88321b72d563390e641ba)