### PR TITLE
Reintroduce applyPageBodyClasses to fix compilation in DesignPresetProvisionalHtmlProcessor

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
@@ -258,6 +258,29 @@ public class DesignPresetProvisionalHtmlProcessor {
         }
     }
 
+
+    /**
+     * Aplica classes declaradas em `pagina.body.classes` ao elemento `<body>`.
+     */
+    private void applyPageBodyClasses(Document document, Map<String, Object> page) {
+        if (document == null || page == null) {
+            return;
+        }
+
+        Element body = document.body();
+        if (body == null) {
+            return;
+        }
+
+        Map<String, Object> bodyMap = asMap(firstNonNull(page.get("body"), page.get("corpo")));
+        if (bodyMap.isEmpty()) {
+            return;
+        }
+
+        Object bodyClasses = firstNonNull(bodyMap.get("classes"), bodyMap.get("classList"), bodyMap.get("estilos"));
+        appendClasses(body, collectStyleClasses(bodyClasses));
+    }
+
     private void applyStructuredNodeDataRecursive(Document document, Map<String, Object> node) {
         String id = asString(node.get("id"));
         Element element = resolveElementById(document, id);

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1337,3 +1337,11 @@
   - ajuste dos nós do Mermaid para formato com rótulo entre aspas e `<br/>` compatível com GitHub (`WB`, `OA`, `SD`, `LP`) em `docs/canonical/procedimento-experimento-canon.v1.md`;
   - manutenção do diagrama no mesmo local canônico, sem mudança de arquitetura/regras de fluxo.
 - resultado esperado: renderização estável do diagrama no GitHub sem erro de parse.
+
+## 2026-05-24 01:55:00 UTC
+- solicitação para corrigir falha de compilação no módulo `backend/ads-service` por símbolo ausente em `DesignPresetProvisionalHtmlProcessor` (`applyPageBodyClasses`).
+- causa-raiz identificada: chamadas para aplicação de classes de `pagina.body` permaneceram no fluxo de montagem do HTML, porém o método auxiliar havia sido removido/omitido na classe.
+- correção aplicada:
+  - reintroduzido `applyPageBodyClasses(Document, Map<String,Object>)` com fallback para `body/corpo` e `classes/classList/estilos`, reaproveitando `collectStyleClasses` + `appendClasses` para manter deduplicação e contrato atual tokenizado.
+- resultado esperado: restauração da compilação do `ads-service` e reaplicação consistente de classes globais no `<body>`.
+


### PR DESCRIPTION
### Motivation
- Fix a compilation failure where calls to `applyPageBodyClasses` in `DesignPresetProvisionalHtmlProcessor` referenced a method that had been removed, causing `cannot find symbol` errors during build. 
- Ensure that classes declared in the tokenized preset (`pagina.body`) are applied to the HTML `<body>` with the same deduplication and style-collection logic used elsewhere in the processor.

### Description
- Reintroduced `applyPageBodyClasses(Document, Map<String,Object>)` inside `DesignPresetProvisionalHtmlProcessor`, which resolves the missing-symbol compilation error. 
- The helper reads `pagina.body` with fallbacks to `body`/`corpo` and accepts `classes`/`classList`/`estilos`, then reuses `collectStyleClasses` and `appendClasses` to apply classes to the `<body>`. 
- Added a task log entry in `docs/registros/experimentos.md` documenting the cause and the applied correction.

### Testing
- Ran `mvn -DskipTests compile` in `backend/ads-service`, which completed successfully after the fix. 
- Ran `mvn test -DskipITs` in `backend/ads-service` and the build failed at test compilation due to a pre-existing missing test dependency (`DesignPresetWireframeHtmlGenerator`) unrelated to this change. 
- The change is limited to adding the missing helper and does not modify existing production logic beyond restoring the intended application of page-level classes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12590a04f88321a58835c28a209e0f)