### PR TITLE
feat(mois): exibir produto, coletor e histórico no detalhe da análise

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -384,3 +384,15 @@
 - criada nova rota de detalhe `/mois/sales-pages-library/:pageId` exibindo payloads de resposta do modelo em blocos colapsáveis (`<details>`), além de blocos colapsáveis para request enviado e prompt utilizado.
 - todos os trechos JSON foram apresentados em formato colapsável para reduzir ruído visual e facilitar inspeção.
 - arquivos alterados: `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`, `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`, `frontend/src/App.tsx`.
+
+## 2026-05-21 15:34:02 UTC-3
+- solicitado ajuste na tela de detalhe da análise da biblioteca de páginas de vendas (MOIS) para reforçar contexto do produto e rastreabilidade operacional.
+- substituído o título estático pelo nome do produto e adicionado subtítulo com o coletor/origem usado na obtenção.
+- após os cards de JSON, foi adicionado um card "Histórico da página" com linha do tempo de eventos (coleta/ingestão, snapshots brutos e avaliação), sempre com data e hora formatadas.
+- criadas consultas no frontend para endpoint de detalhe da página e snapshots já existentes no backend, sem necessidade de novo contrato.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+  - frontend/src/api/mois/useMoisSalesLibrary.ts
+  - frontend/src/api/mois/types.ts

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -293,6 +293,20 @@ export interface MoisSalesLibraryPageAnalysis {
   updatedAt: string;
 }
 
+
+export interface MoisSalesLibraryPageSnapshot {
+  snapshotId: number;
+  pageId: number;
+  snapshotHash?: string;
+  status: string;
+  httpStatus?: number;
+  contentType?: string;
+  rawHtmlBytes: number;
+  screenshotBytes: number;
+  capturedAt?: string;
+  updatedAt?: string;
+}
+
 export interface MoisSalesLibraryReanalyzeResponse {
   pageId: number;
   jobId: number;

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -3,8 +3,10 @@ import axios from "axios";
 import type {
   MoisSalesLibraryEntryPageResponse,
   MoisSalesLibraryJobPageResponse,
+  MoisSalesLibraryPage,
   MoisSalesLibraryPageAnalysis,
   MoisSalesLibraryPageListResponse,
+  MoisSalesLibraryPageSnapshot,
   MoisSalesLibraryReanalyzeResponse,
 } from "./types";
 
@@ -82,4 +84,27 @@ export function getSalesLibraryJobBadgeClass(job: { status?: string; analysisSta
     default:
       return "bg-secondary-subtle text-secondary-emphasis";
   }
+}
+
+
+export function useMoisSalesLibraryPage(pageId?: number) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "page", pageId],
+    enabled: Boolean(pageId),
+    queryFn: async () => {
+      const { data } = await axios.get<MoisSalesLibraryPage>(`/api/mois/sales-library/pages/${pageId}`);
+      return data;
+    },
+  });
+}
+
+export function useMoisSalesLibraryPageSnapshots(pageId?: number) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "page-snapshots", pageId],
+    enabled: Boolean(pageId),
+    queryFn: async () => {
+      const { data } = await axios.get<MoisSalesLibraryPageSnapshot[]>(`/api/mois/sales-library/pages/${pageId}/snapshots`);
+      return data;
+    },
+  });
 }

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -1,6 +1,10 @@
 import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
-import { useMoisSalesLibraryPageAnalysis } from "../../api/mois/useMoisSalesLibrary";
+import {
+  useMoisSalesLibraryPage,
+  useMoisSalesLibraryPageAnalysis,
+  useMoisSalesLibraryPageSnapshots,
+} from "../../api/mois/useMoisSalesLibrary";
 
 function formatDate(value?: string) {
   if (!value) return "—";
@@ -19,25 +23,79 @@ function JsonCollapse({ title, content }: { title: string; content?: string }) {
   );
 }
 
+type HistoryItem = {
+  key: string;
+  stage: string;
+  date?: string;
+  detail: string;
+};
+
 export default function MoisSalesPageLibraryDetailPage() {
   const params = useParams<{ pageId: string }>();
   const pageId = Number(params.pageId);
-  const analysisQuery = useMoisSalesLibraryPageAnalysis(Number.isFinite(pageId) ? pageId : undefined);
+  const normalizedPageId = Number.isFinite(pageId) ? pageId : undefined;
+
+  const pageQuery = useMoisSalesLibraryPage(normalizedPageId);
+  const analysisQuery = useMoisSalesLibraryPageAnalysis(normalizedPageId);
+  const snapshotsQuery = useMoisSalesLibraryPageSnapshots(normalizedPageId);
+
+  const isLoading = pageQuery.isLoading || analysisQuery.isLoading || snapshotsQuery.isLoading;
+  const isError = pageQuery.isError || analysisQuery.isError || snapshotsQuery.isError;
+
+  const history: HistoryItem[] = [];
+  if (pageQuery.data) {
+    history.push({
+      key: "page-updated",
+      stage: "Coleta / ingestão da URL",
+      date: pageQuery.data.updatedAt,
+      detail: `URL canônica registrada (${pageQuery.data.urlCanonical}).`,
+    });
+    if (pageQuery.data.analyzedAt) {
+      history.push({
+        key: "page-analyzed",
+        stage: "Avaliação concluída",
+        date: pageQuery.data.analyzedAt,
+        detail: `Status final da avaliação: ${pageQuery.data.analysisStatus || "SEM ANÁLISE"}.`,
+      });
+    }
+  }
+
+  (snapshotsQuery.data || []).forEach((snapshot) => {
+    history.push({
+      key: `snapshot-${snapshot.snapshotId}`,
+      stage: "Coleta de snapshot bruto",
+      date: snapshot.capturedAt || snapshot.updatedAt,
+      detail: `Snapshot ${snapshot.snapshotId} com status ${snapshot.status} (HTTP ${snapshot.httpStatus || "—"}).`,
+    });
+  });
+
+  if (analysisQuery.data) {
+    history.push({
+      key: "analysis-updated",
+      stage: "Avaliação do modelo",
+      date: analysisQuery.data.analyzedAt || analysisQuery.data.updatedAt,
+      detail: `Modelo ${analysisQuery.data.modelName || "—"} com status ${analysisQuery.data.status}.`,
+    });
+  }
+
+  history.sort((a, b) => new Date(a.date || 0).getTime() - new Date(b.date || 0).getTime());
 
   return (
     <div className="d-flex flex-column gap-4">
       <header className="d-flex flex-wrap justify-content-between gap-3">
         <div>
-          <PageTitle>Detalhe da análise da página</PageTitle>
-          <p className="text-secondary mb-0">Respostas do modelo, payload enviado e prompt usado na análise.</p>
+          <PageTitle>{pageQuery.data?.title || "Detalhe da análise da página"}</PageTitle>
+          <p className="text-secondary mb-0">
+            Coletor usado: <strong>{pageQuery.data?.source || "—"}</strong>
+          </p>
         </div>
         <Link className="btn btn-outline-secondary" to="/mois/sales-pages-library">
           Voltar para biblioteca
         </Link>
       </header>
 
-      {analysisQuery.isLoading ? <p className="text-secondary mb-0">Carregando detalhe...</p> : null}
-      {analysisQuery.isError ? <div className="alert alert-danger mb-0">Falha ao carregar detalhe da análise.</div> : null}
+      {isLoading ? <p className="text-secondary mb-0">Carregando detalhe...</p> : null}
+      {isError ? <div className="alert alert-danger mb-0">Falha ao carregar detalhe da análise.</div> : null}
 
       {analysisQuery.data ? (
         <section className="card border-0 shadow-sm">
@@ -59,6 +117,27 @@ export default function MoisSalesPageLibraryDetailPage() {
           </div>
         </section>
       ) : null}
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <h2 className="h5 mb-3">Histórico da página</h2>
+          {history.length === 0 ? (
+            <p className="text-secondary mb-0">Ainda não há eventos registrados para esta página.</p>
+          ) : (
+            <div className="d-flex flex-column gap-3">
+              {history.map((item) => (
+                <div key={item.key} className="border rounded p-3 bg-light-subtle">
+                  <div className="d-flex flex-wrap justify-content-between gap-2">
+                    <strong>{item.stage}</strong>
+                    <span className="text-secondary small">{formatDate(item.date)}</span>
+                  </div>
+                  <p className="mb-0 mt-2 small">{item.detail}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Melhorar o contexto operacional da tela de detalhe da análise exibindo o nome do produto como título e o coletor/origem usado como subtítulo para facilitar triagem.
- Fornecer rastreabilidade completa adicionando um card de histórico com todas as etapas (coleta/ingestão, snapshots, avaliação) com data e hora.
- Reaproveitar os endpoints já existentes no backend para evitar mudanças de contrato e permitir inspeção operacional direta.

### Description
- Atualizada a página de detalhe `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx` para usar o `title` da página como `PageTitle`, exibir o `source` como subtítulo e renderizar o card `Histórico da página` ordenado cronologicamente.
- Adicionados hooks no frontend em `frontend/src/api/mois/useMoisSalesLibrary.ts`: `useMoisSalesLibraryPage` e `useMoisSalesLibraryPageSnapshots` que consomem `GET /api/mois/sales-library/pages/{pageId}` e `GET /api/mois/sales-library/pages/{pageId}/snapshots` respectivamente.
- Incluída a tipagem `MoisSalesLibraryPageSnapshot` em `frontend/src/api/mois/types.ts` para suportar os snapshots retornados pelo backend.
- Registrado o ajuste operacional em `docs/registros/mois1.md` conforme fluxo de registros do módulo MOIS.

### Testing
- Executed frontend build attempt with `npm run build`, which failed in the current environment due to missing `vite` (`sh: 1: vite: not found`).
- No additional automated unit/integration tests were run in this rollout; backend endpoints were consumed as-is and no backend code changes were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f4fb2e090832198961c533be3a82a)