### PR TITLE
fix: align mois sales library worker deploy env with ai-worker secret pattern

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -233,3 +233,13 @@
   - docs/canonical/mois-worker-canon.v1.md
   - docs/canonical/system-governance-canon.v2.md
   - docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-worker-biblioteca-sales-pages.md
+
+## 2026-05-19 21:29:49 UTC-3
+- diagnóstico de falha operacional no worker da biblioteca de sales pages: jobs em FAILED por ausência de chave OpenAI no runtime do deploy.
+- análise de causa-raiz comparando composição do `mois-sales-library-worker` com o padrão já funcional do `ai-worker` no mesmo host.
+- ajuste aplicado no `docker-compose.deploy.yml` do módulo para incluir variáveis de ambiente de runtime (backend/base URL, polling e OpenAI) e bind mount do arquivo de segredo `OPENAI_API_KEY_HOST_FILE -> /run/secrets/openai_api_key`, alinhando o padrão de injeção de secret usado no ai-worker.
+- documentos lidos para tratar a situação:
+  - ai-worker/docker-compose.yml
+  - mois-sales-library-worker/docker-compose.yml
+  - mois-sales-library-worker/docker-compose.deploy.yml
+  - docs/registros/mois1.md

--- a/mois-sales-library-worker/docker-compose.deploy.yml
+++ b/mois-sales-library-worker/docker-compose.deploy.yml
@@ -1,3 +1,17 @@
 services:
   mois-sales-library-worker:
     image: ${MOIS_SALES_LIBRARY_WORKER_IMAGE:-ghcr.io/marketing-hub-org/marketing-hub/mois-sales-library-worker:latest}
+    container_name: mois-sales-library-worker
+    restart: unless-stopped
+    environment:
+      BACKEND_BASE_URL: ${BACKEND_BASE_URL:-http://191.252.181.168:80}
+      MOIS_WORKSPACE_ID: ${MOIS_WORKSPACE_ID:-workspace-001}
+      MOIS_SOURCE: ${MOIS_SOURCE:-CLICKBANK}
+      MOIS_SOURCES: ${MOIS_SOURCES:-CLICKBANK,HOTMART}
+      MOIS_POLL_INTERVAL_MS: ${MOIS_POLL_INTERVAL_MS:-15000}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_API_KEY_FILE: ${OPENAI_API_KEY_FILE:-/run/secrets/openai_api_key}
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
+      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-5.2}
+    volumes:
+      - ${OPENAI_API_KEY_HOST_FILE:-/root/infra/openai-token/openai_api_key}:/run/secrets/openai_api_key:ro


### PR DESCRIPTION
### Motivation
- The `mois-sales-library-worker` jobs were failing with `OpenAI api key não configurada` because the deploy compose did not provide the OpenAI secret file or runtime environment used by the working `ai-worker` instance.
- Align the deploy composition with the existing, functional secret-injection pattern so the worker can resolve `OPENAI_API_KEY_FILE` at runtime. 

### Description
- Updated `mois-sales-library-worker/docker-compose.deploy.yml` to add `container_name`, `restart: unless-stopped`, runtime `environment` variables and a `volumes` bind for the OpenAI secret file.
- Added `BACKEND_BASE_URL` default to `http://191.252.181.168:80` and MOIS runtime settings (`MOIS_WORKSPACE_ID`, `MOIS_SOURCE`, `MOIS_SOURCES`, `MOIS_POLL_INTERVAL_MS`).
- Exposed OpenAI configuration in the deploy compose by adding `OPENAI_API_KEY`, `OPENAI_API_KEY_FILE`, `OPENAI_BASE_URL` and `OPENAI_MODEL` environment entries and binding `${OPENAI_API_KEY_HOST_FILE}` to `/run/secrets/openai_api_key:ro`.
- Recorded the operational diagnosis and the applied fix in `docs/registros/mois1.md` with timestamped entry. 

### Testing
- Attempted to validate the rendered deploy compose with `docker compose -f mois-sales-library-worker/docker-compose.deploy.yml config`, but the execution environment lacks the Docker CLI (`docker: command not found`), so compose validation could not be run here.
- No unit tests were modified or executed as part of this change; existing module tests remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0039327c832182fc64f1430b8542)