### PR TITLE
Adiciona whitelist de atributos CSS ao prompt GeraLanding Wireframe

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -50,6 +50,16 @@ Regras fixas da etapa (formato simplificado):
 - Entregar somente JSON válido no formato raiz `pagina`.
 - Estrutura obrigatória: `pagina.head.texto`, `pagina.corpo.estilos[]`, `pagina.corpo.secoes[]`.
 - Cada item de `estilos[]` deve ter apenas `nome` e `valor`.
+- Whitelist de atributos CSS permitidos em qualquer `estilos[]` (usar apenas estes nomes, sem criar outros):
+  - `position`, `top`, `right`, `bottom`, `left`, `z-index`, `display`, `float`, `clear`, `visibility`, `overflow`, `overflow-x`, `overflow-y`
+  - `width`, `height`, `min-width`, `min-height`, `max-width`, `max-height`, `box-sizing`
+  - `margin`, `margin-top`, `margin-right`, `margin-bottom`, `margin-left`
+  - `padding`, `padding-top`, `padding-right`, `padding-bottom`, `padding-left`
+  - `flex`, `flex-direction`, `flex-wrap`, `flex-flow`, `justify-content`, `align-items`, `align-content`, `align-self`, `gap`, `row-gap`, `column-gap`, `order`, `flex-grow`, `flex-shrink`, `flex-basis`
+  - `grid`, `grid-template`, `grid-template-columns`, `grid-template-rows`, `grid-template-areas`, `grid-column`, `grid-column-start`, `grid-column-end`, `grid-row`, `grid-row-start`, `grid-row-end`, `grid-area`, `justify-items`, `place-items`, `place-content`
+  - `transform`, `translate`, `scale`, `rotate`, `transform-origin`, `border`, `opacity`
+- Se um atributo estiver fora dessa whitelist, não usar no wireframe.
+
 - Cada seção deve conter: `nome`, `objetivo`, `oQueQuerProvocarNoUsuario`, `papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada`, `fonteContexto[]`, `id`, `estilos[]`, `elementosSeccao[]`.
 - Cada item de `elementosSeccao[]` deve conter: `id`, `tag`, `texto`, `estilos[]`, `elementosInternos[]`.
 - Quando `tag = "img"`, o elemento deve conter também `briefingVisual` com:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -771,3 +771,7 @@
 - foi feito:
   - atualização do documento canônico `docs/canonical/procedimento-experimento-canon.v1.md`, seção de publicação da landing;
   - detalhado o fluxo pós-aprovação executado por `GeraLandingStageExecutionService.approveAndPublishLanding`, incluindo: resolução do HTML base, injeções (tracking/funnel/pixel), publicação no Lead Portal e persistência da `follow_up_action_url`.
+
+## 2026-05-21 — Ajuste prompt GeraLanding Wireframe (whitelist CSS)
+- Atualizado o prompt `landing-page-wireframe.md` para incluir whitelist explícita de atributos CSS permitidos em `estilos[]`.
+- Regra adicional: proibido usar atributos fora da whitelist para evitar divergência de contrato de estilo no artefato wireframe.


### PR DESCRIPTION
### Motivation
- Reduzir variação indevida de estilos gerados pelo modelo e evitar atributos CSS fora do contrato do wireframe.
- Garantir que os artefatos de wireframe sigam uma lista controlada de propriedades CSS para manter consistência entre wireframe, planejamento de imagens e HTML final.

### Description
- Adiciona uma `whitelist` explícita de atributos CSS permitidos no arquivo de prompt `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` (ex.: `position`, `top`, `right`, `bottom`, `left`, `z-index`, `display`, `width`, `height`, `margin`, `padding`, `flex`/`grid` relacionados, `transform`, `border`, `opacity`, etc.).
- Insere a regra de bloqueio textual: atributos fora dessa whitelist não devem ser usados no wireframe.
- Registra a alteração no diário de experimentos `docs/registros/experimentos.md` com data e breve justificativa.

### Testing
- Nenhum teste automatizado foi executado pois a mudança é textual em prompts e documentação e não altera código compilável nem contratos Java.
- Recomenda-se rodar os testes do módulo `ai-worker` e os testes de contrato do pipeline (`backend/ads-service` related tests) se houver preocupação de regressão funcional em execuções posteriores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eb1083dcc8321a34a0e05c21208e4)