### PR TITLE
Use `definicoes` + `pagina` shape and 12 CSS groups for landing-page-design-preset

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset-schema.json
@@ -3,283 +3,79 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "landingPageDesignPreset"
+    "definicoes",
+    "pagina"
   ],
   "properties": {
-    "landingPageDesignPreset": {
+    "definicoes": {
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "presetId",
-        "theme",
-        "sectionPresets",
-        "elementPresets"
+        "cores-fundo",
+        "tipografia",
+        "texto",
+        "bordas",
+        "contorno",
+        "sombras-transparencia",
+        "filtro-efeitos",
+        "cursor",
+        "listas",
+        "imagens",
+        "transições",
+        "animações"
       ],
       "properties": {
-        "presetId": {
-          "type": "string",
-          "minLength": 1
-        },
-        "theme": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "palette",
-            "typography",
-            "spacing",
-            "accessibility"
-          ],
-          "properties": {
-            "palette": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "background",
-                "surface",
-                "textPrimary",
-                "textMuted",
-                "brandPrimary",
-                "brandSecondary",
-                "ctaPrimary"
-              ],
-              "properties": {
-                "background": {"type": "string"},
-                "surface": {"type": "string"},
-                "textPrimary": {"type": "string"},
-                "textMuted": {"type": "string"},
-                "brandPrimary": {"type": "string"},
-                "brandSecondary": {"type": "string"},
-                "ctaPrimary": {"type": "string"}
-              }
-            },
-            "typography": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "lineHeightBody",
-                "maxLineLength"
-              ],
-              "properties": {
-                "lineHeightBody": {"type": "string"},
-                "maxLineLength": {"type": "string"}
-              }
-            },
-            "spacing": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "sectionGapMobile"
-              ],
-              "properties": {
-                "sectionGapMobile": {"type": "string"}
-              }
-            },
-            "accessibility": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "textContrastBody",
-                "focusRing"
-              ],
-              "properties": {
-                "textContrastBody": {"type": "string"},
-                "focusRing": {"type": "string"}
-              }
-            },
-            "radius": {
-              "type": "object",
-              "additionalProperties": false
-            },
-            "shadow": {
-              "type": "object",
-              "additionalProperties": false
-            }
-          }
-        },
-        "sectionPresets": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "sectionId",
-              "surfaceStyle",
-              "contrastMode",
-              "sectionAttributes"
-            ],
-            "properties": {
-              "sectionId": {
-                "type": "string",
-                "minLength": 1
-              },
-              "surfaceStyle": {
-                "type": "string",
-                "enum": [
-                  "band",
-                  "solid",
-                  "gradient-soft",
-                  "image-tint"
-                ]
-              },
-              "contrastMode": {
-                "type": "string",
-                "enum": [
-                  "normal",
-                  "high",
-                  "soft"
-                ]
-              },
-              "sectionAttributes": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/$defs/attribute"
-                }
-              }
-            }
-          }
-        },
-        "elementPresets": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "sectionId",
-              "elementId",
-              "tag",
-              "attributes",
-              "tokenBindings"
-            ],
-            "properties": {
-              "sectionId": {
-                "type": "string",
-                "minLength": 1
-              },
-              "elementId": {
-                "type": "string",
-                "minLength": 1
-              },
-              "tag": {
-                "type": "string",
-                "minLength": 1
-              },
-              "attributes": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/$defs/attribute"
-                }
-              },
-              "tokenBindings": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "required": [
-                    "attributeName",
-                    "tokenPath"
-                  ],
-                  "properties": {
-                    "attributeName": {
-                      "type": "string",
-                      "enum": [
-                        "color",
-                        "background",
-                        "background-color",
-                        "background-image",
-                        "background-size",
-                        "background-position",
-                        "background-repeat",
-                        "background-attachment",
-                        "background-clip",
-                        "background-origin",
-                        "font",
-                        "font-family",
-                        "font-size",
-                        "font-weight",
-                        "font-style",
-                        "font-variant",
-                        "line-height",
-                        "letter-spacing",
-                        "word-spacing",
-                        "text-align",
-                        "text-decoration",
-                        "text-decoration-line",
-                        "text-decoration-color",
-                        "text-decoration-style",
-                        "text-transform",
-                        "text-shadow",
-                        "white-space",
-                        "border",
-                        "border-width",
-                        "border-style",
-                        "border-color",
-                        "border-top",
-                        "border-right",
-                        "border-bottom",
-                        "border-left",
-                        "border-radius",
-                        "outline",
-                        "outline-width",
-                        "outline-style",
-                        "outline-color",
-                        "outline-offset",
-                        "box-shadow",
-                        "opacity",
-                        "filter",
-                        "backdrop-filter",
-                        "mix-blend-mode",
-                        "isolation",
-                        "cursor",
-                        "appearance",
-                        "caret-color",
-                        "accent-color",
-                        "list-style",
-                        "list-style-type",
-                        "list-style-position",
-                        "list-style-image",
-                        "object-fit",
-                        "object-position",
-                        "transition",
-                        "transition-property",
-                        "transition-duration",
-                        "transition-timing-function",
-                        "transition-delay",
-                        "animation",
-                        "animation-name",
-                        "animation-duration",
-                        "animation-timing-function",
-                        "animation-delay",
-                        "animation-iteration-count",
-                        "animation-direction",
-                        "animation-fill-mode",
-                        "animation-play-state"
-                      ]
-                    },
-                    "tokenPath": {
-                      "type": "string",
-                      "minLength": 1
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+        "cores-fundo": { "$ref": "#/$defs/grupo" },
+        "tipografia": { "$ref": "#/$defs/grupo" },
+        "texto": { "$ref": "#/$defs/grupo" },
+        "bordas": { "$ref": "#/$defs/grupo" },
+        "contorno": { "$ref": "#/$defs/grupo" },
+        "sombras-transparencia": { "$ref": "#/$defs/grupo" },
+        "filtro-efeitos": { "$ref": "#/$defs/grupo" },
+        "cursor": { "$ref": "#/$defs/grupo" },
+        "listas": { "$ref": "#/$defs/grupo" },
+        "imagens": { "$ref": "#/$defs/grupo" },
+        "transições": { "$ref": "#/$defs/grupo" },
+        "animações": { "$ref": "#/$defs/grupo" }
       }
+    },
+    "pagina": {
+      "type": "object"
     }
   },
   "$defs": {
-    "attribute": {
+    "grupo": {
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "name",
-        "value"
+        "desktop",
+        "mobile"
       ],
       "properties": {
-        "name": {
+        "desktop": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/definicaoCss" }
+        },
+        "mobile": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/definicaoCss" }
+        }
+      }
+    },
+    "definicaoCss": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "nome",
+        "atributoCss",
+        "valor"
+      ],
+      "properties": {
+        "nome": {
+          "type": "string",
+          "minLength": 1
+        },
+        "atributoCss": {
           "type": "string",
           "enum": [
             "color",
@@ -355,7 +151,7 @@
             "animation-play-state"
           ]
         },
-        "value": {
+        "valor": {
           "type": "string",
           "minLength": 1
         }

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
@@ -1,137 +1,134 @@
 Você está na etapa `landing-page-design-preset` do pipeline Gera Landing.
 
 Objetivo:
-- Gerar o artefato `landingPageDesignPreset` cobrindo tema visual e presets por seção/elemento.
-- Produzir atributos CSS explícitos por seção e por elemento.
+- Retornar um JSON no mesmo formato estrutural da etapa wireframe (objeto raiz com `definicoes` e `pagina`).
+- Usar o JSON de `landingPageWireframe` como base da página (`pagina`) e aplicar somente acabamento visual de preset.
+- Trocar a lista antiga de `definicoes` pelos 12 grupos abaixo.
 
 Regras obrigatórias:
-1. Responda somente JSON válido no contrato solicitado.
-2. Não inventar `sectionId`: use apenas os ids existentes em `landingPageWireframe`.
-3. Para cada seção em `sectionPresets`, preencher `sectionId`, `surfaceStyle`, `contrastMode` e `sectionAttributes`.
-4. Para cada elemento em `elementPresets`, preencher `elementId`, `tag`, `attributes` e `tokenBindings`.
-5. Todo item de `attributes[].name` deve vir exatamente da whitelist abaixo.
-6. Não usar json em string. Campos estruturados devem ser objetos/arrays JSON reais.
-7. Manter consistência com objetivo comercial de conversão (clareza visual, contraste, hierarquia e foco no CTA).
-8. `theme.typography` é obrigatório e detalhado por tokens semânticos: `display`, `h1`, `h2`, `h3`, `body`, `lead`, `caption`, `overline`, `button`, `legal`.
-9. Para cada token tipográfico, declarar explicitamente todos os atributos CSS abaixo (sem omissões): `font`, `font-family`, `font-size`, `font-weight`, `font-style`, `font-variant`, `line-height`, `letter-spacing`, `word-spacing`, `text-align`, `text-decoration`, `text-decoration-line`, `text-decoration-color`, `text-decoration-style`, `text-transform`, `text-shadow`, `white-space`.
-10. Cada atributo tipográfico deve ter valor CSS concreto e válido; não usar vazio/null e evitar valores genéricos (`inherit`, `unset`, `initial`, `revert`) quando não houver intenção explícita.
-11. Reforçar hierarquia tipográfica: diferença perceptível entre títulos, subtítulos, corpo, apoio e CTA (escala, peso, espaçamento e contraste), mantendo legibilidade em desktop e mobile.
-12. Gerar variações `desktop` e `mobile` para cada token tipográfico, preservando a mesma hierarquia visual entre breakpoints.
-13. Em `consistencyChecks`, validar explicitamente: presença de todos os atributos tipográficos obrigatórios, legibilidade, contraste e força tipográfica de `display/h1/button`.
-14. Se faltar qualquer atributo obrigatório em qualquer token, registrar `FAIL` em `consistencyChecks` com detalhes objetivos; não omitir erro silenciosamente.
-15. Evitar geração de presets redundantes do LHM: em `elementPresets`, incluir somente elementos que realmente existem no `landingPageWireframe` e que exigem override para conversão/legibilidade; não criar entradas extras apenas para repetir defaults já cobertos por `theme`/`sectionPresets` e não inventar classes/tokens fora do contrato.
+1. Responda somente JSON válido.
+2. Preserve a estrutura de `pagina` recebida no wireframe (mesmos ids, mesma hierarquia, sem inventar seções/elementos).
+3. Aplique definições visuais pelos grupos em `definicoes`, com variações `desktop` e `mobile`.
+4. Cada item de `desktop/mobile` deve seguir exatamente:
+   - `nome`: nome da classe utilitária
+   - `atributoCss`: propriedade CSS
+   - `valor`: valor CSS válido
+5. Não usar JSON serializado em string.
+6. Usar exclusivamente propriedades CSS permitidas em `docs/gera-landing/listas-css-estrutura-acabamento.md`.
+7. Manter foco de conversão: contraste legível, CTA destacado e consistência entre seção e elementos.
 
-Whitelist de atributos CSS permitidos (`attributes[].name`):
-- color
-- background
-- background-color
-- background-image
-- background-size
-- background-position
-- background-repeat
-- background-attachment
-- background-clip
-- background-origin
-- font
-- font-family
-- font-size
-- font-weight
-- font-style
-- font-variant
-- line-height
-- letter-spacing
-- word-spacing
-- text-align
-- text-decoration
-- text-decoration-line
-- text-decoration-color
-- text-decoration-style
-- text-transform
-- text-shadow
-- white-space
-- border
-- border-width
-- border-style
-- border-color
-- border-top
-- border-right
-- border-bottom
-- border-left
-- border-radius
-- outline
-- outline-width
-- outline-style
-- outline-color
-- outline-offset
-- box-shadow
-- opacity
-- filter
-- backdrop-filter
-- mix-blend-mode
-- isolation
-- cursor
-- appearance
-- caret-color
-- accent-color
-- list-style
-- list-style-type
-- list-style-position
-- list-style-image
-- object-fit
-- object-position
-- transition
-- transition-property
-- transition-duration
-- transition-timing-function
-- transition-delay
-- animation
-- animation-name
-- animation-duration
-- animation-timing-function
-- animation-delay
-- animation-iteration-count
-- animation-direction
-- animation-fill-mode
-- animation-play-state
+Estrutura obrigatória de `definicoes` (substitui a lista anterior):
 
-Formato de saída:
+- `cores-fundo`
+  - color
+  - background
+  - background-color
+  - background-image
+  - background-size
+  - background-position
+  - background-repeat
+  - background-attachment
+  - background-clip
+  - background-origin
+
+- `tipografia`
+  - font
+  - font-family
+  - font-size
+  - font-weight
+  - font-style
+  - font-variant
+  - line-height
+  - letter-spacing
+  - word-spacing
+
+- `texto`
+  - text-align
+  - text-decoration
+  - text-decoration-line
+  - text-decoration-color
+  - text-decoration-style
+  - text-transform
+  - text-shadow
+  - white-space
+
+- `bordas`
+  - border
+  - border-width
+  - border-style
+  - border-color
+  - border-top
+  - border-right
+  - border-bottom
+  - border-left
+  - border-radius
+
+- `contorno`
+  - outline
+  - outline-width
+  - outline-style
+  - outline-color
+  - outline-offset
+
+- `sombras-transparencia`
+  - box-shadow
+  - opacity
+
+- `filtro-efeitos`
+  - filter
+  - backdrop-filter
+  - mix-blend-mode
+  - isolation
+
+- `cursor`
+  - cursor
+  - appearance
+  - caret-color
+  - accent-color
+
+- `listas`
+  - list-style
+  - list-style-type
+  - list-style-position
+  - list-style-image
+
+- `imagens`
+  - object-fit
+  - object-position
+
+- `transições`
+  - transition
+  - transition-property
+  - transition-duration
+  - transition-timing-function
+  - transition-delay
+
+- `animações`
+  - animation
+  - animation-name
+  - animation-duration
+  - animation-timing-function
+  - animation-delay
+  - animation-iteration-count
+  - animation-direction
+  - animation-fill-mode
+  - animation-play-state
+
+Formato esperado de saída:
 {
-  "landingPageDesignPreset": {
-    "presetId": "string",
-    "theme": {
-      "palette": {},
-      "typography": {},
-      "spacing": {}
-    },
-    "sectionPresets": [
-      {
-        "sectionId": "string",
-        "surfaceStyle": "band|solid|gradient-soft|image-tint",
-        "contrastMode": "normal|high|soft",
-        "sectionAttributes": [
-          { "name": "background-color", "value": "#FFFFFF" }
-        ]
-      }
-    ],
-    "elementPresets": [
-      {
-        "sectionId": "string",
-        "elementId": "string",
-        "tag": "string",
-        "attributes": [
-          { "name": "font-size", "value": "16px" }
-        ],
-        "tokenBindings": [
-          { "attributeName": "font-size", "tokenPath": "theme.typography.baseSize" }
-        ]
-      }
-    ],
-    "consistencyChecks": [
-      {
-        "check": "TYPOGRAPHY_REQUIRED_ATTRIBUTES",
-        "status": "PASS|WARN|FAIL",
-        "details": "string"
-      }
-    ]
-  }
+  "definicoes": {
+    "cores-fundo": { "desktop": [{ "nome": "string", "atributoCss": "background-color", "valor": "#FFFFFF" }], "mobile": [] },
+    "tipografia": { "desktop": [], "mobile": [] },
+    "texto": { "desktop": [], "mobile": [] },
+    "bordas": { "desktop": [], "mobile": [] },
+    "contorno": { "desktop": [], "mobile": [] },
+    "sombras-transparencia": { "desktop": [], "mobile": [] },
+    "filtro-efeitos": { "desktop": [], "mobile": [] },
+    "cursor": { "desktop": [], "mobile": [] },
+    "listas": { "desktop": [], "mobile": [] },
+    "imagens": { "desktop": [], "mobile": [] },
+    "transições": { "desktop": [], "mobile": [] },
+    "animações": { "desktop": [], "mobile": [] }
+  },
+  "pagina": { "...": "estrutura do wireframe aplicada" }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1007,3 +1007,19 @@
   - atualização do `WireframeHtmlGenerator` para alternar `background-color` automático em seções sem fundo explícito (`#FFFFFF` e `#F7F9FC`);
   - inclusão de heurística de imagem no `img` para sugerir `width` e `height` por média entre `minWidth/maxWidth` e `minHeight/maxHeight` quando presentes (com fallback 960x540);
   - inclusão de fallback de Lorem Ipsum quando `texto.conteudo` estiver vazio, usando média entre `textMinWords/textMaxWords` quando disponíveis.
+
+## 2026-05-22 23:40:00 UTC
+- ajuste solicitado: alterar prompt e schema da etapa `landing-page-design-preset` para usar grupos de estrutura equivalentes ao acabamento da etapa wireframe e aplicar definições no JSON de elementos recebido do wireframe.
+- causa-raiz: o contrato anterior listava propriedades CSS isoladas, sem agrupamento semântico obrigatório nem validação explícita de vínculo com os elementos reais do wireframe.
+- foi feito:
+  - atualização do prompt para exigir os 12 grupos de estrutura (`cores-fundo`, `tipografia`, `texto`, `bordas`, `contorno`, `sombras-transparencia`, `filtro-efeitos`, `cursor`, `listas`, `imagens`, `transições`, `animações`) com detalhamento literal de cada atributo CSS por grupo;
+  - atualização do formato de saída no prompt para exigir `group` em cada atributo de `sectionAttributes` e `attributes` de `elementPresets`, além de reforçar aplicação somente em `sectionId/elementId` existentes no wireframe;
+  - atualização do schema JSON da etapa para tornar `group` obrigatório em cada atributo, validar os 12 grupos via `enum` e exigir `consistencyChecks` com status `PASS|WARN|FAIL`.
+
+## 2026-05-22 23:58:00 UTC
+- ajuste solicitado: deixar o JSON da etapa `landing-page-design-preset` parecido com o exemplo `/exemplos/model-response-7179cef3-1f8f-4464-a9d5-c43a49a37fff.json`, mantendo `definicoes` + `pagina`, mas trocando as listas de `definicoes` pelos 12 grupos de acabamento.
+- causa-raiz: a mudança anterior manteve um contrato alternativo (`landingPageDesignPreset`) que não seguia o shape operacional esperado pelo fluxo atual baseado em `definicoes/pagina`.
+- foi feito:
+  - reescrita do prompt para exigir saída no shape `definicoes` + `pagina` (espelhando wireframe) e aplicação apenas nos elementos existentes do wireframe;
+  - substituição dos grupos de `definicoes` para os 12 grupos solicitados (`cores-fundo`, `tipografia`, `texto`, `bordas`, `contorno`, `sombras-transparencia`, `filtro-efeitos`, `cursor`, `listas`, `imagens`, `transições`, `animações`);
+  - reescrita do schema para validar o novo contrato com grupos obrigatórios, arrays `desktop/mobile` e itens `{nome, atributoCss, valor}`.


### PR DESCRIPTION
### Motivation
- Alinhar o contrato da etapa `landing-page-design-preset` ao formato operacional do wireframe (`definicoes` + `pagina`) e impor grupos semânticos de acabamento em vez de uma lista plana de atributos CSS.
- Evitar discrepâncias entre o formato esperado pelo pipeline e a saída do prompt/schema anterior, garantindo validação explícita e vínculo com `sectionId`/`elementId` do wireframe.

### Description
- Replaced the previous root `landingPageDesignPreset` schema with a new root consisting of `definicoes` and `pagina`, and made `definicoes` require 12 semantic groups (`cores-fundo`, `tipografia`, `texto`, `bordas`, `contorno`, `sombras-transparencia`, `filtro-efeitos`, `cursor`, `listas`, `imagens`, `transições`, `animações`).
- Introduced a `$defs/definicaoCss` object that enforces items to have `nome`, `atributoCss` (enum of allowed CSS properties) and `valor`, and changed group payloads to provide `desktop` and `mobile` arrays of these items.
- Updated the prompt `landing-page-design-preset.md` to require output in the `definicoes` + `pagina` shape, list the 12 groups and their allowed attributes, and provide explicit output formatting rules (no JSON-in-string, preserve `pagina` ids/hierarchy, desktop/mobile items structure).
- Updated documentation `docs/registros/experimentos.md` with a record of the contract change and the justification (and examples) for the new schema/prompt shape.

### Testing
- Ran the project's automated test suite and JSON schema validation against the updated schema; all tests completed successfully.
- Performed schema validation of example payloads to confirm `definicoes`/`pagina` shape and `desktop`/`mobile` arrays parse as expected; validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fb9a7de60832188edb7c0f1893b16)