### PR TITLE
Fix MOIS sales-library OpenAI batch contract errors and expose failures

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -62,6 +62,7 @@ O worker seleciona a fonte por ciclo com a seguinte ordem canônica:
 - `openai.model` → `${OPENAI_MODEL:gpt-5.2}`
 - `openai.batch-poll-interval-ms` → `${OPENAI_BATCH_POLL_INTERVAL_MS:2000}`
 - `openai.batch-timeout-ms` → `${OPENAI_BATCH_TIMEOUT_MS:300000}`
+- Para payload de `/v1/responses`, o formato estruturado deve usar `text.format` (não usar `response_format`).
 
 ## 8. Regra canônica de timeout OpenAI Batch (MOIS Worker)
 Para integrações batch com OpenAI no contexto do MOIS Worker, o timeout canônico é de **30 minutos** (`300000 ms` / `PT30M`), e não deve ser reduzido sem versionamento explícito deste cânone.
@@ -102,6 +103,10 @@ Para acompanhamento operacional na tela de Biblioteca de Páginas de Vendas, o s
 - O worker **não acessa banco diretamente**; todo tráfego de dados passa pelo backend principal.
 - Transições de estado devem ocorrer exclusivamente pelos endpoints do backend MOIS.
 - Falhas devem ser registradas com contexto e stack trace para diagnóstico de causa-raiz.
+- Erros de contrato/integração OpenAI retornados no output do batch (ex.: `response.status_code >= 400` com `response.body.error`) são falhas terminais e devem:
+  1. ser convertidos em mensagem legível com `status`, `requestId`, `type`, `code` e `message`;
+  2. ser enviados ao endpoint `jobs/{jobId}:fail` para persistência;
+  3. ficar disponíveis para exibição ao usuário na tela de jobs (`errorMessage`).
 
 ## 10. Substituição documental
 Este documento é o único cânone ativo para o worker do MOIS.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -268,3 +268,16 @@
   - docs/canonical/system-governance-canon.v2.md
   - docs/canonical/mois-worker-canon.v1.md
   - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+
+## 2026-05-20 00:00:00 UTC-3
+- correção de vulnerabilidade operacional no worker da biblioteca de páginas de vendas (MOIS): erro OpenAI de contrato não estava sendo propagado para a tela de jobs.
+- ajuste no cliente OpenAI batch (`OpenAiSalesPageAnalyzer`) para usar o contrato atual da Responses API (`text.format`) no lugar de `response_format`, removendo a causa-raiz do erro `unsupported_parameter`.
+- implementado tratamento explícito de erro no output do batch quando `response.status_code >= 400` e/ou `error` de linha, com construção de mensagem detalhada (`status`, `requestId`, `type`, `code`, `message`) para persistência no backend via `jobs/{jobId}:fail`.
+- atualização do cânone `docs/canonical/mois-worker-canon.v1.md` para formalizar:
+  - uso obrigatório de `text.format` na integração `/v1/responses`;
+  - obrigatoriedade de persistir e expor ao usuário os erros de contrato OpenAI no `errorMessage` do job.
+- documentos lidos para tratar a situação:
+  - docs/canonical/system-governance-canon.v2.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
+  - mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
@@ -64,7 +64,9 @@ public class OpenAiSalesPageAnalyzer {
                                     Map.of("role", "system", "content", "Você analisa páginas de venda e responde exclusivamente em JSON válido sem markdown."),
                                     Map.of("role", "user", "content", prompt)
                             ),
-                            "response_format", Map.of("type", "json_object")
+                            "text", Map.of(
+                                    "format", Map.of("type", "json_object")
+                            )
                     )
             ));
         } catch (JsonProcessingException e) {
@@ -115,6 +117,14 @@ public class OpenAiSalesPageAnalyzer {
         try {
             String line = outputJsonl.lines().filter(StringUtils::hasText).findFirst().orElseThrow();
             JsonNode root = objectMapper.readTree(line);
+            JsonNode statusCodeNode = root.path("response").path("status_code");
+            if (statusCodeNode.isInt() && statusCodeNode.asInt() >= 400) {
+                throw new IllegalStateException(buildBatchErrorMessage(root));
+            }
+            JsonNode lineError = root.path("error");
+            if (!lineError.isMissingNode() && !lineError.isNull()) {
+                throw new IllegalStateException("OpenAI batch retornou erro de linha: " + lineError.toString());
+            }
             JsonNode outputText = root.path("response").path("body").path("output").get(0).path("content").get(0).path("text");
             if (outputText.isMissingNode() || outputText.isNull()) {
                 outputText = root.path("response").path("body").path("output_text");
@@ -135,6 +145,18 @@ public class OpenAiSalesPageAnalyzer {
             log.error("Falha parse output batch OpenAI. output={}", outputJsonl, e);
             throw new IllegalStateException("Falha ao interpretar output do batch OpenAI", e);
         }
+    }
+
+    private String buildBatchErrorMessage(JsonNode root) {
+        int status = root.path("response").path("status_code").asInt(0);
+        String requestId = root.path("response").path("request_id").asText("");
+        JsonNode error = root.path("response").path("body").path("error");
+        String upstreamMessage = error.path("message").asText("");
+        String upstreamType = error.path("type").asText("");
+        String upstreamCode = error.path("code").asText("");
+        return "OpenAI batch retornou erro HTTP " + status
+                + " (requestId=" + requestId + ", type=" + upstreamType + ", code=" + upstreamCode + "): "
+                + upstreamMessage;
     }
 
     private record FileUploadResponse(String id) {}


### PR DESCRIPTION
### Motivation
- A integração batch com a Responses API falhava com `Unsupported parameter: 'response_format'` porque o payload estava usando `response_format` em vez de `text.format`. 
- Esse erro de contrato não era capturado e persistido no job, deixando falhas opacas na UI da Biblioteca de Páginas de Vendas. 
- É necessário alinhar o cliente MOIS ao contrato atual da API e garantir que erros de integração sejam convertidos em mensagens visíveis ao usuário. 

### Description
- Alinhado o payload do batch para `/v1/responses` trocando `response_format` por `text.format` em `mois-sales-library-worker/src/main/java/.../OpenAiSalesPageAnalyzer.java` (método `buildBatchLine`).
- Adicionado tratamento explícito no parser (`parseBatchOutput`) para detectar `response.status_code >= 400` e objetos `error` em cada linha, construindo mensagem detalhada (`status`, `requestId`, `type`, `code`, `message`) via `buildBatchErrorMessage` e lançando `IllegalStateException` para acionar o fluxo de `fail` do job.
- Atualizado o cânone operacional em `docs/canonical/mois-worker-canon.v1.md` para exigir `text.format` e obrigar a persistência/exposição de erros OpenAI de contrato no `errorMessage` do job.
- Registrado o trabalho e a correção em `docs/registros/mois1.md` com diagnóstico e ações aplicadas. 

### Testing
- Executado `mvn -f mois-sales-library-worker/pom.xml test -q` e a suíte do módulo completou com sucesso. 
- Validação manual do fluxo de parse: quando a linha do batch contém `response.status_code >= 400` ou `error`, o cliente lança erro detalhado que o `PipelineRunner` já encaminha ao endpoint `jobs/{jobId}:fail` (permitindo persistência de `errorMessage`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d233d88fc83219dcc788f267195cb)