### PR TITLE
Add totals summary to MOIS Sales Pages Library screen

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -444,3 +444,13 @@
 ## 2026-05-23 00:00:00 UTC
 - ajuste no diagrama de sequência da seção 12.2 do cânone MOIS para posicionar o elemento MySQL como o mais à direita da arquitetura.
 - aplicado destaque visual do MySQL em cor distinta usando `box rgb(255, 245, 210)` para separar a camada de persistência no Mermaid.
+
+## 2026-05-23 14:13:48 UTC-3
+- solicitada melhoria na tela da Biblioteca Sales Pages do MOIS para exibir totalizações operacionais de produtos.
+- foi aproveitado o contrato já existente do endpoint da biblioteca, calculando os indicadores no frontend sem necessidade de novo endpoint.
+- adicionados cards com: total coletados, total de produtos Hotmart, total de produtos Clickbank e total com análise.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+  - docs/registros/mois1.md

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -26,6 +26,24 @@ function getPipelinePhase(status?: string | null) {
 
 export default function MoisSalesPagesLibraryPage() {
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
+  const summary = pagesQuery.data?.items.reduce(
+    (acc, item) => {
+      const source = item.source?.toUpperCase();
+      const hasAnalysis = item.analysisStatus && item.analysisStatus !== "PENDING";
+      acc.totalCollected += 1;
+      if (source === "HOTMART") {
+        acc.totalHotmart += 1;
+      }
+      if (source === "CLICKBANK") {
+        acc.totalClickbank += 1;
+      }
+      if (hasAnalysis) {
+        acc.totalWithAnalysis += 1;
+      }
+      return acc;
+    },
+    { totalCollected: 0, totalHotmart: 0, totalClickbank: 0, totalWithAnalysis: 0 },
+  );
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -38,6 +56,43 @@ export default function MoisSalesPagesLibraryPage() {
           Voltar ao workspace
         </Link>
       </header>
+
+      {summary ? (
+        <section className="row g-3">
+          <div className="col-sm-6 col-lg-3">
+            <div className="card border-0 shadow-sm h-100">
+              <div className="card-body">
+                <p className="text-secondary mb-1">Total coletados</p>
+                <h3 className="mb-0">{summary.totalCollected}</h3>
+              </div>
+            </div>
+          </div>
+          <div className="col-sm-6 col-lg-3">
+            <div className="card border-0 shadow-sm h-100">
+              <div className="card-body">
+                <p className="text-secondary mb-1">Produtos Hotmart</p>
+                <h3 className="mb-0">{summary.totalHotmart}</h3>
+              </div>
+            </div>
+          </div>
+          <div className="col-sm-6 col-lg-3">
+            <div className="card border-0 shadow-sm h-100">
+              <div className="card-body">
+                <p className="text-secondary mb-1">Produtos Clickbank</p>
+                <h3 className="mb-0">{summary.totalClickbank}</h3>
+              </div>
+            </div>
+          </div>
+          <div className="col-sm-6 col-lg-3">
+            <div className="card border-0 shadow-sm h-100">
+              <div className="card-body">
+                <p className="text-secondary mb-1">Total com análise</p>
+                <h3 className="mb-0">{summary.totalWithAnalysis}</h3>
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : null}
 
       <section className="card border-0 shadow-sm">
         <div className="card-body table-responsive">


### PR DESCRIPTION
### Motivation
- For the Biblioteca de Páginas de Vendas screen we need quick operational KPIs showing totals collected, totals by source (Hotmart / ClickBank) and how many have analysis. 
- The change should reuse the existing backend contract and compute indicators in the frontend to avoid new endpoints. 

### Description
- Added a summary calculation using `items.reduce(...)` in `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx` that counts `totalCollected`, `totalHotmart`, `totalClickbank` and `totalWithAnalysis`. 
- Rendered four KPI cards above the table showing those totals with responsive Bootstrap layout. 
- Recorded the change in the MOIS operational log `docs/registros/mois1.md` with the required UTC-3 timestamp. 

### Testing
- Attempted a local frontend build with `cd frontend && npm run build`, but the command failed in the environment due to missing `vite` (`sh: 1: vite: not found`). 
- No backend contract changes were made and no automated unit tests were added or modified for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e014705083219a0e9fb9f6c34a98)