### PR TITLE
Reset image generation counters on image prompt rerun

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -129,7 +129,9 @@ function resolveJobNumberFromStageContent(content: string) {
     }
 
     const valueAsString = String(jobValue).trim();
-    return valueAsString.length > 0 ? sanitizeFilenamePart(valueAsString) : "sem-job";
+    return valueAsString.length > 0
+      ? sanitizeFilenamePart(valueAsString)
+      : "sem-job";
   } catch {
     return "sem-job";
   }
@@ -169,6 +171,8 @@ export default function ExperimentDetailPage() {
   const [isStartingImagePrompts, setIsStartingImagePrompts] = useState(false);
   const [isStartingDeliverables, setIsStartingDeliverables] = useState(false);
   const [isStartingImageGeneration, setIsStartingImageGeneration] =
+    useState(false);
+  const [resetFrameworkImageCounters, setResetFrameworkImageCounters] =
     useState(false);
   const [isGeneratingLandingHtml, setIsGeneratingLandingHtml] = useState(false);
   const [optimisticWireframeExecution, setOptimisticWireframeExecution] =
@@ -508,6 +512,7 @@ export default function ExperimentDetailPage() {
       toast.success(
         `Solicitação registrada. Código: ${startResponse.idJob} | Status: ${startResponse.status}`,
       );
+      setResetFrameworkImageCounters(true);
       await Promise.all([
         refetchPendingGeraLandingImagePromptsExecutions(),
         refetchCompletedGeraLandingImagePromptsExecutions(),
@@ -560,6 +565,7 @@ export default function ExperimentDetailPage() {
     setIsStartingImageGeneration(true);
     try {
       await generateFrameworkImages.mutateAsync();
+      setResetFrameworkImageCounters(false);
       toast.success("Gera Imagem iniciado com sucesso.");
     } catch (error) {
       const message = axios.isAxiosError(error)
@@ -2339,8 +2345,11 @@ export default function ExperimentDetailPage() {
                       )}
                     </button>
                     {isLoadingPendingGeraLandingImagePromptsExecutions ? (
-                      <p className="text-muted mb-0">Carregando jobs da etapa...</p>
-                    ) : runningGeraLandingImagePromptsExecutions.length === 0 ? (
+                      <p className="text-muted mb-0">
+                        Carregando jobs da etapa...
+                      </p>
+                    ) : runningGeraLandingImagePromptsExecutions.length ===
+                      0 ? (
                       <p className="text-muted mb-0">
                         Nenhum job pendente ou em execução.
                       </p>
@@ -2500,13 +2509,15 @@ export default function ExperimentDetailPage() {
                       </span>
                     </div>
                   </div>
-                  {frameworkImageSummary ? (
+                  {frameworkImageSummary || resetFrameworkImageCounters ? (
                     <div className="row g-2">
                       <div className="col-6 col-md-4">
                         <div className="small border rounded p-2 bg-light">
                           Em processamento:{" "}
                           <strong>
-                            {frameworkImageSummary.processingCount}
+                            {resetFrameworkImageCounters
+                              ? 0
+                              : (frameworkImageSummary?.processingCount ?? 0)}
                           </strong>
                         </div>
                       </div>
@@ -2514,7 +2525,10 @@ export default function ExperimentDetailPage() {
                         <div className="small border rounded p-2 bg-light">
                           Aguardando OpenAI batch:{" "}
                           <strong>
-                            {frameworkImageSummary.waitingOpenAiBatchCount}
+                            {resetFrameworkImageCounters
+                              ? 0
+                              : (frameworkImageSummary?.waitingOpenAiBatchCount ??
+                                0)}
                           </strong>
                         </div>
                       </div>
@@ -2522,20 +2536,30 @@ export default function ExperimentDetailPage() {
                         <div className="small border rounded p-2 bg-light">
                           Concluídas:{" "}
                           <strong>
-                            {frameworkImageSummary.completedCount}
+                            {resetFrameworkImageCounters
+                              ? 0
+                              : (frameworkImageSummary?.completedCount ?? 0)}
                           </strong>
                         </div>
                       </div>
                       <div className="col-6 col-md-4">
                         <div className="small border rounded p-2 bg-light">
                           Falhas:{" "}
-                          <strong>{frameworkImageSummary.failedCount}</strong>
+                          <strong>
+                            {resetFrameworkImageCounters
+                              ? 0
+                              : (frameworkImageSummary?.failedCount ?? 0)}
+                          </strong>
                         </div>
                       </div>
                       <div className="col-6 col-md-4">
                         <div className="small border rounded p-2 bg-light">
                           Total de itens:{" "}
-                          <strong>{frameworkImageSummary.totalItems}</strong>
+                          <strong>
+                            {resetFrameworkImageCounters
+                              ? 0
+                              : (frameworkImageSummary?.totalItems ?? 0)}
+                          </strong>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
### Motivation
- Avoid showing stale counts in the "Gerar imagens em lote" block when the user re-runs the image prompt phase.
- Make the UI reflect an immediate reset of image counters while a new prompt-run is being prepared and resume live counts when real generation starts.

### Description
- Added local state `resetFrameworkImageCounters` in `ExperimentDetailPage.tsx` to control a UI-only reset of image counters.
- Set `resetFrameworkImageCounters` to `true` when starting `Gera Prompt Imagem` and set it to `false` when starting `Gera Imagem` so live counters resume.
- Updated the rendering of the framework image summary to show zeros while the reset flag is active and otherwise show values from `frameworkImageSummary`.
- Ran `prettier` on the modified file to normalize formatting changes introduced by the patch.

### Testing
- Ran `cd frontend && npx prettier --check src/pages/experiment/ExperimentDetailPage.tsx`, which reported style issues prior to auto-fix as expected.
- Ran `cd frontend && npx prettier --write src/pages/experiment/ExperimentDetailPage.tsx`, which completed successfully and formatted the file.
- Confirmed the modified file was committed (`git commit`) after formatting; no unit tests were modified or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148740907c83219efa6dd3d576860e)