### PR TITLE
test(ai-worker): enforce GeraLanding subpackage isolation with ArchUnit

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.worker.geralanding;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
@@ -10,6 +11,7 @@ import com.tngtech.archunit.lang.ArchRule;
 @AnalyzeClasses(packages = "com.marketinghub.worker", importOptions = ImportOption.DoNotIncludeTests.class)
 class GeraLandingArchitectureTest {
 
+    /** Garante que o módulo de geração de landing não dependa do pipeline legado de experimentos. */
     @ArchTest
     static final ArchRule geralanding_must_not_depend_on_experimentpipeline = noClasses()
             .that()
@@ -17,4 +19,11 @@ class GeraLandingArchitectureTest {
             .should()
             .dependOnClassesThat()
             .resideInAPackage("..experimentpipeline..");
+
+    /** Garante independência entre subpacotes do GeraLanding para evitar acoplamento cruzado. */
+    @ArchTest
+    static final ArchRule geralanding_subpackages_must_be_independent = slices()
+            .matching("com.marketinghub.worker.geralanding.(wireframe|copy|imageplanning|presetdesign)..")
+            .should()
+            .notDependOnEachOther();
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1062,3 +1062,15 @@
 - foi feito:
   - atualização do log de montagem do prompt para incluir dinamicamente `execution.stageCode()`;
   - atualização do log de falha para incluir dinamicamente `execution.stageCode()` e evitar diagnóstico incorreto da etapa em erro.
+
+## 2026-05-22 15:54:24 UTC-3
+- solicitação para reforçar isolamento arquitetural entre etapas de GeraLanding no ai-worker com ArchUnit.
+- raciocínio aplicado: prevenir acoplamento cruzado entre etapas (wireframe, copy, imageplanning e presetdesign) mantendo fronteiras claras de domínio e reduzindo regressões futuras.
+- foi feito:
+  - atualização do teste `GeraLandingArchitectureTest` para adicionar regra ArchUnit baseada em `slices` que impede dependência entre os subpacotes `geralanding.wireframe`, `geralanding.copy`, `geralanding.imageplanning` e `geralanding.presetdesign`.
+  - preservação da regra existente que bloqueia dependência de `geralanding` para `experimentpipeline`.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/registros/experimentos.md
+  - ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java


### PR DESCRIPTION
### Motivation
- Prevent accidental coupling between GeraLanding stages in the AI worker by enforcing clear package boundaries so each stage can evolve independently and avoid cross-subpackage usages.
- Preserve the existing constraint that `geralanding` must not depend on the legacy `experimentpipeline` module to keep module responsibilities strict.

### Description
- Added an ArchUnit rule in `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java` that uses `slices().matching(...).notDependOnEachOther()` to forbid dependencies between `geralanding.wireframe`, `geralanding.copy`, `geralanding.imageplanning` and `geralanding.presetdesign`.
- Kept the existing `noClasses().that().resideInAPackage("..geralanding..")...dependOnClassesThat().resideInAPackage("..experimentpipeline..")` rule to block `geralanding -> experimentpipeline` dependencies.
- Added an entry to `docs/registros/experimentos.md` recording the architectural change following the repository's append-only audit convention and UTC-3 timestamp.

### Testing
- Ran the targeted ArchUnit test with `mvn -f ai-worker/pom.xml -Dtest=GeraLandingArchitectureTest test` to validate the new rule.
- Result: the build failed before test execution due to a missing private artifact resolution (`com.marketinghub:ads-service:0.0.1-SNAPSHOT` returning HTTP 401 from GitHub Packages), so the ArchUnit assertions were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a62ab80c8321a47f87d935a8f1f4)