### PR TITLE
Remover cards migrados para Gera Landing da aba de Conteúdo

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -518,3 +518,13 @@
   - AGENTS.md
   - frontend/AGENTS.md
   - docs/registros/experimentos.md
+
+## 2026-05-19 20:38:34 UTC-3
+- solicitação para remover da tela de Conteúdo os cards que já migraram para o fluxo Gera Landing.
+- raciocínio aplicado: manter a tela focada apenas nas etapas que continuam sendo gerenciadas no pipeline local, evitando duplicidade operacional e ruído visual.
+- foi feito no frontend: remoção das seções/cards `Gere Wireframe`, `Gera Copy`, `Gera Preset Design` e `Gera Html` da lista renderizada na aba de geração de conteúdo.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -94,34 +94,6 @@ const CONTENT_GENERATION_SECTIONS: ContentGenerationSection[] = [
       "Crie prompts para orientar a geração de criativos visuais coerentes com o ângulo.",
     defaultQuantity: 4,
   },
-  {
-    key: "landing-layout",
-    label: "Gere Wireframe",
-    description:
-      "Estruture a arquitetura da landing em seções com hierarquia e fluxo de leitura.",
-    defaultQuantity: 1,
-  },
-  {
-    key: "landing-copy",
-    label: "Gera Copy",
-    description:
-      "Produza a copy completa da landing seguindo o framework canônico de conversão.",
-    defaultQuantity: 1,
-  },
-  {
-    key: "landing-design-preset",
-    label: "Gera Preset Design",
-    description:
-      "Defina direcionamentos visuais para garantir consistência de estilo e identidade.",
-    defaultQuantity: 1,
-  },
-  {
-    key: "landing-html",
-    label: "Gera Html",
-    description:
-      "Monte o HTML provisório da landing com base nas etapas anteriores.",
-    defaultQuantity: 1,
-  },
 ];
 
 const SECTION_LABEL_BY_KEY: Record<ContentGenerationSectionKey, string> =


### PR DESCRIPTION
### Motivation
- Remover da UI de geração de conteúdo as etapas que já foram deslocadas para o fluxo centralizado Gera Landing para evitar duplicidade operacional e reduzir ruído visual. 
- Manter a aba de Conteúdo focada apenas nas etapas ainda gerenciadas pelo pipeline local (ângulo da campanha, texto do anúncio e prompt de imagens).

### Description
- Removido do array `CONTENT_GENERATION_SECTIONS` em `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx` os itens `landing-layout` (`Gere Wireframe`), `landing-copy` (`Gera Copy`), `landing-design-preset` (`Gera Preset Design`) e `landing-html` (`Gera Html`).
- Ajustada a construção de `SECTION_LABEL_BY_KEY` e demais lógicas que derivam de `CONTENT_GENERATION_SECTIONS` ao reduzir a lista de seções visíveis. 
- Registrada a alteração no arquivo canônico `docs/registros/experimentos.md` com timestamp UTC-3 e descrição do trabalho conforme as regras do projeto.

### Testing
- Verificação automatizada por busca de texto executada com `rg "Gere Wireframe|Gera Copy|Gera Preset Design|Gera Html" frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx -n` confirmou ausência das labels removidas (sem ocorrências).
- Alterações validadas localmente através de inspeção dos arquivos `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx` e `docs/registros/experimentos.md`, sem testes de build/unit adicionais executados neste PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf43c1f9883219c013d390bec69ab)