### PR TITLE
Ordena histórico de Gera Imagem por data mais recente

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -895,3 +895,11 @@
 - foi feito:
   - atualização do schema `landing-page-image-planning-schema.json` para exigir `landingPageImagePlanning.imagePlan` (substituindo `images` nesta etapa);
   - reforço do prompt da etapa com regra explícita de retorno em objeto único com atributo raiz `imagePlan` e proibição de array na raiz/JSON duplicado.
+
+## 2026-05-21 20:20:00 UTC
+- solicitação: exibir o histórico da seção "Gera Imagem" em ordem cronológica com o mais recente primeiro.
+- causa-raiz: a lista `historyGeraLandingImagePromptsExecutions` fazia apenas merge + deduplicação e não aplicava ordenação por `executionRequestedAt`, permitindo ordem inconsistente na UI.
+- foi feito:
+  - ajuste do cálculo de histórico em `ExperimentDetailPage.tsx` para incluir status de falha explicitamente (`hasFailedExecution`);
+  - aplicação de ordenação decrescente por timestamp (`Date.parse(executionRequestedAt)`) antes da deduplicação;
+  - manutenção da deduplicação por `idJob` após ordenação para preservar apenas a ocorrência mais recente por job.

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -868,20 +868,40 @@ export default function ExperimentDetailPage() {
   const historyGeraLandingImagePromptsExecutions = useMemo(() => {
     const completedHistory = (
       completedGeraLandingImagePromptsExecutions ?? []
-    ).filter((execution) => isCompletedExecution(execution.status));
-    const failedFromPending = (
-      pendingGeraLandingImagePromptsExecutions ?? []
     ).filter(
       (execution) =>
-        !isRunningExecution(execution.status) &&
-        !isCompletedExecution(execution.status),
+        isCompletedExecution(execution.status) ||
+        hasFailedExecution(execution.status),
     );
-    const merged = [...failedFromPending, ...completedHistory];
-    const dedupMap = new Map<string, GeraLandingStageExecutionItem>();
-    merged.forEach((execution) => {
-      dedupMap.set(execution.idJob, execution);
-    });
-    return Array.from(dedupMap.values());
+    const failedFromPending = (
+      pendingGeraLandingImagePromptsExecutions ?? []
+    ).filter((execution) => hasFailedExecution(execution.status));
+
+    const sortedExecutions = [...failedFromPending, ...completedHistory].sort(
+      (leftExecution, rightExecution) => {
+        const leftTimestamp = Date.parse(
+          leftExecution.executionRequestedAt ?? "",
+        );
+        const rightTimestamp = Date.parse(
+          rightExecution.executionRequestedAt ?? "",
+        );
+        const normalizedLeftTimestamp = Number.isNaN(leftTimestamp)
+          ? 0
+          : leftTimestamp;
+        const normalizedRightTimestamp = Number.isNaN(rightTimestamp)
+          ? 0
+          : rightTimestamp;
+
+        return normalizedRightTimestamp - normalizedLeftTimestamp;
+      },
+    );
+
+    return sortedExecutions.filter(
+      (execution, index, allExecutions) =>
+        allExecutions.findIndex(
+          (candidate) => candidate.idJob === execution.idJob,
+        ) === index,
+    );
   }, [
     completedGeraLandingImagePromptsExecutions,
     pendingGeraLandingImagePromptsExecutions,


### PR DESCRIPTION
### Motivation
- Corrigir a visualização do histórico da etapa “Gera Imagem” para que as execuções sejam exibidas em ordem cronológica decrescente (mais recente primeiro) evitando apresentação fora de ordem na UI.

### Description
- Atualiza o cálculo de `historyGeraLandingImagePromptsExecutions` em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` para incluir falhas via `hasFailedExecution`, agregar entradas pendentes e concluídas e aplicar ordenação decrescente por `executionRequestedAt` antes da deduplicação por `idJob`.
- Substitui a estratégia anterior de merge+Map de deduplicação por uma ordenação explícita seguida de um filtro que preserva a ocorrência mais recente por `idJob`.
- Registra a mudança em `docs/registros/experimentos.md` com solicitação, causa-raiz e resumo das ações executadas.

### Testing
- Foi executado o typecheck do frontend com `npm run typecheck` em `frontend`, que falhou devido a tipagens ausentes e opções depreciadas no ambiente (`@testing-library/jest-dom`, `vite/client`, `vitest/globals` e configurações de `tsconfig.json`), erro este não relacionado com a lógica de ordenação aplicada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f738a13688321bf5d64d0638bfef0)