### PR TITLE
Resilient parsing of landingPageImagePlanning to handle Markdown, escaped and concatenated JSON

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationService.java
@@ -423,12 +423,11 @@ public class FrameworkImageGenerationService {
     }
 
     private List<PlanningItem> parsePlanningItems(Experiment experiment) {
-        String rawPlanning = experiment.getLandingPageImagePlanning();
-        if (!StringUtils.hasText(rawPlanning)) {
+        JsonNode rootNode = parsePlanningJsonNode(experiment.getLandingPageImagePlanning());
+        if (rootNode == null) {
             return List.of();
         }
         try {
-            JsonNode rootNode = objectMapper.readTree(rawPlanning);
             JsonNode planningNode = resolvePlanningNode(rootNode);
             JsonNode imagesNode = planningNode.path("images");
             if (!imagesNode.isArray()) {
@@ -453,6 +452,157 @@ public class FrameworkImageGenerationService {
         }
     }
 
+    private JsonNode parsePlanningJsonNode(String rawPlanning) {
+        if (!StringUtils.hasText(rawPlanning)) {
+            return null;
+        }
+        JsonNode parsed = readJsonNode(rawPlanning);
+        if (parsed != null) {
+            return parsed;
+        }
+        String normalizedPlanning = sanitizeCodeFence(rawPlanning);
+        if (!Objects.equals(normalizedPlanning, rawPlanning)) {
+            parsed = readJsonNode(normalizedPlanning);
+            if (parsed != null) {
+                return parsed;
+            }
+        }
+        String unescapedPlanning = unescapeJsonLikeContent(normalizedPlanning);
+        if (!Objects.equals(unescapedPlanning, normalizedPlanning)) {
+            parsed = readJsonNode(unescapedPlanning);
+            if (parsed != null) {
+                return parsed;
+            }
+        }
+        String extractedJsonObject = extractFirstJsonObject(unescapedPlanning);
+        if (extractedJsonObject != null) {
+            return readJsonNode(extractedJsonObject);
+        }
+        return null;
+    }
+
+    private JsonNode readJsonNode(String value) {
+        try {
+            return objectMapper.readTree(value);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    private String sanitizeCodeFence(String rawPlanning) {
+        String trimmedPlanning = rawPlanning.trim();
+        if (!trimmedPlanning.startsWith("```")) {
+            return rawPlanning;
+        }
+        int firstLineBreak = trimmedPlanning.indexOf('\n');
+        if (firstLineBreak < 0) {
+            return rawPlanning;
+        }
+        String maybeBody = trimmedPlanning.substring(firstLineBreak + 1);
+        int lastFence = maybeBody.lastIndexOf("```");
+        if (lastFence < 0) {
+            return rawPlanning;
+        }
+        return maybeBody.substring(0, lastFence).trim();
+    }
+
+    private String extractFirstJsonObject(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        int firstBrace = value.indexOf('{');
+        if (firstBrace < 0) {
+            return null;
+        }
+
+        boolean inString = false;
+        boolean escaping = false;
+        int depth = 0;
+        for (int index = firstBrace; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (inString) {
+                if (escaping) {
+                    escaping = false;
+                    continue;
+                }
+                if (current == '\\') {
+                    escaping = true;
+                    continue;
+                }
+                if (current == '"') {
+                    inString = false;
+                }
+                continue;
+            }
+            if (current == '"') {
+                inString = true;
+                continue;
+            }
+            if (current == '{') {
+                depth++;
+                continue;
+            }
+            if (current == '}') {
+                depth--;
+                if (depth == 0) {
+                    return value.substring(firstBrace, index + 1);
+                }
+            }
+        }
+        return null;
+    }
+
+    private String unescapeJsonLikeContent(String value) {
+        if (!StringUtils.hasText(value) || value.indexOf('\\') < 0) {
+            return value;
+        }
+        StringBuilder output = new StringBuilder(value.length());
+        boolean escaping = false;
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (!escaping) {
+                if (current == '\\') {
+                    escaping = true;
+                } else {
+                    output.append(current);
+                }
+                continue;
+            }
+
+            escaping = false;
+            switch (current) {
+                case 'n' -> output.append('\n');
+                case 'r' -> output.append('\r');
+                case 't' -> output.append('\t');
+                case 'b' -> output.append('\b');
+                case 'f' -> output.append('\f');
+                case '"' -> output.append('"');
+                case '\\' -> output.append('\\');
+                case '/' -> output.append('/');
+                case 'u' -> {
+                    if (index + 4 < value.length()) {
+                        String hex = value.substring(index + 1, index + 5);
+                        try {
+                            output.append((char) Integer.parseInt(hex, 16));
+                            index += 4;
+                            break;
+                        } catch (NumberFormatException ignored) {
+                            output.append("\\u").append(hex);
+                            index += 4;
+                            break;
+                        }
+                    }
+                    output.append("\\u");
+                }
+                default -> output.append(current);
+            }
+        }
+        if (escaping) {
+            output.append('\\');
+        }
+        return output.toString();
+    }
+
     private JsonNode resolvePlanningNode(JsonNode rootNode) {
         if (rootNode == null || !rootNode.isObject()) {
             return objectMapper.createObjectNode();
@@ -465,6 +615,9 @@ public class FrameworkImageGenerationService {
         JsonNode imagePlan = rootNode.path("imagePlan");
         if (imagePlan.isObject()) {
             return imagePlan;
+        }
+        if (imagePlan.isArray()) {
+            return objectMapper.createObjectNode().set("images", imagePlan);
         }
         JsonNode artifactContent = rootNode.path("artifact").path("content");
         if (artifactContent.isObject()) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationServiceTest.java
@@ -215,6 +215,75 @@ class FrameworkImageGenerationServiceTest {
     }
 
     @Test
+    void listJobsByExperimentParsesPlanningWrappedInMarkdownCodeFence() {
+        Experiment experiment = Experiment.builder()
+                .id(31L)
+                .landingPageImagePlanning("""
+                        ```json
+                        {
+                          "images": [
+                            {"sectionId":"hero","sectionName":"Hero","imagePrompt":"Prompt Hero"},
+                            {"sectionId":"faq","sectionName":"FAQ","imagePrompt":"Prompt FAQ"}
+                          ]
+                        }
+                        ```
+                        """)
+                .build();
+        when(experimentRepository.findById(31L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.findByExperimentIdOrderByCreatedAtDesc(31L)).thenReturn(List.of());
+
+        List<FrameworkImageGenerationItemStatusDto> items = service.listJobsByExperiment(31L);
+
+        assertThat(items).hasSize(2);
+        assertThat(items).extracting(FrameworkImageGenerationItemStatusDto::planningItemKey)
+                .containsExactly("hero", "faq");
+        assertThat(items).extracting(FrameworkImageGenerationItemStatusDto::status)
+                .containsOnly("PLANNED");
+    }
+
+    @Test
+    void listJobsByExperimentParsesFirstJsonObjectWhenPayloadIsDuplicated() {
+        String onePlan = """
+                {
+                  "images": [
+                    {"sectionId":"hero","sectionName":"Hero","imagePrompt":"Prompt Hero"},
+                    {"sectionId":"faq","sectionName":"FAQ","imagePrompt":"Prompt FAQ"}
+                  ]
+                }
+                """;
+        Experiment experiment = Experiment.builder()
+                .id(32L)
+                .landingPageImagePlanning(onePlan + onePlan)
+                .build();
+        when(experimentRepository.findById(32L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.findByExperimentIdOrderByCreatedAtDesc(32L)).thenReturn(List.of());
+
+        List<FrameworkImageGenerationItemStatusDto> items = service.listJobsByExperiment(32L);
+
+        assertThat(items).hasSize(2);
+        assertThat(items).extracting(FrameworkImageGenerationItemStatusDto::planningItemKey)
+                .containsExactly("hero", "faq");
+    }
+
+    @Test
+    void listJobsByExperimentParsesEscapedAndDuplicatedImagePlanPayload() {
+        String escapedDuplicatedPlan = "{\\n  \\\"imagePlan\\\": [\\n    {\\\"sectionId\\\":\\\"hero\\\",\\\"sectionName\\\":\\\"Hero\\\",\\\"imagePrompt\\\":\\\"Prompt Hero\\\"},\\n    {\\\"sectionId\\\":\\\"faq\\\",\\\"sectionName\\\":\\\"FAQ\\\",\\\"imagePrompt\\\":\\\"Prompt FAQ\\\"}\\n  ]\\n}"
+                + "{\\n  \\\"imagePlan\\\": [\\n    {\\\"sectionId\\\":\\\"hero\\\",\\\"sectionName\\\":\\\"Hero\\\",\\\"imagePrompt\\\":\\\"Prompt Hero\\\"}\\n  ]\\n}";
+        Experiment experiment = Experiment.builder()
+                .id(33L)
+                .landingPageImagePlanning(escapedDuplicatedPlan)
+                .build();
+        when(experimentRepository.findById(33L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.findByExperimentIdOrderByCreatedAtDesc(33L)).thenReturn(List.of());
+
+        List<FrameworkImageGenerationItemStatusDto> items = service.listJobsByExperiment(33L);
+
+        assertThat(items).hasSize(2);
+        assertThat(items).extracting(FrameworkImageGenerationItemStatusDto::planningItemKey)
+                .containsExactly("hero", "faq");
+    }
+
+    @Test
     void listPendingWebnizationAssetsReturnsCompletedAssetsWithoutWebUrl() {
         FrameworkImageGenerationJob pendingWebnization = FrameworkImageGenerationJob.builder()
                 .id(UUID.randomUUID())

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -731,3 +731,29 @@
   - AGENTS.md
   - docs/gera-landing/modelo-canonico-gera-landing.md
   - docs/registros/experimentos.md
+
+## 2026-05-21 00:20:00 UTC
+- solicitação: experimento 23 com prompt de imagens gerado, porém totalizadores da etapa "Gera Imagem" permanecendo zerados.
+- causa-raiz identificada: o parser de `landingPageImagePlanning` no backend aceitava apenas JSON puro; quando o planejamento vinha encapsulado em bloco markdown (```json ... ```), a leitura falhava silenciosamente e o resumo devolvia zero itens.
+- foi feito:
+  - fortalecido o parse em `FrameworkImageGenerationService` com fallback para:
+    1) remoção de code fence markdown;
+    2) extração do primeiro objeto JSON válido do texto;
+    3) parse resiliente por tentativas.
+  - adicionado teste unitário cobrindo explicitamente planejamento encapsulado em markdown code fence, garantindo que os itens planejados voltem a ser contabilizados como `PLANNED`.
+- impacto esperado: os totalizadores de imagens deixam de ficar em zero quando o planejamento vier com envelope textual/markdown, refletindo corretamente os itens do experimento.
+
+## 2026-05-21 03:00:00 UTC
+- ajuste complementar após validação em produção: o payload de planejamento retornado pelo modelo pode vir concatenado (dois objetos JSON completos em sequência), além de conter caracteres escapados.
+- causa-raiz complementar: o fallback anterior extraía do primeiro `{` até o último `}`, formando JSON inválido quando havia múltiplos objetos concatenados.
+- foi feito:
+  - substituída a extração ingênua por extração balanceada do **primeiro objeto JSON completo** (`extractFirstJsonObject`), com tratamento de aspas/escape para não quebrar chaves dentro de strings;
+  - adicionado teste unitário para cenário com payload duplicado concatenado (`onePlan + onePlan`), garantindo que o parser recupere o primeiro objeto válido e os totalizadores sejam calculados.
+
+## 2026-05-21 03:20:00 UTC
+- solicitação complementar: payload retornado com `\\n` e `\\\"` literais (json escapado) concatenado em sequência, mantendo totalizadores zerados mesmo após o ajuste anterior.
+- causa-raiz complementar: o parser ainda tentava extrair objeto JSON sem decodificar escapes textuais; com isso o primeiro caractere real era válido, mas o conteúdo interno permanecia inválido para parse direto.
+- foi feito:
+  - adicionado passo de normalização `unescapeJsonLikeContent` para decodificar sequências `\\n`, `\\r`, `\\t`, `\\\"`, `\\\\` e `\\uXXXX` antes da extração do primeiro objeto;
+  - mantida a extração balanceada do primeiro objeto após normalização;
+  - adicionado teste de regressão com payload `imagePlan` escapado + duplicado em sequência.


### PR DESCRIPTION
### Motivation
- The existing parser only handled pure JSON and silently failed when `landingPageImagePlanning` was wrapped in Markdown code fences or contained escaped/concatenated JSON, causing image planning totals to be zero. 
- The change aims to make planning parsing robust against common model-produced formats so planned items are correctly recognized and counted.

### Description
- Reworked `parsePlanningItems` to use a resilient `parsePlanningJsonNode` entry that attempts multiple parsing fallbacks. 
- Added helpers `readJsonNode`, `sanitizeCodeFence`, `unescapeJsonLikeContent`, and `extractFirstJsonObject` to strip Markdown fences, decode escape sequences, and extract the first balanced JSON object. 
- Enhanced `resolvePlanningNode` to accept an `imagePlan` array by wrapping it as `{ "images": ... }`, and kept existing normalization/deduplication behavior. 
- Added unit tests in `FrameworkImageGenerationServiceTest` covering Markdown code fences, duplicated concatenated JSON, and escaped+duplicated payload scenarios.

### Testing
- Ran the module unit test suite for `backend/ads-service` and verified the existing tests still pass. 
- Added and ran `listJobsByExperimentParsesPlanningWrappedInMarkdownCodeFence`, `listJobsByExperimentParsesFirstJsonObjectWhenPayloadIsDuplicated`, and `listJobsByExperimentParsesEscapedAndDuplicatedImagePlanPayload`, all of which passed. 
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6f905f288321834b88531fe2e156)