### PR TITLE
feat(backend): add external access test endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/system/web/ExternalAccessTestController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/system/web/ExternalAccessTestController.java
@@ -1,0 +1,20 @@
+package com.marketinghub.system.web;
+
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/system")
+public class ExternalAccessTestController {
+
+    @GetMapping("/external-access-test")
+    public Map<String, String> externalAccessTest() {
+        return Map.of(
+                "status", "ok",
+                "message", "external access test endpoint is reachable",
+                "timestamp", Instant.now().toString());
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/system/web/ExternalAccessTestControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/system/web/ExternalAccessTestControllerTest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.system.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ExternalAccessTestController.class)
+class ExternalAccessTestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldReturnExternalAccessTestPayload() throws Exception {
+        mockMvc.perform(get("/api/system/external-access-test"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ok"))
+                .andExpect(jsonPath("$.message").value("external access test endpoint is reachable"))
+                .andExpect(jsonPath("$.timestamp").isNotEmpty());
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, safe endpoint to quickly validate external reachability of the backend (smoke-test network/port accessibility) without touching business flows.

### Description
- Added `ExternalAccessTestController` at `GET /api/system/external-access-test` which returns a small JSON payload with `status`, `message` and `timestamp`, and added a focused controller contract test `ExternalAccessTestControllerTest`; example curl checks: `curl -i http://SEU_HOST/api/system/external-access-test` (port 80) and `curl -i http://SEU_HOST:8000/api/system/external-access-test` (port 8000).

### Testing
- Ran `mvn -q -Dtest=ExternalAccessTestControllerTest test` for the new controller test and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2b1c3fa88321a7744e80a90a8299)