### PR TITLE
fix: remove obsolete KPI/preset requirement when approving experiment landing

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -302,3 +302,13 @@
 - arquivos alterados:
   - frontend/src/pages/experiment/ExperimentDetailPage.tsx
   - docs/registros/experimentos.md
+
+## 2026-05-18 14:48:47 UTC-3
+- solicitação para corrigir bloqueio indevido no botão de aprovação de landing na aba de experimento, que exigia campos obsoletos (meta de KPI e preset de métricas).
+- raciocínio aplicado: a validação local no frontend estava impondo pré-condição que não faz mais parte do fluxo vigente, impedindo aprovação mesmo com landing válida.
+- foi feito: remoção da checagem de `kpiTarget`/`metricPresetId` antes da chamada de aprovação/publicação da landing, mantendo apenas os bloqueios reais (HTML existente e request em andamento).
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/experiment/LandingTab.tsx

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -40,16 +40,6 @@ export default function LandingTab({ experiment }: LandingTabProps) {
   const campaignDestinationUrl = resolveStandaloneLandingUrl(`/landing/${experiment.id}`);
 
   const handleApproveLanding = async () => {
-    const kpiTargetValue = experiment.kpiTarget ?? experiment.kpiTargetCpl;
-    if (kpiTargetValue == null || experiment.metricPresetId == null) {
-      setFeedback({
-        variant: "error",
-        message:
-          "Defina a meta de KPI e o preset de métricas antes de aprovar a landing como destino da campanha.",
-      });
-      return;
-    }
-
     setFeedback(null);
 
     try {


### PR DESCRIPTION
### Motivation
- The Landing approval button in the experiment UI was blocked by a local frontend validation that required `kpiTarget`/`metricPresetId`, fields that are now obsolete and should not prevent approval.

### Description
- Removed the local gate in `handleApproveLanding` that checked `experiment.kpiTarget` / `experiment.metricPresetId` in `frontend/src/pages/experiment/LandingTab.tsx` so the approval flow calls the publish API when HTML is present and not pending. 
- Kept existing UX behavior: the button remains disabled while `approveAndPublishLanding.isPending` or when there is no `landingHtml`, and the approval API flow itself was not changed. 
- Added an append-only operational entry in `docs/registros/experimentos.md` with timestamp `2026-05-18 14:48:47 UTC-3` describing the root cause and the fix. 

### Testing
- Ran the frontend typecheck with `npm -C frontend run typecheck`, which failed due to pre-existing TypeScript/environment issues (missing type definitions `@testing-library/jest-dom`, `vite/client`, `vitest/globals` and deprecation warnings in `tsconfig`) that are unrelated to this change. 
- No frontend unit tests were added or modified for this small UI guard removal and no other automated test suites were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b50d5ef7c832183dcfc0032f1ff4f)