### PR TITLE
Simplify Experiment creation: make journeyTemplate/stage/imagesPerPackage optional and add DB defaults

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -90,8 +90,8 @@ public class Experiment {
     @JoinColumn(name = "metric_preset_id")
     private MetricPreset metricPreset;
 
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    @JoinColumn(name = "journey_template_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "journey_template_id")
     private JourneyTemplate journeyTemplate;
 
     @Column(precision = 10, scale = 2)
@@ -145,7 +145,7 @@ public class Experiment {
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
-    @Column(name = "stage", length = 32, nullable = false)
+    @Column(name = "stage", length = 32)
     private ExperimentStage stage = ExperimentStage.AD;
 
     @Enumerated(EnumType.STRING)
@@ -228,7 +228,7 @@ public class Experiment {
 
     /** Quantidade de imagens que cada pacote deve conter. */
     @Builder.Default
-    @Column(name = "images_per_package", nullable = false)
+    @Column(name = "images_per_package")
     private Integer imagesPerPackage = 20;
 
     /** Quantidade de imagens abertas por pacote. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -237,22 +237,13 @@ public class ExperimentService {
         if (repository.existsByNicheAndName(niche, request.getName())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name already exists for niche");
         }
-        if (request.getKpiTargetCpl() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "kpiTargetCpl required");
-        }
         if (request.getMetricPresetId() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "metricPresetId required");
         }
-        if (request.getStage() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "stage required");
-        }
         String normalizedPrimaryVariable = normalizePrimaryDescriptor(request.getPrimaryVariable(), "primaryVariable");
         String normalizedPrimaryMetric = normalizePrimaryDescriptor(request.getPrimaryMetric(), "primaryMetric");
-        if (request.getJourneyTemplateId() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "journeyTemplateId required");
-        }
         MetricPreset preset = metricPresetService.get(request.getMetricPresetId());
-        java.math.BigDecimal computedStopLoss = request.getKpiTargetCpl().multiply(preset.getStopLossFactor());
+        java.math.BigDecimal computedStopLoss = request.getKpiTargetCpl() != null ? request.getKpiTargetCpl().multiply(preset.getStopLossFactor()) : null;
         if (request.getSampleSize() != null && request.getSampleSize() < 1) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "sampleSize must be at least 1");
         }
@@ -263,7 +254,7 @@ public class ExperimentService {
                 request.getBaselineCvr().compareTo(request.getTargetCvr()) >= 0) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "baselineCvr must be < targetCvr");
         }
-        JourneyTemplate journeyTemplate = attachJourneyTemplate(request.getJourneyTemplateId());
+        JourneyTemplate journeyTemplate = request.getJourneyTemplateId() != null ? attachJourneyTemplate(request.getJourneyTemplateId()) : null;
         LeadPortalFlow leadPortalFlow = attachLeadPortalFlow(request.getLeadPortalFlowId(), niche.getId());
         String followUpActionUrl = normalizeFollowUpActionUrl(request.getFollowUpActionUrl());
         ImageGenerationSelection imageSelection =
@@ -295,7 +286,7 @@ public class ExperimentService {
                 .endDate(request.getEndDate())
                 .status(ExperimentStatus.PLANNED)
                 .platform(ExperimentPlatform.FACEBOOK)
-                .stage(request.getStage())
+                .stage(request.getStage() != null ? request.getStage() : ExperimentStage.AD)
                 .primaryVariable(normalizedPrimaryVariable)
                 .primaryMetric(normalizedPrimaryMetric)
                 .creativesToGenerate(request.getCreativesToGenerate())

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-17-experiment-create-simplification-columns.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-17-experiment-create-simplification-columns.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-17-experiment-create-simplification-columns
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: MARK_RAN
+        - dbms:
+            type: mysql
+      changes:
+        - dropNotNullConstraint:
+            tableName: experiment
+            columnName: journey_template_id
+            columnDataType: BIGINT
+        - dropNotNullConstraint:
+            tableName: experiment
+            columnName: stage
+            columnDataType: VARCHAR(32)
+        - dropNotNullConstraint:
+            tableName: experiment
+            columnName: images_per_package
+            columnDataType: INT
+        - addDefaultValue:
+            tableName: experiment
+            columnName: stage
+            defaultValue: AD
+        - addDefaultValue:
+            tableName: experiment
+            columnName: images_per_package
+            defaultValueNumeric: 20

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -772,3 +772,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-05-17-mois-sales-library-analysis.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-05-17-experiment-create-simplification-columns.yaml

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -692,7 +692,7 @@ class ExperimentServiceTest {
     }
 
     @Test
-    void createRequiresJourneyTemplateId() {
+    void createAllowsMissingJourneyTemplateId() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste").build());
         var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
         var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
@@ -723,9 +723,9 @@ class ExperimentServiceTest {
         req.setInstagramAccountId(createInstagramAccount().getId());
         req.setLeadPortalFlowId(createLeadPortalFlow(niche));
 
-        assertThatThrownBy(() -> service.create(req))
-                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
-                .hasMessageContaining("journeyTemplateId required");
+        Experiment created = service.create(req);
+
+        assertThat(created.getJourneyTemplate()).isNull();
     }
 
     @Test

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -226,13 +226,9 @@ erDiagram
       BIGINT facebook_page_id FK
       BIGINT facebook_instant_form_id FK
       BIGINT lead_portal_flow_id FK
-      BIGINT journey_template_id FK
       DECIMAL daily_budget
       VARCHAR status
-      VARCHAR stage
       VARCHAR creative_generation_mode
-      VARCHAR primary_variable
-      VARCHAR primary_metric
       DATE start_date
       DATE end_date
       DATETIME facebook_release_requested_at
@@ -512,11 +508,8 @@ erDiagram
 
 ## Observações de implementação
 
-- Cada registro de `EXPERIMENT` guarda agora `stage`, `primary_variable` e `primary_metric`.
-  - `stage` representa a etapa do funil (AD, LANDING, SAMPLE ou SALES) e direciona o que está sendo testado.
-  - `primary_variable` descreve o ângulo/variável do experimento em linguagem natural.
-  - `primary_metric` registra qual indicador decide o sucesso da hipótese e deve ser tratado como texto legível (ex.: "CTR de link (%)").
-- O endpoint `/api/experiment-playbook` provê o playbook canônico por etapa com descrições e sugestões para preencher esses campos.
+- A criação de experimento foi simplificada e não exige mais os campos de configuração tática removidos da UI (etapa do experimento, variável principal, métrica principal, meta de KPI, template de jornada, qualidade das variações, quantidades de imagens por lote/abertas/compactadas, tamanho da amostra e margem de erro).
+- Esses parâmetros deixam de fazer parte do contrato obrigatório de entrada no fluxo de criação e não devem ser considerados como fonte primária de verdade no modelo de dados de cadastro.
 - Registros gerados por processos do Worker IA devem manter `model` e `prompt`
   preenchidos nos objetos aplicáveis (ex.: `targeting_element`, `ad_set`,
   `lead_portal_flow`, `deliverable_package`, `proof_artifact`).

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -232,3 +232,22 @@
   - backend/AGENTS.md
   - docs/registros/experimentos.md
   - backend/ads-service/src/main/java/com/marketinghub/experiment/service/MetricPresetService.java
+
+## 2026-05-17 22:20:00 UTC
+- validação solicitada sobre remoção de campos obsoletos na criação de experimentos e aderência do modelo de dados documental.
+- foi feito: atualização do documento `docs/modelo-dados-experimento.md` para refletir que os campos removidos da criação (etapa, variável/métrica principal, meta de KPI, template de jornada, qualidade/quantidades de imagens, tamanho da amostra e margem de erro) não compõem mais contrato obrigatório de entrada no cadastro.
+- ajuste adicional: limpeza do diagrama ER textual da entidade `EXPERIMENT`, removendo colunas obsoletas da visão focada de criação (`journey_template_id`, `stage`, `primary_variable`, `primary_metric`).
+- arquivos alterados:
+  - docs/modelo-dados-experimento.md
+  - docs/registros/experimentos.md
+
+## 2026-05-17 22:45:00 UTC
+- ajuste complementar solicitado: não apenas documentação, mas também alteração estrutural nas tabelas para refletir simplificação da criação de experimentos.
+- foi feito no backend/Liquibase: criação de changeset para flexibilizar colunas antes obrigatórias no cadastro (`journey_template_id`, `stage`, `images_per_package`) e manter defaults compatíveis (`stage='AD'`, `images_per_package=20`).
+- foi feito no serviço de criação: remoção das validações obrigatórias de `stage`, `journeyTemplateId` e `kpiTargetCpl`, com fallback para `stage=AD` quando ausente e stop-loss somente quando houver KPI.
+- arquivos alterados:
+  - backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-17-experiment-create-simplification-columns.yaml
+  - backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+  - backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+  - backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Simplify the experiment creation flow by removing several tactical fields from being required so the UI can submit minimal payloads without errors.
- Keep existing behavior compatible by providing sensible defaults for fields that were previously mandatory.

### Description
- Relaxed JPA constraints in `Experiment` by making `journeyTemplate`, `stage` and `imagesPerPackage` nullable at the entity level and keeping a default `stage = AD` and `imagesPerPackage = 20` in the model.
- Made `kpiTargetCpl`, `stage` and `journeyTemplateId` optional in the creation flow inside `ExperimentService.create(...)`, adding a fallback `stage` when missing and computing `stopLossCpl` only when `kpiTargetCpl` is present.
- Added a Liquibase changeset `changesets/2026-05-17-experiment-create-simplification-columns.yaml` and included it in `db.changelog-master.yaml` to drop NOT NULL constraints on `journey_template_id`, `stage` and `images_per_package` and to add defaults for `stage` and `images_per_package` at the DB level.
- Adjusted tests and documentation: updated `ExperimentServiceTest` to allow missing `journeyTemplateId`, updated docs under `docs/` to reflect the simplified creation contract, and removed obsolete ER diagram columns from the creation-focused view.

### Testing
- Updated unit test `ExperimentServiceTest` to assert that creation succeeds without `journeyTemplateId`, and the test passed.
- Ran the service unit test suite which includes experiment creation scenarios, and all modified/related tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a4e83239c832191987a237690df31)