### PR TITLE
docs(gera-landing): adicionar diagrama de fluxo do StageExecutionService para assemblers

### DIFF
--- a/docs/gera-landing/modelo-canonico-gera-landing.md
+++ b/docs/gera-landing/modelo-canonico-gera-landing.md
@@ -53,6 +53,24 @@ A ordem oficial de execução no fluxo **Total Gera Landing (todas as etapas)** 
 
 Observação operacional: no worker `geralanding`, etapas fora desse conjunto ainda são ignoradas com log informativo.
 
+
+### 1.4 Diagrama canônico — montagem de dados por estágio
+
+```mermaid
+flowchart TD
+    A[GeraLandingStageExecutionService] --> B[WireframeProvisionalHtmlAssembler]
+    A --> C[CopyProvisionalHtmlAssembler]
+    A --> D[DesignPresetProvisionalHtmlAssembler]
+    A --> E[ImagePlanningProvisionalHtmlAssembler]
+
+    B --> F[(gera_landing_stage_execution)]
+    C --> F
+    D --> F
+    E --> F
+```
+
+Leitura operacional: o `GeraLandingStageExecutionService` orquestra a execução por etapa e aciona o assembler correspondente (wireframe, copy, preset/design e image-planning), gerando os dados derivados que são persistidos no registro da tabela `gera_landing_stage_execution`.
+
 ---
 
 ## 2) Modelo de dados canônico (`gera_landing_stage_execution`)

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1133,3 +1133,5 @@
 - 2026-05-23 (UTC): ampliadas regras ArchUnit do GeraLanding para também bloquear no `GeraLandingStageExecutionService` o uso de assinaturas legadas dos assemblers de wireframe (`assemble(modelResponse)`) e copy (`assemble(copyModelResponse, wireframeModelResponse)`), forçando os contratos com `jobId`.
 
 - 2026-05-23 (UTC): adicionadas regras ArchUnit positivas para exigir que `GeraLandingStageExecutionService` chame explicitamente os assemblers canônicos nas assinaturas padrão: wireframe (`assemble(modelResponse, jobId)`), design preset (`assemble(modelResponse, jobId)`) e copy (`assemble(copyModelResponse, wireframeModelResponse, jobId)`).
+
+- 2026-05-23 (UTC): atualização do documento canônico do Gera Landing com diagrama de fluxo mostrando `GeraLandingStageExecutionService` acionando os assemblers de wireframe, copy, design-preset e image-planning, e a persistência dos dados gerados na tabela `gera_landing_stage_execution`.


### PR DESCRIPTION
### Motivation
- Melhorar a visualização arquitetural e o alinhamento entre backend e worker ao documentar como o `GeraLandingStageExecutionService` aciona os assemblers e onde os dados gerados por cada etapa são persistidos.

### Description
- Adiciona a seção "1.4 Diagrama canônico" em `docs/gera-landing/modelo-canonico-gera-landing.md` contendo um diagrama Mermaid que mostra `GeraLandingStageExecutionService` chamando `WireframeProvisionalHtmlAssembler`, `CopyProvisionalHtmlAssembler`, `DesignPresetProvisionalHtmlAssembler` e `ImagePlanningProvisionalHtmlAssembler`, todos convergindo para a persistência na tabela `gera_landing_stage_execution`, e registra a atividade em `docs/registros/experimentos.md` conforme o procedimento de registros.

### Testing
- Nenhum teste automatizado foi necessário por se tratar de alteração exclusivamente documental; os arquivos foram adicionados e commitados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1122e15c1c832183f46b9de72c6fd4)