### PR TITLE
Assemble design-preset provisional HTML using Experiment data (inject ExperimentRepository)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -448,7 +448,7 @@ public class GeraLandingStageExecutionService {
             return resolveImagePlanningProvisionalHtml(idJob, request, execution);
         }
         if (STAGE_DESIGN_PRESET.equalsIgnoreCase(request.stageCode())) {
-            return designPresetProvisionalHtmlAssembler.assemble(request.modelResponse(), idJob);
+            return designPresetProvisionalHtmlAssembler.assemble(request.experimentId(), request.modelResponse(), idJob);
         }
         return null;
     }
@@ -517,6 +517,7 @@ public class GeraLandingStageExecutionService {
             String htmlFromDesignPreset = execution.getProvisionalHtml();
             if (!StringUtils.hasText(htmlFromDesignPreset)) {
                 htmlFromDesignPreset = designPresetProvisionalHtmlAssembler.assemble(
+                        request.experimentId(),
                         request.modelResponse(),
                         fromDatabaseIdJob(execution.getIdJob()));
             }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
@@ -1,6 +1,9 @@
 package com.marketinghub.geralanding.designpreset;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -15,10 +18,14 @@ public class DesignPresetProvisionalHtmlAssembler {
 
     private final DesignPresetProvisionalHtmlProcessor processor;
     private final ObjectMapper objectMapper;
+    private final ExperimentRepository experimentRepository;
 
-    public DesignPresetProvisionalHtmlAssembler(DesignPresetProvisionalHtmlProcessor processor, ObjectMapper objectMapper) {
+    public DesignPresetProvisionalHtmlAssembler(DesignPresetProvisionalHtmlProcessor processor,
+                                                ObjectMapper objectMapper,
+                                                ExperimentRepository experimentRepository) {
         this.processor = processor;
         this.objectMapper = objectMapper;
+        this.experimentRepository = experimentRepository;
     }
 
 
@@ -30,6 +37,23 @@ public class DesignPresetProvisionalHtmlAssembler {
             return null;
         }
         return preserveCanonicalHtml(designPresetOutput, jobId);
+    }
+
+    /**
+     * Recupera os artefatos do experimento e monta o HTML final do preset de design.
+     */
+    public String assemble(Long experimentId, String designPresetOutput, String jobId) {
+        if (experimentId == null || !StringUtils.hasText(designPresetOutput)) {
+            return null;
+        }
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+        return assemble(
+                experiment.getLandingPageWireframe(),
+                experiment.getLandingPageCopy(),
+                experiment.getLandingPageImagePlanning(),
+                designPresetOutput,
+                jobId);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.geralanding;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAssembler;
 import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlProcessor;
 import org.junit.jupiter.api.Test;
@@ -21,9 +22,13 @@ class DesignPresetProvisionalHtmlAssemblerTest {
     @Test
     void shouldAssembleHtmlWithoutInjectingBehaviorTrackingScript() {
         DesignPresetProvisionalHtmlProcessor processor = mock(DesignPresetProvisionalHtmlProcessor.class);
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         when(processor.process(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn("<html><head><title>x</title></head><body><section data-section-id='hero'></section></body></html>");
-        DesignPresetProvisionalHtmlAssembler assembler = new DesignPresetProvisionalHtmlAssembler(processor, new ObjectMapper());
+        DesignPresetProvisionalHtmlAssembler assembler = new DesignPresetProvisionalHtmlAssembler(
+                processor,
+                new ObjectMapper(),
+                experimentRepository);
 
         String html = assembler.assemble(
                 "{\"landingPageWireframe\":{\"sectionOrder\":[]}}",

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java
@@ -3,6 +3,9 @@ package com.marketinghub.geralanding;
 import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlProcessor;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -80,5 +83,27 @@ class DesignPresetProvisionalHtmlProcessorTest {
                 "{\"landingPageDesignPreset\":{\"theme\":{}}}"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("formato tokenizado");
+    }
+
+    @Test
+    void shouldProcessTokenizedDesignPresetExamplesFromRepository() throws Exception {
+        DesignPresetProvisionalHtmlProcessor processor = new DesignPresetProvisionalHtmlProcessor();
+        String wireframe = "{\"pagina\":{\"head\":{},\"corpo\":{\"secoes\":[]}}}";
+        String copy = "{\"bodySections\":[]}";
+
+        Path examplesDir = Path.of("..", "..", "exemplos");
+        String[] exampleFiles = {
+                "model-response-7179cef3-1f8f-4464-a9d5-c43a49a37fff.json",
+                "model-response-eb0ad12f-09a7-46f0-abc6-658755220c83.json"
+        };
+
+        for (String exampleFile : exampleFiles) {
+            String designPreset = Files.readString(examplesDir.resolve(exampleFile));
+            String html = processor.process(wireframe, copy, "{}", designPreset);
+
+            assertThat(html)
+                    .as("HTML gerado para exemplo %s", exampleFile)
+                    .contains("id=\"lhm-legacy-design-preset-css\"");
+        }
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -379,7 +379,7 @@ class GeraLandingStageExecutionServiceTest {
         when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc("id-design".getBytes(StandardCharsets.UTF_8)))
                 .thenReturn(Optional.of(execution));
         when(experimentRepository.findById(79L)).thenReturn(Optional.of(experiment), Optional.of(experiment));
-        when(designPresetProvisionalHtmlAssembler.assemble(request.modelResponse(), "id-design"))
+        when(designPresetProvisionalHtmlAssembler.assemble(79L, request.modelResponse(), "id-design"))
                 .thenReturn("<html><img src=\"https://cdn/design-1.png\"></html>");
 
         service.receiveResult("id-design", request);


### PR DESCRIPTION
### Motivation

- Allow the design-preset provisional HTML assembler to build final HTML using canonical artifacts stored on the `Experiment` instead of relying only on a single JSON payload.
- Ensure the stage execution service can request assembled HTML for a design preset by providing the `experimentId` so the assembler can fetch missing artifacts.

### Description

- Injects `ExperimentRepository` into `DesignPresetProvisionalHtmlAssembler` and stores it as a field.
- Adds a new overload `assemble(Long experimentId, String designPresetOutput, String jobId)` that fetches the `Experiment` and delegates to the existing multi-argument `assemble` method, throwing `EntityNotFoundException` if the experiment is absent.
- Updates `GeraLandingStageExecutionService` to pass `request.experimentId()` into the assembler when resolving provisional HTML for the `landing-page-design-preset` stage and when computing `htmlFromDesignPreset` before saving the `Experiment`.
- Adjusts unit tests to match the new constructor and call signature and adds an example-driven test for `DesignPresetProvisionalHtmlProcessor` to validate tokenized presets from example files.

### Testing

- Updated and ran unit tests `DesignPresetProvisionalHtmlAssemblerTest`, `DesignPresetProvisionalHtmlProcessorTest`, and `GeraLandingStageExecutionServiceTest` locally under the project test suite with `mvn test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11346ebe28832190ed2b4f96ec697f)