### PR TITLE
Isolate Gera Landing HTML assembly by stage; add image-planning assembler and reorganize packages

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -3,6 +3,8 @@ package com.marketinghub.worker.geralanding;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.stage.GeraLandingStageDefinition;
+import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -25,11 +27,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
  */
 public class GeraLandingExecutionService {
     private static final Logger log = LoggerFactory.getLogger(GeraLandingExecutionService.class);
-    private static final String STAGE_WIREFRAME = "landing-page-wireframe";
-    private static final String STAGE_COPY = "landing-page-copy";
-    private static final String STAGE_IMAGE_PROMPTS = "landing-page-image-planning";
-    private static final String STAGE_DESIGN_PRESET = "landing-page-design-preset";
-    private static final String STAGE_DELIVERABLES = "landing-page-deliverables";
     private static final Pattern BANNED_COPY_TEXT_PATTERN = Pattern.compile(
             "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-|lorem ipsum|como funciona \\(passo)");
 
@@ -37,6 +34,7 @@ public class GeraLandingExecutionService {
     private final GeraLandingService geraLandingService;
     private final GeraLandingOpenAiBatchClient openAiClient;
     private final ObjectMapper objectMapper;
+    private final GeraLandingStageSchemaResolver stageSchemaResolver;
     private final int pendingLimit;
     private final Resource wireframeSchemaResource;
     private final Resource copySchemaResource;
@@ -48,6 +46,7 @@ public class GeraLandingExecutionService {
                                        GeraLandingService geraLandingService,
                                        GeraLandingOpenAiBatchClient openAiClient,
                                        ObjectMapper objectMapper,
+                                       GeraLandingStageSchemaResolver stageSchemaResolver,
                                        @Value("${geralanding.execution.pending-limit:20}") int pendingLimit,
                                        @Value("classpath:prompts/geralanding/landing-page-wireframe-schema.json")
                                        Resource wireframeSchemaResource,
@@ -63,6 +62,7 @@ public class GeraLandingExecutionService {
         this.geraLandingService = geraLandingService;
         this.openAiClient = openAiClient;
         this.objectMapper = objectMapper;
+        this.stageSchemaResolver = stageSchemaResolver;
         this.pendingLimit = Math.max(1, pendingLimit);
         this.wireframeSchemaResource = wireframeSchemaResource;
         this.copySchemaResource = copySchemaResource;
@@ -92,11 +92,8 @@ public class GeraLandingExecutionService {
             return;
         }
         String normalizedStage = execution.stageCode().trim().toLowerCase(Locale.ROOT);
-        if (!STAGE_WIREFRAME.equals(normalizedStage)
-                && !STAGE_COPY.equals(normalizedStage)
-                && !STAGE_IMAGE_PROMPTS.equals(normalizedStage)
-                && !STAGE_DESIGN_PRESET.equals(normalizedStage)
-                && !STAGE_DELIVERABLES.equals(normalizedStage)) {
+        GeraLandingStageDefinition stage = GeraLandingStageDefinition.fromCode(normalizedStage);
+        if (stage == null) {
             log.info("Skipping gera-landing executionId={} because stageCode {} is not supported",
                     execution.idJob(), execution.stageCode());
             return;
@@ -121,7 +118,7 @@ public class GeraLandingExecutionService {
                     "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
             log.info("OpenAI payload built for gera-landing executionId={} (length={})", execution.idJob(), openAiRequestBody.length());
             log.info("Payload OpenAI do gera-landing executionId={}: {}", execution.idJob(), openAiRequestBody);
-            String schemaJson = objectMapper.writeValueAsString(readSchemaByStage(normalizedStage));
+            String schemaJson = objectMapper.writeValueAsString(readSchemaByStage(stage));
             backendClient.receivePrompt(
                     execution.idJob(),
                     execution.experimentId(),
@@ -142,7 +139,7 @@ public class GeraLandingExecutionService {
                     null);
             log.info("Enviando gera-landing executionId={} para OpenAI em modo flex", execution.idJob());
             GeraLandingJobCompletionPayload payload = openAiClient.generate(openAiJob);
-            validateCopyPayloadText(normalizedStage, payload);
+            validateCopyPayloadText(stage, payload);
             log.info(
                     "Resposta OpenAI recebida para gera-landing executionId={} (experimentId={}, openAiJobId={}, inputTokens={}, outputTokens={}, costUsd={}, responseContentLength={}, rawResponseLength={})",
                     execution.idJob(),
@@ -178,8 +175,8 @@ public class GeraLandingExecutionService {
         }
     }
 
-    private void validateCopyPayloadText(String normalizedStage, GeraLandingJobCompletionPayload payload) {
-        if (!STAGE_COPY.equals(normalizedStage) || payload == null || !StringUtils.hasText(payload.responseContent())) {
+    private void validateCopyPayloadText(GeraLandingStageDefinition stage, GeraLandingJobCompletionPayload payload) {
+        if (stage != GeraLandingStageDefinition.COPY || payload == null || !StringUtils.hasText(payload.responseContent())) {
             return;
         }
         try {
@@ -273,22 +270,13 @@ public class GeraLandingExecutionService {
         return objectMapper.writeValueAsString(body);
     }
 
-    private Map<String, Object> readSchemaByStage(String stageCode) throws JsonProcessingException {
-        Resource schemaResource = wireframeSchemaResource;
-        if (STAGE_COPY.equals(stageCode)) {
-            schemaResource = copySchemaResource;
-        } else if (STAGE_IMAGE_PROMPTS.equals(stageCode)) {
-            schemaResource = imagePlanningSchemaResource;
-        } else if (STAGE_DESIGN_PRESET.equals(stageCode)) {
-            schemaResource = designPresetSchemaResource;
-        } else if (STAGE_DELIVERABLES.equals(stageCode)) {
-            schemaResource = deliverablesSchemaResource;
-        }
-        try {
-            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
-        } catch (IOException ex) {
-            throw new JsonProcessingException("Falha ao carregar schema da etapa " + stageCode) {
-            };
-        }
+    private Map<String, Object> readSchemaByStage(GeraLandingStageDefinition stage) throws JsonProcessingException {
+        return stageSchemaResolver.resolveSchema(
+                stage,
+                wireframeSchemaResource,
+                copySchemaResource,
+                imagePlanningSchemaResource,
+                designPresetSchemaResource,
+                deliverablesSchemaResource);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/stage/GeraLandingStageDefinition.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/stage/GeraLandingStageDefinition.java
@@ -1,0 +1,32 @@
+package com.marketinghub.worker.geralanding.stage;
+
+/**
+ * Catálogo canônico das etapas do GeraLanding no Worker AI.
+ * Cada definição representa um conjunto exclusivo de etapa.
+ */
+public enum GeraLandingStageDefinition {
+    WIREFRAME("landing-page-wireframe"),
+    COPY("landing-page-copy"),
+    IMAGE_PLANNING("landing-page-image-planning"),
+    DESIGN_PRESET("landing-page-design-preset"),
+    DELIVERABLES("landing-page-deliverables");
+
+    private final String code;
+
+    GeraLandingStageDefinition(String code) {
+        this.code = code;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public static GeraLandingStageDefinition fromCode(String stageCode) {
+        for (GeraLandingStageDefinition value : values()) {
+            if (value.code.equalsIgnoreCase(stageCode)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/stage/GeraLandingStageSchemaResolver.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/stage/GeraLandingStageSchemaResolver.java
@@ -1,0 +1,42 @@
+package com.marketinghub.worker.geralanding.stage;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Map;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolve exclusivamente o schema por etapa no Worker AI, mantendo isolamento por conjunto.
+ */
+@Component
+public class GeraLandingStageSchemaResolver {
+
+    private final ObjectMapper objectMapper;
+
+    public GeraLandingStageSchemaResolver(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public Map<String, Object> resolveSchema(GeraLandingStageDefinition stage,
+                                             Resource wireframeSchemaResource,
+                                             Resource copySchemaResource,
+                                             Resource imagePlanningSchemaResource,
+                                             Resource designPresetSchemaResource,
+                                             Resource deliverablesSchemaResource) throws JsonProcessingException {
+        Resource schemaResource = switch (stage) {
+            case COPY -> copySchemaResource;
+            case IMAGE_PLANNING -> imagePlanningSchemaResource;
+            case DESIGN_PRESET -> designPresetSchemaResource;
+            case DELIVERABLES -> deliverablesSchemaResource;
+            case WIREFRAME -> wireframeSchemaResource;
+        };
+        try {
+            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
+        } catch (IOException ex) {
+            throw new JsonProcessingException("Falha ao carregar schema da etapa " + stage.code()) {
+            };
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -25,7 +25,7 @@ import com.marketinghub.experiment.frameworkimage.service.FrameworkImageGenerati
 import com.marketinghub.experiment.pipeline.lhm.LandingHtmlModule;
 import com.marketinghub.experiment.pipeline.repository.ExperimentPipelineGenerationJobRepository;
 import com.marketinghub.experiment.repository.ExperimentRepository;
-import com.marketinghub.geralanding.CopyProvisionalHtmlAssembler;
+import com.marketinghub.geralanding.copy.CopyProvisionalHtmlAssembler;
 import com.marketinghub.hypothesis.dto.HypothesisFrameworkDto;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.integration.LeadPortalFlowPublisher;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -2,6 +2,10 @@ package com.marketinghub.geralanding;
 
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.pipeline.service.LandingPageImageInjector;
+import com.marketinghub.geralanding.copy.CopyProvisionalHtmlAssembler;
+import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAssembler;
+import com.marketinghub.geralanding.imageplanning.ImagePlanningProvisionalHtmlAssembler;
+import com.marketinghub.geralanding.wireframe.WireframeProvisionalHtmlAssembler;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -49,6 +53,7 @@ public class GeraLandingStageExecutionService {
     private final GeraLandingStageExecutionRepository executionRepository;
     private final WireframeProvisionalHtmlAssembler wireframeProvisionalHtmlAssembler;
     private final CopyProvisionalHtmlAssembler copyProvisionalHtmlAssembler;
+    private final ImagePlanningProvisionalHtmlAssembler imagePlanningProvisionalHtmlAssembler;
     private final DesignPresetProvisionalHtmlAssembler designPresetProvisionalHtmlAssembler;
     private final LandingPageImageInjector landingPageImageInjector;
     private final RestTemplate restTemplate;
@@ -59,6 +64,7 @@ public class GeraLandingStageExecutionService {
             GeraLandingStageExecutionRepository executionRepository,
             WireframeProvisionalHtmlAssembler wireframeProvisionalHtmlAssembler,
             CopyProvisionalHtmlAssembler copyProvisionalHtmlAssembler,
+            ImagePlanningProvisionalHtmlAssembler imagePlanningProvisionalHtmlAssembler,
             DesignPresetProvisionalHtmlAssembler designPresetProvisionalHtmlAssembler,
             LandingPageImageInjector landingPageImageInjector,
             RestTemplate restTemplate,
@@ -67,6 +73,7 @@ public class GeraLandingStageExecutionService {
         this.executionRepository = executionRepository;
         this.wireframeProvisionalHtmlAssembler = wireframeProvisionalHtmlAssembler;
         this.copyProvisionalHtmlAssembler = copyProvisionalHtmlAssembler;
+        this.imagePlanningProvisionalHtmlAssembler = imagePlanningProvisionalHtmlAssembler;
         this.designPresetProvisionalHtmlAssembler = designPresetProvisionalHtmlAssembler;
         this.landingPageImageInjector = landingPageImageInjector;
         this.restTemplate = restTemplate;
@@ -274,13 +281,12 @@ public class GeraLandingStageExecutionService {
             throw new IllegalStateException("Não foi possível montar HTML provisório: experiment.landingPageCopy ausente");
         }
 
-        String completeHtml = copyProvisionalHtmlAssembler.assembleComplete(
+        String copyStageHtml = imagePlanningProvisionalHtmlAssembler.assemble(
+                experimentId,
                 experiment.getLandingPageCopy(),
                 experiment.getLandingPageWireframe(),
-                experiment.getLandingPageImagePlanning(),
-                experiment.getLandingPageDesignPreset(),
                 jobId);
-        String htmlWithGeneratedImages = landingPageImageInjector.injectImages(experimentId, completeHtml);
+        String htmlWithGeneratedImages = copyStageHtml;
         String enrichedImagePlanning = landingPageImageInjector.injectImageUrlsIntoPlanning(
                 experimentId,
                 experiment.getLandingPageImagePlanning());
@@ -440,17 +446,15 @@ public class GeraLandingStageExecutionService {
         if (experiment == null || !StringUtils.hasText(experiment.getLandingPageWireframe()) || !StringUtils.hasText(experiment.getLandingPageCopy())) {
             return null;
         }
-        String baseHtml = copyProvisionalHtmlAssembler.assembleComplete(
+        String baseHtml = imagePlanningProvisionalHtmlAssembler.assemble(
+                experiment.getId(),
                 experiment.getLandingPageCopy(),
                 experiment.getLandingPageWireframe(),
-                request.modelResponse(),
-                experiment.getLandingPageDesignPreset(),
                 idJob);
         if (!StringUtils.hasText(baseHtml)) {
             return null;
         }
-        String htmlWithGeneratedImages = landingPageImageInjector.injectImages(experiment.getId(), baseHtml);
-        return htmlWithGeneratedImages;
+        return baseHtml;
     }
 
     private String resolveDesignPresetProvisionalHtml(String idJob, GeraLandingResultReceiveRequest request, GeraLandingStageExecution execution) {

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlAssembler.java
@@ -1,10 +1,14 @@
-package com.marketinghub.geralanding;
+package com.marketinghub.geralanding.copy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 @Component
+/**
+ * Conjunto exclusivo da etapa LANDING_PAGE_COPY: coordena o payload resolver e o processor
+ * da etapa de copy para gerar HTML provisório sem invadir responsabilidades das demais etapas.
+ */
 public class CopyProvisionalHtmlAssembler {
 
     private final CopyProvisionalHtmlPayloadResolver payloadResolver;
@@ -31,31 +35,6 @@ public class CopyProvisionalHtmlAssembler {
             return appendJobIdCommentBeforeHead(html, jobId);
         } catch (Exception e) {
             throw new IllegalArgumentException("Falha ao montar HTML provisório a partir de wireframe + copy", e);
-        }
-    }
-
-
-
-    public String assembleComplete(String copyModelResponse,
-                                   String wireframeModelResponse,
-                                   String imagePlanningModelResponse,
-                                   String designPresetModelResponse,
-                                   String jobId) {
-        if (!StringUtils.hasText(copyModelResponse) || !StringUtils.hasText(wireframeModelResponse)) {
-            return null;
-        }
-        try {
-            CopyProvisionalHtmlPayloadResolver.CopyProvisionalHtmlPayload payload =
-                    payloadResolver.resolve(copyModelResponse, wireframeModelResponse);
-
-            String html = processor.processComplete(
-                    payloadResolverToJson(payload.wireframe()),
-                    payloadResolverToJson(payload.copy()),
-                    imagePlanningModelResponse,
-                    designPresetModelResponse);
-            return appendJobIdCommentBeforeHead(html, jobId);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Falha ao montar HTML provisório completo", e);
         }
     }
     private String payloadResolverToJson(Object payload) throws Exception {

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlPayloadResolver.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlPayloadResolver.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding;
+package com.marketinghub.geralanding.copy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlProcessor.java
@@ -1,7 +1,8 @@
-package com.marketinghub.geralanding;
+package com.marketinghub.geralanding.copy;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.geralanding.wireframe.WireframeHtmlGenerator;
 import org.jsoup.Jsoup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +19,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Locale;
 
+/**
+ * Conjunto exclusivo da etapa LANDING_PAGE_COPY: monta o HTML provisório a partir
+ * de wireframe + copy, sem executar responsabilidades de image planning/design preset.
+ */
 @Component
 public class CopyProvisionalHtmlProcessor {
 
@@ -27,17 +32,9 @@ public class CopyProvisionalHtmlProcessor {
 
 
 
-    public String processComplete(String wireframeJson,
-                                  String copyJson,
-                                  String imagePlanningJson,
-                                  String designPresetJson) {
-        String html = process(wireframeJson, copyJson);
-        Document document = Jsoup.parse(html, "", Parser.htmlParser());
-        applyImageUrls(document, imagePlanningJson);
-        applyDesignPreset(document, designPresetJson);
-        return normalizeSerializedHtml(document.outerHtml());
-    }
-
+    /**
+     * Monta o HTML base do wireframe e aplica os textos da etapa de copy.
+     */
     public String process(String wireframeJson, String copyJson) {
         log.info("[GeraLanding][CopyProvisionalHtmlProcessor] Entrada wireframeJson: {}", wireframeJson);
         log.info("[GeraLanding][CopyProvisionalHtmlProcessor] Entrada copyJson: {}", copyJson);
@@ -48,13 +45,16 @@ public class CopyProvisionalHtmlProcessor {
             throw new IllegalArgumentException("JSON de copy ausente");
         }
 
-        Map<String, Object> wireframe = parseJson(wireframeJson);
-        Map<String, Object> copy = parseJson(copyJson);
+        Map<String, Object> wireframe = parseJsonObject(wireframeJson, "wireframeJson");
+        Map<String, Object> copy = parseJsonObject(copyJson, "copyJson");
 
         String baseHtml = buildHtmlFromWireframe(wireframe);
         return process(baseHtml, copy);
     }
 
+    /**
+     * Aplica a copy no HTML já montado usando o mapeamento por id de elemento.
+     */
     public String process(String html, Map<String, Object> copyJson) {
         if (!StringUtils.hasText(html)) {
             throw new IllegalArgumentException("HTML provisório ausente para aplicar a copy");
@@ -137,11 +137,14 @@ public class CopyProvisionalHtmlProcessor {
                 .replace(" />", "/>");
     }
 
-    private Map<String, Object> parseJson(String json) {
+    /**
+     * Interpreta um JSON cujo elemento raiz esperado é um objeto ({...}).
+     */
+    private Map<String, Object> parseJsonObject(String json, String payloadLabel) {
         try {
             return OBJECT_MAPPER.readValue(json, new TypeReference<>() {});
         } catch (Exception e) {
-            throw new IllegalArgumentException("Falha ao interpretar JSON de entrada", e);
+            throw new IllegalArgumentException("Falha ao interpretar " + payloadLabel + ": esperado JSON objeto ({...}) com elementos compatíveis com o contrato.", e);
         }
     }
 
@@ -260,70 +263,6 @@ public class CopyProvisionalHtmlProcessor {
     }
 
 
-    private void applyImageUrls(Document document, String imagePlanningJson) {
-        if (!StringUtils.hasText(imagePlanningJson)) {
-            return;
-        }
-        Map<String, Object> planning = parseJson(imagePlanningJson);
-        Object rawImages = firstNonNull(planning.get("images"), planning.get("landingPageImagePlanning"));
-        List<String> urls = new ArrayList<>();
-        if (rawImages instanceof List<?> list) {
-            for (Object item : list) {
-                if (item instanceof Map<?, ?> imageMap) {
-                    String url = firstNonBlank(asString(imageMap.get("imageUrl")), asString(imageMap.get("url")));
-                    if (StringUtils.hasText(url)) {
-                        urls.add(url.trim());
-                    }
-                }
-            }
-        } else if (rawImages instanceof Map<?, ?> wrapper && wrapper.get("images") instanceof List<?> nested) {
-            for (Object item : nested) {
-                if (item instanceof Map<?, ?> imageMap) {
-                    String url = firstNonBlank(asString(imageMap.get("imageUrl")), asString(imageMap.get("url")));
-                    if (StringUtils.hasText(url)) {
-                        urls.add(url.trim());
-                    }
-                }
-            }
-        }
-        if (urls.isEmpty()) {
-            return;
-        }
-        int i = 0;
-        for (Element img : document.select("img")) {
-            if (i >= urls.size()) {
-                break;
-            }
-            img.attr("src", urls.get(i++));
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private void applyDesignPreset(Document document, String designPresetJson) {
-        if (!StringUtils.hasText(designPresetJson)) {
-            return;
-        }
-        Map<String, Object> root = parseJson(designPresetJson);
-        Map<String, Object> preset = root;
-        Object nested = root.get("landingPageDesignPreset");
-        if (nested instanceof Map<?, ?> nestedMap) {
-            preset = (Map<String, Object>) nestedMap;
-        }
-        String presetId = asString(preset.get("presetId"));
-        if (StringUtils.hasText(presetId) && document.body() != null) {
-            document.body().attr("data-preset-id", presetId.trim());
-        }
-        Object runtimeObj = preset.get("lhmRuntime");
-        if (runtimeObj instanceof Map<?, ?> runtime) {
-            String baseCss = asString(runtime.get("baseCss"));
-            if (StringUtils.hasText(baseCss)) {
-                Element head = document.head();
-                if (head != null) {
-                    head.appendElement("style").attr("id", "lhm-base-css").text(baseCss.trim());
-                }
-            }
-        }
-    }
 
     private Object firstNonNull(Object... values) {
         for (Object value : values) {

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding;
+package com.marketinghub.geralanding.designpreset;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
@@ -1,7 +1,8 @@
-package com.marketinghub.geralanding;
+package com.marketinghub.geralanding.designpreset;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.geralanding.wireframe.WireframeHtmlGenerator;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -18,6 +19,10 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 @Component
+/**
+ * Responsável por consolidar o HTML provisório final da etapa de design preset,
+ * aplicando copy, URLs de imagens planejadas e preset visual no wireframe base.
+ */
 public class DesignPresetProvisionalHtmlProcessor {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/ImagePlanningProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/ImagePlanningProvisionalHtmlAssembler.java
@@ -1,0 +1,37 @@
+package com.marketinghub.geralanding.imageplanning;
+
+import com.marketinghub.experiment.pipeline.service.LandingPageImageInjector;
+import com.marketinghub.geralanding.copy.CopyProvisionalHtmlAssembler;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Conjunto exclusivo da etapa LANDING_PAGE_IMAGE_PLANNING: monta o HTML provisório base
+ * a partir da etapa de copy e enriquece com URLs de imagens geradas para esta etapa.
+ */
+@Component
+public class ImagePlanningProvisionalHtmlAssembler {
+
+    private final CopyProvisionalHtmlAssembler copyProvisionalHtmlAssembler;
+    private final LandingPageImageInjector landingPageImageInjector;
+
+    public ImagePlanningProvisionalHtmlAssembler(CopyProvisionalHtmlAssembler copyProvisionalHtmlAssembler,
+                                                 LandingPageImageInjector landingPageImageInjector) {
+        this.copyProvisionalHtmlAssembler = copyProvisionalHtmlAssembler;
+        this.landingPageImageInjector = landingPageImageInjector;
+    }
+
+    /**
+     * Gera o HTML provisório da etapa de image planning usando copy+wireframe e aplica as URLs finais de imagem.
+     */
+    public String assemble(Long experimentId,
+                           String copyModelResponse,
+                           String wireframeModelResponse,
+                           String jobId) {
+        String copyStageHtml = copyProvisionalHtmlAssembler.assemble(copyModelResponse, wireframeModelResponse, jobId);
+        if (!StringUtils.hasText(copyStageHtml)) {
+            return null;
+        }
+        return landingPageImageInjector.injectImages(experimentId, copyStageHtml);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/WireframeHtmlGenerator.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/WireframeHtmlGenerator.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding;
+package com.marketinghub.geralanding.wireframe;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,6 +11,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class WireframeHtmlGenerator {
+    /**
+     * Conjunto exclusivo da etapa LANDING_PAGE_WIREFRAME: renderiza HTML base
+     * a partir do artefato JSON de wireframe, sem responsabilidades de copy/imagens/design.
+     */
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/WireframeProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/WireframeProvisionalHtmlAssembler.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding;
+package com.marketinghub.geralanding.wireframe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
@@ -7,6 +7,10 @@ import org.springframework.util.StringUtils;
 import java.util.Map;
 
 @Component
+/**
+ * Conjunto exclusivo da etapa LANDING_PAGE_WIREFRAME: transforma o JSON do wireframe
+ * em HTML provisório sem aplicar regras de outras etapas do pipeline.
+ */
 public class WireframeProvisionalHtmlAssembler {
 
     private final ObjectMapper objectMapper;

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -95,6 +95,15 @@ Regras:
 1. Um conjunto de etapa não pode consolidar regras de outra etapa.
 2. Enriquecimentos transversais (ex.: injeção de URLs finais de imagem) devem ocorrer em serviço auxiliar dedicado e orquestrados pelo serviço da etapa, sem transferir a responsabilidade de etapa entre processadores.
 
+### 5.5 Worker AI — divisão equivalente por etapa (obrigatória)
+
+No `ai-worker`, a mesma divisão por etapa deve ser mantida para evitar acoplamento entre execução, prompt e schema:
+
+- `com.marketinghub.worker.geralanding.stage.GeraLandingStageDefinition`
+- `com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver`
+
+Regra operacional: a seleção de schema/prompt por etapa no worker deve ocorrer por definição de etapa explícita, sem ifs ad-hoc espalhados no serviço de execução.
+
 ## 6. Geração e aprovação de anúncios
 
 Após os artefatos de base:

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -71,8 +71,29 @@ Regras complementares:
 |---|---|---|
 | `LANDING_PAGE_WIREFRAME` | `WireframeProvisionalHtmlAssembler` | `gera_landing_stage_execution.provisional_html` |
 | `LANDING_PAGE_COPY` | `CopyProvisionalHtmlAssembler` | `gera_landing_stage_execution.provisional_html` |
-| `LANDING_PAGE_IMAGE_PLANNING` | Não há assembler exclusivo da etapa; usa `CopyProvisionalHtmlAssembler.assembleComplete(...)` + `LandingPageImageInjector.injectImages(...)`. | `gera_landing_stage_execution.provisional_html` e `experiment.landing_page_html` (quando `provisionalHtml` existe na execução). |
+| `LANDING_PAGE_IMAGE_PLANNING` | `ImagePlanningProvisionalHtmlAssembler` (usa internamente `CopyProvisionalHtmlAssembler` + `LandingPageImageInjector` apenas para esta etapa). | `gera_landing_stage_execution.provisional_html` e `experiment.landing_page_html` (quando `provisionalHtml` existe na execução). |
 | `LANDING_PAGE_DESIGN_PRESET` | `DesignPresetProvisionalHtmlAssembler` + `LandingPageImageInjector.injectImages(...)` | `gera_landing_stage_execution.provisional_html`, `experiment.landing_page_design_preset` (HTML consolidado da etapa) e `experiment.landing_page_html` |
+
+### 5.4 Regra de isolamento por conjunto (obrigatória)
+
+Cada conjunto de montagem de HTML deve atuar **exclusivamente** na sua etapa canônica, com pacote dedicado dentro de `com.marketinghub.geralanding`:
+
+- `com.marketinghub.geralanding.wireframe` → etapa `LANDING_PAGE_WIREFRAME`
+  - `WireframeProvisionalHtmlAssembler`
+  - `WireframeHtmlGenerator`
+- `com.marketinghub.geralanding.copy` → etapa `LANDING_PAGE_COPY`
+  - `CopyProvisionalHtmlPayloadResolver`
+  - `CopyProvisionalHtmlProcessor`
+  - `CopyProvisionalHtmlAssembler`
+- `com.marketinghub.geralanding.designpreset` → etapa `LANDING_PAGE_DESIGN_PRESET`
+  - `DesignPresetProvisionalHtmlProcessor`
+  - `DesignPresetProvisionalHtmlAssembler`
+- `com.marketinghub.geralanding.imageplanning` → etapa `LANDING_PAGE_IMAGE_PLANNING`
+  - `ImagePlanningProvisionalHtmlAssembler`
+
+Regras:
+1. Um conjunto de etapa não pode consolidar regras de outra etapa.
+2. Enriquecimentos transversais (ex.: injeção de URLs finais de imagem) devem ocorrer em serviço auxiliar dedicado e orquestrados pelo serviço da etapa, sem transferir a responsabilidade de etapa entre processadores.
 
 ## 6. Geração e aprovação de anúncios
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -812,3 +812,36 @@
   - adicionado comentário de responsabilidade da classe e comentário do método `buildSystemPrompt` em `ExperimentPipelineGenerationService`;
   - adicionado comentário de responsabilidade da classe e comentário do método `buildOpenAiRequestBody` em `GeraLandingExecutionService`;
   - adicionado comentário de responsabilidade da classe e comentário do método `buildRequestBodyFromPrompt` em `GeraLandingOpenAiBatchClient`.
+
+## 2026-05-21 17:45:00 UTC
+- ajuste solicitado: melhorar erro de contrato do planejamento de imagens da etapa `landing-page-image-planning` e aceitar chave `imagePlan` no payload raiz.
+- causa-raiz: parser da montagem de HTML provisório esperava apenas objeto com chaves legadas (`images`/`landingPageImagePlanning`) e não reportava com clareza quando faltava o elemento contratual esperado.
+- foi feito:
+  - `CopyProvisionalHtmlProcessor` passou a ler `imagePlan` no objeto raiz do JSON de planejamento de imagens;
+  - adicionada validação explícita com mensagem orientativa quando o elemento `imagePlan` não está presente;
+  - melhorada mensagem de erro de parsing para indicar que o payload deve ser JSON objeto (`{...}`) compatível com o contrato;
+  - adicionados comentários de responsabilidade da classe e comentários de métodos principais da classe ajustada.
+
+## 2026-05-21 18:00:00 UTC
+- solicitação: conferir o quadro canônico de etapas/processadores e explicitar responsabilidade nos processadores envolvidos.
+- validação: o quadro operacional de referência está em `docs/canonical/procedimento-experimento-canon.v1.md` seção 5.3.
+- foi feito:
+  - comentário de responsabilidade ajustado em `CopyProvisionalHtmlProcessor` para deixar explícito que ele atende a etapa de copy e também enriquecimentos de image planning/design preset;
+  - comentário de responsabilidade adicionado em `DesignPresetProvisionalHtmlProcessor` para explicitar consolidação final da etapa de design preset.
+
+## 2026-05-21 18:20:00 UTC
+- solicitação: isolar conjuntos de geração de HTML por etapa, documentar no cânone e comentar responsabilidade nas classes.
+- causa-raiz: classes/fluxo de HTML estavam acoplados entre etapas, especialmente copy acumulando comportamento de image planning/design preset.
+- foi feito:
+  - reorganização de pacotes por etapa em `com.marketinghub.geralanding.{wireframe,copy,designpreset}`;
+  - `CopyProvisionalHtmlAssembler/Processor` restritos à etapa `LANDING_PAGE_COPY` (remoção do caminho `assembleComplete/processComplete`);
+  - orquestração de image planning ajustada para usar HTML base da copy + `LandingPageImageInjector` no serviço;
+  - atualização do cânone em `procedimento-experimento-canon.v1.md` com regra obrigatória de isolamento por conjunto e mapeamento por pacote;
+  - comentários de responsabilidade adicionados/ajustados nas classes dos conjuntos.
+
+## 2026-05-21 18:40:00 UTC
+- ajuste complementar solicitado: incluir o conjunto da etapa de prompt/image planning que estava faltando no isolamento por etapa.
+- foi feito:
+  - criação do conjunto `com.marketinghub.geralanding.imageplanning` com `ImagePlanningProvisionalHtmlAssembler`;
+  - orquestração do `GeraLandingStageExecutionService` atualizada para usar o assembler exclusivo da etapa `LANDING_PAGE_IMAGE_PLANNING`;
+  - atualização do quadro canônico e mapeamento por pacote para incluir explicitamente o conjunto de image planning.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -845,3 +845,11 @@
   - criação do conjunto `com.marketinghub.geralanding.imageplanning` com `ImagePlanningProvisionalHtmlAssembler`;
   - orquestração do `GeraLandingStageExecutionService` atualizada para usar o assembler exclusivo da etapa `LANDING_PAGE_IMAGE_PLANNING`;
   - atualização do quadro canônico e mapeamento por pacote para incluir explicitamente o conjunto de image planning.
+
+## 2026-05-21 18:55:00 UTC
+- solicitação: replicar no Worker AI a divisão por etapa aplicada no backend (incluindo prompt image).
+- foi feito:
+  - criado `GeraLandingStageDefinition` para centralizar etapas canônicas do worker;
+  - criado `GeraLandingStageSchemaResolver` para resolver schema por etapa de forma isolada;
+  - `GeraLandingExecutionService` atualizado para usar definição de etapa + resolver dedicado, removendo seleção ad-hoc por string;
+  - cânone atualizado com seção específica do Worker AI para divisão obrigatória por etapa.


### PR DESCRIPTION
### Motivation
- Decouple responsibilities of each Gera Landing pipeline stage so each assembler only handles its canonical concerns and avoids cross-stage coupling. 
- Introduce an explicit assembler for `LANDING_PAGE_IMAGE_PLANNING` to centralize image URL enrichment without leaking image logic into copy/design processors. 
- Improve error messages and add class/method responsibility comments to make parsing/contract failures clearer for image planning payloads. 
- Update canonical documentation to reflect the new per-stage package layout and rules of isolation.

### Description
- Reorganized landing HTML assembly into per-stage packages: `com.marketinghub.geralanding.wireframe`, `com.marketinghub.geralanding.copy`, `com.marketinghub.geralanding.designpreset`, and `com.marketinghub.geralanding.imageplanning`, and updated imports accordingly. 
- Removed cross-stage entry points from `CopyProvisionalHtmlAssembler` (`assembleComplete`) and simplified `CopyProvisionalHtmlProcessor` to only produce copy-level provisional HTML, improving parse error messages and adding responsibility comments. 
- Added `ImagePlanningProvisionalHtmlAssembler` that builds the copy-stage HTML and applies `LandingPageImageInjector.injectImages(...)` for the image-planning stage. 
- Updated `GeraLandingStageExecutionService` to depend on and use the new `ImagePlanningProvisionalHtmlAssembler` for image-planning flows and adjusted the flow that persists/returns provisional HTML. 
- Kept `DesignPresetProvisionalHtmlProcessor` responsibilities for final consolidation and ensured `WireframeHtmlGenerator`/`WireframeProvisionalHtmlAssembler` remain focused on wireframe rendering. 
- Updated documentation `docs/canonical/procedimento-experimento-canon.v1.md` and rollout records `docs/registros/experimentos.md` to reflect the new stage isolation and the created `imageplanning` assembler.

### Testing
- Ran the project's unit test suite with `mvn -DskipTests=false test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f40efabe4832195efd68acc352f29)