### PR TITLE
Move Gera Landing architecture diagram to experiment canon and fix Mermaid rendering

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -394,41 +394,6 @@ graph TD
 - A persistência em MySQL 5.7 ocorre apenas nos pacotes de serviço/repositório do backend.
 
 
-### 12.6 Diagrama de arquitetura por módulo/pacote — Gera Landing (Worker AI x Backend)
+### 12.6 Diagrama de arquitetura por módulo/pacote — Gera Landing (movido)
 
-Diagrama canônico de referência para o fluxo Gera Landing, separando explicitamente o lado do **Worker AI** e o lado do **Backend**, com fronteira de integração via HTTP e persistência exclusiva no backend.
-
-```mermaid
-flowchart LR
-    subgraph W[Worker AI — ai-worker\nPacote: com.marketinghub.worker.geralanding]
-      WS[GeraLandingExecutionScheduler] --> WE[GeraLandingExecutionService]
-      WE --> WB[GeraLandingBackendClient\n(HTTP backend)]
-      WE --> OA[GeraLandingOpenAiFlexClient\n(OpenAI Responses)]
-      WE --> SD[stage/*\nSchema + Prompt Resolver]
-    end
-
-    subgraph B[Backend — ads-service\nPacote: com.marketinghub.geralanding]
-      BC[GeraLandingInternalController / GeraLandingContoller] --> BS[GeraLandingStageExecutionService]
-      BS --> BH[Html Assemblers/Processors\n(copy, wireframe, designpreset, imageplanning)]
-      BS --> BR[GeraLandingStageExecutionRepository]
-      BR --> DB[(MySQL 5.7)]
-      BS --> LP[Publicação Lead Portal\n(endpoint externo)]
-    end
-
-    WB -->|claim/dispath/receive/complete/fail| BC
-    OA -->|resultado estruturado por etapa| WE
-    BS -->|workerPrompt + stage config| BC
-
-    classDef worker fill:#E8F4FF,stroke:#4D90FE,color:#0B3D91;
-    classDef backend fill:#FFF4E5,stroke:#F39C12,color:#8A4B08;
-    classDef db fill:#FDEDEC,stroke:#C0392B,color:#7B241C;
-
-    class WS,WE,WB,OA,SD worker;
-    class BC,BS,BH,BR,LP backend;
-    class DB db;
-```
-
-#### Regras de integração refletidas no diagrama (Gera Landing)
-- O **Worker AI não acessa banco**; toda leitura/gravação de estado da execução passa pelo backend Gera Landing.
-- O backend concentra regras de contrato, montagem de HTML provisório/final e publicação para Lead Portal.
-- O Worker AI concentra orquestração por etapa e integração com OpenAI, devolvendo resultados ao backend pelos endpoints do próprio domínio Gera Landing.
+Este diagrama foi movido para o cânone de experimento em `docs/canonical/procedimento-experimento-canon.v1.md`, seção **15.4**, para centralizar as regras canônicas do fluxo Gera Landing em um único documento.

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -225,3 +225,43 @@ Qualquer correção de falha onde o preset design não gerar HTML provisório de
 3. persistência do resultado em `provisional_html` da execução e em `experiment.html_geralanding`;
 4. cobertura por teste unitário da etapa garantindo que o HTML é produzido/persistido.
 
+
+
+### 15.4 Diagrama de arquitetura por módulo/pacote — Gera Landing (Worker AI x Backend)
+
+Diagrama canônico de referência para o fluxo Gera Landing, separando explicitamente o lado do **Worker AI** e o lado do **Backend**, com fronteira de integração via HTTP e persistência exclusiva no backend.
+
+```mermaid
+flowchart LR
+    subgraph W[Worker AI - ai-worker<br/>Pacote: com.marketinghub.worker.geralanding]
+      WS[GeraLandingExecutionScheduler] --> WE[GeraLandingExecutionService]
+      WE --> WB[GeraLandingBackendClient<br/>(HTTP backend)]
+      WE --> OA[GeraLandingOpenAiFlexClient<br/>(OpenAI Responses)]
+      WE --> SD[stage/*<br/>Schema + Prompt Resolver]
+    end
+
+    subgraph B[Backend - ads-service<br/>Pacote: com.marketinghub.geralanding]
+      BC[GeraLandingInternalController / GeraLandingController] --> BS[GeraLandingStageExecutionService]
+      BS --> BH[Html Assemblers/Processors<br/>(copy, wireframe, designpreset, imageplanning)]
+      BS --> BR[GeraLandingStageExecutionRepository]
+      BR --> DB[(MySQL 5.7)]
+      BS --> LP[Publicação Lead Portal<br/>(endpoint externo)]
+    end
+
+    WB -->|claim/dispatch/receive/complete/fail| BC
+    OA -->|resultado estruturado por etapa| WE
+    BS -->|workerPrompt + stage config| BC
+
+    classDef worker fill:#E8F4FF,stroke:#4D90FE,color:#0B3D91;
+    classDef backend fill:#FFF4E5,stroke:#F39C12,color:#8A4B08;
+    classDef db fill:#FDEDEC,stroke:#C0392B,color:#7B241C;
+
+    class WS,WE,WB,OA,SD worker;
+    class BC,BS,BH,BR,LP backend;
+    class DB db;
+```
+
+#### Regras de integração refletidas no diagrama (Gera Landing)
+- O **Worker AI não acessa banco**; toda leitura/gravação de estado da execução passa pelo backend Gera Landing.
+- O backend concentra regras de contrato, montagem de HTML provisório/final e publicação para Lead Portal.
+- O Worker AI concentra orquestração por etapa e integração com OpenAI, devolvendo resultados ao backend pelos endpoints do próprio domínio Gera Landing.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1287,3 +1287,15 @@
   - AGENTS.md
   - docs/canonical/mois-worker-canon.v1.md
   - docs/registros/experimentos.md
+## 2026-05-23 20:20:00 UTC
+- solicitação para mover o diagrama de arquitetura do Gera Landing para o documento canônico de experimento e corrigir erro de parse no Mermaid exibido no GitHub.
+- causa-raiz identificada: o diagrama estava no cânone do MOIS (documento fora do escopo principal do fluxo Gera Landing) e utilizava quebras `\n` em labels Mermaid, além de typo em `GeraLandingContoller`, gerando falha de renderização.
+- foi feito:
+  - remoção da seção detalhada do diagrama no `mois-worker-canon.v1.md` e inclusão de apontamento para o novo local canônico;
+  - inclusão da seção `15.4 Diagrama de arquitetura por módulo/pacote — Gera Landing (Worker AI x Backend)` em `procedimento-experimento-canon.v1.md`;
+  - ajuste de sintaxe Mermaid para compatibilidade com renderer do GitHub (`<br/>` em labels e correção `GeraLandingController`), além do ajuste de `dispatch` na seta de integração.
+- documentos/arquivos lidos e atualizados:
+  - AGENTS.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/canonical/procedimento-experimento-canon.v1.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Centralize the canonical Gera Landing architecture diagram inside the experiment canon so the flow and rules for Gera Landing live in the single authoritative document `procedimento-experimento-canon.v1.md`.
- Fix a GitHub Mermaid parse/render error caused by label linebreaks and a controller name typo that prevented the diagram from displaying correctly.

### Description
- Removed the full Gera Landing Mermaid diagram from `docs/canonical/mois-worker-canon.v1.md` and replaced it with a short pointer noting the diagram was moved to the experiment canon (`15.4`).
- Added section `15.4` to `docs/canonical/procedimento-experimento-canon.v1.md` containing the corrected Mermaid diagram for Gera Landing with renderer-friendly labels (replaced `\n` with `<br/>`) and fixed `GeraLandingController` typo and the `dispatch` label.
- Updated the operational log `docs/registros/experimentos.md` with the change record, root cause, and applied corrections.

### Testing
- Verified diagram relocation and presence with `rg -n` (search) to confirm the old section was removed and the new `15.4` section exists.
- Inspected the target files with `nl -ba` and `sed -n` to validate the mermaid block insertion and surrounding headings.
- Performed structural validation of the Mermaid block formatting to ensure GitHub-compatible labels and corrected identifiers; checks passed (no Mermaid label artifacts left).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12287b57888321b4aa7e418fcf1b3d)