### PR TITLE
Strip JSON code fences from model responses and add sanitizer test

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
@@ -56,6 +56,9 @@ public class GeraLandingOpenAiFlexClient {
         return enabled;
     }
 
+    /**
+     * Executa a geração no endpoint /responses da OpenAI e devolve o payload final da etapa.
+     */
     public GeraLandingJobCompletionPayload generate(GeraLandingJobDto job) {
         if (!enabled) {
             throw new IllegalStateException("OpenAI API key não configurada");
@@ -143,6 +146,9 @@ public class GeraLandingOpenAiFlexClient {
     }
 
 
+    /**
+     * Remove cercas markdown de JSON (```json ... ```) para manter o conteúdo parseável no pipeline.
+     */
     String sanitizeModelResponse(String modelResponse, GeraLandingJobDto job) {
         if (!StringUtils.hasText(modelResponse)) {
             return modelResponse;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
@@ -67,7 +67,7 @@ public class GeraLandingOpenAiFlexClient {
                     job.id(), job.section(), preview(job.requestBodyJson()));
             OpenAiResponse response = createFlexResponse(job);
             String rawOutput = objectMapper.writeValueAsString(response);
-            String modelResponse = response.firstText();
+            String modelResponse = sanitizeModelResponse(response.firstText(), job);
             log.info("Resposta OpenAI recebida para gera-landing [jobId={}, stage={}, responseId={}, rawOutputLength={}, modelResponseLength={}, modelResponsePreview={}]",
                     job.id(),
                     job.section(),
@@ -140,6 +140,25 @@ public class GeraLandingOpenAiFlexClient {
             return buildRequestBodyFromPrompt(job, trimmed);
         }
         return buildRequestBodyFromPrompt(job, job.prompt());
+    }
+
+
+    String sanitizeModelResponse(String modelResponse, GeraLandingJobDto job) {
+        if (!StringUtils.hasText(modelResponse)) {
+            return modelResponse;
+        }
+        String trimmed = modelResponse.trim();
+        if (!trimmed.startsWith("```json")) {
+            return modelResponse;
+        }
+
+        String withoutPrefix = trimmed.substring("```json".length()).trim();
+        if (withoutPrefix.endsWith("```")) {
+            withoutPrefix = withoutPrefix.substring(0, withoutPrefix.length() - 3).trim();
+        }
+        log.warn("Model response veio com code fence JSON; removendo cercas markdown [jobId={}, stage={}]",
+                job.id(), job.section());
+        return withoutPrefix;
     }
 
     /**

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClientTest.java
@@ -66,4 +66,28 @@ class GeraLandingOpenAiFlexClientTest {
         Map<?, ?> textItem = assertInstanceOf(Map.class, content.get(0));
         assertEquals(prompt, textItem.get("text"));
     }
+
+    @Test
+    void sanitizeModelResponse_removesJsonCodeFenceWhenPresent() {
+        GeraLandingOpenAiFlexClient client = new GeraLandingOpenAiFlexClient(
+                WebClient.builder(),
+                new ObjectMapper(),
+                "test-key",
+                "http://localhost",
+                Duration.ofSeconds(30));
+
+        GeraLandingJobDto job = new GeraLandingJobDto(
+                UUID.randomUUID(),
+                24L,
+                "landing-page-copy",
+                "gpt-5.2",
+                "prompt",
+                "prompt",
+                Instant.now());
+
+        String sanitized = client.sanitizeModelResponse("```json\n{\"ok\":true}\n```", job);
+
+        assertEquals("{\"ok\":true}", sanitized);
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Model outputs can be wrapped in Markdown JSON code fences (```json ... ```), which breaks downstream JSON consumption and logging, so responses must be sanitized before use.

### Description
- Added `sanitizeModelResponse(String, GeraLandingJobDto)` to strip a leading ```json fence and trailing ``` fence, trim the result, and log a warning when fences are removed.
- Integrated the sanitizer into `generate(...)` so `response.firstText()` is sanitized before validation, logging, and payload construction.
- Added unit test `sanitizeModelResponse_removesJsonCodeFenceWhenPresent` in `GeraLandingOpenAiFlexClientTest` to verify correct removal of code fences.

### Testing
- Ran the unit tests for `GeraLandingOpenAiFlexClientTest` using `mvn -Dtest=GeraLandingOpenAiFlexClientTest test`, and the new test passed.
- Existing tests in the same test class (including `prepareRequestBodyForFlex` checks) were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10b58ed9588321ac26bd15de307162)