### PR TITLE
docs: add module/package architecture diagrams for Hotmart and ClickBank collectors

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -388,6 +388,41 @@ graph TD
     BR -->|READ/WRITE: ingest, jobs, analyses, snapshots| DB
 ```
 
+
+#### 12.5.1 Hotmart Collector — arquitetura por módulo/pacote
+
+```mermaid
+graph TD
+    HS[hotmart.com
+Fonte externa] -->|Coleta de produtos/URLs| HC[mois-hotmart-collector\npackage: com.marketinghub.mois.hotmart.collector]
+
+    HC -->|POST /api/mois/sales-library/urls:ingest\nsource=HOTMART| BM[backend/ads-service\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.web]
+
+    subgraph Backend MOIS
+      BM --> BS[backend/ads-service\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service]
+      BS --> BR[backend/ads-service\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.repository]
+    end
+
+    BR -->|UPSERT ingest + criação job PENDING| DB[(MySQL 5.7)]
+```
+
+#### 12.5.2 ClickBank Collector — arquitetura por módulo/pacote
+
+```mermaid
+graph TD
+    CB[api.clickbank.com / marketplace
+Fonte externa] -->|Coleta de produtos/URLs| CC[mois-clickbank-collector\npackage: com.marketinghub.mois.clickbank.collector]
+
+    CC -->|POST /api/mois/sales-library/urls:ingest\nsource=CLICKBANK| BM[backend/ads-service\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.web]
+
+    subgraph Backend MOIS
+      BM --> BS[backend/ads-service\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service]
+      BS --> BR[backend/ads-service\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.repository]
+    end
+
+    BR -->|UPSERT ingest + criação job PENDING| DB[(MySQL 5.7)]
+```
+
 #### Regras de integração refletidas no diagrama
 - Coletores e worker **não acessam banco diretamente**; todo acesso a dados passa pelo backend MOIS.
 - A integração com OpenAI é realizada pelo `mois-sales-library-worker`, com retorno consolidado ao backend via endpoint de conclusão/falha.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -530,3 +530,12 @@
 Arquivos alterados:
 - docs/canonical/mois-worker-canon.v1.md
 - docs/registros/mois1.md
+
+## 2026-05-23 21:20:34 UTC-3
+- solicitado criar diagramas no mesmo padrão da seção 12.5 para separar a arquitetura por coletor Hotmart e por coletor ClickBank.
+- foram adicionados dois diagramas canônicos independentes na documentação do MOIS Worker, mantendo o backend como ponto único de integração e o MySQL como persistência exclusiva do backend.
+- registro realizado para manter rastreabilidade documental do módulo MOIS conforme política de registros.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/registros/mois1.md


### PR DESCRIPTION
### Motivation
- Improve clarity by providing dedicated architecture-by-module diagrams for the Hotmart and ClickBank collectors following the existing 12.5 pattern. 
- Keep documentation aligned with the canonical MOIS Worker view that treats the backend as the single integration point and MySQL 5.7 as persistence behind the backend.

### Description
- Added `12.5.1 Hotmart Collector — arquitetura por módulo/pacote` with a Mermaid graph showing `hotmart.com -> mois-hotmart-collector -> backend MOIS -> repository -> MySQL 5.7` in `docs/canonical/mois-worker-canon.v1.md`.
- Added `12.5.2 ClickBank Collector — arquitetura por módulo/pacote` with a Mermaid graph showing `api.clickbank.com -> mois-clickbank-collector -> backend MOIS -> repository -> MySQL 5.7` in `docs/canonical/mois-worker-canon.v1.md`.
- Recorded the change in the MOIS operational log `docs/registros/mois1.md` with the required UTC-3 timestamp to preserve traceability.

### Testing
- Verified the updated section content and line ranges with `sed -n` and `nl -ba` to confirm the two Mermaid blocks exist and follow the 12.5 structure. 
- Confirmed the registry entry was appended to `docs/registros/mois1.md` with the expected timestamp format. 
- Performed a local diff inspection of the modified files to ensure only documentation was changed and no executable code was affected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a124432bfdc8321995a37d8f03fcda0)