### PR TITLE
Fix OPRM CNAE volume ordering by active establishments

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -127,3 +127,5 @@
 - 2026-05-21 19:30:00 (UTC): atualização canônica solicitada para OPRM: formalizada no `docs/canonical/oprm-canon.v1.md` a regra da visão `/oprm/cnaes-volume` com ordenação obrigatória por **Quantidade** (descendente, maior→menor) e paginação obrigatória com tamanho padrão de 50 registros por página, com ordenação aplicada no backend.
 
 - 2026-05-21 19:50:00 (UTC): implementação solicitada do ranking `/oprm/cnaes-volume` com paginação real no backend: endpoint `GET /api/oprm/market/import-runs/cnaes/top-volume` atualizado para receber `page` e `size` (default `0`/`50`), serviço OPRM ajustado para aplicar `PageRequest` e frontend alterado para consumir paginação server-side mantendo ordenação por quantidade no backend.
+
+- 2026-05-21 20:05:00 (UTC): correção na tela OPRM `/oprm/cnaes-volume` para garantir ordenação visual do ranking por **Estab. ativos** (descendente, maior→menor) no frontend, adicionando ordenação defensiva client-side em `OprmCnaeVolumePage` após resposta paginada do backend e ajustando o texto da seção para explicitar o critério de estabelecimentos ativos.

--- a/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
@@ -15,7 +15,9 @@ export default function OprmCnaeVolumePage() {
   const cnaeCatalogQuery = useOprmCnaeCatalog();
   const hasVolumeData = (data ?? []).length > 0;
   const hasCatalogData = (cnaeCatalogQuery.data ?? []).length > 0;
-  const paginatedVolumeData = useMemo(() => data ?? [], [data]);
+  const paginatedVolumeData = useMemo(() => {
+    return [...(data ?? [])].sort((a, b) => b.totalEstabelecimentosAtivos - a.totalEstabelecimentosAtivos);
+  }, [data]);
   const hasNextPage = paginatedVolumeData.length === pageSize;
 
   return (
@@ -33,7 +35,7 @@ export default function OprmCnaeVolumePage() {
         <div className="card-body d-flex justify-content-between align-items-center">
           <div>
             <h2 className="h5 mb-1">Top CNAEs por volume</h2>
-            <p className="text-secondary mb-0">Exibindo 50 CNAEs por página, ordenados da maior quantidade para a menor.</p>
+            <p className="text-secondary mb-0">Exibindo 50 CNAEs por página, ordenados da maior quantidade de estabelecimentos ativos para a menor.</p>
           </div>
           <button
             type="button"


### PR DESCRIPTION
### Motivation
- Corrigir a visualização da tela `/oprm/cnaes-volume` para garantir que o ranking exibido obedeça ao critério esperado de maior para menor em `Estab. ativos` quando o backend não devolver ordenação confiável.
- Tornar explícito para o usuário qual critério está sendo mostrado na página.
- Registrar a correção no histórico operacional do módulo OPRM conforme as convenções do repositório.

### Description
- Adicionada ordenação defensiva client-side em `frontend/src/pages/oprm/OprmCnaeVolumePage.tsx` usando `useMemo` para ordenar por `totalEstabelecimentosAtivos` em ordem decrescente antes de renderizar a tabela.
- Atualizado o texto informativo da seção na mesma página para `Exibindo 50 CNAEs por página, ordenados da maior quantidade de estabelecimentos ativos para a menor.`.
- Registrado o ajuste em `docs/registros/oprm1.md` com entrada descrevendo a correção de ordenação visual.

### Testing
- Executei `npm --prefix frontend run typecheck`, que falhou por limitações do ambiente atual (faltam definições de tipos `@testing-library/jest-dom`, `vite/client`, `vitest/globals` e há avisos de deprecação em `tsconfig.json`).
- Não foram adicionados nem alterados testes unitários neste PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f7eb8b3208321a792fb1fdf5ae406)