### PR TITLE
docs: add Section 13 data model (collectors ↔ sales library) and registro entry

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -203,3 +203,113 @@ Quando houver dúvida sobre “onde o fluxo começa”, considerar canonicamente
   - `Marcar como anulado`: registra status `ANULADO` para itens que não serão mais utilizados no funil.
 - Contrato backend oficial: `POST /api/mois/sales-library/pages/{pageId}:status` com payload `{ "status": "PENDING" | "ANULADO", "reason"?: string }`.
 - A interface de detalhe também deve exibir navegação sequencial com botão `Próximo →` para avançar ao próximo item da lista local.
+
+
+## 13. Seção de Dados — Modelo compartilhado (Coletores Hotmart/ClickBank + Biblioteca de Páginas)
+
+Esta seção define o **modelo de dados canônico mínimo** que conecta a coleta de produtos vencedores (Hotmart/ClickBank) com a operação da Biblioteca de Páginas de Vendas.
+
+### 13.1 Visão relacional (macro)
+```mermaid
+erDiagram
+    MOIS_COLLECTED_REFERENCE ||--o{ MOIS_SALES_LIBRARY_URL_INGEST : "origina URLs candidatas"
+    MOIS_SALES_LIBRARY_URL_INGEST ||--o{ MOIS_SALES_LIBRARY_PROCESSING_JOB : "gera jobs"
+    MOIS_SALES_LIBRARY_PROCESSING_JOB ||--o| MOIS_SALES_LIBRARY_PAGE_ANALYSIS : "resultado de análise"
+    MOIS_SALES_LIBRARY_URL_INGEST ||--o{ MOIS_SALES_LIBRARY_PAGE_SNAPSHOT : "versionamento de captura"
+    MOIS_SALES_LIBRARY_PAGE_SNAPSHOT ||--o{ MOIS_SALES_LIBRARY_SNAPSHOT_ARTIFACT : "artefatos por tipo"
+```
+
+### 13.2 Tabelas usadas pelos coletores (Hotmart e ClickBank)
+
+#### 13.2.1 `mois_collected_reference`
+- **Papel no fluxo**: persistir referências coletadas dos marketplaces com sinais de sucesso comercial, servindo de base para seleção de URLs de página de vendas.
+- **Origem principal**: endpoints de persistência do MOIS alimentados pelos coletores Hotmart/ClickBank.
+- **Campos funcionais de destaque**:
+  - identificação e rastreio: `id`, `workspace_id`, `source`, `job_id`, `reference_id`;
+  - dados do produto: `product_name`, `product_url`, `sales_page_url`, `details_url`, `cover_image_url`;
+  - sinais de priorização: `success_score`, `temperature`, `hotmart_price`, `hotmart_currency`, `hotmart_highlights_json`;
+  - auditoria: `collected_at`, `created_at`, `updated_at`.
+- **Índices canônicos de operação**:
+  - unicidade por referência coletada no job (`job_id`, `reference_id`);
+  - busca por workspace/fonte (`workspace_id`, `source`);
+  - ordenação por score (`workspace_id`, `success_score`).
+
+### 13.3 Tabelas usadas no projeto da Biblioteca de Páginas de Vendas
+
+#### 13.3.1 `mois_sales_library_url_ingest`
+- **Papel no fluxo**: tabela de entrada (ingestão) de URLs canônicas provenientes da coleta.
+- **Função operacional**: deduplicar URLs, manter metadados de origem e disparar criação de job para itens novos.
+- **Campos de destaque**: `id`, `workspace_id`, `source`, `url_original`, `url_canonical`, `title`, `captured_at`, `created_at`, `updated_at`.
+
+#### 13.3.2 `mois_sales_library_processing_job`
+- **Papel no fluxo**: orquestrar estado assíncrono do processamento por URL.
+- **Função operacional**: controlar ciclo `PENDING/FETCHING/ANALYZING/RETRY_WAIT/DONE/FAILED`.
+- **Campos de destaque**: `id`, `url_ingest_id`, `status`, `attempt_count`, `error_category`, `error_message`, `next_retry_at`, `created_at`, `updated_at`.
+
+#### 13.3.3 `mois_sales_library_page_analysis`
+- **Papel no fluxo**: armazenar o resultado estruturado da análise comercial executada pelo worker.
+- **Função operacional**: persistir score, seções e sinais semânticos retornados pelo pipeline OpenAI.
+- **Campos de destaque**: `id`, `url_ingest_id`, `job_id`, `status`, `score_total`, `sections_json`, `copy_json`, `visual_json`, `image_json`, `analysis_notes`, `parser_version`, `prompt_version`, `model_name`, `processed_at`, `created_at`, `updated_at`.
+
+#### 13.3.4 `mois_sales_library_page_snapshot`
+- **Papel no fluxo**: guardar snapshots/versionamento da página capturada para comparação temporal.
+- **Função operacional**: registrar mudanças de conteúdo entre capturas e apoiar trilha de auditoria.
+- **Campos de destaque**: `id`, `url_ingest_id`, `snapshot_hash`, `html_content`, `text_content`, `captured_at`, `status`, `created_at`, `updated_at`.
+
+#### 13.3.5 `mois_sales_library_snapshot_artifact`
+- **Papel no fluxo**: armazenar artefatos derivados por snapshot (ex.: sumários ou classificações por tipo).
+- **Função operacional**: separar artefatos auxiliares por `artifact_type` vinculados ao snapshot.
+- **Campos de destaque**: `id`, `snapshot_id`, `artifact_type`, `artifact_payload`, `created_at`, `updated_at`.
+
+### 13.4 Regras de integração entre coletores e biblioteca
+1. A transição **coletor -> biblioteca** deve ocorrer por endpoint backend (`/api/mois/sales-library/urls:ingest`), nunca por escrita direta no banco.
+2. A URL de priorização para ingestão deve seguir ordem canônica: `salesPageUrl` e fallback para `detailsUrl`.
+3. Toda URL nova ingerida deve potencialmente gerar job em `mois_sales_library_processing_job` com status inicial `PENDING`.
+4. Persistência de análise final deve ficar em `mois_sales_library_page_analysis`, mantendo rastreabilidade por `job_id` e `url_ingest_id`.
+5. Snapshots e artefatos complementares não substituem a análise principal; eles enriquecem histórico e diagnóstico.
+
+
+### 13.5 Diagrama de dados (somente chaves)
+```mermaid
+erDiagram
+    MOIS_COLLECTED_REFERENCE {
+        bigint id PK
+        varchar job_id UK
+        varchar reference_id UK
+    }
+
+    MOIS_SALES_LIBRARY_URL_INGEST {
+        bigint id PK
+        varchar url_canonical UK
+    }
+
+    MOIS_SALES_LIBRARY_PROCESSING_JOB {
+        bigint id PK
+        bigint url_ingest_id FK
+    }
+
+    MOIS_SALES_LIBRARY_PAGE_ANALYSIS {
+        bigint id PK
+        bigint url_ingest_id FK
+        bigint job_id FK
+    }
+
+    MOIS_SALES_LIBRARY_PAGE_SNAPSHOT {
+        bigint id PK
+        bigint url_ingest_id FK
+        varchar snapshot_hash UK
+    }
+
+    MOIS_SALES_LIBRARY_SNAPSHOT_ARTIFACT {
+        bigint id PK
+        bigint snapshot_id FK
+    }
+
+    MOIS_COLLECTED_REFERENCE ||--o{ MOIS_SALES_LIBRARY_URL_INGEST : "fornece URLs"
+    MOIS_SALES_LIBRARY_URL_INGEST ||--o{ MOIS_SALES_LIBRARY_PROCESSING_JOB : "1:N jobs"
+    MOIS_SALES_LIBRARY_URL_INGEST ||--o{ MOIS_SALES_LIBRARY_PAGE_ANALYSIS : "1:N análises"
+    MOIS_SALES_LIBRARY_PROCESSING_JOB ||--o| MOIS_SALES_LIBRARY_PAGE_ANALYSIS : "job resultado"
+    MOIS_SALES_LIBRARY_URL_INGEST ||--o{ MOIS_SALES_LIBRARY_PAGE_SNAPSHOT : "1:N snapshots"
+    MOIS_SALES_LIBRARY_PAGE_SNAPSHOT ||--o{ MOIS_SALES_LIBRARY_SNAPSHOT_ARTIFACT : "1:N artefatos"
+```
+

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -420,3 +420,11 @@
 - arquivo alterado: `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`.
 
 - 2026-05-22: Incluída regra operacional no AGENTS do módulo `mois-sales-library-worker` exigindo logs de request/resposta OpenAI e payload ao backend com `jobId` do Marketing Hub.
+
+## 2026-05-23 00:00:00 UTC
+- atualização do cânone MOIS (`docs/canonical/mois-worker-canon.v1.md`) com a nova **Seção 13 — Dados**.
+- adicionado modelo de dados relacional compartilhado entre coletores (Hotmart/ClickBank) e projeto da Biblioteca de Páginas de Vendas.
+- documentadas as tabelas centrais e seus papéis no fluxo: `mois_collected_reference`, `mois_sales_library_url_ingest`, `mois_sales_library_processing_job`, `mois_sales_library_page_analysis`, `mois_sales_library_page_snapshot` e `mois_sales_library_snapshot_artifact`.
+- incluídas regras de integração canônicas entre coleta e biblioteca para preservar rastreabilidade e evitar escrita direta fora do backend.
+- complemento solicitado pelo usuário: adicionado diagrama adicional detalhado de dados (ER com PK/FK/UK e cardinalidades) na seção 13.5 do cânone MOIS.
+- ajuste solicitado: o diagrama da seção 13.5 foi simplificado para exibir **somente chaves** (PK/FK/UK), removendo campos não-chave.


### PR DESCRIPTION
### Motivation
- Provide a canonical, minimal relational data model that connects marketplace collectors (Hotmart/ClickBank) with the Sales Pages Library pipeline to ensure traceability and consistent ingestion semantics.
- Document table responsibilities, keys and integration rules to prevent direct DB writes and to standardize the `POST /api/mois/sales-library/urls:ingest` flow.
- Capture a user-requested simplified keys-only ER diagram for operational clarity and audit/versioning needs.

### Description
- Added a new Section 13 to `docs/canonical/mois-worker-canon.v1.md` with an overview ER diagram, detailed table descriptions for `mois_collected_reference`, `mois_sales_library_url_ingest`, `mois_sales_library_processing_job`, `mois_sales_library_page_analysis`, `mois_sales_library_page_snapshot`, and `mois_sales_library_snapshot_artifact`.
- Included canonical integration rules between collectors and the library, table field highlights, and a keys-only ER diagram in subsection 13.5 showing PK/FK/UK and cardinalities.
- Updated `docs/registros/mois1.md` to record the addition of Section 13 and describe the changes (including the simplified keys-only diagram) in the project changelog.
- Preserved previously added operational notes about OpenAI request/response logging requirement in the AGENTS context and the backend status endpoint contract described in the canonical doc.

### Testing
- Built the documentation with `mkdocs build` and ran `markdownlint` against the changed files, and both completed successfully.
- Ran the repository CI pipeline for docs changes and the pipeline passed all checks.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c83d13f88321acc4bdb6e582e982)