### PR TITLE
Align OpenAI system prompts to 'Especialista em Marketing' and add class/method comments

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -20,6 +20,9 @@ import org.springframework.util.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 @Service
+/**
+ * Executa as etapas pendentes do GeraLanding, preparando prompts, schemas e payloads para a OpenAI.
+ */
 public class GeraLandingExecutionService {
     private static final Logger log = LoggerFactory.getLogger(GeraLandingExecutionService.class);
     private static final String STAGE_WIREFRAME = "landing-page-wireframe";
@@ -115,7 +118,7 @@ public class GeraLandingExecutionService {
                     openAiModel,
                     prompt,
                     "gera-landing-pipeline",
-                    "Você é especialista em execução de pipeline de experimento.");
+                    "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
             log.info("OpenAI payload built for gera-landing executionId={} (length={})", execution.idJob(), openAiRequestBody.length());
             log.info("Payload OpenAI do gera-landing executionId={}: {}", execution.idJob(), openAiRequestBody);
             String schemaJson = objectMapper.writeValueAsString(readSchemaByStage(normalizedStage));
@@ -224,6 +227,9 @@ public class GeraLandingExecutionService {
         return value.substring(0, max) + "...";
     }
 
+    /**
+     * Monta o corpo da requisição da OpenAI Responses API para uma etapa do GeraLanding.
+     */
     private String buildOpenAiRequestBody(String stageCode,
                                           String model,
                                           String prompt,
@@ -233,7 +239,7 @@ public class GeraLandingExecutionService {
         // {
         //   "model": "gpt-5.2",
         //   "input": [
-        //     {"role": "system", "content": "Você é especialista em execução de pipeline de experimento."},
+        //     {"role": "system", "content": "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet."},
         //     {"role": "user", "content": [{"type": "input_text", "text": "SEU PROMPT AQUI"}]}
         //   ],
         //   "text": {
@@ -255,7 +261,7 @@ public class GeraLandingExecutionService {
         String resolvedSystemName = StringUtils.hasText(systemName) ? systemName.trim() : "system";
         String resolvedSystemMessage = StringUtils.hasText(systemMessage)
                 ? systemMessage.trim()
-                : "Você é especialista em execução de pipeline de experimento.";
+                : "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", resolvedModel);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiBatchClient.java
@@ -20,6 +20,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @Component
+/**
+ * Cliente de integração com a OpenAI para execução dos jobs do GeraLanding em modo flex.
+ */
 public class GeraLandingOpenAiBatchClient {
     private static final Logger log = LoggerFactory.getLogger(GeraLandingOpenAiBatchClient.class);
     private static final int LOG_PREVIEW_LIMIT = 1200;
@@ -139,6 +142,9 @@ public class GeraLandingOpenAiBatchClient {
         return buildRequestBodyFromPrompt(job, job.prompt());
     }
 
+    /**
+     * Cria um corpo mínimo de requisição quando apenas o prompt textual está disponível.
+     */
     private Map<String, Object> buildRequestBodyFromPrompt(GeraLandingJobDto job, String promptText) {
         if (!StringUtils.hasText(promptText)) {
             throw new IllegalStateException("Payload da OpenAI ausente: requestBodyJson e prompt vazios para gera-landing");
@@ -146,7 +152,7 @@ public class GeraLandingOpenAiBatchClient {
         Map<String, Object> requestBody = new LinkedHashMap<>();
         requestBody.put("model", StringUtils.hasText(job.model()) ? job.model() : "gpt-5.2");
         requestBody.put("input", List.of(
-                Map.of("role", "system", "content", "[gera-landing-pipeline] Você é especialista em execução de pipeline de experimento."),
+                Map.of("role", "system", "content", "[gera-landing-pipeline] Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet."),
                 Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", promptText)))));
         return requestBody;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -77,6 +77,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Service
+/**
+ * Orquestra a geração das etapas do pipeline de experimento e a publicação da landing com apoio de IA.
+ */
 public class ExperimentPipelineGenerationService {
     private static final Logger log = LoggerFactory.getLogger(ExperimentPipelineGenerationService.class);
     private static final Pattern FORM_CONTROL_TAG_PATTERN = Pattern.compile("(?is)<(input|textarea|select)\\b[^>]*>");
@@ -1163,8 +1166,11 @@ public class ExperimentPipelineGenerationService {
         );
     }
 
+    /**
+     * Monta o prompt de sistema base para orientar a geração da seção atual do pipeline.
+     */
     private String buildSystemPrompt(ExperimentPipelineSection section) {
-        return "Você é especialista em execução de pipeline de experimento. "
+        return "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet. "
                 + "Siga estritamente o template da etapa fornecido pelo Worker AI. "
                 + "Seção atual: " + section.path() + ".";
     }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -788,3 +788,27 @@
   - docs/gera-landing/modelo-canonico-gera-landing.md
   - docs/canonical/system-governance-canon.v2.md
   - docs/registros/experimentos.md
+
+## 2026-05-21 13:05:00 UTC
+- solicitação: ajustar o campo `system` enviado para OpenAI na geração dos dados do pipeline de experimentos para orientar o modelo como especialista em marketing focado em vendas de produtos digitais pela internet.
+- causa-raiz: prompt de sistema padrão ainda estava genérico ("especialista em execução de pipeline") sem explicitar foco de marketing orientado a vendas digitais.
+- foi feito:
+  - atualização do `buildSystemPrompt` no backend de experimentos para incluir a instrução explícita de especialista em marketing focado em vendas de produtos digitais pela Internet;
+  - atualização do fallback de `systemMessage` no `GeraLandingExecutionService` com a mesma orientação;
+  - atualização do payload batch (`GeraLandingOpenAiBatchClient`) para manter a mesma diretriz no campo `system`.
+
+## 2026-05-21 15:55:00 UTC
+- ajuste solicitado: remover a expressão "pipeline de experimento" do campo `system` enviado à OpenAI no fluxo de geração.
+- causa-raiz: o prompt ainda continha orientação secundária de "execução de pipeline", divergindo da instrução de manter apenas posicionamento de especialista em marketing/vendas digitais.
+- foi feito:
+  - removida a frase de "execução de pipeline de experimento" do `buildSystemPrompt` no backend;
+  - removida a mesma frase do `systemMessage` explícito e do fallback no `GeraLandingExecutionService`;
+  - removida a mesma frase do payload batch no `GeraLandingOpenAiBatchClient`.
+
+## 2026-05-21 16:10:00 UTC
+- ajuste solicitado: adicionar comentários de responsabilidade/orientação nas classes Java alteradas do fluxo de geração de experimentos.
+- causa-raiz: classes alteradas no PR anterior não continham comentários explícitos em todos os pontos exigidos pelo fluxo operacional do AGENTS.
+- foi feito:
+  - adicionado comentário de responsabilidade da classe e comentário do método `buildSystemPrompt` em `ExperimentPipelineGenerationService`;
+  - adicionado comentário de responsabilidade da classe e comentário do método `buildOpenAiRequestBody` em `GeraLandingExecutionService`;
+  - adicionado comentário de responsabilidade da classe e comentário do método `buildRequestBodyFromPrompt` em `GeraLandingOpenAiBatchClient`.


### PR DESCRIPTION
### Motivation
- Align the system-level instruction sent to OpenAI with the desired persona: an expert in marketing focused on selling digital products online, instead of a generic "pipeline" specialist.
- Remove the mention of "execução de pipeline de experimento" from system prompts to avoid mixed guidance to the model.
- Make class responsibilities and key methods explicit via JavaDoc comments to comply with documentation/governance requirements.

### Description
- Replaced the system message fallback/content in `GeraLandingExecutionService.buildOpenAiRequestBody` from the generic pipeline phrasing to: "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet." and added a method comment for the method.
- Updated `GeraLandingOpenAiBatchClient.buildRequestBodyFromPrompt` to use the same marketing-focused system message and added a class-level comment plus a comment for the method that builds a minimal request body from a prompt.
- Updated `ExperimentPipelineGenerationService.buildSystemPrompt` to return the marketing-focused system prompt and added a class-level comment plus a method comment for `buildSystemPrompt`.
- Added brief class-level JavaDoc comments to `GeraLandingExecutionService`, `GeraLandingOpenAiBatchClient`, and `ExperimentPipelineGenerationService` and method comments on the mentioned methods.
- Updated `docs/registros/experimentos.md` with changelog entries describing these prompt and comment updates.

### Testing
- Ran project build and tests for the changed modules with `./gradlew :ai-worker:build :backend:ads-service:build` and `./gradlew test` where applicable; the build completed and automated tests passed.
- Performed static compilation checks on the modified Java sources during the build and there were no compilation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f280cca08832180542ff42b0cc57e)