### PR TITLE
docs: adicionar guia de seções da Biblioteca de Páginas de Vendas (MOIS) e registrar alteração

### DIFF
--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/guia-secoes-biblioteca-paginas-vendas.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/guia-secoes-biblioteca-paginas-vendas.md
@@ -1,0 +1,95 @@
+# Guia das seções — Biblioteca de Páginas de Vendas (MOIS)
+
+Data: 2026-05-18
+
+## Contexto
+A tela **Biblioteca de Páginas de Vendas** (rota `/mois/sales-pages-library`) foi criada para acompanhamento operacional do pipeline de biblioteca de sales pages no MOIS, cobrindo ingestão, processamento e diagnóstico de análise.
+
+## Acesso
+- Menu lateral: **Biblioteca Sales Pages**.
+- Rota: `/mois/sales-pages-library`.
+
+## Estrutura da página
+
+### 1) Cabeçalho
+- Título da página: **Biblioteca de Páginas de Vendas**.
+- Subtítulo: acompanhamento de ingestão, fila de análise e resultado por página.
+- Ação: botão **Voltar ao workspace** (retorna para `/mois`).
+
+### 2) Entradas ingeridas
+Objetivo: mostrar tudo que já entrou na biblioteca.
+
+Colunas exibidas:
+- URL canônica
+- Origem
+- Título
+- Ingestões
+- Última captura
+
+Comportamentos:
+- estado de carregamento;
+- estado de erro;
+- estado vazio (sem entradas);
+- paginação simples (anterior/próxima + total).
+
+### 3) Fila de jobs de análise
+Objetivo: monitorar o processamento assíncrono das páginas.
+
+Recursos:
+- filtro por status: `PENDING`, `FETCHING`, `DONE`, `FAILED`.
+
+Colunas exibidas:
+- Job
+- Status
+- Tentativas
+- Atualizado em
+- Erro
+
+Comportamentos:
+- estado de carregamento;
+- estado de erro;
+- estado vazio;
+- paginação simples.
+
+### 4) Páginas e status da análise
+Objetivo: listar páginas da biblioteca e o resultado agregado da análise.
+
+Colunas exibidas:
+- Página
+- URL canônica
+- Status
+- Score
+- Ações
+
+Ações da linha:
+- **Ver análise**: seleciona a página para abrir o detalhe abaixo.
+- **Reanalisar**: dispara novo processamento para a página.
+
+UX assíncrona:
+- durante a reanálise, o botão fica desabilitado e exibe spinner.
+
+### 5) Detalhes da análise da página
+Objetivo: detalhar a análise da página selecionada.
+
+Exibe:
+- badges de contexto (página, job, status, score);
+- notas da análise;
+- payloads de análise em JSON:
+  - Seções;
+  - Copy;
+  - Visual;
+  - Imagem.
+
+Estados:
+- sem página selecionada;
+- carregando análise;
+- análise indisponível;
+- análise disponível.
+
+## Resultado prático para operação
+A página permite:
+1. validar a qualidade da ingestão;
+2. identificar gargalos e falhas de job;
+3. acompanhar score/status por página;
+4. reprocessar rapidamente itens com problema;
+5. inspecionar os artefatos JSON gerados na análise.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -125,3 +125,12 @@
   - frontend/src/api/mois/useMoisSalesLibrary.ts
   - frontend/src/api/mois/types.ts
   - backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
+
+
+## 2026-05-18 00:00:00 UTC
+- solicitado registro documental das seções da tela Biblioteca de Páginas de Vendas (MOIS).
+- criado documento em `docs/novos-modulos/mois-biblioteca-pagina-venda/guia-secoes-biblioteca-paginas-vendas.md` descrevendo acesso, seções, comportamentos e objetivo operacional.
+- documentos/códigos consultados:
+  - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+  - frontend/src/components/MainNavigation.tsx
+  - frontend/src/App.tsx


### PR DESCRIPTION
### Motivation
- Registrar e documentar as seções e comportamentos da nova tela Biblioteca de Páginas de Vendas (`/mois/sales-pages-library`) para operação e engenharia.
- Atualizar o histórico de registros para refletir a criação do documento e os arquivos frontend consultados durante a implementação.

### Description
- Adiciona o guia operacional `docs/novos-modulos/mois-biblioteca-pagina-venda/guia-secoes-biblioteca-paginas-vendas.md` com acesso, estrutura da página, seções, colunas exibidas, estados e ações esperadas.
- Atualiza `docs/registros/mois1.md` para incluir o resumo da atividade de `2026-05-18` e o registro documental da criação do guia, listando os arquivos consultados.

### Testing
- Nenhum teste automatizado foi executado porque a mudança é exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6d8ddb108321a4826844cd090c3c)