### PR TITLE
Integrate OpenAI Batch analysis into mois-sales-library-worker (v1)

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -197,3 +197,9 @@
   - o pacote não pode depender de outros pacotes `com.marketinghub` fora do próprio namespace;
   - outros pacotes `com.marketinghub` não podem depender dele.
 - adicionada a mesma política de isolamento no módulo `mois-hotmart-collector` com teste ArchUnit dedicado e dependência de teste `archunit-junit5`.
+
+## 2026-05-19 — Integração OpenAI batch no mois-sales-library-worker (v1)
+- Pipeline do worker passou a analisar página de vendas via OpenAI Batch API no modelo padrão `gpt-5.2`.
+- Criado subpacote `openai` em `v1` com cliente dedicado de upload de arquivo JSONL, criação de batch, polling de status e parsing do output.
+- `PipelineRunner` agora faz fetch da página com Jsoup e envia o texto para análise OpenAI, persistindo resultado via endpoint `:complete`.
+- Adicionadas propriedades `openai.*` no `application.yml` para chave, base URL, modelo e timeouts de batch.

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/config/WorkerConfig.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/config/WorkerConfig.java
@@ -1,12 +1,13 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.config;
 
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai.OpenAiProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 
 @Configuration
-@EnableConfigurationProperties(WorkerProperties.class)
+@EnableConfigurationProperties({WorkerProperties.class, OpenAiProperties.class})
 public class WorkerConfig {
     @Bean
     RestClient restClient(WorkerProperties properties) {

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiProperties.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiProperties.java
@@ -1,0 +1,31 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "openai")
+public record OpenAiProperties(
+        String apiKey,
+        String baseUrl,
+        String model,
+        long batchPollIntervalMs,
+        long batchTimeoutMs
+) {
+    public String normalizedBaseUrl() {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            return "https://api.openai.com/v1";
+        }
+        return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+    }
+
+    public String normalizedModel() {
+        return (model == null || model.isBlank()) ? "gpt-5.2" : model.trim();
+    }
+
+    public long normalizedBatchPollIntervalMs() {
+        return batchPollIntervalMs <= 0 ? 2000 : batchPollIntervalMs;
+    }
+
+    public long normalizedBatchTimeoutMs() {
+        return batchTimeoutMs <= 0 ? 300000 : batchTimeoutMs;
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
@@ -1,0 +1,142 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+@Component
+@Slf4j
+public class OpenAiSalesPageAnalyzer {
+
+    private static final Set<String> TERMINAL_BATCH_STATUSES = Set.of("completed", "failed", "expired", "cancelled");
+
+    private final RestClient restClient;
+    private final OpenAiProperties properties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public OpenAiSalesPageAnalyzer(RestClient.Builder builder, OpenAiProperties properties) {
+        this.properties = properties;
+        this.restClient = builder.baseUrl(properties.normalizedBaseUrl())
+                .defaultHeader("Authorization", "Bearer " + properties.apiKey())
+                .defaultHeader("OpenAI-Beta", "reasoning=1")
+                .build();
+    }
+
+    public SalesPageAnalysisResult analyze(long pageId, String canonicalUrl, String htmlBodyText) {
+        if (!StringUtils.hasText(properties.apiKey())) {
+            throw new IllegalStateException("OpenAI api key não configurada para análise de sales page");
+        }
+        String payloadLine = buildBatchLine(pageId, canonicalUrl, htmlBodyText);
+        String inputFileId = uploadInputFile(payloadLine);
+        BatchInfo batch = createBatch(inputFileId);
+        BatchInfo completed = awaitBatch(batch);
+        if (!"completed".equalsIgnoreCase(completed.status()) || !StringUtils.hasText(completed.outputFileId())) {
+            throw new IllegalStateException("Batch da OpenAI não completou com output_file_id. status=" + completed.status());
+        }
+        String output = downloadOutput(completed.outputFileId());
+        return parseBatchOutput(output);
+    }
+
+    private String buildBatchLine(long pageId, String canonicalUrl, String htmlBodyText) {
+        String prompt = "Analise a página de vendas e devolva JSON válido com os campos: score_total (0-100), sections_json (objeto), copy_json (objeto), visual_json (objeto), image_json (objeto), analysis_notes (texto curto). URL: "
+                + canonicalUrl + "\nConteúdo: " + htmlBodyText;
+        try {
+            return objectMapper.writeValueAsString(Map.of(
+                    "custom_id", "page-" + pageId,
+                    "method", "POST",
+                    "url", "/v1/responses",
+                    "body", Map.of(
+                            "model", properties.normalizedModel(),
+                            "input", List.of(
+                                    Map.of("role", "system", "content", "Você analisa páginas de venda e responde exclusivamente em JSON válido sem markdown."),
+                                    Map.of("role", "user", "content", prompt)
+                            ),
+                            "response_format", Map.of("type", "json_object")
+                    )
+            ));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Falha ao serializar linha batch", e);
+        }
+    }
+
+    private String uploadInputFile(String line) {
+        MultiValueMap<String, Object> multipart = new LinkedMultiValueMap<>();
+        multipart.add("purpose", "batch");
+        multipart.add("file", new org.springframework.core.io.ByteArrayResource((line + "\n").getBytes(StandardCharsets.UTF_8)) {
+            @Override public String getFilename() { return "sales-page-analysis.jsonl"; }
+        });
+        FileUploadResponse response = restClient.post().uri("/files").contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(multipart).retrieve().body(FileUploadResponse.class);
+        if (response == null || !StringUtils.hasText(response.id())) throw new IllegalStateException("Upload do arquivo batch falhou");
+        return response.id();
+    }
+
+    private BatchInfo createBatch(String inputFileId) {
+        BatchInfo response = restClient.post().uri("/batches")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("input_file_id", inputFileId, "endpoint", "/v1/responses", "completion_window", "24h"))
+                .retrieve().body(BatchInfo.class);
+        if (response == null || !StringUtils.hasText(response.id())) throw new IllegalStateException("Criação do batch falhou");
+        return response;
+    }
+
+    private BatchInfo awaitBatch(BatchInfo batch) {
+        Instant start = Instant.now();
+        BatchInfo current = batch;
+        while (!TERMINAL_BATCH_STATUSES.contains(current.status())) {
+            if (Instant.now().toEpochMilli() - start.toEpochMilli() > properties.normalizedBatchTimeoutMs()) {
+                throw new IllegalStateException("Timeout aguardando batch " + current.id());
+            }
+            try { Thread.sleep(properties.normalizedBatchPollIntervalMs()); } catch (InterruptedException e) { Thread.currentThread().interrupt(); throw new IllegalStateException(e); }
+            current = restClient.get().uri("/batches/{id}", current.id()).retrieve().body(BatchInfo.class);
+            if (current == null || !StringUtils.hasText(current.status())) throw new IllegalStateException("Batch status inválido");
+        }
+        return current;
+    }
+
+    private String downloadOutput(String outputFileId) {
+        return restClient.get().uri("/files/{id}/content", outputFileId).retrieve().body(String.class);
+    }
+
+    private SalesPageAnalysisResult parseBatchOutput(String outputJsonl) {
+        try {
+            String line = outputJsonl.lines().filter(StringUtils::hasText).findFirst().orElseThrow();
+            JsonNode root = objectMapper.readTree(line);
+            JsonNode outputText = root.path("response").path("body").path("output").get(0).path("content").get(0).path("text");
+            if (outputText.isMissingNode() || outputText.isNull()) {
+                outputText = root.path("response").path("body").path("output_text");
+            }
+            JsonNode parsed = objectMapper.readTree(outputText.asText());
+            return new SalesPageAnalysisResult(
+                    parsed.path("score_total").decimalValue(),
+                    objectMapper.writeValueAsString(parsed.path("sections_json")),
+                    objectMapper.writeValueAsString(parsed.path("copy_json")),
+                    objectMapper.writeValueAsString(parsed.path("visual_json")),
+                    objectMapper.writeValueAsString(parsed.path("image_json")),
+                    parsed.path("analysis_notes").asText("Análise gerada via OpenAI batch"),
+                    "html-v1",
+                    "openai-batch-v1",
+                    properties.normalizedModel()
+            );
+        } catch (Exception e) {
+            log.error("Falha parse output batch OpenAI. output={}", outputJsonl, e);
+            throw new IllegalStateException("Falha ao interpretar output do batch OpenAI", e);
+        }
+    }
+
+    private record FileUploadResponse(String id) {}
+    private record BatchInfo(String id, String status, @JsonProperty("output_file_id") String outputFileId) {}
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/SalesPageAnalysisResult.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/SalesPageAnalysisResult.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai;
+
+import java.math.BigDecimal;
+
+public record SalesPageAnalysisResult(
+        BigDecimal scoreTotal,
+        String sectionsJson,
+        String copyJson,
+        String visualJson,
+        String imageJson,
+        String analysisNotes,
+        String parserVersion,
+        String promptVersion,
+        String modelName
+) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
@@ -1,16 +1,14 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.client.BackendClient;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.config.WorkerProperties;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.*;
-import java.math.BigDecimal;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai.OpenAiSalesPageAnalyzer;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai.SalesPageAnalysisResult;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,11 +16,13 @@ import org.jsoup.Jsoup;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-@Service @Slf4j @RequiredArgsConstructor
+@Service
+@Slf4j
+@RequiredArgsConstructor
 public class PipelineRunner {
     private final BackendClient backendClient;
     private final WorkerProperties properties;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final OpenAiSalesPageAnalyzer openAiSalesPageAnalyzer;
     private final AtomicInteger sourceCursor = new AtomicInteger(0);
 
     @Scheduled(fixedDelayString = "${worker.poll-interval-ms:15000}")
@@ -35,18 +35,26 @@ public class PipelineRunner {
             log.info("MOIS sales-library worker cycle finished without claimed job.");
             return;
         }
+
         long jobId = claim.job().jobId();
         try {
-            log.info("MOIS sales-library worker claimed job. jobId={}, pageId={}, urlCanonical={}", jobId, claim.job().pageId(), claim.job().urlCanonical());
+            log.info("MOIS sales-library worker claimed job. jobId={}, pageId={}, urlCanonical={}",
+                    jobId, claim.job().pageId(), claim.job().urlCanonical());
             var doc = Jsoup.connect(claim.job().urlCanonical()).timeout(properties.requestTimeoutMs()).get();
             String text = doc.body() != null ? doc.body().text() : "";
-            Map<String, Object> sections = new HashMap<>();
-            sections.put("hasHeadline", doc.select("h1,h2").size() > 0);
-            sections.put("hasCta", text.toLowerCase().contains("comprar") || text.toLowerCase().contains("quero") || text.toLowerCase().contains("inscreva"));
-            sections.put("hasProof", text.toLowerCase().contains("depoimento") || text.toLowerCase().contains("prova") || text.toLowerCase().contains("resultado"));
-            BigDecimal score = BigDecimal.valueOf((Boolean.TRUE.equals(sections.get("hasHeadline")) ? 33 : 0) + (Boolean.TRUE.equals(sections.get("hasCta")) ? 33 : 0) + (Boolean.TRUE.equals(sections.get("hasProof")) ? 34 : 0));
-            String sectionsJson = objectMapper.writeValueAsString(sections);
-            backendClient.complete(jobId, new CompleteRequest(score, sectionsJson, "{}", "{}", "{}", "Análise inicial automatizada", "html-v1", "heuristic-v1", "local-jsoup", Instant.now()));
+            SalesPageAnalysisResult analysis =
+                    openAiSalesPageAnalyzer.analyze(claim.job().pageId(), claim.job().urlCanonical(), text);
+            backendClient.complete(jobId, new CompleteRequest(
+                    analysis.scoreTotal(),
+                    analysis.sectionsJson(),
+                    analysis.copyJson(),
+                    analysis.visualJson(),
+                    analysis.imageJson(),
+                    analysis.analysisNotes(),
+                    analysis.parserVersion(),
+                    analysis.promptVersion(),
+                    analysis.modelName(),
+                    Instant.now()));
             log.info("MOIS library job {} completed for page {}", jobId, claim.job().pageId());
         } catch (Exception ex) {
             backendClient.fail(jobId, new FailRequest("PIPELINE_ERROR", ex.getMessage()));

--- a/mois-sales-library-worker/src/main/resources/application.yml
+++ b/mois-sales-library-worker/src/main/resources/application.yml
@@ -8,3 +8,10 @@ worker:
   sources: ${MOIS_SOURCES:}
   poll-interval-ms: ${MOIS_POLL_INTERVAL_MS:15000}
   request-timeout-ms: ${MOIS_REQUEST_TIMEOUT_MS:30000}
+
+openai:
+  api-key: ${OPENAI_API_KEY:}
+  base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}
+  model: ${OPENAI_MODEL:gpt-5.2}
+  batch-poll-interval-ms: ${OPENAI_BATCH_POLL_INTERVAL_MS:2000}
+  batch-timeout-ms: ${OPENAI_BATCH_TIMEOUT_MS:300000}


### PR DESCRIPTION
### Motivation

- Replace the previous lightweight heuristic Jsoup scoring with a more robust OpenAI Batch-based analysis to generate structured JSON analysis for sales pages. 
- Add configuration and wiring to enable batch uploads, polling and result parsing via the OpenAI batch endpoints.

### Description

- Added `OpenAiProperties` (`openai.*`) and registered it in `WorkerConfig` via `@EnableConfigurationProperties` to expose OpenAI settings. 
- Implemented `OpenAiSalesPageAnalyzer` to upload a JSONL input file, create a batch, poll for completion, download the output and parse the JSONL response into a structured `SalesPageAnalysisResult`. 
- Added `SalesPageAnalysisResult` record to carry analysis fields such as `scoreTotal`, `sectionsJson`, `copyJson`, `visualJson`, `imageJson`, `analysisNotes`, `parserVersion`, `promptVersion`, and `modelName`. 
- Replaced the heuristic scoring in `PipelineRunner` with the OpenAI analysis call and forwarded the parsed fields to the backend via the existing `complete` call. 
- Added `openai` configuration defaults to `mois-sales-library-worker/src/main/resources/application.yml`. 
- Updated docs (`docs/registros/mois1.md`) to record the integration and other recent worker changes. 

### Testing

- No automated tests were added or modified for this change; existing tests were not changed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca1e094a08321a54ba2fd30bea0be)