### PR TITLE
Defer funnel-tracking initialization until DOM is ready to avoid premature section collection

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -550,54 +550,64 @@ public class GeraLandingStageExecutionService {
                   window.__mhFunnelTrackingInstalled = true;
                   var debugPrefix = '[MH funnel tracking]';
                   window.dataLayer = window.dataLayer || [];
+
                   function emit(name, payload){
                     var eventPayload = Object.assign({event:name, source:'landing-page-design-preset'}, payload||{});
                     console.debug(debugPrefix, 'emit', eventPayload);
                     window.dataLayer.push(eventPayload);
                   }
-                  console.debug(debugPrefix, 'bootstrap');
-                  emit('page_view', {ts: Date.now()});
-                  var sections = Array.prototype.slice.call(document.querySelectorAll('[data-track-section]'));
-                  console.debug(debugPrefix, 'sections-found', {count: sections.length});
-                  var stats = {};
-                  sections.forEach(function(node){
-                    var id = node.getAttribute('data-track-section');
-                    stats[id] = {visibleSince:null, elapsedMs:0};
-                  });
-                  function flushSection(id, reason){
-                    var s = stats[id];
-                    if (!s || s.visibleSince === null) return;
-                    s.elapsedMs += Date.now() - s.visibleSince;
-                    s.visibleSince = null;
-                    console.debug(debugPrefix, 'section-flush', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
-                    emit('section_view_time', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
-                  }
-                  var observer = new IntersectionObserver(function(entries){
-                    entries.forEach(function(entry){
-                      var id = entry.target.getAttribute('data-track-section');
-                      if (!id || !stats[id]) return;
-                      if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
-                        if (stats[id].visibleSince === null) {
-                          stats[id].visibleSince = Date.now();
-                          console.debug(debugPrefix, 'section-visible', {sectionId:id, ts:stats[id].visibleSince});
-                          emit('section_view_start', {sectionId:id});
+
+                  function initTracking(){
+                    console.debug(debugPrefix, 'bootstrap');
+                    emit('page_view', {ts: Date.now()});
+                    var sections = Array.prototype.slice.call(document.querySelectorAll('[data-track-section]'));
+                    console.debug(debugPrefix, 'sections-found', {count: sections.length});
+                    var stats = {};
+                    sections.forEach(function(node){
+                      var id = node.getAttribute('data-track-section');
+                      stats[id] = {visibleSince:null, elapsedMs:0};
+                    });
+                    function flushSection(id, reason){
+                      var s = stats[id];
+                      if (!s || s.visibleSince === null) return;
+                      s.elapsedMs += Date.now() - s.visibleSince;
+                      s.visibleSince = null;
+                      console.debug(debugPrefix, 'section-flush', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
+                      emit('section_view_time', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
+                    }
+                    var observer = new IntersectionObserver(function(entries){
+                      entries.forEach(function(entry){
+                        var id = entry.target.getAttribute('data-track-section');
+                        if (!id || !stats[id]) return;
+                        if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+                          if (stats[id].visibleSince === null) {
+                            stats[id].visibleSince = Date.now();
+                            console.debug(debugPrefix, 'section-visible', {sectionId:id, ts:stats[id].visibleSince});
+                            emit('section_view_start', {sectionId:id});
+                          }
+                        } else {
+                          flushSection(id, 'intersection-change');
                         }
-                      } else {
-                        flushSection(id, 'intersection-change');
+                      });
+                    }, {threshold:[0,0.5,1]});
+                    sections.forEach(function(node){ observer.observe(node); });
+                    document.addEventListener('visibilitychange', function(){
+                      if (document.hidden) {
+                        console.debug(debugPrefix, 'visibility-hidden');
+                        Object.keys(stats).forEach(function(id){ flushSection(id, 'tab-hidden'); });
                       }
                     });
-                  }, {threshold:[0,0.5,1]});
-                  sections.forEach(function(node){ observer.observe(node); });
-                  document.addEventListener('visibilitychange', function(){
-                    if (document.hidden) {
-                      console.debug(debugPrefix, 'visibility-hidden');
-                      Object.keys(stats).forEach(function(id){ flushSection(id, 'tab-hidden'); });
-                    }
-                  });
-                  window.addEventListener('beforeunload', function(){
-                    console.debug(debugPrefix, 'beforeunload-flush');
-                    Object.keys(stats).forEach(function(id){ flushSection(id, 'before-unload'); });
-                  });
+                    window.addEventListener('beforeunload', function(){
+                      console.debug(debugPrefix, 'beforeunload-flush');
+                      Object.keys(stats).forEach(function(id){ flushSection(id, 'before-unload'); });
+                    });
+                  }
+
+                  if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', initTracking);
+                  } else {
+                    initTracking();
+                  }
                 })();
                 </script>
                 """;

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,11 @@
+## 2026-05-21 01:05:00 UTC-3
+- solicitação: corrigir ingestão de tracking que iniciava cedo demais na landing do experimento 26.
+- causa-raiz identificada: o script `data-mh-funnel-tracking` era executado imediatamente após injeção no `<head>`, podendo consultar seções antes do DOM estar pronto.
+- foi feito:
+  - refatorado o script injetado em `GeraLandingStageExecutionService` para encapsular a inicialização em `initTracking`;
+  - adicionada guarda de prontidão do DOM (`document.readyState` + `DOMContentLoaded`) antes de buscar `[data-track-section]` e iniciar `IntersectionObserver`.
+- impacto esperado: evitar corrida de inicialização, garantir contagem correta de seções e reduzir perda de eventos de tracking no primeiro carregamento.
+
 # Registros — Experimentos
 
 > 🔴 **Arquivo canônico principal (atual)** para registro operacional do tema Experimentos.


### PR DESCRIPTION
### Motivation
- The injected `data-mh-funnel-tracking` script could run immediately after being appended to the `<head>`, querying sections before the DOM was ready and losing initial section data, which manifested in incorrect tracking for an experiment.

### Description
- Refactored the injected script in `GeraLandingStageExecutionService.injectBehaviorTrackingAttributesAndScript` to encapsulate setup in an `initTracking` function and moved bootstrap logic inside it.
- Added a readiness guard to run `initTracking` on `DOMContentLoaded` when `document.readyState === 'loading'` and to run immediately otherwise, preventing early queries for `[data-track-section]`.
- Kept the `IntersectionObserver`, `visibilitychange` and `beforeunload` flush logic intact but moved their registration into `initTracking` to ensure correct section discovery and timing.
- Appended an operational note to `docs/registros/experimentos.md` documenting the fix and root cause.

### Testing
- Ran service tests for the ads service with `./gradlew :backend:ads-service:test` and they passed.
- Ran the full project test suite with `./gradlew test` and the build/tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f7c8f51108321ade56dd63999edab)