### PR TITLE
docs: add plain-language explanation for Facebook campaign publication and update experiment log

### DIFF
--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -60,6 +60,25 @@ Implementação: `ExperimentReadinessService` (backend) expõe os mesmos critér
 
 Se qualquer bloqueio falhar o worker interrompe a publicação e retorna a lista de pendências no alerta cinza da UI.
 
+## 5.1 Explicação complementar em linguagem simples (para operação)
+
+Este resumo existe para facilitar o entendimento de quem opera a campanha no dia a dia.
+
+Em termos práticos, o experimento só pode ser liberado para campanha quando 3 perguntas forem respondidas com **sim**:
+
+1. **Tem anúncio aprovado?**
+   - Pelo menos um criativo do experimento precisa estar pronto para uso.
+2. **Tem página de destino publicada?**
+   - A landing precisa estar aprovada e com URL final preenchida para receber o tráfego.
+3. **Tem público definido?**
+   - Precisa haver público aprovado (no fluxo manual, no mínimo 1 cargo aprovado).
+
+Se qualquer resposta for **não**, a liberação deve ser interrompida até a pendência ser resolvida.
+
+Depois que estiver tudo certo e o operador clicar em **Liberar para o Facebook Ads Worker**, o sistema coloca o experimento na fila de publicação e mantém o controle para evitar campanha duplicada do mesmo experimento.
+
+> Esta seção é apenas explicativa para operação; as regras válidas continuam sendo as regras canônicas e técnicas definidas nas seções 5, 6 e 7.
+
 ## 6. Configurações monitoradas (não bloqueantes)
 
 O cartão também lista itens operacionais que não travam o worker, mas devem ser revisados antes da liberação:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -183,3 +183,12 @@
 - arquivos alterados:
   - frontend/src/pages/experiment/LandingTab.tsx
   - docs/registros/experimentos.md
+
+
+## 2026-05-17 21:05:00 UTC
+- atualização documental no cânone de publicação de campanhas para incluir explicação complementar em linguagem menos técnica para usuários operacionais.
+- objetivo: facilitar entendimento do gate de liberação sem alterar regras de domínio já estabelecidas.
+- documento alterado:
+  - `docs/canonical/facebook-campaign-publication-canon.v1.md`
+- registro desta tarefa realizado em:
+  - `docs/registros/experimentos.md`


### PR DESCRIPTION
### Motivation

- Make the canonical Facebook campaign publication criteria easier to understand for operators by providing a concise, plain-language checklist. 
- Keep the experiment change log synchronized with the documentation update so the change is discoverable in `docs/registros/experimentos.md`.

### Description

- Added a new section `5.1` to `docs/canonical/facebook-campaign-publication-canon.v1.md` that summarizes the publication gate in simple terms and lists the three practical checks (`creative approved`, `landing published`, `audience defined`).
- Clarified that the new section is explanatory only and does not change the canonical technical rules in sections `5`, `6` and `7`.
- Appended a log entry to `docs/registros/experimentos.md` documenting the addition of the plain-language explanation and linking it to the canonical document.

### Testing

- This is a documentation-only change, so no automated tests were required or executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3ae9f9a483219a6a64ea35142dce)