### PR TITLE
fix(liquibase): include missing MOIS sales library analysis changeset

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,9 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-05-17-mois-sales-library-analysis.yaml
+      relativeToChangelogFile: true
+
+  - include:
       file: changesets/2026-05-16-mois-sales-library-processing-job.yaml
       relativeToChangelogFile: true
 


### PR DESCRIPTION
### Motivation
- Liquibase failed to parse the master changelog because the changeset file `changesets/2026-05-17-mois-sales-library-analysis.yaml` existed on disk but was not referenced from `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`, causing a "file was not found in the configured search path" error.

### Description
- Added an `include` entry for `changesets/2026-05-17-mois-sales-library-analysis.yaml` with `relativeToChangelogFile: true` at the top of `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` to register the changeset.

### Testing
- Verified the changeset file exists with `rg --files | rg 'AGENTS.md|db.changelog-master.yaml|2026-05-17-mois-sales-library-analysis.yaml'`, inspected the master changelog with `sed -n '1,220p' backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`, and committed the update; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e18846c1483219533221291f2e39a)