### PR TITLE
chore(oprm): reagendar ingestão CNAE para 12:30 de hoje

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -101,3 +101,5 @@
 - 2026-05-20 14:35:00 (UTC): criado documento canônico específico do OPRM em `docs/canonical/oprm-canon.v1.md`, formalizando regra de chamar `completeRun` apenas após leitura total da run, bloqueio `HTTP 409` com `ESTABELECIMENTOS` em `STARTED`, regra de identificação de CNAE e requisitos mínimos de observabilidade.
 - 2026-05-20 14:50:00 (UTC): ajuste canônico solicitado: removido integralmente o item 14 de `system-governance-canon.v2.md` e migrado para `docs/canonical/oprm-canon.v1.md`, com título explícito sobre ingestão de CNAE e totalização de market size.
 - 2026-05-20 15:05:00 (UTC): ajuste de implementação no `oprm-coletor-mei` para garantir que `completeRun` seja chamado somente após concluir a leitura de todos os arquivos da run. Adicionada guarda `readAllFilesInRun` no `OprmMarketImportScheduler` e proteção para falha de publicação de evento `FAILED` sem abortar o loop de leitura.
+
+- 2026-05-20 15:30:00 (UTC): ajuste solicitado para agendar nova ingestão de CNAEs para **12:30 de hoje (20/05)** no fuso `America/Sao_Paulo`, com cron hardcoded de `runScheduledImport` alterado para `0 30 12 20 5 *` no `oprm-coletor-mei`.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
@@ -47,7 +47,7 @@ public class OprmMarketImportScheduler {
         this.restClient = restClient;
     }
 
-    @Scheduled(cron = "0 0 9 20 5 *", zone = "America/Sao_Paulo")
+    @Scheduled(cron = "0 30 12 20 5 *", zone = "America/Sao_Paulo")
     public void runScheduledImport() {
         if (!scheduleProperties.enabled()) {
             log.info("Scheduler OPRM market import desabilitado.");
@@ -161,7 +161,7 @@ public class OprmMarketImportScheduler {
             }
         }
 
-        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 23:30 ({}) com {} arquivos.",
+        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 12:30 ({}) com {} arquivos.",
                 snapshotDate,
                 scheduleProperties.timezone(),
                 files.size());


### PR DESCRIPTION
### Motivation
- Agendar execução pontual da ingestão de CNAEs para o horário solicitado hoje às 12:30 (America/Sao_Paulo) para permitir execução operacional manual/adiantada do pipeline.

### Description
- Altereio o `@Scheduled` do método `runScheduledImport` em `oprm-coletor-mei` para `cron = "0 30 12 20 5 *"` e atualizei a mensagem de log de confirmação para exibir `12:30`.
- Registrei a ação no diário operacional `docs/registros/oprm1.md` conforme o padrão do módulo OPRM.

### Testing
- Executei os testes do módulo com `mvn test -q` dentro de `oprm-coletor-mei` e a execução dos testes do módulo completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dccdc9d2c8321835da859254413c2)