### PR TITLE
docs: adicionar diagrama canônico do Gera Landing (Worker AI x Backend)

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -392,3 +392,43 @@ graph TD
 - Coletores e worker **não acessam banco diretamente**; todo acesso a dados passa pelo backend MOIS.
 - A integração com OpenAI é realizada pelo `mois-sales-library-worker`, com retorno consolidado ao backend via endpoint de conclusão/falha.
 - A persistência em MySQL 5.7 ocorre apenas nos pacotes de serviço/repositório do backend.
+
+
+### 12.6 Diagrama de arquitetura por módulo/pacote — Gera Landing (Worker AI x Backend)
+
+Diagrama canônico de referência para o fluxo Gera Landing, separando explicitamente o lado do **Worker AI** e o lado do **Backend**, com fronteira de integração via HTTP e persistência exclusiva no backend.
+
+```mermaid
+flowchart LR
+    subgraph W[Worker AI — ai-worker\nPacote: com.marketinghub.worker.geralanding]
+      WS[GeraLandingExecutionScheduler] --> WE[GeraLandingExecutionService]
+      WE --> WB[GeraLandingBackendClient\n(HTTP backend)]
+      WE --> OA[GeraLandingOpenAiFlexClient\n(OpenAI Responses)]
+      WE --> SD[stage/*\nSchema + Prompt Resolver]
+    end
+
+    subgraph B[Backend — ads-service\nPacote: com.marketinghub.geralanding]
+      BC[GeraLandingInternalController / GeraLandingContoller] --> BS[GeraLandingStageExecutionService]
+      BS --> BH[Html Assemblers/Processors\n(copy, wireframe, designpreset, imageplanning)]
+      BS --> BR[GeraLandingStageExecutionRepository]
+      BR --> DB[(MySQL 5.7)]
+      BS --> LP[Publicação Lead Portal\n(endpoint externo)]
+    end
+
+    WB -->|claim/dispath/receive/complete/fail| BC
+    OA -->|resultado estruturado por etapa| WE
+    BS -->|workerPrompt + stage config| BC
+
+    classDef worker fill:#E8F4FF,stroke:#4D90FE,color:#0B3D91;
+    classDef backend fill:#FFF4E5,stroke:#F39C12,color:#8A4B08;
+    classDef db fill:#FDEDEC,stroke:#C0392B,color:#7B241C;
+
+    class WS,WE,WB,OA,SD worker;
+    class BC,BS,BH,BR,LP backend;
+    class DB db;
+```
+
+#### Regras de integração refletidas no diagrama (Gera Landing)
+- O **Worker AI não acessa banco**; toda leitura/gravação de estado da execução passa pelo backend Gera Landing.
+- O backend concentra regras de contrato, montagem de HTML provisório/final e publicação para Lead Portal.
+- O Worker AI concentra orquestração por etapa e integração com OpenAI, devolvendo resultados ao backend pelos endpoints do próprio domínio Gera Landing.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1279,3 +1279,11 @@
   - docs/canonical/procedimento-experimento-canon.v1.md
   - ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
   - docs/registros/experimentos.md
+## 2026-05-23 19:08:43 UTC-3
+- solicitação para criar um diagrama canônico semelhante ao do MOIS, agora para Gera Landing, destacando os lados Worker AI e Backend.
+- raciocínio aplicado: manter padrão visual/estrutural do documento canônico atual e explicitar fronteiras de responsabilidade e integração para reduzir ambiguidade operacional.
+- foi feito: adicionada a seção `12.6 Diagrama de arquitetura por módulo/pacote — Gera Landing (Worker AI x Backend)` em `docs/canonical/mois-worker-canon.v1.md` com Mermaid separado em subgraphs (Worker AI e Backend), incluindo conexões com OpenAI, backend, MySQL e publicação no Lead Portal.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Melhorar a clareza arquitetural do fluxo Gera Landing explicando a fronteira de responsabilidade entre o Worker AI e o Backend. 
- Manter o padrão visual e estrutural dos diagramas canônicos já existentes no documento do MOIS para reduzir ambiguidade operacional entre módulos.

### Description
- Adiciona a seção `12.6 Diagrama de arquitetura por módulo/pacote — Gera Landing (Worker AI x Backend)` ao arquivo `docs/canonical/mois-worker-canon.v1.md` com um diagrama Mermaid separando explicitamente o subgraph do Worker AI (`com.marketinghub.worker.geralanding`) e do Backend (`com.marketinghub.geralanding`).
- Documenta integrações relevantes no diagrama: `GeraLandingOpenAiFlexClient` (OpenAI), `GeraLandingBackendClient` (HTTP), `GeraLandingStageExecutionRepository` → `MySQL 5.7` e publicação para `Lead Portal`.
- Inclui regras de integração reforçando que o Worker AI não acessa o banco diretamente e que o backend concentra montagem/persistência/contratos do Gera Landing.
- Registra a atividade em `docs/registros/experimentos.md` com timestamp UTC-3 seguindo a política append-only.

### Testing
- Validações operacionais realizadas: `git status --short` para confirmar arquivos modificados, `git add` + `git commit` para persistir a alteração e `TZ=America/Sao_Paulo date` para gerar o timestamp obrigatório; todos os comandos concluíram com sucesso.
- Nenhuma modificação de código compilável foi feita, portanto não foram executados testes unitários ou de integração automáticos neste PR. 
- A alteração é estritamente documental e não afeta artefatos binários ou contratos de API existentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12253ad8a883219f545e9dcb18e2df)