### PR TITLE
Standardize sales-library package namespace to com.marketinghub.mois.bibliotecapaginavenda.worker.v1

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -1,4 +1,4 @@
-package com.marketinghub.mois.biblioteca.dto;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -1,6 +1,6 @@
-package com.marketinghub.mois.biblioteca.service;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
-import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.sql.Timestamp;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotScheduler.java
@@ -1,6 +1,6 @@
-package com.marketinghub.mois.biblioteca.service;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
-import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
@@ -1,6 +1,6 @@
-package com.marketinghub.mois.biblioteca.service;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
-import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -1,8 +1,8 @@
-package com.marketinghub.mois.biblioteca.web;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.web;
 
-import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
-import com.marketinghub.mois.biblioteca.service.MoisSalesLibraryService;
-import com.marketinghub.mois.biblioteca.service.MoisSalesLibrarySnapshotService;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryService;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibrarySnapshotService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
@@ -1,8 +1,8 @@
-package com.marketinghub.mois.biblioteca.service;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -29,7 +29,7 @@ public class MoisSalesLibrarySnapshotServiceTest {
                 ""
         );
         jdbcTemplate = new JdbcTemplate(dataSource);
-        jdbcTemplate.execute("CREATE ALIAS IF NOT EXISTS UTC_TIMESTAMP FOR \"com.marketinghub.mois.biblioteca.service.MoisSalesLibrarySnapshotServiceTest.utcTimestamp\"");
+        jdbcTemplate.execute("CREATE ALIAS IF NOT EXISTS UTC_TIMESTAMP FOR \"com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibrarySnapshotServiceTest.utcTimestamp\"");
         createSchema();
         service = new MoisSalesLibrarySnapshotService(jdbcTemplate);
         server = HttpServer.create(new InetSocketAddress(0), 0);

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -1,4 +1,4 @@
-package com.marketinghub.mois.biblioteca.web;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.web;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -7,9 +7,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.marketinghub.mois.biblioteca.dto.MoisSalesLibraryDtos;
-import com.marketinghub.mois.biblioteca.service.MoisSalesLibraryService;
-import com.marketinghub.mois.biblioteca.service.MoisSalesLibrarySnapshotService;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryService;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibrarySnapshotService;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -160,3 +160,16 @@
   - backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
   - mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/service/PipelineRunner.java
   - mois-sales-library-worker/src/main/resources/application.yml
+
+## 2026-05-19 00:00:00 UTC
+- implementado/alinhado o worker da biblioteca de páginas de vendas conforme especificação, mantendo ciclo de polling, claim de 1 job por ciclo, processamento da URL, complete/fail e logs operacionais.
+- padronizado o namespace do módulo para `com.marketinghub.mois.bibliotecapaginavenda.worker.v1` no worker e no backend do módulo de biblioteca de páginas de vendas.
+- documentos/códigos consultados:
+  - docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-worker-biblioteca-sales-pages.md
+  - mois-sales-library-worker/src/main/java/com/marketinghub/mois/libraryworker/service/PipelineRunner.java
+  - backend/ads-service/src/main/java/com/marketinghub/mois/biblioteca/web/MoisSalesLibraryController.java
+
+## 2026-05-19 00:00:00 UTC
+- ajustado o worker da biblioteca de páginas de vendas para que **todo o código** fique fisicamente e logicamente no pacote `com.marketinghub.mois.bibliotecapaginavenda.worker.v1`.
+- movidos os arquivos Java do caminho legado `.../mois/libraryworker/...` para `.../mois/bibliotecapaginavenda/worker/v1/...`, mantendo os imports internos exclusivamente dentro do namespace do módulo.
+- validação realizada para garantir ausência de referências ao pacote legado no worker.

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/MoisSalesLibraryWorkerApplication.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/MoisSalesLibraryWorkerApplication.java
@@ -1,4 +1,4 @@
-package com.marketinghub.mois.libraryworker;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/client/BackendClient.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/client/BackendClient.java
@@ -1,6 +1,6 @@
-package com.marketinghub.mois.libraryworker.client;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.client;
 
-import com.marketinghub.mois.libraryworker.model.WorkerDtos.*;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/config/WorkerConfig.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/config/WorkerConfig.java
@@ -1,4 +1,4 @@
-package com.marketinghub.mois.libraryworker.config;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/config/WorkerProperties.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/config/WorkerProperties.java
@@ -1,4 +1,4 @@
-package com.marketinghub.mois.libraryworker.config;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
@@ -1,4 +1,4 @@
-package com.marketinghub.mois.libraryworker.model;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model;
 
 import java.math.BigDecimal;
 import java.time.Instant;

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
@@ -1,9 +1,9 @@
-package com.marketinghub.mois.libraryworker.service;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.mois.libraryworker.client.BackendClient;
-import com.marketinghub.mois.libraryworker.config.WorkerProperties;
-import com.marketinghub.mois.libraryworker.model.WorkerDtos.*;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.client.BackendClient;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.config.WorkerProperties;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.*;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.HashMap;


### PR DESCRIPTION
### Motivation
- Align the sales-pages library worker and backend code under a single logical and physical package namespace per the new worker specification. 
- Remove legacy mixed package usage (`com.marketinghub.mois.biblioteca` / `com.marketinghub.mois.libraryworker`) to avoid cross-package references and improve module isolation.

### Description
- Renamed packages across the backend `ads-service` and the `mois-sales-library-worker` module from the legacy namespaces to `com.marketinghub.mois.bibliotecapaginavenda.worker.v1` and updated all corresponding `package` declarations. 
- Updated imports and references in DTOs, services, controllers, schedulers, client, config, model, and the application main class to use the new namespace. 
- Adjusted tests to reference the new package (including the H2 `CREATE ALIAS` string) and updated documentation `docs/registros/mois1.md` to record the namespace and worker changes. 
- No functional logic was changed; this is a package/path refactor to standardize the module namespace.

### Testing
- Ran unit tests `MoisSalesLibrarySnapshotServiceTest` and `MoisSalesLibraryControllerTest` after the rename and they passed. 
- Built the backend and worker modules to verify compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be8d920088321ae604f4b20a6f6b6)