### PR TITLE
Ajusta schema/prompt do preset design para estilos diretos em pagina

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset-schema.json
@@ -25,22 +25,81 @@
         "animações"
       ],
       "properties": {
-        "cores-fundo": { "$ref": "#/$defs/grupo" },
-        "tipografia": { "$ref": "#/$defs/grupo" },
-        "texto": { "$ref": "#/$defs/grupo" },
-        "bordas": { "$ref": "#/$defs/grupo" },
-        "contorno": { "$ref": "#/$defs/grupo" },
-        "sombras-transparencia": { "$ref": "#/$defs/grupo" },
-        "filtro-efeitos": { "$ref": "#/$defs/grupo" },
-        "cursor": { "$ref": "#/$defs/grupo" },
-        "listas": { "$ref": "#/$defs/grupo" },
-        "imagens": { "$ref": "#/$defs/grupo" },
-        "transições": { "$ref": "#/$defs/grupo" },
-        "animações": { "$ref": "#/$defs/grupo" }
+        "cores-fundo": {
+          "$ref": "#/$defs/grupo"
+        },
+        "tipografia": {
+          "$ref": "#/$defs/grupo"
+        },
+        "texto": {
+          "$ref": "#/$defs/grupo"
+        },
+        "bordas": {
+          "$ref": "#/$defs/grupo"
+        },
+        "contorno": {
+          "$ref": "#/$defs/grupo"
+        },
+        "sombras-transparencia": {
+          "$ref": "#/$defs/grupo"
+        },
+        "filtro-efeitos": {
+          "$ref": "#/$defs/grupo"
+        },
+        "cursor": {
+          "$ref": "#/$defs/grupo"
+        },
+        "listas": {
+          "$ref": "#/$defs/grupo"
+        },
+        "imagens": {
+          "$ref": "#/$defs/grupo"
+        },
+        "transições": {
+          "$ref": "#/$defs/grupo"
+        },
+        "animações": {
+          "$ref": "#/$defs/grupo"
+        }
       }
     },
     "pagina": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "body": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "estilos": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "corpo": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "estilos": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "secoes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/paginaNode"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "$defs": {
@@ -54,11 +113,15 @@
       "properties": {
         "desktop": {
           "type": "array",
-          "items": { "$ref": "#/$defs/definicaoCss" }
+          "items": {
+            "$ref": "#/$defs/definicaoCss"
+          }
         },
         "mobile": {
           "type": "array",
-          "items": { "$ref": "#/$defs/definicaoCss" }
+          "items": {
+            "$ref": "#/$defs/definicaoCss"
+          }
         }
       }
     },
@@ -154,6 +217,31 @@
         "valor": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "paginaNode": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "estilos": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "elementosSeccao": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/paginaNode"
+          }
+        },
+        "elementosInternos": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/paginaNode"
+          }
         }
       }
     }

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
@@ -60,16 +60,18 @@ landingPageWireframe:
 Regras obrigatórias:
 1. Responda somente JSON válido.
 2. Preserve a estrutura de `pagina` recebida no wireframe (mesmos ids, mesma hierarquia, sem inventar seções/elementos).
-3. Aplique definições visuais pelos grupos em `definicoes`, com variações `desktop` e `mobile`.
-4. Cada item de `desktop/mobile` deve seguir exatamente:
+3. Aplique variação `desktop/mobile` somente em `definicoes`; em `pagina` use classes diretas sem separar por device.
+4. Em `pagina.body`, incluir obrigatoriamente a lista `estilos` com classes globais do body.
+5. Em cada elemento de `pagina` (`secoes`, `elementosSeccao`, `elementosInternos`), usar `estilos` como lista simples de classes (array de string), sem objetos `desktop/mobile`.
+6. Cada item de `definicoes.desktop/mobile` deve seguir exatamente:
    - `nome`: nome da classe utilitária
    - `atributoCss`: propriedade CSS
    - `valor`: valor CSS válido
-5. Não usar JSON serializado em string.
-6. Usar exclusivamente propriedades CSS permitidas em `docs/gera-landing/listas-css-estrutura-acabamento.md`.
-7. Manter foco de conversão: contraste legível, CTA destacado e consistência entre seção e elementos.
-8. Criar tokens de cor de texto dedicados e não reutilizar `opacity` para simular cor de texto.
-9. Garantir estados interativos reais (ex.: `:hover`) por combinação consistente de tokens base + tokens de hover.
+7. Não usar JSON serializado em string.
+8. Usar exclusivamente propriedades CSS permitidas em `docs/gera-landing/listas-css-estrutura-acabamento.md`.
+9. Manter foco de conversão: contraste legível, CTA destacado e consistência entre seção e elementos.
+10. Criar tokens de cor de texto dedicados e não reutilizar `opacity` para simular cor de texto.
+11. Garantir estados interativos reais (ex.: `:hover`) por combinação consistente de tokens base + tokens de hover.
 
 Checklist obrigatório de consistência visual (deve ser atendido no JSON):
 - Cores de texto obrigatórias: criar classes para `textPrimary`, `textMuted`, `textSubtle`, `textOnButtonPrimary`, `textOnInput`, `placeholderText`.
@@ -194,5 +196,8 @@ Formato esperado de saída:
     "transições": { "desktop": [], "mobile": [] },
     "animações": { "desktop": [], "mobile": [] }
   },
-  "pagina": { "...": "estrutura do wireframe aplicada" }
+  "pagina": {
+    "body": { "estilos": ["pageRoot", "bgBody", "fontBase", "textPrimary"] },
+    "corpo": { "secoes": [ { "id": "sec-hero", "estilos": ["sectionHero", "surfaceBand"], "elementosSeccao": [] } ] }
+  }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1389,3 +1389,11 @@
   - ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
   - ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
   - ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset-schema.json
+
+## 2026-05-24 12:20:00 UTC
+- solicitação para ajustar a etapa `landing-page-design-preset`: separar `desktop/mobile` apenas em `definicoes`, aplicar classes diretamente nos elementos de `pagina` e incluir lista `estilos` também em `pagina.body`.
+- causa-raiz identificada: o contrato do prompt/schema ainda permitia ambiguidade no `pagina`, incentivando formatos mistos (`desktop/mobile` dentro de elementos) e sem obrigatoriedade explícita de `body.estilos`.
+- correção aplicada:
+  - atualização do schema `landing-page-design-preset-schema.json` para documentar `pagina.body.estilos` como lista de strings e nós de página com `estilos` em formato direto;
+  - atualização do prompt `landing-page-design-preset.md` para instruir explicitamente que `desktop/mobile` existe somente em `definicoes` e que os elementos de `pagina` usam `estilos` como array simples de classes.
+- resultado esperado: payloads de preset design mais consistentes com renderização direta das classes no HTML provisório.


### PR DESCRIPTION
### Motivation
- Reduzir ambiguidade no contrato do preset de design movendo a variação `desktop/mobile` apenas para `definicoes` e simplificar a referência de classes em `pagina` para aplicação direta no HTML provisório. 
- Garantir que classes globais sejam declaradas e aplicadas no `<body>` por meio de uma lista `pagina.body.estilos` para consistência na montagem do HTML. 
- Facilitar o processamento do preset pelo renderer ao unificar o formato de `estilos` em nós de página e permitir recursão consistente em `elementosSeccao`/`elementosInternos`.

### Description
- Atualiza o schema `ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset-schema.json` para documentar `pagina.body.estilos` como `array<string>`, adicionar `pagina.corpo.secoes` com referência a `/$defs/paginaNode` e introduzir o `paginaNode` com `estilos`, `elementosSeccao` e `elementosInternos` (todos aceitando listas simples de classes). 
- Ajusta o prompt em `ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md` para instruir explicitamente que `desktop/mobile` existe somente em `definicoes`, exigir `pagina.body.estilos` e que elementos de `pagina` usem `estilos` como array de strings. 
- Registra a alteração operativa em `docs/registros/experimentos.md` descrevendo a mudança de contrato e o propósito da correção.

### Testing
- Executou validação JSON com `python -m json.tool ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset-schema.json` e o comando retornou sucesso. 
- Verificou localmente que os arquivos modificados estão staged/committed (`git status`) e incluídos no PR. 
- Nenhum teste unitário Java adicional foi alterado ou executado neste PR; apenas a validação de esquema JSON foi rodada com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131c24ca4483219cb8da8c5270525b)