### PR TITLE
Improve assembler error diagnostics for copy and design-preset HTML generation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlAssembler.java
@@ -26,6 +26,9 @@ public class CopyProvisionalHtmlAssembler {
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * Orquestra o resolver+processor para montar HTML provisório da etapa copy.
+     */
     public String assemble(String copyModelResponse, String wireframeModelResponse, String jobId) {
         if (!StringUtils.hasText(copyModelResponse) || !StringUtils.hasText(wireframeModelResponse)) {
             return null;
@@ -36,16 +39,43 @@ public class CopyProvisionalHtmlAssembler {
 
             return processor.process(payloadResolverToJson(payload.wireframe()), payloadResolverToJson(payload.copy()));
         } catch (Exception e) {
+            String errorDetails = buildErrorDetails(e);
             log.error(
-                    "Falha ao montar HTML provisório (jobId={}, copyLength={}, wireframeLength={}, copyPreview={}, wireframePreview={})",
+                    "Falha ao montar HTML provisório (jobId={}, copyLength={}, wireframeLength={}, copyPreview={}, wireframePreview={}, errorDetails={})",
                     jobId,
                     lengthOf(copyModelResponse),
                     lengthOf(wireframeModelResponse),
                     preview(copyModelResponse),
                     preview(wireframeModelResponse),
+                    errorDetails,
                     e);
-            throw new IllegalArgumentException("Falha ao montar HTML provisório a partir de wireframe + copy", e);
+            throw new IllegalArgumentException(
+                    "Falha ao montar HTML provisório a partir de wireframe + copy. "
+                            + "jobId=" + normalizeJobId(jobId)
+                            + ", copyLength=" + lengthOf(copyModelResponse)
+                            + ", wireframeLength=" + lengthOf(wireframeModelResponse)
+                            + ", errorDetails=" + errorDetails,
+                    e);
         }
+    }
+
+    /**
+     * Monta detalhes da exceção com causa-raiz para acelerar o diagnóstico de erros.
+     */
+    private String buildErrorDetails(Exception ex) {
+        Throwable rootCause = ex;
+        while (rootCause.getCause() != null) {
+            rootCause = rootCause.getCause();
+        }
+        String rootMessage = StringUtils.hasText(rootCause.getMessage()) ? rootCause.getMessage() : "<sem-mensagem>";
+        return rootCause.getClass().getSimpleName() + ": " + rootMessage.replaceAll("\\s+", " ").trim();
+    }
+
+    /**
+     * Normaliza o jobId para logs e mensagens de erro.
+     */
+    private String normalizeJobId(String jobId) {
+        return StringUtils.hasText(jobId) ? jobId : "<sem-jobId>";
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
@@ -1,6 +1,8 @@
 package com.marketinghub.geralanding.designpreset;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -12,6 +14,8 @@ import java.util.Map;
  * Monta o HTML provisório da etapa de preset de design a partir dos artefatos canônicos anteriores.
  */
 public class DesignPresetProvisionalHtmlAssembler {
+
+    private static final Logger log = LoggerFactory.getLogger(DesignPresetProvisionalHtmlAssembler.class);
 
     private final DesignPresetProvisionalHtmlProcessor processor;
     private final ObjectMapper objectMapper;
@@ -58,8 +62,52 @@ public class DesignPresetProvisionalHtmlAssembler {
                     designPresetOutputJson);
             return preserveCanonicalHtml(html, jobId);
         } catch (Exception e) {
-            throw new IllegalArgumentException("Falha ao montar HTML provisório da fase landing-page-design-preset", e);
+            String errorDetails = buildErrorDetails(e);
+            log.error("Falha ao montar HTML provisório da fase landing-page-design-preset "
+                            + "(jobId={}, wireframeLength={}, copyLength={}, imagePlanningLength={}, designPresetLength={}, errorDetails={})",
+                    normalizeJobId(jobId),
+                    lengthOf(wireframeJson),
+                    lengthOf(copyJson),
+                    lengthOf(imagePlanningJson),
+                    lengthOf(designPresetOutputJson),
+                    errorDetails,
+                    e);
+            throw new IllegalArgumentException(
+                    "Falha ao montar HTML provisório da fase landing-page-design-preset. "
+                            + "jobId=" + normalizeJobId(jobId)
+                            + ", wireframeLength=" + lengthOf(wireframeJson)
+                            + ", copyLength=" + lengthOf(copyJson)
+                            + ", imagePlanningLength=" + lengthOf(imagePlanningJson)
+                            + ", designPresetLength=" + lengthOf(designPresetOutputJson)
+                            + ", errorDetails=" + errorDetails,
+                    e);
         }
+    }
+
+    /**
+     * Monta detalhes compactos da causa-raiz para facilitar diagnóstico operacional.
+     */
+    private String buildErrorDetails(Exception ex) {
+        Throwable rootCause = ex;
+        while (rootCause.getCause() != null) {
+            rootCause = rootCause.getCause();
+        }
+        String rootMessage = StringUtils.hasText(rootCause.getMessage()) ? rootCause.getMessage() : "<sem-mensagem>";
+        return rootCause.getClass().getSimpleName() + ": " + rootMessage.replaceAll("\\s+", " ").trim();
+    }
+
+    /**
+     * Normaliza identificador de job para mensagens e logs.
+     */
+    private String normalizeJobId(String jobId) {
+        return StringUtils.hasText(jobId) ? jobId : "<sem-jobId>";
+    }
+
+    /**
+     * Retorna o tamanho do payload para ampliar contexto de falhas.
+     */
+    private int lengthOf(String payload) {
+        return payload == null ? 0 : payload.length();
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
@@ -141,10 +141,16 @@ public class DesignPresetProvisionalHtmlProcessor {
      * Constrói um elemento HTML a partir de um nó do wireframe.
      */
     private Element buildElementFromNode(Document document, Map<String, Object> node) {
-        String tag = firstNonBlank(asString(node.get("tag")), "section");
+        String rawTag = asString(node.get("tag"));
+        String tag = firstNonBlank(rawTag, "section");
         tag = sanitizeTagName(tag);
 
-        Element element = document.createElement(tag);
+        Element element;
+        try {
+            element = document.createElement(tag);
+        } catch (RuntimeException ex) {
+            throw new IllegalArgumentException("Falha ao criar elemento do wireframe: " + describeNode(node, rawTag), ex);
+        }
 
         String id = asString(node.get("id"));
         if (StringUtils.hasText(id)) {
@@ -156,34 +162,59 @@ public class DesignPresetProvisionalHtmlProcessor {
          * applyTokenizedPresetStyles podem reforçar/duplicar sem causar problemas,
          * porque appendClasses evita duplicatas.
          */
-        appendClasses(element, collectStyleClasses(node.get("estilos")));
+        try {
+            appendClasses(element, collectStyleClasses(node.get("estilos")));
 
-        applyInitialTextFromNode(element, node);
-        applyTargetSectionId(element, node);
-        applyAsset(element, node);
-        applyFieldContract(element, node);
-        applyFormContract(element, node);
+            applyInitialTextFromNode(element, node);
+            applyTargetSectionId(element, node);
+            applyAsset(element, node);
+            applyFieldContract(element, node);
+            applyFormContract(element, node);
+        } catch (RuntimeException ex) {
+            throw new IllegalArgumentException("Falha ao processar propriedades do elemento: " + describeNode(node, rawTag), ex);
+        }
 
         for (Map<String, Object> child : asList(node.get("elementosSeccao"))) {
-            Element childElement = buildElementFromNode(document, child);
-            if (childElement != null) {
-                element.appendChild(childElement);
+            try {
+                Element childElement = buildElementFromNode(document, child);
+                if (childElement != null) {
+                    element.appendChild(childElement);
+                }
+            } catch (RuntimeException ex) {
+                throw new IllegalArgumentException("Falha ao processar filho de " + describeNode(node, rawTag), ex);
             }
         }
 
         for (Map<String, Object> child : asList(node.get("elementosInternos"))) {
-            Element childElement = buildElementFromNode(document, child);
-            if (childElement != null) {
-                element.appendChild(childElement);
+            try {
+                Element childElement = buildElementFromNode(document, child);
+                if (childElement != null) {
+                    element.appendChild(childElement);
+                }
+            } catch (RuntimeException ex) {
+                throw new IllegalArgumentException("Falha ao processar filho interno de " + describeNode(node, rawTag), ex);
             }
         }
 
         /*
          * Ajustes mínimos de HTML válido.
          */
-        applyTagDefaults(element);
+        try {
+            applyTagDefaults(element);
+        } catch (RuntimeException ex) {
+            throw new IllegalArgumentException("Falha ao aplicar defaults do elemento: " + describeNode(node, rawTag), ex);
+        }
 
         return element;
+    }
+
+    /**
+     * Descreve o nó atual para mensagens de erro detalhadas durante montagem do HTML.
+     */
+    private String describeNode(Map<String, Object> node, String rawTag) {
+        String nodeId = asString(node.get("id"));
+        String nodeTag = firstNonBlank(rawTag, asString(node.get("tag")), "<tag-ausente>");
+        return "id=" + firstNonBlank(nodeId, "<id-ausente>") + ", tag=" + nodeTag;
     }
 
     private void applyInitialTextFromNode(Element element, Map<String, Object> node) {

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlAssemblerErrorDetailTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlAssemblerErrorDetailTest.java
@@ -1,0 +1,37 @@
+package com.marketinghub.geralanding;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.geralanding.copy.CopyProvisionalHtmlAssembler;
+import com.marketinghub.geralanding.copy.CopyProvisionalHtmlPayloadResolver;
+import com.marketinghub.geralanding.copy.CopyProvisionalHtmlProcessor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CopyProvisionalHtmlAssemblerErrorDetailTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final CopyProvisionalHtmlAssembler assembler = new CopyProvisionalHtmlAssembler(
+            new CopyProvisionalHtmlPayloadResolver(objectMapper),
+            new CopyProvisionalHtmlProcessor(),
+            objectMapper);
+
+    @Test
+    void shouldIncludeDetailedContextWhenAssemblyFails() {
+        String invalidCopyJson = "{invalid-json";
+        String validWireframeJson = "{" +
+                "\"landingPageWireframe\":{\"pagina\":{\"corpo\":{\"secoes\":[]}}}" +
+                "}";
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> assembler.assemble(invalidCopyJson, validWireframeJson, "job-copy-erro-1"));
+
+        assertTrue(exception.getMessage().contains("jobId=job-copy-erro-1"));
+        assertTrue(exception.getMessage().contains("copyLength="));
+        assertTrue(exception.getMessage().contains("wireframeLength="));
+        assertTrue(exception.getMessage().contains("errorDetails="));
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerErrorDetailTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerErrorDetailTest.java
@@ -1,0 +1,39 @@
+package com.marketinghub.geralanding;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAssembler;
+import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlProcessor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DesignPresetProvisionalHtmlAssemblerErrorDetailTest {
+
+    @Test
+    void shouldIncludeElementDetailWhenDesignPresetAssemblyFails() {
+        DesignPresetProvisionalHtmlProcessor processor = mock(DesignPresetProvisionalHtmlProcessor.class);
+        when(processor.process(anyString(), anyString(), anyString(), anyString()))
+                .thenThrow(new IllegalArgumentException("Falha ao processar propriedades do elemento: id=hero-title, tag=h1"));
+
+        DesignPresetProvisionalHtmlAssembler assembler = new DesignPresetProvisionalHtmlAssembler(
+                processor,
+                new ObjectMapper());
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> assembler.assemble(
+                        "{\"landingPageWireframe\":{\"pagina\":{\"corpo\":{\"secoes\":[]}}}}",
+                        "{\"landingPageCopy\":{\"bodySections\":[]}}",
+                        "{\"landingPageImagePlanning\":{\"images\":[]}}",
+                        "{\"landingPageDesignPreset\":{\"definicoes\":{},\"pagina\":{}}}",
+                        "job-design-erro-1"));
+
+        assertTrue(ex.getMessage().contains("jobId=job-design-erro-1"));
+        assertTrue(ex.getMessage().contains("errorDetails="));
+        assertTrue(ex.getMessage().contains("id=hero-title"));
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1422,3 +1422,32 @@
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/WireframeHtmlGenerator.java
   - ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
   - docs/registros/experimentos.md
+
+## 2026-05-24 17:20:00 UTC
+- solicitação para detalhar erros no assembler de HTML da etapa `landing-page-copy`.
+- causa-raiz identificada: quando o `CopyProvisionalHtmlAssembler` falhava, a exceção retornada para o fluxo superior tinha contexto insuficiente para diagnóstico rápido (sem detalhe da causa-raiz textual no erro propagado).
+- correção aplicada:
+  - enriquecimento do tratamento de erro no `CopyProvisionalHtmlAssembler` com `errorDetails` contendo classe e mensagem da causa-raiz;
+  - inclusão de `jobId`, `copyLength` e `wireframeLength` na mensagem da `IllegalArgumentException` propagada;
+  - adição de teste unitário cobrindo a presença dos detalhes na mensagem de erro quando o JSON de copy é inválido.
+- documentos/arquivos lidos:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlAssembler.java
+  - backend/ads-service/src/test/java/com/marketinghub/geralanding/CopyProvisionalHtmlAssemblerErrorDetailTest.java
+  - docs/registros/experimentos.md
+
+## 2026-05-24 17:45:00 UTC
+- solicitação para aplicar no assembler da etapa `landing-page-design-preset` o mesmo padrão de diagnóstico detalhado, incluindo indicação exata do elemento com falha de processamento.
+- causa-raiz identificada: falhas do fluxo de design preset eram propagadas com contexto genérico no assembler, sem detalhar payloads e sem destacar elemento (`id/tag`) que quebrou no processor.
+- correção aplicada:
+  - enriquecimento do `DesignPresetProvisionalHtmlAssembler` com log/erro propagado contendo `jobId`, tamanhos dos payloads e `errorDetails` da causa-raiz;
+  - reforço no `DesignPresetProvisionalHtmlProcessor` para lançar erro contextual com `id/tag` do elemento ao falhar na criação/processamento do nó e de seus filhos;
+  - adição de teste unitário validando que o assembler propaga mensagem com detalhe de elemento quando ocorre erro no processor.
+- documentos/arquivos lidos:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
+  - backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerErrorDetailTest.java
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Failures during provisional HTML assembly lacked actionable context, making operational diagnosis slow for `landing-page-copy` and `landing-page-design-preset` flows. 
- Processor errors did not surface the offending wireframe element (`id`/`tag`) which hindered root-cause identification. 
- Documentation of the investigation and fixes was added to keep an audit trail of the changes. 

### Description
- Enriched `CopyProvisionalHtmlAssembler` to log root-cause details and propagate an `IllegalArgumentException` containing `jobId`, payload lengths and compact `errorDetails`, and added helper methods `buildErrorDetails` and `normalizeJobId`. 
- Enhanced `DesignPresetProvisionalHtmlAssembler` with similar logging and error-message enrichment plus helpers `buildErrorDetails`, `normalizeJobId`, and `lengthOf` to include payload context on failure. 
- Hardened `DesignPresetProvisionalHtmlProcessor` to wrap element creation and child processing in guarded blocks that throw contextual `IllegalArgumentException`s and added `describeNode` to include the node `id`/`tag` in error messages. 
- Added unit tests `CopyProvisionalHtmlAssemblerErrorDetailTest` and `DesignPresetProvisionalHtmlAssemblerErrorDetailTest` and updated `docs/registros/experimentos.md` with the experiment notes. 

### Testing
- Ran `CopyProvisionalHtmlAssemblerErrorDetailTest` which asserts the assembler includes `jobId`, payload lengths and `errorDetails` in the propagated exception, and the test passed. 
- Ran `DesignPresetProvisionalHtmlAssemblerErrorDetailTest` which asserts the assembler message contains `jobId`, `errorDetails` and the element `id` when the processor fails, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a132ec35c4c832189c36ecb26a6ddc7)