### PR TITLE
Instrument GeraLanding publish flow with detailed logs and surface post-publish errors

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -71,41 +71,73 @@ public class GeraLandingStageExecutionService {
 
     @Transactional
     public GeraLandingPublishResponse approveAndPublishLanding(Long experimentId) {
+        log.info("GeraLanding publish approval started (experimentId={})", experimentId);
         Experiment experiment = experimentRepository.findById(experimentId)
                 .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
-        if (!StringUtils.hasText(experiment.getLandingPageHtml())) {
+        log.info("GeraLanding publish approval loaded experiment (experimentId={}, experimentName={})",
+                experimentId, experiment.getName());
+
+        String landingPageHtml = experiment.getLandingPageHtml();
+        if (!StringUtils.hasText(landingPageHtml)) {
+            log.warn("GeraLanding publish approval blocked because landing HTML is missing (experimentId={})",
+                    experimentId);
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Landing HTML ainda não foi gerado para este experimento");
         }
+        log.info("GeraLanding publish approval found landing HTML (experimentId={}, htmlLength={})",
+                experimentId, landingPageHtml.length());
+
         String slug = "exp-" + experimentId + "-landing-geralanding";
-        String htmlWithFunnelControls = injectFunnelControls(experiment.getLandingPageHtml());
-        String htmlWithFacebookPixel = injectFacebookPixel(htmlWithFunnelControls, resolveFacebookPixelId(experiment));
+        log.info("GeraLanding publish approval resolved slug (experimentId={}, slug={})", experimentId, slug);
+
+        String htmlWithFunnelControls = injectFunnelControls(landingPageHtml);
+        log.info("GeraLanding publish approval injected funnel controls (experimentId={}, htmlLengthBefore={}, htmlLengthAfter={})",
+                experimentId, landingPageHtml.length(), htmlWithFunnelControls.length());
+
+        String facebookPixelId = resolveFacebookPixelId(experiment);
+        log.info("GeraLanding publish approval resolved Facebook Pixel (experimentId={}, hasPixelId={})",
+                experimentId, StringUtils.hasText(facebookPixelId));
+        String htmlWithFacebookPixel = injectFacebookPixel(htmlWithFunnelControls, facebookPixelId);
+        log.info("GeraLanding publish approval injected Facebook Pixel (experimentId={}, htmlLengthBefore={}, htmlLengthAfter={})",
+                experimentId, htmlWithFunnelControls.length(), htmlWithFacebookPixel.length());
+
+        log.info("GeraLanding publish approval sending flow to Lead Portal (experimentId={}, slug={}, htmlLength={})",
+                experimentId, slug, htmlWithFacebookPixel.trim().length());
         publishToLeadPortal(slug, "Landing GeraLanding - Experimento " + experimentId, htmlWithFacebookPixel.trim());
-        try {
-            String iframeUrl = resolveIframeUrl(slug);
-            String standaloneUrl = resolveStandaloneLandingUrl(iframeUrl);
-            experiment.setFollowUpActionUrl(standaloneUrl);
-            experimentRepository.save(experiment);
-            return new GeraLandingPublishResponse(experimentId, null, iframeUrl, standaloneUrl,
-                    "Landing publicada com sucesso pelo GeraLanding.");
-        } catch (RuntimeException ex) {
-            String rootCauseMessage = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
-            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
-                    "Falha ao publicar landing do GeraLanding: " + rootCauseMessage, ex);
-        }
+        log.info("GeraLanding publish approval sent flow to Lead Portal successfully (experimentId={}, slug={})",
+                experimentId, slug);
+        log.info("GeraLanding publish approval resolving publication URLs (experimentId={}, slug={})", experimentId, slug);
+        String iframeUrl = resolveIframeUrl(slug);
+        String standaloneUrl = resolveStandaloneLandingUrl(iframeUrl);
+        log.info("GeraLanding publish approval resolved publication URLs (experimentId={}, iframeUrl={}, standaloneUrl={})",
+                experimentId, iframeUrl, standaloneUrl);
+
+        experiment.setFollowUpActionUrl(standaloneUrl);
+        experimentRepository.save(experiment);
+        log.info("GeraLanding publish approval saved follow-up URL (experimentId={}, followUpActionUrl={})",
+                experimentId, standaloneUrl);
+        return new GeraLandingPublishResponse(experimentId, null, iframeUrl, standaloneUrl,
+                "Landing publicada com sucesso pelo GeraLanding.");
     }
 
     private void publishToLeadPortal(String slug, String name, String html) {
         if (!StringUtils.hasText(leadPortalBaseUrl)) {
+            log.warn("GeraLanding Lead Portal publication blocked because base URL is not configured (slug={})", slug);
             throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Lead Portal base URL não configurada");
         }
         URI uri = UriComponentsBuilder.fromHttpUrl(leadPortalBaseUrl).path("/api/flows/{slug}").buildAndExpand(slug).toUri();
+        log.info("GeraLanding Lead Portal publication request prepared (slug={}, uri={}, name={}, htmlLength={})",
+                slug, uri, name, html == null ? 0 : html.length());
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         GeraLandingLeadPortalPublishRequest payload = new GeraLandingLeadPortalPublishRequest(
                 slug, name, "Fluxo publicado pelo módulo GeraLanding", html, html, "custom_html");
         try {
             restTemplate.put(uri, new HttpEntity<>(payload, headers));
+            log.info("GeraLanding Lead Portal publication request completed (slug={}, uri={})", slug, uri);
         } catch (RestClientException ex) {
+            String rootCauseMessage = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
+            log.error("GeraLanding Lead Portal publication request failed (slug={}, uri={}, rootCause={})",
+                    slug, uri, rootCauseMessage, ex);
             throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Falha ao enviar fluxo para o Lead Portal", ex);
         }
     }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -379,3 +379,23 @@
   - docs/registros/experimentos.md
   - frontend/src/api/experiment/useApproveAndPublishLanding.ts
   - frontend/src/pages/experiment/LandingTab.tsx
+
+## 2026-05-18 22:30:00 UTC
+- solicitação: instrumentar o trecho de aprovação/publicação da landing do GeraLanding para diagnosticar cada etapa do experimento 21.
+- raciocínio aplicado: adicionar logs explícitos antes/depois das etapas críticas, preservando a causa-raiz da falha de publicação no Lead Portal sem alterar contrato de API nem modelo de dados.
+- foi feito:
+  - adicionados logs de início da aprovação, carregamento do experimento, presença/tamanho do HTML, slug resolvido, injeção de controles de funil, resolução/injeção de Facebook Pixel, envio ao Lead Portal, URLs publicadas e gravação de `followUpActionUrl`.
+  - adicionados logs no `publishToLeadPortal` para registrar URL de destino, tamanho do HTML e root cause de falha da chamada HTTP ao Lead Portal.
+- arquivos alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+  - docs/registros/experimentos.md
+
+## 2026-05-18 22:45:00 UTC
+- solicitação: remover o `try/catch` após a publicação no Lead Portal no fluxo de aprovação da landing do GeraLanding para deixar o erro aparecer diretamente nos logs.
+- raciocínio aplicado: preservar os logs de passagem por etapa, mas eliminar a captura genérica que mascarava exceções posteriores à publicação com `ResponseStatusException`.
+- foi feito:
+  - removido o bloco `try/catch (RuntimeException ex)` em `approveAndPublishLanding` depois de `publishToLeadPortal`.
+  - mantidos os logs de resolução de URLs, gravação de `followUpActionUrl` e retorno de sucesso no fluxo linear.
+- arquivos alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Add observability to the GeraLanding approval/publish flow to diagnose failures and understand intermediate state for published experiments.
- Make failures after sending payload to Lead Portal observable in logs by avoiding a generic swallow of runtime exceptions.
- Record metadata such as HTML presence and size, resolved slug, Facebook Pixel resolution, and remote request details to help triage publishing problems.

### Description
- Added detailed `log` statements throughout `GeraLandingStageExecutionService.approveAndPublishLanding` to record start, experiment load, landing HTML presence/length, slug resolution, funnel control injection, Facebook Pixel resolution, HTML lengths before/after injections, and resolved publication URLs.
- Instrumented `publishToLeadPortal` with logs for prepared request details, successful completion, and enhanced error logging that includes the root cause message and stack trace when the HTTP call fails.
- Replaced the previous `try/catch` that wrapped post-publish URL resolution with a linear flow so exceptions after `publishToLeadPortal` are not masked and will appear in logs; also added a warning when `leadPortalBaseUrl` is not configured and when landing HTML is missing.
- Updated `docs/registros/experimentos.md` to record the changes made (instrumentation and removal of the post-publish `try/catch`).

### Testing
- No automated tests were added or modified for this change.
- No automated test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b8e5302588321ab2b5dbf413f1fc2)