### PR TITLE
fix(frontend): prevent crash in Estrutura de Conteúdo after section refactor

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -272,3 +272,11 @@
 - arquivos alterados:
   - frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
   - docs/registros/experimentos.md
+
+## 2026-05-18 11:30:00 UTC
+- solicitação: corrigir erro na aba "Estrutura de Conteúdo" após refatoração recente, com crash `Cannot read properties of undefined (reading 'completedAt')` em `ExperimentContentGenerationTab.tsx`.
+- causa-raiz: a refatoração removeu seções de landing da constante `CONTENT_GENERATION_SECTIONS`; isso também reduziu o estado inicial de requisições e deixou chaves ainda usadas por cálculos de fluxo (`landing-image-planning`) como `undefined`.
+- foi feito: criação da constante `ALL_CONTENT_GENERATION_SECTION_KEYS` para manter o estado inicial completo de todas as seções (inclusive as ocultas na UI), preservando cálculos internos e evitando acesso a propriedades em `undefined`.
+- arquivos alterados:
+  - frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+  - docs/registros/experimentos.md

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -144,11 +144,22 @@ interface AutoQueueState {
 
 type LandingImageFlowStatus = "NOT_STARTED" | "STARTED" | "PROCESSING" | "COMPLETED";
 
+const ALL_CONTENT_GENERATION_SECTION_KEYS: ContentGenerationSectionKey[] = [
+  "campaign-angle",
+  "ad-copy",
+  "image-prompt",
+  "landing-copy",
+  "landing-layout",
+  "landing-image-planning",
+  "landing-design-preset",
+  "landing-html",
+];
+
 const SECTION_REQUEST_INITIAL_STATE: Record<
   ContentGenerationSectionKey,
   SectionRequestState
-> = CONTENT_GENERATION_SECTIONS.reduce(
-  (acc, section) => ({ ...acc, [section.key]: { status: "IDLE" } }),
+> = ALL_CONTENT_GENERATION_SECTION_KEYS.reduce(
+  (acc, sectionKey) => ({ ...acc, [sectionKey]: { status: "IDLE" } }),
   {} as Record<ContentGenerationSectionKey, SectionRequestState>,
 );
 


### PR DESCRIPTION
### Motivation
- A refatoração que removeu as seções de landing da lista visível também reduziu o estado inicial de requisições, deixando chaves ainda usadas pela lógica interna (ex.: `landing-image-planning`) como `undefined` e causando o crash `Cannot read properties of undefined (reading 'completedAt')` na aba "Estrutura de Conteúdo".

### Description
- Restaurado o estado inicial completo criando `ALL_CONTENT_GENERATION_SECTION_KEYS` e passando essa lista para `SECTION_REQUEST_INITIAL_STATE` para garantir que todas as chaves (inclusive as ocultas na UI) existam no estado.
- Mantida a lista visível reduzida (`CONTENT_GENERATION_SECTIONS`) para a UI, preservando o comportamento da interface sem quebrar cálculos internos.
- Atualizado o log de experimentos em `docs/registros/experimentos.md` com a causa-raiz e a correção aplicada.

### Testing
- Tentativa de build do frontend com `cd frontend && npm run -s build` foi executada, mas falhou na environment do container com `vite: not found`, impedindo validação completa de compilação (falta de dependências/do runtime nesta máquina).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a891eeed88321bc6c2ebae94b8bf0)