### PR TITLE
mois worker: aumentar timeout batch OpenAI para 30 minutos

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -61,11 +61,11 @@ O worker seleciona a fonte por ciclo com a seguinte ordem canônica:
 ### 7.2 OpenAI
 - `openai.model` → `${OPENAI_MODEL:gpt-5.2}`
 - `openai.batch-poll-interval-ms` → `${OPENAI_BATCH_POLL_INTERVAL_MS:2000}`
-- `openai.batch-timeout-ms` → `${OPENAI_BATCH_TIMEOUT_MS:300000}`
+- `openai.batch-timeout-ms` → `${OPENAI_BATCH_TIMEOUT_MS:1800000}`
 - Para payload de `/v1/responses`, o formato estruturado deve usar `text.format` (não usar `response_format`).
 
 ## 8. Regra canônica de timeout OpenAI Batch (MOIS Worker)
-Para integrações batch com OpenAI no contexto do MOIS Worker, o timeout canônico é de **30 minutos** (`300000 ms` / `PT30M`), e não deve ser reduzido sem versionamento explícito deste cânone.
+Para integrações batch com OpenAI no contexto do MOIS Worker, o timeout canônico é de **30 minutos** (`1800000 ms` / `PT30M`), e não deve ser reduzido sem versionamento explícito deste cânone.
 
 
 ## 8.1 Taxonomia canônica de status (monitoramento de fetching)

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -331,3 +331,12 @@
   - docs/canonical/mois-worker-canon.v1.md
   - mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
   - docs/registros/mois1.md
+
+## 2026-05-20 14:47:23 UTC-3
+- aumento do timeout do modo batch OpenAI no worker da biblioteca de páginas de vendas (MOIS) para 30 minutos efetivos, ajustando o default de `OPENAI_BATCH_TIMEOUT_MS` para `1800000` no `application.yml`.
+- atualização do cânone `docs/canonical/mois-worker-canon.v1.md` para manter consistência documental com o novo valor default de timeout (`1800000 ms` / `PT30M`).
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - mois-sales-library-worker/src/main/resources/application.yml
+  - docs/registros/mois1.md

--- a/mois-sales-library-worker/src/main/resources/application.yml
+++ b/mois-sales-library-worker/src/main/resources/application.yml
@@ -15,4 +15,4 @@ openai:
   base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}
   model: ${OPENAI_MODEL:gpt-5.2}
   batch-poll-interval-ms: ${OPENAI_BATCH_POLL_INTERVAL_MS:2000}
-  batch-timeout-ms: ${OPENAI_BATCH_TIMEOUT_MS:300000}
+  batch-timeout-ms: ${OPENAI_BATCH_TIMEOUT_MS:1800000}


### PR DESCRIPTION
### Motivation
- Evitar timeout prematuro em solicitações OpenAI em modo batch no worker da biblioteca de páginas de venda (MOIS).
- Garantir que o valor default refletido na configuração e na documentação canônica esteja alinhado com o comportamento esperado do worker.

### Description
- Atualiza o default `OPENAI_BATCH_TIMEOUT_MS` de `300000` para `1800000` (30 minutos) em `mois-sales-library-worker/src/main/resources/application.yml` alterando `batch-timeout-ms` para `1800000`.
- Alinha o documento canônico em `docs/canonical/mois-worker-canon.v1.md` para referenciar o novo valor `1800000 ms / PT30M` como timeout canônico de batch OpenAI.
- Registra a alteração no histórico operacional adicionando uma entrada em `docs/registros/mois1.md` com detalhes da mudança.

### Testing
- Nenhum teste unitário foi executado; a alteração foi validada por inspeção de arquivos e buscas textuais com `rg` e por inspeção do estado do repositório com `git status`.
- Execuções de verificação incluíram `rg -n "batch-timeout-ms|1800000|300000 ms"` para confirmar substituições e `git commit` que retornou com sucesso a mudança aplicada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df379ea148321a89c5a3c00b1b53e)