### PR TITLE
Canonicalize landing HTML generation command in docs and add audit log entry

### DIFF
--- a/docs/canonical/experiments-automation-flow-canon.v1.md
+++ b/docs/canonical/experiments-automation-flow-canon.v1.md
@@ -252,8 +252,8 @@ Definição operacional do LHM:
 - entrega como saída canônica: `htmlDocument` final da landing;
 - roda no backend como fonte única de verdade para aplicação de contratos e
   validações de publicação.
-- a UI pode oferecer o comando `Gerar com LHM` como alternativa explícita ao
-  `Gerar com IA` na etapa `landing-page-html`.
+- a UI deve expor apenas o comando canônico vigente para geração de HTML na etapa
+  `landing-page-html`, sem distinção por tipos/variantes de acionamento.
 
 ### 8.7 Aba canônica de destino da campanha (Landing)
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -288,3 +288,11 @@
 - arquivos alterados:
   - frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
   - docs/registros/experimentos.md
+
+## 2026-05-18 14:24:03 UTC-3
+- ajuste de documentação do fluxo Gera Landing para remover referência a dois tipos de acionamento de geração de HTML.
+- raciocínio: a documentação precisava refletir o estado atual informado pelo usuário, sem citar tipos/variantes que não existem mais.
+- registro do que foi feito: atualizado o cânone `experiments-automation-flow-canon.v1.md` para manter apenas comando canônico único na etapa `landing-page-html`.
+- documentos lidos para pesquisar e resolver o problema:
+  - docs/canonical/experiments-automation-flow-canon.v1.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation

- Align documentation with the current UI by removing references to multiple activation variants and enforcing a single canonical command for HTML generation in the `landing-page-html` step. 

### Description

- Updated the canonical flow `docs/canonical/experiments-automation-flow-canon.v1.md` to remove the alternative `Gerar com LHM` vs `Gerar com IA` wording and require the UI to expose only the single canonical command for HTML generation. 
- Added an audit entry to `docs/registros/experimentos.md` describing the documentation update and listing the documents consulted. 

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b49e2037083218eb8b0555b892375)