### PR TITLE
test: require journeyTemplateId in experiment creation unit test

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -692,7 +692,7 @@ class ExperimentServiceTest {
     }
 
     @Test
-    void createAllowsMissingJourneyTemplateId() {
+    void createRejectsMissingJourneyTemplateId() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste").build());
         var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
         var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
@@ -723,9 +723,10 @@ class ExperimentServiceTest {
         req.setInstagramAccountId(createInstagramAccount().getId());
         req.setLeadPortalFlowId(createLeadPortalFlow(niche));
 
-        Experiment created = service.create(req);
-
-        assertThat(created.getJourneyTemplate()).isNull();
+        assertThatThrownBy(() -> service.create(req))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+                .hasMessageContaining("400 BAD_REQUEST")
+                .hasMessageContaining("journeyTemplateId required");
     }
 
     @Test

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -251,3 +251,11 @@
   - backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
   - backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
   - docs/registros/experimentos.md
+
+## 2026-05-18 02:06:00 UTC
+- solicitação: remover dos testes unitários a premissa obsoleta de criação de experimento sem `journeyTemplateId`.
+- foi feito: ajuste no teste `ExperimentServiceTest` para validar o comportamento atual do backend (rejeitar criação sem `journeyTemplateId` com `400 BAD_REQUEST` e mensagem `journeyTemplateId required`), substituindo o cenário anterior que permitia ausência desse campo.
+- validação executada: `mvn -Dtest=ExperimentServiceTest test` com sucesso.
+- arquivos alterados:
+  - backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- The experiment creation contract was changed to require `journeyTemplateId`, so tests must stop assuming creation can omit this field.

### Description
- Replace the previous `createAllowsMissingJourneyTemplateId` test with `createRejectsMissingJourneyTemplateId` in `backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java` to assert a `400 BAD_REQUEST` `ResponseStatusException` containing `journeyTemplateId required`, and record the change in `docs/registros/experimentos.md`.

### Testing
- Executed `cd backend/ads-service && mvn -Dtest=ExperimentServiceTest test` and the test class passed (`Tests run: 19, Failures: 0, Errors: 0, Skipped: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a7348c49c83218e0126ebf949c4ad)