### PR TITLE
Apply wireframe tokenized styles to HTML and forbid preset name collisions; add tests and prompt rule

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
@@ -72,6 +72,7 @@ Regras obrigatórias:
 9. Manter foco de conversão: contraste legível, CTA destacado e consistência entre seção e elementos.
 10. Criar tokens de cor de texto dedicados e não reutilizar `opacity` para simular cor de texto.
 11. Garantir estados interativos reais (ex.: `:hover`) por combinação consistente de tokens base + tokens de hover.
+12. É proibido criar em `definicoes` qualquer classe (`nome`) que já exista no `landingPageWireframe.definicoes`; os nomes do preset de design devem ser sempre inéditos em relação ao wireframe.
 
 Checklist obrigatório de consistência visual (deve ser atendido no JSON):
 - Cores de texto obrigatórias: criar classes para `textPrimary`, `textMuted`, `textSubtle`, `textOnButtonPrimary`, `textOnInput`, `placeholderText`.

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlProcessor.java
@@ -88,6 +88,7 @@ public class DesignPresetProvisionalHtmlProcessor {
          * CSS e classes do preset tokenizado.
          */
         applyTokenizedPresetStyles(document, designRoot);
+        applyTokenizedPresetStyles(document, wireframeRoot);
 
         return normalizeSerializedHtml(document.outerHtml());
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlProcessorTest.java
@@ -160,4 +160,41 @@ class DesignPresetProvisionalHtmlProcessorTest {
         assertThat(html).contains("id=\"hero-container\"").contains("class=\"container-desktop\"");
         assertThat(html).contains("id=\"hero-title\"").contains("class=\"h1-size\"");
     }
+
+    @Test
+    void shouldApplyWireframeDefinitionCssAndClassesInDesignPresetAssembly() {
+        DesignPresetProvisionalHtmlProcessor processor = new DesignPresetProvisionalHtmlProcessor();
+
+        String wireframe = """
+                {
+                  "definicoes": {
+                    "layout": {
+                      "desktop": [{"nome":"wireframe-layout","atributoCss":"display","valor":"grid"}],
+                      "mobile": [{"nome":"wireframe-layout","atributoCss":"display","valor":"block"}]
+                    }
+                  },
+                  "pagina": {
+                    "corpo": {
+                      "secoes": [
+                        {"id":"sec-hero","tag":"section","estilos":{"desktop":["wireframe-layout"],"mobile":[]}}
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        String design = """
+                {
+                  "definicoes": {},
+                  "pagina": { "corpo": { "secoes": [] } }
+                }
+                """;
+
+        String html = processor.process(wireframe, "{\"bodySections\":[]}", "{}", design);
+
+        assertThat(html).contains(".wireframe-layout{display:grid;}");
+        assertThat(html).contains("@media (max-width: 768px)");
+        assertThat(html).contains(".wireframe-layout{display:block;}");
+        assertThat(html).contains("id=\"sec-hero\"").contains("class=\"wireframe-layout\"");
+    }
 }


### PR DESCRIPTION
### Motivation
- Ensure CSS utility classes declared in a `landingPageWireframe.definicoes` are emitted into the provisional HTML build so wireframe-provided styling is preserved in the assembled output. 
- Prevent accidental name collisions between a design preset and the wireframe by enforcing that preset `definicoes` must not reuse names already present in `landingPageWireframe.definicoes`.
- Add coverage to verify that wireframe definitions produce both classes and responsive rules in the generated HTML.

### Description
- Call `applyTokenizedPresetStyles(document, wireframeRoot)` in `DesignPresetProvisionalHtmlProcessor` so tokenized styles coming from the wireframe are applied to the document in addition to those from the design preset. 
- Extend the landing page design prompt (`landing-page-design-preset.md`) with a new mandatory rule forbidding preset class names that already exist in the wireframe (`landingPageWireframe.definicoes`).
- Add unit test `shouldApplyWireframeDefinitionCssAndClassesInDesignPresetAssembly` to `DesignPresetProvisionalHtmlProcessorTest` to assert that wireframe `definicoes` produce CSS rules, responsive `@media` blocks, and element classes in the HTML output.

### Testing
- Ran `DesignPresetProvisionalHtmlProcessorTest` including the new `shouldApplyWireframeDefinitionCssAndClassesInDesignPresetAssembly` test, which verifies emitted CSS rules, media queries, and class attributes; the test passed. 
- Existing assembly tests asserting body classes and presence of IDs/classes still executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a136d3be7408321b4500e45cc5b1324)