### PR TITLE
Fix experiment creation after simplified new-experiment form

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -209,3 +209,14 @@
   - frontend/AGENTS.md
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/NewExperimentPage.tsx
+
+## 2026-05-17 19:31:55 UTC-3
+- investigação do erro ao salvar na tela `/experiments/new` após simplificação recente.
+- causa-raiz identificada: o backend continua exigindo `journeyTemplateId` na criação do experimento, porém a UI simplificada deixou de coletar/enviar esse campo.
+- foi feito: ajuste no frontend para carregar templates de jornada, selecionar automaticamente o primeiro template disponível no payload de criação, bloquear salvamento quando não existir template cadastrado e exibir alerta orientando cadastro.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/experiment/NewExperimentPage.tsx
+  - backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -7,6 +7,7 @@ import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche"
 import { useHypothesis } from "../../api/hypothesis/useHypothesis";
 import { useAllFacebookPages } from "../../api/useAllFacebookPages";
 import { useInstagramAccounts } from "../../api/useInstagramAccounts";
+import { useJourneyTemplates } from "../../api/journey/useJourneyTemplates";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
 import { getStatisticsDefaultsForBudget } from "./statisticsDefaults";
@@ -79,6 +80,8 @@ export default function NewExperimentPage() {
     (n) => n.id === Number(form.nicheId),
   );
   const { data: imageModels } = useImageGenerationModels();
+  const { data: journeyTemplates, isLoading: isLoadingJourneyTemplates } =
+    useJourneyTemplates({ size: 200 });
   const { data: facebookPages, isLoading: isLoadingFacebookPages } =
     useAllFacebookPages();
   const { data: instagramAccounts, isLoading: isLoadingInstagramAccounts } =
@@ -140,6 +143,13 @@ export default function NewExperimentPage() {
         alert("Selecione uma conta do Instagram");
         return;
       }
+      const defaultJourneyTemplateId = journeyTemplates?.content?.[0]?.id;
+      if (!defaultJourneyTemplateId) {
+        alert(
+          "Cadastre ao menos um template de jornada antes de criar o experimento.",
+        );
+        return;
+      }
       const parsedDailyBudget = Number(form.dailyBudget);
       if (!form.dailyBudget || Number.isNaN(parsedDailyBudget) || parsedDailyBudget <= 0) {
         alert("Informe um orçamento diário válido");
@@ -170,7 +180,7 @@ export default function NewExperimentPage() {
           workerRequests.instantForms > 0 ? workerRequests.instantForms : undefined,
         emailsToGenerate:
           workerRequests.emails > 0 ? workerRequests.emails : undefined,
-        journeyTemplateId: undefined,
+        journeyTemplateId: defaultJourneyTemplateId,
         facebookPageId: form.facebookPageId
           ? Number(form.facebookPageId)
           : undefined,
@@ -396,6 +406,20 @@ export default function NewExperimentPage() {
           </div>
         </div>
       )}
+      {!isLoadingJourneyTemplates && !journeyTemplates?.content?.length && (
+        <div className="alert alert-warning" role="alert">
+          Nenhum template de jornada está cadastrado. Cadastre um template antes
+          de criar novos experimentos.
+          <div className="mt-2">
+            <a
+              className="btn btn-outline-primary btn-sm"
+              href="/journey-templates"
+            >
+              Abrir templates de jornada
+            </a>
+          </div>
+        </div>
+      )}
       <label className="form-label" htmlFor="facebookPage">
         Página do Facebook
       </label>
@@ -437,7 +461,9 @@ export default function NewExperimentPage() {
         className="btn btn-primary d-flex align-items-center gap-2"
         onClick={submit}
         disabled={
-          create.isPending || noInstagramAccounts
+          create.isPending ||
+          noInstagramAccounts ||
+          (!isLoadingJourneyTemplates && !journeyTemplates?.content?.length)
         }
       >
         {create.isPending ? (


### PR DESCRIPTION
### Motivation
- The simplified `/experiments/new` UI stopped sending `journeyTemplateId` but the backend still requires it, causing saves to fail with bad-request validation. 
- Restore compatibility by ensuring the UI provides a valid `journeyTemplateId` or blocks saving with a clear message when none exist.

### Description
- Load journey templates via `useJourneyTemplates` and pick the first available template id as the default `journeyTemplateId` in the create payload. 
- Add UX guards: show an alert when no journey templates are registered and disable the Save button to prevent a backend rejection; include a shortcut link to the journey-templates page. 
- Update `NewExperimentPage.tsx` to import and use `useJourneyTemplates` and to set `journeyTemplateId` in the payload sent to `POST /api/experiments`. 
- Record the investigation and fix in `docs/registros/experimentos.md` (append-only entry with UTC-3 timestamp).

### Testing
- Ran frontend typecheck with `npm run typecheck`; it failed in this environment due to missing type-definition packages (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) and `tsconfig` deprecation warnings unrelated to the functional change, so typecheck errors are environmental and not caused by this patch. 
- No backend unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a4191aa2883219a12ce50611893ce)