### PR TITLE
GeraLanding: add end-to-end tracing logs for OpenAI requests and backend reporting

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineBackendClient.java
@@ -20,6 +20,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Component
+/**
+ * Cliente HTTP responsável por sincronizar o status e os artefatos do pipeline de experimento com o backend.
+ */
 public class ExperimentPipelineBackendClient {
     private static final Logger log = LoggerFactory.getLogger(ExperimentPipelineBackendClient.class);
     private static final Pattern FORM_CONTROL_TAG_PATTERN = Pattern.compile("(?is)<(input|textarea|select)\\b[^>]*>");
@@ -174,6 +177,9 @@ public class ExperimentPipelineBackendClient {
 
 
 
+    /**
+     * Registra no backend o retorno da OpenAI para uma execução do GeraLanding.
+     */
     public void registerGeraLandingResult(Long experimentId,
                                           String stageCode,
                                           String jobId,
@@ -186,7 +192,16 @@ public class ExperimentPipelineBackendClient {
         body.put("inputTokens", payload.inputTokens());
         body.put("outputTokens", payload.outputTokens());
         body.put("costUsd", payload.costUsd());
-        webClient.post().uri(url).bodyValue(body).retrieve().bodyToMono(Void.class).onErrorResume(err -> Mono.empty()).block();
+        log.info("Enviando retorno para backend (jobId={}, url={}, payload={})", jobId, url, body);
+        webClient.post()
+                .uri(url)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .doOnSuccess(ignored -> log.info("Retorno do GeraLanding enviado ao backend (jobId={}, url={})", jobId, url))
+                .doOnError(err -> log.error("Falha ao enviar retorno do GeraLanding ao backend (jobId={}, url={}, payload={})", jobId, url, body, err))
+                .onErrorResume(err -> Mono.empty())
+                .block();
     }
 
     private Flux<ExperimentPipelineJobDto> handleListResponse(String uri,

--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -31,6 +31,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 @Component
+/**
+ * Cliente responsável por enviar jobs do pipeline de experimento para a OpenAI e validar o contrato de retorno.
+ */
 public class ExperimentPipelineOpenAiClient {
     private static final Logger log = LoggerFactory.getLogger(ExperimentPipelineOpenAiClient.class);
     private static final String REQUIRED_TEXT_MODEL = "gpt-5.2";
@@ -257,16 +260,19 @@ public class ExperimentPipelineOpenAiClient {
                     job.id(), job.experimentId(), job.section(), effectiveModel);
             log.info("OpenAI payload completo para job {}: {}", job.id(),
                     objectMapper.writeValueAsString(payload));
+            log.info("Enviando requisição para OpenAI com jobId={} (experimentId={}, section={}, model={})",
+                    job.id(), job.experimentId(), job.section(), effectiveModel);
             OpenAiResponse response = requestWithTransientRetries(payload, job);
             if (response == null || response.hasError()) {
                 throw new IllegalStateException(response != null ? response.errorMessage() : "Resposta vazia da OpenAI");
             }
-            log.info("Received OpenAI response for job {} (responseId={}, status={}, inputTokens={}, outputTokens={})",
+            log.info("Retorno recebido da OpenAI com jobId={} (responseId={}, status={}, inputTokens={}, outputTokens={}, respostaCompleta={})",
                     job.id(),
                     response.id(),
                     response.status(),
                     response.usage() != null ? response.usage().effectiveInputTokens() : null,
-                    response.usage() != null ? response.usage().effectiveOutputTokens() : null);
+                    response.usage() != null ? response.usage().effectiveOutputTokens() : null,
+                    objectMapper.writeValueAsString(response));
             String content = response.firstText();
             if (!StringUtils.hasText(content)) {
                 throw new IllegalStateException("Resposta da OpenAI sem conteúdo JSON");

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1082,3 +1082,6 @@
 - foi feito:
   - atualização de `GeraLandingArchitectureTest` para permitir avaliação vazia com `.allowEmptyShould(true)` na regra `geralanding_subpackages_must_be_independent`;
   - manutenção da validação de não dependência entre subpacotes quando existirem classes compatíveis.
+
+- 2026-05-22 — AI Worker / GeraLanding: adicionado log com `jobId` no envio para OpenAI, no recebimento da resposta da OpenAI e no envio do retorno ao backend com `url` e `payload` para rastreabilidade ponta a ponta.
+- 2026-05-22 — AI Worker / GeraLanding: ajustado log de retorno da OpenAI para incluir a resposta completa do modelo (`respostaCompleta`) junto com `jobId`.


### PR DESCRIPTION
### Motivation
- Improve observability and traceability of GeraLanding pipeline executions by logging `jobId`, request `url`, `payload`, and the full model response during the OpenAI request/response and backend reporting flows.
- Make client responsibilities clearer by adding class-level documentation for the OpenAI and backend clients.

### Description
- Added JavaDoc comments to `ExperimentPipelineBackendClient` and `ExperimentPipelineOpenAiClient` to clarify their responsibilities.
- Enhanced `registerGeraLandingResult` in `ExperimentPipelineBackendClient` to log the outbound payload and URL, and to log success and error outcomes with contextual fields (`jobId`, `url`, `payload`).
- Added additional logging in `ExperimentPipelineOpenAiClient.generate` to log when a request is sent to OpenAI and to include the complete OpenAI response JSON (`respostaCompleta`) along with `jobId` when the response is received.
- Updated `docs/registros/experimentos.md` to record these observability improvements.

### Testing
- Ran the AI worker unit test suite including ArchUnit rules with `./gradlew :ai-worker:test`; tests including `GeraLandingArchitectureTest` executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10af54b84c83218cf984ed4727d2f0)