### PR TITLE
Remove duplicate landing validation in experiment detail checklist

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -599,3 +599,15 @@
   - AGENTS.md
   - docs/registros/experimentos.md
 
+
+## 2026-05-20 23:40:00 UTC
+- solicitação para remover validação duplicada de landing na tela de detalhes do experimento.
+- causa-raiz identificada: a mesma condição de validação de URL de destino da landing estava aparecendo em dois grupos de checklist diferentes (bloqueios e fluxo operacional), gerando redundância visual.
+- foi feito no frontend:
+  - removido o item duplicado "Landing aprovada como destino da campanha" do `operationalChecklist`, mantendo a validação apenas em "Bloqueios de publicação".
+- impacto esperado: checklist mais claro, sem repetição de informação e com foco nas validações realmente distintas.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/experiment/ExperimentDetailPage.tsx

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1306,16 +1306,6 @@ export default function ExperimentDetailPage() {
 
   const operationalChecklist: ChecklistItem[] = [
     {
-      id: "landing-destination",
-      title: "Landing aprovada como destino da campanha",
-      isMet: Boolean(data.followUpActionUrl),
-      hint: data.followUpActionUrl
-        ? `URL de destino ativa: ${data.followUpActionUrl}.`
-        : "Aprove uma landing na aba Landing para definir a URL de destino da campanha.",
-      action: data.followUpActionUrl ? undefined : openLandingActions,
-      actionLabel: data.followUpActionUrl ? undefined : "Ir para Landing",
-    },
-    {
       id: "platform",
       title: "Plataforma configurada para Facebook Ads",
       isMet: data.platform === "FACEBOOK",


### PR DESCRIPTION
### Motivation
- Remover redundância visual na tela de detalhes do experimento onde a mesma validação de URL de destino da landing aparecia em dois grupos de checklist distintos.

### Description
- Removido o item `landing-destination` do `operationalChecklist` em `frontend/src/pages/experiment/ExperimentDetailPage.tsx`, mantendo a validação apenas no grupo `blockingChecklist`.
- Atualizado o registro de atividade em `docs/registros/experimentos.md` documentando causa-raiz e a ação aplicada.
- Nenhuma lógica de validação foi alterada; a verificação continua a usar `data.followUpActionUrl` como condição de presença.

### Testing
- Executado `npm run typecheck` em `frontend`, que falhou por falta de definições de tipos e configurações de `tsconfig` no ambiente atual, mas a falha é ambiental e não relacionada à remoção pontual do item de checklist.
- Não foram executados testes unitários adicionais neste patch; alteração é estritamente de apresentação (UI) e registro de documento.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d1d41d3e88321bd22ffc0b02f529a)