### PR TITLE
fix(liquibase): mark simplification changelog include as relative

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -775,3 +775,4 @@ databaseChangeLog:
 
   - include:
       file: changesets/2026-05-17-experiment-create-simplification-columns.yaml
+      relativeToChangelogFile: true


### PR DESCRIPTION
### Motivation
- Fix Liquibase `ChangeLogParseException` caused by an `include` entry in the `ads-service` master changelog that was missing `relativeToChangelogFile: true`, which made the changeset file resolution fail in CI and local validations.

### Description
- Add `relativeToChangelogFile: true` to the `include` of `changesets/2026-05-17-experiment-create-simplification-columns.yaml` in `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` so the changeset is resolved relative to the master changelog.

### Testing
- Ran `mvn -q liquibase:validate` which progressed past the previous changelog parse error, and then failed due to missing database URL in the local environment, confirming the parse/file-not-found issue was resolved but full validation cannot complete without a configured DB URL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a77fabd948321b4d8bf490b961d3d)