### PR TITLE
Add ArchUnit rules and OpenAiPromptResultRecorder in mois-sales-library-worker

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -552,3 +552,7 @@ Arquivos alterados:
   - AGENTS.md
   - docs/canonical/mois-worker-canon.v1.md
   - docs/registros/mois1.md
+
+- 2026-05-24: Adicionada regra ArchUnit no módulo `mois-sales-library-worker` para exigir classe no pacote `bibliotecapaginavenda.worker.vN.service` com método `recordPromptBuilderOpenAiResult` recebendo request bruto, resposta bruta, jobId OpenAI e JSON validado; incluída implementação inicial `OpenAiPromptResultRecorder` no v1.
+
+- 2026-05-24: Regra ArchUnit ampliada no `mois-sales-library-worker` para exigir também método de inserção backend (`insertOpenAiIntegrationRecord`) em `mois.bibliotecapaginavenda.worker.vN.service`, com parâmetros: request cru, resposta crua, jobId OpenAI, JSON validado e jobId Marketing Hub.

--- a/mois-sales-library-worker/pom.xml
+++ b/mois-sales-library-worker/pom.xml
@@ -13,6 +13,7 @@
     <dependency><groupId>org.jsoup</groupId><artifactId>jsoup</artifactId><version>1.18.1</version></dependency>
     <dependency><groupId>org.projectlombok</groupId><artifactId>lombok</artifactId><optional>true</optional></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+    <dependency><groupId>com.tngtech.archunit</groupId><artifactId>archunit-junit5</artifactId><version>1.3.0</version><scope>test</scope></dependency>
   </dependencies>
   <build><plugins><plugin><groupId>org.springframework.boot</groupId><artifactId>spring-boot-maven-plugin</artifactId><executions><execution><goals><goal>repackage</goal></goals></execution></executions></plugin><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><configuration><release>21</release></configuration></plugin></plugins></build>
 </project>

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/OpenAiPromptResultRecorder.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/OpenAiPromptResultRecorder.java
@@ -1,0 +1,46 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Responsável por registrar o resultado bruto e validado recebido da OpenAI para uso do PromptBuilder.
+ */
+@Service
+@Slf4j
+public class OpenAiPromptResultRecorder {
+
+    /**
+     * Registra os dados de request/response da OpenAI e o JSON validado para rastreabilidade do pipeline.
+     */
+    public void recordPromptBuilderOpenAiResult(
+            String rawRequestSent,
+            String rawResponseReceived,
+            String openAiJobId,
+            String validatedJson) {
+        log.info(
+                "MOIS prompt builder OpenAI result recorded. openAiJobId={}, rawRequestSent={}, rawResponseReceived={}, validatedJson={}",
+                openAiJobId,
+                rawRequestSent,
+                rawResponseReceived,
+                validatedJson);
+    }
+
+    /**
+     * Insere o registro consolidado da integração OpenAI com vínculo ao job do Marketing Hub.
+     */
+    public void insertOpenAiIntegrationRecord(
+            String rawRequestSent,
+            String rawResponseReceived,
+            String openAiJobId,
+            String validatedJson,
+            Long marketingHubJobId) {
+        log.info(
+                "MOIS OpenAI integration record inserted. marketingHubJobId={}, openAiJobId={}, rawRequestSent={}, rawResponseReceived={}, validatedJson={}",
+                marketingHubJobId,
+                openAiJobId,
+                rawRequestSent,
+                rawResponseReceived,
+                validatedJson);
+    }
+}

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/archunit/PromptBuilderResultRecorderArchUnitTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/archunit/PromptBuilderResultRecorderArchUnitTest.java
@@ -1,0 +1,74 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.archunit;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+
+/** Garante contratos estruturais de rastreabilidade OpenAI consumidos pelo PromptBuilder. */
+@AnalyzeClasses(packages = "com.marketinghub.mois.bibliotecapaginavenda.worker")
+class PromptBuilderResultRecorderArchUnitTest {
+
+    /** Valida assinatura obrigatória com 4 parâmetros para uso direto do PromptBuilder. */
+    @ArchTest
+    static final ArchRule should_have_prompt_builder_record_method = classes()
+            .that()
+            .haveSimpleName("OpenAiPromptResultRecorder")
+            .and()
+            .resideInAPackage("..mois.bibliotecapaginavenda.worker.v1.service")
+            .should(haveRequiredRecordMethod());
+
+    /** Valida assinatura obrigatória com 5 parâmetros para inserção no backend com jobId Marketing Hub. */
+    @ArchTest
+    static final ArchRule should_have_backend_insert_method = classes()
+            .that()
+            .haveSimpleName("OpenAiPromptResultRecorder")
+            .and()
+            .resideInAPackage("..mois.bibliotecapaginavenda.worker.v1.service")
+            .should(haveRequiredInsertMethod());
+
+    private static ArchCondition<com.tngtech.archunit.core.domain.JavaClass> haveRequiredRecordMethod() {
+        return new ArchCondition<>("have method recordPromptBuilderOpenAiResult(String, String, String, String)") {
+            @Override
+            public void check(com.tngtech.archunit.core.domain.JavaClass javaClass, ConditionEvents events) {
+                boolean hasMethod = javaClass.getMethods().stream()
+                        .filter(method -> method.getName().equals("recordPromptBuilderOpenAiResult"))
+                        .anyMatch(PromptBuilderResultRecorderArchUnitTest::hasFourStringParameters);
+                events.add(new SimpleConditionEvent(javaClass, hasMethod,
+                        javaClass.getName() + " must declare method recordPromptBuilderOpenAiResult(String, String, String, String)"));
+            }
+        };
+    }
+
+    private static ArchCondition<com.tngtech.archunit.core.domain.JavaClass> haveRequiredInsertMethod() {
+        return new ArchCondition<>("have method insertOpenAiIntegrationRecord(String, String, String, String, Long)") {
+            @Override
+            public void check(com.tngtech.archunit.core.domain.JavaClass javaClass, ConditionEvents events) {
+                boolean hasMethod = javaClass.getMethods().stream()
+                        .filter(method -> method.getName().equals("insertOpenAiIntegrationRecord"))
+                        .anyMatch(PromptBuilderResultRecorderArchUnitTest::hasExpectedInsertParameters);
+                events.add(new SimpleConditionEvent(javaClass, hasMethod,
+                        javaClass.getName() + " must declare method insertOpenAiIntegrationRecord(String, String, String, String, Long)"));
+            }
+        };
+    }
+
+    private static boolean hasFourStringParameters(JavaMethod method) {
+        return method.getRawParameterTypes().size() == 4
+                && method.getRawParameterTypes().stream().allMatch(type -> type.getName().equals(String.class.getName()));
+    }
+
+    private static boolean hasExpectedInsertParameters(JavaMethod method) {
+        return method.getRawParameterTypes().size() == 5
+                && method.getRawParameterTypes().get(0).getName().equals(String.class.getName())
+                && method.getRawParameterTypes().get(1).getName().equals(String.class.getName())
+                && method.getRawParameterTypes().get(2).getName().equals(String.class.getName())
+                && method.getRawParameterTypes().get(3).getName().equals(String.class.getName())
+                && method.getRawParameterTypes().get(4).getName().equals(Long.class.getName());
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure structural contract and traceability for OpenAI prompt handling used by the PromptBuilder and backend integration. 
- Enforce at compile/test time that a service exists with the exact method signatures required to record raw/validated OpenAI data and to persist an integration record linked to a Marketing Hub job.

### Description
- Added ArchUnit test `PromptBuilderResultRecorderArchUnitTest` to require `OpenAiPromptResultRecorder` in package `..mois.bibliotecapaginavenda.worker.v1.service` with methods `recordPromptBuilderOpenAiResult(String,String,String,String)` and `insertOpenAiIntegrationRecord(String,String,String,String,Long)`. 
- Added concrete placeholder service `OpenAiPromptResultRecorder` with `recordPromptBuilderOpenAiResult` and `insertOpenAiIntegrationRecord` methods that log inputs for auditability. 
- Added `archunit-junit5` test dependency to `mois-sales-library-worker/pom.xml`. 
- Updated documentation `docs/registros/mois1.md` to record the new ArchUnit rule and related changes.

### Testing
- Ran unit tests with `mvn test` on the `mois-sales-library-worker` module and the ArchUnit rules executed as part of the test suite and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a133639b97883219937870ab9048328)