### PR TITLE
MOIS: adicionar status operacionais e filtros na Biblioteca de Páginas de Vendas

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -66,6 +66,38 @@ O worker seleciona a fonte por ciclo com a seguinte ordem canônica:
 ## 8. Regra canônica de timeout OpenAI Batch (MOIS Worker)
 Para integrações batch com OpenAI no contexto do MOIS Worker, o timeout canônico é de **30 minutos** (`300000 ms` / `PT30M`), e não deve ser reduzido sem versionamento explícito deste cânone.
 
+
+## 8.1 Taxonomia canônica de status (monitoramento de fetching)
+Para acompanhamento operacional na tela de Biblioteca de Páginas de Vendas, o status de job deve refletir a etapa real do pipeline e permitir diagnóstico de causa-raiz sem depender apenas de `errorMessage`.
+
+### 8.1.1 Estados canônicos (v1.1 planejado)
+1. `PENDING`
+   - Job criado e aguardando claim pelo worker.
+2. `FETCHING`
+   - Worker em coleta/parsing da página de origem.
+3. `ANALYZING`
+   - Conteúdo já coletado e enviado para processamento OpenAI (batch em andamento).
+4. `RETRY_WAIT`
+   - Falha transitória detectada; job aguardando nova tentativa automática.
+5. `DONE`
+   - Análise concluída e persistida com sucesso.
+6. `FAILED`
+   - Falha terminal após esgotar tentativas ou erro não recuperável de contrato/integração.
+
+### 8.1.2 Regras mínimas de exibição na UI
+- Exibir badge por status e tooltip com definição operacional curta.
+- Exibir coluna `Último evento` com motivo objetivo da etapa atual (ex.: `batch.status=running`, `connect timeout`, `output_file_id ausente`).
+- Exibir coluna `Tempo em etapa` (`agora - updatedAt`) para detectar stuck jobs em `FETCHING`/`ANALYZING`.
+- Exibir `Tentativas` + `Próxima tentativa em` quando status for `RETRY_WAIT`.
+- Exibir CTA de diagnóstico (link para detalhe do job) quando status for `FAILED`.
+
+### 8.1.3 Critérios de transição
+- `PENDING -> FETCHING`: claim confirmado pelo backend.
+- `FETCHING -> ANALYZING`: coleta concluída e requisição batch enviada com sucesso.
+- `ANALYZING -> DONE`: output válido persistido em `:complete`.
+- `ANALYZING -> RETRY_WAIT`: timeout/intermitência recuperável com orçamento de retry restante.
+- `FETCHING|ANALYZING|RETRY_WAIT -> FAILED`: erro terminal de contrato, parsing irrecuperável ou retries esgotados.
+
 ## 9. Restrições e conformidade
 - O worker **não acessa banco diretamente**; todo tráfego de dados passa pelo backend principal.
 - Transições de estado devem ocorrer exclusivamente pelos endpoints do backend MOIS.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -259,3 +259,12 @@
 - documentos lidos para tratar a situação:
   - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
   - docs/registros/mois1.md
+
+## 2026-05-19 23:51:38 UTC-3
+- solicitado planejar melhor acompanhamento de casos em `FETCHING` na tela da biblioteca MOIS, com base em documento canônico.
+- revisado o cânone do worker MOIS e proposta taxonomia explícita de estados operacionais para reduzir ambiguidade no diagnóstico.
+- atualizada a UI de fila de jobs para incluir filtros `ANALYZING` e `RETRY_WAIT` e legenda operacional dos status na própria tela.
+- documentos lidos para tratar a situação:
+  - docs/canonical/system-governance-canon.v2.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -144,6 +144,8 @@ export default function MoisSalesPagesLibraryPage() {
               <option value="">Todos os status</option>
               <option value="PENDING">PENDING</option>
               <option value="FETCHING">FETCHING</option>
+              <option value="ANALYZING">ANALYZING</option>
+              <option value="RETRY_WAIT">RETRY_WAIT</option>
               <option value="DONE">DONE</option>
               <option value="FAILED">FAILED</option>
             </select>
@@ -185,6 +187,9 @@ export default function MoisSalesPagesLibraryPage() {
                 </tbody>
               </table>
               <SimplePaginator page={jobsQuery.data.page} pageSize={jobsQuery.data.pageSize} total={jobsQuery.data.total} onChange={setJobsPage} />
+              <div className="alert alert-light border mt-3 mb-0 small">
+                <strong>Status operacionais:</strong> PENDING (na fila), FETCHING (coletando página), ANALYZING (processando OpenAI), RETRY_WAIT (aguardando nova tentativa), DONE (concluído), FAILED (falha terminal).
+              </div>
             </>
           ) : null}
         </div>


### PR DESCRIPTION
### Motivation
- Melhorar a observabilidade de jobs “presos em FETCHING” distinguindo coleta, análise OpenAI e tentativas de retry para facilitar diagnóstico de causa-raiz. 
- Fornecer uma base canônica (documento de cânone) para alinhar backend e UI sobre os estados operacionais do worker MOIS.

### Description
- Adiciona seção "Taxonomia canônica de status (monitoramento de fetching)" em `docs/canonical/mois-worker-canon.v1.md` com os estados `PENDING`, `FETCHING`, `ANALYZING`, `RETRY_WAIT`, `DONE` e `FAILED`, regras mínimas de exibição e critérios de transição. 
- Atualiza a tela `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx` para incluir filtros `ANALYZING` e `RETRY_WAIT` na lista de status e adiciona uma legenda operacional explicativa abaixo da tabela de jobs. 
- Registra a alteração operacional em `docs/registros/mois1.md` com timestamp conforme política de registro do projeto.

### Testing
- Executada a verificação de tipos do frontend com `cd frontend && npm run -s typecheck`, que falhou devido a definições de tipo ausentes (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) e opções de `tsconfig` depreciadas, portanto a checagem de tipo não pôde ser concluída com sucesso.
- Não foram executados testes unitários ou integrações adicionais neste ambiente automatizado durante esta mudança.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d216e61588321ba2691776cfa1793)