### PR TITLE
Reintroduce Gera Landing steps in Experiment Content tab

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -280,3 +280,11 @@
 - arquivos alterados:
   - frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
   - docs/registros/experimentos.md
+
+## 2026-05-18 12:10:00 UTC
+- solicitação: na tela de experimento, aba de conteúdo, voltar a exibir as etapas do fluxo Gera Landing.
+- causa-raiz: as etapas de landing haviam sido removidas da constante `CONTENT_GENERATION_SECTIONS`, então a UI mostrava apenas etapas parciais.
+- foi feito no frontend: reintroduzidas as seções de Gera Landing na aba de conteúdo: `Gere Wireframe`, `Gera Copy`, `Gera Prompt Imagens`, `Gera Preset Design` e `Gera Html`.
+- arquivos alterados:
+  - frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+  - docs/registros/experimentos.md

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -89,10 +89,38 @@ const CONTENT_GENERATION_SECTIONS: ContentGenerationSection[] = [
   },
   {
     key: "image-prompt",
-    label: "Prompt da Imagem",
+    label: "Gera Prompt Imagens",
     description:
       "Crie prompts para orientar a geração de criativos visuais coerentes com o ângulo.",
     defaultQuantity: 4,
+  },
+  {
+    key: "landing-layout",
+    label: "Gere Wireframe",
+    description:
+      "Estruture a arquitetura da landing em seções com hierarquia e fluxo de leitura.",
+    defaultQuantity: 1,
+  },
+  {
+    key: "landing-copy",
+    label: "Gera Copy",
+    description:
+      "Produza a copy completa da landing seguindo o framework canônico de conversão.",
+    defaultQuantity: 1,
+  },
+  {
+    key: "landing-design-preset",
+    label: "Gera Preset Design",
+    description:
+      "Defina direcionamentos visuais para garantir consistência de estilo e identidade.",
+    defaultQuantity: 1,
+  },
+  {
+    key: "landing-html",
+    label: "Gera Html",
+    description:
+      "Monte o HTML provisório da landing com base nas etapas anteriores.",
+    defaultQuantity: 1,
   },
 ];
 


### PR DESCRIPTION
### Motivation
- Restore the missing Gera Landing stages (Wireframe, Copy, Prompt Imagens, Preset Design, Html) in the experiment content tab because they were removed by a previous refactor and the UI must show the full Gera Landing pipeline.

### Description
- Re-added the landing stages to `CONTENT_GENERATION_SECTIONS` and changed the image prompt label to `Gera Prompt Imagens` in `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx`, and recorded the change in `docs/registros/experimentos.md`.

### Testing
- Attempted to run the frontend test `ExperimentContentGenerationTab.report.test.tsx` with `npm run -s test -- ExperimentContentGenerationTab.report.test.tsx` but the run failed due to the environment missing `vitest` (`vitest: not found`), so no frontend automated tests completed for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b3e859e6c8321af526f369b36ff06)