### PR TITLE
Add OpenAiException to preserve raw request/response and job IDs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiException.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiException.java
@@ -1,0 +1,43 @@
+package com.marketinghub.openai;
+
+/**
+ * Representa falhas de integração com OpenAI preservando os dados essenciais para diagnóstico.
+ */
+public class OpenAiException extends RuntimeException {
+
+    private final String rawRequest;
+    private final String rawResponse;
+    private final String validatedJson;
+    private final String marketingHubJobId;
+    private final String openAiJobId;
+
+    /**
+     * Inicializa a exception com os dados crus e identificadores de rastreabilidade da execução.
+     */
+    public OpenAiException(String rawRequest,
+                           String rawResponse,
+                           String validatedJson,
+                           String marketingHubJobId,
+                           String openAiJobId) {
+        super("Falha de integração OpenAI");
+        this.rawRequest = rawRequest;
+        this.rawResponse = rawResponse;
+        this.validatedJson = validatedJson;
+        this.marketingHubJobId = marketingHubJobId;
+        this.openAiJobId = openAiJobId;
+    }
+
+    /**
+     * Retorna a representação textual completa para logging com todos os campos obrigatórios.
+     */
+    @Override
+    public String toString() {
+        return "OpenAiException{" +
+                "rawRequest='" + rawRequest + '\'' +
+                ", rawResponse='" + rawResponse + '\'' +
+                ", validatedJson='" + validatedJson + '\'' +
+                ", marketingHubJobId='" + marketingHubJobId + '\'' +
+                ", openAiJobId='" + openAiJobId + '\'' +
+                "}";
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1451,3 +1451,14 @@
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
   - backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerErrorDetailTest.java
   - docs/registros/experimentos.md
+
+## 2026-05-24 18:05:00 UTC
+- solicitação para criar exception dedicada de integração OpenAI no backend com construtor único contendo request cru, response cru, json validado, job id do Marketing Hub e job id da OpenAI.
+- correção aplicada:
+  - criada a classe `OpenAiException` em `com.marketinghub.openai` com um único construtor contendo os cinco campos solicitados;
+  - implementado `toString()` para expor literalmente todos os campos, garantindo diagnóstico completo em logs quando a exception for registrada.
+- documentos/arquivos lidos:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiException.java
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- For improved diagnostics of OpenAI integration failures, capture raw request/response payloads, validated JSON and both Marketing Hub and OpenAI job identifiers in a dedicated exception.

### Description
- Added `com.marketinghub.openai.OpenAiException` with fields `rawRequest`, `rawResponse`, `validatedJson`, `marketingHubJobId`, and `openAiJobId`.
- Implemented a single constructor that initializes all five fields and sets the exception message to `"Falha de integração OpenAI"`.
- Overrode `toString()` to render all fields literally for comprehensive logging.
- Appended an entry to `docs/registros/experimentos.md` documenting the change.

### Testing
- Nenhum teste automatizado foi adicionado para esta exceção.
- Nenhuma suíte de testes automatizada foi executada como parte desta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a133c171a688321962c40bd900ff38f)