### PR TITLE
Require imagePlan root in GeraLanding image-planning schema and prompt

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-image-planning-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-image-planning-schema.json
@@ -6,7 +6,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "images": {
+        "imagePlan": {
           "type": "array",
           "minItems": 1,
           "items": {
@@ -22,7 +22,7 @@
           }
         }
       },
-      "required": ["images"]
+      "required": ["imagePlan"]
     }
   },
   "required": ["landingPageImagePlanning"]

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-image-planning.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-image-planning.md
@@ -7,7 +7,8 @@ Objetivo: ler o wireframe salvo no experimento e gerar um planejamento de prompt
 ## Regras
 - Use como base os elementos de imagem definidos no wireframe (`tag: img`).
 - Não altere estrutura do wireframe nem da copy; apenas planeje imagens.
-- Cada item deve possuir `sectionId`, `elementId`, `imagePrompt` e `imageGoal`.
+- A resposta DEVE ser um objeto com o atributo raiz `imagePlan` (array) e cada item deve possuir `sectionId`, `elementId`, `imagePrompt` e `imageGoal`.
+- É proibido retornar array na raiz ou concatenar múltiplos JSONs; retorne exatamente um único objeto JSON com `imagePlan`.
 - O prompt deve ser claro para execução posterior no Worker AI, com contexto comercial e visual.
 
 ## Contexto disponível

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -888,3 +888,10 @@
   - docs/registros/experimentos.md
   - ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
   - ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+
+## 2026-05-21 20:05:00 UTC
+- solicitação: endurecer o schema da etapa de briefing de imagens para obrigar o formato com atributo `imagePlan`.
+- causa-raiz: o modelo estava variando entre payload válido e formatos inválidos (array na raiz e JSON concatenado), quebrando o contrato esperado no consumidor da etapa.
+- foi feito:
+  - atualização do schema `landing-page-image-planning-schema.json` para exigir `landingPageImagePlanning.imagePlan` (substituindo `images` nesta etapa);
+  - reforço do prompt da etapa com regra explícita de retorno em objeto único com atributo raiz `imagePlan` e proibição de array na raiz/JSON duplicado.


### PR DESCRIPTION
### Motivation
- The image-planning worker produced inconsistent outputs (root arrays and concatenated JSON), which broke downstream consumers, so the stage contract must be strict about the expected shape.

### Description
- Updated the GeraLanding image-planning JSON schema at `ai-worker/src/main/resources/prompts/geralanding/landing-page-image-planning-schema.json` to replace `images` with a required `landingPageImagePlanning.imagePlan` array and enforce item properties (`sectionId`, `elementId`, `imageGoal`, `imagePrompt`).
- Reinforced the stage prompt at `ai-worker/src/main/resources/prompts/geralanding/landing-page-image-planning.md` to require a single JSON object with root attribute `imagePlan` and to forbid root-level arrays or concatenated JSON outputs.
- Recorded the change in `docs/registros/experimentos.md` describing the request, root cause and applied fix.

### Testing
- Attempted to run targeted ai-worker tests with `mvn -f ai-worker/pom.xml -DskipITs -Dtest=GeraLandingExecutionServiceTest,ExperimentPipelineOpenAiClientTest test`, but the build failed due to dependency resolution (401 Unauthorized fetching private `com.marketinghub:ads-service:0.0.1-SNAPSHOT`); no ai-worker tests completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f5b60d4448321b47b2778d9beea96)