### PR TITLE
landing-page-wireframe: migrate to `definicoes`+`pagina` schema and update prompt to v3

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -2,6 +2,30 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "definicoes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "estrutura": {
+          "$ref": "#/$defs/categoriaDefinicoesEstrutura"
+        },
+        "posicao": {
+          "$ref": "#/$defs/categoriaDefinicoesPosicao"
+        },
+        "layout": {
+          "$ref": "#/$defs/categoriaDefinicoesLayout"
+        },
+        "mistas": {
+          "$ref": "#/$defs/categoriaDefinicoesMistas"
+        }
+      },
+      "required": [
+        "estrutura",
+        "posicao",
+        "layout",
+        "mistas"
+      ]
+    },
     "pagina": {
       "type": "object",
       "additionalProperties": false,
@@ -22,102 +46,15 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "estilos": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "$ref": "#/$defs/estilo"
-              }
-            },
             "secoes": {
               "type": "array",
               "minItems": 4,
               "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "nome": {
-                    "type": "string"
-                  },
-                  "objetivo": {
-                    "type": "string"
-                  },
-                  "oQueQuerProvocarNoUsuario": {
-                    "type": "string"
-                  },
-                  "papelComercial": {
-                    "type": "string"
-                  },
-                  "fasePersuasao": {
-                    "type": "string"
-                  },
-                  "objeçãoQueRemove": {
-                    "type": "string"
-                  },
-                  "prioridadeConversao": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 10
-                  },
-                  "acaoEsperada": {
-                    "type": "string"
-                  },
-                  "fonteContexto": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "id": {
-                    "type": "string"
-                  },
-                  "estilos": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                      "$ref": "#/$defs/estilo"
-                    }
-                  },
-                  "elementosSeccao": {
-                    "type": "array",
-                    "minItems": 1,
-                    "contains": {
-                      "type": "object",
-                      "properties": {
-                        "tag": {
-                          "const": "img"
-                        }
-                      },
-                      "required": [
-                        "tag"
-                      ]
-                    },
-                    "minContains": 1,
-                    "items": {
-                      "$ref": "#/$defs/elementoSecao"
-                    }
-                  }
-                },
-                "required": [
-                  "nome",
-                  "objetivo",
-                  "oQueQuerProvocarNoUsuario",
-                  "papelComercial",
-                  "fasePersuasao",
-                  "objeçãoQueRemove",
-                  "prioridadeConversao",
-                  "acaoEsperada",
-                  "fonteContexto",
-                  "id",
-                  "estilos",
-                  "elementosSeccao"
-                ]
+                "$ref": "#/$defs/secao"
               }
             }
           },
           "required": [
-            "estilos",
             "secoes"
           ]
         }
@@ -129,29 +66,239 @@
     }
   },
   "required": [
+    "definicoes",
     "pagina"
   ],
   "$defs": {
-    "estilo": {
+    "referenciasCategoria": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "desktop": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "mobile": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "desktop",
+        "mobile"
+      ]
+    },
+    "secao": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "nome": {
+          "type": "string"
+        },
+        "objetivo": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "estrutura": {
+          "$ref": "#/$defs/referenciasCategoria"
+        },
+        "posicao": {
+          "$ref": "#/$defs/referenciasCategoria"
+        },
+        "layout": {
+          "$ref": "#/$defs/referenciasCategoria"
+        },
+        "mistas": {
+          "$ref": "#/$defs/referenciasCategoria"
+        },
+        "elementosSeccao": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/elementoSecao"
+          }
+        },
+        "oQueQuerProvocarNoUsuario": {
+          "type": "string"
+        },
+        "papelComercial": {
+          "type": "string"
+        },
+        "fasePersuasao": {
+          "type": "string"
+        },
+        "objeçãoQueRemove": {
+          "type": "string"
+        },
+        "prioridadeConversao": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "acaoEsperada": {
+          "type": "string"
+        },
+        "fonteContexto": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "estilos": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "nome",
+        "objetivo",
+        "oQueQuerProvocarNoUsuario",
+        "papelComercial",
+        "fasePersuasao",
+        "objeçãoQueRemove",
+        "prioridadeConversao",
+        "acaoEsperada",
+        "fonteContexto",
+        "id",
+        "estilos",
+        "estrutura",
+        "posicao",
+        "layout",
+        "mistas",
+        "elementosSeccao"
+      ]
+    },
+    "textoElemento": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tamMaximo": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "tamMinimo": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "conteudo": {
+          "type": "string",
+          "maxLength": 0
+        }
+      },
+      "required": [
+        "tamMaximo",
+        "tamMinimo",
+        "conteudo"
+      ]
+    },
+    "elementoSecao": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "texto": {
+          "$ref": "#/$defs/textoElemento"
+        },
+        "elementosInternos": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/elementoSecao"
+          }
+        },
+        "estilos": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "briefingVisual": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/briefingVisual"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "tag",
+        "texto",
+        "estilos",
+        "briefingVisual",
+        "elementosInternos"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "tag": {
+                "const": "img"
+              }
+            },
+            "required": [
+              "tag"
+            ]
+          },
+          "then": {
+            "properties": {
+              "briefingVisual": {
+                "$ref": "#/$defs/briefingVisual"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tag": {
+                "not": {
+                  "const": "img"
+                }
+              }
+            },
+            "required": [
+              "tag"
+            ]
+          },
+          "then": {
+            "properties": {
+              "briefingVisual": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "definicaoEstrutura": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nome": {
+          "type": "string"
+        },
+        "atributoCss": {
           "type": "string",
           "enum": [
-            "position",
-            "top",
-            "right",
-            "bottom",
-            "left",
-            "z-index",
-            "display",
-            "float",
-            "clear",
-            "visibility",
-            "overflow",
-            "overflow-x",
-            "overflow-y",
             "width",
             "height",
             "min-width",
@@ -168,7 +315,64 @@
             "padding-top",
             "padding-right",
             "padding-bottom",
-            "padding-left",
+            "padding-left"
+          ]
+        },
+        "valor": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "nome",
+        "atributoCss",
+        "valor"
+      ]
+    },
+    "definicaoPosicao": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nome": {
+          "type": "string"
+        },
+        "atributoCss": {
+          "type": "string",
+          "enum": [
+            "position",
+            "top",
+            "right",
+            "bottom",
+            "left",
+            "z-index"
+          ]
+        },
+        "valor": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "nome",
+        "atributoCss",
+        "valor"
+      ]
+    },
+    "definicaoLayout": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nome": {
+          "type": "string"
+        },
+        "atributoCss": {
+          "type": "string",
+          "enum": [
+            "display",
+            "float",
+            "clear",
+            "visibility",
+            "overflow",
+            "overflow-x",
+            "overflow-y",
             "flex",
             "flex-direction",
             "flex-wrap",
@@ -198,7 +402,29 @@
             "grid-area",
             "justify-items",
             "place-items",
-            "place-content",
+            "place-content"
+          ]
+        },
+        "valor": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "nome",
+        "atributoCss",
+        "valor"
+      ]
+    },
+    "definicaoMista": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nome": {
+          "type": "string"
+        },
+        "atributoCss": {
+          "type": "string",
+          "enum": [
             "transform",
             "translate",
             "scale",
@@ -212,110 +438,139 @@
       },
       "required": [
         "nome",
+        "atributoCss",
         "valor"
       ]
     },
-    "textoElemento": {
+    "categoriaDefinicoesEstrutura": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "tamMaximo": {
-          "type": "integer",
-          "minimum": 1
-        },
-        "tamMinimo": {
-          "type": "integer",
-          "minimum": 1
-        },
-        "conteudo": {
-          "type": "string",
-          "maxLength": 0,
-          "description": "No wireframe não deve haver copy final; manter string vazia nesta fase."
-        }
-      },
-      "required": [
-        "tamMaximo",
-        "tamMinimo",
-        "conteudo"
-      ]
-    },
-    "elementoSecao": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "tag": {
-          "type": "string",
-          "description": "Tag HTML do elemento. Regra contratual: `briefingVisual` só pode existir quando `tag` for exatamente `img`."
-        },
-        "texto": {
-          "$ref": "#/$defs/textoElemento"
-        },
-        "estilos": {
+        "desktop": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/estilo"
+            "$ref": "#/$defs/definicaoEstrutura"
           }
         },
-        "elementosInternos": {
+        "mobile": {
           "type": "array",
-          "description": "Lista recursiva de elementos internos com a mesma estrutura do elemento pai.",
-          "minItems": 0,
+          "minItems": 1,
           "items": {
-            "$ref": "#/$defs/elementoSecao"
+            "$ref": "#/$defs/definicaoEstrutura"
+          }
+        }
+      },
+      "required": [
+        "desktop",
+        "mobile"
+      ]
+    },
+    "categoriaDefinicoesPosicao": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "desktop": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/definicaoPosicao"
           }
         },
-        "briefingVisual": {
-          "type": ["object", "null"],
-          "description": "Campo exclusivo para elementos de imagem (`tag = img`). Não usar em outras tags. Se `tag` for diferente de `img`, usar `briefingVisual: null`.",
-          "additionalProperties": false,
-          "properties": {
-            "ondeEntraNoVisual": {
-              "type": "string",
-              "minLength": 1
-            },
-            "tipoVisualEsperado": {
-              "type": "string",
-              "minLength": 1
-            },
-            "funcaoComercial": {
-              "type": "string",
-              "minLength": 1
-            },
-            "objecaoQueRemove": {
-              "type": "string",
-              "minLength": 1
-            },
-            "classificacaoVisual": {
-              "type": "string",
-              "enum": [
-                "mockup",
-                "foto",
-                "ilustração",
-                "diagrama",
-                "print conceitual"
-              ]
-            }
-          },
-          "required": [
-            "ondeEntraNoVisual",
-            "tipoVisualEsperado",
-            "funcaoComercial",
-            "objecaoQueRemove",
-            "classificacaoVisual"
+        "mobile": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/definicaoPosicao"
+          }
+        }
+      },
+      "required": [
+        "desktop",
+        "mobile"
+      ]
+    },
+    "categoriaDefinicoesLayout": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "desktop": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/definicaoLayout"
+          }
+        },
+        "mobile": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/definicaoLayout"
+          }
+        }
+      },
+      "required": [
+        "desktop",
+        "mobile"
+      ]
+    },
+    "categoriaDefinicoesMistas": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "desktop": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/definicaoMista"
+          }
+        },
+        "mobile": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/definicaoMista"
+          }
+        }
+      },
+      "required": [
+        "desktop",
+        "mobile"
+      ]
+    },
+    "briefingVisual": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ondeEntraNoVisual": {
+          "type": "string"
+        },
+        "tipoVisualEsperado": {
+          "type": "string"
+        },
+        "funcaoComercial": {
+          "type": "string"
+        },
+        "objecaoQueRemove": {
+          "type": "string"
+        },
+        "classificacaoVisual": {
+          "type": "string",
+          "enum": [
+            "mockup",
+            "foto",
+            "ilustração",
+            "diagrama",
+            "print conceitual"
           ]
         }
       },
       "required": [
-        "id",
-        "tag",
-        "texto",
-        "estilos",
-        "elementosInternos",
-        "briefingVisual"
+        "ondeEntraNoVisual",
+        "tipoVisualEsperado",
+        "funcaoComercial",
+        "objecaoQueRemove",
+        "classificacaoVisual"
       ]
     }
   }

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -32,7 +32,7 @@ Resultado: {{RESULT_JSON}}
 
 {prompt-regras-globais}
 
-Ângulo da Campanha que vai ser publicada: 
+Ângulo da Campanha que vai ser publicada:
 {dados-campaignAngle}
 
 Copy do Anuncio:
@@ -43,23 +43,41 @@ Briefing das Imagens dos Anuncios:
 
 
 template_id: landing-wireframe
-template_version: v2
+template_version: v3
 artifact_target: landingPageWireframe
 
-Regras fixas da etapa (formato simplificado):
-- Entregar somente JSON válido no formato raiz `pagina`.
-- Estrutura obrigatória: `pagina.head.texto`, `pagina.corpo.estilos[]`, `pagina.corpo.secoes[]`.
-- Cada item de `estilos[]` deve ter apenas `nome` e `valor`.
-- Whitelist de atributos CSS permitidos em qualquer `estilos[]` (usar apenas estes nomes, sem criar outros):
-  - `position`, `top`, `right`, `bottom`, `left`, `z-index`, `display`, `float`, `clear`, `visibility`, `overflow`, `overflow-x`, `overflow-y`
-  - `width`, `height`, `min-width`, `min-height`, `max-width`, `max-height`, `box-sizing`
-  - `margin`, `margin-top`, `margin-right`, `margin-bottom`, `margin-left`
-  - `padding`, `padding-top`, `padding-right`, `padding-bottom`, `padding-left`
-  - `flex`, `flex-direction`, `flex-wrap`, `flex-flow`, `justify-content`, `align-items`, `align-content`, `align-self`, `gap`, `row-gap`, `column-gap`, `order`, `flex-grow`, `flex-shrink`, `flex-basis`
-  - `grid`, `grid-template`, `grid-template-columns`, `grid-template-rows`, `grid-template-areas`, `grid-column`, `grid-column-start`, `grid-column-end`, `grid-row`, `grid-row-start`, `grid-row-end`, `grid-area`, `justify-items`, `place-items`, `place-content`
-  - `transform`, `translate`, `scale`, `rotate`, `transform-origin`, `border`, `opacity`
-- Se um atributo estiver fora dessa whitelist, não usar no wireframe.
+Regras fixas da etapa (Gera Landing, contrato v3):
+- Entregar somente JSON válido com raiz obrigatória: `definicoes` e `pagina`.
+- `definicoes` deve conter exatamente: `estrutura`, `posicao`, `layout`, `mistas`.
+- Cada categoria de `definicoes` deve conter `desktop[]` e `mobile[]`.
+- Cada item de definição deve conter somente: `nome`, `atributoCss`, `valor`.
+- Em `pagina`/`secoes`, usar somente referências por `nome` já definido em `definicoes`.
+- Em `pagina`/`secoes`, separar sempre referências por `desktop` e `mobile`.
+- É proibido repetir `atributoCss`/`valor` fora de `definicoes`.
+- Não invente campos fora do schema.
+- Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
+- Evite JSON dentro de strings; mantenha cada informação no campo próprio.
 
+
+
+Matriz oficial de grupos e atributos CSS (explícita):
+- Grupo `posicionamento` (categoria `definicoes.posicao`): `position`, `top`, `right`, `bottom`, `left`, `z-index`.
+- Grupo `exibicaoFluxo` (categoria `definicoes.layout`): `display`, `float`, `clear`, `visibility`, `overflow`, `overflow-x`, `overflow-y`.
+- Grupo `tamanho` (categoria `definicoes.estrutura`): `width`, `height`, `min-width`, `min-height`, `max-width`, `max-height`, `box-sizing`.
+- Grupo `espacamentoExterno` (categoria `definicoes.estrutura`): `margin`, `margin-top`, `margin-right`, `margin-bottom`, `margin-left`.
+- Grupo `espacamentoInterno` (categoria `definicoes.estrutura`): `padding`, `padding-top`, `padding-right`, `padding-bottom`, `padding-left`.
+- Grupo `flexbox` (categoria `definicoes.layout`): `flex`, `flex-direction`, `flex-wrap`, `flex-flow`, `justify-content`, `align-items`, `align-content`, `align-self`, `gap`, `row-gap`, `column-gap`, `order`, `flex-grow`, `flex-shrink`, `flex-basis`.
+- Grupo `grid` (categoria `definicoes.layout`): `grid`, `grid-template`, `grid-template-columns`, `grid-template-rows`, `grid-template-areas`, `grid-column`, `grid-column-start`, `grid-column-end`, `grid-row`, `grid-row-start`, `grid-row-end`, `grid-area`, `justify-items`, `align-items`, `place-items`, `justify-content`, `align-content`, `place-content`, `gap`, `row-gap`, `column-gap`.
+- Grupo `transformacoes` (categoria `definicoes.mistas`): `transform`, `translate`, `scale`, `rotate`, `transform-origin`.
+
+Regra de conformidade dos grupos:
+- `definicoes.posicao` só pode usar atributos do grupo `posicionamento`.
+- `definicoes.layout` só pode usar atributos dos grupos `exibicaoFluxo`, `flexbox` e `grid`.
+- `definicoes.estrutura` só pode usar atributos dos grupos `tamanho`, `espacamentoExterno` e `espacamentoInterno`.
+- `definicoes.mistas` só pode usar atributos do grupo `transformacoes`.
+
+
+Trecho obrigatório do contrato de seção/elementos (manter):
 - Cada seção deve conter: `nome`, `objetivo`, `oQueQuerProvocarNoUsuario`, `papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada`, `fonteContexto[]`, `id`, `estilos[]`, `elementosSeccao[]`.
 - Cada item de `elementosSeccao[]` deve conter: `id`, `tag`, `texto`, `estilos[]`, `elementosInternos[]`.
 - Quando `tag = "img"`, o elemento deve conter também `briefingVisual` com:
@@ -72,9 +90,16 @@ Regras fixas da etapa (formato simplificado):
 - `elementosInternos[]` representa hierarquia de filhos e deve suportar recursão (filho pode conter netos e assim por diante), sempre com o mesmo contrato do elemento pai.
 - Campo `texto` de cada elemento deve conter exatamente: `tamMaximo`, `tamMinimo`, `conteudo`.
 - `elementosInternos` pode ser lista vazia, mas sempre deve existir.
-- Não invente campos fora do schema.
-- Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
-- Evite JSON dentro de strings; mantenha cada informação no seu campo próprio.
+
+
+- Para cada visual (`img`) planejado no wireframe, explicitar no `objetivo`/metadados da seção:
+  - onde o visual entra na narrativa da página (posição e contexto comercial);
+  - qual tipo de visual é esperado;
+  - qual função comercial o visual cumpre;
+  - qual objeção o visual ajuda a remover;
+  - classificar o visual como: `mockup`, `foto`, `ilustração`, `diagrama` ou `print conceitual`.
+
+Regras comerciais e estruturais obrigatórias (mantidas):
 - Mobile-first obrigatório: priorize leitura vertical e CTA claro nas primeiras seções.
 - Objetivo comercial obrigatório: estruturar a página para venda com foco na coleta de informação para envio de amostra/prova do produto (ex.: formulário/CTA de captura).
 - Fase wireframe NÃO preenche copy: em TODOS os elementos, `texto.conteudo` deve ser string vazia (`""`) nesta etapa.
@@ -82,52 +107,34 @@ Regras fixas da etapa (formato simplificado):
 - Formulário obrigatório da landing: incluir seção/formulário de captura contendo somente os campos `nome` e `email` (não incluir telefone, WhatsApp, CPF, empresa ou outros campos).
 - Hero obrigatório com âncora primária: na primeira dobra (hero), incluir CTA com link âncora direto para a seção do formulário.
 - Âncoras obrigatórias adicionais: incluir mais duas âncoras internas para pontos estratégicos distintos da página (ex.: mecanismo, prova social, oferta), além da âncora do hero para o formulário.
-- Balanceamento visual obrigatório: intercalar blocos de texto e imagem ao longo da página, inserindo elementos `img` em seções relevantes para reduzir paredes de texto e melhorar escaneabilidade.
 - Quantidade mínima de seções obrigatória: gerar no mínimo 4 seções em `pagina.corpo.secoes`.
 - Quantidade mínima de imagens obrigatória: gerar no mínimo 4 elementos `img` no total da página.
 - Regra mandatória para cumprir o mínimo de imagens: cada seção em `pagina.corpo.secoes[]` deve conter pelo menos um elemento `img` em `elementosSeccao` (direto ou em `elementosInternos`).
 - Imagem de produto obrigatória: garantir que pelo menos uma `img` represente visualmente a ideia do produto/entrega que o cliente está comprando (ex.: mockup da solução, amostra do conteúdo, kit/resultado final esperado).
-- Para cada visual (`img`) planejado no wireframe, explicitar no `objetivo`/metadados da seção:
-  - onde o visual entra na narrativa da página (posição e contexto comercial);
-  - qual tipo de visual é esperado;
-  - qual função comercial o visual cumpre;
-  - qual objeção o visual ajuda a remover;
-  - classificar o visual como: `mockup`, `foto`, `ilustração`, `diagrama` ou `print conceitual`.
-- Heurística prática de composição (usar como inspiração, NÃO como regra rígida; adapte ao contexto do nicho/oferta):
-  - Hero bullets: preferir ~3 itens.
-  - Lista de entregáveis: preferir entre 3 e 5 itens.
-  - Antes/depois: preferir 3 itens de "antes" e 3 itens de "depois".
-  - Como funciona: preferir 3 passos.
-  - FAQ: preferir entre 4 e 6 perguntas.
-  - Formulário inicial: em cenários gerais, pode variar entre 3 e 4 campos; quando houver diretriz explícita desta execução, ela prevalece.
-- Heurística para listas longas no mobile (inspiração contextual, não regra absoluta):
-  - Evitar listas grandes no início da página.
-  - Evitar mais de 5 itens visíveis por bloco quando a pessoa ainda não entendeu a oferta.
-  - Evitar misturar no mesmo bloco: benefícios, recursos e explicações extensas.
-  - Evitar estruturas que aumentem sensação de esforço, prejudiquem foco no CTA ou alonguem demais o mobile sem avanço de persuasão.
-  - Listas grandes podem ser aceitáveis quando estiverem em FAQ recolhido, quebradas em cards, com hierarquia clara, posicionadas após entendimento da oferta ou quando necessárias para provar entrega concreta (ex.: mini-kit com 5 itens).
+- Balanceamento visual obrigatório: intercalar blocos de texto e imagem ao longo da página para reduzir paredes de texto e melhorar escaneabilidade.
 
-- Ajuste de intenção por seção (referência do esboço):
-  - `papelComercial`: descreva a função comercial da seção no funil da landing (ex.: primeira dobra de conversão, remoção de risco, fechamento).
-  - `fasePersuasao`: explicite a fase predominante (ex.: dor-promessa-prova-acao).
-  - `objeçãoQueRemove`: declare a principal objeção que a seção resolve.
-  - `prioridadeConversao`: inteiro de 1 a 10 (10 = mais crítico para conversão).
-  - `acaoEsperada`: qual ação concreta o usuário deve tomar após consumir a seção.
-  - `fonteContexto[]`: liste de onde a seção foi derivada (ex.: `PAIN_JSON.surface`, `campaignAngle.primaryPromise`).
+Heurísticas de composição (inspiração, não regra rígida):
+- Hero bullets: preferir ~3 itens.
+- Lista de entregáveis: preferir entre 3 e 5 itens.
+- Antes/depois: preferir 3 itens de "antes" e 3 itens de "depois".
+- Como funciona: preferir 3 passos.
+- FAQ: preferir entre 4 e 6 perguntas.
+
+Heurística para listas longas no mobile (inspiração contextual):
+- Evitar listas grandes no início da página.
+- Evitar mais de 5 itens visíveis por bloco quando a pessoa ainda não entendeu a oferta.
+- Evitar misturar no mesmo bloco: benefícios, recursos e explicações extensas.
+- Evitar estruturas que aumentem sensação de esforço, prejudiquem foco no CTA ou alonguem demais o mobile sem avanço de persuasão.
+
+Ajuste de intenção por seção (referência do esboço):
+- `papelComercial`: descreva a função comercial da seção no funil da landing (ex.: primeira dobra de conversão, remoção de risco, fechamento).
+- `fasePersuasao`: explicite a fase predominante (ex.: dor-promessa-prova-acao).
+- `objeçãoQueRemove`: declare a principal objeção que a seção resolve.
+- `prioridadeConversao`: inteiro de 1 a 10 (10 = mais crítico para conversão).
+- `acaoEsperada`: qual ação concreta o usuário deve tomar após consumir a seção.
+- `fonteContexto[]`: liste de onde a seção foi derivada (ex.: `PAIN_JSON.surface`, `campaignAngle.primaryPromise`).
+- `objetivo`: declarar a função comercial central da seção.
+- `nome` e `id`: manter coerência com a etapa do funil e com a navegação por âncoras.
 
 OUTPUT_CONTRACT
-Responda em JSON válido e estritamente aderente ao artefato `landingPageWireframe` simplificado.
-
-Campos obrigatórios:
-- pagina
-- pagina.head.texto
-- pagina.corpo.estilos[] com nome, valor
-- pagina.corpo.secoes[] com nome, objetivo, oQueQuerProvocarNoUsuario, papelComercial, fasePersuasao, objeçãoQueRemove, prioridadeConversao, acaoEsperada, fonteContexto, id, estilos, elementosSeccao
-- pagina.corpo.secoes[].elementosSeccao[] com id, tag, texto, estilos, elementosInternos
-- Para `tag = "img"`, `pagina.corpo.secoes[].elementosSeccao[].briefingVisual` é obrigatório no contrato.
-- Para tags diferentes de `img`, `briefingVisual` deve existir com valor `null`.
-- pagina.corpo.secoes[].elementosSeccao[].texto com tamMaximo, tamMinimo, conteudo
-- Em wireframe, `conteudo` deve ser sempre `""` (sem texto final).
-
-Formato de resposta:
-- Precisamos da resposta em Json-Schema.
+Responda em JSON válido e estritamente aderente ao schema `landing-page-wireframe-schema.json` da etapa Gera Landing.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -943,3 +943,43 @@
   - ai-worker/AGENTS.md
   - docs/registros/experimentos.md
   - ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
+
+## 2026-05-21 23:58:00 UTC
+- ajuste solicitado: correção de escopo — alteração deve ser aplicada no Gera Landing (AI Worker), não no schema de pipeline do backend.
+- causa-raiz: a mudança anterior foi feita em `backend/ads-service` (pipeline), enquanto a necessidade era no contrato/prompt operacional da etapa `landing-page-wireframe` do módulo `ai-worker` (Gera Landing).
+- foi feito:
+  - atualização do schema `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` para o formato com raiz `definicoes` + `pagina`;
+  - inclusão das categorias `estrutura`, `posicao`, `layout`, `mistas` em `definicoes`, cada uma com `desktop`/`mobile` e itens `{nome, atributoCss, valor}`;
+  - ajuste de `pagina.corpo.secoes` para usar somente referências por `nome` (separadas em desktop/mobile) nas quatro categorias;
+  - atualização do prompt `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` para reforçar explicitamente as novas regras do contrato no escopo Gera Landing.
+
+## 2026-05-22 00:25:00 UTC
+- ajuste solicitado: no prompt do gera wireframe, não remover em massa; remover apenas o que conflita claramente com a nova definição `definicoes + pagina`.
+- causa-raiz: a versão anterior do prompt v3 ficou excessivamente enxuta e descartou regras operacionais/comerciais úteis que continuam válidas no novo contrato.
+- foi feito:
+  - reintroduzidas regras de negócio e qualidade (mobile-first, CTA/âncoras, mínimo de seções/imagens, formulário com nome+email, conteúdo vazio no wireframe, heurísticas de escaneabilidade e composição);
+  - mantida apenas a remoção de itens incompatíveis com o novo schema (ex.: instruções de `estilos[]` inline e `briefingVisual` obrigatório em `img`);
+  - preservado o contrato novo com raiz `definicoes` + `pagina` e referências por nome em desktop/mobile.
+
+## 2026-05-22 00:55:00 UTC
+- ajuste solicitado: explicitar no Gera Wireframe os atributos CSS que compõem cada grupo (posicionamento, exibição, tamanho etc.), conforme `/docs/gera-landing/listas-css-estrutura-acabamento.md`.
+- causa-raiz: o contrato v3 já separava `definicoes` em categorias, porém sem lista explícita/validável de atributos por grupo, gerando ambiguidade e maior risco de payload inválido.
+- foi feito:
+  - atualização do prompt `landing-page-wireframe.md` com matriz explícita de grupos e atributos permitidos (`posicionamento`, `exibicaoFluxo`, `tamanho`, `espacamentoExterno`, `espacamentoInterno`, `flexbox`, `grid`, `transformacoes`) e regras de conformidade por categoria (`estrutura`, `posicao`, `layout`, `mistas`);
+  - atualização do schema `landing-page-wireframe-schema.json` para validar `atributoCss` por categoria com `enum` explícito, removendo o tipo genérico anterior e criando definições tipadas por categoria.
+
+## 2026-05-22 01:20:00 UTC
+- ajuste solicitado: manter explicitamente no wireframe o trecho de contrato com campos comerciais da seção, `estilos[]` em seção/elemento e `briefingVisual` obrigatório para `img`.
+- causa-raiz: versão anterior havia simplificado o contrato focando nas `definicoes`, removendo campos ainda necessários para a etapa de estrutura comercial e direção visual dos elementos de imagem.
+- foi feito:
+  - reintroduzido no prompt o trecho obrigatório de contrato exatamente com os campos exigidos para seção/elementos;
+  - expandido o schema com os campos comerciais de seção (`oQueQuerProvocarNoUsuario`, `papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada`, `fonteContexto`), além de `estilos[]` em seção e elemento;
+  - adicionada validação condicional de `briefingVisual`: obrigatório para `tag=img` e `null` para demais tags.
+
+## 2026-05-22 01:40:00 UTC
+- ajuste solicitado: manter também a regra explícita de metadados comerciais por visual `img` e o ajuste de intenção por seção com `prioridadeConversao` numérica.
+- causa-raiz: o contrato/prompt estava parcialmente explícito, mas faltavam instruções literais pedidas para narrativa visual por imagem e restrição de tipo para prioridade de conversão.
+- foi feito:
+  - inclusão no prompt da regra de explicitação por visual `img` (narrativa/contexto, tipo visual, função comercial, objeção removida e classificação visual);
+  - ajuste da seção "Ajuste de intenção por seção" para o formato solicitado, incluindo exemplos de `fonteContexto[]`;
+  - ajuste do schema para `prioridadeConversao` como inteiro de 1 a 10.


### PR DESCRIPTION
### Motivation
- Fix scope and make the wireframe contract live in the Gera Landing (AI Worker) prompt/schema rather than in the backend pipeline, and remove ambiguity that produced invalid payloads.  
- Provide a stricter, typed contract for CSS attributes grouped by purpose (estrutura/posicao/layout/mistas) to avoid attribute duplication and invalid names.  
- Preserve commercial/heuristic requirements for sections and image briefings while enforcing the new definicoes-based referencing model.  

### Description
- Replaced the previous flat schema with a new JSON Schema `definicoes` + `pagina` shape in `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json`, adding categories `estrutura`, `posicao`, `layout`, `mistas` each with `desktop`/`mobile` arrays and typed `{nome, atributoCss, valor}` entries.  
- Introduced typed `definicao*` definitions and explicit `enum` lists for `atributoCss` per category and conditional validation so `briefingVisual` is required for `tag = "img"` and must be `null` otherwise.  
- Consolidated section/element contracts into a reusable `secao` and `elementoSecao` definitions, reintroducing commercial metadata fields (`oQueQuerProvocarNoUsuario`, `papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada`, `fonteContexto`) and `estilos[]` at section/element levels.  
- Updated the prompt file `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` to `template_version: v3` and to explicitly document the new `definicoes` matrix, group-to-category mapping, compliance rules, mandatory wireframe constraints (mobile-first, CTA/anchor rules, minimum sections/images, form fields, and empty `texto.conteudo`), and other heuristics.  
- Added rollout/documentation notes to `docs/registros/experimentos.md` describing the change history and rationale.  

### Testing
- Validated the new JSON Schema locally with `ajv` against representative sample fixtures to ensure the new `definicoes` + `pagina` layout and enums accept expected payloads; validation succeeded.  
- Ran `markdownlint` on the updated prompt and docs to ensure formatting and readability; linting succeeded.  
- Executed the repository's schema/contract quick-check (schema-based sample generator/validator used by AI Worker tooling) against the updated schema and prompt; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f9802b80483218334098b2bd7f46c)