### PR TITLE
GeraLanding: Add approve-and-publish endpoint to publish landing to Lead Portal

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContoller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContoller.java
@@ -76,4 +76,9 @@ public class GeraLandingContoller {
     String provisionalHtml = executionService.generateAndPersistProvisionalHtmlFromExperiment(experimentId, jobId);
     return ResponseEntity.ok(new GeraLandingProvisionalHtmlResponse(provisionalHtml));
   }
+
+  @PostMapping("/landing/approve-and-publish")
+  public ResponseEntity<GeraLandingPublishResponse> approveAndPublishLanding(@PathVariable Long experimentId) {
+    return ResponseEntity.ok(executionService.approveAndPublishLanding(experimentId));
+  }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingLeadPortalPublishRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingLeadPortalPublishRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.geralanding;
+
+public record GeraLandingLeadPortalPublishRequest(
+        String slug,
+        String name,
+        String description,
+        String customFormHtml,
+        String legacyPreviewHtml,
+        String renderMode) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingPublishResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingPublishResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.geralanding;
+
+public record GeraLandingPublishResponse(
+        Long experimentId,
+        Long flowId,
+        String iframeUrl,
+        String standaloneUrl,
+        String message) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -13,7 +13,19 @@ import java.time.Instant;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
+import java.util.Locale;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
 
 @Service
 public class GeraLandingStageExecutionService {
@@ -35,6 +47,8 @@ public class GeraLandingStageExecutionService {
     private final CopyProvisionalHtmlAssembler copyProvisionalHtmlAssembler;
     private final DesignPresetProvisionalHtmlAssembler designPresetProvisionalHtmlAssembler;
     private final LandingPageImageInjector landingPageImageInjector;
+    private final RestTemplate restTemplate;
+    private final String leadPortalBaseUrl;
 
     public GeraLandingStageExecutionService(
             ExperimentRepository experimentRepository,
@@ -42,13 +56,141 @@ public class GeraLandingStageExecutionService {
             WireframeProvisionalHtmlAssembler wireframeProvisionalHtmlAssembler,
             CopyProvisionalHtmlAssembler copyProvisionalHtmlAssembler,
             DesignPresetProvisionalHtmlAssembler designPresetProvisionalHtmlAssembler,
-            LandingPageImageInjector landingPageImageInjector) {
+            LandingPageImageInjector landingPageImageInjector,
+            RestTemplate restTemplate,
+            @Value("${integrations.lead-portal.base-url:}") String leadPortalBaseUrl) {
         this.experimentRepository = experimentRepository;
         this.executionRepository = executionRepository;
         this.wireframeProvisionalHtmlAssembler = wireframeProvisionalHtmlAssembler;
         this.copyProvisionalHtmlAssembler = copyProvisionalHtmlAssembler;
         this.designPresetProvisionalHtmlAssembler = designPresetProvisionalHtmlAssembler;
         this.landingPageImageInjector = landingPageImageInjector;
+        this.restTemplate = restTemplate;
+        this.leadPortalBaseUrl = leadPortalBaseUrl;
+    }
+
+    @Transactional
+    public GeraLandingPublishResponse approveAndPublishLanding(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+        if (!StringUtils.hasText(experiment.getLandingPageHtml())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Landing HTML ainda não foi gerado para este experimento");
+        }
+        String slug = "exp-" + experimentId + "-landing-geralanding";
+        String htmlWithFunnelControls = injectFunnelControls(experiment.getLandingPageHtml());
+        String htmlWithFacebookPixel = injectFacebookPixel(htmlWithFunnelControls, resolveFacebookPixelId(experiment));
+        publishToLeadPortal(slug, "Landing GeraLanding - Experimento " + experimentId, htmlWithFacebookPixel.trim());
+        try {
+            String iframeUrl = resolveIframeUrl(slug);
+            String standaloneUrl = resolveStandaloneLandingUrl(iframeUrl);
+            experiment.setFollowUpActionUrl(standaloneUrl);
+            experimentRepository.save(experiment);
+            return new GeraLandingPublishResponse(experimentId, null, iframeUrl, standaloneUrl,
+                    "Landing publicada com sucesso pelo GeraLanding.");
+        } catch (RuntimeException ex) {
+            String rootCauseMessage = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                    "Falha ao publicar landing do GeraLanding: " + rootCauseMessage, ex);
+        }
+    }
+
+    private void publishToLeadPortal(String slug, String name, String html) {
+        if (!StringUtils.hasText(leadPortalBaseUrl)) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Lead Portal base URL não configurada");
+        }
+        URI uri = UriComponentsBuilder.fromHttpUrl(leadPortalBaseUrl).path("/api/flows/{slug}").buildAndExpand(slug).toUri();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        GeraLandingLeadPortalPublishRequest payload = new GeraLandingLeadPortalPublishRequest(
+                slug, name, "Fluxo publicado pelo módulo GeraLanding", html, html, "custom_html");
+        try {
+            restTemplate.put(uri, new HttpEntity<>(payload, headers));
+        } catch (RestClientException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Falha ao enviar fluxo para o Lead Portal", ex);
+        }
+    }
+
+    private String resolveIframeUrl(String slug) {
+        return UriComponentsBuilder.fromHttpUrl(leadPortalBaseUrl)
+                .path("/api/public/flows/{slug}")
+                .buildAndExpand(slug)
+                .toUriString();
+    }
+
+    private String injectFunnelControls(String html) {
+        String controls = """
+                <script data-mh-funnel-controls=\"true\">
+                  window.__MH_FUNNEL_CONTROLS__ = { enabled: true, source: 'geralanding' };
+                </script>
+                """;
+        if (html.toLowerCase(Locale.ROOT).contains("data-mh-funnel-controls")) {
+            return html;
+        }
+        if (html.toLowerCase(Locale.ROOT).contains("</head>")) {
+            return html.replaceFirst("(?i)</head>", controls + "\n</head>");
+        }
+        return controls + "\n" + html;
+    }
+
+    private String resolveFacebookPixelId(Experiment experiment) {
+        if (experiment == null || experiment.getNiche() == null) {
+            return null;
+        }
+        String pixelId = experiment.getNiche().getFacebookPixelId();
+        return StringUtils.hasText(pixelId) ? pixelId.trim() : null;
+    }
+
+    private String injectFacebookPixel(String html, String facebookPixelId) {
+        if (!StringUtils.hasText(html) || !StringUtils.hasText(facebookPixelId)) {
+            return html;
+        }
+        if (html.contains("data-mh-facebook-pixel")) {
+            return html;
+        }
+        String pixelSnippet = """
+                <script data-mh-facebook-pixel="true">
+                  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+                  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+                  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+                  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script',
+                  'https://connect.facebook.net/en_US/fbevents.js');
+                  fbq('init', '%s');
+                  fbq('track', 'PageView');
+                </script>
+                <noscript><img height="1" width="1" style="display:none"
+                  src="https://www.facebook.com/tr?id=%s&ev=PageView&noscript=1"
+                /></noscript>
+                """.formatted(facebookPixelId, facebookPixelId).trim();
+        if (html.toLowerCase(Locale.ROOT).contains("</head>")) {
+            return html.replaceFirst("(?i)</head>", pixelSnippet + "\n</head>");
+        }
+        if (html.toLowerCase(Locale.ROOT).contains("<body")) {
+            return html.replaceFirst("(?i)<body", pixelSnippet + "\n<body");
+        }
+        return pixelSnippet + "\n" + html;
+    }
+
+    private String resolveStandaloneLandingUrl(String iframeUrl) {
+        if (!StringUtils.hasText(iframeUrl)) {
+            return null;
+        }
+        try {
+            URI parsed = URI.create(iframeUrl);
+            String[] segments = parsed.getPath().split("/");
+            String slug = segments.length == 0 ? "" : segments[segments.length - 1];
+            if (!StringUtils.hasText(slug)) {
+                return null;
+            }
+            return UriComponentsBuilder.newInstance()
+                    .scheme(parsed.getScheme())
+                    .host(parsed.getHost())
+                    .port(parsed.getPort())
+                    .path("/api/flows/{slug}/page")
+                    .buildAndExpand(slug)
+                    .toUriString();
+        } catch (RuntimeException ex) {
+            return null;
+        }
     }
 
     @Transactional

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -312,3 +312,30 @@
   - frontend/AGENTS.md
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/LandingTab.tsx
+## 2026-05-18 18:34:00 UTC
+- solicitação: criar endpoint no pacote `geralanding` para aprovar/publicar landing diretamente usando `landing_page_html` do experimento.
+- foi feito no backend:
+  - novo endpoint `POST /api/experiments/{experimentId}/geralanding/landing/approve-and-publish`.
+  - serviço publica no lead portal, retorna URL iframe e URL standalone para uso em campanha.
+  - fluxo injeta controles de funil no HTML antes da publicação; o pixel do Facebook permanece injetado no payload de publicação do Lead Portal.
+- arquivos alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContoller.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingPublishResponse.java
+  - docs/registros/experimentos.md
+
+## 2026-05-18 18:41:00 UTC
+- solicitação: incluir explicitamente o pixel do Facebook no HTML publicado pelo endpoint de aprovação/publicação do GeraLanding.
+- foi feito no backend: adição de injeção direta do pixel no `customFormHtml` antes da publicação, usando `experiment.niche.facebookPixelId` e marcador `data-mh-facebook-pixel` para evitar duplicidade.
+- arquivos alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+  - docs/registros/experimentos.md
+
+## 2026-05-18 18:55:00 UTC
+- solicitação: no endpoint do GeraLanding, não depender de classes externas ao pacote para publicar.
+- ajuste aplicado: remoção da dependência de classes de `leadportal` no serviço do GeraLanding, com payload e publicação HTTP próprios no pacote `geralanding`.
+- comportamento mantido: usa `landing_page_html` pronto, injeta pixel do Facebook e controles de funil, publica e devolve URL iframe/standalone.
+- arquivos alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingLeadPortalPublishRequest.java
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Provide a backend endpoint to approve and publish a generated `landing_page_html` for an experiment directly from the GeraLanding flow to the Lead Portal. 
- Ensure published HTML contains funnel controls and an injected Facebook Pixel when available, and remove dependency on external `leadportal` classes by handling the HTTP publish payload in-package. 
- Surface publishing results (iframe and standalone URLs) back to the experiment and persist a follow-up URL.

### Description
- Added a new controller endpoint `POST /api/experiments/{experimentId}/geralanding/landing/approve-and-publish` by introducing `approveAndPublishLanding` in `GeraLandingContoller`. 
- Implemented `approveAndPublishLanding` workflow in `GeraLandingStageExecutionService` to validate `landing_page_html`, inject funnel controls and Facebook Pixel, publish to the Lead Portal using a `RestTemplate` and a configurable `integrations.lead-portal.base-url`, and return a `GeraLandingPublishResponse` containing iframe and standalone URLs. 
- Introduced DTOs `GeraLandingLeadPortalPublishRequest` and `GeraLandingPublishResponse` and added helper methods `injectFunnelControls`, `injectFacebookPixel`, `publishToLeadPortal`, `resolveIframeUrl`, and `resolveStandaloneLandingUrl`. 
- Updated constructor of `GeraLandingStageExecutionService` to accept `RestTemplate` and `leadPortalBaseUrl`, and updated docs `docs/registros/experimentos.md` to record the new endpoint and behavior.

### Testing
- Built the ads-service module with `./gradlew :backend:ads-service:build` which compiled the new classes successfully. 
- Ran the ads-service unit test suite with `./gradlew :backend:ads-service:test` and the tests completed successfully. 
- No failing automated tests were observed for the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b55c1f13083218d5c05b011c633c9)