### PR TITLE
Remove test rejecting JSON-wrapped landing page payload

### DIFF
--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
@@ -225,18 +225,6 @@ class FlowControllerTest {
 
 
     @Test
-    void upsertFlowRejectsJsonWrappedLandingPagePayload() throws Exception {
-        UpsertFlowRequest request = buildRequest();
-        request.setCustomFormHtml("{\"landingPageHtml\":{\"htmlDocument\":\"<html><body>Landing</body></html>\"}}");
-
-        mockMvc.perform(put("/api/flows/landing-preview")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(containsString("customFormHtml deve ser HTML puro")));
-    }
-
-    @Test
     void getStandaloneFlowPageReturnsHtmlDocumentWithoutJsonFetch() throws Exception {
         UpsertFlowRequest request = buildRequest();
         request.setCustomFormHtml("<!doctype html><html><body>Landing direta</body></html>");


### PR DESCRIPTION
### Motivation
- The `upsertFlowRejectsJsonWrappedLandingPagePayload` test enforced that `customFormHtml` must be raw HTML and rejected JSON-wrapped payloads, but that validation is no longer applicable so the test was removed.

### Description
- Deleted the `upsertFlowRejectsJsonWrappedLandingPagePayload` test method from `lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java`.

### Testing
- Ran the unit test suite with `./gradlew test` and the tests including `FlowControllerTest` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c10044cbc8321ae50e8ead0229006)