### PR TITLE
feat(mois): exibir URL da página de venda na tela de detalhe

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -413,3 +413,8 @@
 - implementado renderizador recursivo de árvore JSON para objetos e arrays, com contagem de itens por nó e expansão inicial da raiz para facilitar inspeção.
 - adicionado fallback seguro: quando o conteúdo não for JSON válido, a UI mantém exibição textual para não bloquear diagnóstico.
 - arquivo alterado: `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`.
+
+## 2026-05-22 23:20:00 UTC
+- ajuste na tela de detalhe da Biblioteca de Páginas de Vendas (MOIS) para mostrar explicitamente a URL da página de venda usada como base da análise do modelo.
+- a URL canônica (`urlCanonical`) agora aparece no cabeçalho e é clicável em nova aba (`target="_blank"`), facilitando auditoria do conteúdo de origem das respostas.
+- arquivo alterado: `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`.

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -122,6 +122,16 @@ export default function MoisSalesPageLibraryDetailPage() {
           <p className="text-secondary mb-0">
             Coletor usado: <strong>{pageQuery.data?.source || "—"}</strong>
           </p>
+          <p className="text-secondary mb-0">
+            URL da página de venda usada no modelo:{" "}
+            {pageQuery.data?.urlCanonical ? (
+              <a href={pageQuery.data.urlCanonical} target="_blank" rel="noreferrer">
+                {pageQuery.data.urlCanonical}
+              </a>
+            ) : (
+              "—"
+            )}
+          </p>
         </div>
         <div className="d-flex flex-wrap gap-2">
           {nextItem ? (


### PR DESCRIPTION
### Motivation
- Melhorar rastreabilidade e auditoria mostrando explicitamente a URL canônica da página de venda usada como base para as respostas geradas pelo modelo na tela de detalhe da biblioteca MOIS.

### Description
- Exibe a `urlCanonical` como link clicável (`<a href=... target="_blank" rel="noreferrer">`) no cabeçalho da página de detalhe em `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx` e registra a alteração em `docs/registros/mois1.md`.

### Testing
- Executei o build do frontend com `npm run build`, que falhou no ambiente de execução por `vite: not found`, portanto não houve build/CI bem‑sucedido nem testes automatizados adicionais rodados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fbc49c83083219d01b4cf4d33f26c)