### PR TITLE
Fix Mermaid parse error in MOIS worker architecture diagram

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -387,7 +387,7 @@ graph TD
 
     WK[mois-sales-library-worker\npackage: com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service] -->|"jobs:claim, jobs/{id}:complete, jobs/{id}:fail"| BM
     WK --> PB[Prompt Builder\nopenai.OpenAiSalesPageAnalyzer]
-    PB -->|Monta prompt (URL + texto da página)\nDefine promptVersion/parserVersion| OAI[OpenAI API /v1/responses]
+    PB -->|"Monta prompt (URL + texto da página)\nDefine promptVersion/parserVersion"| OAI[OpenAI API /v1/responses]
     OAI -->|Retorna JSON estruturado da análise| PB
     PB -->|Resultado validado (score, sections, copy, visual, image, notes)| WK
 


### PR DESCRIPTION
### Motivation
- The Mermaid diagram in `docs/canonical/mois-worker-canon.v1.md` failed to render on GitHub due to a multiline edge label containing parentheses and accented characters being parsed incorrectly.

### Description
- Wrapped the `PB --> OAI` edge label in quotes in `docs/canonical/mois-worker-canon.v1.md` to remove the parser ambiguity and allow the Mermaid graph to render.

### Testing
- Ran repository inspection and file checks including `rg --files -g 'AGENTS.md'`, `sed -n '1,260p' docs/canonical/mois-worker-canon.v1.md`, `rg -n "Monta prompt|PB -->" docs/canonical/mois-worker-canon.v1.md`, `git diff -- docs/canonical/mois-worker-canon.v1.md`, and `nl -ba docs/canonical/mois-worker-canon.v1.md | sed -n '380,396p'`, all of which validated the single-line change and the commit `0f514b4` was created successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1303608df483218734ea72a0eb3fcd)