### PR TITLE
docs: mapear persistência real de etapas Gera Landing no diagrama canônico

### DIFF
--- a/docs/gera-landing/modelo-canonico-gera-landing.md
+++ b/docs/gera-landing/modelo-canonico-gera-landing.md
@@ -58,18 +58,39 @@ Observação operacional: no worker `geralanding`, etapas fora desse conjunto ai
 
 ```mermaid
 flowchart TD
-    A[GeraLandingStageExecutionService] --> B[WireframeProvisionalHtmlAssembler]
-    A --> C[CopyProvisionalHtmlAssembler]
-    A --> D[DesignPresetProvisionalHtmlAssembler]
-    A --> E[ImagePlanningProvisionalHtmlAssembler]
+    EXP[(experiments)] --> A[GeraLandingStageExecutionService.receiveResult]
+    A --> EREP[ExperimentRepository.save
+(tabela experiments)]
+    A --> SREP[GeraLandingStageExecutionRepository.save
+(tabela gera_landing_stage_execution)]
 
-    B --> F[(gera_landing_stage_execution)]
-    C --> F
-    D --> F
-    E --> F
+    A -->|landing-page-wireframe| W[WireframeProvisionalHtmlAssembler.assemble(modelResponse, jobId)]
+    A -->|landing-page-copy| C[CopyProvisionalHtmlAssembler.assemble(copyModelResponse, wireframeModelResponse, jobId)]
+    A -->|landing-page-image-planning| I[ImagePlanningProvisionalHtmlAssembler.assemble(experimentId, copy, wireframe, jobId)]
+    A -->|landing-page-design-preset| D[DesignPresetProvisionalHtmlAssembler.assemble(modelResponse, jobId)]
+
+    W --> SREP
+    C --> SREP
+    I --> SREP
+    D --> SREP
+
+    A -->|wireframe persistido| EF1[experiments.landing_page_wireframe
++ landing_page_wireframe_job_id]
+    A -->|copy persistida| EF2[experiments.landing_page_copy
++ landing_page_copy_job_id]
+    A -->|image planning persistido| EF3[experiments.landing_page_image_planning
++ landing_page_html]
+    A -->|design preset persistido| EF4[experiments.landing_page_design_preset
++ html_geralanding
++ landing_page_html]
 ```
 
-Leitura operacional: o `GeraLandingStageExecutionService` orquestra a execução por etapa e aciona o assembler correspondente (wireframe, copy, preset/design e image-planning), gerando os dados derivados que são persistidos no registro da tabela `gera_landing_stage_execution`.
+Leitura operacional (mapeamento por causa-raiz de persistência): a orquestração principal acontece em `GeraLandingStageExecutionService.receiveResult(...)`, que primeiro grava `modelResponse/provisionalHtml/status` em `gera_landing_stage_execution` via `GeraLandingStageExecutionRepository.save(...)` e, em seguida, persiste o artefato da etapa em `experiments` pelo método `persistStageArtifactOnExperiment(...)` com `ExperimentRepository.save(...)`. Para as quatro etapas solicitadas:
+
+- **Gera Wireframe** (`landing-page-wireframe`): usa `WireframeProvisionalHtmlAssembler` para montar o HTML provisório e persiste `landing_page_wireframe` + `landing_page_wireframe_job_id` na `experiments`.
+- **Gera Copy** (`landing-page-copy`): usa `CopyProvisionalHtmlAssembler` com o wireframe já salvo em `experiments` e persiste `landing_page_copy` + `landing_page_copy_job_id`.
+- **Gera Prompt Images** (`landing-page-image-planning`): usa `ImagePlanningProvisionalHtmlAssembler` com `landing_page_copy` e `landing_page_wireframe`; persiste `landing_page_image_planning` e atualiza `landing_page_html` quando houver HTML provisório.
+- **Gera Preset Design** (`landing-page-design-preset`): usa `DesignPresetProvisionalHtmlAssembler`; persiste `landing_page_design_preset` e atualiza `html_geralanding` + `landing_page_html` quando houver HTML derivado.
 
 ---
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1136,3 +1136,28 @@
 
 - 2026-05-23 (UTC): atualização do documento canônico do Gera Landing com diagrama de fluxo mostrando `GeraLandingStageExecutionService` acionando os assemblers de wireframe, copy, design-preset e image-planning, e a persistência dos dados gerados na tabela `gera_landing_stage_execution`.
 - 2026-05-23 (UTC): pipeline legado de conteúdo ajustado para encerrar a continuação automática após `AD_IMAGE_BRIEFING`, evitando enfileirar `landing-page-wireframe` sem execução manual de Gera Landing; adicionado teste unitário cobrindo que a conclusão de `AD_IMAGE_BRIEFING` não cria job pendente de `LANDING_PAGE_WIREFRAME`.
+
+## 2026-05-23 00:58:21 UTC-3
+- solicitação para continuar o diagrama canônico da seção 1.4 do Gera Landing e explicitar as inserções usadas da tabela `experiments`.
+- raciocínio aplicado: manter o foco na causa-raiz da montagem de contexto por estágio, deixando explícita a origem dos dados antes da persistência em `gera_landing_stage_execution`.
+- foi feito: atualização do diagrama mermaid com o nó `experiments` alimentando os assemblers (wireframe/copy/design-preset/image-planning) e complemento textual listando os principais campos inseridos/consumidos no fluxo.
+- documentos/arquivos lidos:
+  - AGENTS.md
+  - docs/gera-landing/modelo-canonico-gera-landing.md
+  - docs/registros/experimentos.md
+
+## 2026-05-23 02:15:00 UTC-3
+- solicitação: pesquisar no código as classes de persistência envolvidas nas tabelas `gera_landing_stage_execution` e `experiments` para as etapas wireframe, copy, preset design e prompt images, e completar o diagrama canônico.
+- causa-raiz tratada: o diagrama anterior mostrava apenas visão de alto nível dos assemblers, sem explicitar os pontos reais de escrita por etapa (service + repositories + campos persistidos).
+- foi feito:
+  - rastreamento no backend (`ads-service`) do fluxo `GeraLandingStageExecutionService.receiveResult(...)` e do método `persistStageArtifactOnExperiment(...)`;
+  - atualização da seção 1.4 com diagrama mermaid completo incluindo `GeraLandingStageExecutionRepository.save(...)`, `ExperimentRepository.save(...)`, assemblers por etapa e colunas gravadas em `experiments`;
+  - complemento textual com mapeamento objetivo de persistência por etapa.
+- classes identificadas no código:
+  - `com.marketinghub.geralanding.GeraLandingStageExecutionService`
+  - `com.marketinghub.geralanding.GeraLandingStageExecutionRepository`
+  - `com.marketinghub.experiment.repository.ExperimentRepository`
+  - `com.marketinghub.geralanding.wireframe.WireframeProvisionalHtmlAssembler`
+  - `com.marketinghub.geralanding.copy.CopyProvisionalHtmlAssembler`
+  - `com.marketinghub.geralanding.imageplanning.ImagePlanningProvisionalHtmlAssembler`
+  - `com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAssembler`


### PR DESCRIPTION
### Motivation
- Deixar o diagrama canônico da seção 1.4 aderente ao comportamento real do backend, explicitando onde os artefatos gerados por cada etapa são gravados e quais classes fazem a persistência.

### Description
- Atualizei `docs/gera-landing/modelo-canonico-gera-landing.md` para substituir o diagrama por uma versão que mostra a orquestração em `GeraLandingStageExecutionService.receiveResult(...)`, gravação em `GeraLandingStageExecutionRepository.save(...)` (tabela `gera_landing_stage_execution`) e persistência em `ExperimentRepository.save(...)` (tabela `experiments`).
- Documentei o mapeamento por etapa com os assemblers e as colunas persistidas em `experiments`: `landing_page_wireframe` + `landing_page_wireframe_job_id`, `landing_page_copy` + `landing_page_copy_job_id`, `landing_page_image_planning` (+ atualização de `landing_page_html`), e `landing_page_design_preset` (+ `html_geralanding` + `landing_page_html`).
- Registrei a investigação em `docs/registros/experimentos.md` incluindo a lista das classes identificadas no código: `com.marketinghub.geralanding.GeraLandingStageExecutionService`, `com.marketinghub.geralanding.GeraLandingStageExecutionRepository`, `com.marketinghub.experiment.repository.ExperimentRepository`, `com.marketinghub.geralanding.wireframe.WireframeProvisionalHtmlAssembler`, `com.marketinghub.geralanding.copy.CopyProvisionalHtmlAssembler`, `com.marketinghub.geralanding.imageplanning.ImagePlanningProvisionalHtmlAssembler` e `com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAssembler`.
- Arquivos modificados: `docs/gera-landing/modelo-canonico-gera-landing.md` e `docs/registros/experimentos.md`.

### Testing
- Executei `git -C /workspace/marketing-hub status --short` para validar o estado do trabalho local e a execução retornou com sucesso. 
- Realizei `git -C /workspace/marketing-hub commit -m "docs: mapear classes de persistencia por etapa no diagrama gera landing"` e o commit foi criado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1125b67dc48321883cb2d623cccf85)