### PR TITLE
Fix MOIS job timestamps to display in GMT

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -281,3 +281,20 @@
   - docs/canonical/mois-worker-canon.v1.md
   - mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
   - mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
+
+## 2026-05-20 00:27:24 UTC-3
+- ajuste na tela MOIS Biblioteca de Páginas de Vendas para padronizar o campo "Atualizado em" no fuso GMT, eliminando ambiguidade de horário local.
+- identificado que a formatação estava fixa em America/Sao_Paulo, o que causava divergência com a expectativa operacional de leitura em GMT.
+- alterada a função de formatação para usar timezone  e sufixo literal  no valor exibido em cada linha da fila de jobs.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/mois1.md
+
+## 2026-05-20 00:27:36 UTC-3
+- correção de registro anterior: a linha de detalhe técnico perdeu os literais por expansão indevida de shell durante escrita do markdown.
+- valor correto aplicado no frontend: timezone `Etc/GMT` e sufixo literal `GMT` na coluna "Atualizado em" da fila de jobs MOIS.
+- mantido o registro anterior por política append-only, com este complemento de correção.
+- documentos lidos para tratar a situação:
+  - docs/registros/mois1.md
+  - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -13,9 +13,9 @@ import {
 const WORKSPACE_ID = "workspace-001";
 const PAGE_SIZE = 20;
 
-const SAO_PAULO_TIMEZONE = "America/Sao_Paulo";
+const GMT_TIMEZONE = "Etc/GMT";
 
-function formatDateTimeInSaoPaulo(value?: string | null) {
+function formatDateTimeInGmt(value?: string | null) {
   if (!value) {
     return "—";
   }
@@ -26,14 +26,14 @@ function formatDateTimeInSaoPaulo(value?: string | null) {
   }
 
   return new Intl.DateTimeFormat("pt-BR", {
-    timeZone: SAO_PAULO_TIMEZONE,
+    timeZone: GMT_TIMEZONE,
     day: "2-digit",
     month: "2-digit",
     year: "numeric",
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
-  }).format(parsedDate);
+  }).format(parsedDate) + " GMT";
 }
 
 
@@ -179,7 +179,7 @@ export default function MoisSalesPagesLibraryPage() {
                           <span className={`badge ${getSalesLibraryJobBadgeClass(job)}`}>{job.status}</span>
                         </td>
                         <td>{job.attempts}</td>
-                        <td>{formatDateTimeInSaoPaulo(job.updatedAt)}</td>
+                        <td>{formatDateTimeInGmt(job.updatedAt)}</td>
                         <td>{job.errorMessage || "—"}</td>
                       </tr>
                     ))


### PR DESCRIPTION
### Motivation
- The MOIS Sales Pages Library UI was rendering the "Atualizado em" column using the `America/Sao_Paulo` timezone, but the operational expectation is to display timestamps in GMT to avoid local-ambiguous readings. 

### Description
- Replaced the São Paulo formatter with a GMT formatter by introducing `GMT_TIMEZONE = "Etc/GMT"` and renaming the helper to `formatDateTimeInGmt`, which appends a literal `GMT` suffix to the rendered value. 
- Updated the jobs table to call `formatDateTimeInGmt(job.updatedAt)` instead of the previous São Paulo formatter. 
- Added two append-only operational records in `docs/registros/mois1.md` documenting the UI change and a follow-up correction entry (shell expansion fix) as required by project logging policy. 
- Files changed: `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`, `docs/registros/mois1.md`.

### Testing
- Ran the frontend typecheck with `cd frontend && npm run -s typecheck`, which failed due to missing environment type definitions (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) and TS deprecation errors in `tsconfig.json`, so no clean typecheck result could be produced in this environment. 
- No other automated tests were executed in this rollout; local code edits were verified by a successful commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d29eeb45083218f433e319dbbd0be)