### PR TITLE
Fix 500 in POST /api/experiments when hypothesis has no niche

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -227,6 +227,10 @@ public class ExperimentService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "hypothesisId required");
         }
         com.marketinghub.hypothesis.Hypothesis hyp = attachHypothesis(request.getHypothesisId());
+        if (hyp.getMarketNiche() == null || hyp.getMarketNiche().getId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "hypothesis is not associated with a market niche");
+        }
         if (!hyp.getMarketNiche().getId().equals(nicheId)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "hypothesis and experiment niche mismatch");
         }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -220,3 +220,11 @@
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/NewExperimentPage.tsx
   - backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+
+## 2026-05-17 23:22:00 UTC
+- investigação de erro `500 Internal Server Error` no `POST /api/experiments` após simplificação da criação de experimentos.
+- causa-raiz tratada: hipótese sem vínculo de nicho (`market_niche`) acionava `NullPointerException` na validação de consistência (`hyp.getMarketNiche().getId()`), resultando em 500.
+- foi feito: validação defensiva no backend para retornar `400 Bad Request` com mensagem explícita quando a hipótese não estiver associada a nicho, evitando falha genérica e orientando correção dos dados.
+- arquivos alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- A `500 Internal Server Error` occurred when creating experiments because the service dereferenced `hyp.getMarketNiche().getId()` for hypotheses that had no associated `market_niche`, causing a `NullPointerException`. 
- The goal is to provide a clear `400 Bad Request` error for invalid input (hypothesis without niche) and avoid the generic server error after the recent UI simplification of experiment creation.

### Description
- Added a defensive validation in `ExperimentService.create(Long, CreateExperimentRequest)` that checks `hyp.getMarketNiche()` and its `id` and throws `ResponseStatusException(HttpStatus.BAD_REQUEST, "hypothesis is not associated with a market niche")` when missing. 
- Updated the operational registry `docs/registros/experimentos.md` with the investigation, root cause and the applied fix.

### Testing
- Attempted to run `./mvnw -pl ads-service -Dtest=ExperimentControllerTest test` from the `/backend` path which failed due to incorrect reactor selection. 
- Ran `../mvnw -Dtest=ExperimentControllerTest test` from `backend/ads-service` and the `ExperimentControllerTest` suite completed successfully with all tests passing (10 tests, `BUILD SUCCESS`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a4c39efe08321aaf15a728152cd55)