### PR TITLE
Reagenda coletor CNAE para 04:40 (America/Sao_Paulo)

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -85,3 +85,5 @@
 - 2026-05-19 00:20:00 (UTC-3): ajuste solicitado para remover índice 0 na semente de arquivos da importação CNPJ/CNAE no `oprm-coletor-mei`: `buildFiles` passou a gerar `Estabelecimentos1.zip..Estabelecimentos9.zip` e `Socios1.zip..Socios9.zip` (além de `Empresas1.zip..Empresas9.zip` já vigente), eliminando referências `*0.zip` que vinham provocando falha/`PARTIAL` quando inexistentes na fonte.
 
 - 2026-05-19 09:55:00 (UTC-3): ajuste solicitado para reagendar a próxima execução da importação OPRM CNPJ/CNAE para **10:00 de hoje (19/05)** no fuso `America/Sao_Paulo`, com cron hardcoded `0 0 10 19 5 *` na anotação `@Scheduled` de `runScheduledImport`.
+
+- 2026-05-19 01:40:00 (UTC-3): ajuste solicitado no `oprm-coletor-mei` para reagendar o coletor CNPJ/CNAE para **04:40** no fuso `America/Sao_Paulo`, atualizando o cron hardcoded de `runScheduledImport` para `0 40 4 * * *` e sincronizando o cron padrão em `application.yml` para o mesmo horário.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
@@ -44,7 +44,7 @@ public class OprmMarketImportScheduler {
         this.restClient = restClient;
     }
 
-    @Scheduled(cron = "0 0 10 19 5 *", zone = "America/Sao_Paulo")
+    @Scheduled(cron = "0 40 4 * * *", zone = "America/Sao_Paulo")
     public void runScheduledImport() {
         if (!scheduleProperties.enabled()) {
             log.info("Scheduler OPRM market import desabilitado.");
@@ -139,7 +139,7 @@ public class OprmMarketImportScheduler {
             publishRunComplete(runResponse.runId(), filesProcessed, totalRowsRead, totalRowsValid, totalRowsRejected, hasFailure);
         }
 
-        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 22:00 ({}) com {} arquivos.",
+        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 04:40 ({}) com {} arquivos.",
                 snapshotDate,
                 scheduleProperties.timezone(),
                 files.size());

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -22,7 +22,7 @@ oprm:
       temp-dir: ${OPRM_MARKET_IMPORT_TEMP_DIR:/tmp/oprm-cnpj-import}
     schedule:
       enabled: ${OPRM_MARKET_IMPORT_SCHEDULE_ENABLED:true}
-      cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 50 14 * * *}
+      cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 40 4 * * *}
       timezone: ${OPRM_MARKET_IMPORT_SCHEDULE_TIMEZONE:America/Sao_Paulo}
       snapshot-date: ${OPRM_MARKET_IMPORT_SNAPSHOT_DATE:2026-05-10}
       source-base-url: ${OPRM_MARKET_IMPORT_SOURCE_BASE_URL:https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos}


### PR DESCRIPTION
### Motivation
- Ajustar o horário diário do coletor OPRM CNPJ/CNAE para executar mais cedo às 04:40 no fuso `America/Sao_Paulo` para alinhar operação/cronograma operacional.
- Garantir que o valor padrão configurável e o agendamento hardcoded estejam sincronizados para evitar divergências entre deploys e variáveis de ambiente.
- Registrar a mudança no histórico operacional do módulo conforme política de registros do OPRM (append-only).

### Description
- Atualiza o `@Scheduled` em `OprmMarketImportScheduler.runScheduledImport` para usar o cron `0 40 4 * * *` (fuso `America/Sao_Paulo`).
- Atualiza a mensagem de log de startup do import run para refletir o novo horário `04:40`.
- Sincroniza o cron padrão em `oprm-coletor-mei/src/main/resources/application.yml` para `0 40 4 * * *` (`OPRM_MARKET_IMPORT_SCHEDULE_CRON` default).
- Adiciona entrada de registro em `docs/registros/oprm1.md` descrevendo a mudança de agendamento.

### Testing
- Nenhum teste automatizado foi executado como parte desta mudança (ajuste pontual de agendamento e documentação).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c103768088321be9b27310082aa97)