### PR TITLE
Docs: fix Mermaid parse issues, add Hotmart ingest sequence diagram, and update registros

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -197,7 +197,30 @@ sequenceDiagram
     end
 ```
 
-### 12.2.1 Tabelas lidas e gravadas por etapa do fluxo
+### 12.2.1 Diagrama de sequência focado no coletor Hotmart
+```mermaid
+sequenceDiagram
+    autonumber
+    participant HC as Hotmart Collector
+    participant API as Backend MOIS (/api/mois/sales-library)
+    participant DB as MySQL 5.7
+
+    rect rgb(245,245,245)
+    Note over HC,API: 1) Coleta e envio de URLs vencedoras da Hotmart
+    HC->>API: POST /urls:ingest (source=HOTMART, urls[])
+    end
+
+    rect rgb(245,245,245)
+    Note over API,DB: 2) Normalização, deduplicação e criação de job
+    API->>DB: READ mois_sales_library_url_ingest\n(validar URL já existente por canonicalização)
+    API->>DB: WRITE mois_sales_library_url_ingest (UPSERT)\n(url_original, url_canonical, title, capturedAt...)
+    API->>DB: WRITE mois_sales_library_processing_job (INSERT)\n(status=PENDING) para URL nova
+    end
+
+    API-->>HC: 200 OK (itens processados da ingestão)
+```
+
+### 12.2.2 Tabelas lidas e gravadas por etapa do fluxo
 
 | Etapa | Leitura (READ) | Gravação (WRITE) |
 |---|---|---|
@@ -346,7 +369,7 @@ graph TD
     CC[mois-clickbank-collector\npackage: com.marketinghub.mois.clickbank.collector] -->|POST /api/mois/sales-library/urls:ingest| BM
 
     WK[mois-sales-library-worker\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service] -->|"jobs:claim, jobs/{id}:complete, jobs/{id}:fail"| BM
-    WK -->|/v1/responses (batch)| OAI[OpenAI API]
+    WK -->|"/v1/responses (batch)"| OAI[OpenAI API]
 
     BM -->|JPA/SQL via camada backend| DB[(MySQL 5.7)]
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -502,3 +502,21 @@
   - AGENTS.md
   - docs/canonical/mois-worker-canon.v1.md
   - docs/registros/mois1.md
+
+## 2026-05-23 17:56:00 UTC
+- correção adicional do diagrama Mermaid na seção 12.5 do cânone MOIS Worker após falha de parse no GitHub Preview.
+- causa-raiz: label de aresta com `/v1/responses (batch)` sem aspas no `graph TD`, gerando token inválido no parser do GitHub.
+- correção aplicada: encapsulada a label da aresta entre aspas (`|"/v1/responses (batch)"|`) para aderência à gramática Mermaid suportada.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/registros/mois1.md
+
+## 2026-05-23 18:05:00 UTC
+- inclusão de diagrama de sequência focado exclusivamente no coletor Hotmart logo após o diagrama geral do módulo MOIS Worker.
+- causa-raiz: ausência de visão detalhada da etapa de ingestão Hotmart no trecho imediatamente subsequente ao fluxo ponta a ponta, dificultando leitura operacional solicitada.
+- correção aplicada: adicionada nova subseção `12.2.1` com `sequenceDiagram` dedicado ao fluxo Hotmart (`POST /urls:ingest`, normalização/deduplicação e criação de job `PENDING`), e renumerada a seção de tabelas para `12.2.2`.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/registros/mois1.md


### PR DESCRIPTION
### Motivation
- Fix Mermaid rendering failures in the MOIS Worker canonical doc that broke GitHub Preview by removing unsupported constructs and invalid tokens.
- Provide a focused operational view of the Hotmart ingestion step to improve clarity for collectors and operators.
- Keep the change log in `docs/registros/mois1.md` accurate by recording the applied documentation fixes.

### Description
- Replaced `box`+`Note` constructs with `rect` blocks in `docs/canonical/mois-worker-canon.v1.md` to satisfy the GitHub-supported Mermaid grammar.
- Quoted the edge label as `"/v1/responses (batch)"` in the `graph TD` to eliminate an invalid token in the diagram.
- Added a new subsection `12.2.1` with a `sequenceDiagram` dedicated to the Hotmart collector (`POST /urls:ingest`) and renumbered the tables subsection to `12.2.2`.
- Updated `docs/registros/mois1.md` with entries documenting the Mermaid fixes and the new Hotmart sequence diagram.

### Testing
- No automated tests were run on these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12145b279083218deef865fd47773c)