### PR TITLE
Schedule OPRM CNPJ/CNAE import for 2026-05-23 00:01 and sync defaults/docs

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -143,3 +143,5 @@
 - 2026-05-22 00:00:00 (UTC): correção de causa-raiz na persistência de contagem MEI por CNAE no `oprm-coletor-mei`: o scheduler publicava `marketSizes` apenas nos arquivos `ESTABELECIMENTOS`, antes do processamento do `Simples.zip`, fazendo `total_empresas_mei`/`total_empresas_simples` persistirem como zero. Ajustado `runScheduledImport` para recalcular e publicar snapshot consolidado de `marketSizes` também após o dataset `SIMPLES`, garantindo atualização de `total_empresas`, `total_empresas_mei` e `total_empresas_simples` no backend para cada CNAE.
 
 - 2026-05-22 15:50:00 (UTC-3): ajuste solicitado para agendar a próxima ingestão OPRM CNPJ/CNAE para **16:30** no fuso `America/Sao_Paulo`, com atualização do cron hardcoded de `runScheduledImport` para `0 30 16 * * *` e sincronização do cron padrão em `application.yml`.
+
+- 2026-05-23 00:00:00 (UTC): ajuste solicitado para executar a ingestão OPRM CNPJ/CNAE às **00:01 de 23/05/2026** no fuso `America/Sao_Paulo`, com atualização do cron hardcoded de `runScheduledImport` para `0 1 0 23 5 *`, sincronização do cron padrão em `application.yml` e correção da mensagem de log final para refletir 00:01.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
@@ -57,7 +57,7 @@ public class OprmMarketImportScheduler {
     }
 
     /** Executa a ingestão completa de arquivos CNPJ/CNAE no horário agendado para a execução operacional. */
-    @Scheduled(cron = "0 30 16 * * *", zone = "America/Sao_Paulo")
+    @Scheduled(cron = "0 1 0 23 5 *", zone = "America/Sao_Paulo")
     public void runScheduledImport() {
         if (!scheduleProperties.enabled()) {
             log.info("Scheduler OPRM market import desabilitado.");
@@ -202,7 +202,7 @@ public class OprmMarketImportScheduler {
             }
         }
 
-        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 14:30 ({}) com {} arquivos.",
+        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 00:01 ({}) com {} arquivos.",
                 snapshotDate,
                 scheduleProperties.timezone(),
                 files.size());

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -22,7 +22,7 @@ oprm:
       temp-dir: ${OPRM_MARKET_IMPORT_TEMP_DIR:/tmp/oprm-cnpj-import}
     schedule:
       enabled: ${OPRM_MARKET_IMPORT_SCHEDULE_ENABLED:true}
-      cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 30 16 * * *}
+      cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 1 0 23 5 *}
       timezone: ${OPRM_MARKET_IMPORT_SCHEDULE_TIMEZONE:America/Sao_Paulo}
       snapshot-date: ${OPRM_MARKET_IMPORT_SNAPSHOT_DATE:2026-05-10}
       source-base-url: ${OPRM_MARKET_IMPORT_SOURCE_BASE_URL:https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos}


### PR DESCRIPTION
### Motivation

- Operacional request to execute the OPRM CNPJ/CNAE ingestion at `00:01` on `23/05/2026` in the `America/Sao_Paulo` zone required updating the hardcoded scheduler and default cron value.
- The final run log message needed to reflect the new scheduled time for clearer observability.
- The change was recorded in the project change log to keep documentation in sync with the schedule change.

### Description

- Updated the scheduled cron on `OprmMarketImportScheduler` by changing the `@Scheduled` annotation to `@Scheduled(cron = "0 1 0 23 5 *", zone = "America/Sao_Paulo")`.
- Synchronized the default cron in `oprm-coletor-mei/src/main/resources/application.yml` to `0 1 0 23 5 *` under `oprm.market-import.schedule.cron`.
- Adjusted the informational log in `OprmMarketImportScheduler` to report the new `00:01` time in the completion message.
- Appended a new registro entry in `docs/registros/oprm1.md` documenting the schedule change and the log-message correction.

### Testing

- No automated tests were added or modified in this change; existing CI should run the project test suite to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a110f8c7ba0832185f1bb3bd08b3e37)