### PR TITLE
Move OPRM totalization scheduler from 00:00 to 11:00 on 18/05 and update docs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/service/OprmMarketImportFinalizationScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/service/OprmMarketImportFinalizationScheduler.java
@@ -20,9 +20,9 @@ public class OprmMarketImportFinalizationScheduler {
     private final OprmCnpjImportRunRepository runRepository;
     private final OprmMarketImportService importService;
 
-    @Scheduled(cron = "0 0 0 18 5 *", zone = SCHEDULE_TIMEZONE)
-    public void finalizeLatestStartedRunAt0000May18() {
-        finalizeLatestStartedRun("00:00 18/05");
+    @Scheduled(cron = "0 0 11 18 5 *", zone = SCHEDULE_TIMEZONE)
+    public void finalizeLatestStartedRunAt1100May18() {
+        finalizeLatestStartedRun("11:00 18/05");
     }
 
     private void finalizeLatestStartedRun(String scheduleLabel) {

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -76,3 +76,4 @@
 - 2026-05-18 02:12:52 (UTC): ajuste solicitado no backend OPRM para remover o agendamento das 19:40 e manter somente a totalização diária fixa às 23:30 no fuso America/Sao_Paulo.
 
 - 2026-05-18 02:30:00 (UTC): ajuste solicitado no backend OPRM para reagendar a execução do totalizador para **00:00 do dia 18 de maio** (fuso `America/Sao_Paulo`), alterando o cron do `OprmMarketImportFinalizationScheduler` para `0 0 0 18 5 *` e atualizando o rótulo de execução para `00:00 18/05`.
+- 2026-05-18 00:00:00 (UTC): agendamento do `OprmMarketImportFinalizationScheduler` alterado para 11:00 no dia 18/05 (fuso `America/Sao_Paulo`), com cron hardcoded `0 0 11 18 5 *` na anotação `@Scheduled`.


### PR DESCRIPTION
### Motivation
- Change the hardcoded one-off scheduler execution time for OPRM totalization on 18 May from midnight to 11:00 Sao_Paulo time to match an operational re-schedule and record that change in the operational log.

### Description
- Update `OprmMarketImportFinalizationScheduler` to use cron `0 0 11 18 5 *`, rename the scheduled method to `finalizeLatestStartedRunAt1100May18`, and adjust the schedule label to `11:00 18/05` in the scheduler log and invocation.
- Document the schedule change in `docs/registros/oprm1.md` by adding an entry noting the new hardcoded cron and execution time.

### Testing
- No automated tests were added or modified as part of this change and no test suite was executed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a8a9a287c83218b60c6f5a44165ed)