### PR TITLE
Expose backend on host ports 80 and 8000 in docker-compose

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     environment:
       TZ: America/Sao_Paulo
     ports:
-      - "${BACKEND_PORT:-80}:8000"
+      - "80:8000"
+      - "8000:8000"
     volumes:
       - ./volumes/backend/uploads:/app/uploads
       - ./volumes/backend/logs:/app/logs


### PR DESCRIPTION
### Motivation
- Make the backend container reachable on both standard HTTP port and container port by replacing the environment-driven host port mapping with explicit host bindings to `80` and `8000`.

### Description
- Update `deploy/docker-compose.yml` to change the backend `ports` from `"${BACKEND_PORT:-80}:8000"` to explicit mappings `"80:8000"` and `"8000:8000"` so the service is bound to both host ports.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b633ceb388321bec2a4195e9e384c)