### PR TITLE
Expose port 80 and forward to 8000 in ads-service Dockerfile using socat

### DIFF
--- a/backend/ads-service/Dockerfile
+++ b/backend/ads-service/Dockerfile
@@ -23,19 +23,19 @@ FROM eclipse-temurin:21-jre
 ENV JAVA_OPTS ""
 WORKDIR /app
 
-# Install curl for healthcheck probes
+# Install curl for healthcheck probes and socat to forward 80 -> 8000 inside the container
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends curl socat \
     && rm -rf /var/lib/apt/lists/*
 
 # Create directories that will be mounted as volumes
 RUN mkdir -p uploads logs
 
 COPY --from=build /workspace/backend/ads-service/target/app.jar /app/app.jar
-EXPOSE 8000
+EXPOSE 8000 80
 VOLUME ["/app/uploads", "/app/logs"]
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD curl -fsS http://127.0.0.1:8000/ops-mh-observability-v2/health || exit 1
 
-ENTRYPOINT ["/bin/sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/bin/sh", "-c", "socat TCP-LISTEN:80,fork,reuseaddr TCP:127.0.0.1:8000 & exec java $JAVA_OPTS -jar /app/app.jar"]


### PR DESCRIPTION
### Motivation
- Allow incoming traffic on port 80 to reach the Spring Boot app that listens on port 8000 inside the container for environments where port 80 is expected.

### Description
- Install `socat` and `curl`, add `EXPOSE 80` alongside `8000`, and start a background `socat` process to forward `TCP:80` to `TCP:127.0.0.1:8000` in the container `ENTRYPOINT`.

### Testing
- No automated unit or integration tests were added or modified; the Dockerfile change is intended to be validated by the CI image build (image build step expected to complete successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b26b626b883218d81c43fc523a039)