### PR TITLE
Refina etapa de design preset para descartar presets LHM sem uso

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
@@ -19,6 +19,7 @@ Regras obrigatórias:
 12. Gerar variações `desktop` e `mobile` para cada token tipográfico, preservando a mesma hierarquia visual entre breakpoints.
 13. Em `consistencyChecks`, validar explicitamente: presença de todos os atributos tipográficos obrigatórios, legibilidade, contraste e força tipográfica de `display/h1/button`.
 14. Se faltar qualquer atributo obrigatório em qualquer token, registrar `FAIL` em `consistencyChecks` com detalhes objetivos; não omitir erro silenciosamente.
+15. Evitar geração de presets redundantes do LHM: em `elementPresets`, incluir somente elementos que realmente existem no `landingPageWireframe` e que exigem override para conversão/legibilidade; não criar entradas extras apenas para repetir defaults já cobertos por `theme`/`sectionPresets` e não inventar classes/tokens fora do contrato.
 
 Whitelist de atributos CSS permitidos (`attributes[].name`):
 - color

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -933,3 +933,13 @@
   - docs/canonical/procedimento-experimento-canon.v1.md
   - docs/modelo-dados-experimento.md
   - docs/registros/experimentos.md
+
+## 2026-05-21 19:20:11 UTC-3
+- solicitação para reduzir ruído na etapa de preset design, que estava gerando muitos presets LHM sem uso prático.
+- causa-raiz tratada no prompt: ausência de regra explícita para restringir `elementPresets` somente a elementos existentes e com necessidade real de override.
+- foi feito: atualização do prompt `landing-page-design-preset` no AI Worker para descartar geração redundante de presets LHM, proibindo entradas extras que apenas repetem defaults de `theme`/`sectionPresets` e evitando criação de classes/tokens fora do contrato.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/registros/experimentos.md
+  - ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md


### PR DESCRIPTION
### Motivation
- Reduzir o ruído e presets LHM redundantes gerados na etapa `landing-page-design-preset` adicionando regra clara para que apenas elementos existentes e que precisam de override sejam incluídos em `elementPresets`.

### Description
- Atualiza o prompt da etapa `landing-page-design-preset` no AI Worker (`ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md`) adicionando a regra que proíbe geração de presets LHM redundantes e evita criação de classes/tokens fora do contrato, e registra a mudança no log canônico (`docs/registros/experimentos.md`).

### Testing
- Não foram executados testes automatizados de unidade/integração por se tratar de alteração de prompt; foi feita revisão estática do conteúdo do prompt e atualização do registro canônico para rastreabilidade.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f84f7a600832182a7cc3217cd60d5)