### PR TITLE
Adjust ArchUnit rules to require new DesignPreset assembler signature

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/GeraLandingAssemblerArchitectureTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/GeraLandingAssemblerArchitectureTest.java
@@ -16,7 +16,7 @@ import com.tngtech.archunit.lang.ArchRule;
 class GeraLandingAssemblerArchitectureTest {
 
     @ArchTest
-    static final ArchRule stageExecutionServiceMustNotCallLegacyFiveArgDesignPresetAssembler = noClasses()
+    static final ArchRule stageExecutionServiceMustNotCallLegacyTwoArgDesignPresetAssembler = noClasses()
             .that()
             .haveFullyQualifiedName("com.marketinghub.geralanding.GeraLandingStageExecutionService")
             .should()
@@ -24,11 +24,8 @@ class GeraLandingAssemblerArchitectureTest {
                     DesignPresetProvisionalHtmlAssembler.class,
                     "assemble",
                     String.class,
-                    String.class,
-                    String.class,
-                    String.class,
                     String.class)
-            .because("o serviço deve usar o contrato padronizado assemble(modelResponse, jobId) para design-preset");
+            .because("o serviço deve usar o contrato padronizado com os novos parâmetros do design-preset");
 
 
     @ArchTest
@@ -77,8 +74,11 @@ class GeraLandingAssemblerArchitectureTest {
                     DesignPresetProvisionalHtmlAssembler.class,
                     "assemble",
                     String.class,
+                    String.class,
+                    String.class,
+                    String.class,
                     String.class)
-            .because("quando STAGE_DESIGN_PRESET for processado, o assembler canônico de design preset deve ser usado");
+            .because("quando STAGE_DESIGN_PRESET for processado, o assembler canônico de design preset com novos parâmetros deve ser usado");
 
     @ArchTest
     static final ArchRule stageExecutionServiceMustCallStandardCopyAssembler = classes()

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1198,3 +1198,11 @@
   - removido o overload `assemble(Long experimentId, ...)` no assembler;
   - `GeraLandingStageExecutionService` passou a fornecer explicitamente `wireframe/copy/imagePlanning` já carregados do experimento para o assembler.
 - validação: teste `ModuleIsolationArchitectureTest` executado com sucesso após o ajuste.
+
+## 2026-05-23 06:12:00 UTC
+- solicitação: ajustar teste de arquitetura do GeraLanding para refletir a chamada do assembler de design preset com novos parâmetros.
+- causa-raiz: o teste ArchUnit ainda tratava a assinatura com cinco parâmetros como legado proibido, embora o serviço já use essa assinatura no fluxo atual.
+- correção aplicada:
+  - regra de bloqueio atualizada para proibir o overload antigo `assemble(String, String)` em `DesignPresetProvisionalHtmlAssembler`;
+  - regra de conformidade atualizada para exigir a chamada `assemble(String, String, String, String, String)` no `GeraLandingStageExecutionService`.
+- validação: teste `GeraLandingAssemblerArchitectureTest` executado com sucesso.


### PR DESCRIPTION
### Motivation
- The architecture test needed updating to reflect the real contract now used by `GeraLandingStageExecutionService` so tests enforce the canonical design-preset assembler usage and avoid false violations.
- Keep the project canon and experiment logs consistent by recording the change in the experiment registry.

### Description
- Updated `backend/ads-service/src/test/java/com/marketinghub/architecture/GeraLandingAssemblerArchitectureTest.java` to forbid the legacy `DesignPresetProvisionalHtmlAssembler.assemble(String, String)` overload and to require the new `assemble(String, String, String, String, String)` call from `GeraLandingStageExecutionService`.
- Adjusted the `because(...)` messages to reflect the new parameter contract for the design-preset assembler.
- Appended an entry to `docs/registros/experimentos.md` documenting the change and rationale per project process.

### Testing
- Executed the targeted ArchUnit test with `../../backend/mvnw -q -Dtest=GeraLandingAssemblerArchitectureTest test` from `backend/ads-service`; the test passed (green).
- No production code was changed; only architecture tests and experiment records were modified, and the updated test validated the intended contract enforcement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11445b11f48321acef457710974074)