### PR TITLE
docs: incluir Hotmart Site e URL acessada no diagrama MOIS

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -201,11 +201,16 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     autonumber
+    participant HS as Hotmart Site (hotmart.com)
     participant HC as Hotmart Collector
     participant API as Backend MOIS (/api/mois/sales-library)
     participant DB as MySQL 5.7
 
     rect rgb(245,245,245)
+    Note over HS,HC: Coleta no site da Hotmart
+    HC->>HS: GET product details (salesPageUrl com fallback em detailsUrl)
+    HS-->>HC: 200 OK (url acessada para captura)
+
     Note over HC,API: 1) Coleta e envio de URLs vencedoras da Hotmart
     HC->>API: POST /urls:ingest (source=HOTMART, urls[])
     end

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -520,3 +520,13 @@
   - AGENTS.md
   - docs/canonical/mois-worker-canon.v1.md
   - docs/registros/mois1.md
+
+
+## 2026-05-23 — Diagrama Hotmart com site de origem e URL acessada
+- atualizado o diagrama `12.2.1` em `docs/canonical/mois-worker-canon.v1.md` para incluir explicitamente o participante **Hotmart Site (hotmart.com)** no fluxo.
+- detalhado no diagrama que o coletor acessa `salesPageUrl` com fallback para `detailsUrl`, deixando explícita a URL de origem consultada antes do `POST /urls:ingest`.
+- objetivo: reduzir ambiguidade operacional sobre qual URL está sendo acessada no passo de coleta.
+
+Arquivos alterados:
+- docs/canonical/mois-worker-canon.v1.md
+- docs/registros/mois1.md


### PR DESCRIPTION
### Motivation
- Evitar ambiguidade operacional sobre qual URL é consultada na etapa de coleta Hotmart. 
- Deixar explícito que o coletor acessa `salesPageUrl` com fallback em `detailsUrl` no `Hotmart Site (hotmart.com)` antes do envio ao backend.

### Description
- Atualiza `docs/canonical/mois-worker-canon.v1.md` na seção `12.2.1` para inserir o participante `Hotmart Site (hotmart.com)` e as interações `HC->>HS: GET product details (salesPageUrl com fallback em detailsUrl)` e `HS-->>HC: 200 OK` no diagrama de sequência. 
- Mantém inalterado o fluxo canônico de ingestão que segue para `POST /api/mois/sales-library/urls:ingest` após a coleta. 
- Registra a alteração em `docs/registros/mois1.md` com entrada datada `2026-05-23` descrevendo a intenção e os arquivos alterados (`docs/canonical/mois-worker-canon.v1.md` e `docs/registros/mois1.md`).

### Testing
- Alteração é puramente documental; não houve testes unitários automáticos aplicáveis nem executados. 
- Verificou-se a correção do diagrama Mermaid no contexto prévio de ajustes de render (para evitar regressões de parsing) e a modificação foi registrada no histórico do módulo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1220914284832185b6aa732214f76a)