### PR TITLE
fix(canon): corrigir renderização dos diagramas Mermaid no cânone MOIS worker

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -151,8 +151,7 @@ sequenceDiagram
 
     %% Banco destacado com cor própria
     rect rgb(255, 245, 210)
-    Note over DB: Camada de Persistência (MySQL 5.7)
-Banco de dados principal
+    Note over DB: Camada de Persistência (MySQL 5.7)\nBanco de dados principal
     end
 
     rect rgb(245,245,245)
@@ -346,7 +345,7 @@ graph TD
     HC[mois-hotmart-collector\npackage: com.marketinghub.mois.hotmart.collector] -->|POST /api/mois/sales-library/urls:ingest| BM[backend/ads-service\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.web]
     CC[mois-clickbank-collector\npackage: com.marketinghub.mois.clickbank.collector] -->|POST /api/mois/sales-library/urls:ingest| BM
 
-    WK[mois-sales-library-worker\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service] -->|jobs:claim, jobs/{id}:complete, jobs/{id}:fail| BM
+    WK[mois-sales-library-worker\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service] -->|"jobs:claim, jobs/{id}:complete, jobs/{id}:fail"| BM
     WK -->|/v1/responses (batch)| OAI[OpenAI API]
 
     BM -->|JPA/SQL via camada backend| DB[(MySQL 5.7)]


### PR DESCRIPTION
### Motivation
- Dois diagramas em `docs/canonical/mois-worker-canon.v1.md` não eram renderizados pelo GitHub devido a erros de sintaxe Mermaid que resultavam em parse errors e impediam a visualização canônica do fluxo do worker.

### Description
- Ajustada a anotação `Note over DB` no diagrama de sequência (12.2) para incluir a quebra de linha como `\n` dentro da instrução Mermaid, eliminando a linha solta que gerava erro de parse. 
- Ajustado o rótulo da aresta contendo `jobs/{id}:...` no diagrama de arquitetura (12.5) ao colocá-lo entre aspas para evitar conflito léxico com chaves no parser do flowchart; alteração aplicada em `docs/canonical/mois-worker-canon.v1.md`.

### Testing
- Executadas verificações automatizadas de conteúdo e posição das mudanças com `rg --line-number`, `sed -n` para inspeção de trechos e `nl -ba` para conferência de linhas alteradas, todas as verificações retornaram sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a120a8dc8f48321978f1ac7ff601b54)