### PR TITLE
test: enforce GeraLanding subpackage isolation with ArchUnit

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
@@ -8,10 +8,17 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
+/**
+ * Garante isolamento arquitetural entre módulos/pacotes internos do backend.
+ */
 @AnalyzeClasses(packages = "com.marketinghub")
 class ModuleIsolationArchitectureTest {
 
     private static final String MOIS_SALES_LIBRARY_PACKAGE = "com.marketinghub.mois.bibliotecapaginavenda.worker.v1";
+    private static final String GERALANDING_WIREFRAME_PACKAGE = "com.marketinghub.geralanding.wireframe";
+    private static final String GERALANDING_COPY_PACKAGE = "com.marketinghub.geralanding.copy";
+    private static final String GERALANDING_IMAGEPLANNING_PACKAGE = "com.marketinghub.geralanding.imageplanning";
+    private static final String GERALANDING_PRESETDESIGN_PACKAGE = "com.marketinghub.geralanding.designpreset";
 
     @ArchTest
     static final ArchRule moisMustNotDependOnOtherMarketingHubPackages = noClasses()
@@ -48,6 +55,39 @@ class ModuleIsolationArchitectureTest {
             .resideInAPackage(MOIS_SALES_LIBRARY_PACKAGE + "..")
             .because("nenhum outro pacote interno deve depender da biblioteca de páginas de vendas do MOIS");
 
+    @ArchTest
+    static final ArchRule geralandingWireframeMustBeIsolated = isolatedFromOtherMarketingHubPackages(
+            GERALANDING_WIREFRAME_PACKAGE,
+            "o subpacote geralanding.wireframe deve ficar independente dos demais pacotes internos");
+
+    @ArchTest
+    static final ArchRule geralandingCopyMustBeIsolated = isolatedFromOtherMarketingHubPackages(
+            GERALANDING_COPY_PACKAGE,
+            "o subpacote geralanding.copy deve ficar independente dos demais pacotes internos");
+
+    @ArchTest
+    static final ArchRule geralandingImagePlanningMustBeIsolated = isolatedFromOtherMarketingHubPackages(
+            GERALANDING_IMAGEPLANNING_PACKAGE,
+            "o subpacote geralanding.imageplanning deve ficar independente dos demais pacotes internos");
+
+    @ArchTest
+    static final ArchRule geralandingPresetDesignMustBeIsolated = isolatedFromOtherMarketingHubPackages(
+            GERALANDING_PRESETDESIGN_PACKAGE,
+            "o subpacote geralanding.designpreset deve ficar independente dos demais pacotes internos");
+
+    /**
+     * Constrói regra para impedir dependências para outros pacotes internos fora do prefixo permitido.
+     */
+    private static ArchRule isolatedFromOtherMarketingHubPackages(String allowedPackagePrefix, String reason) {
+        return noClasses().that().resideInAPackage(allowedPackagePrefix + "..")
+                .should()
+                .dependOnClassesThat(otherMarketingHubPackagesExcept(allowedPackagePrefix))
+                .because(reason);
+    }
+
+    /**
+     * Retorna predicado que identifica classes internas fora do pacote permitido.
+     */
     private static DescribedPredicate<JavaClass> otherMarketingHubPackagesExcept(String allowedPackagePrefix) {
         return new DescribedPredicate<>("other com.marketinghub packages except " + allowedPackagePrefix) {
             @Override

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1039,3 +1039,11 @@
   - inclusão de sanitização de partes do nome de arquivo com remoção de acentos/caracteres inválidos;
   - inclusão de extração de número do job a partir do JSON da etapa (`jobNumber`, `jobId` ou `job_id`) com fallback `sem-job`;
   - atualização do padrão final do arquivo para `<nome-da-etapa>-job-<numero>.json`.
+
+## 2026-05-22 17:40:00 UTC
+- ajuste solicitado: usar ArchUnit para bloquear dependências cruzadas entre os subpacotes de GeraLanding (`wireframe`, `copy`, `imageplanning` e `designpreset`).
+- causa-raiz: não existia um teste de arquitetura específico para impedir acoplamento indevido entre esses subpacotes, permitindo regressões silenciosas de dependência interna.
+- foi feito:
+  - ampliação do teste `ModuleIsolationArchitectureTest` com regras dedicadas de isolamento para cada subpacote de GeraLanding;
+  - extração de helper para padronizar as regras de isolamento e reduzir duplicação;
+  - inclusão de comentários de responsabilidade na classe e métodos do teste para aderência ao padrão do backend.


### PR DESCRIPTION
### Motivation

- Garantir limites arquiteturais claros entre os subpacotes do GeraLanding para evitar acoplamento indevido e regressões silenciosas.
- Adicionar guardrails automáticos que reflitam a convenção de cada módulo ser independente e facilitar refatorações futuras.

### Description

- Adicionei regras ArchUnit em `ModuleIsolationArchitectureTest` para isolar `com.marketinghub.geralanding.wireframe`, `com.marketinghub.geralanding.copy`, `com.marketinghub.geralanding.imageplanning` e `com.marketinghub.geralanding.designpreset` do restante do backend.
- Introduzi constantes de package, o helper `isolatedFromOtherMarketingHubPackages(...)` para reduzir duplicação e um comentário de responsabilidade (JavaDoc) na classe de teste.
- Registrei a alteração no histórico de experimentos em `docs/registros/experimentos.md` conforme as regras operacionais do projeto.

### Testing

- Executei o teste direcionado com `../mvnw -Dtest=ModuleIsolationArchitectureTest test` a partir de `backend/ads-service` e observei a execução do ArchUnit contra o código compilado.
- Resultado: os testes falharam (arquitetura violada), revelando dependências reais a serem refatoradas hoje: `geralanding.copy -> geralanding.wireframe`, `geralanding.imageplanning -> geralanding.copy` e `geralanding.imageplanning -> com.marketinghub.experiment.pipeline.service`, e `geralanding.designpreset -> geralanding.wireframe`, portanto a mudança introduz as guardas e expõe os pontos que precisam de correção.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1092efe3c4832194d03f92f07f23c6)