### PR TITLE
docs: add operational mapping for provisional HTML assemblers in landing pipeline

### DIFF
--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -64,6 +64,16 @@ Regras complementares:
 - a instrumentação deve ser idempotente (não pode ser injetada em duplicidade no mesmo HTML);
 - o payload publicado no artefato final deve manter apenas campos/eventos previstos em contrato canônico, sem metadado técnico fora do escopo funcional.
 
+
+### 5.3 Quadro operacional — etapas, assembler de HTML e persistência de HTML provisório
+
+| Etapa | Classe que faz assembler do HTML da etapa | Campo(s) de tabela onde grava HTML provisório |
+|---|---|---|
+| `LANDING_PAGE_WIREFRAME` | `WireframeProvisionalHtmlAssembler` | `gera_landing_stage_execution.provisional_html` |
+| `LANDING_PAGE_COPY` | `CopyProvisionalHtmlAssembler` | `gera_landing_stage_execution.provisional_html` |
+| `LANDING_PAGE_IMAGE_PLANNING` | Não há assembler exclusivo da etapa; usa `CopyProvisionalHtmlAssembler.assembleComplete(...)` + `LandingPageImageInjector.injectImages(...)`. | `gera_landing_stage_execution.provisional_html` e `experiment.landing_page_html` (quando `provisionalHtml` existe na execução). |
+| `LANDING_PAGE_DESIGN_PRESET` | `DesignPresetProvisionalHtmlAssembler` + `LandingPageImageInjector.injectImages(...)` | `gera_landing_stage_execution.provisional_html` e `experiment.landing_page_html` |
+
 ## 6. Geração e aprovação de anúncios
 
 Após os artefatos de base:


### PR DESCRIPTION
### Motivation
- Clarify which assembler classes produce provisional HTML for each step of the `Gera Landing` pipeline and where that HTML is persisted to remove ambiguity for implementers. 
- Explicitly document the behavior of `LANDING_PAGE_IMAGE_PLANNING` regarding image injection and when `experiment.landing_page_html` is written.

### Description
- Add section `5.3 Quadro operacional` to `docs/canonical/procedimento-experimento-canon.v1.md` containing a table that maps pipeline steps to HTML assembler classes and persistence fields. 
- Document that `LANDING_PAGE_WIREFRAME` uses `WireframeProvisionalHtmlAssembler` and persists to `gera_landing_stage_execution.provisional_html`, and that `LANDING_PAGE_COPY` uses `CopyProvisionalHtmlAssembler` and persists to `gera_landing_stage_execution.provisional_html`. 
- Document that `LANDING_PAGE_IMAGE_PLANNING` reuses `CopyProvisionalHtmlAssembler.assembleComplete(...)` plus `LandingPageImageInjector.injectImages(...)` and writes to `gera_landing_stage_execution.provisional_html` and to `experiment.landing_page_html` when `provisionalHtml` exists, and that `LANDING_PAGE_DESIGN_PRESET` uses `DesignPresetProvisionalHtmlAssembler` plus `LandingPageImageInjector.injectImages(...)` with persistence to the same fields.

### Testing
- This change is documentation-only and no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e845935848321b4c7afe3446e2eac)