### PR TITLE
Fix GeraLandingExecutionService logs to include actual stageCode (remove hardcoded 'wireframe')

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -107,8 +107,8 @@ public class GeraLandingExecutionService {
                     backendClient.loadPromptData(execution.experimentId()));
             String prompt = geraLandingService.montarERegistrarPromptEtapa(context, normalizedStage);
             String promptMarkdownContent = geraLandingService.carregarPromptMarkdownCru(normalizedStage);
-            log.info("Prompt de gera-landing wireframe montado para executionId={} (experimentId={})",
-                    execution.idJob(), execution.experimentId());
+            log.info("Prompt de gera-landing da etapa {} montado para executionId={} (experimentId={})",
+                    execution.stageCode(), execution.idJob(), execution.experimentId());
 
             String openAiRequestBody = buildOpenAiRequestBody(
                     stage,
@@ -160,8 +160,8 @@ public class GeraLandingExecutionService {
             log.info("Resultado OpenAI registrado para gera-landing executionId={} (experimentId={})",
                     execution.idJob(), execution.experimentId());
         } catch (Exception ex) {
-            log.error("Falha ao processar etapa wireframe para executionId={} (experimentId={})",
-                    execution.idJob(), execution.experimentId(), ex);
+            log.error("Falha ao processar etapa {} para executionId={} (experimentId={})",
+                    execution.stageCode(), execution.idJob(), execution.experimentId(), ex);
             try {
                 backendClient.receiveFailure(
                         execution.idJob(),

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1055,3 +1055,10 @@
   - `copy` e `designpreset`: introduzidos geradores locais de HTML de wireframe (`CopyWireframeHtmlGenerator` e `DesignPresetWireframeHtmlGenerator`) para remover dependência direta com `geralanding.wireframe`;
   - `imageplanning`: substituída dependência concreta por contratos internos (`CopyStageHtmlProvider` e `ImageHtmlInjector`) e criada configuração de adaptação (`GeraLandingImagePlanningConfig`) para conectar integrações fora do subpacote;
   - atualização do assembler de image planning para usar apenas contratos internos do próprio subpacote.
+
+## 2026-05-22 18:45:00 UTC
+- ajuste solicitado: corrigir logs do AI Worker para não indicar incorretamente a etapa `wireframe` durante execuções da etapa `landing-page-copy`.
+- causa-raiz: mensagens de log em `GeraLandingExecutionService` estavam hardcoded com o texto `wireframe`, independentemente do `stageCode` em processamento.
+- foi feito:
+  - atualização do log de montagem do prompt para incluir dinamicamente `execution.stageCode()`;
+  - atualização do log de falha para incluir dinamicamente `execution.stageCode()` e evitar diagnóstico incorreto da etapa em erro.


### PR DESCRIPTION
### Motivation
- Prevent misleading log lines that always referenced the `wireframe` stage even when other stages (e.g. `landing-page-copy`) were being processed, and record the fix in the experiment log.

### Description
- Updated `GeraLandingExecutionService.processExecution` to include `execution.stageCode()` in the prompt-assembly log instead of the hardcoded text `wireframe`.
- Updated the error log in `processExecution` to include `execution.stageCode()` so failures are attributed to the correct stage.
- Added an entry to `docs/registros/experimentos.md` documenting the logging fix and its rationale.

### Testing
- Ran unit tests with `./gradlew test` including `ModuleIsolationArchitectureTest` (ArchUnit) and they passed.
- Built the project with `./gradlew assemble` and ran the CI smoke checks, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a109f85be648321a5ec9b1e617cb21e)