### PR TITLE
fix: reorder experiment stage cards (show 3 - Gera Imagem before 5 - Gera Entregáveis)

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -479,3 +479,13 @@
   - backend/AGENTS.md
   - docs/registros/experimentos.md
   - backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+
+## 2026-05-19 19:20:00 UTC
+- solicitação para corrigir a ordenação visual dos cards de etapas na tela de experimento.
+- causa-raiz: o card `5 - Gera Entregáveis` estava renderizado antes do card `3 - Gera Imagem` no JSX de `ExperimentDetailPage`, causando sequência inconsistente para o usuário.
+- foi feito: reordenação dos blocos JSX para exibir `3 - Gera Imagem` antes de `5 - Gera Entregáveis`.
+- impacto esperado: fluxo visual da página segue a ordem lógica das etapas, reduzindo ambiguidade operacional.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -2354,125 +2354,6 @@ export default function ExperimentDetailPage() {
               <div className="card">
                 <div className="card-body d-flex flex-column gap-3">
                   <div className="d-flex flex-wrap justify-content-between align-items-start gap-2">
-                    <h5 className="card-title mb-0">
-                      5 - Gera Entregáveis
-                    </h5>
-                    <span className="badge text-bg-light border fs-6 fw-semibold">
-                      Total execuções:{" "}
-                      {formatCurrencyUsd(
-                        historyGeraLandingDeliverablesExecutions.reduce(
-                          (sum, execution) =>
-                            sum + (resolveExecutionCostUsd(execution) ?? 0),
-                          0,
-                        ),
-                      )}
-                    </span>
-                  </div>
-                  <button
-                    type="button"
-                    className="btn btn-primary align-self-start"
-                    onClick={handleStartDeliverables}
-                    disabled={
-                      isStartingDeliverables ||
-                      hasRunningGeraLandingDeliverablesExecution
-                    }
-                  >
-                    {isStartingDeliverables ? (
-                      <>
-                        <span
-                          className="spinner-border spinner-border-sm me-2"
-                          role="status"
-                          aria-hidden="true"
-                        />
-                        Iniciando...
-                      </>
-                    ) : (
-                      "Iniciar"
-                    )}
-                  </button>
-                  {isLoadingPendingGeraLandingDeliverablesExecutions ? (
-                    <p className="text-muted mb-0">Carregando jobs da etapa...</p>
-                  ) : runningGeraLandingDeliverablesExecutions.length === 0 ? (
-                    <p className="text-muted mb-0">
-                      Nenhum job pendente ou em execução.
-                    </p>
-                  ) : (
-                    <div className="table-responsive">
-                      <table className="table table-sm align-middle mb-0">
-                        <thead>
-                          <tr>
-                            <th scope="col">Job ID</th>
-                            <th scope="col">Status</th>
-                            <th scope="col">Data-hora</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {runningGeraLandingDeliverablesExecutions.map((execution) => (
-                            <tr key={execution.idJob}>
-                              <td>
-                                <Link
-                                  to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
-                                  className="fw-semibold text-decoration-none"
-                                >
-                                  {execution.idJob}
-                                </Link>
-                              </td>
-                              <td>{execution.status}</td>
-                              <td>{formatDateTimeValue(execution.executionRequestedAt)}</td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </div>
-                  )}
-                  <div className="rounded border bg-light-subtle p-3 d-flex flex-column gap-3">
-                    <h6 className="mb-0">Histórico de execuções</h6>
-                    {isLoadingCompletedGeraLandingDeliverablesExecutions ? (
-                      <p className="text-muted mb-0">Carregando execuções...</p>
-                    ) : historyGeraLandingDeliverablesExecutions.length === 0 ? (
-                      <p className="text-muted mb-0">
-                        Nenhuma execução registrada para esta etapa.
-                      </p>
-                    ) : (
-                      <div className="table-responsive">
-                        <table className="table table-sm align-middle mb-0">
-                          <thead>
-                            <tr>
-                              <th scope="col">Job ID</th>
-                              <th scope="col">Status</th>
-                              <th scope="col">Data-hora</th>
-                              <th scope="col" className="text-end">Custo</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {historyGeraLandingDeliverablesExecutions.map((execution) => (
-                              <tr key={execution.idJob}>
-                                <td>
-                                  <Link
-                                    to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
-                                    className="fw-semibold text-decoration-none"
-                                  >
-                                    {execution.idJob}
-                                  </Link>
-                                </td>
-                                <td>{execution.status}</td>
-                                <td>{formatDateTimeValue(execution.executionRequestedAt)}</td>
-                                <td className="text-end">
-                                  {formatCurrencyUsd(resolveExecutionCostUsd(execution))}
-                                </td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              <div className="card">
-                <div className="card-body d-flex flex-column gap-3">
-                  <div className="d-flex flex-wrap justify-content-between align-items-start gap-2">
                     <h5 className="card-title mb-0">3 - Gera Imagem</h5>
                     <span className="badge text-bg-light border fs-6 fw-semibold">
                       Pendentes: {frameworkImagePendingCount}
@@ -2669,6 +2550,125 @@ export default function ExperimentDetailPage() {
                   ) : null}
                 </div>
               </div>
+              <div className="card">
+                <div className="card-body d-flex flex-column gap-3">
+                  <div className="d-flex flex-wrap justify-content-between align-items-start gap-2">
+                    <h5 className="card-title mb-0">
+                      5 - Gera Entregáveis
+                    </h5>
+                    <span className="badge text-bg-light border fs-6 fw-semibold">
+                      Total execuções:{" "}
+                      {formatCurrencyUsd(
+                        historyGeraLandingDeliverablesExecutions.reduce(
+                          (sum, execution) =>
+                            sum + (resolveExecutionCostUsd(execution) ?? 0),
+                          0,
+                        ),
+                      )}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    className="btn btn-primary align-self-start"
+                    onClick={handleStartDeliverables}
+                    disabled={
+                      isStartingDeliverables ||
+                      hasRunningGeraLandingDeliverablesExecution
+                    }
+                  >
+                    {isStartingDeliverables ? (
+                      <>
+                        <span
+                          className="spinner-border spinner-border-sm me-2"
+                          role="status"
+                          aria-hidden="true"
+                        />
+                        Iniciando...
+                      </>
+                    ) : (
+                      "Iniciar"
+                    )}
+                  </button>
+                  {isLoadingPendingGeraLandingDeliverablesExecutions ? (
+                    <p className="text-muted mb-0">Carregando jobs da etapa...</p>
+                  ) : runningGeraLandingDeliverablesExecutions.length === 0 ? (
+                    <p className="text-muted mb-0">
+                      Nenhum job pendente ou em execução.
+                    </p>
+                  ) : (
+                    <div className="table-responsive">
+                      <table className="table table-sm align-middle mb-0">
+                        <thead>
+                          <tr>
+                            <th scope="col">Job ID</th>
+                            <th scope="col">Status</th>
+                            <th scope="col">Data-hora</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {runningGeraLandingDeliverablesExecutions.map((execution) => (
+                            <tr key={execution.idJob}>
+                              <td>
+                                <Link
+                                  to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                  className="fw-semibold text-decoration-none"
+                                >
+                                  {execution.idJob}
+                                </Link>
+                              </td>
+                              <td>{execution.status}</td>
+                              <td>{formatDateTimeValue(execution.executionRequestedAt)}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                  <div className="rounded border bg-light-subtle p-3 d-flex flex-column gap-3">
+                    <h6 className="mb-0">Histórico de execuções</h6>
+                    {isLoadingCompletedGeraLandingDeliverablesExecutions ? (
+                      <p className="text-muted mb-0">Carregando execuções...</p>
+                    ) : historyGeraLandingDeliverablesExecutions.length === 0 ? (
+                      <p className="text-muted mb-0">
+                        Nenhuma execução registrada para esta etapa.
+                      </p>
+                    ) : (
+                      <div className="table-responsive">
+                        <table className="table table-sm align-middle mb-0">
+                          <thead>
+                            <tr>
+                              <th scope="col">Job ID</th>
+                              <th scope="col">Status</th>
+                              <th scope="col">Data-hora</th>
+                              <th scope="col" className="text-end">Custo</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {historyGeraLandingDeliverablesExecutions.map((execution) => (
+                              <tr key={execution.idJob}>
+                                <td>
+                                  <Link
+                                    to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                    className="fw-semibold text-decoration-none"
+                                  >
+                                    {execution.idJob}
+                                  </Link>
+                                </td>
+                                <td>{execution.status}</td>
+                                <td>{formatDateTimeValue(execution.executionRequestedAt)}</td>
+                                <td className="text-end">
+                                  {formatCurrencyUsd(resolveExecutionCostUsd(execution))}
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+
             </div>
           </Tabs.Content>
           <Tabs.Content value="content-structure" asChild>


### PR DESCRIPTION
### Motivation
- Corrigir a sequência visual das etapas na tela de detalhe do experimento porque o card `5 - Gera Entregáveis` estava sendo renderizado antes do card `3 - Gera Imagem`, causando ordem inconsistente para o usuário.

### Description
- Reordenei os blocos JSX em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` para exibir `3 - Gera Imagem` antes de `5 - Gera Entregáveis` sem alterar o comportamento interno dos cards.
- Adicionei um registro da alteração em `docs/registros/experimentos.md` com solicitação, causa-raiz, ação aplicada e impacto esperado.

### Testing
- Executado `npm run -s lint` (frontend) — falhou por ausência/configuração do script de lint no `package.json` (não relacionado à alteração de ordenação visual).
- Executado `npm run -s typecheck` (frontend) — falhou devido a tipos/dependências locais não resolvidas e avisos de depreciação em `tsconfig.json`, sem relação direta com a mudança aplicada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ce1f6a1848321bdfb8021de214950)