### PR TITLE
feat(mois): exibir JSONs da análise em visualização colapsável

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -350,3 +350,8 @@
 - correção de causa-raiz para `ValidationFailedException` do Liquibase por `duplicate identifiers`: o mesmo changelog `changesets/2026-05-17-mois-sales-library-analysis.yaml` estava incluído duas vezes no `db.changelog-master.yaml` do `backend/ads-service`.
 - removido o include duplicado no topo do master, mantendo apenas a inclusão única já existente na seção cronológica de changesets.
 - impacto: elimina duplicidade de changeset id (`2026-05-17-mois-sales-library-analysis-01::codex`) durante `liquibase validate/update`.
+
+## 2026-05-20 21:20:00 UTC
+- frontend MOIS (`/mois/sales-pages-library`): os blocos de JSON em "Detalhes da análise da página" foram migrados para visualização colapsável usando `CollapsibleJsonViewer`, substituindo `<pre>` estático para facilitar leitura e navegação de payloads longos.
+- seções afetadas: `Seções (JSON)`, `Copy (JSON)`, `Visual (JSON)` e `Imagem (JSON)`.
+- arquivo alterado: `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`.

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import CollapsibleJsonViewer from "../../components/CollapsibleJsonViewer";
 import PageTitle from "../../components/PageTitle";
 import {
   getSalesLibraryJobBadgeClass,
@@ -305,19 +306,19 @@ export default function MoisSalesPagesLibraryPage() {
               </div>
               <div>
                 <h3 className="h6">Seções (JSON)</h3>
-                <pre className="bg-light p-3 rounded small mb-0 text-wrap">{analysisQuery.data.sectionsJson || "{}"}</pre>
+                <CollapsibleJsonViewer content={analysisQuery.data.sectionsJson || "{}"} initiallyCollapsed />
               </div>
               <div>
                 <h3 className="h6">Copy (JSON)</h3>
-                <pre className="bg-light p-3 rounded small mb-0 text-wrap">{analysisQuery.data.copyJson || "{}"}</pre>
+                <CollapsibleJsonViewer content={analysisQuery.data.copyJson || "{}"} initiallyCollapsed />
               </div>
               <div>
                 <h3 className="h6">Visual (JSON)</h3>
-                <pre className="bg-light p-3 rounded small mb-0 text-wrap">{analysisQuery.data.visualJson || "{}"}</pre>
+                <CollapsibleJsonViewer content={analysisQuery.data.visualJson || "{}"} initiallyCollapsed />
               </div>
               <div>
                 <h3 className="h6">Imagem (JSON)</h3>
-                <pre className="bg-light p-3 rounded small mb-0 text-wrap">{analysisQuery.data.imageJson || "{}"}</pre>
+                <CollapsibleJsonViewer content={analysisQuery.data.imageJson || "{}"} initiallyCollapsed />
               </div>
             </div>
           ) : null}


### PR DESCRIPTION
### Motivation
- Melhorar a leitura e navegação de payloads JSON longos na tela `/mois/sales-pages-library` tornando os blocos colapsáveis em vez de exibir blocos estáticos `<pre>`.

### Description
- Substitui os blocos estáticos `<pre>` pelas visualizações colapsáveis usando o componente `CollapsibleJsonViewer` nas seções `Seções (JSON)`, `Copy (JSON)`, `Visual (JSON)` e `Imagem (JSON)`.
- Arquivos alterados: `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx` e registro de atividade em `docs/registros/mois1.md`.
- A alteração é apenas de apresentação no frontend e não altera contrato de API nem payloads enviados/recebidos.

### Testing
- Executei `npm run typecheck` (frontend), que falhou no ambiente por definições de tipos ausentes (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) e opções de TS depreciadas, problema existente no repositório e não relacionado à modificação implementada.
- Não foram executados outros testes automatizados neste rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e25558e648321b07a9b125c897591)