### PR TITLE
Add logging and safe log formatting to CustomFormHtmlResolver

### DIFF
--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/CustomFormHtmlResolver.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/CustomFormHtmlResolver.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -13,6 +15,7 @@ import org.springframework.util.StringUtils;
  */
 @Component
 public class CustomFormHtmlResolver {
+    private static final Logger log = LoggerFactory.getLogger(CustomFormHtmlResolver.class);
 
     private static final Pattern HTML_HINT = Pattern.compile("(?is)^\\s*(?:<!doctype|<html|<body|<main|<section|<div|<header|<footer)");
     private static final Pattern WRAPPED_JSON_IN_BODY = Pattern.compile("(?is)<body[^>]*>\\s*(\\{[\\s\\S]*?})\\s*</body>");
@@ -25,14 +28,32 @@ public class CustomFormHtmlResolver {
      */
     public String normalize(String rawValue) {
         if (!StringUtils.hasText(rawValue)) {
+            log.info("customFormHtml recebido vazio. rawValue={}", formatForLog(rawValue));
             return null;
         }
         String trimmed = rawValue.trim();
+        log.info(
+                "Validando customFormHtml. rawValueOriginal={} rawValueTrimmed={}",
+                formatForLog(rawValue),
+                formatForLog(trimmed));
         if (looksLikeHtml(trimmed)) {
             return rescueLegacyWrappedPayload(trimmed).orElse(trimmed);
         }
+        log.info("customFormHtml rejeitado por não parecer HTML. rawValue={}", formatForLog(rawValue));
         throw new IllegalArgumentException(
                 "customFormHtml deve ser HTML puro. Payload JSON/misto não é mais aceito.");
+    }
+
+    private String formatForLog(String value) {
+        if (value == null) {
+            return "<null>";
+        }
+        String escaped = value
+                .replace("\\", "\\\\")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+        return "[len=" + value.length() + "] <<<" + escaped + ">>>";
     }
 
     private boolean looksLikeHtml(String value) {


### PR DESCRIPTION
### Motivation
- Improve observability when normalizing and validating custom HTML payloads so invalid or legacy-wrapped inputs can be diagnosed. 
- Avoid leaking unescaped control characters in logs by providing a safe formatting helper for payload preview.

### Description
- Introduces an SLF4J `Logger` to `CustomFormHtmlResolver` and adds informational logs at key points: empty input, start of validation, and rejection when input does not look like HTML. 
- Adds a `formatForLog` helper that escapes control characters and includes the payload length to produce safe, concise log previews. 
- Keeps the existing normalization and legacy-wrapped-payload rescue logic intact while augmenting it with the new logging.

### Testing
- Ran the project's automated unit tests with `mvn test`, and the test suite completed successfully. 
- Executed a full build with `mvn package`, which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be4c624ac8321b04dadc76bb5a401)