### PR TITLE
fix(frontend): improve stage badge contrast on execution detail

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -895,3 +895,10 @@
 - foi feito:
   - atualização do schema `landing-page-image-planning-schema.json` para exigir `landingPageImagePlanning.imagePlan` (substituindo `images` nesta etapa);
   - reforço do prompt da etapa com regra explícita de retorno em objeto único com atributo raiz `imagePlan` e proibição de array na raiz/JSON duplicado.
+
+## 2026-05-21 18:12:00 UTC
+- solicitação: ajustar legibilidade do subtítulo/badge na tela de detalhe de execução do Gera Landing, pois texto azul sobre fundo azul ficou sem contraste.
+- causa-raiz: o badge de `stageCode` na composição do título usava estilo contextual que podia herdar cor de texto do heading em certos contextos, resultando em contraste insuficiente.
+- foi feito:
+  - atualização da classe CSS do badge para aplicar fundo azul fixo (`bg-primary`) com texto explicitamente branco (`text-white`) e peso `fw-semibold`, garantindo leitura consistente.
+- validação: inspeção estática do componente em `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx`.

--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -154,7 +154,7 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
           <PageTitle icon={experimentIcon}>
             Detalhe da execução Gera Landing
             {detailQuery.data?.stageCode ? (
-              <span className="badge text-bg-primary ms-3 align-middle">
+              <span className="badge bg-primary text-white ms-3 align-middle fw-semibold">
                 {detailQuery.data.stageCode}
               </span>
             ) : null}


### PR DESCRIPTION
### Motivation
- The `stageCode` badge in the Gera Landing execution detail header could render as blue text on a blue background in some contexts, causing poor contrast and unreadable text.

### Description
- Updated the badge markup in `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx` to use explicit classes `bg-primary text-white fw-semibold` to guarantee foreground/background contrast.
- Recorded the change in `docs/registros/experimentos.md` following the project's operational logging rules for experiment-related fixes.

### Testing
- No automated tests were executed for this visual-only change; validation was performed via static inspection of `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx` and the updated experiment registry entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f72a5aee88321b8748069a5210eb7)