### PR TITLE
Add sales-library snapshot capture: service, endpoints, scheduler and DB schema

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/dto/MoisSalesLibraryDtos.java
@@ -168,4 +168,51 @@ public final class MoisSalesLibraryDtos {
             Instant createdAt
     ) {
     }
+
+    public record SalesLibrarySnapshotCaptureRequest(
+            @NotBlank String workspaceId,
+            Integer limit,
+            Boolean force
+    ) {
+    }
+
+    public record SalesLibrarySnapshotCaptureItem(
+            long pageId,
+            Long snapshotId,
+            String urlCanonical,
+            String status,
+            String snapshotHash,
+            Integer httpStatus,
+            long rawHtmlBytes,
+            long screenshotBytes,
+            String errorMessage
+    ) {
+    }
+
+    public record SalesLibrarySnapshotCaptureResponse(
+            String workspaceId,
+            int requestedLimit,
+            boolean force,
+            int processed,
+            int captured,
+            int failed,
+            List<SalesLibrarySnapshotCaptureItem> items,
+            Instant capturedAt
+    ) {
+    }
+
+    public record SalesLibraryPageSnapshotResponse(
+            long snapshotId,
+            long pageId,
+            String snapshotHash,
+            String status,
+            Integer httpStatus,
+            String contentType,
+            long rawHtmlBytes,
+            long screenshotBytes,
+            Instant capturedAt,
+            Instant updatedAt
+    ) {
+    }
+
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibrarySnapshotScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibrarySnapshotScheduler.java
@@ -1,0 +1,23 @@
+package com.marketinghub.mois.biblioteca.service;
+
+import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MoisSalesLibrarySnapshotScheduler {
+
+    private final MoisSalesLibrarySnapshotService snapshotService;
+
+    @Scheduled(cron = "0 */30 * * * *")
+    public void captureMissingSnapshots() {
+        var response = snapshotService.captureSnapshots(
+                new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureRequest("workspace-001", 5, false));
+        log.info("MOIS sales-library snapshot scheduler finished. workspaceId={}, processed={}, captured={}, failed={}",
+                response.workspaceId(), response.processed(), response.captured(), response.failed());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibrarySnapshotService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibrarySnapshotService.java
@@ -1,0 +1,272 @@
+package com.marketinghub.mois.biblioteca.service;
+
+import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import javax.imageio.ImageIO;
+import javax.swing.JEditorPane;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MoisSalesLibrarySnapshotService {
+
+    private static final int DEFAULT_LIMIT = 5;
+    private static final int MAX_LIMIT = 20;
+    private static final String ARTIFACT_RAW_HTML = "RAW_HTML";
+    private static final String ARTIFACT_SCREENSHOT_PNG = "SCREENSHOT_PNG";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(15))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+    public MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureResponse captureSnapshots(
+            MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureRequest request
+    ) {
+        int limit = normalizeLimit(request.limit());
+        boolean force = Boolean.TRUE.equals(request.force());
+        List<PageToCapture> pages = findPagesToCapture(request.workspaceId(), limit, force);
+        List<MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem> items = pages.stream()
+                .map(this::captureOneSafely)
+                .toList();
+        int captured = (int) items.stream().filter(item -> "CAPTURED".equals(item.status()) || "DUPLICATE".equals(item.status())).count();
+        int failed = (int) items.stream().filter(item -> "FAILED".equals(item.status())).count();
+        return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureResponse(
+                request.workspaceId(), limit, force, items.size(), captured, failed, items, Instant.now());
+    }
+
+    public List<MoisSalesLibraryDtos.SalesLibraryPageSnapshotResponse> listSnapshots(long pageId) {
+        return jdbcTemplate.query("""
+                SELECT s.id, s.url_ingest_id, s.snapshot_hash, s.status, s.http_status, s.content_type,
+                       COALESCE(raw.size_bytes, 0) AS raw_html_bytes,
+                       COALESCE(png.size_bytes, 0) AS screenshot_bytes,
+                       s.captured_at, s.updated_at
+                FROM mois_sales_library_page_snapshot s
+                LEFT JOIN mois_sales_library_snapshot_artifact raw
+                  ON raw.snapshot_id = s.id AND raw.artifact_type = 'RAW_HTML'
+                LEFT JOIN mois_sales_library_snapshot_artifact png
+                  ON png.snapshot_id = s.id AND png.artifact_type = 'SCREENSHOT_PNG'
+                WHERE s.url_ingest_id = ?
+                ORDER BY s.captured_at DESC, s.id DESC
+                LIMIT 20
+                """, (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryPageSnapshotResponse(
+                rs.getLong("id"),
+                rs.getLong("url_ingest_id"),
+                rs.getString("snapshot_hash"),
+                rs.getString("status"),
+                (Integer) rs.getObject("http_status"),
+                rs.getString("content_type"),
+                rs.getLong("raw_html_bytes"),
+                rs.getLong("screenshot_bytes"),
+                toInstant(rs.getTimestamp("captured_at")),
+                toInstant(rs.getTimestamp("updated_at"))
+        ), pageId);
+    }
+
+    private List<PageToCapture> findPagesToCapture(String workspaceId, int limit, boolean force) {
+        String forceClause = force ? "" : """
+                AND NOT EXISTS (
+                    SELECT 1 FROM mois_sales_library_page_snapshot s
+                    WHERE s.url_ingest_id = i.id AND s.status = 'CAPTURED'
+                )
+                """;
+        return jdbcTemplate.query("""
+                SELECT i.id, i.url_canonical
+                FROM mois_sales_library_url_ingest i
+                WHERE i.workspace_id = ?
+                """ + forceClause + """
+                ORDER BY i.updated_at DESC, i.id DESC
+                LIMIT ?
+                """, (rs, rowNum) -> new PageToCapture(rs.getLong("id"), rs.getString("url_canonical")), workspaceId, limit);
+    }
+
+    private MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem captureOneSafely(PageToCapture page) {
+        try {
+            return captureOne(page);
+        } catch (Exception ex) {
+            log.warn("Falha ao capturar snapshot bruto da sales page MOIS. pageId={}, url={}", page.pageId(), page.urlCanonical(), ex);
+            Long snapshotId = persistFailedSnapshot(page, ex.getMessage());
+            return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
+                    page.pageId(), snapshotId, page.urlCanonical(), "FAILED", null, null, 0L, 0L, ex.getMessage());
+        }
+    }
+
+    private MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem captureOne(PageToCapture page) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(page.urlCanonical()))
+                .timeout(Duration.ofSeconds(30))
+                .header("User-Agent", "MarketingHub-MOIS-SalesLibrarySnapshot/1.0")
+                .GET()
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        String rawHtml = response.body() == null ? "" : response.body();
+        String contentType = response.headers().firstValue("content-type").orElse("text/html");
+        log.info("MOIS sales-library snapshot payload bruto recebido. pageId={}, url={}, httpStatus={}, contentType={}, htmlPreview={}",
+                page.pageId(), page.urlCanonical(), response.statusCode(), contentType, truncate(rawHtml, 4000));
+
+        if (response.statusCode() < 200 || response.statusCode() >= 400 || rawHtml.isBlank()) {
+            Long snapshotId = persistFailedSnapshot(page, "HTTP " + response.statusCode() + " sem HTML capturável");
+            return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
+                    page.pageId(), snapshotId, page.urlCanonical(), "FAILED", null, response.statusCode(), 0L, 0L,
+                    "HTTP " + response.statusCode() + " sem HTML capturável");
+        }
+
+        String hash = sha256(rawHtml);
+        Long existingSnapshotId = findExistingSnapshot(page.pageId(), hash);
+        if (existingSnapshotId != null) {
+            return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
+                    page.pageId(), existingSnapshotId, page.urlCanonical(), "DUPLICATE", hash, response.statusCode(), rawHtml.getBytes(StandardCharsets.UTF_8).length, 0L, null);
+        }
+
+        long snapshotId = insertSnapshot(page, hash, response.statusCode(), contentType);
+        byte[] rawHtmlBytes = rawHtml.getBytes(StandardCharsets.UTF_8);
+        insertTextArtifact(snapshotId, ARTIFACT_RAW_HTML, "text/html; charset=UTF-8", rawHtml, rawHtmlBytes.length);
+        byte[] screenshot = renderBasicScreenshot(rawHtml, page.urlCanonical());
+        insertBinaryArtifact(snapshotId, ARTIFACT_SCREENSHOT_PNG, "image/png", screenshot);
+        return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
+                page.pageId(), snapshotId, page.urlCanonical(), "CAPTURED", hash, response.statusCode(), rawHtmlBytes.length, screenshot.length, null);
+    }
+
+    private Long persistFailedSnapshot(PageToCapture page, String errorMessage) {
+        try {
+            return insertFailedSnapshot(page, truncate(errorMessage, 1000));
+        } catch (Exception persistEx) {
+            log.warn("Falha ao persistir snapshot FAILED da sales page MOIS. pageId={}", page.pageId(), persistEx);
+            return null;
+        }
+    }
+
+    private long insertSnapshot(PageToCapture page, String hash, int httpStatus, String contentType) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement("""
+                    INSERT INTO mois_sales_library_page_snapshot
+                    (url_ingest_id, snapshot_hash, status, http_status, content_type, captured_at, created_at, updated_at)
+                    VALUES (?, ?, 'CAPTURED', ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                    """, Statement.RETURN_GENERATED_KEYS);
+            ps.setLong(1, page.pageId());
+            ps.setString(2, hash);
+            ps.setInt(3, httpStatus);
+            ps.setString(4, truncate(contentType, 255));
+            return ps;
+        }, keyHolder);
+        return generatedId(keyHolder);
+    }
+
+    private long insertFailedSnapshot(PageToCapture page, String errorMessage) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement("""
+                    INSERT INTO mois_sales_library_page_snapshot
+                    (url_ingest_id, status, error_message, captured_at, created_at, updated_at)
+                    VALUES (?, 'FAILED', ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                    """, Statement.RETURN_GENERATED_KEYS);
+            ps.setLong(1, page.pageId());
+            ps.setString(2, errorMessage);
+            return ps;
+        }, keyHolder);
+        return generatedId(keyHolder);
+    }
+
+    private Long findExistingSnapshot(long pageId, String hash) {
+        List<Long> rows = jdbcTemplate.query("""
+                SELECT id FROM mois_sales_library_page_snapshot
+                WHERE url_ingest_id = ? AND snapshot_hash = ?
+                LIMIT 1
+                """, (rs, rowNum) -> rs.getLong("id"), pageId, hash);
+        return rows.isEmpty() ? null : rows.get(0);
+    }
+
+    private long generatedId(KeyHolder keyHolder) {
+        if (keyHolder.getKeys() != null && keyHolder.getKeys().get("id") instanceof Number id) {
+            return id.longValue();
+        }
+        Number key = keyHolder.getKey();
+        return key == null ? 0L : key.longValue();
+    }
+
+    private void insertTextArtifact(long snapshotId, String artifactType, String contentType, String contentText, long sizeBytes) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_snapshot_artifact
+                (snapshot_id, artifact_type, content_type, storage_kind, content_text, size_bytes, created_at)
+                VALUES (?, ?, ?, 'DATABASE_TEXT', ?, ?, UTC_TIMESTAMP())
+                """, snapshotId, artifactType, contentType, contentText, sizeBytes);
+    }
+
+    private void insertBinaryArtifact(long snapshotId, String artifactType, String contentType, byte[] contentBlob) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_snapshot_artifact
+                (snapshot_id, artifact_type, content_type, storage_kind, content_blob, size_bytes, created_at)
+                VALUES (?, ?, ?, 'DATABASE_BLOB', ?, ?, UTC_TIMESTAMP())
+                """, snapshotId, artifactType, contentType, contentBlob, contentBlob.length);
+    }
+
+    private byte[] renderBasicScreenshot(String rawHtml, String url) throws Exception {
+        int width = 1280;
+        int height = 1800;
+        JEditorPane pane = new JEditorPane("text/html", rawHtml);
+        pane.setEditable(false);
+        pane.setSize(new Dimension(width, height));
+        Dimension preferred = pane.getPreferredSize();
+        int renderHeight = Math.max(900, Math.min(2400, preferred.height + 80));
+        pane.setSize(new Dimension(width, renderHeight));
+        BufferedImage image = new BufferedImage(width, renderHeight, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setColor(Color.WHITE);
+        graphics.fillRect(0, 0, width, renderHeight);
+        pane.paint(graphics);
+        graphics.setColor(new Color(245, 245, 245));
+        graphics.fillRect(0, 0, width, 32);
+        graphics.setColor(Color.DARK_GRAY);
+        graphics.drawString("Marketing Hub snapshot: " + url, 12, 21);
+        graphics.dispose();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", output);
+        return output.toByteArray();
+    }
+
+    private int normalizeLimit(Integer limit) {
+        if (limit == null) return DEFAULT_LIMIT;
+        return Math.max(1, Math.min(limit, MAX_LIMIT));
+    }
+
+    private String sha256(String value) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null) return null;
+        return value.length() <= maxLength ? value : value.substring(0, maxLength);
+    }
+
+    private Instant toInstant(Timestamp timestamp) {
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    private record PageToCapture(long pageId, String urlCanonical) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
@@ -2,7 +2,9 @@ package com.marketinghub.mois.biblioteca.web;
 
 import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
 import com.marketinghub.mois.biblioteca.service.MoisSalesLibraryService;
+import com.marketinghub.mois.biblioteca.service.MoisSalesLibrarySnapshotService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -23,6 +25,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class MoisSalesLibraryController {
 
     private final MoisSalesLibraryService service;
+    private final MoisSalesLibrarySnapshotService snapshotService;
 
     @GetMapping("/entries")
     public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(
@@ -89,6 +92,18 @@ public class MoisSalesLibraryController {
         }
     }
 
+    @PostMapping("/snapshots:capture")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureResponse captureSnapshots(
+            @Valid @RequestBody MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureRequest request
+    ) {
+        return snapshotService.captureSnapshots(request);
+    }
+
+    @GetMapping("/pages/{pageId}/snapshots")
+    public List<MoisSalesLibraryDtos.SalesLibraryPageSnapshotResponse> listPageSnapshots(@PathVariable long pageId) {
+        return snapshotService.listSnapshots(pageId);
+    }
 
     @PostMapping("/jobs:claim")
     public MoisSalesLibraryDtos.SalesLibraryClaimResponse claimJob(

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-18-mois-sales-library-page-snapshot.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-18-mois-sales-library-page-snapshot.yaml
@@ -1,0 +1,74 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-18-mois-sales-library-page-snapshot-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_library_url_ingest
+        - not:
+            tableExists:
+              tableName: mois_sales_library_page_snapshot
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_library_page_snapshot (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                url_ingest_id BIGINT NOT NULL,
+                snapshot_hash VARCHAR(128) NULL,
+                status VARCHAR(32) NOT NULL,
+                http_status INT NULL,
+                content_type VARCHAR(255) NULL,
+                error_message VARCHAR(1000) NULL,
+                captured_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_mois_sales_library_snapshot_hash (url_ingest_id, snapshot_hash),
+                KEY idx_mois_sales_library_snapshot_page_captured (url_ingest_id, captured_at),
+                KEY idx_mois_sales_library_snapshot_status (status, updated_at),
+                CONSTRAINT fk_mois_sales_library_snapshot_url_ingest
+                  FOREIGN KEY (url_ingest_id) REFERENCES mois_sales_library_url_ingest(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+  - changeSet:
+      id: 2026-05-18-mois-sales-library-page-snapshot-02
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_library_page_snapshot
+        - not:
+            tableExists:
+              tableName: mois_sales_library_snapshot_artifact
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_library_snapshot_artifact (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                snapshot_id BIGINT NOT NULL,
+                artifact_type VARCHAR(40) NOT NULL,
+                content_type VARCHAR(255) NOT NULL,
+                storage_kind VARCHAR(40) NOT NULL,
+                content_text LONGTEXT NULL,
+                content_blob LONGBLOB NULL,
+                size_bytes BIGINT NOT NULL DEFAULT 0,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_mois_sales_library_snapshot_artifact_type (snapshot_id, artifact_type),
+                KEY idx_mois_sales_library_artifact_snapshot (snapshot_id),
+                CONSTRAINT fk_mois_sales_library_artifact_snapshot
+                  FOREIGN KEY (snapshot_id) REFERENCES mois_sales_library_page_snapshot(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -772,6 +772,9 @@ databaseChangeLog:
   - include:
       file: changesets/2026-05-17-mois-sales-library-analysis.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-05-18-mois-sales-library-page-snapshot.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-05-17-experiment-create-simplification-columns.yaml

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibrarySnapshotServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibrarySnapshotServiceTest.java
@@ -1,0 +1,138 @@
+package com.marketinghub.mois.biblioteca.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+public class MoisSalesLibrarySnapshotServiceTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private HttpServer server;
+    private MoisSalesLibrarySnapshotService service;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource(
+                "jdbc:h2:mem:mois_snapshot;MODE=MySQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1",
+                "sa",
+                ""
+        );
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.execute("CREATE ALIAS IF NOT EXISTS UTC_TIMESTAMP FOR \"com.marketinghub.mois.biblioteca.service.MoisSalesLibrarySnapshotServiceTest.utcTimestamp\"");
+        createSchema();
+        service = new MoisSalesLibrarySnapshotService(jdbcTemplate);
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/sales", exchange -> {
+            byte[] body = """
+                    <html>
+                      <head><title>Oferta Teste</title></head>
+                      <body><h1>Oferta Teste</h1><p>Promessa clara com prova e CTA.</p></body>
+                    </html>
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "text/html; charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void shouldCaptureRawHtmlAndScreenshotArtifacts() {
+        String url = "http://localhost:" + server.getAddress().getPort() + "/sales";
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_url_ingest
+                (id, workspace_id, source, url_original, url_canonical, title, ingest_count, created_at, updated_at)
+                VALUES (1, 'workspace-001', 'TEST', ?, ?, 'Oferta Teste', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """, url, url);
+
+        var response = service.captureSnapshots(
+                new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureRequest("workspace-001", 5, false));
+
+        assertThat(response.processed()).isEqualTo(1);
+        assertThat(response.captured()).isEqualTo(1);
+        assertThat(response.failed()).isZero();
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.items().getFirst().status()).isEqualTo("CAPTURED");
+        assertThat(response.items().getFirst().rawHtmlBytes()).isPositive();
+        assertThat(response.items().getFirst().screenshotBytes()).isPositive();
+
+        Integer snapshotCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_page_snapshot", Integer.class);
+        Integer artifactCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_snapshot_artifact", Integer.class);
+        Integer htmlCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_snapshot_artifact WHERE artifact_type = 'RAW_HTML' AND content_text LIKE '%Oferta Teste%'", Integer.class);
+        Integer screenshotCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_snapshot_artifact WHERE artifact_type = 'SCREENSHOT_PNG' AND content_blob IS NOT NULL", Integer.class);
+
+        assertThat(snapshotCount).isEqualTo(1);
+        assertThat(artifactCount).isEqualTo(2);
+        assertThat(htmlCount).isEqualTo(1);
+        assertThat(screenshotCount).isEqualTo(1);
+        assertThat(service.listSnapshots(1)).hasSize(1);
+    }
+
+    public static Timestamp utcTimestamp() {
+        return Timestamp.from(Instant.now());
+    }
+
+    private void createSchema() {
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_sales_library_url_ingest (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  workspace_id VARCHAR(120) NOT NULL,
+                  source VARCHAR(40) NOT NULL,
+                  url_original VARCHAR(1024) NOT NULL,
+                  url_canonical VARCHAR(1024) NOT NULL,
+                  title VARCHAR(512),
+                  first_captured_at TIMESTAMP,
+                  last_captured_at TIMESTAMP,
+                  ingest_count INT NOT NULL DEFAULT 1,
+                  created_at TIMESTAMP NOT NULL,
+                  updated_at TIMESTAMP NOT NULL
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_sales_library_page_snapshot (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  url_ingest_id BIGINT NOT NULL,
+                  snapshot_hash VARCHAR(128),
+                  status VARCHAR(32) NOT NULL,
+                  http_status INT,
+                  content_type VARCHAR(255),
+                  error_message VARCHAR(1000),
+                  captured_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_sales_library_snapshot_artifact (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  snapshot_id BIGINT NOT NULL,
+                  artifact_type VARCHAR(40) NOT NULL,
+                  content_type VARCHAR(255) NOT NULL,
+                  storage_kind VARCHAR(40) NOT NULL,
+                  content_text LONGTEXT,
+                  content_blob LONGBLOB,
+                  size_bytes BIGINT NOT NULL DEFAULT 0,
+                  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryControllerTest.java
@@ -1,0 +1,103 @@
+package com.marketinghub.mois.biblioteca.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.biblioteca.service.MoisSalesLibraryService;
+import com.marketinghub.mois.biblioteca.service.MoisSalesLibrarySnapshotService;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MoisSalesLibraryController.class)
+class MoisSalesLibraryControllerTest {
+
+    @SpringBootApplication
+    static class TestConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MoisSalesLibraryService service;
+
+    @MockBean
+    private MoisSalesLibrarySnapshotService snapshotService;
+
+    @Test
+    void shouldExposeSnapshotCaptureEndpoint() throws Exception {
+        when(snapshotService.captureSnapshots(any(MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureRequest.class)))
+                .thenReturn(new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureResponse(
+                        "workspace-001",
+                        3,
+                        false,
+                        1,
+                        1,
+                        0,
+                        List.of(new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
+                                10L,
+                                20L,
+                                "https://example.test/sales",
+                                "CAPTURED",
+                                "abc123",
+                                200,
+                                512L,
+                                1024L,
+                                null
+                        )),
+                        Instant.parse("2026-05-18T22:00:00Z")
+                ));
+
+        mockMvc.perform(post("/api/mois/sales-library/snapshots:capture")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "workspaceId": "workspace-001",
+                                  "limit": 3,
+                                  "force": false
+                                }
+                                """))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.workspaceId").value("workspace-001"))
+                .andExpect(jsonPath("$.captured").value(1))
+                .andExpect(jsonPath("$.items[0].status").value("CAPTURED"))
+                .andExpect(jsonPath("$.items[0].rawHtmlBytes").value(512))
+                .andExpect(jsonPath("$.items[0].screenshotBytes").value(1024));
+    }
+
+    @Test
+    void shouldExposePageSnapshotsEndpoint() throws Exception {
+        when(snapshotService.listSnapshots(10L))
+                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageSnapshotResponse(
+                        20L,
+                        10L,
+                        "abc123",
+                        "CAPTURED",
+                        200,
+                        "text/html; charset=UTF-8",
+                        512L,
+                        1024L,
+                        Instant.parse("2026-05-18T22:00:00Z"),
+                        Instant.parse("2026-05-18T22:00:01Z")
+                )));
+
+        mockMvc.perform(get("/api/mois/sales-library/pages/10/snapshots"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].snapshotId").value(20))
+                .andExpect(jsonPath("$[0].status").value("CAPTURED"))
+                .andExpect(jsonPath("$[0].rawHtmlBytes").value(512))
+                .andExpect(jsonPath("$[0].screenshotBytes").value(1024));
+    }
+}

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -674,3 +674,23 @@ Para suportar o gerenciamento administrativo de ocupações no módulo OPRM (cad
   - `GET /api/mois/sales-library/pages/{pageId}`
   - `GET /api/mois/sales-library/pages/{pageId}/analysis`
   - `POST /api/mois/sales-library/pages/{pageId}:reanalyze`
+
+
+## MOIS — Biblioteca de páginas de vendas (snapshots brutos e artefatos, 2026-05-18)
+
+- Novas tabelas backend: `mois_sales_library_page_snapshot` e `mois_sales_library_snapshot_artifact`.
+- Objetivo: persistir a camada bruta prevista para a biblioteca de sales pages, separando metadados do snapshot dos artefatos capturados.
+- Relacionamentos:
+  - `mois_sales_library_page_snapshot.url_ingest_id -> mois_sales_library_url_ingest.id`.
+  - `mois_sales_library_snapshot_artifact.snapshot_id -> mois_sales_library_page_snapshot.id`.
+- Artefatos iniciais suportados:
+  - `RAW_HTML`: HTML bruto recebido da URL, salvo em `content_text` com `content_type = text/html; charset=UTF-8`.
+  - `SCREENSHOT_PNG`: renderização PNG básica do HTML capturado, salva em `content_blob` com `content_type = image/png`.
+- Colunas operacionais de snapshot: `snapshot_hash`, `status`, `http_status`, `content_type`, `error_message`, `captured_at`, `created_at`, `updated_at`.
+- Colunas operacionais de artefato: `artifact_type`, `content_type`, `storage_kind`, `content_text`, `content_blob`, `size_bytes`, `created_at`.
+- Índices/regras: unicidade por `(url_ingest_id, snapshot_hash)` para evitar duplicar o mesmo HTML bruto de uma página; unicidade por `(snapshot_id, artifact_type)` para manter um artefato de cada tipo por snapshot.
+- Endpoints backend adicionados:
+  - `POST /api/mois/sales-library/snapshots:capture` para acionar captura manual de URLs sem snapshot ou recaptura com `force=true`.
+  - `GET /api/mois/sales-library/pages/{pageId}/snapshots` para consultar os snapshots/artefatos de uma página.
+- Agendamento: `MoisSalesLibrarySnapshotScheduler` executa a cada 30 minutos para capturar uma pequena leva de páginas sem snapshot no workspace operacional inicial (`workspace-001`).
+- Regra operacional: o backend principal busca a URL, registra o HTML bruto recebido em log de ingestão com prévia truncada e persiste os artefatos antes da análise estruturada.

--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-biblioteca-sales-pages.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-biblioteca-sales-pages.md
@@ -206,6 +206,23 @@ Para manter o domínio da biblioteca isolado dentro do contexto MOIS no backend 
 - `com.marketinghub.mois.biblioteca.service`
 - `com.marketinghub.mois.biblioteca.web`
 
+
+### 8.6 Captura de snapshots brutos e artefatos (implementado)
+
+- `POST /api/mois/sales-library/snapshots:capture`
+  - entrada: `workspaceId`, `limit` e `force`;
+  - função: buscar páginas ingeridas sem snapshot bruto, capturar HTML e gerar artefato PNG de screenshot básico;
+  - uso: execução manual/operacional e suporte ao agendamento de captura incremental.
+
+- `GET /api/mois/sales-library/pages/{pageId}/snapshots`
+  - função: listar snapshots capturados para uma página, com status, hash, bytes de HTML e bytes de screenshot.
+
+- Agendamento backend: `MoisSalesLibrarySnapshotScheduler` executa `captureSnapshots` a cada 30 minutos para reduzir o backlog de páginas sem camada bruta.
+
+- Persistência física:
+  - `mois_sales_library_page_snapshot` guarda metadados do snapshot bruto;
+  - `mois_sales_library_snapshot_artifact` guarda os artefatos separados `RAW_HTML` e `SCREENSHOT_PNG`.
+
 ---
 
 ## 9. Regras de qualidade

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -4,6 +4,22 @@
 > Toda alteração em `mois-hotmart-collector` , `mois-sales-library-worker` e `mois-clickbank-collector` deve ser registrada neste arquivo.
 > Em caso de dúvida entre arquivos de registro, este é o ponto único de verdade.
 
+
+## 2026-05-18 19:27:36 UTC-3
+- criada a camada backend de snapshots brutos da Biblioteca de Páginas de Vendas do MOIS.
+- adicionado endpoint `POST /api/mois/sales-library/snapshots:capture` para capturar HTML bruto e screenshot PNG básico das URLs ingeridas.
+- adicionado endpoint `GET /api/mois/sales-library/pages/{pageId}/snapshots` para consultar snapshots por página.
+- criado agendamento `MoisSalesLibrarySnapshotScheduler` com cron fixo a cada 30 minutos para capturar URLs sem snapshot no workspace operacional inicial.
+- criadas tabelas `mois_sales_library_page_snapshot` e `mois_sales_library_snapshot_artifact` via Liquibase para separar metadados do snapshot e artefatos (`RAW_HTML`, `SCREENSHOT_PNG`).
+- atualizado `docs/modelo-dados-experimento.md` e a especificação da biblioteca de sales pages para registrar o novo contrato e o modelo de dados.
+- teste unitário criado para validar persistência de HTML bruto e screenshot PNG em artefatos separados.
+- arquivos principais alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibrarySnapshotService.java
+  - backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibrarySnapshotScheduler.java
+  - backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
+  - backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-18-mois-sales-library-page-snapshot.yaml
+  - backend/ads-service/src/test/java/com/marketinghub/mois/biblioteca/service/MoisSalesLibrarySnapshotServiceTest.java
+
 ## Template obrigatório de novo registro
 
 ```md


### PR DESCRIPTION
### Motivation
- Provide a raw snapshot layer for the MOIS sales-library to persist fetched HTML and a basic PNG screenshot before structured analysis.
- Avoid duplicate snapshots by storing a `snapshot_hash` and enable operational capture (manual and scheduled) to reduce backlog.
- Expose endpoints to trigger captures and list page snapshots for observability and operator workflows.

### Description
- Added DTOs for snapshot requests/responses: `SalesLibrarySnapshotCaptureRequest`, `SalesLibrarySnapshotCaptureItem`, `SalesLibrarySnapshotCaptureResponse`, and `SalesLibraryPageSnapshotResponse` in `MoisSalesLibraryDtos`.
- Implemented `MoisSalesLibrarySnapshotService` to fetch pages via `HttpClient`, compute `sha256` hash, persist `mois_sales_library_page_snapshot` metadata and `mois_sales_library_snapshot_artifact` artifacts (`RAW_HTML` and `SCREENSHOT_PNG`), and render a simple screenshot using `JEditorPane`.
- Added `MoisSalesLibrarySnapshotScheduler` with `@Scheduled(cron = "0 */30 * * * *")` to capture a small batch periodically and updated `MoisSalesLibraryController` with `POST /api/mois/sales-library/snapshots:capture` and `GET /api/mois/sales-library/pages/{pageId}/snapshots` endpoints.
- Created Liquibase changelog `2026-05-18-mois-sales-library-page-snapshot.yaml` to add `mois_sales_library_page_snapshot` and `mois_sales_library_snapshot_artifact` tables and wired it into `db.changelog-master.yaml`, and updated documentation files to describe the feature and data model.

### Testing
- Added `MoisSalesLibrarySnapshotServiceTest` which runs an in-memory H2 schema, starts a local HTTP server, executes `captureSnapshots`, and asserts snapshot and artifact rows were created; the test passed.
- Added `MoisSalesLibraryControllerTest` as a WebMvc test that verifies the new capture and list endpoints return the expected JSON shape; the test passed.
- No other automated test failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b8e3327b48321936180636d58bb40)