### PR TITLE
docs: adiciona estrutura hierárquica (Mermaid) para score-psi

### DIFF
--- a/docs/novos-modulos/score-psi/estrutura-hierarquica-modulos-score-psi.md
+++ b/docs/novos-modulos/score-psi/estrutura-hierarquica-modulos-score-psi.md
@@ -1,0 +1,37 @@
+# Estrutura Hierárquica de Módulos — Score PSI
+
+```mermaid
+graph TD
+    A[MarketNiche] --> B[Hypothesis]
+
+    B --> C[HypothesisSymbolicProfile]
+    B --> D[CommunicationConcept A]
+    B --> E[CommunicationConcept B]
+    B --> F[CommunicationConcept C]
+
+    D --> D1[Experiment A]
+    E --> E1[Experiment B]
+    F --> F1[Experiment C]
+
+    D1 --> D2[Creative]
+    D1 --> D3[LandingPage]
+    D1 --> D4[LandingPageSectionMetrics]
+    D1 --> D5[MarketPsychologicalScore]
+
+    E1 --> E2[Creative]
+    E1 --> E3[LandingPage]
+    E1 --> E4[LandingPageSectionMetrics]
+    E1 --> E5[MarketPsychologicalScore]
+
+    F1 --> F2[Creative]
+    F1 --> F3[LandingPage]
+    F1 --> F4[LandingPageSectionMetrics]
+    F1 --> F5[MarketPsychologicalScore]
+```
+
+## Leitura rápida
+
+- `MarketNiche` é o contexto macro de mercado.
+- Cada `Hypothesis` concentra o perfil simbólico e múltiplos conceitos de comunicação.
+- Cada `CommunicationConcept` gera um experimento próprio para validação.
+- Cada experimento é medido por criativo, landing, métricas por seção e score psicológico final.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -689,3 +689,12 @@
   - `registerLandingPageAnalyticsEvent` agora persiste evento no `experiment_funnel_event` (source `landing-page-analytics`) para `page_view` e `section_view_time`, além do log operacional;
   - payload persistido inclui `eventId`, `eventType`, `sessionId`, `sectionId`, `elapsedMs` e `pageUrl`.
 - impacto esperado: manter aderência ao documento canônico e garantir rastreabilidade operacional no backend para eventos mínimos de visualização de landing.
+
+## 2026-05-20 15:22:06 UTC-3
+- solicitação para ler o plano do módulo score-psi e criar um documento separado com a estrutura hierárquica em formato gráfico markdown.
+- raciocínio aplicado: extrair a hierarquia conceitual principal do plano e representar em `mermaid graph TD` para facilitar visualização de módulos e dependências.
+- foi feito: criação do documento `docs/novos-modulos/score-psi/estrutura-hierarquica-modulos-score-psi.md` com grafo hierárquico e resumo de leitura rápida.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/novos-modulos/score-psi/plano_market_psychological_fit_score.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Facilitar a visualização da hierarquia conceitual do plano `score-psi` representando relações entre `MarketNiche`, `Hypothesis`, `CommunicationConcepts` e os blocos de cada experimento em um grafo reutilizável.

### Description
- Adicionado `docs/novos-modulos/score-psi/estrutura-hierarquica-modulos-score-psi.md` contendo o grafo em `mermaid` e uma seção de `Leitura rápida` explicando os níveis do modelo.
- Registrada a operação no arquivo canônico `docs/registros/experimentos.md` com timestamp obrigatório e referência ao plano original `docs/novos-modulos/score-psi/plano_market_psychological_fit_score.md`.

### Testing
- Alteração documental apenas; não há testes automatizados aplicáveis para este tipo de mudança.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dfbab1c3c8321b347dfd10d14a81c)