### PR TITLE
Corrige contraste do badge de stage na página de detalhe Gera Landing

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1501,3 +1501,11 @@
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlPayloadResolver.java
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/CopyProvisionalHtmlProcessor.java
   - docs/registros/experimentos.md
+
+## 2026-05-25 14:55:00 UTC
+- ajuste visual na tela de detalhe da execução Gera Landing para corrigir legibilidade do nome da etapa (`stageCode`) no cabeçalho.
+- causa-raiz identificada: badge da etapa estava com esquema `bg-primary`, gerando contraste inadequado (texto azul sobre fundo azul) no contexto atual da UI.
+- correção aplicada: troca para badge neutra (`text-bg-light` + `text-dark` + borda suave), mantendo destaque sem comprometer leitura.
+- arquivos alterados:
+  - `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx`
+  - `docs/registros/experimentos.md`

--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -154,7 +154,7 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
           <PageTitle icon={experimentIcon}>
             Detalhe da execução Gera Landing
             {detailQuery.data?.stageCode ? (
-              <span className="badge bg-primary text-white ms-3 align-middle fw-semibold">
+              <span className="badge text-bg-light border border-secondary-subtle text-dark ms-3 align-middle fw-semibold">
                 {detailQuery.data.stageCode}
               </span>
             ) : null}


### PR DESCRIPTION
### Motivation
- Corrigir legibilidade do nome da etapa (`stageCode`) no cabeçalho da página de detalhe da execução Gera Landing, onde o esquema anterior gerava texto azul sobre fundo azul.

### Description
- Substituído o `className` do badge em `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx` de `badge bg-primary text-white ...` para `badge text-bg-light border border-secondary-subtle text-dark ...` e registrado o ajuste em `docs/registros/experimentos.md` com causa e correção.

### Testing
- Executados `npm --prefix frontend run -s lint` e `npm run typecheck` (no diretório `frontend`); ambos falharam por problemas de ambiente/depêndencias (`@testing-library/jest-dom`, `vite/client`, `vitest/globals` e avisos TS) que são independentes desta alteração; commit e PR gerados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148d44b2a88321b555cfa8657823d5)