### PR TITLE
Ajusta contrato do Gera Copy para CTA, microcopy, compliance e alt text

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json
@@ -105,14 +105,27 @@
           "messageMatchNotes": {
             "type": "string",
             "pattern": "^(?!.*(?i:(adCopy\\\\.|campaignAngle\\\\.|landingMatchLine|mechanismSummary|primaryCTA|messageMatchNotes|ctaMatchNotes|matchAdCta|usa literalmente|id[eê]ntic[oa] ao an[úu]ncio|[âa]ncora para o formul[áa]rio|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\\\bV[1-3]-|lorem ipsum|como funciona \\\\(passo)))).+"
+          },
+          "ctaType": {
+            "type": "string",
+            "enum": [
+              "conversion",
+              "navigation"
+            ]
+          },
+          "targetSectionId": {
+            "type": "string",
+            "minLength": 1
           }
         },
         "required": [
           "placement",
           "ctaVariant",
+          "ctaType",
           "ctaLabel",
           "ctaUrl",
           "matchAdCta",
+          "targetSectionId",
           "ctaSupport",
           "messageMatchNotes"
         ]
@@ -182,6 +195,51 @@
     "complianceNotes": {
       "type": "string",
       "pattern": "^(?!.*(?i:(adCopy\\\\.|campaignAngle\\\\.|landingMatchLine|mechanismSummary|primaryCTA|messageMatchNotes|ctaMatchNotes|matchAdCta|usa literalmente|id[eê]ntic[oa] ao an[úu]ncio|[âa]ncora para o formul[áa]rio|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\\\bV[1-3]-|lorem ipsum|como funciona \\\\(passo)))).+"
+    },
+    "formMicrocopy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "privacyNotice": {
+          "type": "string",
+          "minLength": 20
+        },
+        "consentNotice": {
+          "type": "string",
+          "minLength": 20
+        }
+      },
+      "required": [
+        "privacyNotice",
+        "consentNotice"
+      ]
+    },
+    "imageAccessibilityPlan": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "imageId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sectionId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "altText": {
+            "type": "string",
+            "minLength": 8
+          }
+        },
+        "required": [
+          "imageId",
+          "sectionId",
+          "altText"
+        ]
+      }
     }
   },
   "required": [
@@ -191,7 +249,9 @@
     "primaryCTA",
     "bodySections",
     "ctaBlocks",
+    "formMicrocopy",
     "faq",
+    "imageAccessibilityPlan",
     "consistencyChecks",
     "complianceNotes"
   ],

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
@@ -58,8 +58,13 @@ Regras obrigatórias:
 5. Manter continuidade com promessa e CTA do anúncio, preservando o direcionamento de `campaignAngle`.
 6. Se houver conflito entre contexto e wireframe, priorize wireframe (`uiTags` + `uiSizeTexts`).
 7. Responder somente com JSON válido aderente ao schema da etapa.
-8. Campos explicativos (`messageMatchNotes`, `ctaMatchNotes`, `matchAdCta`, `consistencyChecks.details`) também são conteúdo de negócio e devem ser escritos em linguagem natural para time de marketing; nunca referencie nomes de campos/paths técnicos (ex.: `campaignAngle.primaryCTA`, `landingMatchLine`, `mechanismSummary`) e nunca escreva instruções como “usa literalmente”, “idêntico ao anúncio” ou “âncora para o formulário”.
-9. Proibido copiar trechos literais do prompt, schema, metadados ou contrato. Se detectar risco de vazamento técnico em qualquer campo textual, reescreva o texto antes de finalizar o JSON.
+8. Em `ctaBlocks`, diferenciar intenção de CTA: use `ctaType = "conversion"` para CTAs de captura/conversão e `ctaType = "navigation"` para CTAs de navegação/prova.
+9. Quando `ctaType = "navigation"`, preencher `targetSectionId` com a seção de destino real (ex.: `sec-prova`) e manter `ctaUrl` coerente com esse destino.
+10. Para formulário completo, sempre incluir `formMicrocopy` com pelo menos: `privacyNotice` e `consentNotice` em linguagem simples e objetiva.
+11. Regras de compliance para promessa temporal: só citar "2 minutos" (ou variações) quando o contexto indicar claramente preenchimento de briefing/cadastro inicial; não usar para prometer geração/entrega completa.
+12. Sempre preencher `imageAccessibilityPlan[]` com `imageId`, `sectionId` e `altText`, produzindo texto alternativo claro, específico e útil para acessibilidade.
+13. Campos explicativos (`messageMatchNotes`, `ctaMatchNotes`, `matchAdCta`, `consistencyChecks.details`) também são conteúdo de negócio e devem ser escritos em linguagem natural para time de marketing; nunca referencie nomes de campos/paths técnicos (ex.: `campaignAngle.primaryCTA`, `landingMatchLine`, `mechanismSummary`) e nunca escreva instruções como “usa literalmente”, “idêntico ao anúncio” ou “âncora para o formulário”.
+14. Proibido copiar trechos literais do prompt, schema, metadados ou contrato. Se detectar risco de vazamento técnico em qualquer campo textual, reescreva o texto antes de finalizar o JSON.
 
 CASE_DATA
 {{CASE_DATA_BLOCK}}
@@ -73,7 +78,9 @@ Campos obrigatórios:
 - primaryCTA
 - complianceNotes
 - bodySections[] com sectionId e items[] (cada item contendo apenas id e texto)
-- ctaBlocks[] com placement, ctaVariant, ctaLabel, ctaUrl, matchAdCta, ctaSupport, messageMatchNotes
+- ctaBlocks[] com placement, ctaVariant, ctaType, ctaLabel, ctaUrl, targetSectionId, matchAdCta, ctaSupport, messageMatchNotes
+- formMicrocopy com privacyNotice e consentNotice
+- imageAccessibilityPlan[] com imageId, sectionId, altText
 - faq[] com question, answer, objectionTag
 - consistencyChecks[] com check, status (PASS/WARN/FAIL), details
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1299,3 +1299,10 @@
   - docs/canonical/mois-worker-canon.v1.md
   - docs/canonical/procedimento-experimento-canon.v1.md
   - docs/registros/experimentos.md
+## 2026-05-23 21:05:00 UTC
+- solicitação para corrigir o prompt de Gera Copy da landing com foco em causa-raiz de divergência entre intenção do CTA, destino de navegação, compliance temporal, microcopy de formulário e acessibilidade de imagens.
+- causa-raiz identificada: o contrato da etapa `landing-page-copy` não separava semanticamente CTA de conversão vs navegação, não exigia destino explícito de CTA secundário, não obrigava microcopy de privacidade/consentimento no formulário e não exigia plano de alt text por imagem.
+- foi feito:
+  - atualização do prompt `landing-page-copy.md` com regras obrigatórias para `ctaType`, `targetSectionId`, `formMicrocopy`, `imageAccessibilityPlan` e compliance da promessa de "2 minutos";
+  - atualização do schema `landing-page-copy-schema.json` para refletir o novo contrato (campos obrigatórios para tipagem de CTA, microcopy de formulário e acessibilidade de imagens).
+- resultado esperado: reduzir 400/422 por ambiguidade de payload e melhorar aderência de copy/HTML no fluxo de prova, conversão e acessibilidade.


### PR DESCRIPTION
### Motivation
- Corrigir divergências recorrentes entre texto (copy) e destino/intenções dos CTAs que causavam payloads inválidos e desalinhamento com o HTML final.
- Garantir presença de microcopy obrigatória no formulário (privacidade/consentimento) para reduzir riscos de compliance e dúvidas do usuário.
- Controlar promessas temporais (ex.: "2 minutos") para que só sejam usadas em contexto de briefing/cadastro inicial e não prometam entrega completa.
- Cobrir acessibilidade adicionando requisito de `altText` por imagem para evitar omissão de descrições visuais.

### Description
- Atualiza o prompt/contrato de geração `ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md` com regras obrigatórias para `ctaType`, `targetSectionId`, `formMicrocopy`, `imageAccessibilityPlan` e compliance de promessa temporal.
- Expande o schema `ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json` adicionando `ctaType` (enum `conversion|navigation`) e `targetSectionId` em `ctaBlocks`, incluindo o novo objeto obrigatório `formMicrocopy` com `privacyNotice`/`consentNotice`, e um array obrigatório `imageAccessibilityPlan` com `imageId`, `sectionId` e `altText`.
- Atualiza os critérios de saída no prompt (OUTPUT_CONTRACT) para exigir os novos campos e registra a alteração em `docs/registros/experimentos.md` com causa-raiz e ação corretiva.
- Commit das alterações aplicadas aos arquivos mencionados e criação do PR com título correspondente.

### Testing
- Validação sintática do JSON schema executada com `python -m json.tool ai-worker/src/main/resources/prompts/geralanding/landing-page-copy-schema.json` e retornou sucesso.
- Verificação de estado do repositório com `git status --short` mostrou os três arquivos modificados e o commit foi criado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123e3dda588321a6cf831f4af83cd5)