### PR TITLE
Add detailed logging and safe-preview helpers to GeraLanding OpenAI flex client

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
@@ -19,6 +19,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 @Component
 public class GeraLandingOpenAiBatchClient {
     private static final Logger log = LoggerFactory.getLogger(GeraLandingOpenAiBatchClient.class);
+    private static final int LOG_PREVIEW_LIMIT = 1200;
 
     private final ObjectMapper objectMapper;
     private final WebClient webClient;
@@ -54,14 +55,27 @@ public class GeraLandingOpenAiBatchClient {
             throw new IllegalStateException("OpenAI API key não configurada");
         }
         try {
+            log.info("Iniciando geração gera-landing via OpenAI flex [jobId={}, stage={}, model={}, requestBodyLength={}]",
+                    job.id(), job.section(), job.model(), safeLength(job.requestBodyJson()));
+            log.info("Payload requestBodyJson do gera-landing [jobId={}, stage={}, requestBodyPreview={}]",
+                    job.id(), job.section(), preview(job.requestBodyJson()));
             OpenAiResponse response = createFlexResponse(job);
             String rawOutput = objectMapper.writeValueAsString(response);
             String modelResponse = response.firstText();
+            log.info("Resposta OpenAI recebida para gera-landing [jobId={}, stage={}, responseId={}, rawOutputLength={}, modelResponseLength={}, modelResponsePreview={}]",
+                    job.id(),
+                    job.section(),
+                    response.id(),
+                    safeLength(rawOutput),
+                    safeLength(modelResponse),
+                    preview(modelResponse));
             if (!StringUtils.hasText(modelResponse)) {
                 throw new IllegalStateException("Modelo não retornou conteúdo para gera-landing");
             }
             Integer inputTokens = response.usage() != null ? response.usage().effectiveInputTokens() : null;
             Integer outputTokens = response.usage() != null ? response.usage().effectiveOutputTokens() : null;
+            log.info("Finalizando geração gera-landing [jobId={}, stage={}, responseId={}, inputTokens={}, outputTokens={}]",
+                    job.id(), job.section(), response.id(), inputTokens, outputTokens);
             return new GeraLandingJobCompletionPayload(
                     modelResponse,
                     rawOutput,
@@ -76,13 +90,21 @@ public class GeraLandingOpenAiBatchClient {
                     job.id(), job.section(), statusCode.value(), ex.getResponseBodyAsString());
             throw new IllegalStateException("Falha HTTP ao gerar conteúdo de gera-landing em modo flex", ex);
         } catch (Exception ex) {
+            log.error("Falha inesperada no gera-landing em modo flex [jobId={}, stage={}, model={}, requestBodyPreview={}]",
+                    job.id(), job.section(), job.model(), preview(job.requestBodyJson()), ex);
             throw new IllegalStateException("Falha ao gerar conteúdo de gera-landing em modo flex", ex);
         }
     }
 
     private OpenAiResponse createFlexResponse(GeraLandingJobDto job) throws Exception {
+        log.info("Iniciando parse do requestBodyJson para flex [jobId={}, stage={}, requestBodyJsonPreview={}]",
+                job.id(), job.section(), preview(job.requestBodyJson()));
         Map<String, Object> requestBody = objectMapper.readValue(job.requestBodyJson(), Map.class);
+        log.info("RequestBody parseado para flex [jobId={}, stage={}, keys={}, requestBodyMapPreview={}]",
+                job.id(), job.section(), requestBody.keySet(), preview(objectMapper.writeValueAsString(requestBody)));
         requestBody.put("service_tier", "flex");
+        log.info("RequestBody final para /responses [jobId={}, stage={}, requestBodyWithFlexPreview={}]",
+                job.id(), job.section(), preview(objectMapper.writeValueAsString(requestBody)));
 
         OpenAiResponse response = webClient.post().uri("/responses")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -98,5 +120,20 @@ public class GeraLandingOpenAiBatchClient {
             throw new IllegalStateException("OpenAI flex retornou erro para gera-landing: " + response.errorMessage());
         }
         return response;
+    }
+
+    private int safeLength(String value) {
+        return value != null ? value.length() : 0;
+    }
+
+    private String preview(String value) {
+        if (!StringUtils.hasText(value)) {
+            return "<empty>";
+        }
+        String normalized = value.replace("\n", "\\n").replace("\r", "\\r");
+        if (normalized.length() <= LOG_PREVIEW_LIMIT) {
+            return normalized;
+        }
+        return normalized.substring(0, LOG_PREVIEW_LIMIT) + "...(truncated)";
     }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -707,3 +707,17 @@
   - logs e mensagens de erro foram atualizados para explicitar “modo flex” no Gera Landing;
   - atualização do documento canônico `procedimento-experimento-canon.v1.md` com a nova regra de processamento OpenAI para Gera Landing.
 - validação executada: suíte de testes do módulo `geralanding` no ai-worker e compilação do `ai-worker`.
+
+## 2026-05-20 18:45:00 UTC
+- solicitação: ampliar logs no trecho de geração OpenAI do Worker AI (Gera Landing), incluindo contexto no catch final.
+- causa-raiz tratada: dificuldade de diagnóstico da resposta real do modelo na etapa `landing-page-design-preset` (erro de parse com `Unexpected character '#'`) por ausência de telemetria suficiente do retorno e do contexto operacional no ponto de falha.
+- foi feito:
+  - adicionado log de início da geração flex com `jobId`, `stage`, `model` e tamanho do request;
+  - adicionado log após resposta da OpenAI com `responseId`, tamanho do `rawOutput`, tamanho do `modelResponse` e preview sanitizado/truncado do conteúdo retornado;
+  - adicionado log de finalização com tokens de entrada/saída;
+  - adicionado log no `catch (Exception ex)` com contexto completo (`jobId`, `stage`, `model`, preview do request) e stack trace (`ex`);
+  - incluídos helpers de segurança para preview e cálculo de tamanho, evitando logar payloads ilimitados em uma única linha.
+- impacto esperado: acelerar análise de causa-raiz em falhas de contrato/formato de resposta do modelo, com evidência literal do início da saída retornada.
+- ajuste complementar: adicionado log explícito do conteúdo de `job.requestBodyJson()` (preview sanitizado/truncado) no início do `generate`, para facilitar correlação direta entre payload enviado e falhas subsequentes.
+- ajuste complementar 2: adicionados logs dentro de `createFlexResponse` para mostrar o `requestBody` parseado (chaves + preview) e o payload final após injeção de `service_tier=flex` antes do POST em `/responses`.
+- ajuste complementar 3: reposicionado/adicionado log **antes** do `readValue(job.requestBodyJson(), Map.class)` em `createFlexResponse`, para garantir visibilidade do payload bruto mesmo quando ocorrer erro de parse JSON nesse ponto.


### PR DESCRIPTION
### Motivation
- Improve observability for the Gera Landing OpenAI flex flow to accelerate root-cause analysis of parse/format errors from model responses.
- Provide context-rich logs that correlate the request payload and the model response to help diagnose issues such as unexpected characters during parsing. 
- Avoid unbounded log bodies by sanitizing and truncating large payloads before emitting them to logs.

### Description
- Added structured logs around the flex generation lifecycle in `GeraLandingOpenAiBatchClient`: start of generation, parsed request body, outgoing request body, received response, and finalization including token counts. 
- Enhanced error logging in the generic `catch (Exception)` to include `jobId`, `stage`, `model`, a sanitized preview of the request body and the exception stack trace. 
- Introduced `LOG_PREVIEW_LIMIT`, `safeLength(String)`, and `preview(String)` helpers to produce sanitized, newline-escaped and truncated previews of JSON and model outputs before logging. 
- Updated `docs/registros/experimentos.md` with a record of the logging changes and rationale.

### Testing
- Ran the `geralanding` module test suite and it passed successfully. 
- Built the `ai-worker` project and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e24db863083218a39fdf9f0942d5f)