### PR TITLE
Corrige classes de body no HTML da etapa Preset Design

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
@@ -277,12 +277,26 @@ public class DesignPresetProvisionalHtmlProcessor {
             return;
         }
 
-        Object bodyClasses = firstNonNull(
-                bodyMap.get("classes"),
-                bodyMap.get("classList"),
-                bodyMap.get("estilos"),
-                bodyMap);
-        appendClasses(body, collectStyleClasses(bodyClasses));
+        appendClasses(body, collectBodyClasses(bodyMap));
+    }
+
+    /**
+     * Coleta classes do body aceitando múltiplos formatos de contrato.
+     */
+    private List<String> collectBodyClasses(Map<String, Object> bodyMap) {
+        List<String> classes = new ArrayList<>();
+
+        classes.addAll(collectStyleClasses(bodyMap));
+
+        Object classesNode = firstNonNull(bodyMap.get("classes"), bodyMap.get("classList"));
+        classes.addAll(collectStyleClasses(classesNode));
+        classes.addAll(readStringList(classesNode));
+
+        Object estilosNode = bodyMap.get("estilos");
+        classes.addAll(collectStyleClasses(estilosNode));
+        classes.addAll(readStringList(estilosNode));
+
+        return classes;
     }
 
     private void applyStructuredNodeDataRecursive(Document document, Map<String, Object> node) {

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java
@@ -1,7 +1,10 @@
 package com.marketinghub.geralanding;
 
 import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlProcessor;
+import org.jsoup.Jsoup;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -149,7 +152,10 @@ class DesignPresetProvisionalHtmlProcessorTest {
 
         String html = processor.process(wireframe, copy, "{}", design);
 
-        assertThat(html).contains("<body class=\"pageRoot bgBody fontBase textPrimary textSizeBase lineHeightBase marginReset\"");
+        List<String> expectedBodyClasses = List.of(
+                "pageRoot", "bgBody", "fontBase", "textPrimary", "textSizeBase", "lineHeightBase", "marginReset");
+        List<String> bodyClasses = Jsoup.parse(html).body().classNames().stream().toList();
+        assertThat(bodyClasses).containsAll(expectedBodyClasses);
         assertThat(html).contains("id=\"sec-hero\"").contains("class=\"section-desktop\"");
         assertThat(html).contains("id=\"hero-container\"").contains("class=\"container-desktop\"");
         assertThat(html).contains("id=\"hero-title\"").contains("class=\"h1-size\"");

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java
@@ -119,8 +119,8 @@ class DesignPresetProvisionalHtmlProcessorTest {
                   "definicoes": {},
                   "pagina": {
                     "body": {
-                      "desktop": ["pageRoot","bgBody"],
-                      "mobile": ["pageRoot","bgBody"]
+                      "desktop": ["pageRoot","bgBody","fontBase","textPrimary","textSizeBase","lineHeightBase","marginReset"],
+                      "mobile": ["pageRoot","bgBody","fontBase","textPrimary","textSizeBase","lineHeightBase","marginReset"]
                     },
                     "corpo": {
                       "secoes": [
@@ -149,7 +149,7 @@ class DesignPresetProvisionalHtmlProcessorTest {
 
         String html = processor.process(wireframe, copy, "{}", design);
 
-        assertThat(html).contains("<body class=\"pageRoot bgBody\"");
+        assertThat(html).contains("<body class=\"pageRoot bgBody fontBase textPrimary textSizeBase lineHeightBase marginReset\"");
         assertThat(html).contains("id=\"sec-hero\"").contains("class=\"section-desktop\"");
         assertThat(html).contains("id=\"hero-container\"").contains("class=\"container-desktop\"");
         assertThat(html).contains("id=\"hero-title\"").contains("class=\"h1-size\"");

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1371,3 +1371,9 @@
   - no `DesignPresetProvisionalHtmlProcessor`, criação do método `collectBodyClasses` para consolidar classes do `<body>` em múltiplos formatos (`desktop/mobile` diretos, `classes`, `classList`, `estilos`), com deduplicação preservada;
   - atualização do teste `shouldApplyBodyClassesAndNestedSectionClassesFromTokenizedPreset` para validar explicitamente as 7 classes esperadas no `<body>` (`pageRoot`, `bgBody`, `fontBase`, `textPrimary`, `textSizeBase`, `lineHeightBase`, `marginReset`).
 - resultado esperado: o HTML da etapa preset design passa a refletir integralmente as classes globais no `<body>` conforme o JSON gerado.
+
+## 2026-05-24 10:55:00 UTC
+- ajuste complementar solicitado: remover rigidez da validação de classes do `<body>` na regressão do preset design, pois a quantidade de classes pode variar por experimento/prompt.
+- causa-raiz identificada: o teste anterior validava uma string fixa de `<body class="...">`, acoplando o cenário exatamente a 7 classes e à ordem literal.
+- correção aplicada: teste atualizado para parsear o HTML com Jsoup e validar que o `<body>` contém pelo menos as classes esperadas do payload, sem assumir quantidade total fixa.
+- resultado esperado: regressão cobre o comportamento funcional correto mesmo quando o preset gerar mais ou menos classes globais.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1363,3 +1363,11 @@
 - cobertura de regressão adicionada:
   - novo teste `shouldApplyBodyClassesAndNestedSectionClassesFromTokenizedPreset` validando classe no `<body>`, em seção e em nós aninhados.
 - resultado esperado: classes do preset design passam a ser refletidas corretamente no HTML provisório em toda a árvore.
+
+## 2026-05-24 10:35:00 UTC
+- solicitação para garantir que as classes do preset design exibidas em `pagina.body.desktop/mobile` sejam aplicadas no elemento `<body>` do HTML provisório.
+- causa-raiz identificada: o parser de classes do `<body>` cobria parcialmente formatos alternativos, mas não consolidava todos os formatos aceitos em uma única coleta robusta, causando perda de classes em alguns payloads da etapa 6.
+- correção aplicada:
+  - no `DesignPresetProvisionalHtmlProcessor`, criação do método `collectBodyClasses` para consolidar classes do `<body>` em múltiplos formatos (`desktop/mobile` diretos, `classes`, `classList`, `estilos`), com deduplicação preservada;
+  - atualização do teste `shouldApplyBodyClassesAndNestedSectionClassesFromTokenizedPreset` para validar explicitamente as 7 classes esperadas no `<body>` (`pageRoot`, `bgBody`, `fontBase`, `textPrimary`, `textSizeBase`, `lineHeightBase`, `marginReset`).
+- resultado esperado: o HTML da etapa preset design passa a refletir integralmente as classes globais no `<body>` conforme o JSON gerado.


### PR DESCRIPTION
### Motivation
- O HTML gerado pela etapa `landing-page-design-preset` não estava recebendo todas as classes globais definidas em `pagina.body` do preset tokenizado, causando perda de estilos esperados no `<body>`.

### Description
- No `DesignPresetProvisionalHtmlProcessor`, `applyPageBodyClasses` agora consolida classes do `<body>` usando o novo método `collectBodyClasses` para aceitar formatos `desktop/mobile` diretos, `classes`, `classList` e `estilos` com deduplicação preservada (arquivo `backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java`).
- O teste de regressão foi atualizado para validar explicitamente a presença das sete classes esperadas no `<body>` (`pageRoot`, `bgBody`, `fontBase`, `textPrimary`, `textSizeBase`, `lineHeightBase`, `marginReset`) (arquivo `backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java`).
- O registro da atividade foi adicionado em `docs/registros/experimentos.md` para rastreabilidade do ajuste no fluxo GeraLanding/Preset Design.

### Testing
- Executed `cd backend/ads-service && ../mvnw -q -Dtest=DesignPresetProvisionalHtmlProcessorTest test` and the test suite for `DesignPresetProvisionalHtmlProcessorTest` passed successfully after the fix.
- An earlier test run (before the changes) exposed a failing assertion which was addressed by the code and test updates, and the final verification run is green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fc20962883219ed6c224cdfa5ea7)