### PR TITLE
Remover etapas de landing da aba Estrutura de Conteúdo (frontend)

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -264,3 +264,11 @@
 - Removida a obrigatoriedade de `metricPresetId`, `primaryVariable` e `primaryMetric` na criação de experimento.
 - Backend agora aceita payload sem esses campos e calcula `stopLossCpl` apenas quando `metricPresetId` está preenchido com preset válido.
 - Frontend de criação deixou de enviar os valores obsoletos `primaryVariable: "OBSOLETO"` e `primaryMetric: "OBSOLETO"`; `metricPresetId` passa a ser opcional no payload.
+
+## 2026-05-18 10:15:00 UTC
+- solicitação: na tela de experimento, aba "Estrutura de Conteúdo", remover as etapas que migraram para o fluxo Gera Landing.
+- foi feito no frontend: removidas da listagem da aba as seções de landing `landing-layout`, `landing-copy`, `landing-design-preset`, `landing-image-planning` e `landing-html`.
+- resultado: a aba "Estrutura de Conteúdo" passa a exibir apenas as etapas de conteúdo base (dor, mecanismo, provas, ângulos, anúncio e prompt de imagem), evitando duplicidade com o fluxo Gera Landing.
+- arquivos alterados:
+  - frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+  - docs/registros/experimentos.md

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -94,41 +94,6 @@ const CONTENT_GENERATION_SECTIONS: ContentGenerationSection[] = [
       "Crie prompts para orientar a geração de criativos visuais coerentes com o ângulo.",
     defaultQuantity: 4,
   },
-  {
-    key: "landing-layout",
-    label: "Layout da Landing",
-    description:
-      "Sugira estruturas visuais e ordem de seções para a página de conversão.",
-    defaultQuantity: 2,
-  },
-  {
-    key: "landing-copy",
-    label: "Texto da Landing",
-    description:
-      "Produza blocos de copy para título, prova, benefícios e CTA da landing.",
-    defaultQuantity: 4,
-  },
-  {
-    key: "landing-design-preset",
-    label: "Preset de Design da Landing",
-    description:
-      "Defina tema visual, paleta e presets por seção antes da composição final do HTML.",
-    defaultQuantity: 1,
-  },
-  {
-    key: "landing-image-planning",
-    label: "Planejamento de Imagens da Landing",
-    description:
-      "Planeje prompts, posicionamento e direção visual das imagens antes da geração final do HTML.",
-    defaultQuantity: 1,
-  },
-  {
-    key: "landing-html",
-    label: "HTML da Landing",
-    description:
-      "Integre copy + layout e gere o HTML final com CSS e scripts para uso no formulário.",
-    defaultQuantity: 1,
-  },
 ];
 
 const SECTION_LABEL_BY_KEY: Record<ContentGenerationSectionKey, string> =


### PR DESCRIPTION
### Motivation
- Evitar duplicidade entre a aba "Estrutura de Conteúdo" e o fluxo "Gera Landing" removendo as seções que agora fazem parte do fluxo de geração de landing pages.

### Description
- Removidas as seções de landing da constante `CONTENT_GENERATION_SECTIONS` em `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx`, mantendo apenas `campaign-angle`, `ad-copy` e `image-prompt`.
- A lógica de rótulos continua a ser construída via `SECTION_LABEL_BY_KEY` a partir de `CONTENT_GENERATION_SECTIONS` sem as entradas de landing removidas.
- Atualizado o registro operacional em `docs/registros/experimentos.md` documentando a remoção e o motivo da mudança.
- Arquivos alterados: `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx` e `docs/registros/experimentos.md`.

### Testing
- Executado `npm --prefix frontend run -s typecheck`, que falhou no ambiente com erros de tipos ausentes (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) e avisos de depreciação em `tsconfig.json`; portanto a checagem de tipos não concluiu com sucesso.
- Não houve execução de testes unitários adicionais no frontend devido ao estado do ambiente de tipagem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a820a56c8832186723b47cd981993)