### PR TITLE
Fix Mermaid rendering error in MOIS canonical diagram

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -155,10 +155,8 @@ sequenceDiagram
 
     rect rgb(245,245,245)
     Note over API,DB: 2) URL disponível na biblioteca
-    API->>DB: UPSERT mois_sales_library_url_ingest
-(url_original, url_canonical, title, capturedAt...)
-    API->>DB: INSERT mois_sales_library_processing_job
-(status=PENDING) para URL nova
+    API->>DB: UPSERT mois_sales_library_url_ingest<br/>(url_original, url_canonical, title, capturedAt...)
+    API->>DB: INSERT mois_sales_library_processing_job<br/>(status=PENDING) para URL nova
     end
 
     rect rgb(245,245,245)
@@ -171,15 +169,13 @@ sequenceDiagram
 
     rect rgb(245,245,245)
     Note over WK,OAI: 4) Prompt/schema de análise
-    WK->>OAI: Batch line -> /v1/responses
-text.format.type=json_object
+    WK->>OAI: Batch line -> /v1/responses<br/>text.format.type=json_object
     OAI-->>WK: output JSON (score_total, sections_json, ...)
     end
 
     rect rgb(245,245,245)
     Note over WK,DB: 5) Persistência dos resultados
-    WK->>API: POST /jobs/{jobId}:complete
-(scoreTotal, sectionsJson, copyJson, visualJson, imageJson...)
+    WK->>API: POST /jobs/{jobId}:complete<br/>(scoreTotal, sectionsJson, copyJson, visualJson, imageJson...)
     API->>DB: INSERT mois_sales_library_page_analysis (status=DONE)
     API->>DB: UPDATE mois_sales_library_processing_job -> DONE
     alt erro terminal
@@ -200,4 +196,3 @@ text.format.type=json_object
 
 ### 12.4 Regra operacional para evitar divergência de leitura
 Quando houver dúvida sobre “onde o fluxo começa”, considerar canonicamente que a alimentação da biblioteca inicia nos coletores (Hotmart/ClickBank), passa obrigatoriamente pelo endpoint `/urls:ingest` no backend e só então entra no ciclo assíncrono do worker.
-

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -366,3 +366,9 @@
   - persistência final em `mois_sales_library_page_analysis` e transições `DONE`/`FAILED`.
 - sem mudança de código executável; atualização estritamente documental canônica.
 
+
+## 2026-05-21 03:45:00 UTC
+- correção de sintaxe do diagrama Mermaid na seção `12.2 Diagrama (sequência ponta a ponta)` do cânone MOIS para eliminar erro de renderização no GitHub (`Parse error on line 19`).
+- causa-raiz: quebras de linha literais dentro do texto das setas (`API->>DB`, `WK->>OAI`, `WK->>API`) sem escape adequado para Mermaid sequenceDiagram.
+- correção aplicada: substituição das quebras por `<br/>` nas mensagens das setas, mantendo o mesmo conteúdo funcional.
+- arquivo alterado: `docs/canonical/mois-worker-canon.v1.md`.


### PR DESCRIPTION
### Motivation
- The Mermaid sequence diagram in `docs/canonical/mois-worker-canon.v1.md` failed to render on GitHub due to literal line breaks inside arrow labels that the parser rejects. 
- The change is documentation-only to restore correct diagram rendering and preserve the canonical workflow description for the MOIS worker.

### Description
- Rewrote the problematic arrow labels in the sequence diagram to use Mermaid-safe `<br/>` line breaks in `docs/canonical/mois-worker-canon.v1.md`, keeping the same endpoints and payload details. 
- Specifically adjusted the labels for the `API->>DB`, `WK->>OAI` and `WK->>API` messages to avoid literal multi-line text. 
- Added an entry documenting the fix and root cause to `docs/registros/mois1.md`.

### Testing
- Verified file changes with `git status --short` and inspected the modified region with `nl -ba docs/canonical/mois-worker-canon.v1.md | sed -n '165,245p'`, both succeeding. 
- Committed the changes with `git commit` and created the PR metadata using the repository PR tooling, both operations completed successfully. 
- No automated unit/integration tests were required because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ea9a17d948321a97134eeaeba8a27)