### PR TITLE
Fix Mermaid rendering in Gera Landing canonical diagram

### DIFF
--- a/docs/gera-landing/modelo-canonico-gera-landing.md
+++ b/docs/gera-landing/modelo-canonico-gera-landing.md
@@ -59,10 +59,8 @@ Observação operacional: no worker `geralanding`, etapas fora desse conjunto ai
 ```mermaid
 flowchart TD
     EXP[(experiments)] --> A[GeraLandingStageExecutionService.receiveResult]
-    A --> EREP[ExperimentRepository.save
-(tabela experiments)]
-    A --> SREP[GeraLandingStageExecutionRepository.save
-(tabela gera_landing_stage_execution)]
+    A --> EREP["ExperimentRepository.save<br/>(tabela experiments)"]
+    A --> SREP["GeraLandingStageExecutionRepository.save<br/>(tabela gera_landing_stage_execution)"]
 
     A -->|landing-page-wireframe| W[WireframeProvisionalHtmlAssembler.assemble(modelResponse, jobId)]
     A -->|landing-page-copy| C[CopyProvisionalHtmlAssembler.assemble(copyModelResponse, wireframeModelResponse, jobId)]
@@ -74,15 +72,10 @@ flowchart TD
     I --> SREP
     D --> SREP
 
-    A -->|wireframe persistido| EF1[experiments.landing_page_wireframe
-+ landing_page_wireframe_job_id]
-    A -->|copy persistida| EF2[experiments.landing_page_copy
-+ landing_page_copy_job_id]
-    A -->|image planning persistido| EF3[experiments.landing_page_image_planning
-+ landing_page_html]
-    A -->|design preset persistido| EF4[experiments.landing_page_design_preset
-+ html_geralanding
-+ landing_page_html]
+    A -->|wireframe persistido| EF1["experiments.landing_page_wireframe<br/>+ landing_page_wireframe_job_id"]
+    A -->|copy persistida| EF2["experiments.landing_page_copy<br/>+ landing_page_copy_job_id"]
+    A -->|image planning persistido| EF3["experiments.landing_page_image_planning<br/>+ landing_page_html"]
+    A -->|design preset persistido| EF4["experiments.landing_page_design_preset<br/>+ html_geralanding<br/>+ landing_page_html"]
 ```
 
 Leitura operacional (mapeamento por causa-raiz de persistência): a orquestração principal acontece em `GeraLandingStageExecutionService.receiveResult(...)`, que primeiro grava `modelResponse/provisionalHtml/status` em `gera_landing_stage_execution` via `GeraLandingStageExecutionRepository.save(...)` e, em seguida, persiste o artefato da etapa em `experiments` pelo método `persistStageArtifactOnExperiment(...)` com `ExperimentRepository.save(...)`. Para as quatro etapas solicitadas:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1161,3 +1161,14 @@
   - `com.marketinghub.geralanding.copy.CopyProvisionalHtmlAssembler`
   - `com.marketinghub.geralanding.imageplanning.ImagePlanningProvisionalHtmlAssembler`
   - `com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAssembler`
+
+## 2026-05-23 01:30:00 UTC-3
+- solicitação: corrigir erro de renderização Mermaid na seção 1.4 do documento canônico de Gera Landing exibido no GitHub.
+- causa-raiz: labels do diagrama continham quebra de linha e parênteses em formato que o parser do Mermaid no GitHub interpretou como sintaxe inválida.
+- foi feito:
+  - ajuste dos nós com textos multi-linha para formato string com `<br/>` (entre aspas), evitando ambiguidades de parsing;
+  - manutenção do mesmo conteúdo funcional do diagrama (service, repositories e campos persistidos);
+  - registro desta manutenção no histórico de experimentos.
+- arquivos alterados:
+  - docs/gera-landing/modelo-canonico-gera-landing.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Corrigir erro de renderização do diagrama Mermaid em `docs/gera-landing/modelo-canonico-gera-landing.md` causado por labels multilinha e parênteses que quebravam o parser do GitHub.

### Description
- Substituí labels multilinha por labels entre aspas contendo `<br/>` para preservar a quebra visual sem gerar sintaxe inválida no Mermaid; as alterações afetam os nós `EREP`, `SREP` e `EF1..EF4` no diagrama da seção 1.4.
- Mantive o mesmo significado operacional do diagrama e a referência aos métodos `GeraLandingStageExecutionService.receiveResult`, `ExperimentRepository.save` e `GeraLandingStageExecutionRepository.save`.
- Atualizei o log de experimentos em `docs/registros/experimentos.md` registrando a solicitação, causa-raiz e correção aplicada.
- Arquivos modificados: `docs/gera-landing/modelo-canonico-gera-landing.md` e `docs/registros/experimentos.md`.

### Testing
- Verifiquei o diff e o conteúdo das linhas alteradas com `nl -ba docs/gera-landing/modelo-canonico-gera-landing.md | sed -n '55,95p'`, e a saída conferiu as substituições esperadas.
- Confirmei o histórico de registro com `tail`/`nl` em `docs/registros/experimentos.md` para garantir que a tarefa foi logada corretamente.
- Validei o estado do repositório com `git status --short` e criei o commit com `git commit`, ambos executados com sucesso.
- Criei a PR via ferramenta interna (`make_pr`) e o processo retornou o título e corpo do PR conforme esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a112c6b45a88321b52d04d4f3100560)