### PR TITLE
Ordena ranking de CNAEs por estabelecimentos ativos (desc)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/repository/OprmMarketSizeByCnaeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/repository/OprmMarketSizeByCnaeRepository.java
@@ -23,7 +23,7 @@ public interface OprmMarketSizeByCnaeRepository extends JpaRepository<OprmMarket
             from OprmMarketSizeByCnae ms
             left join OprmCnpjCnaeDim c on c.cnaeCode = ms.id.cnaeCode
             where ms.id.snapshotDate = (select max(m2.id.snapshotDate) from OprmMarketSizeByCnae m2)
-            order by ms.totalEmpresas desc
+            order by ms.totalEstabelecimentosAtivos desc
             """)
     List<OprmTopCnaeMarketVolumeDto> findTopByLatestSnapshot(Pageable pageable);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/repository/OprmMarketSizeByCnaeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/repository/OprmMarketSizeByCnaeRepository.java
@@ -8,7 +8,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+/**
+ * Repositório responsável por consultar e paginar os agregados de tamanho de mercado por CNAE.
+ */
 public interface OprmMarketSizeByCnaeRepository extends JpaRepository<OprmMarketSizeByCnae, OprmMarketSizeByCnaeId> {
+    /**
+     * Retorna o ranking paginado dos CNAEs no snapshot mais recente, ordenado por estabelecimentos ativos.
+     */
     @Query("""
             select new com.marketinghub.oprm.market.dto.OprmTopCnaeMarketVolumeDto(
                 ms.id.snapshotDate,

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -129,3 +129,5 @@
 - 2026-05-21 19:50:00 (UTC): implementação solicitada do ranking `/oprm/cnaes-volume` com paginação real no backend: endpoint `GET /api/oprm/market/import-runs/cnaes/top-volume` atualizado para receber `page` e `size` (default `0`/`50`), serviço OPRM ajustado para aplicar `PageRequest` e frontend alterado para consumir paginação server-side mantendo ordenação por quantidade no backend.
 
 - 2026-05-21 20:05:00 (UTC): correção na tela OPRM `/oprm/cnaes-volume` para garantir ordenação visual do ranking por **Estab. ativos** (descendente, maior→menor) no frontend, adicionando ordenação defensiva client-side em `OprmCnaeVolumePage` após resposta paginada do backend e ajustando o texto da seção para explicitar o critério de estabelecimentos ativos.
+
+- 2026-05-21 17:20:00 (UTC-3): ajuste solicitado na tela de CNAEs para exibir os 50 registros com maior quantidade de estabelecimentos ativos em ordem decrescente: ordenação backend do endpoint `GET /api/oprm/market/import-runs/cnaes/top-volume` alterada para `totalEstabelecimentosAtivos DESC`, preservando paginação de 50 por página.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -131,3 +131,5 @@
 - 2026-05-21 20:05:00 (UTC): correção na tela OPRM `/oprm/cnaes-volume` para garantir ordenação visual do ranking por **Estab. ativos** (descendente, maior→menor) no frontend, adicionando ordenação defensiva client-side em `OprmCnaeVolumePage` após resposta paginada do backend e ajustando o texto da seção para explicitar o critério de estabelecimentos ativos.
 
 - 2026-05-21 17:20:00 (UTC-3): ajuste solicitado na tela de CNAEs para exibir os 50 registros com maior quantidade de estabelecimentos ativos em ordem decrescente: ordenação backend do endpoint `GET /api/oprm/market/import-runs/cnaes/top-volume` alterada para `totalEstabelecimentosAtivos DESC`, preservando paginação de 50 por página.
+
+- 2026-05-21 17:35:00 (UTC-3): adição de comentários de responsabilidade no `OprmMarketSizeByCnaeRepository` (classe e método) para atender revisão de PR e manter conformidade com a regra de documentação Java do projeto.


### PR DESCRIPTION
### Motivation
- Garantir que a tela de CNAEs exiba os 50 CNAEs com maior quantidade de estabelecimentos ativos em ordem decrescente, alinhando o backend à regra canônica de ordenação do ranking.

### Description
- Altera a consulta JPQL em `OprmMarketSizeByCnaeRepository` para usar `order by ms.totalEstabelecimentosAtivos desc`, fazendo com que o endpoint `GET /api/oprm/market/import-runs/cnaes/top-volume` retorne a ordenação correta por estabelecimentos ativos no snapshot mais recente; atualiza `docs/registros/oprm1.md` registrando a alteração.

### Testing
- Executei os testes do módulo `ads-service` com `cd backend/ads-service && ../mvnw -q -DskipITs test` e a suíte foi executada sem falhas; tentativas anteriores de executar `./mvnw` no diretório errado e `./mvnw -pl ads-service` falharam por seleção de reactor/working directory incorretos, por isso a execução válida foi feita no diretório do módulo com o wrapper pai.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f9a9e79788321b35e63f9a0dab451)