### PR TITLE
Allow empty ArchUnit slice evaluation for GeraLanding packages

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
@@ -25,5 +25,6 @@ class GeraLandingArchitectureTest {
     static final ArchRule geralanding_subpackages_must_be_independent = slices()
             .matching("com.marketinghub.worker.geralanding.(wireframe|copy|imageplanning|presetdesign)..")
             .should()
-            .notDependOnEachOther();
+            .notDependOnEachOther()
+            .allowEmptyShould(true);
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1074,3 +1074,11 @@
   - ai-worker/AGENTS.md
   - docs/registros/experimentos.md
   - ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
+
+
+## 2026-05-22 19:10:00 UTC
+- ajuste solicitado: aplicar `allowEmptyShould(true)` na regra ArchUnit de independência dos subpacotes de GeraLanding.
+- causa-raiz: a regra `slices` falhava quando nenhum pacote correspondente era encontrado no recorte avaliado, por comportamento padrão de falha em regra vazia.
+- foi feito:
+  - atualização de `GeraLandingArchitectureTest` para permitir avaliação vazia com `.allowEmptyShould(true)` na regra `geralanding_subpackages_must_be_independent`;
+  - manutenção da validação de não dependência entre subpacotes quando existirem classes compatíveis.


### PR DESCRIPTION
### Motivation
- An ArchUnit test for `geralanding` subpackages was failing when the `slices().matching(...)` rule matched no classes, producing an assertion that suggested using `.allowEmptyShould(true)`.
- The change prevents false-negative CI/test failures while preserving dependency checks when matching classes exist.

### Description
- Updated `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java` to append `.allowEmptyShould(true)` to the slice-based rule `geralanding_subpackages_must_be_independent`.
- Added an entry to `docs/registros/experimentos.md` recording the request, root cause, and applied fix as required by repository conventions.

### Testing
- Ran `mvn -f ai-worker/pom.xml -Dtest=GeraLandingArchitectureTest test` to validate the change.
- The Maven run could not complete because a private dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT` could not be fetched from GitHub Packages (HTTP 401 Unauthorized), so the test execution could not be fully validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a92993a8832195f5e45f19bdf2a6)