### PR TITLE
Fix Mermaid parse error in Gera Landing canonical architecture diagram

### DIFF
--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -235,9 +235,9 @@ Diagrama canônico de referência para o fluxo Gera Landing, separando explicita
 flowchart LR
     subgraph W[Worker AI - ai-worker<br>Pacote: com.marketinghub.worker.geralanding]
       WS[GeraLandingExecutionScheduler] --> WE[GeraLandingExecutionService]
-      WE --> WB[GeraLandingBackendClient<br>(HTTP backend)]
-      WE --> OA[GeraLandingOpenAiFlexClient<br>(OpenAI Responses)]
-      WE --> SD[stage/*<br>Schema + Prompt Resolver]
+      WE --> WB["GeraLandingBackendClient<br/>HTTP backend"]
+      WE --> OA["GeraLandingOpenAiFlexClient<br/>OpenAI Responses"]
+      WE --> SD["stage/*<br/>Schema + Prompt Resolver"]
     end
 
     subgraph B[Backend - ads-service<br>Pacote: com.marketinghub.geralanding]
@@ -245,7 +245,7 @@ flowchart LR
       BS --> BH[Html Assemblers/Processors<br>(copy, wireframe, designpreset, imageplanning)]
       BS --> BR[GeraLandingStageExecutionRepository]
       BR --> DB[(MySQL 5.7)]
-      BS --> LP[Publicação Lead Portal<br>(endpoint externo)]
+      BS --> LP["Publicação Lead Portal<br/>endpoint externo"]
     end
 
     WB -->|claim/dispatch/receive/complete/fail| BC

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1318,3 +1318,11 @@
 - foi feito:
   - atualização de `ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md` com regras obrigatórias e checklist operacional cobrindo `textPrimary/textMuted/textSubtle/textOnButtonPrimary/textOnInput/placeholderText`, preset `pageRoot`, completude de botão/input, regra de hover real, proibição de usar `opacityMuted` como substituto de cor e metas WCAG (4.5:1 e 3:1).
 - impacto esperado: reduzir presets incompletos e aumentar consistência visual/acessibilidade do HTML provisório gerado nas etapas seguintes.
+
+## 2026-05-24 00:20:00 UTC
+- solicitação para corrigir erro de renderização Mermaid no diagrama canônico `15.4` de Gera Landing no documento de procedimento de experimento.
+- causa-raiz identificada: labels Mermaid com quebra HTML + parênteses sem aspas em nós específicos, gerando falha de parsing no renderer do GitHub.
+- foi feito:
+  - ajuste dos nós do Mermaid para formato com rótulo entre aspas e `<br/>` compatível com GitHub (`WB`, `OA`, `SD`, `LP`) em `docs/canonical/procedimento-experimento-canon.v1.md`;
+  - manutenção do diagrama no mesmo local canônico, sem mudança de arquitetura/regras de fluxo.
+- resultado esperado: renderização estável do diagrama no GitHub sem erro de parse.


### PR DESCRIPTION
### Motivation
- Fix a GitHub Mermaid render failure in the Gera Landing architecture diagram caused by unquoted node labels mixing HTML line breaks and parenthesized text which produced a parser tokenization error.

### Description
- Updated problematic Mermaid node labels (`WB`, `OA`, `SD`, `LP`) to use quoted text with `<br/>` in `docs/canonical/procedimento-experimento-canon.v1.md` and added a log entry describing the fix to `docs/registros/experimentos.md`.

### Testing
- Verified the edited Mermaid block and file contents using `sed`/`nl` and `rg`, checked repository status with `git status`, and committed the changes with `git commit`, and all verification commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12436b726c8321a3095a75b1a2abe3)