### PR TITLE
Refina prompt de preset design do Gera Landing para tokens, estados e contraste

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
@@ -68,6 +68,18 @@ Regras obrigatórias:
 5. Não usar JSON serializado em string.
 6. Usar exclusivamente propriedades CSS permitidas em `docs/gera-landing/listas-css-estrutura-acabamento.md`.
 7. Manter foco de conversão: contraste legível, CTA destacado e consistência entre seção e elementos.
+8. Criar tokens de cor de texto dedicados e não reutilizar `opacity` para simular cor de texto.
+9. Garantir estados interativos reais (ex.: `:hover`) por combinação consistente de tokens base + tokens de hover.
+
+Checklist obrigatório de consistência visual (deve ser atendido no JSON):
+- Cores de texto obrigatórias: criar classes para `textPrimary`, `textMuted`, `textSubtle`, `textOnButtonPrimary`, `textOnInput`, `placeholderText`.
+- Body global obrigatório: criar preset `pageRoot` com `bgBody`, `fontBase`, `textPrimary` para herança consistente.
+- Tipografia não fragmentada: `h1`, `h2`, `h3` devem herdar `font-family` e cor do body, ou receber classes completas equivalentes.
+- Botão primário completo: além de `bgButtonPrimary`, `radiusButton`, `shadowButton`, incluir classes para `padding`, `display:inline-flex`, `align-items:center`, `justify-content:center`, `font-weight`, `color` (`textOnButtonPrimary`).
+- Input completo: além de `bgInput`, `radiusInput`, `borderSoft`, `caretAccent`, incluir classes para `padding`, `color` (`textOnInput`), `::placeholder` (`placeholderText`), `font` e `min-height`.
+- Hover real obrigatório: tokens `bgButtonPrimaryHover` e `bgButtonSecondaryHover` só são válidos quando existirem classes utilitárias preparadas para uso de seletor `:hover` na etapa de HTML/CSS final.
+- Opacidade: não usar `opacityMuted` para resolver cor de texto; preferir `color` com valores RGBA/HEX com contraste controlado.
+- Contraste obrigatório em tema escuro: assegurar WCAG mínimo de 4.5:1 para texto normal e 3:1 para texto grande.
 
 Estrutura obrigatória de `definicoes` (substitui a lista anterior):
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1312,3 +1312,9 @@
   - reforço do prompt `landing-page-wireframe.md` com regras explícitas de `pagina.body`, intenção funcional de elementos interativos, contrato de asset em `img`, contrato semântico de `input`, componentes semânticos e validação permanente de `texto.conteudo` vazio;
   - atualização do schema `landing-page-wireframe-schema.json` para incluir e validar os novos campos contratuais (`pagina.body.classes`, `interacao`, `asset`, `contratoCampo`, `componente`) com regras condicionais por `tag`.
 - impacto esperado: reduzir geração de wireframe ambígua e eliminar casos de HTML sem `src` em imagem, links sem destino claro e inputs sem contrato de campo.
+## 2026-05-24 00:00:00 UTC
+- solicitação para corrigir lacunas de design system no prompt da etapa `landing-page-design-preset` (tokens de texto, preset global de body, completude de botão/input, hover real, contraste e uso indevido de opacidade).
+- causa-raiz identificada: o prompt definia grupos CSS válidos, mas não explicitava checklist mínimo de classes utilitárias para garantir herança tipográfica/cromática, estados interativos reais e contraste acessível em tema escuro.
+- foi feito:
+  - atualização de `ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md` com regras obrigatórias e checklist operacional cobrindo `textPrimary/textMuted/textSubtle/textOnButtonPrimary/textOnInput/placeholderText`, preset `pageRoot`, completude de botão/input, regra de hover real, proibição de usar `opacityMuted` como substituto de cor e metas WCAG (4.5:1 e 3:1).
+- impacto esperado: reduzir presets incompletos e aumentar consistência visual/acessibilidade do HTML provisório gerado nas etapas seguintes.


### PR DESCRIPTION
### Motivation
- Fechar lacunas do design system no passo `landing-page-design-preset` para evitar presets incompletos que quebram herança tipográfica/cromática e estados interativos. 
- Assegurar acessibilidade e contraste adequado em temas escuros conforme WCAG para reduzir 400/422 e regressões visuais nas etapas seguintes.

### Description
- Atualiza `ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md` adicionando regras obrigatórias e checklist operacional cobrindo tokens de texto (`textPrimary`, `textMuted`, `textSubtle`, `textOnButtonPrimary`, `textOnInput`, `placeholderText`) e a obrigação do preset global `pageRoot` com `bgBody`, `fontBase`, `textPrimary`.
- Define completude mínima para botão e input, exigindo padding, `display:inline-flex`, `align-items:center`, `justify-content:center`, `font-weight`, `color` (`textOnButtonPrimary`) e para inputs `padding`, `color` (`textOnInput`), `::placeholder` (`placeholderText`), `font` e `min-height`.
- Exige tokens de hover utilizáveis (para gerar `:hover` reais) e proíbe o uso de `opacityMuted` como substituto de cor, recomendando `color` com RGBA/HEX controlados; adiciona meta de contraste WCAG (4.5:1 texto normal, 3:1 texto grande).
- Registra a alteração no log de experimentos em `docs/registros/experimentos.md` com causa-raiz, correção aplicada e impacto esperado.

### Testing
- Executado `git diff --check` para validar formatação e whitespace, sem erros detectados. 
- Verificado o status do workspace com `git status --short` para confirmar os arquivos modificados; verificação concluída com saída esperada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123faec5008321b97732c69847c2d2)