### PR TITLE
feat(experiment): restore landing content cards in Conteúdo tab

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -288,3 +288,11 @@
 - arquivos alterados:
   - frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
   - docs/registros/experimentos.md
+
+## 2026-05-18 12:45:00 UTC
+- solicitação: voltar com o bloco de etapas de landing na aba "Conteúdo" da página de experimentos.
+- causa-raiz: o array `pipelineContentCards` em `ExperimentDetailPage` estava reduzido às etapas 1 e 2, ocultando os campos de landing persistidos no experimento.
+- foi feito no frontend: reintroduzidos os cards de conteúdo bruto para `landing_page_wireframe`, `landing_page_copy`, `landing_page_image_planning`, `landing_page_design_preset`, `landing_page_html` e `landing_page_deliverables`, com as dependências do `useMemo` atualizadas para re-renderizar corretamente.
+- arquivos alterados:
+  - frontend/src/pages/experiment/ExperimentDetailPage.tsx
+  - docs/registros/experimentos.md

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -238,8 +238,55 @@ export default function ExperimentDetailPage() {
         description: "Conteúdo bruto salvo na coluna ad_copy.",
         rawValue: data?.adCopy,
       },
+      {
+        key: "wireframe",
+        title: "Etapa 3 · Landing Wireframe",
+        description: "Conteúdo bruto salvo na coluna landing_page_wireframe.",
+        rawValue: data?.landingPageWireframe,
+      },
+      {
+        key: "copy",
+        title: "Etapa 4 · Landing Copy",
+        description: "Conteúdo bruto salvo na coluna landing_page_copy.",
+        rawValue: data?.landingPageCopy,
+      },
+      {
+        key: "image-planning",
+        title: "Etapa 5 · Planejamento de Imagens",
+        description:
+          "Conteúdo bruto salvo na coluna landing_page_image_planning.",
+        rawValue: data?.landingPageImagePlanning,
+      },
+      {
+        key: "design-preset",
+        title: "Etapa 6 · Preset Design",
+        description:
+          "Conteúdo bruto salvo na coluna landing_page_design_preset.",
+        rawValue: data?.landingPageDesignPreset,
+      },
+      {
+        key: "landing-page-deliverables",
+        title: "Etapa 8 · Landing Page Deliverables",
+        description: "JSON final dos entregáveis da amostra e do produto final.",
+        rawValue: data?.landingPageDeliverables,
+      },
+      {
+        key: "landing-html",
+        title: "Etapa 7 · Landing HTML",
+        description: "Conteúdo bruto salvo na coluna landing_page_html.",
+        rawValue: data?.landingPageHtml,
+      },
     ],
-    [data?.adCopy, data?.campaignAngle],
+    [
+      data?.adCopy,
+      data?.campaignAngle,
+      data?.landingPageCopy,
+      data?.landingPageDesignPreset,
+      data?.landingPageDeliverables,
+      data?.landingPageHtml,
+      data?.landingPageImagePlanning,
+      data?.landingPageWireframe,
+    ],
   );
   useBreadcrumbs([
     {


### PR DESCRIPTION
### Motivation
- The experiment detail page lost several landing-related content cards which hid persisted landing artifacts from the user interface, impairing visibility of `landingPage*` fields. 
- The `useMemo` dependencies needed to include landing fields so the pipeline content cards re-render when those persisted values change.

### Description
- Reintroduced landing content cards in `pipelineContentCards` inside `frontend/src/pages/experiment/ExperimentDetailPage.tsx` for `wireframe`, `copy`, `image-planning`, `design-preset`, `landing-html` and `landing-page-deliverables`. 
- Updated the `useMemo` dependency array to include `data?.landingPageWireframe`, `data?.landingPageCopy`, `data?.landingPageImagePlanning`, `data?.landingPageDesignPreset`, `data?.landingPageHtml`, and `data?.landingPageDeliverables` to ensure proper re-render. 
- Recorded the change in `docs/registros/experimentos.md` under the experiment registry for traceability.

### Testing
- Attempted to run the frontend tests with `npm run -s test -- ExperimentContentGenerationTab.report.test.ts` but the run failed in this environment because `vitest` is not available on the PATH, so automated tests could not be executed here (failed). 
- Local UI verification performed by rendering the Experiment Detail page (manual smoke-check) confirmed the cards are displayed and their copy/description map to the correct `data?.landingPage*` fields (manual check, not an automated test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b49b0f6488321a53467a354acebdf)