### PR TITLE
Fix Liquibase changelog include for MOIS sales library analysis

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,7 +1,7 @@
 databaseChangeLog:
   - include:
-      file: db/changelog/changesets/2026-05-17-mois-sales-library-analysis.yaml
-
+      file: changesets/2026-05-17-mois-sales-library-analysis.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-05-16-mois-sales-library-processing-job.yaml

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -340,3 +340,8 @@
   - docs/canonical/mois-worker-canon.v1.md
   - mois-sales-library-worker/src/main/resources/application.yml
   - docs/registros/mois1.md
+
+## 2026-05-20 20:49:01 UTC
+- correção no `backend/ads-service` para validação do Liquibase: o `include` do changelog master apontava para `db/changelog/changesets/...` sem `relativeToChangelogFile`, causando erro de arquivo não encontrado no classpath.
+- ajuste aplicado em `src/main/resources/db/changelog/db.changelog-master.yaml` para usar `changesets/2026-05-17-mois-sales-library-analysis.yaml` com `relativeToChangelogFile: true`, alinhando com o padrão dos demais includes.
+- validação executada: `mvn -q liquibase:validate` (neste ambiente falhou por ausência de `database URL`, sem novo erro de arquivo ausente).


### PR DESCRIPTION
### Motivation
- Liquibase failed parsing `db.changelog-master.yaml` because the first `include` referenced `db/changelog/changesets/...` without `relativeToChangelogFile`, causing the changeset file to be unresolved on the classpath. 

### Description
- Updated `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` to use `file: changesets/2026-05-17-mois-sales-library-analysis.yaml` and added `relativeToChangelogFile: true` so the include is resolved relative to the master changelog. 
- Added an entry in `docs/registros/mois1.md` documenting the root cause, the fix, and the validation attempt. 

### Testing
- Ran `mvn -q liquibase:validate` in `backend/ads-service`; the execution now fails with `The database URL has not been specified either as a parameter or in a properties file`, indicating Liquibase reached the DB-connection step and the prior "file not found in the configured search path" parse error is no longer reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e1deda9b08321be0d2dfaa7d7ddc8)