### PR TITLE
fix(frontend): make journeyTemplateId optional in CreateExperiment payload

### DIFF
--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -26,7 +26,7 @@ export interface CreateExperiment {
   imagesPerPackage?: number;
   openImagesPerPackage?: number;
   compressedImagesPerPackage?: number;
-  journeyTemplateId: number;
+  journeyTemplateId?: number;
   facebookPageId?: number;
   facebookInstantFormId?: number;
   instagramAccountId: number;


### PR DESCRIPTION
### Motivation
- Fix the TypeScript mismatch where `NewExperimentPage` sends `journeyTemplateId` as `undefined`, by aligning the frontend API contract with the UI behavior.

### Description
- Updated `CreateExperiment` in `frontend/src/api/experiment/useCreateExperiment.ts` to declare `journeyTemplateId?: number` instead of a required `number`.

### Testing
- Ran `cd frontend && npm run typecheck` and confirmed the original `TS2322` (`undefined` not assignable to `number`) is resolved, though full typechecking still fails due to unrelated missing type definition packages (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) and TypeScript deprecation warnings in `tsconfig.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3e935f7483219a71d83206326744)