### PR TITLE
fix(frontend): add htmlGeraLanding to Experiment type

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,15 @@
+
+## 2026-05-23 00:00:00 UTC
+- solicitação para corrigir falha de typecheck no frontend em `ExperimentDetailPage` por ausência do campo `htmlGeraLanding` no tipo `Experiment`.
+- causa-raiz identificada: o componente já consome `experiment.htmlGeraLanding`, porém a interface TypeScript compartilhada em `useExperiments.ts` não declarava esse atributo.
+- correção aplicada: inclusão do campo opcional `htmlGeraLanding?: string | null` na interface `Experiment` para alinhar contrato de tipagem com o consumo da tela de Experimentos/GeraLanding.
+- documentos/arquivos lidos:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/api/experiment/useExperiments.ts
+  - frontend/src/pages/experiment/ExperimentDetailPage.tsx
+
 ## 2026-05-21 01:05:00 UTC-3
 - solicitação: corrigir ingestão de tracking que iniciava cedo demais na landing do experimento 26.
 - causa-raiz identificada: o script `data-mh-funnel-tracking` era executado imediatamente após injeção no `<head>`, podendo consultar seções antes do DOM estar pronto.

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -79,6 +79,7 @@ export interface Experiment {
   landingPageDesignPreset?: string | null;
   landingPageDeliverables?: string | null;
   landingPageHtml?: string | null;
+  htmlGeraLanding?: string | null;
   creativeImagePrompt?: string | null;
   instagramAccount?: InstagramAccountSummary | null;
   /**


### PR DESCRIPTION
### Motivation
- Align the frontend TypeScript contract with the UI: `ExperimentDetailPage` reads `experiment.htmlGeraLanding` but the shared `Experiment` interface did not declare it, causing a typecheck failure.

### Description
- Added the optional field `htmlGeraLanding?: string | null` to the `Experiment` interface in `frontend/src/api/experiment/useExperiments.ts` to match runtime usage.
- Appended an operational record describing the change to `docs/registros/experimentos.md` following project logging conventions.

### Testing
- Ran `cd frontend && npm run typecheck`; the original `TS2339` errors for `htmlGeraLanding` are resolved by this change.  
- The typecheck run still reports unrelated environment/toolchain issues (`Cannot find type definition file` for test/vite packages and `tsconfig` deprecation warnings), which are outside this PR's scope and did not block the original fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a111129cdb48321b58b523149a2b038)