### PR TITLE
docs: adicionar URLs acessadas da Hotmart no diagrama do coletor

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -207,9 +207,16 @@ sequenceDiagram
     participant DB as MySQL 5.7
 
     rect rgb(245,245,245)
-    Note over HS,HC: Coleta no site da Hotmart
-    HC->>HS: GET product details (salesPageUrl com fallback em detailsUrl)
-    HS-->>HC: 200 OK (url acessada para captura)
+    Note over HS,HC: Coleta no site da Hotmart (URLs acessadas)
+    HC->>HS: GET https://www.hotmart.com/pt-br/marketplace/produtos/{slug-ou-id}
+    HS-->>HC: 200 OK (detailsUrl com salesPageUrl quando disponível)
+    alt salesPageUrl disponível no detailsUrl
+      HC->>HS: GET {salesPageUrl} (landing oficial do produtor)
+      HS-->>HC: 200 OK (HTML da página de vendas)
+    else salesPageUrl ausente
+      HC->>HS: GET {detailsUrl} (fallback de captura)
+      HS-->>HC: 200 OK (HTML da página de detalhes)
+    end
 
     Note over HC,API: 1) Coleta e envio de URLs vencedoras da Hotmart
     HC->>API: POST /urls:ingest (source=HOTMART, urls[])


### PR DESCRIPTION
### Motivation
- Tornar explícito no diagrama quais endpoints da Hotmart o coletor acessa para que a equipe operacional e de desenvolvimento saiba exatamente as URLs utilizadas durante a captura.

### Description
- Atualiza `docs/canonical/mois-worker-canon.v1.md` na seção `12.2.1` para ampliar o diagrama de sequência e incluir `GET https://www.hotmart.com/pt-br/marketplace/produtos/{slug-ou-id}`, o `GET {salesPageUrl}` quando disponível e fallback para `GET {detailsUrl}` quando `salesPageUrl` estiver ausente.

### Testing
- A alteração foi adicionada e comitada com `git commit` e o trecho alterado foi verificado com `nl -ba docs/canonical/mois-worker-canon.v1.md | sed -n '198,230p'`, ambos os comandos retornaram sucesso.
- O PR foi gerado via `make_pr` com título e corpo corretos e não foram necessários testes unitários por se tratar de mudança apenas em documentação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244f8001883219150f32b1e184bce)