### PR TITLE
Harden Gera Landing wireframe prompt and schema for body, interactions, assets and form fields

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -57,11 +57,36 @@
           "required": [
             "secoes"
           ]
+        },
+        "body": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "classes": {
+              "type": "array",
+              "minItems": 4,
+              "maxItems": 4,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "bgBody",
+                  "fontBase",
+                  "textPrimary",
+                  "marginReset"
+                ]
+              },
+              "uniqueItems": true
+            }
+          },
+          "required": [
+            "classes"
+          ]
         }
       },
       "required": [
         "head",
-        "corpo"
+        "corpo",
+        "body"
       ]
     }
   },
@@ -236,6 +261,113 @@
               "$ref": "#/$defs/briefingVisual"
             }
           ]
+        },
+        "componente": {
+          "type": "string",
+          "enum": [
+            "none",
+            "buttonPrimary",
+            "buttonSecondary",
+            "formInput",
+            "card"
+          ]
+        },
+        "interacao": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "intencaoAcao": {
+              "type": "string"
+            },
+            "targetSectionId": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^#"
+            },
+            "hrefEsperado": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "intencaoAcao",
+            "targetSectionId",
+            "hrefEsperado"
+          ]
+        },
+        "asset": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "src": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "alt": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "width": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "height": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "required": [
+                "src",
+                "alt",
+                "width",
+                "height"
+              ]
+            }
+          ]
+        },
+        "contratoCampo": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "autocomplete": {
+                  "type": "string"
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "placeholder": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "name",
+                "autocomplete",
+                "required",
+                "placeholder"
+              ]
+            }
+          ]
         }
       },
       "required": [
@@ -244,7 +376,11 @@
         "texto",
         "estilos",
         "briefingVisual",
-        "elementosInternos"
+        "elementosInternos",
+        "interacao",
+        "asset",
+        "contratoCampo",
+        "componente"
       ],
       "allOf": [
         {
@@ -282,6 +418,206 @@
           "then": {
             "properties": {
               "briefingVisual": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tag": {
+                "const": "img"
+              }
+            },
+            "required": [
+              "tag"
+            ]
+          },
+          "then": {
+            "properties": {
+              "asset": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "src": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "alt": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "width": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "height": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "src",
+                  "alt",
+                  "width",
+                  "height"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tag": {
+                "not": {
+                  "const": "img"
+                }
+              }
+            },
+            "required": [
+              "tag"
+            ]
+          },
+          "then": {
+            "properties": {
+              "asset": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tag": {
+                "const": "input"
+              }
+            },
+            "required": [
+              "tag"
+            ]
+          },
+          "then": {
+            "properties": {
+              "contratoCampo": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "autocomplete": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  },
+                  "placeholder": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "name",
+                  "autocomplete",
+                  "required",
+                  "placeholder"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tag": {
+                "not": {
+                  "const": "input"
+                }
+              }
+            },
+            "required": [
+              "tag"
+            ]
+          },
+          "then": {
+            "properties": {
+              "contratoCampo": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tag": {
+                "enum": [
+                  "a",
+                  "button"
+                ]
+              }
+            },
+            "required": [
+              "tag"
+            ]
+          },
+          "then": {
+            "properties": {
+              "interacao": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "intencaoAcao": {
+                    "type": "string"
+                  },
+                  "targetSectionId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "pattern": "^#"
+                  },
+                  "hrefEsperado": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "intencaoAcao",
+                  "targetSectionId",
+                  "hrefEsperado"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "tag": {
+                "not": {
+                  "enum": [
+                    "a",
+                    "button"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "tag"
+            ]
+          },
+          "then": {
+            "properties": {
+              "interacao": {
                 "type": "null"
               }
             }

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -59,6 +59,12 @@ Regras fixas da etapa (Gera Landing, contrato v3):
 - Evite JSON dentro de strings; mantenha cada informação no campo próprio.
 
 
+- `pagina.body` obrigatório: declarar classes base aplicadas ao `<body>` usando apenas `bgBody`, `fontBase`, `textPrimary`, `marginReset`.
+- Em TODO elemento interativo (`a`, `button`), declarar `intencaoAcao` e, quando for navegação interna, `targetSectionId` apontando para `id` real de seção (ex.: `#sec-prova`); quando for link externo, declarar `hrefEsperado`.
+- Em toda `img`, declarar contrato de asset em `asset`: `src`, `alt`, `width`, `height` (wireframe deve especificar esses campos mesmo com `src` provisório).
+- Em todo campo de formulário (`input`), declarar `contratoCampo`: `type`, `name`, `autocomplete`, `required`, `placeholder`.
+- Em elementos de ação/entrada, usar componentes semânticos via `componente`: `buttonPrimary`, `buttonSecondary`, `formInput`, `card` (quando aplicável), evitando depender de combinação manual de tokens.
+- `texto.conteudo: ""` significa literalmente “não renderizar texto”; é proibido substituir por placeholder nesta etapa.
 
 Matriz oficial de grupos e atributos CSS (explícita):
 - Grupo `posicionamento` (categoria `definicoes.posicao`): `position`, `top`, `right`, `bottom`, `left`, `z-index`.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1299,3 +1299,10 @@
   - docs/canonical/mois-worker-canon.v1.md
   - docs/canonical/procedimento-experimento-canon.v1.md
   - docs/registros/experimentos.md
+## 2026-05-23 21:05:00 UTC
+- solicitação para corrigir lacunas no prompt do Gera Landing (wireframe) em contrato estrutural/semântico para body, interação, imagens, formulário e componentes.
+- causa-raiz identificada: o contrato da etapa wireframe exigia briefing visual e estrutura geral, mas não obrigava metadados funcionais mínimos (âncora/href, contrato de asset, semântica de input e classes raiz de body), permitindo saídas incompletas no HTML derivado.
+- foi feito:
+  - reforço do prompt `landing-page-wireframe.md` com regras explícitas de `pagina.body`, intenção funcional de elementos interativos, contrato de asset em `img`, contrato semântico de `input`, componentes semânticos e validação permanente de `texto.conteudo` vazio;
+  - atualização do schema `landing-page-wireframe-schema.json` para incluir e validar os novos campos contratuais (`pagina.body.classes`, `interacao`, `asset`, `contratoCampo`, `componente`) com regras condicionais por `tag`.
+- impacto esperado: reduzir geração de wireframe ambígua e eliminar casos de HTML sem `src` em imagem, links sem destino claro e inputs sem contrato de campo.


### PR DESCRIPTION
### Motivation
- Close recurrent contract gaps that produced ambiguous/incomplete wireframes (images without `src`, links without intent, inputs without semantic metadata) and improve downstream HTML reliability.
- Make the wireframe stage explicit about page root classes, interactive intent, asset contracts, semantic input contracts and component roles so generated artifacts are machine-validateable and safe to publish.

### Description
- Updated the prompt instructions in `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` to require `pagina.body` classes (`bgBody`, `fontBase`, `textPrimary`, `marginReset`), interaction metadata for interactive elements, asset contract for images, semantic field contract for inputs, component tagging and the rule that `texto.conteudo: ""` means no rendered text.
- Extended the JSON schema `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` to add `pagina.body.classes` and new `elementoSecao` properties `componente`, `interacao`, `asset` and `contratoCampo` with conditional validations for `tag == "img"`, `tag == "input"` and `tag in ["a","button"]`.
- Recorded the change in the experiment log `docs/registros/experimentos.md` documenting cause, corrective action and expected impact.

### Testing
- Validated the updated JSON schema with `python -m json.tool ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json`, which succeeded.
- Performed static verification of the modified prompt file to ensure the new instructions were inserted and consistent with the schema, and no runtime Java code was changed so module unit tests were left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123e11bc34832183247bcb49c14996)