### PR TITLE
Prepare structured OpenAI 'flex' request body from plain prompts and add tests

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
@@ -2,8 +2,11 @@ package com.marketinghub.worker.geralanding;
 
 import com.marketinghub.worker.openai.OpenAiCostEstimator;
 import com.marketinghub.worker.openai.OpenAiResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,9 +100,9 @@ public class GeraLandingOpenAiBatchClient {
     }
 
     private OpenAiResponse createFlexResponse(GeraLandingJobDto job) throws Exception {
-        log.info("Iniciando parse do requestBodyJson para flex [jobId={}, stage={}, requestBodyJsonPreview={}]",
+        log.info("Iniciando preparação do request para flex [jobId={}, stage={}, requestBodyJsonPreview={}]",
                 job.id(), job.section(), preview(job.requestBodyJson()));
-        Map<String, Object> requestBody = objectMapper.readValue(job.requestBodyJson(), Map.class);
+        Map<String, Object> requestBody = prepareRequestBodyForFlex(job);
         log.info("RequestBody parseado para flex [jobId={}, stage={}, keys={}, requestBodyMapPreview={}]",
                 job.id(), job.section(), requestBody.keySet(), preview(objectMapper.writeValueAsString(requestBody)));
         requestBody.put("service_tier", "flex");
@@ -120,6 +123,32 @@ public class GeraLandingOpenAiBatchClient {
             throw new IllegalStateException("OpenAI flex retornou erro para gera-landing: " + response.errorMessage());
         }
         return response;
+    }
+
+    Map<String, Object> prepareRequestBodyForFlex(GeraLandingJobDto job) throws Exception {
+        String requestBodyJson = job.requestBodyJson();
+        if (StringUtils.hasText(requestBodyJson)) {
+            String trimmed = requestBodyJson.trim();
+            if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+                return objectMapper.readValue(trimmed, new TypeReference<>() {});
+            }
+            log.warn("requestBodyJson não está em JSON; aplicando fallback para payload estruturado [jobId={}, stage={}, startsWith={}]",
+                    job.id(), job.section(), trimmed.substring(0, Math.min(40, trimmed.length())).replace("\n", "\\n"));
+            return buildRequestBodyFromPrompt(job, trimmed);
+        }
+        return buildRequestBodyFromPrompt(job, job.prompt());
+    }
+
+    private Map<String, Object> buildRequestBodyFromPrompt(GeraLandingJobDto job, String promptText) {
+        if (!StringUtils.hasText(promptText)) {
+            throw new IllegalStateException("Payload da OpenAI ausente: requestBodyJson e prompt vazios para gera-landing");
+        }
+        Map<String, Object> requestBody = new LinkedHashMap<>();
+        requestBody.put("model", StringUtils.hasText(job.model()) ? job.model() : "gpt-5.2");
+        requestBody.put("input", List.of(
+                Map.of("role", "system", "content", "[gera-landing-pipeline] Você é especialista em execução de pipeline de experimento."),
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", promptText)))));
+        return requestBody;
     }
 
     private int safeLength(String value) {

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClientTest.java
@@ -1,0 +1,69 @@
+package com.marketinghub.worker.geralanding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+class GeraLandingOpenAiBatchClientTest {
+
+    @Test
+    void prepareRequestBodyForFlex_usesJsonRequestBodyWhenAlreadyStructured() throws Exception {
+        GeraLandingOpenAiBatchClient client = new GeraLandingOpenAiBatchClient(
+                WebClient.builder(),
+                new ObjectMapper(),
+                "test-key",
+                "http://localhost",
+                Duration.ofSeconds(30));
+
+        GeraLandingJobDto job = new GeraLandingJobDto(
+                UUID.randomUUID(),
+                24L,
+                "landing-page-design-preset",
+                "gpt-5.2",
+                "ignored",
+                "{\"model\":\"gpt-5.2\",\"input\":[{\"role\":\"user\",\"content\":\"{}\"}]}",
+                Instant.now());
+
+        Map<String, Object> payload = client.prepareRequestBodyForFlex(job);
+
+        assertEquals("gpt-5.2", payload.get("model"));
+        assertEquals(1, ((List<?>) payload.get("input")).size());
+    }
+
+    @Test
+    void prepareRequestBodyForFlex_buildsStructuredPayloadWhenBodyIsMarkdownPrompt() throws Exception {
+        GeraLandingOpenAiBatchClient client = new GeraLandingOpenAiBatchClient(
+                WebClient.builder(),
+                new ObjectMapper(),
+                "test-key",
+                "http://localhost",
+                Duration.ofSeconds(30));
+
+        String prompt = "# Tarefa\nGerar preset design em JSON.";
+        GeraLandingJobDto job = new GeraLandingJobDto(
+                UUID.randomUUID(),
+                24L,
+                "landing-page-design-preset",
+                "gpt-5.2",
+                prompt,
+                prompt,
+                Instant.now());
+
+        Map<String, Object> payload = client.prepareRequestBodyForFlex(job);
+
+        assertEquals("gpt-5.2", payload.get("model"));
+        List<?> input = assertInstanceOf(List.class, payload.get("input"));
+        Map<?, ?> userMsg = assertInstanceOf(Map.class, input.get(1));
+        List<?> content = assertInstanceOf(List.class, userMsg.get("content"));
+        Map<?, ?> textItem = assertInstanceOf(Map.class, content.get(0));
+        assertEquals(prompt, textItem.get("text"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the client can handle non-JSON `requestBodyJson` payloads by falling back to a structured request body so flex calls do not fail. 
- Provide a sensible default model and stable request shape when only a plain `prompt` is provided, and improve logs for debugging malformed payloads.

### Description
- Replace raw `objectMapper.readValue(job.requestBodyJson(), Map.class)` with a new `prepareRequestBodyForFlex` method that parses JSON when present or builds a structured payload when not. 
- Add `buildRequestBodyFromPrompt` to create a `LinkedHashMap` payload that sets a default model (`gpt-5.2`) and an `input` list containing a system and user message with the prompt. 
- Adjust log messages to reflect preparation rather than direct parsing and use `TypeReference<>` for safer JSON deserialization. 
- Add unit tests in `GeraLandingOpenAiBatchClientTest` that verify JSON request bodies are preserved and markdown/plain prompts are converted into the expected structured payload.

### Testing
- Ran the new JUnit tests in `GeraLandingOpenAiBatchClientTest`, which include `prepareRequestBodyForFlex_usesJsonRequestBodyWhenAlreadyStructured` and `prepareRequestBodyForFlex_buildsStructuredPayloadWhenBodyIsMarkdownPrompt`, and both tests passed. 
- No automated test failures were observed in the modified module after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4433dc448321aeee6b8b42642447)