### PR TITLE
Apply tokenized preset CSS classes to body and nested nodes in provisional HTML

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
@@ -277,7 +277,11 @@ public class DesignPresetProvisionalHtmlProcessor {
             return;
         }
 
-        Object bodyClasses = firstNonNull(bodyMap.get("classes"), bodyMap.get("classList"), bodyMap.get("estilos"));
+        Object bodyClasses = firstNonNull(
+                bodyMap.get("classes"),
+                bodyMap.get("classList"),
+                bodyMap.get("estilos"),
+                bodyMap);
         appendClasses(body, collectStyleClasses(bodyClasses));
     }
 
@@ -835,11 +839,11 @@ public class DesignPresetProvisionalHtmlProcessor {
     private void applyTokenizedSectionClasses(Document document, Map<String, Object> page) {
         Map<String, Object> corpo = asMap(page.get("corpo"));
         for (Map<String, Object> sectionMap : asList(corpo.get("secoes"))) {
-            applyTokenizedNodeClasses(document, sectionMap, "elementosSeccao");
+            applyTokenizedNodeClasses(document, sectionMap);
         }
     }
 
-    private void applyTokenizedNodeClasses(Document document, Map<String, Object> node, String childrenField) {
+    private void applyTokenizedNodeClasses(Document document, Map<String, Object> node) {
         String id = asString(node.get("id"));
         Element element = resolveElementById(document, id);
 
@@ -847,8 +851,11 @@ public class DesignPresetProvisionalHtmlProcessor {
             appendClasses(element, collectStyleClasses(node.get("estilos")));
         }
 
-        for (Map<String, Object> child : asList(node.get(childrenField))) {
-            applyTokenizedNodeClasses(document, child, "elementosInternos");
+        for (Map<String, Object> child : asList(node.get("elementosSeccao"))) {
+            applyTokenizedNodeClasses(document, child);
+        }
+        for (Map<String, Object> child : asList(node.get("elementosInternos"))) {
+            applyTokenizedNodeClasses(document, child);
         }
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java
@@ -81,4 +81,77 @@ class DesignPresetProvisionalHtmlProcessorTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("formato tokenizado");
     }
+
+    @Test
+    void shouldApplyBodyClassesAndNestedSectionClassesFromTokenizedPreset() {
+        DesignPresetProvisionalHtmlProcessor processor = new DesignPresetProvisionalHtmlProcessor();
+
+        String wireframe = """
+                {
+                  "pagina": {
+                    "head": {},
+                    "corpo": {
+                      "secoes": [
+                        {
+                          "id":"sec-hero",
+                          "elementosSeccao":[
+                            {
+                              "id":"hero-container",
+                              "tag":"div",
+                              "elementosInternos":[
+                                {"id":"hero-title","tag":"h1","texto":{"conteudo":""},"elementosInternos":[]}
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        String copy = "{" +
+                "\"bodySections\":[{\"items\":[{\"id\":\"hero-title\",\"texto\":\"Titulo\"}]}]" +
+                "}";
+
+        String design = """
+                {
+                  "definicoes": {},
+                  "pagina": {
+                    "body": {
+                      "desktop": ["pageRoot","bgBody"],
+                      "mobile": ["pageRoot","bgBody"]
+                    },
+                    "corpo": {
+                      "secoes": [
+                        {
+                          "id": "sec-hero",
+                          "estilos": {"desktop": ["section-desktop"], "mobile": []},
+                          "elementosSeccao": [
+                            {
+                              "id": "hero-container",
+                              "estilos": {"desktop": ["container-desktop"], "mobile": []},
+                              "elementosInternos": [
+                                {
+                                  "id": "hero-title",
+                                  "estilos": {"desktop": ["h1-size"], "mobile": []},
+                                  "elementosInternos": []
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        String html = processor.process(wireframe, copy, "{}", design);
+
+        assertThat(html).contains("<body class=\"pageRoot bgBody\"");
+        assertThat(html).contains("id=\"sec-hero\"").contains("class=\"section-desktop\"");
+        assertThat(html).contains("id=\"hero-container\"").contains("class=\"container-desktop\"");
+        assertThat(html).contains("id=\"hero-title\"").contains("class=\"h1-size\"");
+    }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1351,3 +1351,15 @@
 - causa-raiz identificada: teste órfão em `src/test` referenciando classe inexistente no pacote `com.marketinghub.geralanding.designpreset`.
 - correção aplicada: exclusão do arquivo de teste órfão para restaurar a compilação dos testes do módulo.
 - resultado esperado: etapa Maven `testCompile` do `ads-service` volta a compilar sem erro de símbolo não encontrado.
+
+## 2026-05-24 03:05:00 UTC
+- solicitação para corrigir o HTML do gerador preset design, pois as classes CSS do JSON de preset não estavam sendo inseridas no HTML final.
+- causa-raiz identificada:
+  - `pagina.body` no preset tokenizado usa estrutura direta `desktop/mobile`, mas o processor só lia `classes/classList/estilos`, descartando as classes globais de `<body>`;
+  - a recursão de classes tokenizadas percorria apenas `elementosSeccao` na raiz e apenas `elementosInternos` nos níveis seguintes, deixando nós em estruturas mistas sem aplicação de classes.
+- correção aplicada:
+  - no `DesignPresetProvisionalHtmlProcessor`, `applyPageBodyClasses` passou a aceitar fallback para o próprio mapa `body` quando ele já está no formato `desktop/mobile`;
+  - a recursão de `applyTokenizedNodeClasses` foi normalizada para sempre percorrer os dois filhos (`elementosSeccao` e `elementosInternos`) em todos os níveis.
+- cobertura de regressão adicionada:
+  - novo teste `shouldApplyBodyClassesAndNestedSectionClassesFromTokenizedPreset` validando classe no `<body>`, em seção e em nós aninhados.
+- resultado esperado: classes do preset design passam a ser refletidas corretamente no HTML provisório em toda a árvore.


### PR DESCRIPTION
### Motivation
- The provisional HTML generator was not applying CSS classes defined in tokenized presets when `pagina.body` used the direct `desktop/mobile` shape, so global body classes from presets were missing in the output. 
- Recursion used to apply tokenized classes was asymmetric, causing classes on nodes in mixed/more-nested structures to be skipped.

### Description
- Updated `applyPageBodyClasses` in `DesignPresetProvisionalHtmlProcessor` to accept the `body` map in `desktop/mobile` form as a fallback and feed it to `collectStyleClasses` so classes are applied to `<body>` when presets use that shape. 
- Normalized recursion by changing `applyTokenizedNodeClasses` to always traverse both `elementosSeccao` and `elementosInternos` at every level so tokenized classes propagate through mixed nesting. 
- Adjusted `applyTokenizedSectionClasses` to call the simplified `applyTokenizedNodeClasses` signature and removed the `childrenField` parameter. 
- Added a regression unit test `shouldApplyBodyClassesAndNestedSectionClassesFromTokenizedPreset` to `DesignPresetProvisionalHtmlProcessorTest` and recorded the change in `docs/registros/experimentos.md`.

### Testing
- Ran the unit tests with `mvn -f backend/ads-service/pom.xml -Dtest=DesignPresetProvisionalHtmlProcessorTest test`. 
- Test results: `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0` and `BUILD SUCCESS` for the `DesignPresetProvisionalHtmlProcessorTest` suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1269d630488321b7d74f054ae78819)