### PR TITLE
Sanitize JSON code-fences in GeraLanding OpenAI Flex responses and add unit test

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
@@ -56,6 +56,9 @@ public class GeraLandingOpenAiFlexClient {
         return enabled;
     }
 
+    /**
+     * Executa a geração no endpoint /responses da OpenAI e devolve o payload final da etapa.
+     */
     public GeraLandingJobCompletionPayload generate(GeraLandingJobDto job) {
         if (!enabled) {
             throw new IllegalStateException("OpenAI API key não configurada");
@@ -67,7 +70,7 @@ public class GeraLandingOpenAiFlexClient {
                     job.id(), job.section(), preview(job.requestBodyJson()));
             OpenAiResponse response = createFlexResponse(job);
             String rawOutput = objectMapper.writeValueAsString(response);
-            String modelResponse = response.firstText();
+            String modelResponse = sanitizeModelResponse(response.firstText(), job);
             log.info("Resposta OpenAI recebida para gera-landing [jobId={}, stage={}, responseId={}, rawOutputLength={}, modelResponseLength={}, modelResponsePreview={}]",
                     job.id(),
                     job.section(),
@@ -140,6 +143,28 @@ public class GeraLandingOpenAiFlexClient {
             return buildRequestBodyFromPrompt(job, trimmed);
         }
         return buildRequestBodyFromPrompt(job, job.prompt());
+    }
+
+
+    /**
+     * Remove cercas markdown de JSON (```json ... ```) para manter o conteúdo parseável no pipeline.
+     */
+    String sanitizeModelResponse(String modelResponse, GeraLandingJobDto job) {
+        if (!StringUtils.hasText(modelResponse)) {
+            return modelResponse;
+        }
+        String trimmed = modelResponse.trim();
+        if (!trimmed.startsWith("```json")) {
+            return modelResponse;
+        }
+
+        String withoutPrefix = trimmed.substring("```json".length()).trim();
+        if (withoutPrefix.endsWith("```")) {
+            withoutPrefix = withoutPrefix.substring(0, withoutPrefix.length() - 3).trim();
+        }
+        log.warn("Model response veio com code fence JSON; removendo cercas markdown [jobId={}, stage={}]",
+                job.id(), job.section());
+        return withoutPrefix;
     }
 
     /**

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClientTest.java
@@ -66,4 +66,28 @@ class GeraLandingOpenAiFlexClientTest {
         Map<?, ?> textItem = assertInstanceOf(Map.class, content.get(0));
         assertEquals(prompt, textItem.get("text"));
     }
+
+    @Test
+    void sanitizeModelResponse_removesJsonCodeFenceWhenPresent() {
+        GeraLandingOpenAiFlexClient client = new GeraLandingOpenAiFlexClient(
+                WebClient.builder(),
+                new ObjectMapper(),
+                "test-key",
+                "http://localhost",
+                Duration.ofSeconds(30));
+
+        GeraLandingJobDto job = new GeraLandingJobDto(
+                UUID.randomUUID(),
+                24L,
+                "landing-page-copy",
+                "gpt-5.2",
+                "prompt",
+                "prompt",
+                Instant.now());
+
+        String sanitized = client.sanitizeModelResponse("```json\n{\"ok\":true}\n```", job);
+
+        assertEquals("{\"ok\":true}", sanitized);
+    }
+
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -218,6 +218,21 @@
   - docs/registros/experimentos.md
   - frontend/src/pages/experiment/NewExperimentPage.tsx
 
+## 2026-05-22 17:27:31 UTC-3
+- solicitação para deixar o Worker AI resiliente quando a resposta da etapa `landing-page-copy` vier iniciando com markdown code fence (` ```json `).
+- raciocínio aplicado: o erro ocorria após a resposta do modelo porque o conteúdo chegava válido, porém encapsulado em markdown; ao normalizar na borda do cliente OpenAI, o pipeline passa a consumir JSON parseável sem depender do formato de apresentação.
+- foi feito:
+  - adicionado saneamento da resposta no `GeraLandingOpenAiFlexClient` para remover cerca inicial ` ```json ` e cerca final ` ``` ` quando presentes;
+  - integração do saneamento no fluxo `generate(...)`, antes da validação/log/persistência do payload de conclusão;
+  - inclusão de teste unitário cobrindo resposta encapsulada em code fence;
+  - inclusão de comentários de responsabilidade dos métodos alterados conforme regra operacional de Java.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/registros/experimentos.md
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
+  - ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClientTest.java
+
 ## 2026-05-17 19:31:55 UTC-3
 - investigação do erro ao salvar na tela `/experiments/new` após simplificação recente.
 - causa-raiz identificada: o backend continua exigindo `journeyTemplateId` na criação do experimento, porém a UI simplificada deixou de coletar/enviar esse campo.


### PR DESCRIPTION
### Motivation
- Prevent pipeline failures when model responses are presented inside markdown JSON code fences (```json ... ```), which made otherwise-valid JSON unparseable downstream.
- Normalize model output at the OpenAI client boundary so later stages can rely on parseable JSON regardless of model presentation formatting.
- Record the change in experiment logs for operational traceability.

### Description
- Added `sanitizeModelResponse(String, GeraLandingJobDto)` to remove a leading ````json```` fence and a trailing ``````` when present, and integrated it into `generate(...)` so responses are normalized before validation and persistence. 
- Added Javadoc and logging to explain responsibility and to warn when a code fence was removed. 
- Added a unit test `sanitizeModelResponse_removesJsonCodeFenceWhenPresent` in `GeraLandingOpenAiFlexClientTest` to cover the new sanitization behavior. 
- Updated `docs/registros/experimentos.md` with an entry describing the change and rationale.

### Testing
- Ran unit tests including `GeraLandingOpenAiFlexClientTest`, and the test suite succeeded with the new test passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10b58ed9588321ac26bd15de307162)