### PR TITLE
Fix Facebook campaign experiment list test fixture for landing destination readiness

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java
@@ -133,6 +133,7 @@ class FacebookAdsCampaignControllerTest {
                 .name("Exp")
                 .hypothesis("Hipótese")
                 .hypothesisRef(hypothesis)
+                .followUpActionUrl("https://landing.example.com/exp")
                 .kpiTargetCpl(BigDecimal.TEN)
                 .stopLossCpl(BigDecimal.valueOf(20))
                 .sampleSize(1200)


### PR DESCRIPTION
### Motivation
- A unit test was failing because the experiment fixture lacked an approved landing destination, causing `missingConfiguration` to include `landingDestination` and producing a false negative in the readiness check.

### Description
- Add `followUpActionUrl("https://landing.example.com/exp")` to the `Experiment` builder in `backend/ads-service/src/test/java/com/marketinghub/facebookads/web/FacebookAdsCampaignControllerTest.java` to reflect the current readiness rule that requires a landing destination.

### Testing
- Reproduced the failure from the prior run where the test suite reported 1 failing test in `FacebookAdsCampaignControllerTest` and then ran `cd backend/ads-service && mvn -Dtest=FacebookAdsCampaignControllerTest test` against the modified module.
- Result: `BUILD SUCCESS` with `3 tests run, 0 failures` for `FacebookAdsCampaignControllerTest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a27de806c8321aadba5ef5d16c3b7)