### PR TITLE
GeraLanding: exceção de violação de contrato (HTTP 460), simplificação de payload e playbook de diagnóstico

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Toda decisão de arquitetura, dados, prompts, automações, integrações e arte
     2. o que foi enviado (`receivedPayload`),
     3. endpoint/operação,
     4. erro retornado a montante (`upstreamError`).
-  - É proibido responder esse cenário com erro HTTP padrão genérico (400/500/502) sem o envelope de contrato acima.
+  - É proibido responder **esse cenário específico (GeraLanding -> Lead Portal)** com erro HTTP padrão genérico (400/500/502) sem o envelope de contrato acima.
 
 - 🚨 **ORIENTAÇÃO CRÍTICA — PLAYBOOK RÁPIDO PARA ERRO DE CONTRATO (400/422) [OBRIGATÓRIO]**:
   - **Objetivo**: identificar causa-raiz em até 15 minutos e evitar horas de tentativa e erro.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,29 @@ Toda decisão de arquitetura, dados, prompts, automações, integrações e arte
 
 - **Erro 400 (Bad Request) em APIs**: em validações de contrato/payload, o backend pode responder `400 Bad Request` sem registrar detalhes úteis no log de aplicação. Nesses casos, **não basta procurar logs**; é obrigatório inspecionar a requisição enviada (URL, método, headers, body) e comparar com DTO/contrato esperado para identificar campo, estrutura ou tipo inválido.
 
+- 🚨 **PADRÃO OFICIAL — EXCEPTION DE CONTRATO GERALANDING (OBRIGATÓRIO)**:
+  - Para falhas de contrato na publicação do GeraLanding para Lead Portal, usar a exception específica `GeraLandingContractViolationException`.
+  - O status HTTP de resposta desse cenário deve ser **460** (código interno do domínio para violação de contrato), via handler dedicado `GeraLandingContractViolationExceptionHandler`.
+  - O `toString()` da exception deve sempre explicitar de forma literal:
+    1. o que era esperado pelo contrato (`expectedContract`),
+    2. o que foi enviado (`receivedPayload`),
+    3. endpoint/operação,
+    4. erro retornado a montante (`upstreamError`).
+  - É proibido responder esse cenário com erro HTTP padrão genérico (400/500/502) sem o envelope de contrato acima.
+
+- 🚨 **ORIENTAÇÃO CRÍTICA — PLAYBOOK RÁPIDO PARA ERRO DE CONTRATO (400/422) [OBRIGATÓRIO]**:
+  - **Objetivo**: identificar causa-raiz em até 15 minutos e evitar horas de tentativa e erro.
+  - **Passo 1 (2 min)**: capturar e salvar a requisição literal que saiu do sistema (URL, método, headers e body completo).
+  - **Passo 2 (3 min)**: comparar o body enviado com o DTO/contrato atual do endpoint campo a campo (nome, tipo, obrigatoriedade, formato).
+  - **Passo 3 (3 min)**: validar se há campo legado/misto sendo enviado (ex.: campo antigo + campo novo no mesmo payload).
+  - **Passo 4 (3 min)**: montar `curl` mínimo reproduzindo o erro com o mesmo payload para confirmar o diagnóstico sem ruído de fluxo completo.
+  - **Passo 5 (4 min)**: corrigir o payload na origem (builder/mapper/DTO), adicionar teste de regressão do contrato e registrar no documento de registros do tema.
+  - **Regra de bloqueio**: é proibido encerrar a análise sem informar literalmente:
+    1. o payload enviado,
+    2. o payload esperado pelo contrato,
+    3. a diferença exata,
+    4. a correção objetiva aplicada.
+
 - **Erro 422 (Procedimento Obrigatório / SOP)**: Trate toda ocorrência de `422 Unprocessable Entity` como divergência entre payload gerado pelo modelo e contrato/validação do backend até prova em contrário.
   - **Fluxo obrigatório (sempre nesta ordem):**
     1. Acessar logs do backend via MCP Server (`https://mcpserverdigi.shop/mcp`, JSON-RPC).

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContractViolationException.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContractViolationException.java
@@ -1,0 +1,62 @@
+package com.marketinghub.geralanding;
+
+public class GeraLandingContractViolationException extends RuntimeException {
+    public static final int HTTP_STATUS_CODE = 460;
+
+    private final String operation;
+    private final String endpoint;
+    private final String expectedContract;
+    private final String receivedPayload;
+    private final String upstreamError;
+
+    public GeraLandingContractViolationException(
+            String operation,
+            String endpoint,
+            String expectedContract,
+            String receivedPayload,
+            String upstreamError,
+            Throwable cause) {
+        super("Falha de contrato no GeraLanding", cause);
+        this.operation = operation;
+        this.endpoint = endpoint;
+        this.expectedContract = expectedContract;
+        this.receivedPayload = receivedPayload;
+        this.upstreamError = upstreamError;
+    }
+
+    public int getHttpStatusCode() {
+        return HTTP_STATUS_CODE;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getExpectedContract() {
+        return expectedContract;
+    }
+
+    public String getReceivedPayload() {
+        return receivedPayload;
+    }
+
+    public String getUpstreamError() {
+        return upstreamError;
+    }
+
+    @Override
+    public String toString() {
+        return "GeraLandingContractViolationException{" +
+                "httpStatusCode=" + HTTP_STATUS_CODE +
+                ", operation='" + operation + '\'' +
+                ", endpoint='" + endpoint + '\'' +
+                ", expectedContract='" + expectedContract + '\'' +
+                ", receivedPayload='" + receivedPayload + '\'' +
+                ", upstreamError='" + upstreamError + '\'' +
+                '}';
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContractViolationExceptionHandler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingContractViolationExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.marketinghub.geralanding;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GeraLandingContractViolationExceptionHandler {
+
+    @ExceptionHandler(GeraLandingContractViolationException.class)
+    public ResponseEntity<Map<String, Object>> handle(GeraLandingContractViolationException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", "GERALANDING_CONTRACT_VIOLATION");
+        body.put("message", ex.toString());
+        body.put("operation", ex.getOperation());
+        body.put("endpoint", ex.getEndpoint());
+        body.put("expectedContract", ex.getExpectedContract());
+        body.put("receivedPayload", ex.getReceivedPayload());
+        body.put("upstreamError", ex.getUpstreamError());
+        body.put("timestamp", Instant.now().toString());
+        return ResponseEntity.status(HttpStatusCode.valueOf(ex.getHttpStatusCode())).body(body);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingLeadPortalPublishRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingLeadPortalPublishRequest.java
@@ -4,7 +4,5 @@ public record GeraLandingLeadPortalPublishRequest(
         String slug,
         String name,
         String description,
-        String customFormHtml,
-        String legacyPreviewHtml,
-        String renderMode) {
+        String customFormHtml) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -130,7 +130,7 @@ public class GeraLandingStageExecutionService {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         GeraLandingLeadPortalPublishRequest payload = new GeraLandingLeadPortalPublishRequest(
-                slug, name, "Fluxo publicado pelo módulo GeraLanding", html, html, "custom_html");
+                slug, name, "Fluxo publicado pelo módulo GeraLanding", html);
         log.info("GeraLanding Lead Portal publication request parameters (slug={}, uri={}, headers={}, payload={})",
                 slug, uri, headers, payload);
         try {
@@ -140,7 +140,13 @@ public class GeraLandingStageExecutionService {
             String rootCauseMessage = NestedExceptionUtils.getMostSpecificCause(ex).getMessage();
             log.error("GeraLanding Lead Portal publication request failed (slug={}, uri={}, rootCause={})",
                     slug, uri, rootCauseMessage, ex);
-            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Falha ao enviar fluxo para o Lead Portal", ex);
+            throw new GeraLandingContractViolationException(
+                    "publishToLeadPortal",
+                    uri.toString(),
+                    "Esperado: payload JSON contendo apenas slug, name, description e customFormHtml (HTML puro).",
+                    payload.toString(),
+                    rootCauseMessage,
+                    ex);
         }
     }
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -438,3 +438,11 @@
 - documentos lidos para tratar a situação:
   - AGENTS.md
   - docs/registros/experimentos.md
+
+## 2026-05-19 00:49:03 UTC-3
+- solicitação para revisar consistência do AGENTS.md após múltiplas adições sobre erro de contrato.
+- raciocínio aplicado: manter as regras sem conflito entre orientação geral de 400/422 e regra específica de exceção 460 no fluxo GeraLanding -> Lead Portal.
+- foi feito: ajuste textual para deixar explícito que a proibição de usar erro HTTP padrão genérico vale para o cenário específico GeraLanding -> Lead Portal.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/registros/experimentos.md

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -399,3 +399,42 @@
 - arquivos alterados:
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
   - docs/registros/experimentos.md
+
+## 2026-05-19 00:10:16 UTC-3
+- ajuste solicitado para corrigir falha 400 na publicação de landing do GeraLanding no Lead Portal.
+- causa-raiz aplicada: payload enviado como formato misto/legado (`legacyPreviewHtml` + `renderMode`) enquanto o endpoint passou a aceitar apenas `customFormHtml` em HTML puro.
+- foi feito: simplificação do contrato `GeraLandingLeadPortalPublishRequest` para enviar apenas `slug`, `name`, `description` e `customFormHtml`, e atualização da montagem do payload no serviço de publicação.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingLeadPortalPublishRequest.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+
+## 2026-05-19 00:37:35 UTC-3
+- solicitação para incluir orientação em destaque no AGENTS.md para prevenir e acelerar diagnóstico de erros de contrato 400/422.
+- raciocínio aplicado: transformar lição operacional em SOP curto, objetivo e obrigatório, com foco em causa-raiz e comparação literal de payload.
+- foi feito: adicionado no AGENTS.md um playbook crítico (5 passos, timebox de 15 minutos, regra de bloqueio e formato mínimo de diagnóstico).
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/registros/experimentos.md
+
+## 2026-05-19 00:41:42 UTC-3
+- solicitação para criar exceção específica e código HTTP próprio para erro de contrato na publicação da landing.
+- raciocínio aplicado: padronizar diagnóstico com erro explícito de contrato, deixando claro o esperado x recebido e evitando uso de erro HTTP padrão nessa falha.
+- foi feito:
+  - criada `GeraLandingContractViolationException` com código HTTP próprio `460` e `toString()` detalhando operação, endpoint, esperado, recebido e erro upstream.
+  - criada `GeraLandingContractViolationExceptionHandler` (`@RestControllerAdvice`) para responder com status 460 e corpo estruturado do erro.
+  - fluxo `publishToLeadPortal` atualizado para lançar a exceção específica quando ocorrer falha de contrato/integracao no envio.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/registros/experimentos.md
+
+## 2026-05-19 00:45:43 UTC-3
+- solicitação para explicitar no AGENTS.md a definição da exception de contrato e do código HTTP 460.
+- raciocínio aplicado: consolidar regra operacional no contrato do time para evitar regressão e ambiguidade no tratamento de erro de integração do GeraLanding.
+- foi feito: adição de seção em destaque no AGENTS.md formalizando uso obrigatório de `GeraLandingContractViolationException`, handler dedicado e status HTTP 460, incluindo conteúdo mínimo obrigatório no `toString()`.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Padronizar tratamento de falhas de contrato na publicação do GeraLanding para Lead Portal com um erro explícito que exponha o esperado x recebido e preserve a causa-raiz.
- Eliminar payloads mistos/legados que vinham causando `400/422` ao Lead Portal, simplificando o contrato enviado.
- Registrar e documentar um playbook operacional curto e obrigatório para acelerar diagnóstico de erros de contrato `400/422`.

### Description
- Adicionada exceção `GeraLandingContractViolationException` com código HTTP próprio `460` e campos para `operation`, `endpoint`, `expectedContract`, `receivedPayload` e `upstreamError` e `toString()` detalhado.
- Adicionado handler `GeraLandingContractViolationExceptionHandler` (`@RestControllerAdvice`) que responde com status `460` e corpo JSON estruturado contendo os campos da exceção e `timestamp`.
- Simplificado o contrato de publicação `GeraLandingLeadPortalPublishRequest` removendo campos legacy (`legacyPreviewHtml`, `renderMode`) para enviar apenas `slug`, `name`, `description` e `customFormHtml` (HTML puro).
- Atualizado `GeraLandingStageExecutionService.publishToLeadPortal` para construir novo payload simplificado e lançar `GeraLandingContractViolationException` em falhas de comunicação/integridade ao invés de `ResponseStatusException`.
- Atualizado `AGENTS.md` com seção em destaque definindo o padrão obrigatório de exceção de contrato e inserido um playbook rápido (5 passos, timebox 15 minutos, regra de bloqueio e formato mínimo de diagnóstico).
- Atualizado `docs/registros/experimentos.md` com entradas de registro descrevendo as alterações e a justificativa técnica.

### Testing
- Nenhum teste automatizado novo foi adicionado neste PR; as alterações são compatíveis com o contrato reduzido e com o novo fluxo de erro.
- A suíte de testes do projeto foi executada localmente via `mvn test` e a execução dos testes existentes completou sem falhas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd3d7ac9c8321b9dd85dd8a274560)