### PR TITLE
Fix missing running-job status on Gera Imagem card

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -539,3 +539,16 @@
   - ai-worker/AGENTS.md
   - docs/registros/experimentos.md
   - ai-worker/src/main/resources/application.properties
+
+## 2026-05-20 21:55:00 UTC
+- solicitação para alinhar o card `3 - Gera Imagem` com os demais cards da página, exibindo o status do job imediatamente após clicar em iniciar.
+- causa-raiz identificada: o bloco `Gera Prompt Imagem` não renderizava a seção de jobs pendentes/em execução, diferente dos cards anteriores (`Gera Wireframe` e `Gera Copy`).
+- foi feito no frontend:
+  - inclusão da listagem de jobs pendentes/em execução no bloco `Gera Prompt Imagem` (Job ID, Status e Data-hora);
+  - inclusão de spinner no botão `Iniciar` durante requisição assíncrona para manter padrão visual/operacional dos demais cards.
+- impacto esperado: ao iniciar a etapa, o usuário passa a visualizar imediatamente o status do job ativo, reduzindo percepção de falha e mantendo consistência de UX entre etapas.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/experiment/ExperimentDetailPage.tsx

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -2277,8 +2277,60 @@ export default function ExperimentDetailPage() {
                         hasRunningGeraLandingImagePromptsExecution
                       }
                     >
-                      {isStartingImagePrompts ? "Iniciando..." : "Iniciar"}
+                      {isStartingImagePrompts ? (
+                        <>
+                          <span
+                            className="spinner-border spinner-border-sm me-2"
+                            role="status"
+                            aria-hidden="true"
+                          />
+                          Iniciando...
+                        </>
+                      ) : (
+                        "Iniciar"
+                      )}
                     </button>
+                    {isLoadingPendingGeraLandingImagePromptsExecutions ? (
+                      <p className="text-muted mb-0">Carregando jobs da etapa...</p>
+                    ) : runningGeraLandingImagePromptsExecutions.length === 0 ? (
+                      <p className="text-muted mb-0">
+                        Nenhum job pendente ou em execução.
+                      </p>
+                    ) : (
+                      <div className="table-responsive">
+                        <table className="table table-sm align-middle mb-0">
+                          <thead>
+                            <tr>
+                              <th scope="col">Job ID</th>
+                              <th scope="col">Status</th>
+                              <th scope="col">Data-hora</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {runningGeraLandingImagePromptsExecutions.map(
+                              (execution) => (
+                                <tr key={execution.idJob}>
+                                  <td>
+                                    <Link
+                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                      className="fw-semibold text-decoration-none"
+                                    >
+                                      {execution.idJob}
+                                    </Link>
+                                  </td>
+                                  <td>{execution.status}</td>
+                                  <td>
+                                    {formatDateTimeValue(
+                                      execution.executionRequestedAt,
+                                    )}
+                                  </td>
+                                </tr>
+                              ),
+                            )}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
                   </div>
                   <div className="rounded border bg-light-subtle p-3 d-flex flex-column gap-3">
                     <h6 className="mb-0">Histórico de execuções</h6>


### PR DESCRIPTION
### Motivation
- Align the UX of the "3 - Gera Imagem" card with other stage cards so users see job status immediately after starting the step. 
- The `Gera Prompt Imagem` block did not render the pending/running jobs section, causing inconsistent behavior and user confusion.

### Description
- Updated `frontend/src/pages/experiment/ExperimentDetailPage.tsx` to add the pending/running executions listing for the `Gera Prompt Imagem` block, rendering a table with `Job ID`, `Status` and `Data-hora` when present. 
- Added spinner markup inside the `Iniciar` button for `Gera Prompt Imagem` so the button shows a loading state consistent with other cards. 
- Recorded the change and root-cause analysis in `docs/registros/experimentos.md`.

### Testing
- Ran `npm --prefix frontend run prettier -- --check src/pages/experiment/ExperimentDetailPage.tsx` which failed because the project `package.json` does not include a `prettier` script (pre-existing setup issue). 
- Ran `cd frontend && npm run typecheck` which failed due to pre-existing TypeScript environment issues (missing type definitions for `@testing-library/jest-dom`, `vite/client`, `vitest/globals` and deprecated `tsconfig` options) and are unrelated to this change. 
- No backend/API contract changes were required and no new automated frontend tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d049220d083218c7c79cc85a98a33)