### PR TITLE
Fix GeraLanding execution test wiring after constructor update

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
 import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ class GeraLandingExecutionServiceTest {
         GeraLandingService geraLandingService = Mockito.mock(GeraLandingService.class);
         GeraLandingOpenAiFlexClient openAiClient = Mockito.mock(GeraLandingOpenAiFlexClient.class);
         ObjectMapper objectMapper = new ObjectMapper();
+        GeraLandingStageSchemaResolver stageSchemaResolver = Mockito.mock(GeraLandingStageSchemaResolver.class);
 
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
@@ -34,6 +36,7 @@ class GeraLandingExecutionServiceTest {
                         geraLandingService,
                         openAiClient,
                         objectMapper,
+                        stageSchemaResolver,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
@@ -55,6 +58,7 @@ class GeraLandingExecutionServiceTest {
         GeraLandingService geraLandingService = Mockito.mock(GeraLandingService.class);
         GeraLandingOpenAiFlexClient openAiClient = Mockito.mock(GeraLandingOpenAiFlexClient.class);
         ObjectMapper objectMapper = new ObjectMapper();
+        GeraLandingStageSchemaResolver stageSchemaResolver = Mockito.mock(GeraLandingStageSchemaResolver.class);
 
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
@@ -68,6 +72,7 @@ class GeraLandingExecutionServiceTest {
                         geraLandingService,
                         openAiClient,
                         objectMapper,
+                        stageSchemaResolver,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -877,3 +877,14 @@
   - ajuste dos testes para APIs atuais dos assemblers/processors (remoção de chamadas legadas `assembleComplete`/`processComplete`);
   - ajuste de mocks em `GeraLandingStageExecutionServiceTest` para refletir `ImagePlanningProvisionalHtmlAssembler` na etapa de image planning.
 - validação: `mvn -DskipITs test-compile` executado com sucesso no módulo `backend/ads-service`.
+
+## 2026-05-21 15:45:11 UTC-3
+- correção de falha de compilação nos testes do módulo ai-worker após evolução do construtor de `GeraLandingExecutionService`.
+- causa-raiz identificada: os testes continuavam instanciando o serviço sem o novo parâmetro obrigatório `GeraLandingStageSchemaResolver`, gerando incompatibilidade de assinatura.
+- foi feito: atualização de `GeraLandingExecutionServiceTest` para criar mock de `GeraLandingStageSchemaResolver` e passá-lo nas duas instâncias do serviço cobertas pelos testes.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/registros/experimentos.md
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+  - ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java


### PR DESCRIPTION
### Motivation
- `GeraLandingExecutionService` constructor was extended to require a `GeraLandingStageSchemaResolver`, which broke test compilation because `GeraLandingExecutionServiceTest` still used the old signature.

### Description
- Updated `GeraLandingExecutionServiceTest` to import and mock `GeraLandingStageSchemaResolver` and pass it to both `GeraLandingExecutionService` instances used in the tests (`ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java`).
- Added an operational registro entry documenting the root cause and fix in `docs/registros/experimentos.md`.

### Testing
- Ran `mvn -f backend/ads-service/pom.xml -DskipTests install` to install the local dependency used by the `ai-worker` module, and it succeeded.
- Ran targeted tests with `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test` and both tests passed (2 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f528f34688321863aa4bdb1516dbd)