### PR TITLE
docs: registrar auditoria de aderência canônica do GeraLanding

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -853,3 +853,12 @@
   - criado `GeraLandingStageSchemaResolver` para resolver schema por etapa de forma isolada;
   - `GeraLandingExecutionService` atualizado para usar definição de etapa + resolver dedicado, removendo seleção ad-hoc por string;
   - cânone atualizado com seção específica do Worker AI para divisão obrigatória por etapa.
+
+## 2026-05-21 19:10:00 UTC
+- solicitação: verificar se as novas estruturas de pacotes do GeraLanding continuam aderentes ao documento canônico.
+- validação executada:
+  - comparação dos pacotes atuais do backend (`geralanding`, `wireframe`, `copy`, `imageplanning`, `designpreset`) com o mapeamento canônico da seção 5.3 em `docs/canonical/procedimento-experimento-canon.v1.md`;
+  - revisão da orquestração em `GeraLandingStageExecutionService` para confirmar uso de assembler/processador por etapa sem acoplamento cruzado indevido;
+  - revisão do worker (`GeraLandingStageDefinition` + `GeraLandingStageSchemaResolver`) para confirmar resolução de schema por etapa.
+- resultado: estrutura de pacotes e fluxo por etapa seguem o isolamento definido no cânone e mantêm aderência com a regra de conjuntos por etapa.
+- ponto de atenção documental: há referências em documentos legados para `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md`, porém o arquivo atual está em `docs/canonical/obsoletos/`; manter revisão de links em futuras limpezas documentais.


### PR DESCRIPTION
### Motivation

- Verificar se a reorganização de pacotes do GeraLanding (separação por etapas: `wireframe`, `copy`, `imageplanning`, `designpreset`) mantém aderência ao cânone operacional de experimentos.
- Registrar formalmente o resultado da verificação para rastreabilidade e evidência de conformidade com os documentos canônicos.

### Description

- Adiciona uma entrada em `docs/registros/experimentos.md` (2026-05-21 19:10:00 UTC) que descreve a checagem de aderência entre pacotes backend por etapa, orquestração em `GeraLandingStageExecutionService` e isolamento de etapas no worker (`GeraLandingStageDefinition` + `GeraLandingStageSchemaResolver`).
- Documenta as evidências verificadas e aponta um ponto de atenção documental sobre referências legadas ao arquivo `modelo-canonico-artefatos-pipeline-experimento.md` que está em `docs/canonical/obsoletos/`.
- Este PR altera apenas a documentação de registros; não há mudanças funcionais neste patch.

### Testing

- Executei `mvn -f backend/ads-service/pom.xml -Dtest=GeraLandingStageExecutionServiceTest,CopyProvisionalHtmlProcessorNewWireframeFormatTest test` como verificação automática de compilação/testes.
- A execução compilou o código principal mas falhou na fase `testCompile` com erros de `cannot find symbol` para classes montadoras/processadoras (`WireframeProvisionalHtmlAssembler`, `CopyProvisionalHtmlAssembler`, `DesignPresetProvisionalHtmlAssembler`, `CopyProvisionalHtmlProcessor`), indicando que testes ou imports ainda referenciam nomes/locais antigos após o refactor; o teste não passou.
- Resultado dos testes automatizados: falha (compilação de testes com erro de símbolos não encontrados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f4bc4fcf083219d11557b9a79b8e5)