### PR TITLE
Move funnel tracking injection out of DesignPreset assembler and persist design-preset HTML

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssembler.java
@@ -1,10 +1,6 @@
 package com.marketinghub.geralanding;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.parser.Parser;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -42,7 +38,6 @@ public class DesignPresetProvisionalHtmlAssembler {
                     objectMapper.writeValueAsString(copyPayload),
                     imagePlanningJson,
                     designPresetOutputJson);
-            html = appendBehaviorTrackingAttributesAndScript(html);
             return appendJobIdCommentBeforeHead(html, jobId);
         } catch (Exception e) {
             throw new IllegalArgumentException("Falha ao montar HTML provisório da fase landing-page-design-preset", e);
@@ -70,84 +65,4 @@ public class DesignPresetProvisionalHtmlAssembler {
         return html.substring(0, headIndex) + comment + html.substring(headIndex);
     }
 
-    private String appendBehaviorTrackingAttributesAndScript(String html) {
-        if (!StringUtils.hasText(html) || html.contains("data-mh-funnel-tracking")) {
-            return html;
-        }
-        Document document = Jsoup.parse(html, "", Parser.htmlParser());
-        document.outputSettings().prettyPrint(false);
-
-        for (Element section : document.select("section[data-section-id], section[id], [data-section-id]")) {
-            String sectionId = section.hasAttr("data-section-id") ? section.attr("data-section-id") : section.id();
-            if (!StringUtils.hasText(sectionId)) {
-                continue;
-            }
-            section.attr("data-track-section", sectionId.trim());
-        }
-
-        String script = """
-                <script data-mh-funnel-tracking="true">
-                (function(){
-                  if (window.__mhFunnelTrackingInstalled) return;
-                  window.__mhFunnelTrackingInstalled = true;
-                  var debugPrefix = '[MH funnel tracking]';
-                  window.dataLayer = window.dataLayer || [];
-                  function emit(name, payload){
-                    var eventPayload = Object.assign({event:name, source:'landing-page-design-preset'}, payload||{});
-                    console.debug(debugPrefix, 'emit', eventPayload);
-                    window.dataLayer.push(eventPayload);
-                  }
-                  console.debug(debugPrefix, 'bootstrap');
-                  emit('page_view', {ts: Date.now()});
-                  var sections = Array.prototype.slice.call(document.querySelectorAll('[data-track-section]'));
-                  console.debug(debugPrefix, 'sections-found', {count: sections.length});
-                  var stats = {};
-                  sections.forEach(function(node){
-                    var id = node.getAttribute('data-track-section');
-                    stats[id] = {visibleSince:null, elapsedMs:0};
-                  });
-                  function flushSection(id, reason){
-                    var s = stats[id];
-                    if (!s || s.visibleSince === null) return;
-                    s.elapsedMs += Date.now() - s.visibleSince;
-                    s.visibleSince = null;
-                    console.debug(debugPrefix, 'section-flush', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
-                    emit('section_view_time', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
-                  }
-                  var observer = new IntersectionObserver(function(entries){
-                    entries.forEach(function(entry){
-                      var id = entry.target.getAttribute('data-track-section');
-                      if (!id || !stats[id]) return;
-                      if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
-                        if (stats[id].visibleSince === null) {
-                          stats[id].visibleSince = Date.now();
-                          console.debug(debugPrefix, 'section-visible', {sectionId:id, ts:stats[id].visibleSince});
-                          emit('section_view_start', {sectionId:id});
-                        }
-                      } else {
-                        flushSection(id, 'intersection-change');
-                      }
-                    });
-                  }, {threshold:[0,0.5,1]});
-                  sections.forEach(function(node){ observer.observe(node); });
-                  document.addEventListener('visibilitychange', function(){
-                    if (document.hidden) {
-                      console.debug(debugPrefix, 'visibility-hidden');
-                      Object.keys(stats).forEach(function(id){ flushSection(id, 'tab-hidden'); });
-                    }
-                  });
-                  window.addEventListener('beforeunload', function(){
-                    console.debug(debugPrefix, 'beforeunload-flush');
-                    Object.keys(stats).forEach(function(id){ flushSection(id, 'before-unload'); });
-                  });
-                })();
-                </script>
-                """;
-        if (document.head() != null) {
-            document.head().append(script);
-        } else {
-            document.prepend(script);
-        }
-        return document.outerHtml();
-    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -2,6 +2,10 @@ package com.marketinghub.geralanding;
 
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.pipeline.service.LandingPageImageInjector;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.slf4j.Logger;
@@ -77,7 +81,10 @@ public class GeraLandingStageExecutionService {
         log.info("GeraLanding publish approval loaded experiment (experimentId={}, experimentName={})",
                 experimentId, experiment.getName());
 
-        String landingPageHtml = experiment.getLandingPageHtml();
+        String landingPageHtml = experiment.getLandingPageDesignPreset();
+        if (!StringUtils.hasText(landingPageHtml)) {
+            landingPageHtml = experiment.getLandingPageHtml();
+        }
         if (!StringUtils.hasText(landingPageHtml)) {
             log.warn("GeraLanding publish approval blocked because landing HTML is missing (experimentId={})",
                     experimentId);
@@ -89,7 +96,8 @@ public class GeraLandingStageExecutionService {
         String slug = "exp-" + experimentId + "-landing-geralanding";
         log.info("GeraLanding publish approval resolved slug (experimentId={}, slug={})", experimentId, slug);
 
-        String htmlWithFunnelControls = injectFunnelControls(landingPageHtml);
+        String htmlWithTracking = injectBehaviorTrackingAttributesAndScript(landingPageHtml);
+        String htmlWithFunnelControls = injectFunnelControls(htmlWithTracking);
         log.info("GeraLanding publish approval injected funnel controls (experimentId={}, htmlLengthBefore={}, htmlLengthAfter={})",
                 experimentId, landingPageHtml.length(), htmlWithFunnelControls.length());
 
@@ -496,7 +504,6 @@ public class GeraLandingStageExecutionService {
         } else if (STAGE_DELIVERABLES.equalsIgnoreCase(stageCode)) {
             experiment.setLandingPageDeliverables(request.modelResponse());
         } else {
-            experiment.setLandingPageDesignPreset(request.modelResponse());
             String htmlFromDesignPreset = execution.getProvisionalHtml();
             if (!StringUtils.hasText(htmlFromDesignPreset)) {
                 htmlFromDesignPreset = resolveDesignPresetProvisionalHtml(
@@ -505,10 +512,97 @@ public class GeraLandingStageExecutionService {
                         execution);
             }
             if (StringUtils.hasText(htmlFromDesignPreset)) {
+                experiment.setLandingPageDesignPreset(htmlFromDesignPreset);
+            }
+            else {
+                experiment.setLandingPageDesignPreset(request.modelResponse());
+            }
+            if (StringUtils.hasText(htmlFromDesignPreset)) {
                 experiment.setLandingPageHtml(htmlFromDesignPreset);
             }
         }
         experimentRepository.save(experiment);
+    }
+
+    private String injectBehaviorTrackingAttributesAndScript(String html) {
+        if (!StringUtils.hasText(html) || html.contains("data-mh-funnel-tracking")) {
+            return html;
+        }
+        Document document = Jsoup.parse(html, "", Parser.htmlParser());
+        document.outputSettings().prettyPrint(false);
+
+        for (Element section : document.select("section[data-section-id], section[id], [data-section-id]")) {
+            String sectionId = section.hasAttr("data-section-id") ? section.attr("data-section-id") : section.id();
+            if (!StringUtils.hasText(sectionId)) {
+                continue;
+            }
+            section.attr("data-track-section", sectionId.trim());
+        }
+
+        String script = """
+                <script data-mh-funnel-tracking="true">
+                (function(){
+                  if (window.__mhFunnelTrackingInstalled) return;
+                  window.__mhFunnelTrackingInstalled = true;
+                  var debugPrefix = '[MH funnel tracking]';
+                  window.dataLayer = window.dataLayer || [];
+                  function emit(name, payload){
+                    var eventPayload = Object.assign({event:name, source:'landing-page-design-preset'}, payload||{});
+                    console.debug(debugPrefix, 'emit', eventPayload);
+                    window.dataLayer.push(eventPayload);
+                  }
+                  console.debug(debugPrefix, 'bootstrap');
+                  emit('page_view', {ts: Date.now()});
+                  var sections = Array.prototype.slice.call(document.querySelectorAll('[data-track-section]'));
+                  console.debug(debugPrefix, 'sections-found', {count: sections.length});
+                  var stats = {};
+                  sections.forEach(function(node){
+                    var id = node.getAttribute('data-track-section');
+                    stats[id] = {visibleSince:null, elapsedMs:0};
+                  });
+                  function flushSection(id, reason){
+                    var s = stats[id];
+                    if (!s || s.visibleSince === null) return;
+                    s.elapsedMs += Date.now() - s.visibleSince;
+                    s.visibleSince = null;
+                    console.debug(debugPrefix, 'section-flush', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
+                    emit('section_view_time', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
+                  }
+                  var observer = new IntersectionObserver(function(entries){
+                    entries.forEach(function(entry){
+                      var id = entry.target.getAttribute('data-track-section');
+                      if (!id || !stats[id]) return;
+                      if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+                        if (stats[id].visibleSince === null) {
+                          stats[id].visibleSince = Date.now();
+                          console.debug(debugPrefix, 'section-visible', {sectionId:id, ts:stats[id].visibleSince});
+                          emit('section_view_start', {sectionId:id});
+                        }
+                      } else {
+                        flushSection(id, 'intersection-change');
+                      }
+                    });
+                  }, {threshold:[0,0.5,1]});
+                  sections.forEach(function(node){ observer.observe(node); });
+                  document.addEventListener('visibilitychange', function(){
+                    if (document.hidden) {
+                      console.debug(debugPrefix, 'visibility-hidden');
+                      Object.keys(stats).forEach(function(id){ flushSection(id, 'tab-hidden'); });
+                    }
+                  });
+                  window.addEventListener('beforeunload', function(){
+                    console.debug(debugPrefix, 'beforeunload-flush');
+                    Object.keys(stats).forEach(function(id){ flushSection(id, 'before-unload'); });
+                  });
+                })();
+                </script>
+                """;
+        if (document.head() != null) {
+            document.head().append(script);
+        } else {
+            document.prepend(script);
+        }
+        return document.outerHtml();
     }
 
     @Transactional(readOnly = true)

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerTest.java
@@ -3,6 +3,7 @@ package com.marketinghub.geralanding;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -11,7 +12,7 @@ import static org.mockito.Mockito.when;
 class DesignPresetProvisionalHtmlAssemblerTest {
 
     @Test
-    void shouldInjectBehaviorTrackingIntoDesignPresetProvisionalHtml() {
+    void shouldAssembleHtmlWithoutInjectingBehaviorTrackingScript() {
         DesignPresetProvisionalHtmlProcessor processor = mock(DesignPresetProvisionalHtmlProcessor.class);
         when(processor.process(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn("<html><head><title>x</title></head><body><section data-section-id='hero'></section></body></html>");
@@ -24,9 +25,10 @@ class DesignPresetProvisionalHtmlAssemblerTest {
                 "{\"landingPageDesignPreset\":{\"sectionPresets\":[]}}",
                 "job-123");
 
-        assertTrue(html.contains("data-mh-funnel-tracking=\"true\""));
-        assertTrue(html.contains("page_view"));
-        assertTrue(html.contains("section_view_time"));
-        assertTrue(html.contains("data-track-section=\"hero\""));
+        assertFalse(html.contains("data-mh-funnel-tracking=\"true\""));
+        assertFalse(html.contains("page_view"));
+        assertFalse(html.contains("section_view_time"));
+        assertFalse(html.contains("data-track-section=\"hero\""));
+        assertTrue(html.contains("<!-- jobId = job-123 -->"));
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -390,7 +390,7 @@ class GeraLandingStageExecutionServiceTest {
 
         assertTrue(execution.getProvisionalHtml().contains("design-1.png"));
         assertEquals(execution.getProvisionalHtml(), experiment.getLandingPageHtml());
-        assertEquals(request.modelResponse(), experiment.getLandingPageDesignPreset());
+        assertEquals(execution.getProvisionalHtml(), experiment.getLandingPageDesignPreset());
         verify(experimentRepository).save(experiment);
     }
 }

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -72,7 +72,7 @@ Regras complementares:
 | `LANDING_PAGE_WIREFRAME` | `WireframeProvisionalHtmlAssembler` | `gera_landing_stage_execution.provisional_html` |
 | `LANDING_PAGE_COPY` | `CopyProvisionalHtmlAssembler` | `gera_landing_stage_execution.provisional_html` |
 | `LANDING_PAGE_IMAGE_PLANNING` | Não há assembler exclusivo da etapa; usa `CopyProvisionalHtmlAssembler.assembleComplete(...)` + `LandingPageImageInjector.injectImages(...)`. | `gera_landing_stage_execution.provisional_html` e `experiment.landing_page_html` (quando `provisionalHtml` existe na execução). |
-| `LANDING_PAGE_DESIGN_PRESET` | `DesignPresetProvisionalHtmlAssembler` + `LandingPageImageInjector.injectImages(...)` | `gera_landing_stage_execution.provisional_html` e `experiment.landing_page_html` |
+| `LANDING_PAGE_DESIGN_PRESET` | `DesignPresetProvisionalHtmlAssembler` + `LandingPageImageInjector.injectImages(...)` | `gera_landing_stage_execution.provisional_html`, `experiment.landing_page_design_preset` (HTML consolidado da etapa) e `experiment.landing_page_html` |
 
 ## 6. Geração e aprovação de anúncios
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -757,3 +757,11 @@
   - adicionado passo de normalização `unescapeJsonLikeContent` para decodificar sequências `\\n`, `\\r`, `\\t`, `\\\"`, `\\\\` e `\\uXXXX` antes da extração do primeiro objeto;
   - mantida a extração balanceada do primeiro objeto após normalização;
   - adicionado teste de regressão com payload `imagePlan` escapado + duplicado em sequência.
+
+## 2026-05-21 12:10:00 UTC
+- solicitação: remover de `DesignPresetProvisionalHtmlAssembler` a responsabilidade de instrumentação de tracking e manter o assembler apenas como montador do HTML consolidado da etapa `landing-page-design-preset`.
+- causa-raiz identificada: havia acoplamento indevido de responsabilidade (assembler de composição também fazia injeção de tracker), contrariando separação de responsabilidades e dificultando controle de publicação.
+- foi feito:
+  - removida a injeção de tracker (`data-track-section` + script `data-mh-funnel-tracking`) de `DesignPresetProvisionalHtmlAssembler`;
+  - o fluxo `approveAndPublishLanding` passou a ler prioritariamente `experiment.landing_page_design_preset` (com fallback para `landing_page_html` legado), injetar tracker nesse momento e seguir com injeção de controles de funil + Facebook Pixel + publicação no Lead Portal;
+  - no fechamento da etapa `LANDING_PAGE_DESIGN_PRESET`, o backend passou a persistir o HTML consolidado da etapa em `experiment.landing_page_design_preset` (mantendo atualização de `landing_page_html` para compatibilidade).


### PR DESCRIPTION
### Motivation
- Remove responsibility for runtime tracking injection from the `DesignPresetProvisionalHtmlAssembler` so the assembler is only responsible for composing the step's consolidated HTML and to respect separation of concerns. 
- Ensure the published landing contains tracking instrumentation applied at publish-time and allow storing the design-preset HTML artifact separately for inspection and reuse.

### Description
- Removed the tracking injection logic and `jsoup` usage from `DesignPresetProvisionalHtmlAssembler` and stopped appending the `data-mh-funnel-tracking` script during assembly. 
- Added `injectBehaviorTrackingAttributesAndScript` to `GeraLandingStageExecutionService` and invoke it during `approveAndPublishLanding` so the funnel tracking attributes and script are injected at publish-time. 
- Changed `approveAndPublishLanding` to prefer `experiment.landing_page_design_preset` (with fallback to legacy `landing_page_html`) when resolving the HTML to publish. 
- When a design-preset stage result is received, persist the consolidated HTML into `experiment.landing_page_design_preset` (and `landing_page_html` if available) and update tests and docs accordingly.

### Testing
- Updated and ran `DesignPresetProvisionalHtmlAssemblerTest` which now asserts that the assembler no longer injects the tracking script and that the job comment is present, and the test passed. 
- Updated and ran `GeraLandingStageExecutionServiceTest` which now asserts that `experiment.landing_page_design_preset` is set from the provisional HTML and that image injection runs as before, and the test passed. 
- All modified unit tests executed successfully (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ea66f14cc8321a0eed9b39fd46b86)