### PR TITLE
Ajustar agendamento do importador OPRM CNPJ para 23:30 (America/Sao_Paulo)

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -91,3 +91,5 @@
 - 2026-05-20 00:00:00 (UTC): revisão do `runScheduledImport` no `oprm-coletor-mei` confirmou ausência de totalização por CNAE no payload `marketSizes` (sempre `null`). Implementada totalização incremental por CNAE a partir dos arquivos `Estabelecimentos*.zip` no próprio coletor (contagem de `totalEstabelecimentos` e `totalEstabelecimentosAtivos` por `cnae_principal`), com acúmulo em memória durante a run e publicação do snapshot acumulado em `marketSizes` nos eventos `COMPLETED` de cada arquivo de estabelecimentos para persistência em `oprm_market_size_by_cnae` no backend.
 
 - 2026-05-20 08:50:00 (UTC-3): ajuste solicitado para reagendar a execução diária do coletor OPRM CNPJ/CNAE para **21:40** no fuso `America/Sao_Paulo`, com atualização do cron hardcoded de `runScheduledImport` para `0 40 21 * * *` e sincronização do cron padrão em `application.yml` para o mesmo horário.
+
+- 2026-05-20: Ajustado agendamento do importador OPRM CNPJ (runScheduledImport) de 21:40 para 23:30 (America/Sao_Paulo), conforme solicitação operacional.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
@@ -47,7 +47,7 @@ public class OprmMarketImportScheduler {
         this.restClient = restClient;
     }
 
-    @Scheduled(cron = "0 40 21 * * *", zone = "America/Sao_Paulo")
+    @Scheduled(cron = "0 30 23 * * *", zone = "America/Sao_Paulo")
     public void runScheduledImport() {
         if (!scheduleProperties.enabled()) {
             log.info("Scheduler OPRM market import desabilitado.");
@@ -147,7 +147,7 @@ public class OprmMarketImportScheduler {
             publishRunComplete(runResponse.runId(), filesProcessed, totalRowsRead, totalRowsValid, totalRowsRejected, hasFailure);
         }
 
-        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 21:40 ({}) com {} arquivos.",
+        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 23:30 ({}) com {} arquivos.",
                 snapshotDate,
                 scheduleProperties.timezone(),
                 files.size());


### PR DESCRIPTION
### Motivation
- Ajuste operacional para reagendar a execução diária do coletor OPRM CNPJ/CNAE para 23:30 no fuso `America/Sao_Paulo`.
- Atualizar documentação interna de registros para refletir o novo horário de execução solicitado.

### Description
- Alterado o cron da anotação `@Scheduled` no método `runScheduledImport` da classe `OprmMarketImportScheduler` de `0 40 21 * * *` para `0 30 23 * * *` (fuso `America/Sao_Paulo`).
- Atualizada a mensagem de log final em `runScheduledImport` para indicar o novo horário `23:30` no texto informativo da execução agendada.
- Atualizado o arquivo de registro `docs/registros/oprm1.md` para documentar o ajuste do agendamento de `21:40` para `23:30`.

### Testing
- Nenhum teste automatizado foi executado como parte desta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d14c2388c8321a3e3739d61cc67fa)