### PR TITLE
Suporta novo JSON do Gera Wireframe no HTML provisório de copy

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlAssembler.java
@@ -31,26 +31,13 @@ public class CopyProvisionalHtmlAssembler {
             CopyProvisionalHtmlPayloadResolver.CopyProvisionalHtmlPayload payload =
                     payloadResolver.resolve(copyModelResponse, wireframeModelResponse);
 
-            String html = processor.process(payloadResolverToJson(payload.wireframe()), payloadResolverToJson(payload.copy()));
-            return appendJobIdCommentBeforeHead(html, jobId);
+            return processor.process(payloadResolverToJson(payload.wireframe()), payloadResolverToJson(payload.copy()));
         } catch (Exception e) {
             throw new IllegalArgumentException("Falha ao montar HTML provisório a partir de wireframe + copy", e);
         }
     }
     private String payloadResolverToJson(Object payload) throws Exception {
         return objectMapper.writeValueAsString(payload);
-    }
-
-    private String appendJobIdCommentBeforeHead(String html, String jobId) {
-        if (!StringUtils.hasText(html) || !StringUtils.hasText(jobId)) {
-            return html;
-        }
-        String comment = "<!-- jobId = " + jobId + " -->\n";
-        int headIndex = html.toLowerCase().indexOf("<head>");
-        if (headIndex < 0) {
-            return comment + html;
-        }
-        return html.substring(0, headIndex) + comment + html.substring(headIndex);
     }
 
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlProcessor.java
@@ -45,8 +45,8 @@ public class CopyProvisionalHtmlProcessor {
             throw new IllegalArgumentException("JSON de copy ausente");
         }
 
-        Map<String, Object> wireframe = parseJsonObject(wireframeJson, "wireframeJson");
-        Map<String, Object> copy = parseJsonObject(copyJson, "copyJson");
+        Map<String, Object> wireframe = unwrapPayload(parseJsonObject(wireframeJson, "wireframeJson"), "landingPageWireframe");
+        Map<String, Object> copy = unwrapPayload(parseJsonObject(copyJson, "copyJson"), "landingPageCopy");
 
         String baseHtml = buildHtmlFromWireframe(wireframe);
         return process(baseHtml, copy);
@@ -227,6 +227,9 @@ public class CopyProvisionalHtmlProcessor {
     private Map<String, String> collectCopyByItemId(Map<String, Object> copyJson) {
         Map<String, String> result = new LinkedHashMap<>();
         Object rawSections = firstNonNull(copyJson.get("bodySections"), copyJson.get("sections"));
+        if (!(rawSections instanceof List<?>)) {
+            rawSections = loadSectionsFromPaginaModel(copyJson);
+        }
         if (!(rawSections instanceof List<?> sections)) {
             return result;
         }
@@ -236,6 +239,9 @@ public class CopyProvisionalHtmlProcessor {
                 continue;
             }
             Object rawItems = firstNonNull(sectionMap.get("items"), sectionMap.get("values"), sectionMap.get("fields"));
+            if (!(rawItems instanceof List<?>)) {
+                rawItems = sectionMap.get("elementosSeccao");
+            }
             if (!(rawItems instanceof List<?> items)) {
                 continue;
             }
@@ -252,7 +258,8 @@ public class CopyProvisionalHtmlProcessor {
                         asString(itemMap.get("copy")),
                         asString(itemMap.get("value")),
                         asString(itemMap.get("text")),
-                        asString(itemMap.get("texto"))
+                        asString(itemMap.get("texto")),
+                        extractNestedText(itemMap.get("texto"))
                 );
                 if (StringUtils.hasText(id) && StringUtils.hasText(copy)) {
                     result.put(normalizeId(id), copy.trim());
@@ -260,6 +267,28 @@ public class CopyProvisionalHtmlProcessor {
             }
         }
         return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object loadSectionsFromPaginaModel(Map<String, Object> payload) {
+        Object paginaObj = payload.get("pagina");
+        if (!(paginaObj instanceof Map<?, ?> pagina)) {
+            return null;
+        }
+        Object corpoObj = pagina.get("corpo");
+        if (!(corpoObj instanceof Map<?, ?> corpo)) {
+            return null;
+        }
+        return corpo.get("secoes");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> unwrapPayload(Map<String, Object> root, String contractKey) {
+        Object nested = root.get(contractKey);
+        if (nested instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        return root;
     }
 
 
@@ -284,5 +313,14 @@ public class CopyProvisionalHtmlProcessor {
             }
         }
         return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String extractNestedText(Object rawTexto) {
+        if (!(rawTexto instanceof Map<?, ?> textoMap)) {
+            return null;
+        }
+        Object conteudo = textoMap.get("conteudo");
+        return conteudo instanceof String str ? str : null;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/WireframeHtmlGenerator.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/WireframeHtmlGenerator.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -36,6 +37,7 @@ public class WireframeHtmlGenerator {
             Map<String, Object> pagina = asMap(root.get("pagina"));
             Map<String, Object> head = asMap(pagina.get("head"));
             Map<String, Object> corpo = asMap(pagina.get("corpo"));
+            Map<String, Object> definicoes = asMap(root.get("definicoes"));
 
             StringBuilder html = new StringBuilder();
 
@@ -47,6 +49,12 @@ public class WireframeHtmlGenerator {
             html.append("<title>")
                     .append(escapeHtmlText(asText(head.get("texto"), "Wireframe provisório")))
                     .append("</title>\n");
+            String responsiveCss = renderResponsiveCssDefinitions(definicoes);
+            if (StringUtils.hasText(responsiveCss)) {
+                html.append("<style>\n")
+                        .append(responsiveCss)
+                        .append("\n</style>\n");
+            }
             html.append("</head>\n");
 
             html.append("<body");
@@ -121,6 +129,7 @@ public class WireframeHtmlGenerator {
     private void appendCommonAttributes(StringBuilder out, Map<String, Object> node) {
         String id = asText(node.get("id"), "");
         String style = renderInlineStyle(asList(node.get("estilos")));
+        String className = renderClassNameFromResponsiveStyleRefs(asList(node.get("estilos")));
         Map<String, Object> attrs = extractAttributes(node);
 
         if (StringUtils.hasText(id)) {
@@ -160,6 +169,9 @@ public class WireframeHtmlGenerator {
 
         if (StringUtils.hasText(style)) {
             out.append(" style=\"").append(escapeHtmlAttribute(style)).append("\"");
+        }
+        if (StringUtils.hasText(className)) {
+            out.append(" class=\"").append(escapeHtmlAttribute(className)).append("\"");
         }
     }
 
@@ -272,6 +284,87 @@ public class WireframeHtmlGenerator {
         }
 
         return out.toString();
+    }
+
+    private String renderClassNameFromResponsiveStyleRefs(List<Map<String, Object>> estilos) {
+        List<String> classes = new ArrayList<>();
+        for (Map<String, Object> estilo : estilos) {
+            appendClassRefs(classes, estilo.get("desktop"));
+            appendClassRefs(classes, estilo.get("mobile"));
+        }
+        return String.join(" ", classes);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void appendClassRefs(List<String> classes, Object refs) {
+        if (!(refs instanceof List<?> list)) {
+            return;
+        }
+        for (Object item : list) {
+            if (!(item instanceof String className) || !StringUtils.hasText(className)) {
+                continue;
+            }
+            String normalized = className.trim();
+            if (!classes.contains(normalized)) {
+                classes.add(normalized);
+            }
+        }
+    }
+
+    private String renderResponsiveCssDefinitions(Map<String, Object> definicoes) {
+        if (definicoes.isEmpty()) {
+            return "";
+        }
+        Map<String, Map<String, String>> desktopRules = new LinkedHashMap<>();
+        Map<String, Map<String, String>> mobileRules = new LinkedHashMap<>();
+
+        for (Object groupObj : definicoes.values()) {
+            Map<String, Object> group = asMap(groupObj);
+            collectCssRules(desktopRules, group.get("desktop"));
+            collectCssRules(mobileRules, group.get("mobile"));
+        }
+
+        String desktopCss = renderCssRules(desktopRules);
+        String mobileCss = renderCssRules(mobileRules);
+        if (!StringUtils.hasText(desktopCss) && !StringUtils.hasText(mobileCss)) {
+            return "";
+        }
+        if (!StringUtils.hasText(mobileCss)) {
+            return desktopCss;
+        }
+        return desktopCss + "\n@media (max-width: 768px) {\n" + mobileCss + "\n}";
+    }
+
+    @SuppressWarnings("unchecked")
+    private void collectCssRules(Map<String, Map<String, String>> target, Object entriesObj) {
+        if (!(entriesObj instanceof List<?> entries)) {
+            return;
+        }
+        for (Object entryObj : entries) {
+            if (!(entryObj instanceof Map<?, ?> entry)) {
+                continue;
+            }
+            String className = asText(entry.get("nome"), "");
+            String property = asText(entry.get("atributoCss"), "");
+            String value = asText(entry.get("valor"), "");
+            if (!StringUtils.hasText(className) || !StringUtils.hasText(property) || !StringUtils.hasText(value)) {
+                continue;
+            }
+            target.computeIfAbsent(className.trim(), ignored -> new LinkedHashMap<>())
+                    .put(property.trim(), value.trim());
+        }
+    }
+
+    private String renderCssRules(Map<String, Map<String, String>> rulesByClass) {
+        StringBuilder out = new StringBuilder();
+        for (Map.Entry<String, Map<String, String>> entry : rulesByClass.entrySet()) {
+            out.append(".").append(entry.getKey()).append(" {");
+            for (Map.Entry<String, String> property : entry.getValue().entrySet()) {
+                out.append(property.getKey()).append(":").append(property.getValue()).append(";");
+            }
+            out.append("}\n");
+        }
+        return out.toString().trim();
     }
 
     @SuppressWarnings("unchecked")

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessorNewWireframeFormatTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessorNewWireframeFormatTest.java
@@ -178,4 +178,43 @@ class CopyProvisionalHtmlProcessorNewWireframeFormatTest {
 
         assertTrue(html.contains("Título via pagina"));
     }
+
+    @Test
+    void shouldRenderResponsiveCssAndClassReferencesFromNewWireframeDefinitions() {
+        String wireframeJson = """
+                {
+                  "definicoes": {
+                    "layout": {
+                      "desktop": [
+                        {"nome":"section-flex-col","atributoCss":"display","valor":"flex"}
+                      ],
+                      "mobile": [
+                        {"nome":"section-flex-col","atributoCss":"display","valor":"block"}
+                      ]
+                    }
+                  },
+                  "pagina": {
+                    "corpo": {
+                      "secoes": [
+                        {
+                          "id": "s1",
+                          "tag": "section",
+                          "estilos": [{"desktop":["section-flex-col"],"mobile":["section-flex-col"]}],
+                          "elementosSeccao": []
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        String copyJson = "{\"bodySections\":[]}";
+
+        String html = processor.process(wireframeJson, copyJson);
+
+        assertTrue(html.contains(".section-flex-col {display:flex;}"));
+        assertTrue(html.contains("@media (max-width: 768px)"));
+        assertTrue(html.contains(".section-flex-col {display:block;}"));
+        assertTrue(html.contains("class=\"section-flex-col\""));
+    }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessorNewWireframeFormatTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlProcessorNewWireframeFormatTest.java
@@ -135,4 +135,47 @@ class CopyProvisionalHtmlProcessorNewWireframeFormatTest {
 
         assertTrue(html.contains("Landing final"));
     }
+
+    @Test
+    void shouldApplyCopyWhenBodySectionsAreProvidedInsidePaginaSchema() {
+        String wireframeJson = """
+                {
+                  "pagina": {
+                    "corpo": {
+                      "secoes": [
+                        {
+                          "id": "s1-hero",
+                          "tag": "section",
+                          "elementosSeccao": [
+                            {"id":"headline","tag":"h1","texto":{"conteudo":""}}
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        String copyJson = """
+                {
+                  "landingPageCopy": {
+                    "pagina": {
+                      "corpo": {
+                        "secoes": [
+                          {
+                            "elementosSeccao": [
+                              {"id":"headline","texto":{"conteudo":"Título via pagina"}}
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+                """;
+
+        String html = processor.process(wireframeJson, copyJson);
+
+        assertTrue(html.contains("Título via pagina"));
+    }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -991,3 +991,11 @@
   - atualização do `CopyProvisionalHtmlAssembler` para retornar apenas o HTML produzido pelo processor, sem inserir comentário técnico de `jobId`;
   - atualização do `CopyProvisionalHtmlProcessor` para aceitar payloads envelopados (`landingPageWireframe`/`landingPageCopy`) e também copy no schema `pagina.corpo.secoes[].elementosSeccao[]` com `texto.conteudo`;
   - adição de teste cobrindo aplicação de copy no formato `pagina` aninhado para garantir regressão positiva no novo contrato.
+
+## 2026-05-22 02:10:00 UTC
+- ajuste solicitado: tratar CSS do novo wireframe com definições separadas por desktop/mobile ao gerar HTML provisório.
+- causa-raiz: o gerador do formato `pagina` processava somente `estilos` inline antigos e não convertia referências de classe vindas do novo contrato (`definicoes` + `estilos.desktop/mobile`), causando perda de layout no preview.
+- foi feito:
+  - atualização do `WireframeHtmlGenerator` para montar `<style>` responsivo a partir de `definicoes` (desktop + mobile via media query);
+  - atualização da renderização de nós para anexar classes derivadas de `estilos.desktop/mobile`;
+  - inclusão de teste cobrindo geração de CSS desktop/mobile e aplicação de `class` no HTML final.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -983,3 +983,11 @@
   - inclusão no prompt da regra de explicitação por visual `img` (narrativa/contexto, tipo visual, função comercial, objeção removida e classificação visual);
   - ajuste da seção "Ajuste de intenção por seção" para o formato solicitado, incluindo exemplos de `fonteContexto[]`;
   - ajuste do schema para `prioridadeConversao` como inteiro de 1 a 10.
+
+## 2026-05-22 01:57:00 UTC
+- ajuste solicitado: suportar novo JSON da etapa Gera Wireframe no fluxo de montagem de HTML provisório (assembler + processor).
+- causa-raiz: o fluxo de copy provisória assumia principalmente estruturas `bodySections/items` e adicionava metadado técnico (`jobId`) no HTML final, o que dificulta compatibilidade com o novo payload e viola a regra de não contaminar artefato final.
+- foi feito:
+  - atualização do `CopyProvisionalHtmlAssembler` para retornar apenas o HTML produzido pelo processor, sem inserir comentário técnico de `jobId`;
+  - atualização do `CopyProvisionalHtmlProcessor` para aceitar payloads envelopados (`landingPageWireframe`/`landingPageCopy`) e também copy no schema `pagina.corpo.secoes[].elementosSeccao[]` com `texto.conteudo`;
+  - adição de teste cobrindo aplicação de copy no formato `pagina` aninhado para garantir regressão positiva no novo contrato.


### PR DESCRIPTION
### Motivation
- O fluxo de montagem do HTML provisório precisava suportar o novo formato de wireframe (`definicoes + pagina`) produzido pela etapa Gera Wireframe. 
- É obrigatório evitar contaminação do artefato final com metadados técnicos, portanto a injeção de `jobId` no HTML provisório precisava ser removida.

### Description
- Remove a injeção do comentário técnico `jobId` do `CopyProvisionalHtmlAssembler`, retornando diretamente o HTML produzido pelo processor. 
- Atualiza `CopyProvisionalHtmlProcessor` para aceitar payloads envelopados (`landingPageWireframe` / `landingPageCopy`) e para desserializar o novo esquema baseado em `pagina.corpo.secoes[]`. 
- Estende a coleta de copy para suportar `elementosSeccao[]` e campos de texto aninhados `texto.conteudo`, adicionando os helpers `loadSectionsFromPaginaModel`, `unwrapPayload` e `extractNestedText`. 
- Adiciona teste de regressão em `CopyProvisionalHtmlProcessorNewWireframeFormatTest` cobrindo aplicação da copy no schema aninhado `landingPageCopy.pagina.corpo.secoes[].elementosSeccao[].texto.conteudo` e atualiza o registro em `docs/registros/experimentos.md`.

### Testing
- Executado: `cd /workspace/marketing-hub/backend && ./mvnw -pl ads-service -Dtest=CopyProvisionalHtmlProcessorNewWireframeFormatTest,DesignPresetProvisionalHtmlAssemblerTest test` falhou por seleção de projeto no reactor (uso de `-pl` no nível errado). 
- Executado: `cd /workspace/marketing-hub/backend/ads-service && ../mvnw -Dtest=CopyProvisionalHtmlProcessorNewWireframeFormatTest,DesignPresetProvisionalHtmlAssemblerTest test` e os testes alvos passaram com sucesso (5 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fa8edae0c8321a7dd272b0f61cef0)