### PR TITLE
Remove AUTO comment from GeraLanding design preset HTML output

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -464,7 +464,6 @@ public class GeraLandingStageExecutionService {
         }
         String htmlWithGeneratedImages = landingPageImageInjector.injectImages(experiment.getId(), completeHtml);
         return """
-                <!-- AUTO: provisional html regenerated after landing-page-design-preset completion -->
                 %s
                 """.formatted(htmlWithGeneratedImages);
     }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -578,3 +578,15 @@
   - backend/AGENTS.md
   - docs/registros/experimentos.md
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+
+## 2026-05-20 22:30:00 UTC
+- solicitação para retirar o comentário HTML automático `<!-- AUTO: provisional html regenerated after landing-page-design-preset completion -->` do retorno de `resolveDesignPresetProvisionalHtml`.
+- causa-raiz identificada: o método seguia inserindo metadado técnico no HTML final da etapa, gerando ruído no artefato exibido/armazenado.
+- foi feito no backend:
+  - remoção do comentário `AUTO` da string retornada, mantendo apenas o conteúdo HTML processado em `%s`.
+- impacto esperado: artefato de HTML provisório mais limpo e sem marcador operacional embutido no conteúdo.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java


### PR DESCRIPTION
### Motivation
- The provisional HTML returned by the design-preset flow contained an `AUTO` HTML comment that injected operational metadata into persisted/displayed artifacts, creating noise and potential coupling with validations.
- Removing the marker keeps the stored/served `provisionalHtml` clean and focused on the user-visible content.

### Description
- Removed the `<!-- AUTO: provisional html regenerated after landing-page-design-preset completion -->` marker from the string returned by `resolveDesignPresetProvisionalHtml` in `backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java` so only the generated HTML is returned.
- Added an entry to `docs/registros/experimentos.md` documenting the request, root cause, change implemented, and expected impact.

### Testing
- Ran the targeted unit tests with `cd backend/ads-service && mvn -Dtest=GeraLandingStageExecutionServiceTest test` and observed a successful build.
- Test results: `Tests run: 10, Failures: 0, Errors: 0` (BUILD SUCCESS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0e0f02ac832195a699c4b8aee80b)