### PR TITLE
Fix Mermaid rendering error in MOIS worker canon diagram

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -149,9 +149,10 @@ sequenceDiagram
     participant OAI as OpenAI Batch (/v1/responses)
     participant DB as MySQL 5.7
 
-    %% Banco destacado com cor própria e posicionado na extrema direita
-    box rgb(255, 245, 210) Camada de Persistência (MySQL 5.7)
-      Note over DB: Banco de dados principal
+    %% Banco destacado com cor própria
+    rect rgb(255, 245, 210)
+    Note over DB: Camada de Persistência (MySQL 5.7)
+Banco de dados principal
     end
 
     rect rgb(245,245,245)

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -493,3 +493,12 @@
   - frontend/AGENTS.md
   - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
   - docs/registros/mois1.md
+
+## 2026-05-23 14:26:00 UTC-3
+- correção de erro de renderização Mermaid na seção 12.2 do cânone MOIS Worker no GitHub Preview.
+- causa-raiz: uso de bloco `box` com `Note` dentro do `sequenceDiagram`, combinação que o parser Mermaid do GitHub rejeitou na linha do `Note over DB`.
+- correção aplicada: substituição por bloco `rect` destacado e `Note over DB` diretamente, preservando a semântica visual do banco sem violar a gramática suportada.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/registros/mois1.md


### PR DESCRIPTION
### Motivation
- Fix a Mermaid sequenceDiagram rendering error in `docs/canonical/mois-worker-canon.v1.md` so the canonical MOIS documentation displays correctly in GitHub Preview.

### Description
- Replace the unsupported `box ... Note ... end` pattern with a `rect` block plus `Note over DB` in `docs/canonical/mois-worker-canon.v1.md` to comply with GitHub's Mermaid grammar and preserve the visual emphasis on the persistence layer.
- Add a log entry in `docs/registros/mois1.md` recording the root cause and correction applied.

### Testing
- No automated tests were run because this is a documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e34efc7083218e8e565e417e2413)