### PR TITLE
chore(deploy): map backend host port default to 80

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       TZ: America/Sao_Paulo
     ports:
-      - "${BACKEND_PORT:-8000}:8000"
+      - "${BACKEND_PORT:-80}:8000"
     volumes:
       - ./volumes/backend/uploads:/app/uploads
       - ./volumes/backend/logs:/app/logs


### PR DESCRIPTION
### Motivation
- Expose the backend service on host port 80 by default while keeping the container listening on port 8000 to simplify external access.

### Description
- Updated the default port mapping in `deploy/docker-compose.yml` from `${BACKEND_PORT:-8000}:8000` to `${BACKEND_PORT:-80}:8000`.

### Testing
- Verified the change with `git diff deploy/docker-compose.yml`, checked status with `git status --short`, and committed the update using `git commit -m "chore(deploy): map backend host port default to 80"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b571dc3fc83218ec28fa3dda80df3)