### PR TITLE
Remove obsolete items from Experiment Overview tab

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -552,3 +552,16 @@
   - frontend/AGENTS.md
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/ExperimentDetailPage.tsx
+
+## 2026-05-20 22:20:00 UTC
+- solicitação para limpar a aba `Overview` do experimento removendo informações obsoletas.
+- causa-raiz identificada: a aba continha componentes/linhas legadas que adicionavam ruído e não agregavam mais ao fluxo atual.
+- foi feito no frontend:
+  - remoção do item `E-mail de amostra` com valor `Obsoleto` da listagem principal da `Overview`;
+  - remoção dos painéis `ExperimentLearningPanel` e `ExperimentReportPanel` da aba `Overview`, mantendo foco na ficha resumida do experimento.
+- impacto esperado: visão geral mais objetiva, com menos informações obsoletas e melhor legibilidade para operação diária.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/experiment/ExperimentDetailPage.tsx

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -25,8 +25,6 @@ import {
   type ExperimentCampaignResetSummary,
 } from "../../api/experiment/useExperimentCampaignReset";
 import ExperimentFunnelTab from "./ExperimentFunnelTab";
-import ExperimentReportPanel from "./ExperimentReportPanel";
-import ExperimentLearningPanel from "./ExperimentLearningPanel";
 import ExperimentContentGenerationTab from "./ExperimentContentGenerationTab";
 import { ExperimentAudienceTab } from "./ExperimentAudienceTab";
 import LandingTab from "./LandingTab";
@@ -1450,10 +1448,6 @@ export default function ExperimentDetailPage() {
       value: data.sampleEmailsToGenerate ?? "—",
     },
     {
-      label: "E-mail de amostra",
-      value: "Obsoleto",
-    },
-    {
       label: "Fluxo de portal do lead",
       value: data.leadPortalFlowName ? (
         <div className="d-flex flex-column">
@@ -1955,8 +1949,6 @@ export default function ExperimentDetailPage() {
                   </dl>
                 </div>
               </div>
-              <ExperimentLearningPanel experimentId={expId} />
-              <ExperimentReportPanel experimentId={expId} />
             </div>
           </Tabs.Content>
           <Tabs.Content value="funnel" asChild>


### PR DESCRIPTION
### Motivation
- The Overview tab contained legacy fields and panels that no longer add value and create visual noise, so the view was simplified to keep the page focused on the experiment summary.

### Description
- Removed the unused imports `ExperimentLearningPanel` and `ExperimentReportPanel` and stopped rendering those panels inside the `overview` tab in `frontend/src/pages/experiment/ExperimentDetailPage.tsx`.
- Removed the obsolete overview row `"E-mail de amostra: Obsoleto"` from the experiment details list in `ExperimentDetailPage.tsx`.
- Added an entry to `docs/registros/experimentos.md` documenting the change per the repository operational contract.

### Testing
- Attempted frontend build with `npm -C frontend run -s build`, which failed in the current environment due to missing runtime toolchain (`vite: not found`).
- No automated unit tests were executed in this environment; code changes are limited and confined to UI rendering and docs only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0a87f09c8321aa3bffb1fe86d2fc)