### PR TITLE
Require `journeyTemplateId` on experiment create

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -254,7 +254,10 @@ public class ExperimentService {
                 request.getBaselineCvr().compareTo(request.getTargetCvr()) >= 0) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "baselineCvr must be < targetCvr");
         }
-        JourneyTemplate journeyTemplate = request.getJourneyTemplateId() != null ? attachJourneyTemplate(request.getJourneyTemplateId()) : null;
+        if (request.getJourneyTemplateId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "journeyTemplateId required");
+        }
+        JourneyTemplate journeyTemplate = attachJourneyTemplate(request.getJourneyTemplateId());
         LeadPortalFlow leadPortalFlow = attachLeadPortalFlow(request.getLeadPortalFlowId(), niche.getId());
         String followUpActionUrl = normalizeFollowUpActionUrl(request.getFollowUpActionUrl());
         ImageGenerationSelection imageSelection =


### PR DESCRIPTION
### Motivation
- The experiment create endpoint was accepting requests without `journeyTemplateId` but a contract test expects the API to reject such requests with `400 Bad Request`, so the service must enforce the presence of `journeyTemplateId` at creation time.

### Description
- Added an explicit null check in `ExperimentService#create` that throws `ResponseStatusException(HttpStatus.BAD_REQUEST, "journeyTemplateId required")` when `request.getJourneyTemplateId()` is missing, and then always calls `attachJourneyTemplate(...)` for provided IDs; change applied in `backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java`.

### Testing
- Ran the targeted controller test with `mvn -Dtest=ExperimentControllerTest#createEndpointRejectsMissingJourneyTemplate test` and it passed (build success for that test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a70e89b5c8321b3df88fd2067e670)