### PR TITLE
MOIS sales library: add manual status actions (PENDING/ANULADO) and next-item navigation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -169,6 +169,22 @@ public final class MoisSalesLibraryDtos {
     ) {
     }
 
+
+    public record SalesLibraryStatusUpdateRequest(
+            @NotBlank String status,
+            String reason
+    ) {
+    }
+
+    public record SalesLibraryStatusUpdateResponse(
+            long pageId,
+            Long jobId,
+            String status,
+            String reason,
+            Instant createdAt
+    ) {
+    }
+
     public record SalesLibrarySnapshotCaptureRequest(
             @NotBlank String workspaceId,
             Integer limit,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MoisSalesLibraryService {
 
     private static final String JOB_STATUS_PENDING = "PENDING";
+    private static final String ANALYSIS_STATUS_CANCELED = "ANULADO";
 
     private final JdbcTemplate jdbcTemplate;
 
@@ -236,6 +237,37 @@ public class MoisSalesLibraryService {
                 rs.getString("analysis_notes"), toInstant(rs.getTimestamp("analyzed_at")), toInstant(rs.getTimestamp("updated_at"))), pageId);
         if (rows.isEmpty()) throw new IllegalArgumentException("Analysis not found for page: " + pageId);
         return rows.get(0);
+    }
+
+    /**
+     * Atualiza manualmente o status da análise de uma página da biblioteca.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.SalesLibraryStatusUpdateResponse updatePageStatus(
+            long pageId,
+            MoisSalesLibraryDtos.SalesLibraryStatusUpdateRequest request
+    ) {
+        Long exists = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE id = ?", Long.class, pageId);
+        if (exists == null || exists == 0) throw new IllegalArgumentException("Page not found: " + pageId);
+
+        String normalizedStatus = request.status().trim().toUpperCase(Locale.ROOT);
+        if (!JOB_STATUS_PENDING.equals(normalizedStatus) && !ANALYSIS_STATUS_CANCELED.equals(normalizedStatus)) {
+            throw new IllegalArgumentException("Unsupported status: " + request.status());
+        }
+
+        Long jobId = null;
+        String notes = request.reason() == null || request.reason().isBlank() ? "Status atualizado manualmente via API" : request.reason().trim();
+        if (JOB_STATUS_PENDING.equals(normalizedStatus)) {
+            jobId = createPendingJob(pageId);
+        }
+
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_page_analysis
+                (url_ingest_id, job_id, status, analysis_notes, created_at, updated_at)
+                VALUES (?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                """, pageId, jobId, normalizedStatus, notes);
+
+        return new MoisSalesLibraryDtos.SalesLibraryStatusUpdateResponse(pageId, jobId, normalizedStatus, notes, Instant.now());
     }
 
     @Transactional

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -92,6 +92,23 @@ public class MoisSalesLibraryController {
         }
     }
 
+
+    /**
+     * Permite atualizar manualmente o status da análise para pendente ou anulado.
+     */
+    @PostMapping("/pages/{pageId}:status")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public MoisSalesLibraryDtos.SalesLibraryStatusUpdateResponse updatePageStatus(
+            @PathVariable long pageId,
+            @Valid @RequestBody MoisSalesLibraryDtos.SalesLibraryStatusUpdateRequest request
+    ) {
+        try {
+            return service.updatePageStatus(pageId, request);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
+    }
+
     @PostMapping("/snapshots:capture")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureResponse captureSnapshots(

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -196,3 +196,10 @@ sequenceDiagram
 
 ### 12.4 Regra operacional para evitar divergência de leitura
 Quando houver dúvida sobre “onde o fluxo começa”, considerar canonicamente que a alimentação da biblioteca inicia nos coletores (Hotmart/ClickBank), passa obrigatoriamente pelo endpoint `/urls:ingest` no backend e só então entra no ciclo assíncrono do worker.
+
+### 12.4 Ações manuais de status no detalhe da análise (2026-05-21)
+- A tela de detalhe (`/mois/sales-pages-library/{pageId}`) passa a expor comandos operacionais manuais para acelerar triagem:
+  - `Voltar para pendente`: cria novo ciclo de processamento para a página, persistindo status `PENDING`.
+  - `Marcar como anulado`: registra status `ANULADO` para itens que não serão mais utilizados no funil.
+- Contrato backend oficial: `POST /api/mois/sales-library/pages/{pageId}:status` com payload `{ "status": "PENDING" | "ANULADO", "reason"?: string }`.
+- A interface de detalhe também deve exibir navegação sequencial com botão `Próximo →` para avançar ao próximo item da lista local.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -384,3 +384,9 @@
 - criada nova rota de detalhe `/mois/sales-pages-library/:pageId` exibindo payloads de resposta do modelo em blocos colapsáveis (`<details>`), além de blocos colapsáveis para request enviado e prompt utilizado.
 - todos os trechos JSON foram apresentados em formato colapsável para reduzir ruído visual e facilitar inspeção.
 - arquivos alterados: `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`, `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`, `frontend/src/App.tsx`.
+
+## 2026-05-21 15:20:00 UTC
+- tela de detalhe da Biblioteca de Páginas de Vendas (MOIS) ganhou ações manuais de status: **Voltar para pendente** e **Marcar como anulado**.
+- adicionado endpoint backend `POST /api/mois/sales-library/pages/{pageId}:status` para persistir transição manual de status (`PENDING` e `ANULADO`) com registro em `mois_sales_library_page_analysis`.
+- adicionada navegação de produtividade no detalhe com botão **Próximo →** para avançar para o próximo item da lista.
+- arquivos alterados: `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`, `frontend/src/api/mois/useMoisSalesLibrary.ts`, `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java`, `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`.

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -299,3 +299,11 @@ export interface MoisSalesLibraryReanalyzeResponse {
   status: string;
   createdAt: string;
 }
+
+export interface MoisSalesLibraryStatusUpdateResponse {
+  pageId: number;
+  jobId?: number;
+  status: string;
+  reason?: string;
+  createdAt: string;
+}

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -6,6 +6,7 @@ import type {
   MoisSalesLibraryPageAnalysis,
   MoisSalesLibraryPageListResponse,
   MoisSalesLibraryReanalyzeResponse,
+  MoisSalesLibraryStatusUpdateResponse,
 } from "./types";
 
 export function useMoisSalesLibraryEntries(workspaceId: string, page: number, pageSize: number) {
@@ -65,6 +66,21 @@ export function useReanalyzeMoisSalesLibraryPage(workspaceId: string) {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["mois", "sales-library", "pages", workspaceId] });
       void queryClient.invalidateQueries({ queryKey: ["mois", "sales-library", "jobs", workspaceId] });
+    },
+  });
+}
+
+
+export function useUpdateMoisSalesLibraryPageStatus(workspaceId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ pageId, status }: { pageId: number; status: "PENDING" | "ANULADO" }) => {
+      const { data } = await axios.post<MoisSalesLibraryStatusUpdateResponse>(`/api/mois/sales-library/pages/${pageId}:status`, { status });
+      return data;
+    },
+    onSuccess: (_, variables) => {
+      void queryClient.invalidateQueries({ queryKey: ["mois", "sales-library", "pages", workspaceId] });
+      void queryClient.invalidateQueries({ queryKey: ["mois", "sales-library", "analysis", variables.pageId] });
     },
   });
 }

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -1,6 +1,9 @@
 import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
-import { useMoisSalesLibraryPageAnalysis } from "../../api/mois/useMoisSalesLibrary";
+import { useMoisSalesLibraryPageAnalysis, useMoisSalesLibraryPages, useUpdateMoisSalesLibraryPageStatus } from "../../api/mois/useMoisSalesLibrary";
+
+const WORKSPACE_ID = "workspace-001";
+const PAGE_SIZE = 100;
 
 function formatDate(value?: string) {
   if (!value) return "—";
@@ -22,7 +25,14 @@ function JsonCollapse({ title, content }: { title: string; content?: string }) {
 export default function MoisSalesPageLibraryDetailPage() {
   const params = useParams<{ pageId: string }>();
   const pageId = Number(params.pageId);
-  const analysisQuery = useMoisSalesLibraryPageAnalysis(Number.isFinite(pageId) ? pageId : undefined);
+  const validPageId = Number.isFinite(pageId) ? pageId : undefined;
+  const analysisQuery = useMoisSalesLibraryPageAnalysis(validPageId);
+  const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
+  const updateStatusMutation = useUpdateMoisSalesLibraryPageStatus(WORKSPACE_ID);
+
+  const currentIndex = pagesQuery.data?.items.findIndex((item) => item.pageId === validPageId) ?? -1;
+  const nextItem = currentIndex >= 0 ? pagesQuery.data?.items[currentIndex + 1] : undefined;
+  const isMutating = updateStatusMutation.isPending;
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -31,10 +41,40 @@ export default function MoisSalesPageLibraryDetailPage() {
           <PageTitle>Detalhe da análise da página</PageTitle>
           <p className="text-secondary mb-0">Respostas do modelo, payload enviado e prompt usado na análise.</p>
         </div>
-        <Link className="btn btn-outline-secondary" to="/mois/sales-pages-library">
-          Voltar para biblioteca
-        </Link>
+        <div className="d-flex flex-wrap gap-2">
+          {nextItem ? (
+            <Link className="btn btn-outline-primary" to={`/mois/sales-pages-library/${nextItem.pageId}`}>
+              Próximo →
+            </Link>
+          ) : null}
+          <Link className="btn btn-outline-secondary" to="/mois/sales-pages-library">
+            Voltar para biblioteca
+          </Link>
+        </div>
       </header>
+
+      <div className="d-flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="btn btn-outline-warning"
+          disabled={!validPageId || isMutating}
+          onClick={() => validPageId && updateStatusMutation.mutate({ pageId: validPageId, status: "PENDING" })}
+        >
+          {isMutating ? <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" /> : null}
+          Voltar para pendente
+        </button>
+        <button
+          type="button"
+          className="btn btn-outline-danger"
+          disabled={!validPageId || isMutating}
+          onClick={() => validPageId && updateStatusMutation.mutate({ pageId: validPageId, status: "ANULADO" })}
+        >
+          {isMutating ? <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" /> : null}
+          Marcar como anulado
+        </button>
+      </div>
+
+      {updateStatusMutation.isError ? <div className="alert alert-danger mb-0">Falha ao atualizar status da página.</div> : null}
 
       {analysisQuery.isLoading ? <p className="text-secondary mb-0">Carregando detalhe...</p> : null}
       {analysisQuery.isError ? <div className="alert alert-danger mb-0">Falha ao carregar detalhe da análise.</div> : null}


### PR DESCRIPTION
### Motivation
- Provide manual triage controls in the MOIS sales-pages-library detail view to accelerate handling of items that should be retried (`PENDING`) or discarded (`ANULADO`).
- Improve operator productivity with a `Próximo →` navigation control to advance through the list without returning to the table.
- Keep backend contract, DTOs and canonical documentation aligned with the new UI actions.

### Description
- Backend: added DTOs `SalesLibraryStatusUpdateRequest` and `SalesLibraryStatusUpdateResponse` in `MoisSalesLibraryDtos.java` and implemented controller endpoint `POST /api/mois/sales-library/pages/{pageId}:status` in `MoisSalesLibraryController.java` with a brief responsibility comment. 
- Backend: implemented `updatePageStatus` in `MoisSalesLibraryService.java` that validates allowed statuses (`PENDING` or `ANULADO`), creates a pending job when switching to `PENDING`, inserts a row in `mois_sales_library_page_analysis`, and added the `ANALYSIS_STATUS_CANCELED` constant and method comment. 
- Frontend: added `MoisSalesLibraryStatusUpdateResponse` TypeScript interface in `frontend/src/api/mois/types.ts`, a new hook `useUpdateMoisSalesLibraryPageStatus` in `frontend/src/api/mois/useMoisSalesLibrary.ts`, and updated the detail page `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx` to include buttons for `Voltar para pendente` and `Marcar como anulado` with disabled + spinner behavior and a `Próximo →` link to the next item. 
- Docs: updated `docs/canonical/mois-worker-canon.v1.md` and `docs/registros/mois1.md` to record the new contract `POST /api/mois/sales-library/pages/{pageId}:status` and the UI/operational changes.

### Testing
- Ran backend unit tests: `mvn -q -Dtest=MoisSalesLibraryControllerTest,MoisSalesLibraryServiceTest test` and they completed successfully. 
- Attempted frontend build: `npm run -s build` in this environment failed due to missing `vite` (`vite: not found`) which is an environment/tooling limitation and not a functional regression of the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f506c11248321a73ef4e9b82a01dd)