### PR TITLE
Remove fragile GeraLanding unit test and document the change

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -232,60 +232,6 @@ class GeraLandingStageExecutionServiceTest {
     }
 
     @Test
-    void shouldPreserveDesignPresetWhenRegeneratingProvisionalHtmlAfterImagePlanning() {
-        GeraLandingResultReceiveRequest request = new GeraLandingResultReceiveRequest(
-                66L,
-                "landing-page-image-planning",
-                "{\"landingPageImagePlanning\":{\"images\":[]}}",
-                null,
-                null,
-                null,
-                "job-openai-image-planning",
-                10,
-                20,
-                null);
-        Experiment experiment = new Experiment();
-        experiment.setId(66L);
-        experiment.setLandingPageWireframe("{\"landingPageWireframe\":{\"sectionOrder\":[]}}");
-        experiment.setLandingPageCopy("{\"landingPageCopy\":{\"bodySections\":[]}}");
-        experiment.setLandingPageDesignPreset("{\"landingPageDesignPreset\":{\"presetId\":\"preset-1\"}}");
-
-        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
-                .experimentId(66L)
-                .experiment(experiment)
-                .stageCode("landing-page-image-planning")
-                .executionRequestedAt(Instant.parse("2026-05-14T00:00:00Z"))
-                .createdAt(Instant.parse("2026-05-14T00:00:00Z"))
-                .status("EM_PROCESSAMENTO")
-                .idJob("id-image-planning".getBytes(StandardCharsets.UTF_8))
-                .build();
-
-        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc("id-image-planning".getBytes(StandardCharsets.UTF_8)))
-                .thenReturn(Optional.of(execution));
-        when(experimentRepository.findById(66L)).thenReturn(Optional.of(experiment));
-        when(copyProvisionalHtmlAssembler.assembleComplete(
-                experiment.getLandingPageCopy(),
-                experiment.getLandingPageWireframe(),
-                request.modelResponse(),
-                experiment.getLandingPageDesignPreset(),
-                "id-image-planning"))
-                .thenReturn("<html>com-imagens</html>");
-        when(landingPageImageInjector.injectImages(66L, "<html>com-imagens</html>"))
-                .thenReturn("<html>com-imagens</html>");
-
-        service.receiveResult("id-image-planning", request);
-
-        verify(copyProvisionalHtmlAssembler).assembleComplete(
-                experiment.getLandingPageCopy(),
-                experiment.getLandingPageWireframe(),
-                request.modelResponse(),
-                experiment.getLandingPageDesignPreset(),
-                "id-image-planning");
-        assertTrue(execution.getProvisionalHtml().contains("landing-page-image-planning"));
-        assertTrue(execution.getProvisionalHtml().contains("<html>com-imagens</html>"));
-    }
-
-    @Test
     void shouldMarkExecutionAsFailureAndSkipExperimentPersistenceWhenErrorMessageExists() {
         GeraLandingResultReceiveRequest request = new GeraLandingResultReceiveRequest(
                 31L,

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -469,3 +469,13 @@
   - AGENTS.md
   - backend/AGENTS.md
   - docs/registros/experimentos.md
+
+## 2026-05-19 13:39:41 UTC-3
+- solicitação para remover um teste unitário específico que estava falhando no módulo de GeraLanding.
+- raciocínio aplicado: o cenário testado validava um marcador textual no `provisionalHtml` que não é contrato explícito do fluxo `landing-page-image-planning`, gerando falha por expectativa frágil.
+- foi feito: remoção do teste `shouldPreserveDesignPresetWhenRegeneratingProvisionalHtmlAfterImagePlanning` em `GeraLandingStageExecutionServiceTest`.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java


### PR DESCRIPTION
### Motivation
- A unit test in `GeraLandingStageExecutionServiceTest` asserted a textual marker in `provisionalHtml` that is not an explicit contract of the `landing-page-image-planning` flow and produced fragile failures.
- The change is recorded in the experiments log to preserve context and rationale for future reviewers.

### Description
- Remove the test method `shouldPreserveDesignPresetWhenRegeneratingProvisionalHtmlAfterImagePlanning` from `backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java`.
- Add an entry to `docs/registros/experimentos.md` documenting the removal and the reasoning, and list the files reviewed.

### Testing
- Ran the ads-service unit tests with `./gradlew :backend:ads-service:test` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c919e60788321ba06e92f105b297e)