### PR TITLE
Add `html_geralanding` column and persist design-preset HTML separately

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -196,6 +196,9 @@ public class Experiment {
     @Column(name = "landing_page_design_preset", columnDefinition = "LONGTEXT")
     private String landingPageDesignPreset;
 
+    @Column(name = "html_geralanding", columnDefinition = "LONGTEXT")
+    private String htmlGeraLanding;
+
     @Column(name = "landing_page_deliverables", columnDefinition = "LONGTEXT")
     private String landingPageDeliverables;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -35,6 +35,7 @@ public class ExperimentDto {
     private String landingPageWireframe;
     private String landingPageImagePlanning;
     private String landingPageDesignPreset;
+    private String htmlGeraLanding;
     private String landingPageDeliverables;
     private String landingPageHtml;
     private InstagramAccountDto instagramAccount;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -88,7 +88,7 @@ public class GeraLandingStageExecutionService {
         log.info("GeraLanding publish approval loaded experiment (experimentId={}, experimentName={})",
                 experimentId, experiment.getName());
 
-        String landingPageHtml = experiment.getLandingPageDesignPreset();
+        String landingPageHtml = experiment.getHtmlGeraLanding();
         if (!StringUtils.hasText(landingPageHtml)) {
             landingPageHtml = experiment.getLandingPageHtml();
         }
@@ -515,13 +515,9 @@ public class GeraLandingStageExecutionService {
                         request,
                         execution);
             }
+            experiment.setLandingPageDesignPreset(request.modelResponse());
             if (StringUtils.hasText(htmlFromDesignPreset)) {
-                experiment.setLandingPageDesignPreset(htmlFromDesignPreset);
-            }
-            else {
-                experiment.setLandingPageDesignPreset(request.modelResponse());
-            }
-            if (StringUtils.hasText(htmlFromDesignPreset)) {
+                experiment.setHtmlGeraLanding(htmlFromDesignPreset);
                 experiment.setLandingPageHtml(htmlFromDesignPreset);
             }
         }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-21-experiment-html-geralanding-column.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-21-experiment-html-geralanding-column.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-21-experiment-html-geralanding-column
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - sqlCheck:
+            expectedResult: "0"
+            sql: |
+              SELECT COUNT(*)
+              FROM information_schema.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = 'experiment'
+                AND COLUMN_NAME = 'html_geralanding'
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment
+                ADD COLUMN html_geralanding LONGTEXT NULL
+                AFTER landing_page_design_preset;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,9 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-05-21-experiment-html-geralanding-column.yaml
+      relativeToChangelogFile: true
+
+  - include:
       file: changesets/2026-05-16-mois-sales-library-processing-job.yaml
       relativeToChangelogFile: true
 

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -393,7 +393,8 @@ class GeraLandingStageExecutionServiceTest {
 
         assertTrue(execution.getProvisionalHtml().contains("design-1.png"));
         assertEquals(execution.getProvisionalHtml(), experiment.getLandingPageHtml());
-        assertEquals(execution.getProvisionalHtml(), experiment.getLandingPageDesignPreset());
+        assertEquals(execution.getProvisionalHtml(), experiment.getHtmlGeraLanding());
+        assertEquals(request.modelResponse(), experiment.getLandingPageDesignPreset());
         verify(experimentRepository).save(experiment);
     }
 }

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -72,7 +72,7 @@ Regras complementares:
 | `LANDING_PAGE_WIREFRAME` | `WireframeProvisionalHtmlAssembler` | `gera_landing_stage_execution.provisional_html` |
 | `LANDING_PAGE_COPY` | `CopyProvisionalHtmlAssembler` | `gera_landing_stage_execution.provisional_html` |
 | `LANDING_PAGE_IMAGE_PLANNING` | `ImagePlanningProvisionalHtmlAssembler` (usa internamente `CopyProvisionalHtmlAssembler` + `LandingPageImageInjector` apenas para esta etapa). | `gera_landing_stage_execution.provisional_html` e `experiment.landing_page_html` (quando `provisionalHtml` existe na execução). |
-| `LANDING_PAGE_DESIGN_PRESET` | `DesignPresetProvisionalHtmlAssembler` + `LandingPageImageInjector.injectImages(...)` | `gera_landing_stage_execution.provisional_html`, `experiment.landing_page_design_preset` (HTML consolidado da etapa) e `experiment.landing_page_html` |
+| `LANDING_PAGE_DESIGN_PRESET` | `DesignPresetProvisionalHtmlAssembler` + `LandingPageImageInjector.injectImages(...)` | `gera_landing_stage_execution.provisional_html`, `experiment.landing_page_design_preset` (JSON bruto da resposta do modelo), `experiment.html_geralanding` (HTML consolidado da etapa) e `experiment.landing_page_html` |
 
 ### 5.4 Regra de isolamento por conjunto (obrigatória)
 
@@ -141,7 +141,7 @@ A publicação do HTML final da landing ocorre no Lead Portal, com integração 
 Classe responsável no backend: `GeraLandingStageExecutionService` (método `approveAndPublishLanding`).
 
 Fluxo obrigatório executado após a aprovação:
-1. carregar o experimento e resolver o HTML base para publicação (priorizando `experiment.landing_page_design_preset`; fallback legado para `experiment.landing_page_html`);
+1. carregar o experimento e resolver o HTML base para publicação (priorizando `experiment.html_geralanding`; fallback legado para `experiment.landing_page_html`);
 2. injetar instrumentação de tracking comportamental no HTML publicado (`data-track-section` + script `data-mh-funnel-tracking`);
 3. injetar controles de funil (`data-mh-funnel-controls`);
 4. resolver `facebookPixelId` do nicho do experimento e injetar snippet do Facebook Pixel quando elegível;

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -19,8 +19,9 @@ criativos, campanha e objetos de ativação/medição.
 Campo adicionado na entidade/tabela `experiment` para suportar o novo passo canônico de design da landing:
 
 - `landing_page_design_preset` (`LONGTEXT`)
-  - armazena o artefato estruturado `landingPageDesignPreset` produzido no pipeline entre `landingPageImagePlanning` e `landingPageHtml`;
-  - objetivo: separar decisão visual (tema/presets) da composição final do HTML pelo LHM, preservando determinismo e auditabilidade.
+- `html_geralanding` (`LONGTEXT`)
+  - armazena o HTML consolidado produzido no fluxo Gera Landing (a partir do `DesignPresetProvisionalHtmlAssembler`);
+  - objetivo: manter `landing_page_design_preset` como JSON bruto do modelo e separar o HTML operacional para publicação/preview.
 
 Atualização incremental — vínculo do wireframe com execução Gera Landing (07/05/2026):
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -917,3 +917,19 @@
 - foi feito:
   - atualização da classe CSS do badge para aplicar fundo azul fixo (`bg-primary`) com texto explicitamente branco (`text-white`) e peso `fw-semibold`, garantindo leitura consistente.
 - validação: inspeção estática do componente em `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx`.
+
+## 2026-05-21 19:08:31 UTC-3
+- solicitação: corrigir inconsistência da tela de etapas, onde o Preset Design mostrava HTML em vez do JSON bruto retornado pela OpenAI.
+- causa-raiz identificada: o backend persistia o HTML provisório da etapa `landing-page-design-preset` na coluna `experiment.landing_page_design_preset`, sobrescrevendo o artefato JSON dessa etapa.
+- foi feito:
+  - criada a nova coluna `experiment.html_geralanding` (Liquibase incremental) para armazenar exclusivamente o HTML gerado pelo `DesignPresetProvisionalHtmlAssembler`;
+  - ajustada a persistência da etapa `LANDING_PAGE_DESIGN_PRESET` para manter `landing_page_design_preset` como JSON bruto (`modelResponse`) e gravar o HTML consolidado em `html_geralanding`;
+  - ajustado o fluxo de publicação (`approveAndPublishLanding`) para ler prioritariamente `html_geralanding` (fallback para `landing_page_html`);
+  - atualizado o DTO do experimento para expor `htmlGeraLanding` e o texto da UI para explicitar que a etapa 6 mostra JSON bruto.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - frontend/AGENTS.md
+  - docs/canonical/procedimento-experimento-canon.v1.md
+  - docs/modelo-dados-experimento.md
+  - docs/registros/experimentos.md

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -260,7 +260,7 @@ export default function ExperimentDetailPage() {
         key: "design-preset",
         title: "Etapa 6 · Preset Design",
         description:
-          "Conteúdo bruto salvo na coluna landing_page_design_preset.",
+          "Conteúdo bruto (JSON) salvo na coluna landing_page_design_preset.",
         rawValue: data?.landingPageDesignPreset,
       },
       {


### PR DESCRIPTION
### Motivation
- Fix an inconsistency where the design preset HTML was stored in `landing_page_design_preset`, which overwrote the JSON model response and made the UI show HTML instead of the raw JSON for the Preset Design stage.
- Provide a deterministic place to store the consolidated HTML produced by the `DesignPresetProvisionalHtmlAssembler` for publishing and preview workflows.

### Description
- Adds a new `html_geralanding` `LONGTEXT` column via a Liquibase changeset and includes it in `db.changelog-master.yaml` to persist the assembled HTML for the Gera Landing flow.
- Introduces `htmlGeraLanding` field to `Experiment` and exposes it via `ExperimentDto` to surface the HTML in APIs.
- Updates `GeraLandingStageExecutionService` to persist the raw model response in `landing_page_design_preset` and to store the consolidated HTML into `htmlGeraLanding` and `landing_page_html`, and to prefer `html_geralanding` when publishing in `approveAndPublishLanding` (with fallback to `landing_page_html`).
- Updates frontend text to clarify that `landing_page_design_preset` contains raw JSON and updates docs to reflect the new field and the pipeline behavior.
- Adjusts unit test `GeraLandingStageExecutionServiceTest` expectations to assert the new persistence behavior.

### Testing
- Ran the updated unit test `GeraLandingStageExecutionServiceTest` which was modified to match the new persistence logic and it passed.
- Executed the backend unit test suite with the updated test and migrations and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f8028a20c8321b2aace955f8cfc16)