### PR TITLE
Fix Mermaid parsing in MOIS Hotmart cycle diagrams

### DIFF
--- a/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+++ b/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
@@ -210,30 +210,28 @@ Sequência operacional consolidada:
 
 ```mermaid
 flowchart TD
-    A[Scheduler<br/>com.marketinghub.moishotmart.service.HotmartCollectorScheduler] --> B[Service<br/>com.marketinghub.moishotmart.service.HotmartCollectorService.collectFirstCycle]
-    B --> C[Hotmart API<br/>POST https://api-affiliation-market.hotmart.com/v2/market/search]
-    C --> D[Dados recebidos da Hotmart (listagem)<br/>ucode/productUcode, title/name/productName, image/productImage,<br/>reviewRating/rating, totalAnswers, blueprint, priceValue/value,<br/>category, format, producerName, detailsUrl/productUrl/url,<br/>temperature/hotmartTemperature, salesPageUrl/pageUrl]
-    D --> E[Montagem do snapshot base<br/>HotmartProductSnapshot]
-    E --> F[POST backend<br/>/api/v1/mois/collect/references<br/>Controller: com.marketinghub.mois.web.MoisController<br/>Pacote: backend/ads-service/.../com/marketinghub/mois/web]
-    F --> G[Persistência
-MoisCollectionPersistenceService
-com.marketinghub.mois.service]
-    G --> H[Tabela mois_collected_reference]
+    A["Scheduler<br/>com.marketinghub.moishotmart.service.HotmartCollectorScheduler"] --> B["Service<br/>com.marketinghub.moishotmart.service.HotmartCollectorService.collectFirstCycle"]
+    B --> C["Hotmart API<br/>POST https://api-affiliation-market.hotmart.com/v2/market/search"]
+    C --> D["Dados recebidos da Hotmart - listagem<br/>ucode/productUcode, title/name/productName, image/productImage,<br/>reviewRating/rating, totalAnswers, blueprint, priceValue/value,<br/>category, format, producerName, detailsUrl/productUrl/url,<br/>temperature/hotmartTemperature, salesPageUrl/pageUrl"]
+    D --> E["Montagem do snapshot base<br/>HotmartProductSnapshot"]
+    E --> F["POST backend<br/>/api/v1/mois/collect/references<br/>Controller: com.marketinghub.mois.web.MoisController<br/>Pacote: backend/ads-service/.../com/marketinghub/mois/web"]
+    F --> G["Persistência<br/>MoisCollectionPersistenceService<br/>com.marketinghub.mois.service"]
+    G --> H["Tabela mois_collected_reference"]
 ```
 
 ### 11.2 Diagrama — Ciclo 2 (detalhes por produto)
 
 ```mermaid
 flowchart TD
-    A2[Scheduler<br/>com.marketinghub.moishotmart.service.HotmartCollectorScheduler] --> B2[Service<br/>com.marketinghub.moishotmart.service.HotmartCollectorService.collectSecondCycleFromBackend]
-    B2 --> C2[GET backend<br/>/api/v1/mois/hotmart/products?limit={n}<br/>Controller: com.marketinghub.mois.web.MoisController<br/>Pacote: backend/ads-service/.../com/marketinghub/mois/web]
-    C2 --> D2[Lista de produtos já persistidos]
-    D2 --> E2[Hotmart API<br/>GET https://api-affiliation-market.hotmart.com/v1/market/product/{id}/details?userSessionId={session}]
-    E2 --> F2[Dados recebidos da Hotmart (detalhes)<br/>salesPageUrl, pageSalesLink, salesPage, pageUrl, url,<br/>detailsUrl, productUrl, checkoutUrl, name/title, image, producer.name]
-    F2 --> G2[Regra de enriquecimento<br/>salesPageUrl_final = salesPageFromDetails || salesPageUrl_base || detailPageUrl]
-    G2 --> H2[POST backend<br/>/api/v1/mois/collect/references<br/>Controller: com.marketinghub.mois.web.MoisController]
-    H2 --> I2[Persistência com fallback em sales_page_url<br/>rawMetadata.salesPageUrl -> pageSalesLink -> checkoutUrl -> reference.url]
-    I2 --> J2[Tabela mois_collected_reference]
+    A2["Scheduler<br/>com.marketinghub.moishotmart.service.HotmartCollectorScheduler"] --> B2["Service<br/>com.marketinghub.moishotmart.service.HotmartCollectorService.collectSecondCycleFromBackend"]
+    B2 --> C2["GET backend<br/>/api/v1/mois/hotmart/products?limit=numero<br/>Controller: com.marketinghub.mois.web.MoisController<br/>Pacote: backend/ads-service/.../com/marketinghub/mois/web"]
+    C2 --> D2["Lista de produtos já persistidos"]
+    D2 --> E2["Hotmart API<br/>GET https://api-affiliation-market.hotmart.com/v1/market/product/id/details?userSessionId=session"]
+    E2 --> F2["Dados recebidos da Hotmart - detalhes<br/>salesPageUrl, pageSalesLink, salesPage, pageUrl, url,<br/>detailsUrl, productUrl, checkoutUrl, name/title, image, producer.name"]
+    F2 --> G2["Regra de enriquecimento<br/>salesPageUrl_final = salesPageFromDetails || salesPageUrl_base || detailPageUrl"]
+    G2 --> H2["POST backend<br/>/api/v1/mois/collect/references<br/>Controller: com.marketinghub.mois.web.MoisController"]
+    H2 --> I2["Persistência com fallback em sales_page_url<br/>rawMetadata.salesPageUrl -> pageSalesLink -> checkoutUrl -> reference.url"]
+    I2 --> J2["Tabela mois_collected_reference"]
 ```
 
 ### 11.3 Pacotes Java envolvidos (visão rápida)

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -566,3 +566,15 @@ Arquivos alterados:
   - AGENTS.md
   - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
   - docs/registros/mois1.md
+
+## 2026-05-25 — Correção de renderização Mermaid (MOIS Hotmart ciclos 1 e 2)
+- Corrigidos os dois diagramas Mermaid em `docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md` para eliminar erro de parser no GitHub.
+- Causa-raiz: rótulos com caracteres especiais não escapados no conteúdo dos nós (`{}` em URLs com placeholders e quebra de linha literal dentro do nó), que quebravam o parser Mermaid.
+- Correção aplicada:
+  - padronização dos rótulos com aspas (`["..."]`) para texto rico com `<br/>`;
+  - remoção de placeholders com chaves nas labels dos nós (`{n}`, `{id}`, `{session}`), substituindo por texto equivalente sem chaves;
+  - normalização de quebras de linha para `<br/>` no nó de persistência do ciclo 1.
+- Documentos lidos para execução:
+  - AGENTS.md
+  - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+  - docs/registros/mois1.md


### PR DESCRIPTION
### Motivation
- Corrigir erro de renderização Mermaid nas seções dos diagramas dos ciclos Hotmart que impedia o rich display no GitHub.
- Evitar que placeholders com chaves (`{n}`, `{id}`, `{session}`) e quebras de linha literais em labels continuem a quebrar o parser Mermaid.
- Garantir que a documentação canônica seja legível e segura para uso como referência operacional do coletor MOIS.

### Description
- Padronizei os rótulos dos nós dos dois diagramas (`11.1` e `11.2`) usando labels entre aspas e `<br/>` para quebras de linha internas. 
- Removi/substituí placeholders com chaves nos labels por texto equivalente sem `{}` para eliminar tokens que causavam falha no parser Mermaid. 
- Normalizei o nó de persistência do Ciclo 1 para evitar que uma quebra de linha literal permanecesse dentro do nó. 
- Adicionei um registro de atividade em `docs/registros/mois1.md` documentando a causa-raiz e a correção aplicada.

### Testing
- Nenhum teste automatizado foi executado para esta alteração de documentação; a validação foi feita inspecionando os blocos Mermaid atualizados e confirmando a remoção dos padrões que causavam o parse error (pré-condição para renderização correta no GitHub).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14979468308321a42b456f88db76d7)