### PR TITLE
Reschedule OPRM import finalization to 00:00 18/05 and update docs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/service/OprmMarketImportFinalizationScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/service/OprmMarketImportFinalizationScheduler.java
@@ -20,9 +20,9 @@ public class OprmMarketImportFinalizationScheduler {
     private final OprmCnpjImportRunRepository runRepository;
     private final OprmMarketImportService importService;
 
-    @Scheduled(cron = "0 30 23 * * *", zone = SCHEDULE_TIMEZONE)
-    public void finalizeLatestStartedRunAt2330() {
-        finalizeLatestStartedRun("23:30");
+    @Scheduled(cron = "0 0 0 18 5 *", zone = SCHEDULE_TIMEZONE)
+    public void finalizeLatestStartedRunAt0000May18() {
+        finalizeLatestStartedRun("00:00 18/05");
     }
 
     private void finalizeLatestStartedRun(String scheduleLabel) {

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -74,3 +74,5 @@
 - 2026-05-18 02:05:00 (UTC): ajuste solicitado no backend OPRM para deixar os agendamentos de totalização fixos em código (sem variáveis/propriedades): 19:40 e 23:30 em America/Sao_Paulo, removendo configuração via `application.properties`.
 
 - 2026-05-18 02:12:52 (UTC): ajuste solicitado no backend OPRM para remover o agendamento das 19:40 e manter somente a totalização diária fixa às 23:30 no fuso America/Sao_Paulo.
+
+- 2026-05-18 02:30:00 (UTC): ajuste solicitado no backend OPRM para reagendar a execução do totalizador para **00:00 do dia 18 de maio** (fuso `America/Sao_Paulo`), alterando o cron do `OprmMarketImportFinalizationScheduler` para `0 0 0 18 5 *` e atualizando o rótulo de execução para `00:00 18/05`.


### PR DESCRIPTION
### Motivation
- A one-off operational request required moving the OPRM import finalization to execute at midnight on 18 May (America/Sao_Paulo) and to make the scheduler reflect that fixed execution time. 
- The change also records the new schedule in the operational registry so run history and diagnostics reflect the adjusted timing.

### Description
- Updated the scheduled cron in `OprmMarketImportFinalizationScheduler` from `0 30 23 * * *` to the specific cron `0 0 0 18 5 *` and set the timezone to `America/Sao_Paulo`. 
- Renamed the scheduled method to `finalizeLatestStartedRunAt0000May18` and updated the execution label passed to `finalizeLatestStartedRun` to `"00:00 18/05"` for clearer logs. 
- Preserved the existing logic that finds the latest `STARTED` run and calls `importService.completeRun(...)` while leaving logging context and behavior unchanged. 
- Updated `docs/registros/oprm1.md` to reflect the rescheduling and add the operational note about the change to `00:00 18/05`.

### Testing
- Ran the project build and unit tests with `./gradlew build` and `./gradlew test`, and the test suite completed successfully. 
- Verified the modified scheduler compiles with the project and that the updated log message label is present at compile time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a7c415fac83219c06ae780967861b)