### PR TITLE
Evita criação de jobs duplicados na ingestão da biblioteca MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -72,7 +72,7 @@ public class MoisSalesLibraryService {
             }
             Instant capturedAt = item.capturedAt() == null ? Instant.now() : item.capturedAt();
             LocalDateTime capturedAtUtc = LocalDateTime.ofInstant(capturedAt, ZoneOffset.UTC);
-            jdbcTemplate.update(
+            int ingestUpsertResult = jdbcTemplate.update(
                     """
                             INSERT INTO mois_sales_library_url_ingest
                             (workspace_id, source, url_original, url_canonical, title, first_captured_at, last_captured_at, ingest_count, created_at, updated_at)
@@ -94,18 +94,20 @@ public class MoisSalesLibraryService {
                     capturedAtUtc
             );
 
-            Long urlIngestId = jdbcTemplate.queryForObject(
-                    """
-                            SELECT id
-                            FROM mois_sales_library_url_ingest
-                            WHERE url_canonical = ?
-                            LIMIT 1
-                            """,
-                    Long.class,
-                    canonical
-            );
-            if (urlIngestId != null) {
-                createPendingJob(urlIngestId);
+            if (ingestUpsertResult == 1) {
+                Long urlIngestId = jdbcTemplate.queryForObject(
+                        """
+                                SELECT id
+                                FROM mois_sales_library_url_ingest
+                                WHERE url_canonical = ?
+                                LIMIT 1
+                                """,
+                        Long.class,
+                        canonical
+                );
+                if (urlIngestId != null) {
+                    createPendingJob(urlIngestId);
+                }
             }
             persisted++;
         }

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -1,0 +1,63 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class MoisSalesLibraryServiceTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private MoisSalesLibraryService service;
+
+    @Test
+    void shouldCreatePendingJobWhenUrlIsNew() {
+        MoisSalesLibraryDtos.SalesLibraryIngestRequest request = new MoisSalesLibraryDtos.SalesLibraryIngestRequest(
+                "10",
+                "hotmart",
+                List.of(new MoisSalesLibraryDtos.SalesLibraryUrlItem("https://example.com/pagina", "Title", Instant.parse("2026-05-19T00:00:00Z")))
+        );
+
+        given(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_url_ingest"), any(), any(), any(), any(), any(), any(), any()))
+                .willReturn(1);
+        given(jdbcTemplate.queryForObject(anyString(), eq(Long.class), any())).willReturn(99L);
+
+        service.ingestUrls(request);
+
+        verify(jdbcTemplate).update(contains("INSERT INTO mois_sales_library_processing_job"), eq(99L), eq("PENDING"));
+    }
+
+    @Test
+    void shouldNotCreatePendingJobWhenUrlAlreadyExists() {
+        MoisSalesLibraryDtos.SalesLibraryIngestRequest request = new MoisSalesLibraryDtos.SalesLibraryIngestRequest(
+                "10",
+                "hotmart",
+                List.of(new MoisSalesLibraryDtos.SalesLibraryUrlItem("https://example.com/pagina", "Title", Instant.parse("2026-05-19T00:00:00Z")))
+        );
+
+        given(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_url_ingest"), any(), any(), any(), any(), any(), any(), any()))
+                .willReturn(2);
+
+        service.ingestUrls(request);
+
+        verify(jdbcTemplate, never()).queryForObject(anyString(), eq(Long.class), any());
+        verify(jdbcTemplate, never()).update(contains("INSERT INTO mois_sales_library_processing_job"), any(), any());
+    }
+}

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -205,3 +205,11 @@
 - Adicionadas propriedades `openai.*` no `application.yml` para chave, base URL, modelo e timeouts de batch.
 
 - Ajustado deploy do `mois-sales-library-worker` para o mesmo host do `ai-worker` (`191.252.120.96`) e com montagem do mesmo arquivo de token OpenAI em volume (`/run/secrets/openai_api_key`).
+
+## 2026-05-19 — Evitar job duplicado no worker da Biblioteca de Páginas de Vendas
+- Ajustado o `ingestUrls` no backend MOIS para criar job `PENDING` **somente quando a URL for nova** na tabela de ingestão (`INSERT` real).
+- Quando a URL já existe (upsert via `ON DUPLICATE KEY UPDATE`), a entrada continua atualizando metadados/counters, mas não cria novo job para o worker processar novamente a mesma página.
+- Adicionados testes unitários cobrindo os dois cenários: URL nova cria job; URL já existente não cria job.
+- Arquivos alterados:
+  - `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+  - `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java`


### PR DESCRIPTION
### Motivation
- Evitar que o worker da biblioteca de páginas de vendas processe novamente URLs que já estão registradas, reduzindo reprocessamentos e custo operacional.

### Description
- Ajustado `MoisSalesLibraryService.ingestUrls` para capturar o resultado do `jdbcTemplate.update(...)` do upsert e só chamar `createPendingJob(...)` quando o upsert efetivamente inserir (`ingestUpsertResult == 1`).
- Mantida a lógica de `ON DUPLICATE KEY UPDATE` para atualizar metadados/`ingest_count` quando a URL já existe, sem criar novo job.
- Adicionado teste unitário `MoisSalesLibraryServiceTest` com dois cenários: URL nova gera job e URL existente não gera job nem consulta `id` para criação.
- Atualizado registro de mudanças em `docs/registros/mois1.md` e alterado `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`.

### Testing
- Executado `mvn -Dtest=MoisSalesLibraryServiceTest test` no módulo `backend/ads-service`.
- Resultado: build de teste bem-sucedido com `2` testes executados e `0` falhas (todos passaram).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ce09107488321b5171ccb4cff046f)