### PR TITLE
Remover comentário AUTO do HTML provisório do Gera Landing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -276,10 +276,7 @@ public class GeraLandingStageExecutionService {
         String enrichedImagePlanning = landingPageImageInjector.injectImageUrlsIntoPlanning(
                 experimentId,
                 experiment.getLandingPageImagePlanning());
-        String provisionalHtml = """
-                <!-- AUTO: provisional html generated manually by /geralanding/html/provisional/generate -->
-                %s
-                """.formatted(htmlWithGeneratedImages);
+        String provisionalHtml = htmlWithGeneratedImages;
 
         if (StringUtils.hasText(enrichedImagePlanning)) {
             experiment.setLandingPageImagePlanning(enrichedImagePlanning);

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -552,3 +552,17 @@
   - frontend/AGENTS.md
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/ExperimentDetailPage.tsx
+
+## 2026-05-20 01:15:00 UTC
+- solicitação para retirar o comentário HTML automático `<!-- AUTO: provisional html generated manually by /geralanding/html/provisional/generate -->` do fluxo Gera Landing e ajustar testes unitários relacionados.
+- causa-raiz identificada: o serviço de geração de HTML provisório adicionava um comentário técnico no conteúdo persistido (`landingPageHtml`/`provisionalHtml`), criando acoplamento desnecessário do artefato final com metadado operacional.
+- foi feito no backend:
+  - remoção da concatenação do comentário AUTO na montagem do `provisionalHtml`, mantendo apenas o HTML efetivamente gerado/injetado.
+- testes executados:
+  - execução dos testes unitários de controller e service do Gera Landing para validar que a remoção não quebrou contratos existentes.
+- impacto esperado: HTML provisório persistido limpo (sem comentário de controle), reduzindo ruído no artefato e evitando validações dependentes desse marcador.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java


### PR DESCRIPTION
### Motivation
- Evitar que o HTML provisório persistido contenha metadado operacional em forma de comentário HTML, reduzindo ruído no artefato final e acoplamento desnecessário.
- Prevenir testes e validações que dependam desse marcador técnico no conteúdo armazenado.

### Description
- Remove a concatenação do comentário `<!-- AUTO: provisional html generated manually by /geralanding/html/provisional/generate -->` e passa a atribuir `provisionalHtml` diretamente como o resultado de `htmlWithGeneratedImages` em `backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java`.
- Atualiza o registro de alterações em `docs/registros/experimentos.md` informando a ação realizada, causa-raiz e impacto esperado.
- Mantém a lógica de injeção de imagens e persistência em `landingPageHtml`/`provisionalHtml` sem outros comportamentos adicionais.

### Testing
- Foi tentado executar `./mvnw -q -Dtest=GeraLandingStageExecutionServiceTest,GeraLandingContollerTest test` mas o wrapper não existe nesse módulo, então a execução falhou por ausência do `./mvnw` (expected environment issue).
- Executado `mvn -q -Dtest=GeraLandingStageExecutionServiceTest,GeraLandingContollerTest test` no diretório `backend/ads-service` e os testes de `GeraLandingStageExecutionServiceTest` e `GeraLandingContollerTest` foram executados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0a03a454832197bc4dcfef3af720)