### PR TITLE
Corrige assinatura do construtor em FlowServiceTest

### DIFF
--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/FlowServiceTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/FlowServiceTest.java
@@ -53,8 +53,7 @@ class FlowServiceTest {
                 meterRegistry,
                 simpleFlowCatalog,
                 flowAssetService,
-                simpleFormStyleDefaults,
-                new CustomFormHtmlResolver());
+                simpleFormStyleDefaults);
         when(simpleFlowCatalog.find(anyString())).thenReturn(Optional.empty());
     }
 


### PR DESCRIPTION
### Motivation
- O teste unitário compilava com erro porque a chamada ao construtor de `FlowService` continha um argumento extra (`CustomFormHtmlResolver`) que não existe mais na assinatura.

### Description
- Atualizei a inicialização em `lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/FlowServiceTest.java` para instanciar `FlowService` com a assinatura atual de 6 argumentos, removendo o argumento obsoleto.

### Testing
- Executei `mvn -Dtest=FlowServiceTest test` em `lead-portal/backend` e o build foi bem-sucedido com `Tests run: 2, Failures: 0, Errors: 0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7942bb908321b8e9c742b4b5ac3a)