### PR TITLE
docs(mois): detalha leitura e gravação de tabelas no fluxo 12.2

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -155,14 +155,17 @@ sequenceDiagram
 
     rect rgb(245,245,245)
     Note over API,DB: 2) URL disponível na biblioteca
-    API->>DB: UPSERT mois_sales_library_url_ingest<br/>(url_original, url_canonical, title, capturedAt...)
-    API->>DB: INSERT mois_sales_library_processing_job<br/>(status=PENDING) para URL nova
+    API->>DB: WRITE mois_sales_library_url_ingest (UPSERT)\n(url_original, url_canonical, title, capturedAt...)
+    API->>DB: READ mois_sales_library_url_ingest\n(validar deduplicação/canonicalização)
+    API->>DB: WRITE mois_sales_library_processing_job (INSERT)\n(status=PENDING) para URL nova
     end
 
     rect rgb(245,245,245)
     Note over WK,API: 3) Worker coleta conteúdo
     WK->>API: POST /jobs:claim (workspaceId, source)
-    API->>DB: UPDATE job PENDING->FETCHING
+    API->>DB: READ mois_sales_library_processing_job\n(seleciona job PENDING por source/workspace)
+    API->>DB: READ mois_sales_library_url_ingest\n(resolve urlCanonical da página)
+    API->>DB: WRITE mois_sales_library_processing_job (UPDATE)\n(PENDING->FETCHING)
     API-->>WK: jobId, pageId, urlCanonical
     WK->>WK: GET urlCanonical + parse HTML (body.text)
     end
@@ -176,14 +179,25 @@ sequenceDiagram
     rect rgb(245,245,245)
     Note over WK,DB: 5) Persistência dos resultados
     WK->>API: POST /jobs/{jobId}:complete<br/>(scoreTotal, sectionsJson, copyJson, visualJson, imageJson...)
-    API->>DB: INSERT mois_sales_library_page_analysis (status=DONE)
-    API->>DB: UPDATE mois_sales_library_processing_job -> DONE
+    API->>DB: READ mois_sales_library_processing_job (jobId vigente)
+    API->>DB: WRITE mois_sales_library_page_analysis (INSERT, status=DONE)
+    API->>DB: WRITE mois_sales_library_processing_job (UPDATE -> DONE)
     alt erro terminal
       WK->>API: POST /jobs/{jobId}:fail (PIPELINE_ERROR, message)
-      API->>DB: UPDATE mois_sales_library_processing_job -> FAILED
+      API->>DB: READ mois_sales_library_processing_job (jobId vigente)
+      API->>DB: WRITE mois_sales_library_processing_job (UPDATE -> FAILED)
     end
     end
 ```
+
+### 12.2.1 Tabelas lidas e gravadas por etapa do fluxo
+
+| Etapa | Leitura (READ) | Gravação (WRITE) |
+|---|---|---|
+| Ingestão (`/urls:ingest`) | `mois_sales_library_url_ingest` (deduplicação/canonicalização) | `mois_sales_library_url_ingest` (upsert), `mois_sales_library_processing_job` (insert `PENDING`) |
+| Claim (`/jobs:claim`) | `mois_sales_library_processing_job` (seleção de job pendente), `mois_sales_library_url_ingest` (obter `urlCanonical`) | `mois_sales_library_processing_job` (update `FETCHING`) |
+| Complete (`/jobs/{jobId}:complete`) | `mois_sales_library_processing_job` (validar job vigente) | `mois_sales_library_page_analysis` (insert), `mois_sales_library_processing_job` (update `DONE`) |
+| Fail (`/jobs/{jobId}:fail`) | `mois_sales_library_processing_job` (validar job vigente) | `mois_sales_library_processing_job` (update `FAILED`) |
 
 ### 12.3 Contratos e tabelas de persistência (referência rápida)
 - **Endpoint de ingestão**: `POST /api/mois/sales-library/urls:ingest`.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -428,3 +428,8 @@
 - incluídas regras de integração canônicas entre coleta e biblioteca para preservar rastreabilidade e evitar escrita direta fora do backend.
 - complemento solicitado pelo usuário: adicionado diagrama adicional detalhado de dados (ER com PK/FK/UK e cardinalidades) na seção 13.5 do cânone MOIS.
 - ajuste solicitado: o diagrama da seção 13.5 foi simplificado para exibir **somente chaves** (PK/FK/UK), removendo campos não-chave.
+
+## 2026-05-23 00:00:00 UTC
+- atualização solicitada no cânone MOIS (`docs/canonical/mois-worker-canon.v1.md`) na seção **12.2 Diagrama (sequência ponta a ponta)** para explicitar quais tabelas são lidas e gravadas em cada etapa do fluxo.
+- diagrama mermaid ajustado com marcações `READ` e `WRITE` por etapa (`/urls:ingest`, `/jobs:claim`, `/jobs/{jobId}:complete`, `/jobs/{jobId}:fail`).
+- adicionada subseção **12.2.1 Tabelas lidas e gravadas por etapa do fluxo** com tabela-resumo operacional por endpoint.


### PR DESCRIPTION
### Motivation
- Tornar explícito, no diagrama de sequência ponta-a-ponta do worker MOIS, quais tabelas são lidas (`READ`) e gravadas (`WRITE`) em cada etapa para facilitar diagnóstico e evitar dúvidas sobre onde ocorrem leituras/escritas no fluxo assíncrono.
- Alinhar a documentação ao princípio operacional que o backend é o único componente que escreve no banco, reforçando rastreabilidade entre coletores, ingestão e worker.

### Description
- Atualiza `docs/canonical/mois-worker-canon.v1.md` seção **12.2** substituindo linhas genéricas de DB por anotações explícitas `READ`/`WRITE` nas etapas `ingest`, `claim`, `complete` e `fail` e detalhando as operações envolvidas (ex.: leitura para deduplicação, leitura de job vigente, inserts/updates). 
- Adiciona a subseção `12.2.1 Tabelas lidas e gravadas por etapa do fluxo` com uma tabela-resumo por endpoint mostrando claramente quais tabelas são lidas e quais são gravadas. 
- Registra a atividade em `docs/registros/mois1.md` conforme processo operacional do projeto.

### Testing
- Executed `git status --short` and `git commit` to record the change, both completed successfully. 
- Previewed the modified ranges with `nl -ba docs/canonical/mois-worker-canon.v1.md | sed -n '139,225p'` and `nl -ba docs/registros/mois1.md | tail -n 25`, both returned the updated content as expected. 
- No automated unit tests apply because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11cc6e83388321ba005d7df61c9f4d)