### PR TITLE
docs: add canonical diagrams for Hotmart collection cycles (Ciclo 1 & 2)

### DIFF
--- a/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+++ b/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
@@ -201,3 +201,56 @@ Sequência operacional consolidada:
 - Se falhar o detalhe de um produto no ciclo 2: manter dados do ciclo 1 para o item e continuar os demais.
 - Registrar em log `status` HTTP e `productId` para diagnóstico de causa-raiz.
 
+
+---
+
+## 11) Diagramas canônicos dos dois fluxos (Ciclo 1 e Ciclo 2)
+
+### 11.1 Diagrama — Ciclo 1 (listagem/search)
+
+```mermaid
+flowchart TD
+    A[Scheduler<br/>com.marketinghub.moishotmart.service.HotmartCollectorScheduler] --> B[Service<br/>com.marketinghub.moishotmart.service.HotmartCollectorService.collectFirstCycle]
+    B --> C[Hotmart API<br/>POST https://api-affiliation-market.hotmart.com/v2/market/search]
+    C --> D[Dados recebidos da Hotmart (listagem)<br/>ucode/productUcode, title/name/productName, image/productImage,<br/>reviewRating/rating, totalAnswers, blueprint, priceValue/value,<br/>category, format, producerName, detailsUrl/productUrl/url,<br/>temperature/hotmartTemperature, salesPageUrl/pageUrl]
+    D --> E[Montagem do snapshot base<br/>HotmartProductSnapshot]
+    E --> F[POST backend<br/>/api/v1/mois/collect/references<br/>Controller: com.marketinghub.mois.web.MoisController<br/>Pacote: backend/ads-service/.../com/marketinghub/mois/web]
+    F --> G[Persistência
+MoisCollectionPersistenceService
+com.marketinghub.mois.service]
+    G --> H[Tabela mois_collected_reference]
+```
+
+### 11.2 Diagrama — Ciclo 2 (detalhes por produto)
+
+```mermaid
+flowchart TD
+    A2[Scheduler<br/>com.marketinghub.moishotmart.service.HotmartCollectorScheduler] --> B2[Service<br/>com.marketinghub.moishotmart.service.HotmartCollectorService.collectSecondCycleFromBackend]
+    B2 --> C2[GET backend<br/>/api/v1/mois/hotmart/products?limit={n}<br/>Controller: com.marketinghub.mois.web.MoisController<br/>Pacote: backend/ads-service/.../com/marketinghub/mois/web]
+    C2 --> D2[Lista de produtos já persistidos]
+    D2 --> E2[Hotmart API<br/>GET https://api-affiliation-market.hotmart.com/v1/market/product/{id}/details?userSessionId={session}]
+    E2 --> F2[Dados recebidos da Hotmart (detalhes)<br/>salesPageUrl, pageSalesLink, salesPage, pageUrl, url,<br/>detailsUrl, productUrl, checkoutUrl, name/title, image, producer.name]
+    F2 --> G2[Regra de enriquecimento<br/>salesPageUrl_final = salesPageFromDetails || salesPageUrl_base || detailPageUrl]
+    G2 --> H2[POST backend<br/>/api/v1/mois/collect/references<br/>Controller: com.marketinghub.mois.web.MoisController]
+    H2 --> I2[Persistência com fallback em sales_page_url<br/>rawMetadata.salesPageUrl -> pageSalesLink -> checkoutUrl -> reference.url]
+    I2 --> J2[Tabela mois_collected_reference]
+```
+
+### 11.3 Pacotes Java envolvidos (visão rápida)
+
+- **Coletor Hotmart (módulo `mois-hotmart-collector`)**
+  - `com.marketinghub.moishotmart.web` (entrada HTTP do coletor)
+  - `com.marketinghub.moishotmart.service` (orquestração dos ciclos e chamadas Hotmart/backend)
+  - `com.marketinghub.moishotmart.dto` (contratos de request/response e snapshots)
+- **Backend MOIS (módulo `backend/ads-service`)**
+  - `com.marketinghub.mois.web` (endpoints `/api/v1/mois/...`)
+  - `com.marketinghub.mois.service` (regras de persistência e leitura de produtos Hotmart)
+
+### 11.4 URLs e endpoints envolvidos
+
+- **Hotmart (externo)**
+  - `POST https://api-affiliation-market.hotmart.com/v2/market/search` (ciclo 1)
+  - `GET https://api-affiliation-market.hotmart.com/v1/market/product/{id}/details?userSessionId={session}` (ciclo 2)
+- **Backend (interno do Marketing Hub)**
+  - `GET /api/v1/mois/hotmart/products` (fonte do ciclo 2)
+  - `POST /api/v1/mois/collect/references` (persistência dos dois ciclos)

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -556,3 +556,13 @@ Arquivos alterados:
 - 2026-05-24: Adicionada regra ArchUnit no módulo `mois-sales-library-worker` para exigir classe no pacote `bibliotecapaginavenda.worker.vN.service` com método `recordPromptBuilderOpenAiResult` recebendo request bruto, resposta bruta, jobId OpenAI e JSON validado; incluída implementação inicial `OpenAiPromptResultRecorder` no v1.
 
 - 2026-05-24: Regra ArchUnit ampliada no `mois-sales-library-worker` para exigir também método de inserção backend (`insertOpenAiIntegrationRecord`) em `mois.bibliotecapaginavenda.worker.vN.service`, com parâmetros: request cru, resposta crua, jobId OpenAI, JSON validado e jobId Marketing Hub.
+
+## 2026-05-25 — Diagramas canônicos dos ciclos de acesso Hotmart (Ciclo 1 e Ciclo 2)
+- Atualizado `docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md` com seção nova de diagramas para os dois fluxos operacionais.
+- Incluído diagrama do **Ciclo 1 (listagem)** com módulos/pacotes Java envolvidos, URL Hotmart de busca, endpoint backend de persistência e dados recebidos da Hotmart.
+- Incluído diagrama do **Ciclo 2 (detalhes)** com módulos/pacotes Java envolvidos, endpoint backend de leitura de produtos, URL Hotmart de detalhes e fallback de `salesPageUrl` na persistência.
+- Documentada uma visão consolidada de pacotes Java por módulo e lista objetiva de URLs/endpoints usados no fluxo.
+- Documentos lidos para execução:
+  - AGENTS.md
+  - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+  - docs/registros/mois1.md


### PR DESCRIPTION
### Motivation
- Esclarecer e documentar os dois ciclos de coleta do coletor Hotmart (Ciclo 1 — listagem/search e Ciclo 2 — detalhes por produto) para facilitar diagnóstico e manutenção. 
- Explicitar a origem e a lógica de fallback do campo `salesPageUrl` e como ele é persistido no backend. 
- Mapear os pacotes Java, endpoints Hotmart e endpoints internos usados pelos fluxos para melhorar a rastreabilidade arquitetural. 

### Description
- Atualizado `docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md` adicionando a nova seção `11) Diagramas canônicos dos dois fluxos (Ciclo 1 e Ciclo 2)` com diagramas `mermaid` para ambos os ciclos. 
- Documentados os passos operacionais de cada ciclo incluindo chamadas externas `POST https://api-affiliation-market.hotmart.com/v2/market/search` e `GET https://api-affiliation-market.hotmart.com/v1/market/product/{id}/details`, e os endpoints internos `GET /api/v1/mois/hotmart/products` e `POST /api/v1/mois/collect/references`. 
- Listados os pacotes Java envolvidos nos módulos `mois-hotmart-collector` e `backend/ads-service` e descrita a regra de enriquecimento/fallback para `salesPageUrl`. 
- Atualizado `docs/registros/mois1.md` com o registro de alteração datado e resumo das modificações realizadas. 

### Testing
- Esta alteração é somente documental e não envolve código de runtime ou testes unitários. 
- Não foram necessários testes automatizados para validar a mudança de conteúdo textuais. 
- A documentação foi atualizada seguindo o padrão existente para diagramas e registros, sem impacto em pipelines de teste de código.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1489c648188321834f22153f3b55fe)