### PR TITLE
Fix Mermaid parse error in experimento canonical diagram

### DIFF
--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -233,19 +233,19 @@ Diagrama canônico de referência para o fluxo Gera Landing, separando explicita
 
 ```mermaid
 flowchart LR
-    subgraph W[Worker AI - ai-worker<br/>Pacote: com.marketinghub.worker.geralanding]
+    subgraph W[Worker AI - ai-worker<br>Pacote: com.marketinghub.worker.geralanding]
       WS[GeraLandingExecutionScheduler] --> WE[GeraLandingExecutionService]
-      WE --> WB[GeraLandingBackendClient<br/>(HTTP backend)]
-      WE --> OA[GeraLandingOpenAiFlexClient<br/>(OpenAI Responses)]
-      WE --> SD[stage/*<br/>Schema + Prompt Resolver]
+      WE --> WB[GeraLandingBackendClient<br>(HTTP backend)]
+      WE --> OA[GeraLandingOpenAiFlexClient<br>(OpenAI Responses)]
+      WE --> SD[stage/*<br>Schema + Prompt Resolver]
     end
 
-    subgraph B[Backend - ads-service<br/>Pacote: com.marketinghub.geralanding]
+    subgraph B[Backend - ads-service<br>Pacote: com.marketinghub.geralanding]
       BC[GeraLandingInternalController / GeraLandingController] --> BS[GeraLandingStageExecutionService]
-      BS --> BH[Html Assemblers/Processors<br/>(copy, wireframe, designpreset, imageplanning)]
+      BS --> BH[Html Assemblers/Processors<br>(copy, wireframe, designpreset, imageplanning)]
       BS --> BR[GeraLandingStageExecutionRepository]
       BR --> DB[(MySQL 5.7)]
-      BS --> LP[Publicação Lead Portal<br/>(endpoint externo)]
+      BS --> LP[Publicação Lead Portal<br>(endpoint externo)]
     end
 
     WB -->|claim/dispatch/receive/complete/fail| BC


### PR DESCRIPTION
### Motivation
- Corrigir erro de renderização no diagrama Mermaid em `docs/canonical/procedimento-experimento-canon.v1.md` causado pelo uso de `<br/>` incompatível com o parser do GitHub.

### Description
- Substituí todas as ocorrências de `<br/>` por `<br>` nos rótulos do diagrama Mermaid em `docs/canonical/procedimento-experimento-canon.v1.md`, sendo mudança apenas em documentação e sem impacto no código de runtime.

### Testing
- Verificações automatizadas realizadas: busca/inspeção do arquivo com `rg`/`sed`, aplicação da substituição com um script Python (`python - <<'PY' ...`), revisão com `git diff`, commit com `git commit` e inspeção final de linhas com `nl | sed`; todas as etapas concluíram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123cc8bcc08321b31aff9baf79aaee)