### PR TITLE
Add funnel tracking instrumentation to design-preset provisional HTML assembler

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssembler.java
@@ -1,6 +1,10 @@
 package com.marketinghub.geralanding;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -38,6 +42,7 @@ public class DesignPresetProvisionalHtmlAssembler {
                     objectMapper.writeValueAsString(copyPayload),
                     imagePlanningJson,
                     designPresetOutputJson);
+            html = appendBehaviorTrackingAttributesAndScript(html);
             return appendJobIdCommentBeforeHead(html, jobId);
         } catch (Exception e) {
             throw new IllegalArgumentException("Falha ao montar HTML provisório da fase landing-page-design-preset", e);
@@ -63,5 +68,75 @@ public class DesignPresetProvisionalHtmlAssembler {
             return comment + html;
         }
         return html.substring(0, headIndex) + comment + html.substring(headIndex);
+    }
+
+    private String appendBehaviorTrackingAttributesAndScript(String html) {
+        if (!StringUtils.hasText(html) || html.contains("data-mh-funnel-tracking")) {
+            return html;
+        }
+        Document document = Jsoup.parse(html, "", Parser.htmlParser());
+        document.outputSettings().prettyPrint(false);
+
+        for (Element section : document.select("section[data-section-id], section[id], [data-section-id]")) {
+            String sectionId = section.hasAttr("data-section-id") ? section.attr("data-section-id") : section.id();
+            if (!StringUtils.hasText(sectionId)) {
+                continue;
+            }
+            section.attr("data-track-section", sectionId.trim());
+        }
+
+        String script = """
+                <script data-mh-funnel-tracking="true">
+                (function(){
+                  if (window.__mhFunnelTrackingInstalled) return;
+                  window.__mhFunnelTrackingInstalled = true;
+                  window.dataLayer = window.dataLayer || [];
+                  function emit(name, payload){
+                    window.dataLayer.push(Object.assign({event:name, source:'landing-page-design-preset'}, payload||{}));
+                  }
+                  emit('page_view', {ts: Date.now()});
+                  var sections = Array.prototype.slice.call(document.querySelectorAll('[data-track-section]'));
+                  var stats = {};
+                  sections.forEach(function(node){
+                    var id = node.getAttribute('data-track-section');
+                    stats[id] = {visibleSince:null, elapsedMs:0};
+                  });
+                  function flushSection(id, reason){
+                    var s = stats[id];
+                    if (!s || s.visibleSince === null) return;
+                    s.elapsedMs += Date.now() - s.visibleSince;
+                    s.visibleSince = null;
+                    emit('section_view_time', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
+                  }
+                  var observer = new IntersectionObserver(function(entries){
+                    entries.forEach(function(entry){
+                      var id = entry.target.getAttribute('data-track-section');
+                      if (!id || !stats[id]) return;
+                      if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+                        if (stats[id].visibleSince === null) {
+                          stats[id].visibleSince = Date.now();
+                          emit('section_view_start', {sectionId:id});
+                        }
+                      } else {
+                        flushSection(id, 'intersection-change');
+                      }
+                    });
+                  }, {threshold:[0,0.5,1]});
+                  sections.forEach(function(node){ observer.observe(node); });
+                  document.addEventListener('visibilitychange', function(){
+                    if (document.hidden) Object.keys(stats).forEach(function(id){ flushSection(id, 'tab-hidden'); });
+                  });
+                  window.addEventListener('beforeunload', function(){
+                    Object.keys(stats).forEach(function(id){ flushSection(id, 'before-unload'); });
+                  });
+                })();
+                </script>
+                """;
+        if (document.head() != null) {
+            document.head().append(script);
+        } else {
+            document.prepend(script);
+        }
+        return document.outerHtml();
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerTest.java
@@ -1,0 +1,32 @@
+package com.marketinghub.geralanding;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DesignPresetProvisionalHtmlAssemblerTest {
+
+    @Test
+    void shouldInjectBehaviorTrackingIntoDesignPresetProvisionalHtml() {
+        DesignPresetProvisionalHtmlProcessor processor = mock(DesignPresetProvisionalHtmlProcessor.class);
+        when(processor.process(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("<html><head><title>x</title></head><body><section data-section-id='hero'></section></body></html>");
+        DesignPresetProvisionalHtmlAssembler assembler = new DesignPresetProvisionalHtmlAssembler(processor, new ObjectMapper());
+
+        String html = assembler.assemble(
+                "{\"landingPageWireframe\":{\"sectionOrder\":[]}}",
+                "{\"landingPageCopy\":{\"bodySections\":[]}}",
+                "{\"landingPageImagePlanning\":{\"images\":[]}}",
+                "{\"landingPageDesignPreset\":{\"sectionPresets\":[]}}",
+                "job-123");
+
+        assertTrue(html.contains("data-mh-funnel-tracking=\"true\""));
+        assertTrue(html.contains("page_view"));
+        assertTrue(html.contains("section_view_time"));
+        assertTrue(html.contains("data-track-section=\"hero\""));
+    }
+}

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -53,6 +53,17 @@ No fluxo atual, a geração da landing segue as etapas:
 ### 5.1 Observação obrigatória — HTML provisório por etapa
 Durante o pipeline de Gera Landing, existe produção incremental/provisória de conteúdo para permitir evolução etapa a etapa. No estágio de design preset é consolidada a base visual e ocorre a etapa usada para ingestão do pixel no fluxo atual.
 
+### 5.2 Instrumentação obrigatória de funil no assembler do design preset
+Para a etapa `LANDING_PAGE_DESIGN_PRESET`, o assembler de HTML provisório deve injetar instrumentação mínima de comportamento para diagnóstico de avanço de funil na landing:
+1. disparo de `page_view` no carregamento da página;
+2. marcação explícita das seções monitoráveis (`data-track-section` derivado de `data-section-id`/`id`);
+3. medição de tempo de visualização por seção usando `IntersectionObserver` com critério de visibilidade (>= 50%);
+4. emissão de evento consolidado por seção (`section_view_time`) com `sectionId` e `elapsedMs` sempre que a seção deixa de ficar visível, quando a aba fica oculta e no `beforeunload`.
+
+Regras complementares:
+- a instrumentação deve ser idempotente (não pode ser injetada em duplicidade no mesmo HTML);
+- o payload publicado no artefato final deve manter apenas campos/eventos previstos em contrato canônico, sem metadado técnico fora do escopo funcional.
+
 ## 6. Geração e aprovação de anúncios
 
 Após os artefatos de base:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -626,3 +626,14 @@
   - ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
   - ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
   - ai-worker/src/main/java/com/marketinghub/worker/creative/CreativeChatGptClient.java
+## 2026-05-20 00:24:25 UTC-3
+- solicitada formalização canônica e implementação de monitoramento comportamental no assembler do design preset (page_view + tempo por seção)
+- definido que a etapa `LANDING_PAGE_DESIGN_PRESET` precisa injetar instrumentação mínima idempotente para diagnóstico de avanço de funil
+- implementado no backend (`DesignPresetProvisionalHtmlAssembler`) a marcação `data-track-section` e script com eventos `page_view`, `section_view_start` e `section_view_time`
+- adicionado teste unitário (`DesignPresetProvisionalHtmlAssemblerTest`) validando a presença da instrumentação no HTML provisório
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/canonical/procedimento-experimento-canon.v1.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssembler.java


### PR DESCRIPTION
### Motivation
- Enable lightweight client-side funnel diagnostics for the `LANDING_PAGE_DESIGN_PRESET` stage by adding page and per-section visibility tracking to provisional HTML artifacts. 
- Make instrumentation idempotent and derive section identifiers from existing `data-section-id` or `id` attributes to avoid changing wireframe shape.

### Description
- Update `DesignPresetProvisionalHtmlAssembler` to call a new `appendBehaviorTrackingAttributesAndScript` step after HTML generation. 
- Implement `appendBehaviorTrackingAttributesAndScript` using `Jsoup` to add `data-track-section` attributes (from `data-section-id` or `id`) and append a single idempotent script marked with `data-mh-funnel-tracking="true"`. 
- The injected script emits a `page_view` event and tracks section visibility with `IntersectionObserver`, emitting `section_view_start` and aggregated `section_view_time` events (with `sectionId` and `elapsedMs`) on visibility changes, tab hide, and `beforeunload`. 
- Add a unit test `DesignPresetProvisionalHtmlAssemblerTest` that verifies the script and attributes are present in the assembled HTML. 
- Update documentation (`docs/canonical/procedimento-experimento-canon.v1.md` and `docs/registros/experimentos.md`) with the new instrumentation requirements and a record of the change.

### Testing
- Added unit test `DesignPresetProvisionalHtmlAssemblerTest` which asserts the presence of `data-mh-funnel-tracking`, `page_view`, `section_view_time`, and `data-track-section` in the assembled HTML, and the test passed. 
- The modified assembler was exercised by the test to validate attribute injection and script appending, and no failures were reported when running the test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d279d8cf88321a5f47e5c55947c26)