### PR TITLE
feat(mcp-server): add filtering and pagination for java_module_logs

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -17,7 +17,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `db_list_tables`: lista todas as tabelas disponíveis no schema atual.
 - `db_read_table`: lê dados de uma tabela com paginação (`table`, `limit`, `offset`).
 - `db_query`: executa SQL de leitura (`SELECT`/`WITH`) com limite de linhas.
-- `java_module_logs`: retorna tail de logs do Spring Boot dos módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-hotmart`, `clickbank-coletor-mois`, `oprm-coletor-receita`).
+- `java_module_logs`: retorna logs do Spring Boot com filtros opcionais por texto/intervalo e paginação (`lines`, `contains`, `from`, `to`, `offset`, `cursor`) para os módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-hotmart`, `clickbank-coletor-mois`, `oprm-coletor-receita`).
 - `meta_docs_get`: busca páginas de documentação da Meta em hosts aprovados.
 - `meta_graph_get`: executa leitura (`GET`) da Graph API com token configurado no MCP.
 - `meta_graph_debug_token`: executa `debug_token` para validar tokens.

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -138,7 +138,12 @@ public class McpController {
                                                     "description", "Módulo Java para consultar logs."),
                                             "lines", Map.of("type", "integer", "minimum", 1,
                                                     "maximum", moduleLogService.maxLines(),
-                                                    "description", "Quantidade de linhas do final do arquivo de log. Padrão: 200.")),
+                                                    "description", "Quantidade de linhas retornadas por página. Padrão: 200."),
+                                            "contains", Map.of("type", "string", "description", "Filtra linhas que contenham este texto literal."),
+                                            "from", Map.of("type", "string", "description", "Data/hora inicial ISO-8601 UTC (ex: 2026-05-21T04:35:00Z)."),
+                                            "to", Map.of("type", "string", "description", "Data/hora final ISO-8601 UTC (ex: 2026-05-21T04:40:00Z)."),
+                                            "offset", Map.of("type", "integer", "minimum", 0, "description", "Offset para paginação dentro do conjunto filtrado."),
+                                            "cursor", Map.of("type", "string", "description", "Cursor retornado em nextCursor para próxima página.")),
                                     "required", List.of("module"),
                                     "additionalProperties", false)
                     ),
@@ -324,9 +329,14 @@ public class McpController {
     private Map<String, Object> callJavaModuleLogsTool(Object id, Map<String, Object> arguments) {
         String module = stringArgument(arguments, "module");
         Integer lines = intArgument(arguments, "lines");
+        String contains = stringArgument(arguments, "contains");
+        String from = stringArgument(arguments, "from");
+        String to = stringArgument(arguments, "to");
+        Integer offset = intArgument(arguments, "offset");
+        String cursor = stringArgument(arguments, "cursor");
 
         try {
-            Map<String, Object> result = moduleLogService.readModuleLogs(module, lines);
+            Map<String, Object> result = moduleLogService.readModuleLogs(module, lines, contains, from, to, offset, cursor);
             return successToolResult(id, result, buildJavaModuleLogsText(result));
         } catch (IllegalArgumentException ex) {
             return error(id, -32602, ex.getMessage());

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -13,7 +13,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,9 +24,7 @@ import java.util.stream.Stream;
 
 @Service
 public class ModuleLogService {
-
     private static final int DEFAULT_LINES = 200;
-
     private final McpProperties properties;
     private final HttpClient httpClient;
     private final Duration logFetchTimeout;
@@ -37,192 +38,132 @@ public class ModuleLogService {
         this.httpTailRangeBytes = properties.logs().httpTailRangeBytes();
         this.fetchAttempts = properties.logs().fetchAttempts();
         this.fetchRetryDelayMillis = properties.logs().fetchRetryDelayMillis();
-        this.httpClient = HttpClient.newBuilder()
-                .connectTimeout(logFetchTimeout)
-                .build();
+        this.httpClient = HttpClient.newBuilder().connectTimeout(logFetchTimeout).build();
     }
 
-    public int maxLines() {
-        return properties.logs().maxLines();
-    }
+    public int maxLines() { return properties.logs().maxLines(); }
 
-    public Map<String, Object> readModuleLogs(String module, Integer requestedLines) {
+    public Map<String, Object> readModuleLogs(String module, Integer requestedLines, String contains, String from, String to, Integer offset, String cursor) {
         String normalizedModule = normalizeModule(module);
         int lines = sanitizeLines(requestedLines);
         String configuredPath = modulePath(normalizedModule);
-
-        if (!StringUtils.hasText(configuredPath)) {
-            throw new IllegalArgumentException("No log path configured for module: " + normalizedModule);
-        }
+        if (!StringUtils.hasText(configuredPath)) throw new IllegalArgumentException("No log path configured for module: " + normalizedModule);
 
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("module", normalizedModule);
-
-        if (isHttpUrl(configuredPath)) {
-            return readLogsFromUrl(configuredPath, lines, response);
-        }
+        if (isHttpUrl(configuredPath)) return readLogsFromUrl(configuredPath, lines, contains, from, to, offset, cursor, response);
 
         Path path = Path.of(configuredPath);
         response.put("path", path.toString());
-
         if (!Files.exists(path)) {
-            response.put("exists", false);
-            response.put("requestedLines", lines);
-            response.put("returnedLines", 0);
-            response.put("lines", List.of());
+            response.put("exists", false);response.put("requestedLines", lines);response.put("returnedLines", 0);response.put("lines", List.of());response.put("nextCursor", "");
             return response;
         }
-
         try (Stream<String> stream = Files.lines(path, StandardCharsets.UTF_8)) {
-            List<String> rows = stream
-                    .skip(Math.max(0, countLines(path) - lines))
-                    .toList();
-
-            response.put("exists", true);
-            response.put("sizeBytes", Files.size(path));
-            response.put("requestedLines", lines);
-            response.put("returnedLines", rows.size());
-            response.put("lines", rows);
-            return response;
+            return buildFilteredResponse(stream.toList(), lines, contains, from, to, offset, cursor, response, Files.size(path));
         } catch (IOException ex) {
             throw new IllegalArgumentException("Failed to read log file: " + ex.getMessage());
         }
     }
 
-    private Map<String, Object> readLogsFromUrl(String configuredUrl, int lines, Map<String, Object> response) {
-        response.put("path", configuredUrl);
-        response.put("source", "http");
-
+    private Map<String, Object> readLogsFromUrl(String configuredUrl, int lines, String contains, String from, String to, Integer offset, String cursor, Map<String, Object> response) {
+        response.put("path", configuredUrl); response.put("source", "http");
         HttpRequest request = buildTailRequest(configuredUrl, true);
         List<String> errors = new ArrayList<>();
         try {
             HttpResponse<String> httpResponse = sendWithRetry(request, errors);
             response.put("httpStatus", httpResponse.statusCode());
-
             if (httpResponse.statusCode() == 416) {
                 HttpResponse<String> fullResponse = sendWithRetry(buildTailRequest(configuredUrl, false), errors);
                 response.put("httpStatus", fullResponse.statusCode());
                 httpResponse = fullResponse;
             }
-
-            if (httpResponse.statusCode() < 200 || httpResponse.statusCode() >= 300) {
-                throw new IllegalArgumentException("Failed to read log stream URL: HTTP " + httpResponse.statusCode()
-                        + " | attempts: " + String.join(" | ", errors));
-            }
-
-            List<String> allLines = httpResponse.body().lines().toList();
-            int startIndex = Math.max(0, allLines.size() - lines);
-            List<String> tailLines = allLines.subList(startIndex, allLines.size());
-
-            response.put("exists", true);
-            response.put("requestedLines", lines);
-            response.put("returnedLines", tailLines.size());
-            response.put("lines", tailLines);
-            return response;
+            if (httpResponse.statusCode() < 200 || httpResponse.statusCode() >= 300) throw new IllegalArgumentException("Failed to read log stream URL: HTTP " + httpResponse.statusCode() + " | attempts: " + String.join(" | ", errors));
+            return buildFilteredResponse(httpResponse.body().lines().toList(), lines, contains, from, to, offset, cursor, response, null);
         } catch (IOException | InterruptedException ex) {
-            if (ex instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
+            if (ex instanceof InterruptedException) Thread.currentThread().interrupt();
             throw new IllegalArgumentException("Failed to read log stream URL: " + ex.getMessage());
         }
     }
 
-    private HttpResponse<String> sendWithRetry(HttpRequest request, List<String> errors) throws IOException, InterruptedException {
-        IOException lastIo = null;
-        InterruptedException lastInterrupt = null;
+    private Map<String, Object> buildFilteredResponse(List<String> allLines, int lines, String contains, String from, String to, Integer offset, String cursor, Map<String, Object> response, Long sizeBytes) {
+        List<String> filtered = applyFilters(allLines, contains, from, to);
+        boolean defaultTailMode = !StringUtils.hasText(contains) && !StringUtils.hasText(from) && !StringUtils.hasText(to) && offset == null && !StringUtils.hasText(cursor);
+        int resolvedOffset = defaultTailMode ? Math.max(0, filtered.size() - lines) : resolveOffset(offset, cursor);
+        if (resolvedOffset < 0 || resolvedOffset > filtered.size()) throw new IllegalArgumentException("offset must be between 0 and " + filtered.size());
+        int end = Math.min(filtered.size(), resolvedOffset + lines);
+        List<String> page = filtered.subList(resolvedOffset, end);
+        response.put("exists", true);
+        if (sizeBytes != null) response.put("sizeBytes", sizeBytes);
+        response.put("requestedLines", lines); response.put("returnedLines", page.size()); response.put("totalFilteredLines", filtered.size()); response.put("offset", resolvedOffset);
+        response.put("contains", contains == null ? "" : contains); response.put("from", from == null ? "" : from); response.put("to", to == null ? "" : to);
+        response.put("lines", page);
+        response.put("nextCursor", end < filtered.size() ? Base64.getEncoder().encodeToString(("offset:" + end).getBytes(StandardCharsets.UTF_8)) : "");
+        return response;
+    }
 
+    private List<String> applyFilters(List<String> lines, String contains, String from, String to) {
+        Instant fromTs = parseInstant(from, "from"); Instant toTs = parseInstant(to, "to");
+        return lines.stream().filter(line -> {
+            if (StringUtils.hasText(contains) && !line.contains(contains)) return false;
+            if (fromTs == null && toTs == null) return true;
+            Instant lineTs = extractFirstInstant(line);
+            if (lineTs == null) return false;
+            if (fromTs != null && lineTs.isBefore(fromTs)) return false;
+            return toTs == null || !lineTs.isAfter(toTs);
+        }).toList();
+    }
+
+    private int resolveOffset(Integer offset, String cursor) {
+        if (StringUtils.hasText(cursor)) {
+            try {
+                String decoded = new String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8);
+                if (!decoded.startsWith("offset:")) throw new IllegalArgumentException("invalid cursor");
+                return Integer.parseInt(decoded.substring(7));
+            } catch (Exception ex) { throw new IllegalArgumentException("invalid cursor"); }
+        }
+        return offset == null ? 0 : offset;
+    }
+
+    private Instant parseInstant(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) return null;
+        try { return Instant.parse(value); } catch (DateTimeParseException ex) { throw new IllegalArgumentException(fieldName + " must be in ISO-8601 UTC format, e.g. 2026-05-21T04:35:00Z"); }
+    }
+
+    private Instant extractFirstInstant(String line) {
+        for (String token : line.split("[\\s\\[\\]]+")) {
+            try { return Instant.parse(token); } catch (DateTimeParseException ignored) { }
+        }
+        return null;
+    }
+
+    private HttpResponse<String> sendWithRetry(HttpRequest request, List<String> errors) throws IOException, InterruptedException { /* unchanged logic */
+        IOException lastIo = null; InterruptedException lastInterrupt = null;
         for (int attempt = 1; attempt <= fetchAttempts; attempt++) {
             try {
                 HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
                 errors.add("attempt " + attempt + " status " + response.statusCode());
-                if (response.statusCode() >= 500 || response.statusCode() == 429) {
-                    if (attempt < fetchAttempts) {
-                        Thread.sleep(fetchRetryDelayMillis);
-                        continue;
-                    }
-                }
+                if (response.statusCode() >= 500 || response.statusCode() == 429) { if (attempt < fetchAttempts) { Thread.sleep(fetchRetryDelayMillis); continue; } }
                 return response;
-            } catch (IOException ex) {
-                lastIo = ex;
-                errors.add("attempt " + attempt + " io-error: " + ex.getClass().getSimpleName() + " - " + ex.getMessage());
-            } catch (InterruptedException ex) {
-                lastInterrupt = ex;
-                errors.add("attempt " + attempt + " interrupted: " + ex.getMessage());
-                break;
-            }
-
-            if (attempt < fetchAttempts) {
-                Thread.sleep(fetchRetryDelayMillis);
-            }
+            } catch (IOException ex) { lastIo = ex; errors.add("attempt " + attempt + " io-error: " + ex.getClass().getSimpleName() + " - " + ex.getMessage()); }
+            catch (InterruptedException ex) { lastInterrupt = ex; errors.add("attempt " + attempt + " interrupted: " + ex.getMessage()); break; }
+            if (attempt < fetchAttempts) Thread.sleep(fetchRetryDelayMillis);
         }
-
-        if (lastInterrupt != null) {
-            throw lastInterrupt;
-        }
-        if (lastIo != null) {
-            throw lastIo;
-        }
-        throw new IOException("Failed to read log stream URL after retries");
+        if (lastInterrupt != null) throw lastInterrupt; if (lastIo != null) throw lastIo; throw new IOException("Failed to read log stream URL after retries");
     }
 
     private HttpRequest buildTailRequest(String configuredUrl, boolean withRange) {
-        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(configuredUrl))
-                .timeout(logFetchTimeout)
-                .GET();
-        if (withRange) {
-            builder.header("Range", "bytes=-" + httpTailRangeBytes);
-        }
+        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(configuredUrl)).timeout(logFetchTimeout).GET();
+        if (withRange) builder.header("Range", "bytes=-" + httpTailRangeBytes);
         return builder.build();
     }
-
-    private boolean isHttpUrl(String value) {
-        String normalized = value.trim().toLowerCase();
-        return normalized.startsWith("http://") || normalized.startsWith("https://");
-    }
-
-    private long countLines(Path path) throws IOException {
-        try (Stream<String> stream = Files.lines(path, StandardCharsets.UTF_8)) {
-            return stream.count();
-        }
-    }
-
-    private String modulePath(String module) {
-        return switch (module) {
-            case "backend" -> properties.logs().backendPath();
-            case "ai-worker" -> properties.logs().aiWorkerPath();
-            case "lead-portal" -> properties.logs().leadPortalPath();
-            case "facebook-ads" -> properties.logs().facebookAdsPath();
-            case "email-service" -> properties.logs().emailServicePath();
-            case "lead-portal-payment" -> properties.logs().leadPortalPaymentPath();
-            case "mds" -> properties.logs().mdsPath();
-            case "mois" -> properties.logs().moisPath();
-            case "mois-hotmart" -> properties.logs().moisHotmartPath();
-            case "clickbank-coletor-mois" -> properties.logs().clickbankColetorMoisPath();
-            case "oprm-coletor-receita" -> properties.logs().oprmColetorReceitaPath();
-            default -> throw new IllegalArgumentException("Unknown module: " + module);
-        };
-    }
-
+    private boolean isHttpUrl(String value) { String normalized = value.trim().toLowerCase(); return normalized.startsWith("http://") || normalized.startsWith("https://"); }
+    private String modulePath(String module) { return switch (module) {
+        case "backend" -> properties.logs().backendPath(); case "ai-worker" -> properties.logs().aiWorkerPath(); case "lead-portal" -> properties.logs().leadPortalPath(); case "facebook-ads" -> properties.logs().facebookAdsPath(); case "email-service" -> properties.logs().emailServicePath(); case "lead-portal-payment" -> properties.logs().leadPortalPaymentPath(); case "mds" -> properties.logs().mdsPath(); case "mois" -> properties.logs().moisPath(); case "mois-hotmart" -> properties.logs().moisHotmartPath(); case "clickbank-coletor-mois" -> properties.logs().clickbankColetorMoisPath(); case "oprm-coletor-receita" -> properties.logs().oprmColetorReceitaPath(); default -> throw new IllegalArgumentException("Unknown module: " + module); }; }
     private String normalizeModule(String module) {
-        if (!StringUtils.hasText(module)) {
-            throw new IllegalArgumentException("module is required");
-        }
-
+        if (!StringUtils.hasText(module)) throw new IllegalArgumentException("module is required");
         String normalized = module.trim().toLowerCase();
-        return switch (normalized) {
-            case "backend", "ai-worker", "lead-portal", "facebook-ads", "email-service", "lead-portal-payment",
-                 "mds", "mois", "mois-hotmart", "clickbank-coletor-mois", "oprm-coletor-receita" -> normalized;
-            default -> throw new IllegalArgumentException(
-                    "module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, " +
-                            "lead-portal-payment, mds, mois, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita");
-        };
+        return switch (normalized) { case "backend", "ai-worker", "lead-portal", "facebook-ads", "email-service", "lead-portal-payment", "mds", "mois", "mois-hotmart", "clickbank-coletor-mois", "oprm-coletor-receita" -> normalized; default -> throw new IllegalArgumentException("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita"); };
     }
-
-    private int sanitizeLines(Integer requestedLines) {
-        int lines = requestedLines == null ? DEFAULT_LINES : requestedLines;
-        if (lines < 1 || lines > maxLines()) {
-            throw new IllegalArgumentException("lines must be between 1 and " + maxLines());
-        }
-        return lines;
-    }
+    private int sanitizeLines(Integer requestedLines) { int lines = requestedLines == null ? DEFAULT_LINES : requestedLines; if (lines < 1 || lines > maxLines()) throw new IllegalArgumentException("lines must be between 1 and " + maxLines()); return lines; }
 }

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -192,6 +192,19 @@ class McpControllerTest {
                         .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita"));
     }
 
+
+
+    @Test
+    void shouldFilterAndPaginateJavaModuleLogs() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","id":15,"method":"tools/call","params":{"name":"java_module_logs","arguments":{"module":"backend","lines":1,"contains":"line","offset":1}}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.structuredContent.returnedLines").value(1))
+                .andExpect(jsonPath("$.result.structuredContent.lines[0]").value("line-2"));
+    }
     @Test
     void shouldHandleErrorResponseWhenRequestIdIsNull() throws Exception {
         mockMvc.perform(post("/mcp")

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
@@ -47,7 +47,7 @@ class ModuleLogServiceTest {
         String url = "http://localhost:" + server.getAddress().getPort() + "/logs";
         ModuleLogService service = new ModuleLogService(buildProperties(url));
 
-        Map<String, Object> result = service.readModuleLogs("backend", 2);
+        Map<String, Object> result = service.readModuleLogs("backend", 2, null, null, null, null, null);
 
         assertEquals(3, calls.get());
         assertEquals(2, result.get("returnedLines"));


### PR DESCRIPTION
### Motivation
- Permitir buscas de logs mais precisas e navegação por páginas (texto, intervalo de tempo e paginação) para diagnósticos do MCP, em vez de ficar restrito ao `tail` das últimas linhas.

### Description
- Estendi o schema da tool `java_module_logs` em `McpController` para aceitar `contains`, `from`, `to`, `offset` e `cursor`, mantendo `module` e `lines` compatíveis com clientes atuais.
- Atualizei a assinatura do serviço para `readModuleLogs(module, lines, contains, from, to, offset, cursor)` e adicionei lógica de filtragem e paginação em `ModuleLogService` com geração de `nextCursor` codificado em Base64.
- Implementei parsing ISO-8601 para `from`/`to`, extração de timestamps das linhas para aplicar filtros temporais, e preservação do comportamento padrão de tail quando nenhum filtro/paginação é informado.
- Atualizei `README.md` e os testes unitários (`ModuleLogServiceTest`, `McpControllerTest`) para cobrir o novo contrato e o caminho de filtro+paginação.

### Testing
- Executei `mvn -q -Dtest=ModuleLogServiceTest,McpControllerTest test` localmente; após ajustar a implementação os testes direcionados foram executados com sucesso na última execução (todos os testes alvo passaram).
- Não foram executados outros suites de teste além dos testes unitários mencionados nesta validação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ea922101483218d6346bd73e64915)