### PR TITLE
Fix GeraLanding HTML persistence boundaries

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -126,6 +126,7 @@ public class GeraLandingStageExecutionService {
         log.info("GeraLanding publish approval resolved publication URLs (experimentId={}, iframeUrl={}, standaloneUrl={})",
                 experimentId, iframeUrl, standaloneUrl);
 
+        experiment.setLandingPageHtml(htmlWithFacebookPixel.trim());
         experiment.setFollowUpActionUrl(standaloneUrl);
         experimentRepository.save(experiment);
         log.info("GeraLanding publish approval saved follow-up URL (experimentId={}, followUpActionUrl={})",
@@ -295,7 +296,6 @@ public class GeraLandingStageExecutionService {
         if (StringUtils.hasText(enrichedImagePlanning)) {
             experiment.setLandingPageImagePlanning(enrichedImagePlanning);
         }
-        experiment.setLandingPageHtml(provisionalHtml);
         experimentRepository.save(experiment);
         GeraLandingStageExecution execution = executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(toDatabaseIdJob(jobId))
                 .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + jobId));
@@ -511,9 +511,6 @@ public class GeraLandingStageExecutionService {
             experiment.setLandingPageCopyJobId(execution.getIdJob());
         } else if (STAGE_IMAGE_PLANNING.equalsIgnoreCase(stageCode)) {
             experiment.setLandingPageImagePlanning(request.modelResponse());
-            if (StringUtils.hasText(execution.getProvisionalHtml())) {
-                experiment.setLandingPageHtml(execution.getProvisionalHtml());
-            }
         } else if (STAGE_DELIVERABLES.equalsIgnoreCase(stageCode)) {
             experiment.setLandingPageDeliverables(request.modelResponse());
         } else {
@@ -526,7 +523,6 @@ public class GeraLandingStageExecutionService {
             experiment.setLandingPageDesignPreset(request.modelResponse());
             if (StringUtils.hasText(htmlFromDesignPreset)) {
                 experiment.setHtmlGeraLanding(htmlFromDesignPreset);
-                experiment.setLandingPageHtml(htmlFromDesignPreset);
             }
         }
         experimentRepository.save(experiment);

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -276,7 +276,7 @@ class GeraLandingStageExecutionServiceTest {
     }
 
     @Test
-    void shouldPersistProvisionalHtmlOnImagePlanningAndExperimentLandingPageHtml() {
+    void shouldPersistProvisionalHtmlOnImagePlanningWithoutPersistingExperimentLandingPageHtml() {
         GeraLandingResultReceiveRequest request = new GeraLandingResultReceiveRequest(
                 77L,
                 "landing-page-image-planning",
@@ -314,7 +314,7 @@ class GeraLandingStageExecutionServiceTest {
         service.receiveResult("id-image", request);
 
         assertTrue(execution.getProvisionalHtml().contains("https://cdn/img-1.png"));
-        assertEquals(execution.getProvisionalHtml(), experiment.getLandingPageHtml());
+        assertEquals(null, experiment.getLandingPageHtml());
         verify(experimentRepository).save(experiment);
     }
 
@@ -341,7 +341,7 @@ class GeraLandingStageExecutionServiceTest {
         String html = service.generateAndPersistProvisionalHtmlFromExperiment(88L, "job-999");
 
         assertTrue(html.contains("with-images"));
-        assertEquals(html, experiment.getLandingPageHtml());
+        assertEquals(null, experiment.getLandingPageHtml());
         assertTrue(experiment.getLandingPageImagePlanning().contains("imageUrl"));
         assertEquals(html, execution.getProvisionalHtml());
         verify(experimentRepository).save(experiment);
@@ -349,7 +349,7 @@ class GeraLandingStageExecutionServiceTest {
     }
 
     @Test
-    void shouldPersistProvisionalHtmlOnDesignPresetAndExperimentLandingPageHtml() {
+    void shouldPersistProvisionalHtmlOnDesignPresetAndHtmlGeraLandingOnly() {
         GeraLandingResultReceiveRequest request = new GeraLandingResultReceiveRequest(
                 79L,
                 "landing-page-design-preset",
@@ -385,7 +385,7 @@ class GeraLandingStageExecutionServiceTest {
         service.receiveResult("id-design", request);
 
         assertTrue(execution.getProvisionalHtml().contains("design-1.png"));
-        assertEquals(execution.getProvisionalHtml(), experiment.getLandingPageHtml());
+        assertEquals(null, experiment.getLandingPageHtml());
         assertEquals(execution.getProvisionalHtml(), experiment.getHtmlGeraLanding());
         assertEquals(request.modelResponse(), experiment.getLandingPageDesignPreset());
         verify(experimentRepository).save(experiment);

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -71,8 +71,8 @@ Regras complementares:
 |---|---|---|
 | `LANDING_PAGE_WIREFRAME` | `WireframeProvisionalHtmlAssembler` | `gera_landing_stage_execution.provisional_html` |
 | `LANDING_PAGE_COPY` | `CopyProvisionalHtmlAssembler` | `gera_landing_stage_execution.provisional_html` |
-| `LANDING_PAGE_IMAGE_PLANNING` | `ImagePlanningProvisionalHtmlAssembler` (usa internamente `CopyProvisionalHtmlAssembler` + `LandingPageImageInjector` apenas para esta etapa). | `gera_landing_stage_execution.provisional_html` e `experiment.landing_page_html` (quando `provisionalHtml` existe na execução). |
-| `LANDING_PAGE_DESIGN_PRESET` | `DesignPresetProvisionalHtmlAssembler` + `LandingPageImageInjector.injectImages(...)` | `gera_landing_stage_execution.provisional_html`, `experiment.landing_page_design_preset` (JSON bruto da resposta do modelo), `experiment.html_geralanding` (HTML consolidado da etapa) e `experiment.landing_page_html` |
+| `LANDING_PAGE_IMAGE_PLANNING` | `ImagePlanningProvisionalHtmlAssembler` (usa internamente `CopyProvisionalHtmlAssembler` + `LandingPageImageInjector` apenas para esta etapa). | `gera_landing_stage_execution.provisional_html` (não persiste em `experiment.landing_page_html` nesta etapa). |
+| `LANDING_PAGE_DESIGN_PRESET` | `DesignPresetProvisionalHtmlAssembler` + `LandingPageImageInjector.injectImages(...)` | `gera_landing_stage_execution.provisional_html`, `experiment.landing_page_design_preset` (JSON bruto da resposta do modelo) e `experiment.html_geralanding` (HTML consolidado da etapa). `experiment.landing_page_html` só é persistido na aprovação/publicação. |
 
 ### 5.4 Regra de isolamento por conjunto (obrigatória)
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1161,3 +1161,9 @@
   - `com.marketinghub.geralanding.copy.CopyProvisionalHtmlAssembler`
   - `com.marketinghub.geralanding.imageplanning.ImagePlanningProvisionalHtmlAssembler`
   - `com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAssembler`
+
+- 2026-05-23 04:34:00 UTC — Correção de persistência do GeraLanding solicitada pelo usuário:
+  - causa-raiz: o backend ainda gravava HTML provisório das etapas internas em `experiment.landing_page_html`, misturando artefato intermediário com artefato de publicação.
+  - ajuste aplicado: etapas `LANDING_PAGE_IMAGE_PLANNING` e `LANDING_PAGE_DESIGN_PRESET` passam a persistir somente em `gera_landing_stage_execution.provisional_html` e `experiment.html_geralanding` (design preset), sem gravar `landing_page_html`.
+  - ajuste aplicado: `landing_page_html` agora é persistido apenas no fluxo de aprovação/publicação (`approveAndPublishLanding`) com o HTML final efetivamente publicado.
+  - validação: testes unitários de `GeraLandingStageExecutionServiceTest` atualizados para garantir ausência de gravação prematura em `landing_page_html`.


### PR DESCRIPTION
### Motivation

- The pipeline was persisting intermediate assembled HTML into `experiment.landing_page_html`, contaminating the publication field with provisional artifacts from `image-planning` and `design-preset` stages. 
- The intended behavior is to keep stage provisional HTML in `gera_landing_stage_execution.provisional_html` and `experiment.html_geralanding` (design preset) and only populate `experiment.landing_page_html` when the landing is approved and actually published.

### Description

- Stop writing provisional HTML into `experiment.landing_page_html` from `generateAndPersistProvisionalHtmlFromExperiment(...)` and from `persistStageArtifactOnExperiment(...)` for `LANDING_PAGE_IMAGE_PLANNING` and `LANDING_PAGE_DESIGN_PRESET` in `GeraLandingStageExecutionService.java`. 
- Ensure `approveAndPublishLanding(...)` is the sole writer of `experiment.landing_page_html`, assigning the final `htmlWithFacebookPixel.trim()` before saving the experiment. 
- Keep `experiment.html_geralanding` as the consolidated HTML produced by the design preset and persist only that field during preset stage. 
- Update unit tests in `GeraLandingStageExecutionServiceTest.java` to assert that intermediate stages no longer populate `landing_page_html` and to validate provisional HTML remains in `provisional_html`/`html_geralanding`. 
- Update canonical documentation `docs/canonical/procedimento-experimento-canon.v1.md` and the experiment log `docs/registros/experimentos.md` to record the new persistence boundaries and rationale.

### Testing

- Ran module tests with `cd backend/ads-service && ../mvnw -Dtest=GeraLandingStageExecutionServiceTest test` and the updated `GeraLandingStageExecutionServiceTest` suite passed (10/10). 
- An attempted top-level invocation `./mvnw -pl ads-service -Dtest=GeraLandingStageExecutionServiceTest test` failed due to module selection in the reactor, but this did not affect the module-level verification which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a112dac7dc8832199f9d84c8a094412)