### PR TITLE
Consolidate EMPRESAS/SIMPLES totals, improve observability, and update schedule in OPRM importer

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -133,3 +133,9 @@
 - 2026-05-21 17:20:00 (UTC-3): ajuste solicitado na tela de CNAEs para exibir os 50 registros com maior quantidade de estabelecimentos ativos em ordem decrescente: ordenação backend do endpoint `GET /api/oprm/market/import-runs/cnaes/top-volume` alterada para `totalEstabelecimentosAtivos DESC`, preservando paginação de 50 por página.
 
 - 2026-05-21 17:35:00 (UTC-3): adição de comentários de responsabilidade no `OprmMarketSizeByCnaeRepository` (classe e método) para atender revisão de PR e manter conformidade com a regra de documentação Java do projeto.
+
+- 2026-05-22 00:00:00 (UTC): iniciado novo processo de ingestão no coletor OPRM para preencher métricas por CNAE com dados de EMPRESAS/SIMPLES. No `OprmMarketImportScheduler`, foi adicionada consolidação de `total_empresas` a partir dos arquivos `Empresas*.zip` (mapeando CNPJ base -> CNAE principal) e consolidação de `total_empresas_simples` / `total_empresas_mei` a partir do `Simples.zip`, com deduplicação por CNPJ base para evitar dupla contagem. Também foi atualizado o payload de `marketSizes` para enviar esses campos preenchidos ao backend.
+
+- 2026-05-22 00:00:00 (UTC): reforçada observabilidade do novo processo OPRM (EMPRESAS/SIMPLES) com logs de etapa e payload em exceções. Foram adicionados logs de contexto no catch do loop principal (datasetType, fileUrl, snapshotDate e contadores) e logs com último payload bruto processado (`lastRawPayload`) nos parsers de EMPRESAS e SIMPLES antes de relançar exceções.
+
+- 2026-05-22 00:00:00 (UTC): ajuste solicitado para agendar execução única da ingestão OPRM CNPJ/CNAE para amanhã (23/05/2026) às 10:00 em America/Sao_Paulo, atualizando o cron hardcoded de `runScheduledImport` para `0 0 10 23 5 *` e sincronizando o valor padrão em `application.yml`. Também foi reforçado o comentário de responsabilidade da classe `OprmMarketImportScheduler`.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
@@ -34,10 +34,11 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
-@Component
 /**
  * Responsável por orquestrar o agendamento e a execução da ingestão de mercado CNPJ/CNAE no OPRM.
+ * Também consolida os totais por CNAE enviados ao backend para atualização de market size.
  */
+@Component
 public class OprmMarketImportScheduler {
     private static final Logger log = LoggerFactory.getLogger(OprmMarketImportScheduler.class);
     private static final Pattern CNAE_7_DIGITS_PATTERN = Pattern.compile("(\\d{7})");
@@ -55,8 +56,8 @@ public class OprmMarketImportScheduler {
         this.restClient = restClient;
     }
 
-    /** Executa a ingestão completa de arquivos CNPJ/CNAE no horário configurado para a rotina diária. */
-    @Scheduled(cron = "0 0 17 * * *", zone = "America/Sao_Paulo")
+    /** Executa a ingestão completa de arquivos CNPJ/CNAE no horário agendado para a execução operacional. */
+    @Scheduled(cron = "0 0 10 23 5 *", zone = "America/Sao_Paulo")
     public void runScheduledImport() {
         if (!scheduleProperties.enabled()) {
             log.info("Scheduler OPRM market import desabilitado.");
@@ -108,6 +109,9 @@ public class OprmMarketImportScheduler {
         int filesProcessed = 0;
         boolean hasFailure = false;
         Map<String, MarketSizeAccumulator> accumulatedMarketSizesByCnae = new LinkedHashMap<>();
+        Map<String, String> cnaeByCnpjBase = new LinkedHashMap<>();
+        java.util.Set<String> simplesCountedCnpjBases = new java.util.HashSet<>();
+        java.util.Set<String> meiCountedCnpjBases = new java.util.HashSet<>();
         boolean readAllFilesInRun = false;
         try {
             Files.createDirectories(runTempDir);
@@ -126,6 +130,15 @@ public class OprmMarketImportScheduler {
                     List<OprmCnaeUpsertDto> cnaes = "CNAE".equalsIgnoreCase(file.datasetType())
                             ? parseCnaesFromZip(zipPath, runResponse.runId(), fileId, file.fileName())
                             : null;
+                    if ("EMPRESAS".equalsIgnoreCase(file.datasetType())) {
+                        parseAndAccumulateCompanyBaseByCnaeFromEmpresasZip(
+                                zipPath, runResponse.runId(), fileId, file.fileName(), cnaeByCnpjBase, accumulatedMarketSizesByCnae);
+                    }
+                    if ("SIMPLES".equalsIgnoreCase(file.datasetType())) {
+                        parseAndAccumulateSimplesAndMeiByCnaeFromSimplesZip(
+                                zipPath, runResponse.runId(), fileId, file.fileName(), cnaeByCnpjBase, accumulatedMarketSizesByCnae,
+                                simplesCountedCnpjBases, meiCountedCnpjBases);
+                    }
                     List<OprmMarketSizeUpsertDto> marketSizes = "ESTABELECIMENTOS".equalsIgnoreCase(file.datasetType())
                             ? parseAndAccumulateMarketSizesFromEstablishmentsZip(
                             zipPath, runResponse.runId(), fileId, file.fileName(), accumulatedMarketSizesByCnae)
@@ -145,7 +158,18 @@ public class OprmMarketImportScheduler {
                     log.info("[run={} fileId={}] Persistência status COMPLETED enviada. rowsRead={}", runResponse.runId(), fileId, rowsRead);
                 } catch (Exception e) {
                     hasFailure = true;
-                    log.error("[run={} fileId={}] Falha no processamento de arquivo {}", runResponse.runId(), fileId, file.fileName(), e);
+                    log.error("[run={} fileId={}] Falha no processamento de arquivo {}. datasetType={} fileUrl={} snapshotDate={} countersAntesFalha={rowsRead:{},rowsValid:{},rowsRejected:{},filesProcessed:{}}",
+                            runResponse.runId(),
+                            fileId,
+                            file.fileName(),
+                            file.datasetType(),
+                            file.fileUrl(),
+                            snapshotDate,
+                            totalRowsRead,
+                            totalRowsValid,
+                            totalRowsRejected,
+                            filesProcessed,
+                            e);
                     try {
                         publishFileEvent(runResponse.runId(), fileId, new OprmImportFileEventRequestDto(
                                 "FAILED", 0L, 0L, 0L, e.getMessage(), Instant.now(), null, null));
@@ -334,18 +358,103 @@ public class OprmMarketImportScheduler {
                     entry.getKey(),
                     acc.totalEstabelecimentos,
                     acc.totalEstabelecimentosAtivos,
-                    0L,
-                    0L,
-                    0L,
+                    acc.totalEmpresas,
+                    acc.totalEmpresasMei,
+                    acc.totalEmpresasSimples,
                     0.0
             ));
         }
         return payload;
     }
 
+    /** Processa EMPRESAS para consolidar o CNAE principal por CNPJ base e total de empresas por CNAE. */
+    private void parseAndAccumulateCompanyBaseByCnaeFromEmpresasZip(Path zipPath,
+                                                                     Long runId,
+                                                                     Long fileId,
+                                                                     String fileName,
+                                                                     Map<String, String> cnaeByCnpjBase,
+                                                                     Map<String, MarketSizeAccumulator> accumulatedMarketSizesByCnae) throws IOException {
+        log.info("[run={} fileId={}] Início parse EMPRESAS para total_empresas por CNAE: {}", runId, fileId, fileName);
+        String lastRawLine = null;
+        try (InputStream in = Files.newInputStream(zipPath);
+             java.util.zip.ZipInputStream zipInputStream = new java.util.zip.ZipInputStream(in, StandardCharsets.ISO_8859_1)) {
+            java.util.zip.ZipEntry entry;
+            while ((entry = zipInputStream.getNextEntry()) != null) {
+                if (entry.isDirectory()) continue;
+                BufferedReader reader = new BufferedReader(new InputStreamReader(zipInputStream, StandardCharsets.ISO_8859_1));
+                String rawLine;
+                while ((rawLine = reader.readLine()) != null) {
+                    lastRawLine = rawLine;
+                    if (rawLine.isBlank()) continue;
+                    String[] cols = rawLine.split(";", -1);
+                    if (cols.length < 7) continue;
+                    String cnpjBase = normalizeField(cols[0]);
+                    String cnaePrincipal = extractPrimaryCnaeCode(normalizeField(cols[6]));
+                    if (cnpjBase.isBlank() || cnaePrincipal.isBlank()) continue;
+                    if (cnaeByCnpjBase.putIfAbsent(cnpjBase, cnaePrincipal) == null) {
+                        MarketSizeAccumulator acc = accumulatedMarketSizesByCnae.computeIfAbsent(cnaePrincipal, key -> new MarketSizeAccumulator());
+                        acc.totalEmpresas++;
+                    }
+                }
+                zipInputStream.closeEntry();
+            }
+        } catch (Exception ex) {
+            log.error("[run={} fileId={}] Falha no parse EMPRESAS. fileName={} lastRawPayload={} mapCnpjBaseSize={} cnaesConsolidados={}",
+                    runId, fileId, fileName, lastRawLine, cnaeByCnpjBase.size(), accumulatedMarketSizesByCnae.size(), ex);
+            throw ex;
+        }
+        log.info("[run={} fileId={}] Parse EMPRESAS concluído. cnpjBaseMapSize={}", runId, fileId, cnaeByCnpjBase.size());
+    }
+
+    /** Processa SIMPLES para consolidar total de empresas no Simples e no MEI por CNAE. */
+    private void parseAndAccumulateSimplesAndMeiByCnaeFromSimplesZip(Path zipPath,
+                                                                      Long runId,
+                                                                      Long fileId,
+                                                                      String fileName,
+                                                                      Map<String, String> cnaeByCnpjBase,
+                                                                      Map<String, MarketSizeAccumulator> accumulatedMarketSizesByCnae,
+                                                                      java.util.Set<String> simplesCountedCnpjBases,
+                                                                      java.util.Set<String> meiCountedCnpjBases) throws IOException {
+        log.info("[run={} fileId={}] Início parse SIMPLES para total_empresas_simples/mei por CNAE: {}", runId, fileId, fileName);
+        String lastRawLine = null;
+        try (InputStream in = Files.newInputStream(zipPath);
+             java.util.zip.ZipInputStream zipInputStream = new java.util.zip.ZipInputStream(in, StandardCharsets.ISO_8859_1)) {
+            java.util.zip.ZipEntry entry;
+            while ((entry = zipInputStream.getNextEntry()) != null) {
+                if (entry.isDirectory()) continue;
+                BufferedReader reader = new BufferedReader(new InputStreamReader(zipInputStream, StandardCharsets.ISO_8859_1));
+                String rawLine;
+                while ((rawLine = reader.readLine()) != null) {
+                    lastRawLine = rawLine;
+                    if (rawLine.isBlank()) continue;
+                    String[] cols = rawLine.split(";", -1);
+                    if (cols.length < 5) continue;
+                    String cnpjBase = normalizeField(cols[0]);
+                    String simplesOptante = normalizeField(cols[1]);
+                    String meiOptante = normalizeField(cols[4]);
+                    String cnaeCode = cnaeByCnpjBase.get(cnpjBase);
+                    if (cnaeCode == null || cnaeCode.isBlank()) continue;
+                    MarketSizeAccumulator acc = accumulatedMarketSizesByCnae.computeIfAbsent(cnaeCode, key -> new MarketSizeAccumulator());
+                    if ("S".equalsIgnoreCase(simplesOptante) && simplesCountedCnpjBases.add(cnpjBase)) acc.totalEmpresasSimples++;
+                    if ("S".equalsIgnoreCase(meiOptante) && meiCountedCnpjBases.add(cnpjBase)) acc.totalEmpresasMei++;
+                }
+                zipInputStream.closeEntry();
+            }
+        } catch (Exception ex) {
+            log.error("[run={} fileId={}] Falha no parse SIMPLES. fileName={} lastRawPayload={} cnpjMapSize={} simplesCounted={} meiCounted={} cnaesConsolidados={}",
+                    runId, fileId, fileName, lastRawLine, cnaeByCnpjBase.size(), simplesCountedCnpjBases.size(), meiCountedCnpjBases.size(), accumulatedMarketSizesByCnae.size(), ex);
+            throw ex;
+        }
+        log.info("[run={} fileId={}] Parse SIMPLES concluído. simplesEmpresas={} meiEmpresas={}",
+                runId, fileId, simplesCountedCnpjBases.size(), meiCountedCnpjBases.size());
+    }
+
     private static final class MarketSizeAccumulator {
         private long totalEstabelecimentos;
         private long totalEstabelecimentosAtivos;
+        private long totalEmpresas;
+        private long totalEmpresasMei;
+        private long totalEmpresasSimples;
     }
 
     /** Monta a lista padrão de arquivos da base CNPJ a serem processados na execução. */

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -22,7 +22,7 @@ oprm:
       temp-dir: ${OPRM_MARKET_IMPORT_TEMP_DIR:/tmp/oprm-cnpj-import}
     schedule:
       enabled: ${OPRM_MARKET_IMPORT_SCHEDULE_ENABLED:true}
-      cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 0 17 * * *}
+      cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 0 10 23 5 *}
       timezone: ${OPRM_MARKET_IMPORT_SCHEDULE_TIMEZONE:America/Sao_Paulo}
       snapshot-date: ${OPRM_MARKET_IMPORT_SNAPSHOT_DATE:2026-05-10}
       source-base-url: ${OPRM_MARKET_IMPORT_SOURCE_BASE_URL:https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos}


### PR DESCRIPTION
### Motivation
- Enrich OPRM market-size payloads with company counts from `Empresas*.zip` and optant MEI/SIMPLES counts from `Simples.zip` to provide richer metrics per CNAE. 
- Improve operational diagnostics to locate root causes of persistence errors and parsing failures by adding contextual logs and last-raw-payload traces. 
- Execute a one-off scheduled import at a specific date/time and keep the runtime cron synchronized with the default configuration. 

### Description
- Added consolidation of `totalEmpresas`, `totalEmpresasSimples` and `totalEmpresasMei` by mapping CNPJ base -> CNAE and deduplicating CNPJ bases in `OprmMarketImportScheduler`. 
- Implemented `parseAndAccumulateCompanyBaseByCnaeFromEmpresasZip` and `parseAndAccumulateSimplesAndMeiByCnaeFromSimplesZip` that parse zip files, update `MarketSizeAccumulator`, and avoid double counting using dedicated sets and a `cnaeByCnpjBase` map. 
- Extended `MarketSizeAccumulator` with fields `totalEmpresas`, `totalEmpresasMei` and `totalEmpresasSimples` and updated `toMarketSizesPayload` to include those values in the `OprmMarketSizeUpsertDto` payload. 
- Hardened logging: added contextual error logs in the main file-processing loop (including `datasetType`, `fileUrl`, `snapshotDate` and counters) and last-raw-line payload logs inside the new parsers for easier diagnosis. 
- Changed the scheduled cron on `runScheduledImport` from `0 0 17 * * *` to a one-time `0 0 10 23 5 *` and synchronized the default in `application.yml`; also updated class-level documentation and a number of docs entries in `docs/registros/oprm1.md`. 

### Testing
- Ran a local build and test lifecycle with `mvn -DskipTests=false verify`, and unit tests completed successfully. 
- Performed a smoke run of the scheduler logic against sample zip fixtures to validate parsing, deduplication and payload composition, and the generated `marketSizes` payload contained the new `totalEmpresas`/`totalEmpresasSimples`/`totalEmpresasMei` fields as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fb9f4daf88321acaa6c59a073315a)