### PR TITLE
Add diagnostic log before Lead Portal publish request in GeraLandingStageExecutionService

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -131,6 +131,8 @@ public class GeraLandingStageExecutionService {
         headers.setContentType(MediaType.APPLICATION_JSON);
         GeraLandingLeadPortalPublishRequest payload = new GeraLandingLeadPortalPublishRequest(
                 slug, name, "Fluxo publicado pelo módulo GeraLanding", html, html, "custom_html");
+        log.info("GeraLanding Lead Portal publication request parameters (slug={}, uri={}, headers={}, payload={})",
+                slug, uri, headers, payload);
         try {
             restTemplate.put(uri, new HttpEntity<>(payload, headers));
             log.info("GeraLanding Lead Portal publication request completed (slug={}, uri={})", slug, uri);


### PR DESCRIPTION
### Motivation
- Improve observability for Lead Portal publication calls to aid debugging when requests fail.

### Description
- Inserted a `log.info` in `publishToLeadPortal` that logs `slug`, `uri`, `headers`, and `payload` immediately before calling `restTemplate.put`.

### Testing
- Executed the project's automated tests with `./gradlew test` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ba83e8fd483219799840c8be89f2f)