### PR TITLE
Deprecate legacy landing pipeline endpoints and switch frontend to geralanding approve/publish

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/web/ExperimentPipelineController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/web/ExperimentPipelineController.java
@@ -49,26 +49,22 @@ public class ExperimentPipelineController {
         return generationService.generate(id, parsed, payload);
     }
 
+    @Deprecated(forRemoval = false)
     @PostMapping("/landing-page-html/apply-to-form")
     public ExperimentDto applyLandingHtmlToForm(@PathVariable Long id) {
-        return generationService.applyLandingHtmlToLeadPortalForm(id);
+        throw obsoleteLandingEndpoint("/landing-page-html/apply-to-form", id);
     }
 
+    @Deprecated(forRemoval = false)
     @PostMapping("/landing-page-html/approve-and-publish")
     public LandingPagePublicationResultDto approveAndPublishLanding(@PathVariable Long id) {
-        return generationService.approveAndPublishLandingPage(id);
+        throw obsoleteLandingEndpoint("/landing-page-html/approve-and-publish", id);
     }
 
+    @Deprecated(forRemoval = false)
     @PostMapping("/landing-page-html/generate-with-lhm")
     public ExperimentDto generateLandingHtmlWithLhm(@PathVariable Long id) {
-        try {
-            return generationService.generateLandingHtmlWithLhm(id);
-        } catch (ResponseStatusException ex) {
-            if (ex.getStatusCode() == HttpStatus.UNPROCESSABLE_ENTITY) {
-                log.warn("Geração LHM da landing falhou com 422 (experimentId={}): {}", id, ex.getReason());
-            }
-            throw ex;
-        }
+        throw obsoleteLandingEndpoint("/landing-page-html/generate-with-lhm", id);
     }
 
     @GetMapping("/jobs")
@@ -116,6 +112,13 @@ public class ExperimentPipelineController {
     public int closeOpenJobs(@PathVariable Long id,
                              @RequestParam(value = "reason", required = false) String reason) {
         return generationService.closeOpenJobs(id, reason);
+    }
+
+    private ResponseStatusException obsoleteLandingEndpoint(String endpoint, Long experimentId) {
+        log.warn("Endpoint obsoleto acessado no pipeline legado. experimentId={}, endpoint={}", experimentId, endpoint);
+        return new ResponseStatusException(
+                HttpStatus.GONE,
+                "Fluxo legado de landing no pipeline está obsoleto. Use /api/experiments/{id}/geralanding/landing/approve-and-publish.");
     }
 
     private ExperimentPipelineSection parseSection(String section) {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -359,3 +359,23 @@
   - docs/registros/experimentos.md
   - frontend/src/api/experiment/useApproveAndPublishLanding.ts
   - backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/web/ExperimentPipelineController.java
+
+## 2026-05-18 18:36:41 UTC-3
+- solicitação para marcar como obsoleto todo o fluxo antigo de aprovação/publicação de landing no pipeline legado.
+- raciocínio aplicado: bloquear explicitamente os endpoints legados para forçar uso do endpoint canônico do Gera Landing e evitar execução em rota descontinuada.
+- foi feito: endpoints legados de landing no `ExperimentPipelineController` foram marcados como `@Deprecated` e passam a retornar `410 GONE` com mensagem de migração para `/api/experiments/{id}/geralanding/landing/approve-and-publish`, incluindo log de advertência quando acessados.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/web/ExperimentPipelineController.java
+
+## 2026-05-18 18:41:50 UTC-3
+- solicitação para alterar o botão do frontend e usar endpoint do Gera Landing na aprovação/publicação da landing.
+- raciocínio aplicado: remover chamada do fluxo legado de pipeline e direcionar para o endpoint canônico do módulo `geralanding`, mantendo compatibilidade de leitura do retorno para exibição das URLs na tela.
+- foi feito: hook de aprovação/publicação atualizado para `POST /api/experiments/{id}/geralanding/landing/approve-and-publish` e ajuste na aba Landing para consumir `iframeUrl/standaloneUrl` do novo contrato, com fallback para contrato legado.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/api/experiment/useApproveAndPublishLanding.ts
+  - frontend/src/pages/experiment/LandingTab.tsx

--- a/frontend/src/api/experiment/useApproveAndPublishLanding.ts
+++ b/frontend/src/api/experiment/useApproveAndPublishLanding.ts
@@ -11,12 +11,14 @@ export interface LandingVariantLinks {
 export interface LandingPublicationResult {
   experimentId: number;
   flowId: number;
-  approved: boolean;
-  published: boolean;
-  publicUrl: string | null;
-  variantLinks: LandingVariantLinks[];
-  facebookPixelId: string | null;
-  pixelAppliedAutomatically: boolean;
+  approved?: boolean;
+  published?: boolean;
+  publicUrl?: string | null;
+  variantLinks?: LandingVariantLinks[];
+  facebookPixelId?: string | null;
+  pixelAppliedAutomatically?: boolean;
+  iframeUrl?: string | null;
+  standaloneUrl?: string | null;
   message: string;
 }
 
@@ -24,7 +26,7 @@ export function useApproveAndPublishLanding(experimentId: number) {
   return useMutation({
     mutationFn: async () => {
       const { data } = await axios.post<LandingPublicationResult>(
-        `/api/experiments/${experimentId}/pipeline/landing-page-html/approve-and-publish`,
+        `/api/experiments/${experimentId}/geralanding/landing/approve-and-publish`,
       );
       return data;
     },

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -46,8 +46,8 @@ export default function LandingTab({ experiment }: LandingTabProps) {
       const publication = await approveAndPublishLanding.mutateAsync();
       const primaryVariant = publication.variantLinks?.[0] ?? null;
       setPublishedUrls({
-        iframeUrl: primaryVariant?.iframeUrl ?? publication.publicUrl ?? null,
-        standaloneUrl: primaryVariant?.standaloneUrl ?? null,
+        iframeUrl: primaryVariant?.iframeUrl ?? publication.iframeUrl ?? publication.publicUrl ?? null,
+        standaloneUrl: primaryVariant?.standaloneUrl ?? publication.standaloneUrl ?? null,
       });
       setFeedback({
         variant: "success",


### PR DESCRIPTION
### Motivation
- Prevent usage of the legacy landing approval/publication flow in the experiment pipeline and force callers to use the canonical `geralanding` endpoints. 
- Align the frontend to the `geralanding` approve-and-publish endpoint and adapt to its slightly different response contract. 
- Record the change in experiment run logs/documentation. 

### Description
- Marked the old landing-related endpoints in `ExperimentPipelineController` as `@Deprecated` and replaced their implementations to return `410 GONE` with a migration message and a warning log via a new helper `obsoleteLandingEndpoint`, encouraging use of `/api/experiments/{id}/geralanding/landing/approve-and-publish` (file: `backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/web/ExperimentPipelineController.java`).
- Updated the frontend API hook to call the `geralanding` endpoint instead of the legacy pipeline endpoint and loosened the `LandingPublicationResult` typing to accept optional fields and include `iframeUrl`/`standaloneUrl` (file: `frontend/src/api/experiment/useApproveAndPublishLanding.ts`).
- Adjusted the Landing tab UI to prefer `iframeUrl`/`standaloneUrl` from the new response contract with sensible fallbacks to the legacy fields when present (file: `frontend/src/pages/experiment/LandingTab.tsx`).
- Added record entries in `docs/registros/experimentos.md` documenting the deprecation and frontend change (file: `docs/registros/experimentos.md`).

### Testing
- No automated tests were added for these changes. 
- Existing automated test suites were not executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b838dfb5c8321b74ff572fdb3bb77)