### PR TITLE
Remover comentário AUTO do início do HTML provisório do GeraLanding

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -445,10 +445,7 @@ public class GeraLandingStageExecutionService {
             return null;
         }
         String htmlWithGeneratedImages = landingPageImageInjector.injectImages(experiment.getId(), baseHtml);
-        return """
-                <!-- AUTO: provisional html regenerated after landing-page-image-planning completion -->
-                %s
-                """.formatted(htmlWithGeneratedImages);
+        return htmlWithGeneratedImages;
     }
 
     private String resolveDesignPresetProvisionalHtml(String idJob, GeraLandingResultReceiveRequest request, GeraLandingStageExecution execution) {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -458,3 +458,14 @@
 - documentos lidos para tratar a situação:
   - AGENTS.md
   - docs/registros/experimentos.md
+
+## 2026-05-19 01:10:00 UTC-3
+- solicitação para remover o comentário AUTO injetado no início do HTML provisório após a etapa de image planning.
+- causa-raiz: o comentário era prefixado no payload HTML e estava interferindo no consumo/renderização downstream.
+- foi feito:
+  - `resolveImagePlanningProvisionalHtml` passou a retornar somente o HTML final com imagens injetadas, sem prefixar comentário `<!-- AUTO: ... -->`.
+- impacto esperado: o HTML publicado deixa de conter metadado textual no topo e evita interferência no processamento do cliente.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- The AUTO HTML comment prefixed to provisional HTML after image planning was injected into published payloads and caused rendering/consumption issues downstream.

### Description
- Removed the `<!-- AUTO: provisional html regenerated after landing-page-image-planning completion -->` prefix so `resolveImagePlanningProvisionalHtml` now returns only the HTML with injected images, and recorded the change in `docs/registros/experimentos.md`.

### Testing
- Ran unit tests for the `ads-service` module with `../mvnw test -DskipITs`; the test run was started and captured portions of test output that show suites executing with no failures in the observed output, while the full module test suite continued in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1cad2d0c83218df7a1e3d58398de)