### PR TITLE
chore(oprm): agendar ingestão de CNAEs para 10:00

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -112,3 +112,5 @@
 - 2026-05-21 00:00:00 (UTC): ajuste solicitado para agendar a próxima execução da importação OPRM CNPJ/CNAE para **00:40** no fuso `America/Sao_Paulo`, com atualização do cron hardcoded de `runScheduledImport` para `0 40 0 * * *` e sincronização do cron padrão em `application.yml` para o mesmo horário.
 - 2026-05-21 00:00:00 (UTC): ajuste de documentação em código no backend (`OprmMarketImportService`) para conformidade: adicionados comentários de responsabilidade da classe e comentários breves em todos os métodos públicos/privados do serviço OPRM de importação.
 - 2026-05-21 00:00:00 (UTC): ajuste solicitado para alterar o agendamento da importação OPRM CNPJ/CNAE para **01:30** no fuso `America/Sao_Paulo`, com atualização do cron hardcoded de `runScheduledImport` para `0 30 1 * * *` e sincronização do cron padrão em `application.yml` para o mesmo horário.
+
+- 2026-05-21: Ajustado o agendamento da ingestão OPRM de CNAEs no coletor MEI para 10:00 (America/Sao_Paulo), atualizando o cron de `runScheduledImport` para `0 0 10 * * *`.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
@@ -49,7 +49,7 @@ public class OprmMarketImportScheduler {
         this.restClient = restClient;
     }
 
-    @Scheduled(cron = "0 30 1 * * *", zone = "America/Sao_Paulo")
+    @Scheduled(cron = "0 0 10 * * *", zone = "America/Sao_Paulo")
     public void runScheduledImport() {
         if (!scheduleProperties.enabled()) {
             log.info("Scheduler OPRM market import desabilitado.");
@@ -163,7 +163,7 @@ public class OprmMarketImportScheduler {
             }
         }
 
-        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 18:30 ({}) com {} arquivos.",
+        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 10:00 ({}) com {} arquivos.",
                 snapshotDate,
                 scheduleProperties.timezone(),
                 files.size());

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -22,7 +22,7 @@ oprm:
       temp-dir: ${OPRM_MARKET_IMPORT_TEMP_DIR:/tmp/oprm-cnpj-import}
     schedule:
       enabled: ${OPRM_MARKET_IMPORT_SCHEDULE_ENABLED:true}
-      cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 30 1 * * *}
+      cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 0 10 * * *}
       timezone: ${OPRM_MARKET_IMPORT_SCHEDULE_TIMEZONE:America/Sao_Paulo}
       snapshot-date: ${OPRM_MARKET_IMPORT_SNAPSHOT_DATE:2026-05-10}
       source-base-url: ${OPRM_MARKET_IMPORT_SOURCE_BASE_URL:https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos}


### PR DESCRIPTION
### Motivation
- Ajustar o horário diário de ingestão de CNAEs do coletor OPRM-MEI para rodar às 10:00 (fuso `America/Sao_Paulo`).

### Description
- Atualiza o `@Scheduled` em `oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java` para `cron = "0 0 10 * * *"`, altera a mensagem de log para indicar `às 10:00`, sincroniza o padrão em `oprm-coletor-mei/src/main/resources/application.yml` para `cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 0 10 * * *}` e registra a ação em `docs/registros/oprm1.md`.

### Testing
- Nenhum teste automatizado foi executado pois a alteração é de agendamento/configuração; a mudança foi aplicada e commitada com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eb2c3b25883218617389fb010be95)