### PR TITLE
Ajusta referências de classes no schema de wireframe (desktop/mobile só em definições)

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -95,29 +95,12 @@
     "pagina"
   ],
   "$defs": {
-    "referenciasCategoria": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "desktop": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string"
-          }
-        },
-        "mobile": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "required": [
-        "desktop",
-        "mobile"
-      ]
+    "referenciasCategoriaPagina": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
     },
     "secao": {
       "type": "object",
@@ -133,16 +116,16 @@
           "type": "string"
         },
         "estrutura": {
-          "$ref": "#/$defs/referenciasCategoria"
+          "$ref": "#/$defs/referenciasCategoriaPagina"
         },
         "posicao": {
-          "$ref": "#/$defs/referenciasCategoria"
+          "$ref": "#/$defs/referenciasCategoriaPagina"
         },
         "layout": {
-          "$ref": "#/$defs/referenciasCategoria"
+          "$ref": "#/$defs/referenciasCategoriaPagina"
         },
         "mistas": {
-          "$ref": "#/$defs/referenciasCategoria"
+          "$ref": "#/$defs/referenciasCategoriaPagina"
         },
         "elementosSeccao": {
           "type": "array",

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -52,7 +52,7 @@ Regras fixas da etapa (Gera Landing, contrato v3):
 - Cada categoria de `definicoes` deve conter `desktop[]` e `mobile[]`.
 - Cada item de definição deve conter somente: `nome`, `atributoCss`, `valor`.
 - Em `pagina`/`secoes`, usar somente referências por `nome` já definido em `definicoes`.
-- Em `pagina`/`secoes`, separar sempre referências por `desktop` e `mobile`.
+- Em `pagina`/`secoes`, usar referências simples por nome de classe (sem separar por `desktop` e `mobile`).
 - É proibido repetir `atributoCss`/`valor` fora de `definicoes`.
 - Não invente campos fora do schema.
 - Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1377,3 +1377,15 @@
 - causa-raiz identificada: o teste anterior validava uma string fixa de `<body class="...">`, acoplando o cenário exatamente a 7 classes e à ordem literal.
 - correção aplicada: teste atualizado para parsear o HTML com Jsoup e validar que o `<body>` contém pelo menos as classes esperadas do payload, sem assumir quantidade total fixa.
 - resultado esperado: regressão cobre o comportamento funcional correto mesmo quando o preset gerar mais ou menos classes globais.
+## 2026-05-24 11:14:04 UTC-3
+- solicitação para ajustar os schemas das etapas “gera wireframe” e “gera preset design” para manter separação `desktop/mobile` apenas em `definicoes` e simplificar os elementos de `pagina` para usar classes sem segmentação por device.
+- raciocínio aplicado: manter responsividade onde ela pertence (catálogo de tokens em `definicoes`) e reduzir complexidade/ambiguidade nas referências em `pagina.secoes`.
+- foi feito:
+  - atualização do schema de wireframe para que `pagina.secoes[].estrutura|posicao|layout|mistas` aceitem apenas lista simples de nomes de classe.
+  - atualização da instrução textual do prompt de wireframe para refletir a nova regra de referências simples em `pagina/secoes`.
+- documentos/arquivos lidos:
+  - AGENTS.md
+  - docs/registros/experimentos.md
+  - ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+  - ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+  - ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset-schema.json


### PR DESCRIPTION
### Motivation
- Simplificar o contrato das etapas “gera wireframe” e “gera preset design” deixando a distinção `desktop`/`mobile` apenas no catálogo de `definicoes` e removendo essa segmentação das referências usadas em `pagina`.
- Reduzir ambiguidade e tamanho do payload em `pagina.secoes` ao referenciar classes por nome único, mantendo a responsividade no nível correto (tokens em `definicoes`).

### Description
- Substituído o tipo complexo `{ desktop:[], mobile:[] }` por um array simples de strings `referenciasCategoriaPagina` e atualizado os campos `pagina.secoes[].estrutura`, `posicao`, `layout` e `mistas` para referenciar esse novo tipo no schema `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json`.
- Atualizada a regra textual do prompt `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` para instruir que em `pagina/secoes` devem ser usadas referências simples por nome de classe (sem separação por device).
- Adicionado registro operacional em `docs/registros/experimentos.md` documentando a mudança com timestamp UTC-3.

### Testing
- Validação do JSON do schema executada com `python -m json.tool ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` e concluída com sucesso.
- Verificações locais de status (`git status`) e commit foram realizadas ficando o repositório em estado consistente após as alterações.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1307687fe88321b67a7286e5a888e4)