### PR TITLE
oprm-coletor-mei: compute and publish CNAE marketSizes from Estabelecimentos zips

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -87,3 +87,5 @@
 - 2026-05-19 09:55:00 (UTC-3): ajuste solicitado para reagendar a próxima execução da importação OPRM CNPJ/CNAE para **10:00 de hoje (19/05)** no fuso `America/Sao_Paulo`, com cron hardcoded `0 0 10 19 5 *` na anotação `@Scheduled` de `runScheduledImport`.
 
 - 2026-05-19 01:40:00 (UTC-3): ajuste solicitado no `oprm-coletor-mei` para reagendar o coletor CNPJ/CNAE para **04:40** no fuso `America/Sao_Paulo`, atualizando o cron hardcoded de `runScheduledImport` para `0 40 4 * * *` e sincronizando o cron padrão em `application.yml` para o mesmo horário.
+
+- 2026-05-20 00:00:00 (UTC): revisão do `runScheduledImport` no `oprm-coletor-mei` confirmou ausência de totalização por CNAE no payload `marketSizes` (sempre `null`). Implementada totalização incremental por CNAE a partir dos arquivos `Estabelecimentos*.zip` no próprio coletor (contagem de `totalEstabelecimentos` e `totalEstabelecimentosAtivos` por `cnae_principal`), com acúmulo em memória durante a run e publicação do snapshot acumulado em `marketSizes` nos eventos `COMPLETED` de cada arquivo de estabelecimentos para persistência em `oprm_market_size_by_cnae` no backend.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
@@ -8,6 +8,7 @@ import com.marketinghub.oprmcoletormei.marketimport.dto.OprmCnaeUpsertDto;
 import com.marketinghub.oprmcoletormei.marketimport.dto.OprmImportFileEventRequestDto;
 import com.marketinghub.oprmcoletormei.marketimport.dto.OprmImportFileSeedDto;
 import com.marketinghub.oprmcoletormei.marketimport.dto.OprmImportRunCreatedResponseDto;
+import com.marketinghub.oprmcoletormei.marketimport.dto.OprmMarketSizeUpsertDto;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -20,7 +21,9 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -95,6 +98,7 @@ public class OprmMarketImportScheduler {
         long totalRowsRejected = 0L;
         int filesProcessed = 0;
         boolean hasFailure = false;
+        Map<String, MarketSizeAccumulator> accumulatedMarketSizesByCnae = new LinkedHashMap<>();
         try {
             Files.createDirectories(runTempDir);
             log.info("[run={}] Diretório temporário criado: {}", runResponse.runId(), runTempDir);
@@ -112,18 +116,22 @@ public class OprmMarketImportScheduler {
                     List<OprmCnaeUpsertDto> cnaes = "CNAE".equalsIgnoreCase(file.datasetType())
                             ? parseCnaesFromZip(zipPath, runResponse.runId(), fileId, file.fileName())
                             : null;
+                    List<OprmMarketSizeUpsertDto> marketSizes = "ESTABELECIMENTOS".equalsIgnoreCase(file.datasetType())
+                            ? parseAndAccumulateMarketSizesFromEstablishmentsZip(
+                            zipPath, runResponse.runId(), fileId, file.fileName(), accumulatedMarketSizesByCnae)
+                            : null;
                     log.info("[run={} fileId={}] Diagnóstico totalização datasetType={} cnaesCount={} marketSizesCount={} (marketSizes ainda não calculado no coletor para este arquivo)",
                             runResponse.runId(),
                             fileId,
                             file.datasetType(),
                             cnaes != null ? cnaes.size() : 0,
-                            0);
+                            marketSizes != null ? marketSizes.size() : 0);
                     totalRowsRead += rowsRead;
                     totalRowsValid += rowsValid;
                     totalRowsRejected += rowsRejected;
                     filesProcessed++;
                     publishFileEvent(runResponse.runId(), fileId, new OprmImportFileEventRequestDto(
-                            "COMPLETED", rowsRead, rowsValid, rowsRejected, null, Instant.now(), cnaes, null));
+                            "COMPLETED", rowsRead, rowsValid, rowsRejected, null, Instant.now(), cnaes, marketSizes));
                     log.info("[run={} fileId={}] Persistência status COMPLETED enviada. rowsRead={}", runResponse.runId(), fileId, rowsRead);
                 } catch (Exception e) {
                     hasFailure = true;
@@ -191,6 +199,64 @@ public class OprmMarketImportScheduler {
             return trimmed.substring(1, trimmed.length() - 1).trim();
         }
         return trimmed;
+    }
+
+    private List<OprmMarketSizeUpsertDto> parseAndAccumulateMarketSizesFromEstablishmentsZip(
+            Path zipPath,
+            Long runId,
+            Long fileId,
+            String fileName,
+            Map<String, MarketSizeAccumulator> accumulatedMarketSizesByCnae) throws IOException {
+        log.info("[run={} fileId={}] Início parse marketSizes (ESTABELECIMENTOS) de {}", runId, fileId, fileName);
+        try (InputStream in = Files.newInputStream(zipPath);
+             java.util.zip.ZipInputStream zipInputStream = new java.util.zip.ZipInputStream(in, StandardCharsets.ISO_8859_1)) {
+            java.util.zip.ZipEntry entry;
+            while ((entry = zipInputStream.getNextEntry()) != null) {
+                if (entry.isDirectory()) continue;
+                String content = new String(zipInputStream.readAllBytes(), StandardCharsets.ISO_8859_1);
+                String[] lines = content.split("\\R");
+                for (String rawLine : lines) {
+                    if (rawLine == null || rawLine.isBlank()) continue;
+                    String[] cols = rawLine.split(";", -1);
+                    if (cols.length < 12) continue;
+                    String situacaoCadastral = normalizeField(cols[5]);
+                    String cnaePrincipal = normalizeField(cols[11]).replaceAll("\\D", "");
+                    if (cnaePrincipal.isBlank()) continue;
+                    MarketSizeAccumulator acc = accumulatedMarketSizesByCnae.computeIfAbsent(cnaePrincipal, key -> new MarketSizeAccumulator());
+                    acc.totalEstabelecimentos++;
+                    if ("02".equals(situacaoCadastral)) {
+                        acc.totalEstabelecimentosAtivos++;
+                    }
+                }
+                zipInputStream.closeEntry();
+            }
+        }
+        List<OprmMarketSizeUpsertDto> marketSizes = toMarketSizesPayload(accumulatedMarketSizesByCnae);
+        log.info("[run={} fileId={}] Parse marketSizes (ESTABELECIMENTOS) concluído. totalCnaesConsolidados={}",
+                runId, fileId, marketSizes.size());
+        return marketSizes;
+    }
+
+    private List<OprmMarketSizeUpsertDto> toMarketSizesPayload(Map<String, MarketSizeAccumulator> accumulatedMarketSizesByCnae) {
+        List<OprmMarketSizeUpsertDto> payload = new ArrayList<>();
+        for (Map.Entry<String, MarketSizeAccumulator> entry : accumulatedMarketSizesByCnae.entrySet()) {
+            MarketSizeAccumulator acc = entry.getValue();
+            payload.add(new OprmMarketSizeUpsertDto(
+                    entry.getKey(),
+                    acc.totalEstabelecimentos,
+                    acc.totalEstabelecimentosAtivos,
+                    0L,
+                    0L,
+                    0L,
+                    0.0
+            ));
+        }
+        return payload;
+    }
+
+    private static final class MarketSizeAccumulator {
+        private long totalEstabelecimentos;
+        private long totalEstabelecimentosAtivos;
     }
 
     private List<OprmImportFileSeedDto> buildFiles(String sourceUrl) {


### PR DESCRIPTION
### Motivation

- The backend was receiving `marketSizes` as null and therefore could not persist CNAE totalizations, so the collector must compute incremental market sizes from establishment files and publish them with file events.

### Description

- Added in-memory accumulation of market sizes keyed by `cnae_principal` using `MarketSizeAccumulator` and a `LinkedHashMap` to preserve insertion order.  
- Implemented `parseAndAccumulateMarketSizesFromEstablishmentsZip` to parse `Estabelecimentos*.zip` files, count total and active establishments per CNAE, and append the consolidated snapshot as `List<OprmMarketSizeUpsertDto>`.  
- Integrated accumulation into the main run flow by creating `accumulatedMarketSizesByCnae`, calling the parser for `ESTABELECIMENTOS` files, and including `marketSizes` in the `COMPLETED` file event payload.  
- Added `toMarketSizesPayload` helper and minor logging updates to report `marketSizesCount` per file and a `MarketSizeAccumulator` inner class.

### Testing

- Ran the project test suite with `./mvnw test` and performed a full build with `./mvnw verify`, both of which completed successfully.  
- No new automated integration tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf717100c8321a1e203f61d282c5c)