### PR TITLE
docs(mois): add architecture-by-module diagram and refine sequence diagram positioning/annotations

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -143,9 +143,14 @@ sequenceDiagram
     participant HC as Hotmart Collector
     participant CC as ClickBank Collector
     participant API as Backend MOIS (/api/mois/sales-library)
-    participant DB as MySQL 5.7
     participant WK as MOIS Sales Library Worker
     participant OAI as OpenAI Batch (/v1/responses)
+    participant DB as MySQL 5.7
+
+    %% Banco destacado com cor própria e posicionado na extrema direita
+    box rgb(255, 245, 210) Camada de Persistência (MySQL 5.7)
+      Note over DB: Banco de dados principal
+    end
 
     rect rgb(245,245,245)
     Note over HC,CC: 1) Ingestão de produtos de sucesso
@@ -327,3 +332,33 @@ erDiagram
     MOIS_SALES_LIBRARY_PAGE_SNAPSHOT ||--o{ MOIS_SALES_LIBRARY_SNAPSHOT_ARTIFACT : "1:N artefatos"
 ```
 
+
+
+### 12.5 Diagrama de arquitetura por módulo/pacote
+
+Diagrama canônico da arquitetura lógica usando como unidade os módulos/pacotes, destacando dependências e integrações com banco e OpenAI.
+
+```mermaid
+graph TD
+    HC[mois-hotmart-collector\npackage: com.marketinghub.mois.hotmart.collector] -->|POST /api/mois/sales-library/urls:ingest| BM[backend/ads-service\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.web]
+    CC[mois-clickbank-collector\npackage: com.marketinghub.mois.clickbank.collector] -->|POST /api/mois/sales-library/urls:ingest| BM
+
+    WK[mois-sales-library-worker\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service] -->|jobs:claim, jobs/{id}:complete, jobs/{id}:fail| BM
+    WK -->|/v1/responses (batch)| OAI[OpenAI API]
+
+    BM -->|JPA/SQL via camada backend| DB[(MySQL 5.7)]
+
+    subgraph Backend MOIS
+      BM
+      BS[backend/ads-service\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service]
+      BR[backend/ads-service\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.repository]
+      BM --> BS --> BR
+    end
+
+    BR -->|READ/WRITE: ingest, jobs, analyses, snapshots| DB
+```
+
+#### Regras de integração refletidas no diagrama
+- Coletores e worker **não acessam banco diretamente**; todo acesso a dados passa pelo backend MOIS.
+- A integração com OpenAI é realizada pelo `mois-sales-library-worker`, com retorno consolidado ao backend via endpoint de conclusão/falha.
+- A persistência em MySQL 5.7 ocorre apenas nos pacotes de serviço/repositório do backend.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -433,3 +433,14 @@
 - atualização solicitada no cânone MOIS (`docs/canonical/mois-worker-canon.v1.md`) na seção **12.2 Diagrama (sequência ponta a ponta)** para explicitar quais tabelas são lidas e gravadas em cada etapa do fluxo.
 - diagrama mermaid ajustado com marcações `READ` e `WRITE` por etapa (`/urls:ingest`, `/jobs:claim`, `/jobs/{jobId}:complete`, `/jobs/{jobId}:fail`).
 - adicionada subseção **12.2.1 Tabelas lidas e gravadas por etapa do fluxo** com tabela-resumo operacional por endpoint.
+
+
+## 2026-05-23 00:00:00 UTC
+- atualização solicitada no documento canônico `docs/canonical/mois-worker-canon.v1.md` com inclusão de diagrama de arquitetura por unidade de módulo/pacote.
+- adicionada a seção **12.5 Diagrama de arquitetura por módulo/pacote** com Mermaid destacando dependências entre coletores, worker, backend MOIS, OpenAI API e MySQL 5.7.
+- reforçadas no próprio cânone as regras de integração: sem acesso direto ao banco fora do backend e integração OpenAI concentrada no worker.
+
+
+## 2026-05-23 00:00:00 UTC
+- ajuste no diagrama de sequência da seção 12.2 do cânone MOIS para posicionar o elemento MySQL como o mais à direita da arquitetura.
+- aplicado destaque visual do MySQL em cor distinta usando `box rgb(255, 245, 210)` para separar a camada de persistência no Mermaid.


### PR DESCRIPTION
### Motivation
- Clarify the MOIS sales-library end-to-end flow and integration boundaries by making the persistence layer and module/package-level architecture explicit in the canonical worker document.
- Improve operational guidance for collectors, backend and worker by documenting which tables are read/written per step and by reinforcing the rule that only the backend accesses the database.
- Provide a compact module-level view to show package boundaries and OpenAI interaction responsibility to aid maintainers and onboarding.

### Description
- Updated `docs/canonical/mois-worker-canon.v1.md` to reposition the MySQL participant to the far right of the sequence diagram and added a colored `box` highlighting the persistence layer in section `12.2`.
- Added a new section `12.5 Diagrama de arquitetura por módulo/pacote` containing a Mermaid graph that maps collectors, backend packages, the worker, OpenAI API and MySQL with explicit package names and interactions.
- Extended diagram annotations and the canonical text to state integration rules that collectors and worker do not access the DB directly and that the worker is responsible for OpenAI calls and reporting results to the backend.
- Updated `docs/registros/mois1.md` changelog entries to record the new diagrams, the sequence-diagram adjustments, and the added architectural guidance.

### Testing
- None — this is a documentation-only change and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11dc9439208321b7805f9d3f2b99c2)