### PR TITLE
Wireframe preview: alternate section backgrounds, image size heuristics and lorem fallback

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/WireframeHtmlGenerator.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/WireframeHtmlGenerator.java
@@ -66,8 +66,10 @@ public class WireframeHtmlGenerator {
 
             html.append(">\n");
 
+            int sectionIndex = 0;
             for (Map<String, Object> secao : asList(corpo.get("secoes"))) {
-                html.append(renderSection(secao));
+                html.append(renderSection(secao, sectionIndex));
+                sectionIndex++;
             }
 
             html.append("</body>\n");
@@ -79,8 +81,14 @@ public class WireframeHtmlGenerator {
         }
     }
 
-    private String renderSection(Map<String, Object> secao) {
-        return renderNode(secao, "section", "elementosSeccao");
+    private String renderSection(Map<String, Object> secao, int sectionIndex) {
+        Map<String, Object> normalizedSection = new LinkedHashMap<>(secao);
+        List<Map<String, Object>> estilos = new ArrayList<>(asList(secao.get("estilos")));
+        if (!containsBackgroundStyle(estilos)) {
+            estilos.add(Map.of("nome", "background-color", "valor", sectionIndex % 2 == 0 ? "#FFFFFF" : "#F7F9FC"));
+        }
+        normalizedSection.put("estilos", estilos);
+        return renderNode(normalizedSection, "section", "elementosSeccao");
     }
 
     private String renderElement(Map<String, Object> node) {
@@ -117,8 +125,11 @@ public class WireframeHtmlGenerator {
         out.append("<").append(tag);
         appendCommonAttributes(out, node);
 
-        if ("img".equals(tag) && !hasAttribute(node, "alt")) {
-            out.append(" alt=\"\"");
+        if ("img".equals(tag)) {
+            if (!hasAttribute(node, "alt")) {
+                out.append(" alt=\"\"");
+            }
+            appendSuggestedImageSize(out, node);
         }
 
         out.append(">\n");
@@ -227,7 +238,8 @@ public class WireframeHtmlGenerator {
         String content = asText(texto.get("conteudo"), "").trim();
 
         if (!StringUtils.hasText(content)) {
-            return "";
+            String lorem = resolveLoremIpsum(node);
+            return StringUtils.hasText(lorem) ? escapeHtmlText(lorem) : "";
         }
 
         return escapeHtmlText(content);
@@ -365,6 +377,76 @@ public class WireframeHtmlGenerator {
             out.append("}\n");
         }
         return out.toString().trim();
+    }
+
+
+    private boolean containsBackgroundStyle(List<Map<String, Object>> estilos) {
+        for (Map<String, Object> estilo : estilos) {
+            String nome = asText(estilo.get("nome"), "").trim().toLowerCase();
+            if ("background".equals(nome) || "background-color".equals(nome)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void appendSuggestedImageSize(StringBuilder out, Map<String, Object> node) {
+        Map<String, Object> attrs = extractAttributes(node);
+        if (hasAttribute(node, "width") || hasAttribute(node, "height")) {
+            return;
+        }
+        int width = averageDimension(attrs.get("minWidth"), attrs.get("maxWidth"), 960);
+        int height = averageDimension(attrs.get("minHeight"), attrs.get("maxHeight"), 540);
+        out.append(" width=\"").append(width).append("\"");
+        out.append(" height=\"").append(height).append("\"");
+    }
+
+    private int averageDimension(Object minValue, Object maxValue, int fallback) {
+        Integer min = parseInteger(minValue);
+        Integer max = parseInteger(maxValue);
+        if (min != null && max != null) {
+            return (min + max) / 2;
+        }
+        if (min != null) {
+            return min;
+        }
+        if (max != null) {
+            return max;
+        }
+        return fallback;
+    }
+
+    private Integer parseInteger(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (!(value instanceof String text) || !StringUtils.hasText(text)) {
+            return null;
+        }
+        String digits = text.replaceAll("[^0-9]", "");
+        if (!StringUtils.hasText(digits)) {
+            return null;
+        }
+        return Integer.parseInt(digits);
+    }
+
+    private String resolveLoremIpsum(Map<String, Object> node) {
+        Integer min = parseInteger(node.get("textMinWords"));
+        Integer max = parseInteger(node.get("textMaxWords"));
+        int words = min != null && max != null ? (min + max) / 2 : 14;
+        if (words <= 0) {
+            return "";
+        }
+        String base = "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt";
+        String[] tokens = base.split(" ");
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < words; i++) {
+            if (i > 0) {
+                out.append(" ");
+            }
+            out.append(tokens[i % tokens.length]);
+        }
+        return out.append(".").toString();
     }
 
     @SuppressWarnings("unchecked")

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -999,3 +999,11 @@
   - atualização do `WireframeHtmlGenerator` para montar `<style>` responsivo a partir de `definicoes` (desktop + mobile via media query);
   - atualização da renderização de nós para anexar classes derivadas de `estilos.desktop/mobile`;
   - inclusão de teste cobrindo geração de CSS desktop/mobile e aplicação de `class` no HTML final.
+
+## 2026-05-22 03:10:00 UTC
+- ajuste solicitado: no assembler do Gera Wireframe aplicar fundo alternado por seção, padronizar tamanho sugerido de imagens e preencher textos vazios com Lorem Ipsum proporcional.
+- causa-raiz: o HTML provisório do wireframe era renderizado sem padronização visual mínima para alternância de superfície, sem heurística de tamanho para `img` e sem fallback textual quando os blocos vinham sem conteúdo.
+- foi feito:
+  - atualização do `WireframeHtmlGenerator` para alternar `background-color` automático em seções sem fundo explícito (`#FFFFFF` e `#F7F9FC`);
+  - inclusão de heurística de imagem no `img` para sugerir `width` e `height` por média entre `minWidth/maxWidth` e `minHeight/maxHeight` quando presentes (com fallback 960x540);
+  - inclusão de fallback de Lorem Ipsum quando `texto.conteudo` estiver vazio, usando média entre `textMinWords/textMaxWords` quando disponíveis.


### PR DESCRIPTION
### Motivation
- Improve the provisional HTML preview generated from the Gera Wireframe artifact by providing minimal visual polish (alternating section surfaces), predictable image sizing and sensible text fallbacks when the wireframe payload omits those details. 
- Avoid rendering artifacts that hurt usability of previews and reduce manual cleanup in downstream flows. 
- Keep the change traceable by registering the experiment in the canonical `docs/registros/experimentos.md` log.

### Description
- `WireframeHtmlGenerator` now iterates sections with an index and injects a `background-color` style into a section's `estilos[]` when no background is present, alternating `#FFFFFF` and `#F7F9FC` by section index. 
- Added `appendSuggestedImageSize`, `averageDimension` and `parseInteger` helpers and updated `renderVoidElement` so `img` elements receive suggested `width`/`height` attributes computed as the average between `minWidth`/`maxWidth` and `minHeight`/`maxHeight`, with a fallback of `960x540` when unspecified. 
- Added `resolveLoremIpsum` and updated `resolveText` to return proportional Lorem Ipsum when `texto.conteudo` is empty, using the mean of `textMinWords`/`textMaxWords` when provided. 
- Documented the change in `docs/registros/experimentos.md` to record the experiment and rationale.

### Testing
- Executed `cd backend/ads-service && mvn -q -Dtest=WireframeHtmlGeneratorTest,WireframeProvisionalHtmlAssemblerTest test`, which initially failed due to a syntax issue introduced during the patch, the issue was fixed and the tests were re-run. 
- Final test run completed and targeted unit tests (`WireframeHtmlGeneratorTest` and `WireframeProvisionalHtmlAssemblerTest`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0faf034d6c83219b3f559382593674)