### PR TITLE
Format 'Atualizado em' in MOIS sales pages to São Paulo timezone

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -243,3 +243,19 @@
   - mois-sales-library-worker/docker-compose.yml
   - mois-sales-library-worker/docker-compose.deploy.yml
   - docs/registros/mois1.md
+
+## 2026-05-19 22:24:46 UTC-3
+- ajuste de usabilidade na tela de Biblioteca de Páginas de Vendas (MOIS) para exibir o campo "Atualizado em" no fuso de São Paulo com formato mais legível para operação diária.
+- foi criada função de formatação no frontend convertendo timestamps ISO para  com timezone .
+- aplicado o novo formato na coluna de jobs de análise para substituir o formato técnico UTC bruto.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+
+## 2026-05-19 22:24:58 UTC-3
+- correção de registro anterior: os literais `pt-BR` e `America/Sao_Paulo` não foram preservados por interpretação de shell no append anterior.
+- o ajuste implementado no frontend usa `Intl.DateTimeFormat("pt-BR", { timeZone: "America/Sao_Paulo" })` para exibir data/hora local de São Paulo no campo "Atualizado em" da fila de jobs.
+- mantido formato legível com dia/mês/ano e hora:minuto:segundo para facilitar leitura operacional.
+- documentos lidos para tratar a situação:
+  - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+  - docs/registros/mois1.md

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -13,6 +13,30 @@ import {
 const WORKSPACE_ID = "workspace-001";
 const PAGE_SIZE = 20;
 
+const SAO_PAULO_TIMEZONE = "America/Sao_Paulo";
+
+function formatDateTimeInSaoPaulo(value?: string | null) {
+  if (!value) {
+    return "—";
+  }
+
+  const parsedDate = new Date(value);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    timeZone: SAO_PAULO_TIMEZONE,
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(parsedDate);
+}
+
+
 function SimplePaginator({
   page,
   pageSize,
@@ -153,7 +177,7 @@ export default function MoisSalesPagesLibraryPage() {
                           <span className={`badge ${getSalesLibraryJobBadgeClass(job)}`}>{job.status}</span>
                         </td>
                         <td>{job.attempts}</td>
-                        <td>{job.updatedAt || "—"}</td>
+                        <td>{formatDateTimeInSaoPaulo(job.updatedAt)}</td>
                         <td>{job.errorMessage || "—"}</td>
                       </tr>
                     ))


### PR DESCRIPTION
### Motivation
- Dates in the MOIS "Biblioteca de Páginas de Vendas" jobs table were shown as raw ISO/UTC strings, which is hard for local operators to read and compare quickly. 

### Description
- Added `SAO_PAULO_TIMEZONE` constant and `formatDateTimeInSaoPaulo` helper in `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx` to format ISO timestamps using `Intl.DateTimeFormat("pt-BR", { timeZone: "America/Sao_Paulo" })` with seconds. 
- Replaced the raw render of `job.updatedAt` with `formatDateTimeInSaoPaulo(job.updatedAt)` in the jobs table. 
- Appended an operational record to `docs/registros/mois1.md` describing the UI change and a correction note about preserved locale/timezone literals. 

### Testing
- Attempted to run frontend tests with `npm run -s test -- --runInBand`, which failed in this environment due to missing `vitest` (`vitest: not found`).
- Manual inspection and a local static review of the modified file were performed to verify the formatting logic and fallback behavior for `null`/invalid timestamps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0d31bd18832199f8effc68e6c1b9)