### PR TITLE
Fix 500 error on POST /api/experiments when metricPresetId is invalid

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/MetricPresetService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/MetricPresetService.java
@@ -2,7 +2,9 @@ package com.marketinghub.experiment.service;
 
 import com.marketinghub.experiment.MetricPreset;
 import com.marketinghub.experiment.repository.MetricPresetRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Service layer for metric presets.
@@ -20,6 +22,10 @@ public class MetricPresetService {
     }
 
     public MetricPreset get(String id) {
-        return repository.findById(id).orElseThrow();
+        if (id == null || id.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "metricPresetId required");
+        }
+        return repository.findById(id).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.BAD_REQUEST, "metricPresetId not found: " + id));
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/MetricPresetServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/MetricPresetServiceTest.java
@@ -1,0 +1,45 @@
+package com.marketinghub.experiment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.experiment.repository.MetricPresetRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class MetricPresetServiceTest {
+
+    @Mock
+    private MetricPresetRepository repository;
+
+    private MetricPresetService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MetricPresetService(repository);
+    }
+
+    @Test
+    void getThrowsBadRequestWhenIdIsBlank() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.get(" "));
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+        assertEquals("metricPresetId required", ex.getReason());
+    }
+
+    @Test
+    void getThrowsBadRequestWhenIdDoesNotExist() {
+        when(repository.findById("legacy")).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.get("legacy"));
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+        assertEquals("metricPresetId not found: legacy", ex.getReason());
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -220,3 +220,15 @@
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/NewExperimentPage.tsx
   - backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+
+
+## 2026-05-17 21:10:00 UTC
+- solicitação para investigar erro `500 Internal Server Error` no `POST /api/experiments` após simplificação da criação de experimento.
+- análise de causa-raiz: a cadeia de validação do backend usava `MetricPresetService.get(...)` com `orElseThrow()` sem mapeamento HTTP; quando o payload chegava com `metricPresetId` inválido/vazio, o backend lançava `NoSuchElementException` e retornava 500 em vez de erro de contrato (400).
+- foi feito: ajuste no backend para validar `metricPresetId` nulo/vazio e inexistente com `ResponseStatusException(HttpStatus.BAD_REQUEST, ...)`, além de teste unitário cobrindo os dois cenários para evitar regressão.
+- tentativa de investigação operacional via MCP: endpoint respondeu com timeout para `java_module_logs` (module=backend), então a correção foi aplicada pela análise direta da causa no código do serviço e pela cobertura de teste.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/main/java/com/marketinghub/experiment/service/MetricPresetService.java


### PR DESCRIPTION
### Motivation
- After simplifying the experiment creation payload the backend could receive missing/invalid `metricPresetId`, which caused an uncaught exception and returned `500 Internal Server Error` instead of a contract error (`400 Bad Request`).
- The intent is to validate the `metricPresetId` earlier in the service layer and provide clear `400` responses to the client to avoid silent 500s and improve debuggability.

### Description
- Validate `metricPresetId` in `MetricPresetService.get(...)` and throw `ResponseStatusException(HttpStatus.BAD_REQUEST, ...)` when the id is null/blank or when the preset is not found. (`backend/ads-service/src/main/java/com/marketinghub/experiment/service/MetricPresetService.java`).
- Add `MetricPresetServiceTest` with two unit tests covering the blank id and unknown id scenarios to prevent regressions. (`backend/ads-service/src/test/java/com/marketinghub/experiment/service/MetricPresetServiceTest.java`).
- Record the investigation, root cause and fix in the operational registry `docs/registros/experimentos.md` per project conventions.

### Testing
- Ran the targeted unit tests with Maven using `./mvnw -f ads-service/pom.xml -Dtest=MetricPresetServiceTest test` and the build succeeded with `Tests run: 2, Failures: 0, Errors: 0`.
- Earlier attempts to run `./mvnw` from incorrect paths failed due to invocation issues, but the focused test execution above validated the change successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a4c39efe08321aaf15a728152cd55)