### PR TITLE
Remove CustomFormHtmlResolver validation from Lead Portal HTML publication

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -446,3 +446,15 @@
 - documentos lidos para tratar a situação:
   - AGENTS.md
   - docs/registros/experimentos.md
+
+## 2026-05-19 00:58:10 UTC-3
+- solicitação para retirar a etapa de validação com `CustomFormHtmlResolver` na publicação de HTML para o Lead Portal.
+- causa-raiz: a validação/normalização restritiva em `FlowService` bloqueava o fluxo de publicação quando o HTML não passava no resolver.
+- foi feito:
+  - `FlowService` deixou de depender de `CustomFormHtmlResolver` no construtor/injeção.
+  - método `normalizeCustomFormHtml` simplificado para no-op (retorna o fluxo original sem validação de conteúdo).
+  - `FlowServiceTest` atualizado para refletir a nova assinatura do serviço (sem resolver).
+- impacto esperado: publicação/sincronização de `customFormHtml` no Lead Portal segue sem bloqueio por validação do resolver.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/registros/experimentos.md

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowService.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/service/FlowService.java
@@ -24,7 +24,6 @@ public class FlowService {
     private final SimpleFlowCatalog simpleFlowCatalog;
     private final FlowAssetService flowAssetService;
     private final SimpleFormStyleDefaults simpleFormStyleDefaults;
-    private final CustomFormHtmlResolver customFormHtmlResolver;
 
     public FlowService(
             FlowRepository repository,
@@ -32,15 +31,13 @@ public class FlowService {
             MeterRegistry meterRegistry,
             SimpleFlowCatalog simpleFlowCatalog,
             FlowAssetService flowAssetService,
-            SimpleFormStyleDefaults simpleFormStyleDefaults,
-            CustomFormHtmlResolver customFormHtmlResolver) {
+            SimpleFormStyleDefaults simpleFormStyleDefaults) {
         this.repository = repository;
         this.accessRepository = accessRepository;
         this.meterRegistry = meterRegistry;
         this.simpleFlowCatalog = simpleFlowCatalog;
         this.flowAssetService = flowAssetService;
         this.simpleFormStyleDefaults = simpleFormStyleDefaults;
-        this.customFormHtmlResolver = customFormHtmlResolver;
     }
 
     @Transactional
@@ -164,27 +161,7 @@ public class FlowService {
             return null;
         }
 
-        String normalizedCustomFormHtml = customFormHtmlResolver.normalize(flow.customFormHtml());
-        if ((flow.customFormHtml() == null && normalizedCustomFormHtml == null)
-                || (flow.customFormHtml() != null && flow.customFormHtml().equals(normalizedCustomFormHtml))) {
-            return flow;
-        }
-
-        return new Flow(
-                flow.slug(),
-                flow.name(),
-                flow.description(),
-                normalizedCustomFormHtml,
-                flow.model(),
-                flow.prompt(),
-                flow.imagePromptModel(),
-                flow.imagePromptTemplate(),
-                flow.imageBatchSize(),
-                flow.questions(),
-                flow.simpleFormStyle(),
-                flow.facebookPixelId(),
-                flow.facebookPixelCode(),
-                flow.facebookPixelCreatedAt());
+        return flow;
     }
 
     private void registerAccess(String slug, FlowAccessMetadata metadata) {

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/FlowServiceTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/service/FlowServiceTest.java
@@ -53,8 +53,7 @@ class FlowServiceTest {
                 meterRegistry,
                 simpleFlowCatalog,
                 flowAssetService,
-                simpleFormStyleDefaults,
-                new CustomFormHtmlResolver());
+                simpleFormStyleDefaults);
         when(simpleFlowCatalog.find(anyString())).thenReturn(Optional.empty());
     }
 


### PR DESCRIPTION
### Motivation
- The `CustomFormHtmlResolver` validation in `FlowService` rejected non‑pure/legacy payloads and blocked publication/synchronization of `customFormHtml` to the Lead Portal, so the validation step needed to be removed to unblock publishing.

### Description
- Removed `CustomFormHtmlResolver` from the `FlowService` constructor and eliminated its use inside the service.
- Simplified `normalizeCustomFormHtml` to a no‑op (`return flow`) so the original `customFormHtml` payload is preserved.
- Updated `FlowServiceTest` to match the new `FlowService` signature and added an entry in `docs/registros/experimentos.md` documenting the change.

### Testing
- Ran `cd lead-portal/backend && mvn -Dtest=FlowServiceTest,CustomFormHtmlResolverTest test`.
- Result: `BUILD SUCCESS` and tests completed with 6 tests run, 0 failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf0440fd08321b32e90aa04373a37)