### PR TITLE
Corrige isolamento ArchUnit do pacote geralanding.designpreset

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
@@ -448,7 +448,16 @@ public class GeraLandingStageExecutionService {
             return resolveImagePlanningProvisionalHtml(idJob, request, execution);
         }
         if (STAGE_DESIGN_PRESET.equalsIgnoreCase(request.stageCode())) {
-            return designPresetProvisionalHtmlAssembler.assemble(request.experimentId(), request.modelResponse(), idJob);
+            Experiment experiment = execution.getExperiment();
+            if (experiment == null && request.experimentId() != null) {
+                experiment = experimentRepository.findById(request.experimentId()).orElse(null);
+            }
+            return designPresetProvisionalHtmlAssembler.assemble(
+                    experiment != null ? experiment.getLandingPageWireframe() : null,
+                    experiment != null ? experiment.getLandingPageCopy() : null,
+                    experiment != null ? experiment.getLandingPageImagePlanning() : null,
+                    request.modelResponse(),
+                    idJob);
         }
         return null;
     }
@@ -517,7 +526,9 @@ public class GeraLandingStageExecutionService {
             String htmlFromDesignPreset = execution.getProvisionalHtml();
             if (!StringUtils.hasText(htmlFromDesignPreset)) {
                 htmlFromDesignPreset = designPresetProvisionalHtmlAssembler.assemble(
-                        request.experimentId(),
+                        experiment.getLandingPageWireframe(),
+                        experiment.getLandingPageCopy(),
+                        experiment.getLandingPageImagePlanning(),
                         request.modelResponse(),
                         fromDatabaseIdJob(execution.getIdJob()));
             }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
@@ -1,9 +1,6 @@
 package com.marketinghub.geralanding.designpreset;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.experiment.Experiment;
-import com.marketinghub.experiment.repository.ExperimentRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -18,14 +15,11 @@ public class DesignPresetProvisionalHtmlAssembler {
 
     private final DesignPresetProvisionalHtmlProcessor processor;
     private final ObjectMapper objectMapper;
-    private final ExperimentRepository experimentRepository;
 
     public DesignPresetProvisionalHtmlAssembler(DesignPresetProvisionalHtmlProcessor processor,
-                                                ObjectMapper objectMapper,
-                                                ExperimentRepository experimentRepository) {
+                                                ObjectMapper objectMapper) {
         this.processor = processor;
         this.objectMapper = objectMapper;
-        this.experimentRepository = experimentRepository;
     }
 
 
@@ -37,23 +31,6 @@ public class DesignPresetProvisionalHtmlAssembler {
             return null;
         }
         return preserveCanonicalHtml(designPresetOutput, jobId);
-    }
-
-    /**
-     * Recupera os artefatos do experimento e monta o HTML final do preset de design.
-     */
-    public String assemble(Long experimentId, String designPresetOutput, String jobId) {
-        if (experimentId == null || !StringUtils.hasText(designPresetOutput)) {
-            return null;
-        }
-        Experiment experiment = experimentRepository.findById(experimentId)
-                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
-        return assemble(
-                experiment.getLandingPageWireframe(),
-                experiment.getLandingPageCopy(),
-                experiment.getLandingPageImagePlanning(),
-                designPresetOutput,
-                jobId);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerTest.java
@@ -1,7 +1,6 @@
 package com.marketinghub.geralanding;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAssembler;
 import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlProcessor;
 import org.junit.jupiter.api.Test;
@@ -22,13 +21,11 @@ class DesignPresetProvisionalHtmlAssemblerTest {
     @Test
     void shouldAssembleHtmlWithoutInjectingBehaviorTrackingScript() {
         DesignPresetProvisionalHtmlProcessor processor = mock(DesignPresetProvisionalHtmlProcessor.class);
-        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         when(processor.process(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn("<html><head><title>x</title></head><body><section data-section-id='hero'></section></body></html>");
         DesignPresetProvisionalHtmlAssembler assembler = new DesignPresetProvisionalHtmlAssembler(
                 processor,
-                new ObjectMapper(),
-                experimentRepository);
+                new ObjectMapper());
 
         String html = assembler.assemble(
                 "{\"landingPageWireframe\":{\"sectionOrder\":[]}}",

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
@@ -379,7 +379,12 @@ class GeraLandingStageExecutionServiceTest {
         when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc("id-design".getBytes(StandardCharsets.UTF_8)))
                 .thenReturn(Optional.of(execution));
         when(experimentRepository.findById(79L)).thenReturn(Optional.of(experiment), Optional.of(experiment));
-        when(designPresetProvisionalHtmlAssembler.assemble(79L, request.modelResponse(), "id-design"))
+        when(designPresetProvisionalHtmlAssembler.assemble(
+                experiment.getLandingPageWireframe(),
+                experiment.getLandingPageCopy(),
+                experiment.getLandingPageImagePlanning(),
+                request.modelResponse(),
+                "id-design"))
                 .thenReturn("<html><img src=\"https://cdn/design-1.png\"></html>");
 
         service.receiveResult("id-design", request);

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1189,3 +1189,12 @@
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
   - backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingStageExecutionServiceTest.java
+
+## 2026-05-23 05:40:00 UTC
+- solicitação: corrigir violação ArchUnit de isolamento do subpacote `geralanding.designpreset`.
+- causa-raiz: `DesignPresetProvisionalHtmlAssembler` dependia diretamente de `ExperimentRepository` e `Experiment`, quebrando a regra de independência do subpacote.
+- correção aplicada:
+  - removida a dependência de `ExperimentRepository`/`Experiment` do assembler de design preset;
+  - removido o overload `assemble(Long experimentId, ...)` no assembler;
+  - `GeraLandingStageExecutionService` passou a fornecer explicitamente `wireframe/copy/imagePlanning` já carregados do experimento para o assembler.
+- validação: teste `ModuleIsolationArchitectureTest` executado com sucesso após o ajuste.


### PR DESCRIPTION
### Motivation
- Arquitetura: o subpacote `com.marketinghub.geralanding.designpreset` estava dependendo de classes de `com.marketinghub.experiment`, violando a regra de isolamento definida pelos testes ArchUnit.
- Objetivo: eliminar acoplamento direto ao `ExperimentRepository`/`Experiment` para manter o subpacote `geralanding.designpreset` independente dos demais pacotes internos.

### Description
- Removida a dependência de `ExperimentRepository` e `Experiment` de `DesignPresetProvisionalHtmlAssembler`, incluindo a remoção do overload `assemble(Long experimentId, ...)`, mantendo apenas as assinaturas que recebem os artefatos por parâmetro.
- Atualizado `GeraLandingStageExecutionService` para carregar o `Experiment` quando necessário e passar explicitamente `landingPageWireframe`, `landingPageCopy` e `landingPageImagePlanning` para o `DesignPresetProvisionalHtmlAssembler` tanto na resolução de HTML provisório quanto na persistência do artefato.
- Ajustados os testes afetados para o novo contrato do assembler em `DesignPresetProvisionalHtmlAssemblerTest` e `GeraLandingStageExecutionServiceTest` e registrada a mudança em `docs/registros/experimentos.md`.

### Testing
- Executado o conjunto de testes relevante com `cd backend/ads-service && ../mvnw -Dtest=ModuleIsolationArchitectureTest,DesignPresetProvisionalHtmlAssemblerTest,GeraLandingStageExecutionServiceTest test -q`.
- Resultado: todos os testes mencionados passaram com sucesso (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a113cb9097c8321837053481c689eae)