### PR TITLE
docs(mois): explicita integração OpenAI e obtenção de prompt nos diagramas canônicos

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -132,6 +132,7 @@ Esta seção consolida o fluxo ponta a ponta de **alimentação da biblioteca** 
 3. **Rotina que obtém conteúdo da página e envia para análise**
    - O worker faz `claim` (`jobs:claim`), muda job para `FETCHING`, baixa HTML da `urlCanonical`, extrai texto (`body.text()`) e inicia análise OpenAI.
 4. **Prompt + schema de saída usados no worker**
+   - O worker monta o prompt com `urlCanonical` + texto extraído (`body.text()`) e versão de parser/prompt para rastreabilidade da análise.
    - O worker envia instrução para análise comercial e exige resposta em JSON via `/v1/responses` com `text.format.type=json_object`.
    - Campos obrigatórios esperados no JSON de saída: `score_total`, `sections_json`, `copy_json`, `visual_json`, `image_json`, `analysis_notes`.
 5. **Receber resultado OpenAI e persistir no banco**
@@ -146,6 +147,7 @@ sequenceDiagram
     participant CC as ClickBank Collector
     participant API as Backend MOIS (/api/mois/sales-library)
     participant WK as MOIS Sales Library Worker
+    participant PR as Prompt Builder (Worker)
     participant OAI as OpenAI Batch (/v1/responses)
     participant DB as MySQL 5.7
 
@@ -179,8 +181,11 @@ sequenceDiagram
 
     rect rgb(245,245,245)
     Note over WK,OAI: 4) Prompt/schema de análise
-    WK->>OAI: Batch line -> /v1/responses<br/>text.format.type=json_object
+    WK->>PR: Monta prompt com urlCanonical + body.text()
+    PR-->>WK: prompt final + promptVersion + parserVersion
+    WK->>OAI: Batch line -> /v1/responses<br/>model + input + text.format.type=json_object
     OAI-->>WK: output JSON (score_total, sections_json, ...)
+    WK->>WK: Parse do output e validação dos campos obrigatórios
     end
 
     rect rgb(245,245,245)
@@ -381,7 +386,10 @@ graph TD
     CC[mois-clickbank-collector\npackage: com.marketinghub.mois.clickbank.collector] -->|POST /api/mois/sales-library/urls:ingest| BM
 
     WK[mois-sales-library-worker\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service] -->|"jobs:claim, jobs/{id}:complete, jobs/{id}:fail"| BM
-    WK -->|"/v1/responses (batch)"| OAI[OpenAI API]
+    WK --> PB[Prompt Builder\nopenai.OpenAiSalesPageAnalyzer]
+    PB -->|Monta prompt (URL + texto da página)\nDefine promptVersion/parserVersion| OAI[OpenAI API /v1/responses]
+    OAI -->|Retorna JSON estruturado da análise| PB
+    PB -->|Resultado validado (score, sections, copy, visual, image, notes)| WK
 
     BM -->|JPA/SQL via camada backend| DB[(MySQL 5.7)]
 
@@ -433,6 +441,7 @@ Fonte externa] -->|Coleta de produtos/URLs| CC[mois-clickbank-collector\npackage
 #### Regras de integração refletidas no diagrama
 - Coletores e worker **não acessam banco diretamente**; todo acesso a dados passa pelo backend MOIS.
 - A integração com OpenAI é realizada pelo `mois-sales-library-worker`, com retorno consolidado ao backend via endpoint de conclusão/falha.
+- A obtenção/montagem de prompt acontece no próprio worker (`OpenAiSalesPageAnalyzer`), combinando URL canônica, texto extraído da página e versão de prompt para rastreabilidade.
 - A persistência em MySQL 5.7 ocorre apenas nos pacotes de serviço/repositório do backend.
 
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -539,3 +539,16 @@ Arquivos alterados:
   - AGENTS.md
   - docs/canonical/mois-worker-canon.v1.md
   - docs/registros/mois1.md
+
+## 2026-05-24 00:00:00 UTC
+- melhoria dos diagramas canônicos da biblioteca de páginas de vendas do MOIS para explicitar integração com OpenAI e o fluxo de obtenção/montagem de prompt.
+- causa-raiz: os diagramas existentes mostravam chamada para OpenAI, mas não deixavam visível a etapa de construção do prompt (URL canônica + conteúdo extraído) e metadados de rastreabilidade (`promptVersion`/`parserVersion`).
+- correção aplicada:
+  - seção 12.1 atualizada para detalhar a montagem do prompt antes do envio ao `/v1/responses`;
+  - seção 12.2 (sequência ponta a ponta) atualizada com participante `Prompt Builder (Worker)` e passos explícitos de montagem/retorno de prompt e validação do output;
+  - seção 12.5 (arquitetura por módulo/pacote) atualizada para destacar o componente `openai.OpenAiSalesPageAnalyzer` entre worker e OpenAI;
+  - regras de integração atualizadas com nota explícita sobre origem do prompt no worker.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/registros/mois1.md


### PR DESCRIPTION
### Motivation
- Os diagramas e o texto do cânone do MOIS não deixavam explícita a etapa de montagem do prompt (combinação de `urlCanonical` + texto extraído) nem a rastreabilidade (`promptVersion`/`parserVersion`), gerando ambiguidade operacional para operação e suporte.
- Tornar visível todo o fluxo de integração com OpenAI melhora entendimento do pipeline de análise de sales pages e facilita auditoria/regressão de prompt/parse. 

### Description
- Atualiza `docs/canonical/mois-worker-canon.v1.md` seção 12.1 para documentar que o worker monta o prompt com `urlCanonical` + `body.text()` e inclui `promptVersion`/`parserVersion` para rastreabilidade. 
- Altera a sequência ponta a ponta (seção 12.2) adicionando o participante `Prompt Builder (Worker)` e passos explícitos: montagem do prompt, retorno `promptVersion`/`parserVersion`, envio para `/v1/responses` e validação/parse do JSON de saída. 
- Atualiza o diagrama de arquitetura por módulo (seção 12.5) para representar `openai.OpenAiSalesPageAnalyzer`/`Prompt Builder` entre o `mois-sales-library-worker` e a OpenAI, e adiciona nota nas regras de integração sobre onde o prompt é obtido/montado. 
- Registra a alteração em `docs/registros/mois1.md` conforme política de registros do módulo MOIS; arquivos modificados: `docs/canonical/mois-worker-canon.v1.md` e `docs/registros/mois1.md`.

### Testing
- Não foram executados testes automatizados pois a alteração é estritamente documental e não impacta runtime. 
- Validação manual: os diagramas Mermaid e texto foram atualizados e verificados localmente para leitura e consistência do conteúdo; não aplicável a testes unitários ou integração automatizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a128cdce3d48321a526fc13fca2e9cc)