### PR TITLE
Add ArchUnit rules enforcing web→service→repository layering for MOIS sales library

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
@@ -1,12 +1,19 @@
 package com.marketinghub.architecture;
 
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Garante isolamento arquitetural entre módulos/pacotes internos do backend.
@@ -19,6 +26,8 @@ class ModuleIsolationArchitectureTest {
     private static final String GERALANDING_COPY_PACKAGE = "com.marketinghub.geralanding.copy";
     private static final String GERALANDING_IMAGEPLANNING_PACKAGE = "com.marketinghub.geralanding.imageplanning";
     private static final String GERALANDING_PRESETDESIGN_PACKAGE = "com.marketinghub.geralanding.designpreset";
+    private static final Pattern SALES_LIBRARY_LAYER_PATTERN = Pattern.compile(
+            "^com\\.marketinghub\\.mois\\.bibliotecapaginavenda\\.([a-zA-Z0-9_]+)\\.(v\\d+)\\.(web|service|repository)(?:\\..*)?$");
 
     @ArchTest
     static final ArchRule moisMustNotDependOnOtherMarketingHubPackages = noClasses()
@@ -75,6 +84,14 @@ class ModuleIsolationArchitectureTest {
             GERALANDING_PRESETDESIGN_PACKAGE,
             "o subpacote geralanding.designpreset deve ficar independente dos demais pacotes internos");
 
+    @ArchTest
+    static final ArchRule moisSalesLibraryWebShouldOnlyDependOnServiceLayer =
+            classes().that(classesBelongingToLayer("web")).should(onlyDependOnLayer("service"));
+
+    @ArchTest
+    static final ArchRule moisSalesLibraryServiceShouldOnlyDependOnRepositoryLayer =
+            classes().that(classesBelongingToLayer("service")).should(onlyDependOnLayer("repository"));
+
     /**
      * Constrói regra para impedir dependências para outros pacotes internos fora do prefixo permitido.
      */
@@ -97,4 +114,66 @@ class ModuleIsolationArchitectureTest {
             }
         };
     }
+
+    /**
+     * Retorna classes de um layer específico da biblioteca de páginas de venda do MOIS.
+     */
+    private static DescribedPredicate<JavaClass> classesBelongingToLayer(String expectedLayer) {
+        return new DescribedPredicate<>("classes in " + expectedLayer + " layer of mois sales library") {
+            @Override
+            public boolean test(JavaClass input) {
+                return extractSalesLibraryPackageInfo(input.getPackageName())
+                        .map(packageInfo -> packageInfo.layer().equals(expectedLayer) && !input.getSimpleName().endsWith("Test"))
+                        .orElse(false);
+            }
+        };
+    }
+
+    /**
+     * Valida que classes de um layer dependem apenas do layer permitido com mesmo x e vN.
+     */
+    private static ArchCondition<JavaClass> onlyDependOnLayer(String allowedTargetLayer) {
+        return new ArchCondition<>("depend only on " + allowedTargetLayer + " in same x/vN") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                Optional<SalesLibraryPackageInfo> sourceInfo = extractSalesLibraryPackageInfo(item.getPackageName());
+                if (sourceInfo.isEmpty()) {
+                    return;
+                }
+                item.getDirectDependenciesFromSelf().forEach(dependency -> {
+                    String targetPackageName = dependency.getTargetClass().getPackageName();
+                    Optional<SalesLibraryPackageInfo> targetInfo = extractSalesLibraryPackageInfo(targetPackageName);
+                    if (targetInfo.isEmpty()) {
+                        return;
+                    }
+                    boolean sameNamespace = sourceInfo.get().namespace().equals(targetInfo.get().namespace())
+                            && sourceInfo.get().version().equals(targetInfo.get().version());
+                    boolean allowedLayer = targetInfo.get().layer().equals(allowedTargetLayer)
+                            || targetInfo.get().layer().equals(sourceInfo.get().layer());
+                    if (!sameNamespace || !allowedLayer) {
+                        String message = item.getName() + " depende de " + dependency.getTargetClass().getName()
+                                + " mas só pode depender de pacote ." + allowedTargetLayer
+                                + " com mesmo x/vN";
+                        events.add(SimpleConditionEvent.violated(item, message));
+                    }
+                });
+            }
+        };
+    }
+
+    /**
+     * Extrai namespace (x), versão (vN) e layer dos pacotes da biblioteca de páginas de venda.
+     */
+    private static Optional<SalesLibraryPackageInfo> extractSalesLibraryPackageInfo(String packageName) {
+        Matcher matcher = SALES_LIBRARY_LAYER_PATTERN.matcher(packageName);
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+        return Optional.of(new SalesLibraryPackageInfo(matcher.group(1), matcher.group(2), matcher.group(3)));
+    }
+
+    /**
+     * Representa a estrutura do pacote da biblioteca de páginas de venda do MOIS.
+     */
+    private record SalesLibraryPackageInfo(String namespace, String version, String layer) {}
 }


### PR DESCRIPTION
### Motivation
- Enforce a strict internal layering for packages matching `com.marketinghub.mois.bibliotecapaginavenda.<x>.vN.<layer>` so `.web` can only use `.service` and `.service` can only use `.repository` within the same `<x>` and `vN` to avoid cross-namespace/version coupling.
- Provide an automated guard in the existing architecture tests to catch accidental dependencies early in CI and local development.

### Description
- Added two ArchUnit rules `moisSalesLibraryWebShouldOnlyDependOnServiceLayer` and `moisSalesLibraryServiceShouldOnlyDependOnRepositoryLayer` to `ModuleIsolationArchitectureTest.java` enforcing the desired layering.
- Implemented package parsing via `SALES_LIBRARY_LAYER_PATTERN` and `SalesLibraryPackageInfo` plus the predicate `classesBelongingToLayer` and condition `onlyDependOnLayer` to validate same-`x`/same-`vN` dependencies.
- Excluded test classes from the layer membership check and allowed same-layer references where appropriate, and added necessary imports and helper methods in `ModuleIsolationArchitectureTest.java`.

### Testing
- Ran `mvn -Dtest=ModuleIsolationArchitectureTest test` in `backend/ads-service` and the suite completed successfully with `Tests run: 10, Failures: 0, Errors: 0`.
- An earlier attempt to run `./gradlew :ads-service:test` failed because there is no `gradlew` wrapper in the repository, so Maven was used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a122279c900832189464f57a466e1a6)