### PR TITLE
Capture OpenAI error_file_id and render OpenAI JSON in MOIS jobs UI

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -104,9 +104,10 @@ Para acompanhamento operacional na tela de Biblioteca de Páginas de Vendas, o s
 - Transições de estado devem ocorrer exclusivamente pelos endpoints do backend MOIS.
 - Falhas devem ser registradas com contexto e stack trace para diagnóstico de causa-raiz.
 - Erros de contrato/integração OpenAI retornados no output do batch (ex.: `response.status_code >= 400` com `response.body.error`) são falhas terminais e devem:
-  1. ser convertidos em mensagem legível com `status`, `requestId`, `type`, `code` e `message`;
-  2. ser enviados ao endpoint `jobs/{jobId}:fail` para persistência;
-  3. ficar disponíveis para exibição ao usuário na tela de jobs (`errorMessage`).
+  1. obter e processar também o arquivo `error_file_id` (JSONL) do batch para diagnóstico completo da causa-raiz;
+  2. converter os detalhes relevantes do erro em mensagem legível com `status`, `requestId`, `type`, `code` e `message`;
+  3. enviar a falha ao endpoint `jobs/{jobId}:fail` para persistência;
+  4. manter os detalhes disponíveis para exibição ao usuário na tela de jobs (`errorMessage`).
 
 ## 10. Substituição documental
 Este documento é o único cânone ativo para o worker do MOIS.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -298,3 +298,36 @@
 - documentos lidos para tratar a situação:
   - docs/registros/mois1.md
   - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+
+## 2026-05-20 11:14:37 UTC-3
+- ajuste na tela de Biblioteca de Páginas de Vendas (MOIS) para exibir o JSON de retorno da OpenAI dentro da coluna de erro da fila de jobs.
+- foi criada formatação defensiva para detectar trecho JSON no erro bruto e renderizar com indentação, preservando o prefixo textual quando existir.
+- a coluna Erro agora usa bloco com quebra de linha para tornar legível o payload de erro retornado pelo backend/OpenAI.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/mois1.md
+
+## 2026-05-20 11:17:54 UTC-3
+- refinamento da exibição de erro OpenAI na tela de jobs MOIS para ficar aderente ao cânone operacional: destaque explícito do bloco `OpenAI JSON` quando o payload JSON estiver presente.
+- corrigida a detecção de início de JSON para evitar comportamento implícito com listas vazias e manter fallback do erro bruto quando não houver JSON válido.
+- documentos lidos para tratar a situação:
+  - docs/canonical/mois-worker-canon.v1.md
+  - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+  - docs/registros/mois1.md
+
+## 2026-05-20 11:21:48 UTC-3
+- atualização de regra canônica do MOIS Worker para erros de integração OpenAI: passou a ser obrigatório obter/processar também o `error_file_id` (JSONL) em caso de falha batch.
+- refinada a seção de conformidade para explicitar que o JSONL de erro é parte do diagnóstico de causa-raiz e da composição da mensagem persistida/exibida no job.
+- documentos lidos para tratar a situação:
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/registros/mois1.md
+
+## 2026-05-20 11:26:28 UTC-3
+- implementação no worker da biblioteca de páginas MOIS para tratamento de erro OpenAI batch com captura de `error_file_id` (JSONL) quando status terminal não for `completed` ou quando faltar `output_file_id`.
+- mensagens de falha agora carregam contexto operacional (`batchId`, `status`, `outputFileId`, `errorFileId`) e incluem o conteúdo `error_jsonl` quando disponível.
+- adicionada leitura defensiva de `error_file_id` com log explícito em caso de falha de download do JSONL.
+- documentos lidos para tratar a situação:
+  - docs/canonical/mois-worker-canon.v1.md
+  - mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
+  - docs/registros/mois1.md

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -36,6 +36,31 @@ function formatDateTimeInGmt(value?: string | null) {
   }).format(parsedDate) + " GMT";
 }
 
+function formatOpenAiErrorMessage(value?: string | null) {
+  if (!value) {
+    return "—";
+  }
+
+  const trimmedValue = value.trim();
+  const jsonStartCandidates = [trimmedValue.indexOf("{"), trimmedValue.indexOf("[")].filter((index) => index >= 0);
+  if (jsonStartCandidates.length === 0) {
+    return value;
+  }
+
+  const jsonStartIndex = Math.min(...jsonStartCandidates);
+  const jsonCandidate = trimmedValue.slice(jsonStartIndex);
+
+  try {
+    const parsed = JSON.parse(jsonCandidate);
+    const pretty = JSON.stringify(parsed, null, 2);
+    const prefix = trimmedValue.slice(0, jsonStartIndex).trim();
+
+    return prefix ? `${prefix}\nOpenAI JSON:\n${pretty}` : `OpenAI JSON:\n${pretty}`;
+  } catch {
+    return value;
+  }
+}
+
 
 function SimplePaginator({
   page,
@@ -180,7 +205,11 @@ export default function MoisSalesPagesLibraryPage() {
                         </td>
                         <td>{job.attempts}</td>
                         <td>{formatDateTimeInGmt(job.updatedAt)}</td>
-                        <td>{job.errorMessage || "—"}</td>
+                        <td>
+                          <pre className="mb-0 text-wrap" style={{ whiteSpace: "pre-wrap" }}>
+                            {formatOpenAiErrorMessage(job.errorMessage)}
+                          </pre>
+                        </td>
                       </tr>
                     ))
                   )}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
@@ -43,8 +43,11 @@ public class OpenAiSalesPageAnalyzer {
         String inputFileId = uploadInputFile(payloadLine);
         BatchInfo batch = createBatch(inputFileId);
         BatchInfo completed = awaitBatch(batch);
-        if (!"completed".equalsIgnoreCase(completed.status()) || !StringUtils.hasText(completed.outputFileId())) {
-            throw new IllegalStateException("Batch da OpenAI não completou com output_file_id. status=" + completed.status());
+        if (!"completed".equalsIgnoreCase(completed.status())) {
+            throw new IllegalStateException(buildBatchTerminalErrorMessage(completed));
+        }
+        if (!StringUtils.hasText(completed.outputFileId())) {
+            throw new IllegalStateException(buildBatchMissingOutputMessage(completed));
         }
         String output = downloadOutput(completed.outputFileId());
         return parseBatchOutput(output);
@@ -113,6 +116,19 @@ public class OpenAiSalesPageAnalyzer {
         return restClient.get().uri("/files/{id}/content", outputFileId).retrieve().body(String.class);
     }
 
+    private String downloadErrorJsonl(BatchInfo batch) {
+        if (batch == null || !StringUtils.hasText(batch.errorFileId())) {
+            return "";
+        }
+        try {
+            String content = restClient.get().uri("/files/{id}/content", batch.errorFileId()).retrieve().body(String.class);
+            return content == null ? "" : content;
+        } catch (Exception ex) {
+            log.error("Falha ao baixar error_file_id da OpenAI. batchId={}, errorFileId={}", batch.id(), batch.errorFileId(), ex);
+            return "";
+        }
+    }
+
     private SalesPageAnalysisResult parseBatchOutput(String outputJsonl) {
         try {
             String line = outputJsonl.lines().filter(StringUtils::hasText).findFirst().orElseThrow();
@@ -159,6 +175,32 @@ public class OpenAiSalesPageAnalyzer {
                 + upstreamMessage;
     }
 
+    private String buildBatchTerminalErrorMessage(BatchInfo completed) {
+        String errorJsonl = downloadErrorJsonl(completed);
+        String trimmedJsonl = errorJsonl.isBlank() ? "" : "\nerror_jsonl=" + errorJsonl.trim();
+        return "Batch da OpenAI finalizou sem sucesso"
+                + " (batchId=" + completed.id()
+                + ", status=" + completed.status()
+                + ", outputFileId=" + completed.outputFileId()
+                + ", errorFileId=" + completed.errorFileId()
+                + ")"
+                + trimmedJsonl;
+    }
+
+    private String buildBatchMissingOutputMessage(BatchInfo completed) {
+        String errorJsonl = downloadErrorJsonl(completed);
+        String trimmedJsonl = errorJsonl.isBlank() ? "" : "\nerror_jsonl=" + errorJsonl.trim();
+        return "Batch da OpenAI completou sem output_file_id"
+                + " (batchId=" + completed.id()
+                + ", status=" + completed.status()
+                + ", errorFileId=" + completed.errorFileId()
+                + ")"
+                + trimmedJsonl;
+    }
+
     private record FileUploadResponse(String id) {}
-    private record BatchInfo(String id, String status, @JsonProperty("output_file_id") String outputFileId) {}
+    private record BatchInfo(String id,
+                             String status,
+                             @JsonProperty("output_file_id") String outputFileId,
+                             @JsonProperty("error_file_id") String errorFileId) {}
 }


### PR DESCRIPTION
### Motivation
- Improve root-cause diagnosis of OpenAI batch failures by obtaining and surfacing the `error_file_id` (JSONL) returned by the OpenAI batch API.  
- Make terminal/contract errors from OpenAI readable in the MOIS jobs list by detecting and pretty-printing JSON payloads.  
- Align implementation and UI with the updated canonical policy in `docs/canonical/mois-worker-canon.v1.md` requiring persistence and exposition of OpenAI contract errors.  

### Description
- Backend: extended `OpenAiSalesPageAnalyzer` to fetch `error_file_id` content via `downloadErrorJsonl`, include `error_file_id` in `BatchInfo`, and build richer terminal/missing-output messages with the `error_jsonl` payload via `buildBatchTerminalErrorMessage` and `buildBatchMissingOutputMessage`.  
- Backend: changed failure handling so a non-`completed` batch throws an error using the enriched message that includes `batchId`, `status`, `outputFileId`, `errorFileId` and trimmed `error_jsonl`.  
- Frontend: added `formatOpenAiErrorMessage` and updated `MoisSalesPagesLibraryPage.tsx` to render the `Erro` column inside a `<pre>` with wrapping and to pretty-print detected JSON with an `OpenAI JSON:` label.  
- Docs/records: updated canonical document `docs/canonical/mois-worker-canon.v1.md` and changelog `docs/registros/mois1.md` to require processing of `error_file_id` and to record the UI/frontend changes.  

### Testing
- Ran backend automated tests with `mvn test` against the worker module and the suite passed.  
- Built and type-checked the frontend with `yarn build`/`yarn lint` and the build completed successfully.  
- Verified no regressions in existing unit tests covering batch parsing and error paths; all affected tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc19177688321a188de95facfc59e)