### PR TITLE
docs(gera-landing): exigir doctype no início do HTML final

### DIFF
--- a/docs/gera-landing/modelo-canonico-gera-landing.md
+++ b/docs/gera-landing/modelo-canonico-gera-landing.md
@@ -172,6 +172,13 @@ Registrar o ciclo de vida completo de uma execução, incluindo:
 
 ---
 
+
+## 3.3 Regra canônica obrigatória para HTML final
+
+- Todo HTML final do Gera Landing (incluindo entregável final e qualquer publicação de página) **deve começar literalmente com** `<!doctype html>`.
+- É proibido iniciar o documento com comentários técnicos, metadados operacionais, whitespace antes do doctype ou qualquer outro prefixo.
+- Essa regra garante compatibilidade de renderização, aderência de contrato e prevenção de contaminação do artefato final com metadado técnico.
+
 ## 4) Fluxo operacional ponta a ponta
 
 ## 4.1 Start manual da etapa

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -721,3 +721,13 @@
 - ajuste complementar: adicionado log explícito do conteúdo de `job.requestBodyJson()` (preview sanitizado/truncado) no início do `generate`, para facilitar correlação direta entre payload enviado e falhas subsequentes.
 - ajuste complementar 2: adicionados logs dentro de `createFlexResponse` para mostrar o `requestBody` parseado (chaves + preview) e o payload final após injeção de `service_tier=flex` antes do POST em `/responses`.
 - ajuste complementar 3: reposicionado/adicionado log **antes** do `readValue(job.requestBodyJson(), Map.class)` em `createFlexResponse`, para garantir visibilidade do payload bruto mesmo quando ocorrer erro de parse JSON nesse ponto.
+
+
+## 2026-05-20 22:47:01 UTC-3
+- solicitação para atualizar o documento canônico do Gera Landing com regra explícita de abertura obrigatória do HTML final.
+- raciocínio aplicado: reforçar contrato de saída para evitar divergências de renderização e prevenir contaminação do artefato com conteúdo técnico antes do doctype.
+- foi feito: adicionada seção canônica determinando que todo HTML final do Gera Landing deve iniciar literalmente com `<!doctype html>`, sem prefixos.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/gera-landing/modelo-canonico-gera-landing.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Garantir que o artefato HTML final gerado pelo Gera Landing respeite contrato de renderização e não seja contaminado por metadados técnicos ou whitespace antes do `<!doctype html>` para prevenir falhas de renderização e divergência de contrato.

### Description
- Adicionada a seção `3.3 Regra canônica obrigatória para HTML final` em `docs/gera-landing/modelo-canonico-gera-landing.md` definindo que todo HTML final deve iniciar literalmente com `<!doctype html>` e proibindo prefixos técnicos ou whitespace antes do doctype.
- Registrado o ajuste no arquivo de rastreio `docs/registros/experimentos.md` com timestamp em UTC-3 seguindo a política append-only.

### Testing
- Não se aplicam testes automatizados pois a alteração é documental; validação feita confirmando a presença das entradas em `docs/gera-landing/modelo-canonico-gera-landing.md` e `docs/registros/experimentos.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e63f214a08321a038cfe17e4c819a)