### PR TITLE
fix(liquibase): remove duplicate changeset include for MOIS sales library analysis

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,9 +1,5 @@
 databaseChangeLog:
   - include:
-      file: changesets/2026-05-17-mois-sales-library-analysis.yaml
-      relativeToChangelogFile: true
-
-  - include:
       file: changesets/2026-05-16-mois-sales-library-processing-job.yaml
       relativeToChangelogFile: true
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -345,3 +345,8 @@
 - correção no `backend/ads-service` para validação do Liquibase: o `include` do changelog master apontava para `db/changelog/changesets/...` sem `relativeToChangelogFile`, causando erro de arquivo não encontrado no classpath.
 - ajuste aplicado em `src/main/resources/db/changelog/db.changelog-master.yaml` para usar `changesets/2026-05-17-mois-sales-library-analysis.yaml` com `relativeToChangelogFile: true`, alinhando com o padrão dos demais includes.
 - validação executada: `mvn -q liquibase:validate` (neste ambiente falhou por ausência de `database URL`, sem novo erro de arquivo ausente).
+
+## 2026-05-20 21:05:00 UTC
+- correção de causa-raiz para `ValidationFailedException` do Liquibase por `duplicate identifiers`: o mesmo changelog `changesets/2026-05-17-mois-sales-library-analysis.yaml` estava incluído duas vezes no `db.changelog-master.yaml` do `backend/ads-service`.
+- removido o include duplicado no topo do master, mantendo apenas a inclusão única já existente na seção cronológica de changesets.
+- impacto: elimina duplicidade de changeset id (`2026-05-17-mois-sales-library-analysis-01::codex`) durante `liquibase validate/update`.


### PR DESCRIPTION
### Motivation
- Liquibase reported `ValidationFailedException: duplicate identifiers` because the same changelog file was included twice in the master changelog, causing duplicate changeSet id `2026-05-17-mois-sales-library-analysis-01::codex`.
- Ensure the `db.changelog-master.yaml` lists each changeset file only once so `liquibase validate`/`update` do not fail due to duplicate identifiers.

### Description
- Removed the duplicate `include` for `changesets/2026-05-17-mois-sales-library-analysis.yaml` from `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` and kept the single canonical include in the chronological block.
- Added an entry to `docs/registros/mois1.md` documenting the root cause and the fix.
- Changes committed with message `fix(liquibase): remove duplicate mois sales library changelog include`.

### Testing
- Ran `mvn -q liquibase:validate` in `backend/ads-service`, which failed due to missing database URL in the environment; the failure is environmental and unrelated to the duplicate-include fix.
- Verified by inspection that `db.changelog-master.yaml` now contains a single include of `changesets/2026-05-17-mois-sales-library-analysis.yaml`, removing the source of duplicate changeSet identifiers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e216a8d508321b2b262ba78ceb789)