### PR TITLE
Add MOIS Sales Pages Library UI, API hooks and types; reanalyze action

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -113,3 +113,15 @@
   - frontend/src/api/settings/useClickbaseCollectedProducts.ts
   - backend/ads-service/src/main/java/com/marketinghub/mois/dto/MoisWorkspaceDtos.java
   - backend/ads-service/src/main/java/com/marketinghub/mois/web/MoisController.java
+
+## 2026-05-18 12:07:38 UTC-3
+- necessidade de telas no frontend para acompanhar análises da biblioteca de páginas de vendas do MOIS.
+- foi mapeado o contrato já existente no backend (`/api/mois/sales-library`) para evitar criação desnecessária de endpoint e garantir aderência ao escopo do módulo.
+- implementadas seções de acompanhamento no frontend: entradas ingeridas, fila de jobs, páginas com status/score, ação de reanálise com botão desabilitado + spinner durante requisição e painel de detalhe da análise por página.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+  - frontend/src/api/mois/useMoisSalesLibrary.ts
+  - frontend/src/api/mois/types.ts
+  - backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -233,3 +233,69 @@ export interface MoisSalesLibraryEntryPageResponse {
   total: number;
   items: MoisSalesLibraryEntry[];
 }
+
+
+export interface MoisSalesLibraryJob {
+  id: number;
+  urlIngestId: number;
+  status: string;
+  attempts: number;
+  errorCategory?: string;
+  errorMessage?: string;
+  nextRetryAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+}
+
+export interface MoisSalesLibraryJobPageResponse {
+  page: number;
+  pageSize: number;
+  total: number;
+  items: MoisSalesLibraryJob[];
+}
+
+export interface MoisSalesLibraryPage {
+  pageId: number;
+  workspaceId: string;
+  source: string;
+  urlCanonical: string;
+  title?: string;
+  analysisStatus?: string;
+  scoreTotal?: number;
+  analyzedAt?: string;
+  updatedAt: string;
+}
+
+export interface MoisSalesLibraryPageListResponse {
+  page: number;
+  pageSize: number;
+  total: number;
+  items: MoisSalesLibraryPage[];
+}
+
+export interface MoisSalesLibraryPageAnalysis {
+  analysisId: number;
+  pageId: number;
+  jobId?: number;
+  status: string;
+  scoreTotal?: number;
+  parserVersion?: string;
+  promptVersion?: string;
+  modelName?: string;
+  sectionsJson?: string;
+  copyJson?: string;
+  visualJson?: string;
+  imageJson?: string;
+  analysisNotes?: string;
+  analyzedAt?: string;
+  updatedAt: string;
+}
+
+export interface MoisSalesLibraryReanalyzeResponse {
+  pageId: number;
+  jobId: number;
+  status: string;
+  createdAt: string;
+}

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -1,10 +1,16 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
-import type { MoisSalesLibraryEntryPageResponse } from "./types";
+import type {
+  MoisSalesLibraryEntryPageResponse,
+  MoisSalesLibraryJobPageResponse,
+  MoisSalesLibraryPageAnalysis,
+  MoisSalesLibraryPageListResponse,
+  MoisSalesLibraryReanalyzeResponse,
+} from "./types";
 
 export function useMoisSalesLibraryEntries(workspaceId: string, page: number, pageSize: number) {
   return useQuery({
-    queryKey: ["mois", "sales-library", workspaceId, page, pageSize],
+    queryKey: ["mois", "sales-library", "entries", workspaceId, page, pageSize],
     queryFn: async () => {
       const { data } = await axios.get<MoisSalesLibraryEntryPageResponse>("/api/mois/sales-library/entries", {
         params: { workspaceId, page, pageSize },
@@ -12,4 +18,68 @@ export function useMoisSalesLibraryEntries(workspaceId: string, page: number, pa
       return data;
     },
   });
+}
+
+export function useMoisSalesLibraryJobs(workspaceId: string, page: number, pageSize: number, status?: string) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "jobs", workspaceId, page, pageSize, status],
+    queryFn: async () => {
+      const { data } = await axios.get<MoisSalesLibraryJobPageResponse>("/api/mois/sales-library/jobs", {
+        params: { workspaceId, page, pageSize, status: status || undefined },
+      });
+      return data;
+    },
+  });
+}
+
+export function useMoisSalesLibraryPages(workspaceId: string, page: number, pageSize: number) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "pages", workspaceId, page, pageSize],
+    queryFn: async () => {
+      const { data } = await axios.get<MoisSalesLibraryPageListResponse>("/api/mois/sales-library/pages", {
+        params: { workspaceId, page, pageSize },
+      });
+      return data;
+    },
+  });
+}
+
+export function useMoisSalesLibraryPageAnalysis(pageId?: number) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "analysis", pageId],
+    enabled: Boolean(pageId),
+    queryFn: async () => {
+      const { data } = await axios.get<MoisSalesLibraryPageAnalysis>(`/api/mois/sales-library/pages/${pageId}/analysis`);
+      return data;
+    },
+  });
+}
+
+export function useReanalyzeMoisSalesLibraryPage(workspaceId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (pageId: number) => {
+      const { data } = await axios.post<MoisSalesLibraryReanalyzeResponse>(`/api/mois/sales-library/pages/${pageId}:reanalyze`);
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["mois", "sales-library", "pages", workspaceId] });
+      void queryClient.invalidateQueries({ queryKey: ["mois", "sales-library", "jobs", workspaceId] });
+    },
+  });
+}
+
+export function getSalesLibraryJobBadgeClass(job: { status?: string; analysisStatus?: string }) {
+  switch (job.status || job.analysisStatus) {
+    case "DONE":
+      return "bg-success-subtle text-success-emphasis";
+    case "FAILED":
+      return "bg-danger-subtle text-danger-emphasis";
+    case "FETCHING":
+      return "bg-primary-subtle text-primary-emphasis";
+    case "PENDING":
+      return "bg-warning-subtle text-warning-emphasis";
+    default:
+      return "bg-secondary-subtle text-secondary-emphasis";
+  }
 }

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -1,87 +1,270 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
-import { useMoisSalesLibraryEntries } from "../../api/mois/useMoisSalesLibrary";
+import {
+  getSalesLibraryJobBadgeClass,
+  useMoisSalesLibraryEntries,
+  useMoisSalesLibraryJobs,
+  useMoisSalesLibraryPageAnalysis,
+  useMoisSalesLibraryPages,
+  useReanalyzeMoisSalesLibraryPage,
+} from "../../api/mois/useMoisSalesLibrary";
 
 const WORKSPACE_ID = "workspace-001";
 const PAGE_SIZE = 20;
 
-export default function MoisSalesPagesLibraryPage() {
-  const [page, setPage] = useState(1);
-  const query = useMoisSalesLibraryEntries(WORKSPACE_ID, page, PAGE_SIZE);
+function SimplePaginator({
+  page,
+  pageSize,
+  total,
+  onChange,
+}: {
+  page: number;
+  pageSize: number;
+  total: number;
+  onChange: (newPage: number) => void;
+}) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  return (
+    <div className="d-flex justify-content-between align-items-center mt-3">
+      <span className="text-secondary small">
+        Página {page} de {totalPages} • Total: {total}
+      </span>
+      <div className="btn-group">
+        <button type="button" className="btn btn-outline-secondary btn-sm" disabled={page <= 1} onClick={() => onChange(Math.max(1, page - 1))}>
+          Anterior
+        </button>
+        <button type="button" className="btn btn-outline-secondary btn-sm" disabled={page >= totalPages} onClick={() => onChange(Math.min(totalPages, page + 1))}>
+          Próxima
+        </button>
+      </div>
+    </div>
+  );
+}
 
-  const totalPages = query.data ? Math.max(1, Math.ceil(query.data.total / query.data.pageSize)) : 1;
+export default function MoisSalesPagesLibraryPage() {
+  const [entriesPage, setEntriesPage] = useState(1);
+  const [jobsPage, setJobsPage] = useState(1);
+  const [pagesPage, setPagesPage] = useState(1);
+  const [jobStatus, setJobStatus] = useState("");
+  const [selectedPageId, setSelectedPageId] = useState<number>();
+
+  const entriesQuery = useMoisSalesLibraryEntries(WORKSPACE_ID, entriesPage, PAGE_SIZE);
+  const jobsQuery = useMoisSalesLibraryJobs(WORKSPACE_ID, jobsPage, PAGE_SIZE, jobStatus || undefined);
+  const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, pagesPage, PAGE_SIZE);
+  const analysisQuery = useMoisSalesLibraryPageAnalysis(selectedPageId);
+  const reanalyzeMutation = useReanalyzeMoisSalesLibraryPage(WORKSPACE_ID);
+
+  const selectedPage = useMemo(() => pagesQuery.data?.items.find((item) => item.pageId === selectedPageId), [pagesQuery.data?.items, selectedPageId]);
 
   return (
     <div className="d-flex flex-column gap-4">
       <header className="d-flex flex-wrap justify-content-between gap-3">
         <div>
           <PageTitle>Biblioteca de Páginas de Vendas</PageTitle>
-          <p className="text-secondary mb-0">Entradas ingeridas da biblioteca (com paginação).</p>
+          <p className="text-secondary mb-0">Acompanhamento de ingestão, fila de análise e resultado por página.</p>
         </div>
         <Link className="btn btn-outline-secondary" to="/mois">
           Voltar ao workspace
         </Link>
       </header>
 
-      {query.isLoading ? <p className="text-secondary">Carregando entradas...</p> : null}
-      {query.isError ? <div className="alert alert-danger">Falha ao carregar entradas da biblioteca.</div> : null}
-
-      {query.data ? (
-        <section className="card border-0 shadow-sm">
-          <div className="card-body table-responsive">
-            <table className="table table-sm align-middle">
-              <thead>
-                <tr>
-                  <th>URL canônica</th>
-                  <th>Origem</th>
-                  <th>Título</th>
-                  <th>Ingestões</th>
-                  <th>Última captura</th>
-                </tr>
-              </thead>
-              <tbody>
-                {query.data.items.length === 0 ? (
+      <section className="card border-0 shadow-sm">
+        <div className="card-body table-responsive">
+          <h2 className="h5 mb-3">Entradas ingeridas</h2>
+          {entriesQuery.isLoading ? <p className="text-secondary">Carregando entradas...</p> : null}
+          {entriesQuery.isError ? <div className="alert alert-danger">Falha ao carregar entradas da biblioteca.</div> : null}
+          {entriesQuery.data ? (
+            <>
+              <table className="table table-sm align-middle">
+                <thead>
                   <tr>
-                    <td colSpan={5} className="text-secondary">
-                      Nenhuma entrada encontrada.
-                    </td>
+                    <th>URL canônica</th>
+                    <th>Origem</th>
+                    <th>Título</th>
+                    <th>Ingestões</th>
+                    <th>Última captura</th>
                   </tr>
-                ) : (
-                  query.data.items.map((item) => (
-                    <tr key={item.id}>
-                      <td className="text-break">{item.urlCanonical}</td>
-                      <td>{item.source}</td>
-                      <td>{item.title || "—"}</td>
-                      <td>{item.ingestCount}</td>
-                      <td>{item.lastCapturedAt || "—"}</td>
+                </thead>
+                <tbody>
+                  {entriesQuery.data.items.length === 0 ? (
+                    <tr>
+                      <td colSpan={5} className="text-secondary">
+                        Nenhuma entrada encontrada.
+                      </td>
                     </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
+                  ) : (
+                    entriesQuery.data.items.map((item) => (
+                      <tr key={item.id}>
+                        <td className="text-break">{item.urlCanonical}</td>
+                        <td>{item.source}</td>
+                        <td>{item.title || "—"}</td>
+                        <td>{item.ingestCount}</td>
+                        <td>{item.lastCapturedAt || "—"}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+              <SimplePaginator page={entriesQuery.data.page} pageSize={entriesQuery.data.pageSize} total={entriesQuery.data.total} onChange={setEntriesPage} />
+            </>
+          ) : null}
+        </div>
+      </section>
 
-            <div className="d-flex justify-content-between align-items-center mt-3">
-              <span className="text-secondary small">
-                Página {query.data.page} de {totalPages} • Total: {query.data.total}
-              </span>
-              <div className="btn-group">
-                <button type="button" className="btn btn-outline-secondary btn-sm" disabled={query.data.page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>
-                  Anterior
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-outline-secondary btn-sm"
-                  disabled={query.data.page >= totalPages}
-                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                >
-                  Próxima
-                </button>
+      <section className="card border-0 shadow-sm">
+        <div className="card-body table-responsive">
+          <div className="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-3">
+            <h2 className="h5 mb-0">Fila de jobs de análise</h2>
+            <select className="form-select form-select-sm" style={{ maxWidth: 220 }} value={jobStatus} onChange={(e) => setJobStatus(e.target.value)}>
+              <option value="">Todos os status</option>
+              <option value="PENDING">PENDING</option>
+              <option value="FETCHING">FETCHING</option>
+              <option value="DONE">DONE</option>
+              <option value="FAILED">FAILED</option>
+            </select>
+          </div>
+          {jobsQuery.isLoading ? <p className="text-secondary">Carregando jobs...</p> : null}
+          {jobsQuery.isError ? <div className="alert alert-danger">Falha ao carregar fila de jobs.</div> : null}
+          {jobsQuery.data ? (
+            <>
+              <table className="table table-sm align-middle">
+                <thead>
+                  <tr>
+                    <th>Job</th>
+                    <th>Status</th>
+                    <th>Tentativas</th>
+                    <th>Atualizado em</th>
+                    <th>Erro</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {jobsQuery.data.items.length === 0 ? (
+                    <tr>
+                      <td colSpan={5} className="text-secondary">
+                        Nenhum job encontrado para este filtro.
+                      </td>
+                    </tr>
+                  ) : (
+                    jobsQuery.data.items.map((job) => (
+                      <tr key={job.id}>
+                        <td>{job.id}</td>
+                        <td>
+                          <span className={`badge ${getSalesLibraryJobBadgeClass(job)}`}>{job.status}</span>
+                        </td>
+                        <td>{job.attempts}</td>
+                        <td>{job.updatedAt || "—"}</td>
+                        <td>{job.errorMessage || "—"}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+              <SimplePaginator page={jobsQuery.data.page} pageSize={jobsQuery.data.pageSize} total={jobsQuery.data.total} onChange={setJobsPage} />
+            </>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body table-responsive">
+          <h2 className="h5 mb-3">Páginas e status da análise</h2>
+          {pagesQuery.isLoading ? <p className="text-secondary">Carregando páginas...</p> : null}
+          {pagesQuery.isError ? <div className="alert alert-danger">Falha ao carregar páginas da biblioteca.</div> : null}
+          {pagesQuery.data ? (
+            <>
+              <table className="table table-sm align-middle">
+                <thead>
+                  <tr>
+                    <th>Página</th>
+                    <th>URL canônica</th>
+                    <th>Status</th>
+                    <th>Score</th>
+                    <th>Ações</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagesQuery.data.items.length === 0 ? (
+                    <tr>
+                      <td colSpan={5} className="text-secondary">
+                        Nenhuma página encontrada.
+                      </td>
+                    </tr>
+                  ) : (
+                    pagesQuery.data.items.map((item) => {
+                      const isReanalyzing = reanalyzeMutation.isPending && reanalyzeMutation.variables === item.pageId;
+                      return (
+                        <tr key={item.pageId}>
+                          <td>{item.pageId}</td>
+                          <td className="text-break">{item.urlCanonical}</td>
+                          <td>
+                            <span className={`badge ${getSalesLibraryJobBadgeClass(item)}`}>{item.analysisStatus || "SEM ANÁLISE"}</span>
+                          </td>
+                          <td>{item.scoreTotal ?? "—"}</td>
+                          <td className="d-flex gap-2 flex-wrap">
+                            <button type="button" className="btn btn-outline-primary btn-sm" onClick={() => setSelectedPageId(item.pageId)}>
+                              Ver análise
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-secondary btn-sm"
+                              disabled={isReanalyzing}
+                              onClick={() => reanalyzeMutation.mutate(item.pageId)}
+                            >
+                              {isReanalyzing ? <span className="spinner-border spinner-border-sm" aria-hidden="true" /> : null}
+                              <span className={isReanalyzing ? "ms-2" : ""}>Reanalisar</span>
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+              <SimplePaginator page={pagesQuery.data.page} pageSize={pagesQuery.data.pageSize} total={pagesQuery.data.total} onChange={setPagesPage} />
+            </>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <h2 className="h5 mb-3">Detalhes da análise da página</h2>
+          {!selectedPageId ? <p className="text-secondary mb-0">Selecione uma página na tabela acima para ver os detalhes.</p> : null}
+          {selectedPageId && analysisQuery.isLoading ? <p className="text-secondary mb-0">Carregando análise da página {selectedPageId}...</p> : null}
+          {selectedPageId && analysisQuery.isError ? <div className="alert alert-warning mb-0">Ainda não há análise disponível para a página selecionada.</div> : null}
+          {selectedPageId && analysisQuery.data ? (
+            <div className="d-flex flex-column gap-3">
+              <div className="d-flex flex-wrap gap-3">
+                <span className="badge bg-secondary">Página: {selectedPage?.pageId}</span>
+                <span className="badge bg-secondary">Job: {analysisQuery.data.jobId ?? "—"}</span>
+                <span className={`badge ${getSalesLibraryJobBadgeClass(analysisQuery.data)}`}>Status: {analysisQuery.data.status}</span>
+                <span className="badge bg-secondary">Score: {analysisQuery.data.scoreTotal ?? "—"}</span>
+              </div>
+              <div>
+                <h3 className="h6">Notas</h3>
+                <p className="mb-0">{analysisQuery.data.analysisNotes || "Sem notas."}</p>
+              </div>
+              <div>
+                <h3 className="h6">Seções (JSON)</h3>
+                <pre className="bg-light p-3 rounded small mb-0 text-wrap">{analysisQuery.data.sectionsJson || "{}"}</pre>
+              </div>
+              <div>
+                <h3 className="h6">Copy (JSON)</h3>
+                <pre className="bg-light p-3 rounded small mb-0 text-wrap">{analysisQuery.data.copyJson || "{}"}</pre>
+              </div>
+              <div>
+                <h3 className="h6">Visual (JSON)</h3>
+                <pre className="bg-light p-3 rounded small mb-0 text-wrap">{analysisQuery.data.visualJson || "{}"}</pre>
+              </div>
+              <div>
+                <h3 className="h6">Imagem (JSON)</h3>
+                <pre className="bg-light p-3 rounded small mb-0 text-wrap">{analysisQuery.data.imageJson || "{}"}</pre>
               </div>
             </div>
-          </div>
-        </section>
-      ) : null}
+          ) : null}
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation

- Provide frontend screens to monitor the MOIS sales pages library ingestion, analysis job queue and per-page analysis details.
- Reuse the existing backend contract at `/api/mois/sales-library` to avoid adding new endpoints and stay aligned with module scope.
- Surface the ability to trigger a reanalysis from the UI and show feedback while the request is in progress.

### Description

- Added new TypeScript models for the sales library in `frontend/src/api/mois/types.ts` including job, page, analysis and paginated responses.
- Implemented React Query hooks in `frontend/src/api/mois/useMoisSalesLibrary.ts` for entries, jobs, pages, page analysis and a reanalyze mutation, plus a helper `getSalesLibraryJobBadgeClass` for status badges.
- Added a new page component `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx` that shows three sections (ingested entries, job queue, pages & analysis), simple pagination, job status filtering, page detail panel and a reanalyze button with spinner/disabled state while pending.
- Updated documentation log `docs/registros/mois1.md` to record the new UI and files consulted.

### Testing

- Performed TypeScript type-check and a frontend build to validate the new types and components via `yarn tsc --noEmit` and `yarn build`, both completed successfully.
- No new automated unit tests were added for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b29f84a1c8321b407559c8e9a9684)