### PR TITLE
Disable `customFormHtml` normalization in Lead Portal FlowService to allow campaign publication

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -339,3 +339,11 @@
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingLeadPortalPublishRequest.java
   - docs/registros/experimentos.md
+
+## 2026-05-18 20:36:00 UTC
+- solicitação: remover validação/normalização de `customFormHtml` no Lead Portal para desbloquear publicação da campanha 21.
+- ajuste aplicado: `FlowService` deixou de injetar `CustomFormHtmlResolver` e o método `normalizeCustomFormHtml` agora apenas retorna o fluxo original, sem validação restritiva de HTML.
+- impacto esperado: o endpoint de publicação não deve mais rejeitar payload com a mensagem `customFormHtml deve ser HTML puro...`.
+- arquivos alterados:
+  - lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowService.java
+  - docs/registros/experimentos.md

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowService.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowService.java
@@ -12,7 +12,6 @@ import com.marketinghub.leadportal.repository.FlowRepository;
 import com.marketinghub.leadportal.style.SimpleFormStyleDefaults;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
-import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +24,6 @@ public class FlowService {
     private final SimpleFlowCatalog simpleFlowCatalog;
     private final FlowAssetService flowAssetService;
     private final SimpleFormStyleDefaults simpleFormStyleDefaults;
-    private final CustomFormHtmlResolver customFormHtmlResolver;
 
     public FlowService(
             FlowRepository repository,
@@ -33,15 +31,13 @@ public class FlowService {
             MeterRegistry meterRegistry,
             SimpleFlowCatalog simpleFlowCatalog,
             FlowAssetService flowAssetService,
-            SimpleFormStyleDefaults simpleFormStyleDefaults,
-            CustomFormHtmlResolver customFormHtmlResolver) {
+            SimpleFormStyleDefaults simpleFormStyleDefaults) {
         this.repository = repository;
         this.accessRepository = accessRepository;
         this.meterRegistry = meterRegistry;
         this.simpleFlowCatalog = simpleFlowCatalog;
         this.flowAssetService = flowAssetService;
         this.simpleFormStyleDefaults = simpleFormStyleDefaults;
-        this.customFormHtmlResolver = customFormHtmlResolver;
     }
 
     @Transactional
@@ -164,25 +160,7 @@ public class FlowService {
         if (flow == null) {
             return null;
         }
-        String normalizedHtml = customFormHtmlResolver.normalize(flow.customFormHtml());
-        if (Objects.equals(normalizedHtml, flow.customFormHtml())) {
-            return flow;
-        }
-        return new Flow(
-                flow.slug(),
-                flow.name(),
-                flow.description(),
-                normalizedHtml,
-                flow.model(),
-                flow.prompt(),
-                flow.imagePromptModel(),
-                flow.imagePromptTemplate(),
-                flow.imageBatchSize(),
-                flow.questions(),
-                flow.simpleFormStyle(),
-                flow.facebookPixelId(),
-                flow.facebookPixelCode(),
-                flow.facebookPixelCreatedAt());
+        return flow;
     }
 
     private void registerAccess(String slug, FlowAccessMetadata metadata) {


### PR DESCRIPTION
### Motivation
- Unblock publication of campaign 21 by removing restrictive validation/normalization that could reject `customFormHtml` payloads with the message `customFormHtml deve ser HTML puro...`.

### Description
- Removed the `CustomFormHtmlResolver` dependency and its usage from `lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowService.java` and simplified `normalizeCustomFormHtml` to return the original `Flow` without transforming `customFormHtml`, and updated `docs/registros/experimentos.md` to record the change.

### Testing
- No automated tests were executed as part of this change and no test files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b76616c108321a438dfdff981447b)