### PR TITLE
Remover alerta amarelo duplicado na campanha de Facebook Ads

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -479,3 +479,15 @@
   - backend/AGENTS.md
   - docs/registros/experimentos.md
   - backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+
+## 2026-05-19 16:20:00 UTC
+- solicitação para remover o quadro amarelo de "Pendências antes da publicação" na aba de campanha de Facebook Ads do experimento.
+- causa-raiz: duplicidade visual das mesmas pendências, já tratadas e listadas na seção de bloqueios logo abaixo, gerando excesso de informação.
+- foi feito:
+  - remoção do alerta amarelo (`alert alert-warning`) condicionado por `hasReadinessIssues` em `ExperimentDetailPage`.
+  - manutenção do estado de carregamento de pendências básicas e da seção de bloqueios detalhada.
+- impacto esperado: interface mais limpa, sem redundância, preservando os bloqueios realmente acionáveis no checklist principal.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1083,8 +1083,6 @@ export default function ExperimentDetailPage() {
     !hasItemsToReset ||
     Boolean(previewErrorMessage) ||
     resetCampaigns.isPending;
-  const readinessIssues = readinessSummary?.issues ?? [];
-  const hasReadinessIssues = readinessIssues.length > 0;
   const formatCurrency = (n?: number | null) =>
     n != null
       ? new Intl.NumberFormat("pt-BR", {
@@ -1613,24 +1611,6 @@ export default function ExperimentDetailPage() {
                 aria-hidden="true"
               />
               <span>Carregando pendências básicas...</span>
-            </div>
-          ) : hasReadinessIssues ? (
-            <div className="alert alert-warning mt-3" role="alert">
-              <h6 className="alert-heading mb-2">
-                Pendências antes da publicação
-              </h6>
-              <ul className="mb-0 ps-3">
-                {readinessIssues.map((issue, index) => (
-                  <li key={`${issue.type}-${index}`} className="mb-2">
-                    <strong>{issue.title}</strong>: {issue.description}
-                    {issue.recommendation ? (
-                      <div className="small text-body-secondary">
-                        {issue.recommendation}
-                      </div>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
             </div>
           ) : null}
           <div className="mt-3 d-flex flex-column flex-lg-row align-items-start gap-3">


### PR DESCRIPTION
### Motivação
- O alerta amarelo “Pendências antes da publicação” duplicava informações já apresentadas na seção de bloqueios abaixo, causando poluição visual e ruído na interface.

### Description
- Removeu o bloco de alerta condicionado por `hasReadinessIssues` em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` para eliminar a duplicidade visual. 
- Eliminou as variáveis locais não usadas `readinessIssues` e `hasReadinessIssues` do mesmo arquivo. 
- Manteve o indicador de carregamento `isLoadingReadiness` e a seção detalhada de checklist (`checklistGroups`) intactos para preservar a operação e feedback ao usuário. 
- Registrou a mudança em `docs/registros/experimentos.md` conforme o processo documental do projeto.

### Testing
- Tentativa de lint com `npm --prefix frontend run lint` falhou porque o projeto não possui o script `lint`. 
- Execução de verificação de tipos com `npm run typecheck` em `frontend` falhou por falta de definições de tipo (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) e opções depreciadas no `tsconfig.json`. 
- Não foram alterados testes unitários; nenhum teste automatizado adicional foi executado com sucesso para esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ce250e73c8321811011282416d83a)