### PR TITLE
Refatora MontaRequest para receber objeto de experimento no GeraLanding

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -129,11 +129,7 @@ public class GeraLandingExecutionService {
                     stage,
                     new GeraLandingExperimentRequest(
                             execution.experimentId(),
-                            prompt,
-                            null,
-                            openAiModel,
-                            "gera-landing-pipeline",
-                            "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet."));
+                            prompt));
             log.info("OpenAI payload built for gera-landing executionId={} (length={})", execution.idJob(), openAiRequestBody.length());
             log.info("Payload OpenAI do gera-landing executionId={}: {}", execution.idJob(), openAiRequestBody);
             String schemaJson = objectMapper.writeValueAsString(readSchemaByStage(stage));
@@ -247,20 +243,12 @@ public class GeraLandingExecutionService {
      */
     private String montarRequestPorEtapa(GeraLandingStageDefinition stage,
                                          GeraLandingExperimentRequest experiment) throws JsonProcessingException {
-        Map<String, Object> schema = readSchemaByStage(stage);
-        GeraLandingExperimentRequest experimentComSchema = new GeraLandingExperimentRequest(
-                experiment.experimentId(),
-                experiment.prompt(),
-                schema,
-                experiment.model(),
-                experiment.systemName(),
-                experiment.systemMessage());
         return switch (stage) {
-            case WIREFRAME -> wireframeMontaRequest.montar(experimentComSchema);
-            case COPY -> copyMontaRequest.montar(experimentComSchema);
-            case IMAGE_PLANNING -> imagePlanningMontaRequest.montar(experimentComSchema);
-            case DESIGN_PRESET -> presetDesignMontaRequest.montar(experimentComSchema);
-            case DELIVERABLES -> deliverablesMontaRequest.montar(experimentComSchema);
+            case WIREFRAME -> wireframeMontaRequest.montar(experiment);
+            case COPY -> copyMontaRequest.montar(experiment);
+            case IMAGE_PLANNING -> imagePlanningMontaRequest.montar(experiment);
+            case DESIGN_PRESET -> presetDesignMontaRequest.montar(experiment);
+            case DELIVERABLES -> deliverablesMontaRequest.montar(experiment);
         };
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -127,10 +127,13 @@ public class GeraLandingExecutionService {
 
             String openAiRequestBody = montarRequestPorEtapa(
                     stage,
-                    openAiModel,
-                    prompt,
-                    "gera-landing-pipeline",
-                    "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
+                    new GeraLandingExperimentRequest(
+                            execution.experimentId(),
+                            prompt,
+                            null,
+                            openAiModel,
+                            "gera-landing-pipeline",
+                            "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet."));
             log.info("OpenAI payload built for gera-landing executionId={} (length={})", execution.idJob(), openAiRequestBody.length());
             log.info("Payload OpenAI do gera-landing executionId={}: {}", execution.idJob(), openAiRequestBody);
             String schemaJson = objectMapper.writeValueAsString(readSchemaByStage(stage));
@@ -243,17 +246,21 @@ public class GeraLandingExecutionService {
      * Direciona a montagem do request da OpenAI para o montador específico de cada etapa.
      */
     private String montarRequestPorEtapa(GeraLandingStageDefinition stage,
-                                         String model,
-                                         String prompt,
-                                         String systemName,
-                                         String systemMessage) throws JsonProcessingException {
+                                         GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> schema = readSchemaByStage(stage);
+        GeraLandingExperimentRequest experimentComSchema = new GeraLandingExperimentRequest(
+                experiment.experimentId(),
+                experiment.prompt(),
+                schema,
+                experiment.model(),
+                experiment.systemName(),
+                experiment.systemMessage());
         return switch (stage) {
-            case WIREFRAME -> wireframeMontaRequest.montar(model, prompt, systemName, systemMessage, schema);
-            case COPY -> copyMontaRequest.montar(model, prompt, systemName, systemMessage, schema);
-            case IMAGE_PLANNING -> imagePlanningMontaRequest.montar(model, prompt, systemName, systemMessage, schema);
-            case DESIGN_PRESET -> presetDesignMontaRequest.montar(model, prompt, systemName, systemMessage, schema);
-            case DELIVERABLES -> deliverablesMontaRequest.montar(model, prompt, systemName, systemMessage, schema);
+            case WIREFRAME -> wireframeMontaRequest.montar(experimentComSchema);
+            case COPY -> copyMontaRequest.montar(experimentComSchema);
+            case IMAGE_PLANNING -> imagePlanningMontaRequest.montar(experimentComSchema);
+            case DESIGN_PRESET -> presetDesignMontaRequest.montar(experimentComSchema);
+            case DELIVERABLES -> deliverablesMontaRequest.montar(experimentComSchema);
         };
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExperimentRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExperimentRequest.java
@@ -1,17 +1,11 @@
 package com.marketinghub.worker.geralanding;
 
-import java.util.Map;
-
 /**
- * Responsabilidade: concentrar os dados do experimento necessários para montar um request da OpenAI no GeraLanding.
+ * Responsabilidade: concentrar os dados mínimos do experimento para montagem do request da OpenAI no GeraLanding.
  */
 public record GeraLandingExperimentRequest(
         Long experimentId,
-        String prompt,
-        Map<String, Object> schema,
-        String model,
-        String systemName,
-        String systemMessage
+        String prompt
 ) {
 
     /** Retorna um valor textual de fallback quando o campo informado estiver nulo ou em branco. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExperimentRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExperimentRequest.java
@@ -1,0 +1,24 @@
+package com.marketinghub.worker.geralanding;
+
+import java.util.Map;
+
+/**
+ * Responsabilidade: concentrar os dados do experimento necessários para montar um request da OpenAI no GeraLanding.
+ */
+public record GeraLandingExperimentRequest(
+        Long experimentId,
+        String prompt,
+        Map<String, Object> schema,
+        String model,
+        String systemName,
+        String systemMessage
+) {
+
+    /** Retorna um valor textual de fallback quando o campo informado estiver nulo ou em branco. */
+    public String resolveText(String value, String fallback) {
+        if (value == null || value.trim().isEmpty()) {
+            return fallback;
+        }
+        return value.trim();
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
@@ -3,9 +3,12 @@ package com.marketinghub.worker.geralanding.copy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -14,33 +17,45 @@ import org.springframework.stereotype.Component;
 @Component
 public class MontaRequest {
 
-    private final ObjectMapper objectMapper;
+    private static final String DEFAULT_MODEL = "gpt-5.2";
+    private static final String DEFAULT_SYSTEM_NAME = "gera-landing-pipeline";
+    private static final String DEFAULT_SYSTEM_MESSAGE =
+            "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
 
-    public MontaRequest(ObjectMapper objectMapper) {
+    private final ObjectMapper objectMapper;
+    private final Resource schemaResource;
+
+    public MontaRequest(ObjectMapper objectMapper,
+                        @Value("classpath:prompts/geralanding/landing-page-copy-schema.json") Resource schemaResource) {
         this.objectMapper = objectMapper;
+        this.schemaResource = schemaResource;
     }
 
-    /** Monta o payload da Responses API para a etapa de copy. */
+    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema e parâmetros padrão. */
     public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_copy");
-        format.put("schema", experiment.schema());
+        format.put("schema", carregarSchema());
         format.put("strict", true);
 
-        String resolvedModel = experiment.resolveText(experiment.model(), "gpt-5.2");
-        String resolvedSystemName = experiment.resolveText(experiment.systemName(), "system");
-        String resolvedSystemMessage = experiment.resolveText(
-                experiment.systemMessage(),
-                "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
-
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("model", resolvedModel);
+        body.put("model", experiment.resolveText(null, DEFAULT_MODEL));
         body.put("input", List.of(
-                Map.of("role", "system", "content", "[" + resolvedSystemName + "] " + resolvedSystemMessage),
+                Map.of("role", "system", "content", "[" + DEFAULT_SYSTEM_NAME + "] " + DEFAULT_SYSTEM_MESSAGE),
                 Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);
+    }
+
+    /** Carrega e converte para mapa o schema JSON da etapa. */
+    private Map<String, Object> carregarSchema() throws JsonProcessingException {
+        try {
+            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
+        } catch (IOException ex) {
+            throw new JsonProcessingException("Falha ao carregar schema da etapa copy") {
+            };
+        }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
@@ -2,11 +2,11 @@ package com.marketinghub.worker.geralanding.copy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 /**
  * Responsabilidade: montar o request da OpenAI para a etapa de copy do GeraLanding.
@@ -21,25 +21,24 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa de copy. */
-    public String montar(String model, String prompt, String systemName, String systemMessage, Map<String, Object> schema)
-            throws JsonProcessingException {
+    public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_copy");
-        format.put("schema", schema);
+        format.put("schema", experiment.schema());
         format.put("strict", true);
 
-        String resolvedModel = StringUtils.hasText(model) ? model.trim() : "gpt-5.2";
-        String resolvedSystemName = StringUtils.hasText(systemName) ? systemName.trim() : "system";
-        String resolvedSystemMessage = StringUtils.hasText(systemMessage)
-                ? systemMessage.trim()
-                : "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
+        String resolvedModel = experiment.resolveText(experiment.model(), "gpt-5.2");
+        String resolvedSystemName = experiment.resolveText(experiment.systemName(), "system");
+        String resolvedSystemMessage = experiment.resolveText(
+                experiment.systemMessage(),
+                "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", resolvedModel);
         body.put("input", List.of(
                 Map.of("role", "system", "content", "[" + resolvedSystemName + "] " + resolvedSystemMessage),
-                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", prompt)))
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
@@ -2,11 +2,11 @@ package com.marketinghub.worker.geralanding.deliverables;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 /**
  * Responsabilidade: montar o request da OpenAI para a etapa de entregáveis do GeraLanding.
@@ -21,25 +21,24 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa de entregáveis. */
-    public String montar(String model, String prompt, String systemName, String systemMessage, Map<String, Object> schema)
-            throws JsonProcessingException {
+    public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_deliverables");
-        format.put("schema", schema);
+        format.put("schema", experiment.schema());
         format.put("strict", true);
 
-        String resolvedModel = StringUtils.hasText(model) ? model.trim() : "gpt-5.2";
-        String resolvedSystemName = StringUtils.hasText(systemName) ? systemName.trim() : "system";
-        String resolvedSystemMessage = StringUtils.hasText(systemMessage)
-                ? systemMessage.trim()
-                : "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
+        String resolvedModel = experiment.resolveText(experiment.model(), "gpt-5.2");
+        String resolvedSystemName = experiment.resolveText(experiment.systemName(), "system");
+        String resolvedSystemMessage = experiment.resolveText(
+                experiment.systemMessage(),
+                "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", resolvedModel);
         body.put("input", List.of(
                 Map.of("role", "system", "content", "[" + resolvedSystemName + "] " + resolvedSystemMessage),
-                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", prompt)))
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
@@ -3,44 +3,59 @@ package com.marketinghub.worker.geralanding.deliverables;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
- * Responsabilidade: montar o request da OpenAI para a etapa de entregáveis do GeraLanding.
+ * Responsabilidade: montar o request da OpenAI para a etapa de deliverables do GeraLanding.
  */
 @Component
 public class MontaRequest {
 
-    private final ObjectMapper objectMapper;
+    private static final String DEFAULT_MODEL = "gpt-5.2";
+    private static final String DEFAULT_SYSTEM_NAME = "gera-landing-pipeline";
+    private static final String DEFAULT_SYSTEM_MESSAGE =
+            "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
 
-    public MontaRequest(ObjectMapper objectMapper) {
+    private final ObjectMapper objectMapper;
+    private final Resource schemaResource;
+
+    public MontaRequest(ObjectMapper objectMapper,
+                        @Value("classpath:prompts/geralanding/landing-page-deliverables-schema.json") Resource schemaResource) {
         this.objectMapper = objectMapper;
+        this.schemaResource = schemaResource;
     }
 
-    /** Monta o payload da Responses API para a etapa de entregáveis. */
+    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema e parâmetros padrão. */
     public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_deliverables");
-        format.put("schema", experiment.schema());
+        format.put("schema", carregarSchema());
         format.put("strict", true);
 
-        String resolvedModel = experiment.resolveText(experiment.model(), "gpt-5.2");
-        String resolvedSystemName = experiment.resolveText(experiment.systemName(), "system");
-        String resolvedSystemMessage = experiment.resolveText(
-                experiment.systemMessage(),
-                "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
-
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("model", resolvedModel);
+        body.put("model", experiment.resolveText(null, DEFAULT_MODEL));
         body.put("input", List.of(
-                Map.of("role", "system", "content", "[" + resolvedSystemName + "] " + resolvedSystemMessage),
+                Map.of("role", "system", "content", "[" + DEFAULT_SYSTEM_NAME + "] " + DEFAULT_SYSTEM_MESSAGE),
                 Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);
+    }
+
+    /** Carrega e converte para mapa o schema JSON da etapa. */
+    private Map<String, Object> carregarSchema() throws JsonProcessingException {
+        try {
+            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
+        } catch (IOException ex) {
+            throw new JsonProcessingException("Falha ao carregar schema da etapa deliverables") {
+            };
+        }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
@@ -3,44 +3,59 @@ package com.marketinghub.worker.geralanding.imageplanning;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
- * Responsabilidade: montar o request da OpenAI para a etapa de planejamento de imagens do GeraLanding.
+ * Responsabilidade: montar o request da OpenAI para a etapa de imageplanning do GeraLanding.
  */
 @Component
 public class MontaRequest {
 
-    private final ObjectMapper objectMapper;
+    private static final String DEFAULT_MODEL = "gpt-5.2";
+    private static final String DEFAULT_SYSTEM_NAME = "gera-landing-pipeline";
+    private static final String DEFAULT_SYSTEM_MESSAGE =
+            "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
 
-    public MontaRequest(ObjectMapper objectMapper) {
+    private final ObjectMapper objectMapper;
+    private final Resource schemaResource;
+
+    public MontaRequest(ObjectMapper objectMapper,
+                        @Value("classpath:prompts/geralanding/landing-page-image-planning-schema.json") Resource schemaResource) {
         this.objectMapper = objectMapper;
+        this.schemaResource = schemaResource;
     }
 
-    /** Monta o payload da Responses API para a etapa de planejamento de imagens. */
+    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema e parâmetros padrão. */
     public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_image_planning");
-        format.put("schema", experiment.schema());
+        format.put("schema", carregarSchema());
         format.put("strict", true);
 
-        String resolvedModel = experiment.resolveText(experiment.model(), "gpt-5.2");
-        String resolvedSystemName = experiment.resolveText(experiment.systemName(), "system");
-        String resolvedSystemMessage = experiment.resolveText(
-                experiment.systemMessage(),
-                "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
-
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("model", resolvedModel);
+        body.put("model", experiment.resolveText(null, DEFAULT_MODEL));
         body.put("input", List.of(
-                Map.of("role", "system", "content", "[" + resolvedSystemName + "] " + resolvedSystemMessage),
+                Map.of("role", "system", "content", "[" + DEFAULT_SYSTEM_NAME + "] " + DEFAULT_SYSTEM_MESSAGE),
                 Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);
+    }
+
+    /** Carrega e converte para mapa o schema JSON da etapa. */
+    private Map<String, Object> carregarSchema() throws JsonProcessingException {
+        try {
+            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
+        } catch (IOException ex) {
+            throw new JsonProcessingException("Falha ao carregar schema da etapa imageplanning") {
+            };
+        }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
@@ -2,11 +2,11 @@ package com.marketinghub.worker.geralanding.imageplanning;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 /**
  * Responsabilidade: montar o request da OpenAI para a etapa de planejamento de imagens do GeraLanding.
@@ -21,25 +21,24 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa de planejamento de imagens. */
-    public String montar(String model, String prompt, String systemName, String systemMessage, Map<String, Object> schema)
-            throws JsonProcessingException {
+    public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_image_planning");
-        format.put("schema", schema);
+        format.put("schema", experiment.schema());
         format.put("strict", true);
 
-        String resolvedModel = StringUtils.hasText(model) ? model.trim() : "gpt-5.2";
-        String resolvedSystemName = StringUtils.hasText(systemName) ? systemName.trim() : "system";
-        String resolvedSystemMessage = StringUtils.hasText(systemMessage)
-                ? systemMessage.trim()
-                : "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
+        String resolvedModel = experiment.resolveText(experiment.model(), "gpt-5.2");
+        String resolvedSystemName = experiment.resolveText(experiment.systemName(), "system");
+        String resolvedSystemMessage = experiment.resolveText(
+                experiment.systemMessage(),
+                "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", resolvedModel);
         body.put("input", List.of(
                 Map.of("role", "system", "content", "[" + resolvedSystemName + "] " + resolvedSystemMessage),
-                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", prompt)))
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
@@ -2,11 +2,11 @@ package com.marketinghub.worker.geralanding.presetdesign;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 /**
  * Responsabilidade: montar o request da OpenAI para a etapa de preset de design do GeraLanding.
@@ -21,25 +21,24 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa de preset de design. */
-    public String montar(String model, String prompt, String systemName, String systemMessage, Map<String, Object> schema)
-            throws JsonProcessingException {
+    public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_design_preset");
-        format.put("schema", schema);
+        format.put("schema", experiment.schema());
         format.put("strict", true);
 
-        String resolvedModel = StringUtils.hasText(model) ? model.trim() : "gpt-5.2";
-        String resolvedSystemName = StringUtils.hasText(systemName) ? systemName.trim() : "system";
-        String resolvedSystemMessage = StringUtils.hasText(systemMessage)
-                ? systemMessage.trim()
-                : "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
+        String resolvedModel = experiment.resolveText(experiment.model(), "gpt-5.2");
+        String resolvedSystemName = experiment.resolveText(experiment.systemName(), "system");
+        String resolvedSystemMessage = experiment.resolveText(
+                experiment.systemMessage(),
+                "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", resolvedModel);
         body.put("input", List.of(
                 Map.of("role", "system", "content", "[" + resolvedSystemName + "] " + resolvedSystemMessage),
-                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", prompt)))
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
@@ -3,44 +3,59 @@ package com.marketinghub.worker.geralanding.presetdesign;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
- * Responsabilidade: montar o request da OpenAI para a etapa de preset de design do GeraLanding.
+ * Responsabilidade: montar o request da OpenAI para a etapa de presetdesign do GeraLanding.
  */
 @Component
 public class MontaRequest {
 
-    private final ObjectMapper objectMapper;
+    private static final String DEFAULT_MODEL = "gpt-5.2";
+    private static final String DEFAULT_SYSTEM_NAME = "gera-landing-pipeline";
+    private static final String DEFAULT_SYSTEM_MESSAGE =
+            "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
 
-    public MontaRequest(ObjectMapper objectMapper) {
+    private final ObjectMapper objectMapper;
+    private final Resource schemaResource;
+
+    public MontaRequest(ObjectMapper objectMapper,
+                        @Value("classpath:prompts/geralanding/landing-page-design-preset-schema.json") Resource schemaResource) {
         this.objectMapper = objectMapper;
+        this.schemaResource = schemaResource;
     }
 
-    /** Monta o payload da Responses API para a etapa de preset de design. */
+    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema e parâmetros padrão. */
     public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_design_preset");
-        format.put("schema", experiment.schema());
+        format.put("schema", carregarSchema());
         format.put("strict", true);
 
-        String resolvedModel = experiment.resolveText(experiment.model(), "gpt-5.2");
-        String resolvedSystemName = experiment.resolveText(experiment.systemName(), "system");
-        String resolvedSystemMessage = experiment.resolveText(
-                experiment.systemMessage(),
-                "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
-
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("model", resolvedModel);
+        body.put("model", experiment.resolveText(null, DEFAULT_MODEL));
         body.put("input", List.of(
-                Map.of("role", "system", "content", "[" + resolvedSystemName + "] " + resolvedSystemMessage),
+                Map.of("role", "system", "content", "[" + DEFAULT_SYSTEM_NAME + "] " + DEFAULT_SYSTEM_MESSAGE),
                 Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);
+    }
+
+    /** Carrega e converte para mapa o schema JSON da etapa. */
+    private Map<String, Object> carregarSchema() throws JsonProcessingException {
+        try {
+            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
+        } catch (IOException ex) {
+            throw new JsonProcessingException("Falha ao carregar schema da etapa presetdesign") {
+            };
+        }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
@@ -2,11 +2,11 @@ package com.marketinghub.worker.geralanding.wireframe;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 /**
  * Responsabilidade: montar o request da OpenAI para a etapa de wireframe do GeraLanding.
@@ -21,25 +21,24 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa de wireframe. */
-    public String montar(String model, String prompt, String systemName, String systemMessage, Map<String, Object> schema)
-            throws JsonProcessingException {
+    public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_wireframe");
-        format.put("schema", schema);
+        format.put("schema", experiment.schema());
         format.put("strict", true);
 
-        String resolvedModel = StringUtils.hasText(model) ? model.trim() : "gpt-5.2";
-        String resolvedSystemName = StringUtils.hasText(systemName) ? systemName.trim() : "system";
-        String resolvedSystemMessage = StringUtils.hasText(systemMessage)
-                ? systemMessage.trim()
-                : "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
+        String resolvedModel = experiment.resolveText(experiment.model(), "gpt-5.2");
+        String resolvedSystemName = experiment.resolveText(experiment.systemName(), "system");
+        String resolvedSystemMessage = experiment.resolveText(
+                experiment.systemMessage(),
+                "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", resolvedModel);
         body.put("input", List.of(
                 Map.of("role", "system", "content", "[" + resolvedSystemName + "] " + resolvedSystemMessage),
-                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", prompt)))
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
@@ -3,9 +3,12 @@ package com.marketinghub.worker.geralanding.wireframe;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -14,33 +17,45 @@ import org.springframework.stereotype.Component;
 @Component
 public class MontaRequest {
 
-    private final ObjectMapper objectMapper;
+    private static final String DEFAULT_MODEL = "gpt-5.2";
+    private static final String DEFAULT_SYSTEM_NAME = "gera-landing-pipeline";
+    private static final String DEFAULT_SYSTEM_MESSAGE =
+            "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
 
-    public MontaRequest(ObjectMapper objectMapper) {
+    private final ObjectMapper objectMapper;
+    private final Resource schemaResource;
+
+    public MontaRequest(ObjectMapper objectMapper,
+                        @Value("classpath:prompts/geralanding/landing-page-wireframe-schema.json") Resource schemaResource) {
         this.objectMapper = objectMapper;
+        this.schemaResource = schemaResource;
     }
 
-    /** Monta o payload da Responses API para a etapa de wireframe. */
+    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema e parâmetros padrão. */
     public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", "experiment_pipeline_landing_page_wireframe");
-        format.put("schema", experiment.schema());
+        format.put("schema", carregarSchema());
         format.put("strict", true);
 
-        String resolvedModel = experiment.resolveText(experiment.model(), "gpt-5.2");
-        String resolvedSystemName = experiment.resolveText(experiment.systemName(), "system");
-        String resolvedSystemMessage = experiment.resolveText(
-                experiment.systemMessage(),
-                "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.");
-
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("model", resolvedModel);
+        body.put("model", experiment.resolveText(null, DEFAULT_MODEL));
         body.put("input", List.of(
-                Map.of("role", "system", "content", "[" + resolvedSystemName + "] " + resolvedSystemMessage),
+                Map.of("role", "system", "content", "[" + DEFAULT_SYSTEM_NAME + "] " + DEFAULT_SYSTEM_MESSAGE),
                 Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);
+    }
+
+    /** Carrega e converte para mapa o schema JSON da etapa. */
+    private Map<String, Object> carregarSchema() throws JsonProcessingException {
+        try {
+            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
+        } catch (IOException ex) {
+            throw new JsonProcessingException("Falha ao carregar schema da etapa wireframe") {
+            };
+        }
     }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1534,3 +1534,11 @@
   - AGENTS.md
   - ai-worker/AGENTS.md
   - docs/registros/experimentos.md
+
+## 2026-05-25 19:10:00 UTC
+- ajuste corretivo após revisão: classes `MontaRequest` do GeraLanding agora recebem somente o objeto de experimento e assumem internamente a responsabilidade de resolver schema e configuração padrão do request.
+- causa-raiz: implementação anterior ainda exigia resolução de schema no `GeraLandingExecutionService`, mantendo parte da responsabilidade fora das classes de montagem.
+- correção aplicada:
+  - simplificação de `GeraLandingExperimentRequest` para conter apenas dados do experimento (`experimentId`, `prompt`);
+  - cada `MontaRequest` passou a carregar o schema da própria etapa via resource classpath e montar o payload completo internamente;
+  - `GeraLandingExecutionService` agora apenas repassa o objeto de experimento para o montador da etapa.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1521,3 +1521,16 @@
   - AGENTS.md
   - ai-worker/AGENTS.md
   - docs/registros/experimentos.md
+
+## 2026-05-25 16:20:00 UTC
+- ajuste solicitado: classes `MontaRequest` do GeraLanding passam a receber apenas um objeto de experimento preenchido e devolver o payload pronto, sem parâmetros soltos.
+- causa-raiz: assinatura com muitos parâmetros (`model`, `prompt`, `systemName`, `systemMessage`, `schema`) aumentava acoplamento e risco de montagem inconsistente entre etapas.
+- correção aplicada:
+  - criação do record `GeraLandingExperimentRequest` para centralizar dados necessários da montagem;
+  - classes `MontaRequest` de `wireframe`, `copy`, `imageplanning`, `presetdesign` e `deliverables` agora recebem somente `GeraLandingExperimentRequest`;
+  - `GeraLandingExecutionService` foi ajustado para construir o objeto de experimento e repassar ao montador da etapa, mantendo o schema resolvido por etapa internamente no fluxo.
+- impacto funcional: mantém o contrato final de request OpenAI, com interface de montagem mais coesa e orientada a objeto de experimento.
+- documentos/arquivos lidos:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Reduzir acoplamento e a quantidade de parâmetros soltos na montagem dos payloads OpenAI do GeraLanding ao centralizar dados do experimento em um único objeto. 
- Tornar a interface dos montadores (`MontaRequest`) por etapa mais coesa e menos propensa a inconsistências entre etapas.

### Description
- Adicionado o `record` `GeraLandingExperimentRequest` para agrupar `experimentId`, `prompt`, `schema`, `model`, `systemName` e `systemMessage` e fornecer `resolveText(...)` para fallback de texto. (`ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExperimentRequest.java`)
- Alterado `GeraLandingExecutionService` para construir o `GeraLandingExperimentRequest`, resolver o `schema` por etapa e delegar a montagem do request às classes de etapa via `montarRequestPorEtapa(...)`. (`ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java`)
- Atualizadas as classes `MontaRequest` em `wireframe`, `copy`, `imageplanning`, `presetdesign` e `deliverables` para receber apenas `GeraLandingExperimentRequest` e produzir o payload final pronto. (arquivos em `ai-worker/src/main/java/com/marketinghub/worker/geralanding/*/MontaRequest.java`)
- Registrado o ajuste no log de experimentos (`docs/registros/experimentos.md`).

### Testing
- Tentativa de compilação do módulo com `mvn -f ai-worker/pom.xml -DskipTests compile` falhou devido a indisponibilidade da dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` no repositório GitHub Packages (erro 401), portanto não foi possível concluir validação de build neste ambiente.
- Nenhum teste unitário novo foi executado neste ambiente por causa da falha de resolução de dependências.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149a2a304c832199eeca358b3cff51)