### PR TITLE
Simplifica Biblioteca de Páginas de Vendas para tabela de fase por produto

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -372,3 +372,9 @@
 - causa-raiz: quebras de linha literais dentro do texto das setas (`API->>DB`, `WK->>OAI`, `WK->>API`) sem escape adequado para Mermaid sequenceDiagram.
 - correção aplicada: substituição das quebras por `<br/>` nas mensagens das setas, mantendo o mesmo conteúdo funcional.
 - arquivo alterado: `docs/canonical/mois-worker-canon.v1.md`.
+
+## 2026-05-21 04:20:00 UTC
+- tela MOIS `Biblioteca de Páginas de Vendas` simplificada para exibir apenas uma tabela consolidada com produto coletado e fase atual, conforme o diagrama canônico `docs/canonical/mois-worker-canon.v1.md#12.2`.
+- removidos da tela os blocos de entradas ingeridas, fila de jobs, paginação e detalhes de análise, mantendo foco na leitura operacional de fase por produto.
+- adicionada função de mapeamento de status (`PENDING`, `FETCHING`, `ANALYZING`, `RETRY_WAIT`, `DONE`, `FAILED`) para fase textual do fluxo canônico.
+- arquivo alterado: `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`.

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -1,118 +1,38 @@
-import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import CollapsibleJsonViewer from "../../components/CollapsibleJsonViewer";
 import PageTitle from "../../components/PageTitle";
-import {
-  getSalesLibraryJobBadgeClass,
-  useMoisSalesLibraryEntries,
-  useMoisSalesLibraryJobs,
-  useMoisSalesLibraryPageAnalysis,
-  useMoisSalesLibraryPages,
-  useReanalyzeMoisSalesLibraryPage,
-} from "../../api/mois/useMoisSalesLibrary";
+import { getSalesLibraryJobBadgeClass, useMoisSalesLibraryPages } from "../../api/mois/useMoisSalesLibrary";
 
 const WORKSPACE_ID = "workspace-001";
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 100;
 
-const GMT_TIMEZONE = "Etc/GMT";
-
-function formatDateTimeInGmt(value?: string | null) {
-  if (!value) {
-    return "—";
+function getPipelinePhase(status?: string | null) {
+  switch (status) {
+    case "PENDING":
+      return "Fase 2 — URL disponível na biblioteca";
+    case "FETCHING":
+      return "Fase 3 — Worker coletando conteúdo da página";
+    case "ANALYZING":
+      return "Fase 4 — Análise com OpenAI em andamento";
+    case "RETRY_WAIT":
+      return "Fase 4 — Aguardando nova tentativa de análise";
+    case "DONE":
+      return "Fase 5 — Resultado persistido no banco";
+    case "FAILED":
+      return "Fase 5 — Falha terminal registrada";
+    default:
+      return "Sem fase definida";
   }
-
-  const parsedDate = new Date(value);
-  if (Number.isNaN(parsedDate.getTime())) {
-    return value;
-  }
-
-  return new Intl.DateTimeFormat("pt-BR", {
-    timeZone: GMT_TIMEZONE,
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  }).format(parsedDate) + " GMT";
-}
-
-function formatOpenAiErrorMessage(value?: string | null) {
-  if (!value) {
-    return "—";
-  }
-
-  const trimmedValue = value.trim();
-  const jsonStartCandidates = [trimmedValue.indexOf("{"), trimmedValue.indexOf("[")].filter((index) => index >= 0);
-  if (jsonStartCandidates.length === 0) {
-    return value;
-  }
-
-  const jsonStartIndex = Math.min(...jsonStartCandidates);
-  const jsonCandidate = trimmedValue.slice(jsonStartIndex);
-
-  try {
-    const parsed = JSON.parse(jsonCandidate);
-    const pretty = JSON.stringify(parsed, null, 2);
-    const prefix = trimmedValue.slice(0, jsonStartIndex).trim();
-
-    return prefix ? `${prefix}\nOpenAI JSON:\n${pretty}` : `OpenAI JSON:\n${pretty}`;
-  } catch {
-    return value;
-  }
-}
-
-
-function SimplePaginator({
-  page,
-  pageSize,
-  total,
-  onChange,
-}: {
-  page: number;
-  pageSize: number;
-  total: number;
-  onChange: (newPage: number) => void;
-}) {
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
-  return (
-    <div className="d-flex justify-content-between align-items-center mt-3">
-      <span className="text-secondary small">
-        Página {page} de {totalPages} • Total: {total}
-      </span>
-      <div className="btn-group">
-        <button type="button" className="btn btn-outline-secondary btn-sm" disabled={page <= 1} onClick={() => onChange(Math.max(1, page - 1))}>
-          Anterior
-        </button>
-        <button type="button" className="btn btn-outline-secondary btn-sm" disabled={page >= totalPages} onClick={() => onChange(Math.min(totalPages, page + 1))}>
-          Próxima
-        </button>
-      </div>
-    </div>
-  );
 }
 
 export default function MoisSalesPagesLibraryPage() {
-  const [entriesPage, setEntriesPage] = useState(1);
-  const [jobsPage, setJobsPage] = useState(1);
-  const [pagesPage, setPagesPage] = useState(1);
-  const [jobStatus, setJobStatus] = useState("");
-  const [selectedPageId, setSelectedPageId] = useState<number>();
-
-  const entriesQuery = useMoisSalesLibraryEntries(WORKSPACE_ID, entriesPage, PAGE_SIZE);
-  const jobsQuery = useMoisSalesLibraryJobs(WORKSPACE_ID, jobsPage, PAGE_SIZE, jobStatus || undefined);
-  const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, pagesPage, PAGE_SIZE);
-  const analysisQuery = useMoisSalesLibraryPageAnalysis(selectedPageId);
-  const reanalyzeMutation = useReanalyzeMoisSalesLibraryPage(WORKSPACE_ID);
-
-  const selectedPage = useMemo(() => pagesQuery.data?.items.find((item) => item.pageId === selectedPageId), [pagesQuery.data?.items, selectedPageId]);
+  const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
 
   return (
     <div className="d-flex flex-column gap-4">
       <header className="d-flex flex-wrap justify-content-between gap-3">
         <div>
           <PageTitle>Biblioteca de Páginas de Vendas</PageTitle>
-          <p className="text-secondary mb-0">Acompanhamento de ingestão, fila de análise e resultado por página.</p>
+          <p className="text-secondary mb-0">Tabela consolidada com cada produto coletado e a fase atual no fluxo canônico.</p>
         </div>
         <Link className="btn btn-outline-secondary" to="/mois">
           Voltar ao workspace
@@ -121,206 +41,39 @@ export default function MoisSalesPagesLibraryPage() {
 
       <section className="card border-0 shadow-sm">
         <div className="card-body table-responsive">
-          <h2 className="h5 mb-3">Entradas ingeridas</h2>
-          {entriesQuery.isLoading ? <p className="text-secondary">Carregando entradas...</p> : null}
-          {entriesQuery.isError ? <div className="alert alert-danger">Falha ao carregar entradas da biblioteca.</div> : null}
-          {entriesQuery.data ? (
-            <>
-              <table className="table table-sm align-middle">
-                <thead>
-                  <tr>
-                    <th>URL canônica</th>
-                    <th>Origem</th>
-                    <th>Título</th>
-                    <th>Ingestões</th>
-                    <th>Última captura</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {entriesQuery.data.items.length === 0 ? (
-                    <tr>
-                      <td colSpan={5} className="text-secondary">
-                        Nenhuma entrada encontrada.
-                      </td>
-                    </tr>
-                  ) : (
-                    entriesQuery.data.items.map((item) => (
-                      <tr key={item.id}>
-                        <td className="text-break">{item.urlCanonical}</td>
-                        <td>{item.source}</td>
-                        <td>{item.title || "—"}</td>
-                        <td>{item.ingestCount}</td>
-                        <td>{item.lastCapturedAt || "—"}</td>
-                      </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
-              <SimplePaginator page={entriesQuery.data.page} pageSize={entriesQuery.data.pageSize} total={entriesQuery.data.total} onChange={setEntriesPage} />
-            </>
-          ) : null}
-        </div>
-      </section>
-
-      <section className="card border-0 shadow-sm">
-        <div className="card-body table-responsive">
-          <div className="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-3">
-            <h2 className="h5 mb-0">Fila de jobs de análise</h2>
-            <select className="form-select form-select-sm" style={{ maxWidth: 220 }} value={jobStatus} onChange={(e) => setJobStatus(e.target.value)}>
-              <option value="">Todos os status</option>
-              <option value="PENDING">PENDING</option>
-              <option value="FETCHING">FETCHING</option>
-              <option value="ANALYZING">ANALYZING</option>
-              <option value="RETRY_WAIT">RETRY_WAIT</option>
-              <option value="DONE">DONE</option>
-              <option value="FAILED">FAILED</option>
-            </select>
-          </div>
-          {jobsQuery.isLoading ? <p className="text-secondary">Carregando jobs...</p> : null}
-          {jobsQuery.isError ? <div className="alert alert-danger">Falha ao carregar fila de jobs.</div> : null}
-          {jobsQuery.data ? (
-            <>
-              <table className="table table-sm align-middle">
-                <thead>
-                  <tr>
-                    <th>Job</th>
-                    <th>Status</th>
-                    <th>Tentativas</th>
-                    <th>Atualizado em</th>
-                    <th>Erro</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {jobsQuery.data.items.length === 0 ? (
-                    <tr>
-                      <td colSpan={5} className="text-secondary">
-                        Nenhum job encontrado para este filtro.
-                      </td>
-                    </tr>
-                  ) : (
-                    jobsQuery.data.items.map((job) => (
-                      <tr key={job.id}>
-                        <td>{job.id}</td>
-                        <td>
-                          <span className={`badge ${getSalesLibraryJobBadgeClass(job)}`}>{job.status}</span>
-                        </td>
-                        <td>{job.attempts}</td>
-                        <td>{formatDateTimeInGmt(job.updatedAt)}</td>
-                        <td>
-                          <pre className="mb-0 text-wrap" style={{ whiteSpace: "pre-wrap" }}>
-                            {formatOpenAiErrorMessage(job.errorMessage)}
-                          </pre>
-                        </td>
-                      </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
-              <SimplePaginator page={jobsQuery.data.page} pageSize={jobsQuery.data.pageSize} total={jobsQuery.data.total} onChange={setJobsPage} />
-              <div className="alert alert-light border mt-3 mb-0 small">
-                <strong>Status operacionais:</strong> PENDING (na fila), FETCHING (coletando página), ANALYZING (processando OpenAI), RETRY_WAIT (aguardando nova tentativa), DONE (concluído), FAILED (falha terminal).
-              </div>
-            </>
-          ) : null}
-        </div>
-      </section>
-
-      <section className="card border-0 shadow-sm">
-        <div className="card-body table-responsive">
-          <h2 className="h5 mb-3">Páginas e status da análise</h2>
-          {pagesQuery.isLoading ? <p className="text-secondary">Carregando páginas...</p> : null}
-          {pagesQuery.isError ? <div className="alert alert-danger">Falha ao carregar páginas da biblioteca.</div> : null}
+          {pagesQuery.isLoading ? <p className="text-secondary mb-0">Carregando produtos coletados...</p> : null}
+          {pagesQuery.isError ? <div className="alert alert-danger mb-0">Falha ao carregar produtos da biblioteca.</div> : null}
           {pagesQuery.data ? (
-            <>
-              <table className="table table-sm align-middle">
-                <thead>
+            <table className="table table-sm align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>Produto</th>
+                  <th>Origem</th>
+                  <th>Status</th>
+                  <th>Fase no diagrama</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pagesQuery.data.items.length === 0 ? (
                   <tr>
-                    <th>Página</th>
-                    <th>URL canônica</th>
-                    <th>Status</th>
-                    <th>Score</th>
-                    <th>Ações</th>
+                    <td colSpan={4} className="text-secondary">
+                      Nenhum produto coletado encontrado.
+                    </td>
                   </tr>
-                </thead>
-                <tbody>
-                  {pagesQuery.data.items.length === 0 ? (
-                    <tr>
-                      <td colSpan={5} className="text-secondary">
-                        Nenhuma página encontrada.
+                ) : (
+                  pagesQuery.data.items.map((item) => (
+                    <tr key={item.pageId}>
+                      <td className="text-break">{item.title || item.urlCanonical}</td>
+                      <td>{item.source || "—"}</td>
+                      <td>
+                        <span className={`badge ${getSalesLibraryJobBadgeClass(item)}`}>{item.analysisStatus || "SEM ANÁLISE"}</span>
                       </td>
+                      <td>{getPipelinePhase(item.analysisStatus)}</td>
                     </tr>
-                  ) : (
-                    pagesQuery.data.items.map((item) => {
-                      const isReanalyzing = reanalyzeMutation.isPending && reanalyzeMutation.variables === item.pageId;
-                      return (
-                        <tr key={item.pageId}>
-                          <td>{item.pageId}</td>
-                          <td className="text-break">{item.urlCanonical}</td>
-                          <td>
-                            <span className={`badge ${getSalesLibraryJobBadgeClass(item)}`}>{item.analysisStatus || "SEM ANÁLISE"}</span>
-                          </td>
-                          <td>{item.scoreTotal ?? "—"}</td>
-                          <td className="d-flex gap-2 flex-wrap">
-                            <button type="button" className="btn btn-outline-primary btn-sm" onClick={() => setSelectedPageId(item.pageId)}>
-                              Ver análise
-                            </button>
-                            <button
-                              type="button"
-                              className="btn btn-outline-secondary btn-sm"
-                              disabled={isReanalyzing}
-                              onClick={() => reanalyzeMutation.mutate(item.pageId)}
-                            >
-                              {isReanalyzing ? <span className="spinner-border spinner-border-sm" aria-hidden="true" /> : null}
-                              <span className={isReanalyzing ? "ms-2" : ""}>Reanalisar</span>
-                            </button>
-                          </td>
-                        </tr>
-                      );
-                    })
-                  )}
-                </tbody>
-              </table>
-              <SimplePaginator page={pagesQuery.data.page} pageSize={pagesQuery.data.pageSize} total={pagesQuery.data.total} onChange={setPagesPage} />
-            </>
-          ) : null}
-        </div>
-      </section>
-
-      <section className="card border-0 shadow-sm">
-        <div className="card-body">
-          <h2 className="h5 mb-3">Detalhes da análise da página</h2>
-          {!selectedPageId ? <p className="text-secondary mb-0">Selecione uma página na tabela acima para ver os detalhes.</p> : null}
-          {selectedPageId && analysisQuery.isLoading ? <p className="text-secondary mb-0">Carregando análise da página {selectedPageId}...</p> : null}
-          {selectedPageId && analysisQuery.isError ? <div className="alert alert-warning mb-0">Ainda não há análise disponível para a página selecionada.</div> : null}
-          {selectedPageId && analysisQuery.data ? (
-            <div className="d-flex flex-column gap-3">
-              <div className="d-flex flex-wrap gap-3">
-                <span className="badge bg-secondary">Página: {selectedPage?.pageId}</span>
-                <span className="badge bg-secondary">Job: {analysisQuery.data.jobId ?? "—"}</span>
-                <span className={`badge ${getSalesLibraryJobBadgeClass(analysisQuery.data)}`}>Status: {analysisQuery.data.status}</span>
-                <span className="badge bg-secondary">Score: {analysisQuery.data.scoreTotal ?? "—"}</span>
-              </div>
-              <div>
-                <h3 className="h6">Notas</h3>
-                <p className="mb-0">{analysisQuery.data.analysisNotes || "Sem notas."}</p>
-              </div>
-              <div>
-                <h3 className="h6">Seções (JSON)</h3>
-                <CollapsibleJsonViewer content={analysisQuery.data.sectionsJson || "{}"} initiallyCollapsed />
-              </div>
-              <div>
-                <h3 className="h6">Copy (JSON)</h3>
-                <CollapsibleJsonViewer content={analysisQuery.data.copyJson || "{}"} initiallyCollapsed />
-              </div>
-              <div>
-                <h3 className="h6">Visual (JSON)</h3>
-                <CollapsibleJsonViewer content={analysisQuery.data.visualJson || "{}"} initiallyCollapsed />
-              </div>
-              <div>
-                <h3 className="h6">Imagem (JSON)</h3>
-                <CollapsibleJsonViewer content={analysisQuery.data.imageJson || "{}"} initiallyCollapsed />
-              </div>
-            </div>
+                  ))
+                )}
+              </tbody>
+            </table>
           ) : null}
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Tornar a tela da Biblioteca de Páginas de Vendas mais operacional, mostrando apenas por produto em qual fase do pipeline canônico ele se encontra.
- Alinhar a visualização da UI ao diagrama canônico `docs/canonical/mois-worker-canon.v1.md#12.2` para facilitar diagnóstico rápido de estágio dos itens coletados.

### Description
- Substitui a tela completa em `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx` por uma tabela única que lista `Produto`, `Origem`, `Status` e `Fase no diagrama` e remove os blocos de entradas, fila de jobs, paginação e painel de detalhes.
- Adiciona a função `getPipelinePhase(status)` que mapeia os status `PENDING`, `FETCHING`, `ANALYZING`, `RETRY_WAIT`, `DONE`, `FAILED` para as fases textuais do diagrama canônico; ajusta `PAGE_SIZE` para 100 e passa a usar apenas `useMoisSalesLibraryPages`.
- Remove imports e componentes não utilizados na nova versão da página (por exemplo `CollapsibleJsonViewer` e hooks relacionados a entries/jobs/analysis).
- Registra a mudança no diário do módulo em `docs/registros/mois1.md` conforme política operacional.

### Testing
- Executei `npm --prefix frontend run typecheck` para validação estática do frontend; o comando falhou por problemas de ambiente/definições de tipos e opções de `tsconfig` (`@testing-library/jest-dom`, `vite/client`, `vitest/globals` ausentes e opções de TS deprecadas) que não são introduzidos por esta alteração.
- Não foram adicionados ou modificados testes automatizados nesta PR e não houve execução de testes unitários adicionais neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3c2ced7c8321a2249707d1af17c2)