### PR TITLE
Persist and surface OpenAI request payload for MOIS sales-library analyses

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -37,6 +37,7 @@ public final class MoisSalesLibraryDtos {
             String visualJson,
             String imageJson,
             String analysisNotes,
+            String requestPayloadJson,
             String parserVersion,
             String promptVersion,
             String modelName,
@@ -156,6 +157,7 @@ public final class MoisSalesLibraryDtos {
             String visualJson,
             String imageJson,
             String analysisNotes,
+            String requestPayloadJson,
             Instant analyzedAt,
             Instant updatedAt
     ) {

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -51,9 +51,9 @@ public class MoisSalesLibraryService {
         if (pageId == null) throw new IllegalArgumentException("Job not found: " + jobId);
         jdbcTemplate.update("""
                 INSERT INTO mois_sales_library_page_analysis
-                (url_ingest_id, job_id, status, score_total, parser_version, prompt_version, model_name, sections_json, copy_json, visual_json, image_json, analysis_notes, analyzed_at, created_at, updated_at)
-                VALUES (?, ?, 'DONE', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
-                """, pageId, jobId, request.scoreTotal(), request.parserVersion(), request.promptVersion(), request.modelName(), request.sectionsJson(), request.copyJson(), request.visualJson(), request.imageJson(), request.analysisNotes(), request.analyzedAt() == null ? Instant.now() : request.analyzedAt());
+                (url_ingest_id, job_id, status, score_total, parser_version, prompt_version, model_name, sections_json, copy_json, visual_json, image_json, analysis_notes, request_payload_json, analyzed_at, created_at, updated_at)
+                VALUES (?, ?, 'DONE', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                """, pageId, jobId, request.scoreTotal(), request.parserVersion(), request.promptVersion(), request.modelName(), request.sectionsJson(), request.copyJson(), request.visualJson(), request.imageJson(), request.analysisNotes(), request.requestPayloadJson(), request.analyzedAt() == null ? Instant.now() : request.analyzedAt());
         jdbcTemplate.update("UPDATE mois_sales_library_processing_job SET status='DONE', finished_at=UTC_TIMESTAMP(), updated_at=UTC_TIMESTAMP() WHERE id=?", jobId);
     }
 
@@ -226,7 +226,7 @@ public class MoisSalesLibraryService {
         List<MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse> rows = jdbcTemplate.query("""
                 SELECT a.id, a.url_ingest_id, a.job_id, a.status, a.score_total, a.parser_version,
                        a.prompt_version, a.model_name, a.sections_json, a.copy_json, a.visual_json,
-                       a.image_json, a.analysis_notes, a.analyzed_at, a.updated_at
+                       a.image_json, a.analysis_notes, a.request_payload_json, a.analyzed_at, a.updated_at
                 FROM mois_sales_library_page_analysis a
                 WHERE a.url_ingest_id = ? ORDER BY a.updated_at DESC LIMIT 1
                 """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse(
@@ -234,7 +234,7 @@ public class MoisSalesLibraryService {
                 rs.getString("status"), rs.getBigDecimal("score_total"), rs.getString("parser_version"),
                 rs.getString("prompt_version"), rs.getString("model_name"), rs.getString("sections_json"),
                 rs.getString("copy_json"), rs.getString("visual_json"), rs.getString("image_json"),
-                rs.getString("analysis_notes"), toInstant(rs.getTimestamp("analyzed_at")), toInstant(rs.getTimestamp("updated_at"))), pageId);
+                rs.getString("analysis_notes"), rs.getString("request_payload_json"), toInstant(rs.getTimestamp("analyzed_at")), toInstant(rs.getTimestamp("updated_at"))), pageId);
         if (rows.isEmpty()) throw new IllegalArgumentException("Analysis not found for page: " + pageId);
         return rows.get(0);
     }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-23-mois-sales-library-request-payload.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-05-23-mois-sales-library-request-payload.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-05-23-mois-sales-library-request-payload-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_library_page_analysis
+        - not:
+            columnExists:
+              tableName: mois_sales_library_page_analysis
+              columnName: request_payload_json
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE mois_sales_library_page_analysis
+                ADD COLUMN request_payload_json LONGTEXT NULL AFTER analysis_notes;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,9 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-05-23-mois-sales-library-request-payload.yaml
+      relativeToChangelogFile: true
+
+  - include:
       file: changesets/2026-05-21-experiment-html-geralanding-column.yaml
       relativeToChangelogFile: true
 

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -260,12 +260,12 @@ erDiagram
 #### 13.3.1 `mois_sales_library_url_ingest`
 - **Papel no fluxo**: tabela de entrada (ingestão) de URLs canônicas provenientes da coleta.
 - **Função operacional**: deduplicar URLs, manter metadados de origem e disparar criação de job para itens novos.
-- **Campos de destaque**: `id`, `workspace_id`, `source`, `url_original`, `url_canonical`, `title`, `captured_at`, `created_at`, `updated_at`.
+- **Campos de destaque**: `id`, `workspace_id`, `source`, `url_original`, `url_canonical`, `title`, `first_captured_at`, `last_captured_at`, `ingest_count`, `created_at`, `updated_at`.
 
 #### 13.3.2 `mois_sales_library_processing_job`
 - **Papel no fluxo**: orquestrar estado assíncrono do processamento por URL.
 - **Função operacional**: controlar ciclo `PENDING/FETCHING/ANALYZING/RETRY_WAIT/DONE/FAILED`.
-- **Campos de destaque**: `id`, `url_ingest_id`, `status`, `attempt_count`, `error_category`, `error_message`, `next_retry_at`, `created_at`, `updated_at`.
+- **Campos de destaque**: `id`, `url_ingest_id`, `status`, `attempts`, `error_category`, `error_message`, `next_retry_at`, `started_at`, `finished_at`, `created_at`, `updated_at`.
 
 #### 13.3.3 `mois_sales_library_page_analysis`
 - **Papel no fluxo**: armazenar o resultado estruturado da análise comercial executada pelo worker.
@@ -275,12 +275,12 @@ erDiagram
 #### 13.3.4 `mois_sales_library_page_snapshot`
 - **Papel no fluxo**: guardar snapshots/versionamento da página capturada para comparação temporal.
 - **Função operacional**: registrar mudanças de conteúdo entre capturas e apoiar trilha de auditoria.
-- **Campos de destaque**: `id`, `url_ingest_id`, `snapshot_hash`, `html_content`, `text_content`, `captured_at`, `status`, `created_at`, `updated_at`.
+- **Campos de destaque**: `id`, `url_ingest_id`, `snapshot_hash`, `status`, `http_status`, `content_type`, `raw_html_bytes`, `screenshot_bytes`, `captured_at`, `updated_at`.
 
 #### 13.3.5 `mois_sales_library_snapshot_artifact`
 - **Papel no fluxo**: armazenar artefatos derivados por snapshot (ex.: sumários ou classificações por tipo).
 - **Função operacional**: separar artefatos auxiliares por `artifact_type` vinculados ao snapshot.
-- **Campos de destaque**: `id`, `snapshot_id`, `artifact_type`, `artifact_payload`, `created_at`, `updated_at`.
+- **Campos de destaque**: `id`, `snapshot_id`, `artifact_type`, `content_type`, `storage_kind`, `content_text`, `content_blob`, `size_bytes`, `created_at`.
 
 ### 13.4 Regras de integração entre coletores e biblioteca
 1. A transição **coletor -> biblioteca** deve ocorrer por endpoint backend (`/api/mois/sales-library/urls:ingest`), nunca por escrita direta no banco.

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -32,6 +32,7 @@ O worker processa de forma assíncrona jobs `PENDING` da biblioteca de páginas 
    - `parserVersion`
    - `promptVersion`
    - `modelName`
+   - `requestPayloadJson`
    - `processedAt`
 6. Em falha, worker chama `POST /api/mois/sales-library/jobs/{jobId}:fail` com categoria `PIPELINE_ERROR` e mensagem de erro.
 
@@ -42,6 +43,7 @@ O worker processa de forma assíncrona jobs `PENDING` da biblioteca de páginas 
 - `visual_json`: sinais visuais relevantes;
 - `image_json`: dados de imagem relevantes;
 - `analysis_notes`: observações adicionais;
+- `request_payload_json`: payload literal enviado ao modelo (JSONL da requisição batch) para auditoria;
 - `parser_version`, `prompt_version`, `model_name`: rastreabilidade técnica.
 
 ## 6. Regras de fonte (source)
@@ -268,7 +270,7 @@ erDiagram
 #### 13.3.3 `mois_sales_library_page_analysis`
 - **Papel no fluxo**: armazenar o resultado estruturado da análise comercial executada pelo worker.
 - **Função operacional**: persistir score, seções e sinais semânticos retornados pelo pipeline OpenAI.
-- **Campos de destaque**: `id`, `url_ingest_id`, `job_id`, `status`, `score_total`, `sections_json`, `copy_json`, `visual_json`, `image_json`, `analysis_notes`, `parser_version`, `prompt_version`, `model_name`, `processed_at`, `created_at`, `updated_at`.
+- **Campos de destaque**: `id`, `url_ingest_id`, `job_id`, `status`, `score_total`, `sections_json`, `copy_json`, `visual_json`, `image_json`, `analysis_notes`, `request_payload_json`, `parser_version`, `prompt_version`, `model_name`, `analyzed_at`, `created_at`, `updated_at`.
 
 #### 13.3.4 `mois_sales_library_page_snapshot`
 - **Papel no fluxo**: guardar snapshots/versionamento da página capturada para comparação temporal.

--- a/docs/modelo-dados-experimento.md
+++ b/docs/modelo-dados-experimento.md
@@ -668,8 +668,9 @@ Para suportar o gerenciamento administrativo de ocupações no módulo OPRM (cad
 - Relacionamentos:
   - `mois_sales_library_page_analysis.url_ingest_id -> mois_sales_library_url_ingest.id`.
   - `mois_sales_library_page_analysis.job_id -> mois_sales_library_processing_job.id` (opcional, `ON DELETE SET NULL`).
-- Colunas operacionais: `status`, `score_total`, `sections_json`, `copy_json`, `visual_json`, `image_json`, `analysis_notes`, `analyzed_at`, `created_at`, `updated_at`.
+- Colunas operacionais: `status`, `score_total`, `sections_json`, `copy_json`, `visual_json`, `image_json`, `analysis_notes`, `request_payload_json`, `analyzed_at`, `created_at`, `updated_at`.
 - Índices operacionais: `(url_ingest_id, updated_at)` para recuperar a versão mais recente por página e `(status, updated_at)` para observabilidade de backlog de análise.
+- Rastreabilidade do request: `request_payload_json` armazena o payload literal enviado ao modelo para auditoria na tela de detalhe.
 - Endpoints backend adicionados para consulta e acionamento:
   - `GET /api/mois/sales-library/pages`
   - `GET /api/mois/sales-library/pages/{pageId}`

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -444,3 +444,26 @@
 ## 2026-05-23 00:00:00 UTC
 - ajuste no diagrama de sequência da seção 12.2 do cânone MOIS para posicionar o elemento MySQL como o mais à direita da arquitetura.
 - aplicado destaque visual do MySQL em cor distinta usando `box rgb(255, 245, 210)` para separar a camada de persistência no Mermaid.
+
+## 2026-05-23 14:11:34 UTC-3
+- ajuste na tela de detalhe da biblioteca de páginas de vendas do MOIS para eliminar interpretação incorreta do bloco "Request enviado ao modelo".
+- identificado que o campo exibido estava usando `analysisNotes`, que representa observações resumidas da análise, e não o payload completo enviado ao modelo.
+- atualizado o frontend para rotular corretamente esse conteúdo como notas do worker e mostrar "Não disponível neste registro" quando o request literal não existe no contrato retornado pela API.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+  - docs/registros/mois1.md
+
+## 2026-05-23 14:15:16 UTC-3
+- correção solicitada: o usuário precisa visualizar o request literal enviado ao modelo na tela, e não apenas notas resumidas.
+- causa-raiz: o pipeline não persistia o payload de request da OpenAI em `mois_sales_library_page_analysis`, portanto o frontend não tinha como exibir esse dado.
+- aplicado ajuste fim-a-fim: worker agora envia `requestPayloadJson`, backend persiste/retorna esse campo e frontend passa a renderizar o request real quando disponível.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - frontend/AGENTS.md
+  - backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+  - backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+  - mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
+  - frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -467,3 +467,12 @@
   - backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
   - mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
   - frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+
+## 2026-05-23 14:20:26 UTC-3
+- revisão solicitada dos documentos canônicos e modelo de dados após inclusão do request literal do modelo na biblioteca MOIS.
+- causa-raiz documental: o código já persistia `request_payload_json`, mas os documentos canônicos ainda não refletiam completamente esse campo e mantinham referência desatualizada (`processed_at`).
+- atualizados `docs/modelo-dados-experimento.md` e `docs/canonical/mois-worker-canon.v1.md` para incluir `request_payload_json` e alinhar o timestamp operacional para `analyzed_at`.
+- documentos lidos para tratar a situação:
+  - docs/modelo-dados-experimento.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/registros/mois1.md

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -476,3 +476,12 @@
   - docs/modelo-dados-experimento.md
   - docs/canonical/mois-worker-canon.v1.md
   - docs/registros/mois1.md
+
+## 2026-05-23 14:23:19 UTC-3
+- ajuste solicitado no modelo de dados dentro do cânone MOIS para aderência ao schema real em produção.
+- causa-raiz documental: seção 13.3 do cânone ainda listava campos legados/incorretos (`captured_at`, `attempt_count`, `html_content`, `artifact_payload`) divergentes das tabelas atuais.
+- correção aplicada: atualização dos campos de destaque de `mois_sales_library_url_ingest`, `mois_sales_library_processing_job`, `mois_sales_library_page_snapshot` e `mois_sales_library_snapshot_artifact` para os nomes efetivos usados no backend.
+- documentos lidos para tratar a situação:
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/modelo-dados-experimento.md
+  - docs/registros/mois1.md

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -289,6 +289,7 @@ export interface MoisSalesLibraryPageAnalysis {
   visualJson?: string;
   imageJson?: string;
   analysisNotes?: string;
+  requestPayloadJson?: string;
   analyzedAt?: string;
   updatedAt: string;
 }

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -60,12 +60,21 @@ function JsonTreeNode({ label, value, defaultOpen = false }: { label: string; va
 }
 
 function JsonCollapse({ title, content }: { title: string; content?: string }) {
+  if (!content) {
+    return (
+      <details className="border rounded p-2 bg-light-subtle">
+        <summary className="fw-semibold" style={{ cursor: "pointer" }}>
+          {title}
+        </summary>
+        <div className="mt-2 small text-secondary">Não disponível neste registro.</div>
+      </details>
+    );
+  }
+
   let parsed: unknown;
   let parseError = false;
 
-  if (!content) {
-    parsed = {};
-  } else {
+  {
     try {
       parsed = JSON.parse(content);
     } catch {
@@ -186,7 +195,8 @@ export default function MoisSalesPageLibraryDetailPage() {
             <JsonCollapse title="Resposta do modelo (copyJson)" content={analysisQuery.data.copyJson} />
             <JsonCollapse title="Resposta do modelo (visualJson)" content={analysisQuery.data.visualJson} />
             <JsonCollapse title="Resposta do modelo (imageJson)" content={analysisQuery.data.imageJson} />
-            <JsonCollapse title="Request enviado ao modelo" content={analysisQuery.data.analysisNotes} />
+            <JsonCollapse title="Notas de análise retornadas pelo worker" content={analysisQuery.data.analysisNotes} />
+            <JsonCollapse title="Request enviado ao modelo" content={analysisQuery.data.requestPayloadJson} />
             <JsonCollapse title="Prompt usado no modelo" content={analysisQuery.data.promptVersion} />
           </div>
         </section>

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
@@ -9,6 +9,6 @@ public final class WorkerDtos {
     public record ClaimRequest(String workspaceId, String source) {}
     public record ClaimedJob(Long jobId, Long pageId, String urlCanonical, String title) {}
     public record ClaimResponse(boolean claimed, ClaimedJob job) {}
-    public record CompleteRequest(BigDecimal scoreTotal, String sectionsJson, String copyJson, String visualJson, String imageJson, String analysisNotes, String parserVersion, String promptVersion, String modelName, Instant analyzedAt) {}
+    public record CompleteRequest(BigDecimal scoreTotal, String sectionsJson, String copyJson, String visualJson, String imageJson, String analysisNotes, String requestPayloadJson, String parserVersion, String promptVersion, String modelName, Instant analyzedAt) {}
     public record FailRequest(String errorCategory, String errorMessage) {}
 }

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
@@ -50,7 +50,7 @@ public class OpenAiSalesPageAnalyzer {
             throw new IllegalStateException(buildBatchMissingOutputMessage(completed));
         }
         String output = downloadOutput(completed.outputFileId());
-        return parseBatchOutput(output);
+        return parseBatchOutput(output, payloadLine);
     }
 
     private String buildBatchLine(long pageId, String canonicalUrl, String htmlBodyText) {
@@ -129,7 +129,10 @@ public class OpenAiSalesPageAnalyzer {
         }
     }
 
-    private SalesPageAnalysisResult parseBatchOutput(String outputJsonl) {
+    /**
+     * Interpreta o JSONL de saída da OpenAI e devolve o resultado estruturado da análise.
+     */
+    private SalesPageAnalysisResult parseBatchOutput(String outputJsonl, String requestPayloadJson) {
         try {
             String line = outputJsonl.lines().filter(StringUtils::hasText).findFirst().orElseThrow();
             JsonNode root = objectMapper.readTree(line);
@@ -153,6 +156,7 @@ public class OpenAiSalesPageAnalyzer {
                     objectMapper.writeValueAsString(parsed.path("visual_json")),
                     objectMapper.writeValueAsString(parsed.path("image_json")),
                     parsed.path("analysis_notes").asText("Análise gerada via OpenAI batch"),
+                    requestPayloadJson,
                     "html-v1",
                     "openai-batch-v1",
                     properties.normalizedModel()

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/SalesPageAnalysisResult.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/SalesPageAnalysisResult.java
@@ -9,6 +9,7 @@ public record SalesPageAnalysisResult(
         String visualJson,
         String imageJson,
         String analysisNotes,
+        String requestPayloadJson,
         String parserVersion,
         String promptVersion,
         String modelName

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
@@ -51,6 +51,7 @@ public class PipelineRunner {
                     analysis.visualJson(),
                     analysis.imageJson(),
                     analysis.analysisNotes(),
+                    analysis.requestPayloadJson(),
                     analysis.parserVersion(),
                     analysis.promptVersion(),
                     analysis.modelName(),


### PR DESCRIPTION
### Motivation
- Capture and persist the literal request payload sent to OpenAI so the frontend can show the exact request used for each analysis, avoiding confusion between `analysisNotes` and the actual model request.
- Keep traceability between worker, backend and UI by storing the request payload in the analysis record and returning it via the API.
- Ensure the database schema contains the new field to support existing records and future writes.

### Description
- Added a new `requestPayloadJson` field to DTOs and models across the worker and backend (`WorkerDtos.CompleteRequest`, `SalesPageAnalysisResult`, `MoisSalesLibraryDtos.SalesLibraryCompleteRequest`, and `SalesLibraryPageAnalysisResponse`) and updated the pipeline to pass this value from the analyzer to the backend via `PipelineRunner` and `backendClient.complete`.
- Modified `OpenAiSalesPageAnalyzer` to retain the serialized batch request line and include it in the parsed `SalesPageAnalysisResult` returned from `parseBatchOutput`.
- Persisted the new field in the DB by adding a Liquibase changeset `changesets/2026-05-23-mois-sales-library-request-payload.yaml` and including it in `db.changelog-master.yaml`, adding the `request_payload_json LONGTEXT` column to `mois_sales_library_page_analysis`.
- Exposed the field to the frontend by updating the TypeScript type (`frontend/src/api/mois/types.ts`) and the detail page UI (`MoisSalesPageLibraryDetailPage.tsx`) to show the request payload under "Request enviado ao modelo" and to render a friendly "Não disponível neste registro." message when absent.
- Adjusted API service SQL to insert and select the new `request_payload_json` column in `MoisSalesLibraryService`.

### Testing
- Verified that the backend and worker compile with the changes and that the new DB migration file is included in `db.changelog-master.yaml` (local build and schema migration checks succeeded).
- Ran the frontend TypeScript typecheck and local UI build to confirm the new `requestPayloadJson` field is handled (typecheck and build succeeded).
- No automated unit tests were added for this change. All existing automated checks referenced above passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11df7ddbfc83219c4853cab8a19faa)