### PR TITLE
Fix MOIS detail page TypeScript build errors

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -401,3 +401,9 @@
   - frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
   - frontend/src/api/mois/useMoisSalesLibrary.ts
   - frontend/src/api/mois/types.ts
+
+## 2026-05-21 15:55:00 UTC
+- correção de erro de compilação TypeScript na tela `MoisSalesPageLibraryDetailPage`.
+- causa-raiz: uso de variável inexistente (`pageQuery`) e uso de `history` sem definição local, que colidia com o tipo global `History`.
+- correção aplicada: adição das queries `useMoisSalesLibraryPage` e `useMoisSalesLibraryPageSnapshots`, além de construção explícita de `history: HistoryItem[]` a partir dos snapshots.
+- arquivo alterado: `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`.

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -1,6 +1,6 @@
 import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
-import { useMoisSalesLibraryPageAnalysis, useMoisSalesLibraryPages, useUpdateMoisSalesLibraryPageStatus } from "../../api/mois/useMoisSalesLibrary";
+import { useMoisSalesLibraryPage, useMoisSalesLibraryPageAnalysis, useMoisSalesLibraryPageSnapshots, useMoisSalesLibraryPages, useUpdateMoisSalesLibraryPageStatus } from "../../api/mois/useMoisSalesLibrary";
 
 const WORKSPACE_ID = "workspace-001";
 const PAGE_SIZE = 100;
@@ -33,13 +33,22 @@ export default function MoisSalesPageLibraryDetailPage() {
   const params = useParams<{ pageId: string }>();
   const pageId = Number(params.pageId);
   const validPageId = Number.isFinite(pageId) ? pageId : undefined;
+  const pageQuery = useMoisSalesLibraryPage(validPageId);
   const analysisQuery = useMoisSalesLibraryPageAnalysis(validPageId);
+  const snapshotsQuery = useMoisSalesLibraryPageSnapshots(validPageId);
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
   const updateStatusMutation = useUpdateMoisSalesLibraryPageStatus(WORKSPACE_ID);
 
   const currentIndex = pagesQuery.data?.items.findIndex((item) => item.pageId === validPageId) ?? -1;
   const nextItem = currentIndex >= 0 ? pagesQuery.data?.items[currentIndex + 1] : undefined;
   const isMutating = updateStatusMutation.isPending;
+
+  const history: HistoryItem[] = (snapshotsQuery.data ?? []).map((item) => ({
+    key: String(item.snapshotId),
+    stage: `Snapshot ${item.status}`,
+    date: item.capturedAt ?? item.updatedAt,
+    detail: `HTTP ${item.httpStatus ?? "—"} • content-type: ${item.contentType ?? "—"} • html bytes: ${item.rawHtmlBytes} • screenshot bytes: ${item.screenshotBytes}`,
+  }));
 
   return (
     <div className="d-flex flex-column gap-4">


### PR DESCRIPTION
### Motivation
- Corrigir falhas de compilação TypeScript que impediam o build da tela de detalhe da Biblioteca de Páginas de Vendas (erros sobre `pageQuery` inexistente e uso de `history` que colidia com o tipo global `History`).
- Melhorar rastreabilidade operacional exibindo histórico de snapshots no detalhe da página para facilitar investigação de coleta/ingestão/avaliação.

### Description
- Importei e usei os hooks `useMoisSalesLibraryPage` e `useMoisSalesLibraryPageSnapshots` em `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx` para obter detalhe da página e snapshots. 
- Substituí referências à variável inexistente por `pageQuery` (`useMoisSalesLibraryPage(validPageId)`) e mantive `analysisQuery`/`pagesQuery` como antes. 
- Construí um array tipado `history: HistoryItem[]` a partir de `snapshotsQuery.data` para eliminar colisão com o tipo global `History` e evitar `implicit any` no mapeamento. 
- Registrei a correção no log de atividades `docs/registros/mois1.md` conforme as convenções do projeto.

### Testing
- Executei a tentativa de build frontend com `npm run build -- --mode production` para validar compilação TypeScript. 
- A execução parou antes de compilar por falta do binário/dependência local (`vite: not found`), então o build completo não pôde ser validado nesse ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f526f28fc832186327ed534cd7f16)