### PR TITLE
Fix GeraLanding stage schema type mismatch

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -111,7 +111,7 @@ public class GeraLandingExecutionService {
                     execution.idJob(), execution.experimentId());
 
             String openAiRequestBody = buildOpenAiRequestBody(
-                    normalizedStage,
+                    stage,
                     openAiModel,
                     prompt,
                     "gera-landing-pipeline",
@@ -227,7 +227,7 @@ public class GeraLandingExecutionService {
     /**
      * Monta o corpo da requisição da OpenAI Responses API para uma etapa do GeraLanding.
      */
-    private String buildOpenAiRequestBody(String stageCode,
+    private String buildOpenAiRequestBody(GeraLandingStageDefinition stage,
                                           String model,
                                           String prompt,
                                           String systemName,
@@ -251,7 +251,7 @@ public class GeraLandingExecutionService {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_copy");
-        format.put("schema", readSchemaByStage(stageCode));
+        format.put("schema", readSchemaByStage(stage));
         format.put("strict", true);
 
         String resolvedModel = StringUtils.hasText(model) ? model.trim() : "gpt-5.2";


### PR DESCRIPTION
### Motivation
- Fix a compilation error caused by passing a `String` stage code where the code path expects a `GeraLandingStageDefinition` enum when building the OpenAI request payload.

### Description
- Change `buildOpenAiRequestBody` signature to accept `GeraLandingStageDefinition` instead of `String` in `ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java`.
- Update the call site to pass the already-resolved `stage` variable to `buildOpenAiRequestBody` instead of `normalizedStage`.
- Use `readSchemaByStage(stage)` when populating the `format.schema` entry so the schema resolver receives the correct type.

### Testing
- Ran `mvn -pl ai-worker -DskipTests compile` which failed because the reactor project selection did not match this environment (project not found). 
- Ran `cd ai-worker && mvn -DskipTests compile` which progressed past the previous type error but failed dependency resolution due to unauthorized access to private artifact `com.marketinghub:ads-service:0.0.1-SNAPSHOT` (HTTP 401), so the full module build could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f4c57adcc8321b30552156e5aa168)