### PR TITLE
Fix Mermaid parse error in MOIS worker architecture diagram

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -389,7 +389,7 @@ graph TD
     WK --> PB[Prompt Builder\nopenai.OpenAiSalesPageAnalyzer]
     PB -->|"Monta prompt (URL + texto da página)\nDefine promptVersion/parserVersion"| OAI[OpenAI API /v1/responses]
     OAI -->|Retorna JSON estruturado da análise| PB
-    PB -->|Resultado validado (score, sections, copy, visual, image, notes)| WK
+    PB -->|"Resultado validado: score; sections; copy; visual; image; notes"| WK
 
     BM -->|JPA/SQL via camada backend| DB[(MySQL 5.7)]
 


### PR DESCRIPTION
### Motivation
- Fix a Mermaid rendering failure caused by an unquoted, comma-heavy edge label in the MOIS architecture diagram that produced an `Unable to render rich display` parse error.

### Description
- Replace the problematic edge label in `docs/canonical/mois-worker-canon.v1.md` (section 12.5) with a quoted, parser-safe label `|"Resultado validado: score; sections; copy; visual; image; notes"|` to avoid Mermaid syntax ambiguity.

### Testing
- Ran quick validations which all succeeded: `rg --line-number "125\. Diagrama|diagrama de arquitetura|Resultado validado" docs/canonical/mois-worker-canon.v1.md`, applied the update via the `python - <<'PY' ...` edit script, and confirmed the change with `nl -ba docs/canonical/mois-worker-canon.v1.md | sed -n '384,396p'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1331f1692c832196bdd915830c228b)