### PR TITLE
feat(mois): exibir respostas JSON em árvore expansível na tela de detalhe

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -407,3 +407,9 @@
 - causa-raiz: uso de variável inexistente (`pageQuery`) e uso de `history` sem definição local, que colidia com o tipo global `History`.
 - correção aplicada: adição das queries `useMoisSalesLibraryPage` e `useMoisSalesLibraryPageSnapshots`, além de construção explícita de `history: HistoryItem[]` a partir dos snapshots.
 - arquivo alterado: `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`.
+
+## 2026-05-21 20:58:00 UTC
+- melhoria na tela de detalhe da Biblioteca de Páginas de Vendas (MOIS) para exibir JSON no formato de navegação hierárquica expansível (clicar para abrir/fechar nós), em vez de texto cru em `<pre>`.
+- implementado renderizador recursivo de árvore JSON para objetos e arrays, com contagem de itens por nó e expansão inicial da raiz para facilitar inspeção.
+- adicionado fallback seguro: quando o conteúdo não for JSON válido, a UI mantém exibição textual para não bloquear diagnóstico.
+- arquivo alterado: `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`.

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -11,13 +11,77 @@ function formatDate(value?: string) {
   return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
 }
 
+function isObjectLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function JsonTreeNode({ label, value, defaultOpen = false }: { label: string; value: unknown; defaultOpen?: boolean }) {
+  if (Array.isArray(value)) {
+    return (
+      <details open={defaultOpen} className="ms-2">
+        <summary className="small" style={{ cursor: "pointer" }}>
+          <strong>{label}</strong>: [{value.length}]
+        </summary>
+        <div className="mt-1 ms-3 d-flex flex-column gap-1">
+          {value.length === 0 ? <span className="text-secondary">[]</span> : null}
+          {value.map((item, index) => (
+            <JsonTreeNode key={`${label}-${index}`} label={`[${index}]`} value={item} />
+          ))}
+        </div>
+      </details>
+    );
+  }
+
+  if (isObjectLike(value)) {
+    const entries = Object.entries(value);
+
+    return (
+      <details open={defaultOpen} className="ms-2">
+        <summary className="small" style={{ cursor: "pointer" }}>
+          <strong>{label}</strong>: {"{"}
+          {entries.length}
+          {"}"}
+        </summary>
+        <div className="mt-1 ms-3 d-flex flex-column gap-1">
+          {entries.length === 0 ? <span className="text-secondary">{"{}"}</span> : null}
+          {entries.map(([entryLabel, entryValue]) => (
+            <JsonTreeNode key={`${label}-${entryLabel}`} label={entryLabel} value={entryValue} />
+          ))}
+        </div>
+      </details>
+    );
+  }
+
+  return (
+    <div className="small ms-2">
+      <strong>{label}</strong>: <span>{JSON.stringify(value)}</span>
+    </div>
+  );
+}
+
 function JsonCollapse({ title, content }: { title: string; content?: string }) {
+  let parsed: unknown;
+  let parseError = false;
+
+  if (!content) {
+    parsed = {};
+  } else {
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      parseError = true;
+      parsed = content;
+    }
+  }
+
   return (
     <details className="border rounded p-2 bg-light-subtle">
       <summary className="fw-semibold" style={{ cursor: "pointer" }}>
         {title}
       </summary>
-      <pre className="mt-2 mb-0 small text-break">{content || "{}"}</pre>
+      <div className="mt-2">
+        {parseError ? <pre className="mb-0 small text-break">{String(parsed)}</pre> : <JsonTreeNode label="root" value={parsed} defaultOpen />}
+      </div>
     </details>
   );
 }


### PR DESCRIPTION
### Motivation
- Melhorar a inspeção das respostas do modelo na tela de detalhe da Biblioteca de Páginas de Vendas (MOIS) apresentando os JSONs de forma navegável em vez de texto cru.
- Facilitar diagnóstico operacional ao permitir que o usuário expanda/colapse nós do JSON por campo/array. 
- Preservar rastreabilidade ao manter fallback textual quando o conteúdo não for JSON válido.

### Description
- Substituído o bloco `<pre>` por um renderizador recursivo de árvore JSON no arquivo `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx` implementando `JsonTreeNode`, `isObjectLike` e adaptação em `JsonCollapse`.
- `JsonTreeNode` navega recursivamente por objetos e arrays exibindo contagem de itens por nó e permitindo expansão por `<details>/<summary>`; a raiz abre por padrão (`defaultOpen`).
- `JsonCollapse` tenta fazer `JSON.parse` do conteúdo e usa o renderizador de árvore quando válido, e em caso de parse falho apresenta o conteúdo original em `<pre>` como fallback seguro.
- Registrada a alteração operacional em `docs/registros/mois1.md` conforme padrão do repositório.

### Testing
- Executado `npm run typecheck` na pasta `frontend`, que falhou devido a problemas de dependências/tipos ausentes (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) e avisos de deprecação no `tsconfig`, sem relação direta com esta mudança.
- Não foram executados testes automatizados adicionais; a alteração é localizada no frontend e o fallback garante comportamento seguro mesmo quando o payload não é JSON.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f9af053908321a0b8cc2b4a1753af)