### PR TITLE
backend: habilita escuta simultânea nas portas 80 e 8000

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/config/AdditionalTomcatConnectorConfig.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/config/AdditionalTomcatConnectorConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class AdditionalTomcatConnectorConfig {
 
-    private static final int ADDITIONAL_HTTP_PORT = 8000;
+    private static final int ADDITIONAL_HTTP_PORT = 80;
 
     @Bean
     public WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatConnectorCustomizer() {

--- a/backend/ads-service/src/main/java/com/marketinghub/config/AdditionalTomcatConnectorConfig.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/config/AdditionalTomcatConnectorConfig.java
@@ -1,0 +1,24 @@
+package com.marketinghub.config;
+
+import org.apache.catalina.connector.Connector;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AdditionalTomcatConnectorConfig {
+
+    private static final int ADDITIONAL_HTTP_PORT = 8000;
+
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatConnectorCustomizer() {
+        return factory -> factory.addAdditionalTomcatConnectors(createConnector(ADDITIONAL_HTTP_PORT));
+    }
+
+    private Connector createConnector(int port) {
+        Connector connector = new Connector(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
+        connector.setPort(port);
+        return connector;
+    }
+}

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -37,7 +37,7 @@ management.endpoints.web.path-mapping.logfile=backend-log-stream-x9k
 management.endpoint.health.show-details=always
 
 
-server.port=8000
+server.port=80
 spring.mvc.async.request-timeout=30000
 spring.servlet.multipart.max-file-size=15MB
 spring.servlet.multipart.max-request-size=15MB

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -37,7 +37,7 @@ management.endpoints.web.path-mapping.logfile=backend-log-stream-x9k
 management.endpoint.health.show-details=always
 
 
-server.port=80
+server.port=8000
 spring.mvc.async.request-timeout=30000
 spring.servlet.multipart.max-file-size=15MB
 spring.servlet.multipart.max-request-size=15MB


### PR DESCRIPTION
### Motivation
- O backend passou a escutar apenas na porta `80` em produção e é necessário manter compatibilidade com clientes/serviços que ainda acessam `:8000`.

### Description
- Ajustado `server.port` para `80` em `backend/ads-service/src/main/resources/application.properties` para porta principal.
- Adicionada a classe `AdditionalTomcatConnectorConfig` em `backend/ads-service/src/main/java/com/marketinghub/config/AdditionalTomcatConnectorConfig.java` que registra um conector Tomcat adicional na porta `8000` via `WebServerFactoryCustomizer<TomcatServletWebServerFactory>`.

### Testing
- Executado `./mvnw -q -f ads-service/pom.xml test` para validar a aplicação e os testes unitários.
- Resultado dos testes: falha com 1 erro (não relacionado à alteração de portas) em `FacebookPageControllerTest.setup` por `DataIntegrityViolation` de H2 ao deletar `experiment` referenciado por `creative`, com total `Tests run: 424, Failures: 0, Errors: 1, Skipped: 1`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b601f8a508321800ea321ee53eae8)