### PR TITLE
Enforce minimum 4 sections and 4 images in landing-page wireframe (schema, prompt, docs)

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -31,7 +31,7 @@
             },
             "secoes": {
               "type": "array",
-              "minItems": 1,
+              "minItems": 4,
               "items": {
                 "type": "object",
                 "additionalProperties": false,
@@ -82,6 +82,18 @@
                   "elementosSeccao": {
                     "type": "array",
                     "minItems": 1,
+                    "contains": {
+                      "type": "object",
+                      "properties": {
+                        "tag": {
+                          "const": "img"
+                        }
+                      },
+                      "required": [
+                        "tag"
+                      ]
+                    },
+                    "minContains": 1,
                     "items": {
                       "$ref": "#/$defs/elementoSecao"
                     }

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -73,6 +73,9 @@ Regras fixas da etapa (formato simplificado):
 - Hero obrigatório com âncora primária: na primeira dobra (hero), incluir CTA com link âncora direto para a seção do formulário.
 - Âncoras obrigatórias adicionais: incluir mais duas âncoras internas para pontos estratégicos distintos da página (ex.: mecanismo, prova social, oferta), além da âncora do hero para o formulário.
 - Balanceamento visual obrigatório: intercalar blocos de texto e imagem ao longo da página, inserindo elementos `img` em seções relevantes para reduzir paredes de texto e melhorar escaneabilidade.
+- Quantidade mínima de seções obrigatória: gerar no mínimo 4 seções em `pagina.corpo.secoes`.
+- Quantidade mínima de imagens obrigatória: gerar no mínimo 4 elementos `img` no total da página.
+- Regra mandatória para cumprir o mínimo de imagens: cada seção em `pagina.corpo.secoes[]` deve conter pelo menos um elemento `img` em `elementosSeccao` (direto ou em `elementosInternos`).
 - Imagem de produto obrigatória: garantir que pelo menos uma `img` represente visualmente a ideia do produto/entrega que o cliente está comprando (ex.: mockup da solução, amostra do conteúdo, kit/resultado final esperado).
 - Para cada visual (`img`) planejado no wireframe, explicitar no `objetivo`/metadados da seção:
   - onde o visual entra na narrativa da página (posição e contexto comercial);

--- a/docs/experiment-pipeline-validation-spec.md
+++ b/docs/experiment-pipeline-validation-spec.md
@@ -88,6 +88,12 @@ mínimos de experiência exigidos pelas plataformas de mídia paga.
     `mobilePriorityScore` (1–10), `dropOffRisk` (`baixo/medio/alto`) e
     `ctaSlot` (objeto com `hasCta`, `ctaLabel`, `ctaVariant`, `matchAdCta`,
     `notes`).
+  - Requisito visual mínimo obrigatório no wireframe: `>= 4` imagens planejadas
+    no total (somando a página inteira), distribuídas nas seções para manter
+    escaneabilidade e prova visual.
+  - Regra operacional para garantir o mínimo de imagens: cada seção em
+    `sectionOrder[]` deve conter ao menos um elemento visual (`img`) no
+    wireframe simplificado desta etapa.
   - `consistencyChecks[]` (≥2) no mesmo formato da copy.
 - **Validações adicionais**
   - Sempre incluir checks `CTA_MATCH` e `EXPERIENCE_CONTINUITY`.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -637,3 +637,12 @@
   - docs/canonical/procedimento-experimento-canon.v1.md
   - docs/registros/experimentos.md
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssembler.java
+
+## 2026-05-20 23:58:00 UTC
+- solicitação para formalizar no cânone e no gera-wireframe os limites mínimos de seções e imagens.
+- causa-raiz: o contrato da etapa wireframe definia mínimo de seções, mas não deixava explícito o mínimo de imagens no mesmo nível de regra operacional.
+- foi feito:
+  - atualizado `docs/experiment-pipeline-validation-spec.md` na seção `LANDING_PAGE_WIREFRAME` para reforçar mínimo de 4 imagens no wireframe e regra operacional de distribuição visual por seção.
+  - atualizado prompt `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` com regras explícitas: mínimo de 4 seções e mínimo de 4 imagens.
+  - atualizado schema `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` com `pagina.corpo.secoes.minItems = 4` e exigência de ao menos um elemento `img` em `elementosSeccao` por seção (via `contains` + `minContains`).
+- impacto esperado: reduzir respostas abaixo do mínimo visual/comercial e evitar reprovação contratual por wireframes com densidade visual insuficiente.


### PR DESCRIPTION
### Motivation
- Clarify and enforce visual/structural minima for the wireframe step to avoid under-visualized landing outputs and reduce contract rejections. 
- Make the requirement operational so workers/clients and automated validators produce wireframes with sufficient images and section distribution.

### Description
- Updated schema `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` to set `pagina.corpo.secoes.minItems = 4` and require at least one `img` element per section by adding a `contains` clause with `minContains: 1` on `elementosSeccao`.
- Updated prompt `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` to document the new rules: minimum 4 sections, minimum 4 images in the page, and the operational rule that each section must include at least one `img` (direct or nested).
- Updated spec `docs/experiment-pipeline-validation-spec.md` to add the wireframe visual minimum (`>= 4` images) and the per-section visual distribution requirement to the `LANDING_PAGE_WIREFRAME` section.
- Recorded the change in the experiments log `docs/registros/experimentos.md` to document rationale and expected impact.

### Testing
- Ran the project unit test suite locally with `mvn test` and existing tests passed. 
- Validated the modified JSON schema for correct syntax and structure with a JSON Schema linter. 
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcc92498883218873016c37dc15c5)