### PR TITLE
Centraliza schema, prompt e montagem nos `MontaRequest` do GeraLanding

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -119,17 +119,17 @@ public class GeraLandingExecutionService {
                     execution.experimentId(),
                     execution.idJob(),
                     execution.stageCode(),
-                    backendClient.loadPromptData(execution.experimentId()));
-            String prompt = geraLandingService.montarERegistrarPromptEtapa(context, normalizedStage);
-            String promptMarkdownContent = geraLandingService.carregarPromptMarkdownCru(normalizedStage);
+                    dadosPrompt);
+            Map<String, Object> dadosPrompt = backendClient.loadPromptData(execution.experimentId());
+            GeraLandingExperimentRequest requestData = new GeraLandingExperimentRequest(execution.experimentId(), dadosPrompt);
+            String prompt = montarPromptPorEtapa(stage, requestData);
+            String promptMarkdownContent = carregarPromptMarkdownPorEtapa(stage);
             log.info("Prompt de gera-landing da etapa {} montado para executionId={} (experimentId={})",
                     execution.stageCode(), execution.idJob(), execution.experimentId());
 
             String openAiRequestBody = montarRequestPorEtapa(
                     stage,
-                    new GeraLandingExperimentRequest(
-                            execution.experimentId(),
-                            prompt));
+                    requestData);
             log.info("OpenAI payload built for gera-landing executionId={} (length={})", execution.idJob(), openAiRequestBody.length());
             log.info("Payload OpenAI do gera-landing executionId={}: {}", execution.idJob(), openAiRequestBody);
             String schemaJson = objectMapper.writeValueAsString(readSchemaByStage(stage));
@@ -252,6 +252,29 @@ public class GeraLandingExecutionService {
         };
     }
 
+
+    /** Direciona a montagem do prompt para o montador específico de cada etapa. */
+    private String montarPromptPorEtapa(GeraLandingStageDefinition stage,
+                                        GeraLandingExperimentRequest experiment) throws IOException {
+        return switch (stage) {
+            case WIREFRAME -> wireframeMontaRequest.montarPrompt(experiment);
+            case COPY -> copyMontaRequest.montarPrompt(experiment);
+            case IMAGE_PLANNING -> imagePlanningMontaRequest.montarPrompt(experiment);
+            case DESIGN_PRESET -> presetDesignMontaRequest.montarPrompt(experiment);
+            case DELIVERABLES -> deliverablesMontaRequest.montarPrompt(experiment);
+        };
+    }
+
+    /** Direciona o carregamento do markdown bruto para o montador específico de cada etapa. */
+    private String carregarPromptMarkdownPorEtapa(GeraLandingStageDefinition stage) throws IOException {
+        return switch (stage) {
+            case WIREFRAME -> wireframeMontaRequest.carregarPromptMarkdownCru();
+            case COPY -> copyMontaRequest.carregarPromptMarkdownCru();
+            case IMAGE_PLANNING -> imagePlanningMontaRequest.carregarPromptMarkdownCru();
+            case DESIGN_PRESET -> presetDesignMontaRequest.carregarPromptMarkdownCru();
+            case DELIVERABLES -> deliverablesMontaRequest.carregarPromptMarkdownCru();
+        };
+    }
     private Map<String, Object> readSchemaByStage(GeraLandingStageDefinition stage) throws JsonProcessingException {
         return stageSchemaResolver.resolveSchema(
                 stage,

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExperimentRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExperimentRequest.java
@@ -1,11 +1,13 @@
 package com.marketinghub.worker.geralanding;
 
+import java.util.Map;
+
 /**
  * Responsabilidade: concentrar os dados mínimos do experimento para montagem do request da OpenAI no GeraLanding.
  */
 public record GeraLandingExperimentRequest(
         Long experimentId,
-        String prompt
+        Map<String, Object> dados
 ) {
 
     /** Retorna um valor textual de fallback quando o campo informado estiver nulo ou em branco. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/MontaRequestSupport.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/MontaRequestSupport.java
@@ -1,0 +1,124 @@
+package com.marketinghub.worker.geralanding;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Responsabilidade: concentrar utilitários de resolução de prompt e schema usados pelos montadores de request do GeraLanding.
+ */
+public final class MontaRequestSupport {
+
+    private static final String GERALANDING_PROMPT_BASE_PATH = "prompts/geralanding/";
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\{(prompt|dados)-([a-zA-Z0-9_-]+)}");
+    private static final Pattern MUSTACHE_PLACEHOLDER_PATTERN = Pattern.compile("\\{\\{([A-Za-z0-9_\\-.]+)}}");
+
+    private MontaRequestSupport() {
+    }
+
+    /** Carrega o markdown bruto do prompt da etapa diretamente do classpath. */
+    public static String carregarPromptMarkdownCru(String promptFileName) throws IOException {
+        return carregarPromptBase(promptFileName);
+    }
+
+    /** Resolve placeholders de prompt e dados para montar o texto final enviado ao modelo. */
+    public static String montarPrompt(String stageCode, String promptFileName, Map<String, Object> dadosPayload, ObjectMapper objectMapper)
+            throws IOException {
+        String template = carregarPromptBase(promptFileName);
+        String resolvedPrompt = resolverPlaceholders(template, dadosPayload, objectMapper);
+        String etapaNormalizada = stageCode == null ? "desconhecida" : stageCode.trim();
+        return """
+                # Tarefa
+                Você deve executar a etapa `%s` do pipeline de landing page e responder estritamente no formato solicitado.
+
+                # Instruções do usuário
+                %s
+                """.formatted(etapaNormalizada, resolvedPrompt == null ? "" : resolvedPrompt.trim());
+    }
+
+    /** Carrega e converte para mapa o schema JSON da etapa. */
+    public static Map<String, Object> carregarSchema(ObjectMapper objectMapper, String schemaPath) throws JsonProcessingException {
+        try {
+            return objectMapper.readValue(new ClassPathResource(schemaPath).getInputStream(), Map.class);
+        } catch (IOException ex) {
+            throw new JsonProcessingException("Falha ao carregar schema: " + schemaPath) {
+            };
+        }
+    }
+
+    private static String resolverPlaceholders(String template, Map<String, Object> dadosPayload, ObjectMapper objectMapper) throws IOException {
+        String resolved = template;
+        Set<String> stack = new LinkedHashSet<>();
+        Deque<String> pending = new ArrayDeque<>();
+        pending.push(template);
+        while (!pending.isEmpty()) {
+            String current = pending.pop();
+            Matcher matcher = PLACEHOLDER_PATTERN.matcher(current);
+            StringBuffer buffer = new StringBuffer();
+            boolean found = false;
+            while (matcher.find()) {
+                found = true;
+                String tipo = matcher.group(1);
+                String nome = matcher.group(2);
+                String replacement;
+                if ("prompt".equals(tipo)) {
+                    String token = tipo + ":" + nome;
+                    if (!stack.add(token)) {
+                        throw new IllegalStateException("Referência circular de prompts detectada: " + token);
+                    }
+                    replacement = resolverPlaceholders(carregarPromptBase(nome + ".md"), dadosPayload, objectMapper);
+                    stack.remove(token);
+                } else {
+                    replacement = renderPlaceholderValue(dadosPayload.get(nome), objectMapper);
+                }
+                matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
+            }
+            matcher.appendTail(buffer);
+            resolved = resolverMustachePlaceholders(buffer.toString(), dadosPayload, objectMapper);
+            if (found) {
+                pending.push(resolved);
+            }
+        }
+        return resolved;
+    }
+
+    private static String resolverMustachePlaceholders(String template, Map<String, Object> dadosPayload, ObjectMapper objectMapper)
+            throws IOException {
+        Matcher matcher = MUSTACHE_PLACEHOLDER_PATTERN.matcher(template);
+        StringBuffer buffer = new StringBuffer();
+        while (matcher.find()) {
+            String nome = matcher.group(1);
+            String replacement = renderPlaceholderValue(dadosPayload.get(nome), objectMapper);
+            matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString();
+    }
+
+    private static String renderPlaceholderValue(Object dado, ObjectMapper objectMapper) throws JsonProcessingException {
+        if (dado == null) {
+            return "";
+        }
+        if (dado instanceof String valor) {
+            return valor;
+        }
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dado);
+    }
+
+    private static String carregarPromptBase(String fileName) throws IOException {
+        ClassPathResource resource = new ClassPathResource(GERALANDING_PROMPT_BASE_PATH + fileName);
+        if (!resource.exists()) {
+            throw new IllegalArgumentException("Prompt não encontrado em geralanding: " + fileName);
+        }
+        return new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
@@ -3,12 +3,11 @@ package com.marketinghub.worker.geralanding.copy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import com.marketinghub.worker.geralanding.MontaRequestSupport;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -21,41 +20,51 @@ public class MontaRequest {
     private static final String DEFAULT_SYSTEM_NAME = "gera-landing-pipeline";
     private static final String DEFAULT_SYSTEM_MESSAGE =
             "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
+    private static final String SCHEMA_RESOURCE_PATH = "prompts/geralanding/landing-page-copy-schema.json";
+    private static final String SCHEMA_NAME = "experiment_pipeline_landing_page_copy";
+    private static final String PROMPT_MARKDOWN_FILE = "landing-page-copy.md";
 
     private final ObjectMapper objectMapper;
-    private final Resource schemaResource;
 
-    public MontaRequest(ObjectMapper objectMapper,
-                        @Value("classpath:prompts/geralanding/landing-page-copy-schema.json") Resource schemaResource) {
+    public MontaRequest(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.schemaResource = schemaResource;
     }
 
-    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema e parâmetros padrão. */
+    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
     public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
-        format.put("name", "experiment_pipeline_landing_page_copy");
-        format.put("schema", carregarSchema());
+        format.put("name", SCHEMA_NAME);
+        format.put("schema", MontaRequestSupport.carregarSchema(objectMapper, SCHEMA_RESOURCE_PATH));
         format.put("strict", true);
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", experiment.resolveText(null, DEFAULT_MODEL));
         body.put("input", List.of(
                 Map.of("role", "system", "content", "[" + DEFAULT_SYSTEM_NAME + "] " + DEFAULT_SYSTEM_MESSAGE),
-                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", montarPrompt(experiment))))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);
     }
 
-    /** Carrega e converte para mapa o schema JSON da etapa. */
-    private Map<String, Object> carregarSchema() throws JsonProcessingException {
-        try {
-            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
-        } catch (IOException ex) {
-            throw new JsonProcessingException("Falha ao carregar schema da etapa copy") {
-            };
-        }
+    /** Retorna o nome do arquivo markdown da etapa. */
+    public String nomePromptMarkdown() {
+        return PROMPT_MARKDOWN_FILE;
+    }
+
+    /** Retorna o nome do arquivo schema json da etapa. */
+    public String nomeSchemaJson() {
+        return SCHEMA_RESOURCE_PATH.substring(SCHEMA_RESOURCE_PATH.lastIndexOf('/') + 1);
+    }
+
+    /** Carrega o markdown bruto da etapa usando o arquivo padrão declarado no montador. */
+    public String carregarPromptMarkdownCru() throws IOException {
+        return MontaRequestSupport.carregarPromptMarkdownCru(PROMPT_MARKDOWN_FILE);
+    }
+
+    /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
+    public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
+        return MontaRequestSupport.montarPrompt(nomePromptMarkdown().replace(".md", ""), PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
@@ -3,12 +3,11 @@ package com.marketinghub.worker.geralanding.deliverables;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import com.marketinghub.worker.geralanding.MontaRequestSupport;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -21,41 +20,51 @@ public class MontaRequest {
     private static final String DEFAULT_SYSTEM_NAME = "gera-landing-pipeline";
     private static final String DEFAULT_SYSTEM_MESSAGE =
             "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
+    private static final String SCHEMA_RESOURCE_PATH = "prompts/geralanding/landing-page-deliverables-schema.json";
+    private static final String SCHEMA_NAME = "experiment_pipeline_landing_page_deliverables";
+    private static final String PROMPT_MARKDOWN_FILE = "landing-page-deliverables.md";
 
     private final ObjectMapper objectMapper;
-    private final Resource schemaResource;
 
-    public MontaRequest(ObjectMapper objectMapper,
-                        @Value("classpath:prompts/geralanding/landing-page-deliverables-schema.json") Resource schemaResource) {
+    public MontaRequest(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.schemaResource = schemaResource;
     }
 
-    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema e parâmetros padrão. */
+    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
     public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
-        format.put("name", "experiment_pipeline_landing_page_deliverables");
-        format.put("schema", carregarSchema());
+        format.put("name", SCHEMA_NAME);
+        format.put("schema", MontaRequestSupport.carregarSchema(objectMapper, SCHEMA_RESOURCE_PATH));
         format.put("strict", true);
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", experiment.resolveText(null, DEFAULT_MODEL));
         body.put("input", List.of(
                 Map.of("role", "system", "content", "[" + DEFAULT_SYSTEM_NAME + "] " + DEFAULT_SYSTEM_MESSAGE),
-                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", montarPrompt(experiment))))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);
     }
 
-    /** Carrega e converte para mapa o schema JSON da etapa. */
-    private Map<String, Object> carregarSchema() throws JsonProcessingException {
-        try {
-            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
-        } catch (IOException ex) {
-            throw new JsonProcessingException("Falha ao carregar schema da etapa deliverables") {
-            };
-        }
+    /** Retorna o nome do arquivo markdown da etapa. */
+    public String nomePromptMarkdown() {
+        return PROMPT_MARKDOWN_FILE;
+    }
+
+    /** Retorna o nome do arquivo schema json da etapa. */
+    public String nomeSchemaJson() {
+        return SCHEMA_RESOURCE_PATH.substring(SCHEMA_RESOURCE_PATH.lastIndexOf('/') + 1);
+    }
+
+    /** Carrega o markdown bruto da etapa usando o arquivo padrão declarado no montador. */
+    public String carregarPromptMarkdownCru() throws IOException {
+        return MontaRequestSupport.carregarPromptMarkdownCru(PROMPT_MARKDOWN_FILE);
+    }
+
+    /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
+    public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
+        return MontaRequestSupport.montarPrompt(nomePromptMarkdown().replace(".md", ""), PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
@@ -3,12 +3,11 @@ package com.marketinghub.worker.geralanding.imageplanning;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import com.marketinghub.worker.geralanding.MontaRequestSupport;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -21,41 +20,51 @@ public class MontaRequest {
     private static final String DEFAULT_SYSTEM_NAME = "gera-landing-pipeline";
     private static final String DEFAULT_SYSTEM_MESSAGE =
             "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
+    private static final String SCHEMA_RESOURCE_PATH = "prompts/geralanding/landing-page-image-planning-schema.json";
+    private static final String SCHEMA_NAME = "experiment_pipeline_landing_page_image_planning";
+    private static final String PROMPT_MARKDOWN_FILE = "landing-page-image-planning.md";
 
     private final ObjectMapper objectMapper;
-    private final Resource schemaResource;
 
-    public MontaRequest(ObjectMapper objectMapper,
-                        @Value("classpath:prompts/geralanding/landing-page-image-planning-schema.json") Resource schemaResource) {
+    public MontaRequest(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.schemaResource = schemaResource;
     }
 
-    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema e parâmetros padrão. */
+    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
     public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
-        format.put("name", "experiment_pipeline_landing_page_image_planning");
-        format.put("schema", carregarSchema());
+        format.put("name", SCHEMA_NAME);
+        format.put("schema", MontaRequestSupport.carregarSchema(objectMapper, SCHEMA_RESOURCE_PATH));
         format.put("strict", true);
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", experiment.resolveText(null, DEFAULT_MODEL));
         body.put("input", List.of(
                 Map.of("role", "system", "content", "[" + DEFAULT_SYSTEM_NAME + "] " + DEFAULT_SYSTEM_MESSAGE),
-                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", montarPrompt(experiment))))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);
     }
 
-    /** Carrega e converte para mapa o schema JSON da etapa. */
-    private Map<String, Object> carregarSchema() throws JsonProcessingException {
-        try {
-            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
-        } catch (IOException ex) {
-            throw new JsonProcessingException("Falha ao carregar schema da etapa imageplanning") {
-            };
-        }
+    /** Retorna o nome do arquivo markdown da etapa. */
+    public String nomePromptMarkdown() {
+        return PROMPT_MARKDOWN_FILE;
+    }
+
+    /** Retorna o nome do arquivo schema json da etapa. */
+    public String nomeSchemaJson() {
+        return SCHEMA_RESOURCE_PATH.substring(SCHEMA_RESOURCE_PATH.lastIndexOf('/') + 1);
+    }
+
+    /** Carrega o markdown bruto da etapa usando o arquivo padrão declarado no montador. */
+    public String carregarPromptMarkdownCru() throws IOException {
+        return MontaRequestSupport.carregarPromptMarkdownCru(PROMPT_MARKDOWN_FILE);
+    }
+
+    /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
+    public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
+        return MontaRequestSupport.montarPrompt(nomePromptMarkdown().replace(".md", ""), PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
@@ -3,12 +3,11 @@ package com.marketinghub.worker.geralanding.presetdesign;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import com.marketinghub.worker.geralanding.MontaRequestSupport;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -21,41 +20,51 @@ public class MontaRequest {
     private static final String DEFAULT_SYSTEM_NAME = "gera-landing-pipeline";
     private static final String DEFAULT_SYSTEM_MESSAGE =
             "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
+    private static final String SCHEMA_RESOURCE_PATH = "prompts/geralanding/landing-page-design-preset-schema.json";
+    private static final String SCHEMA_NAME = "experiment_pipeline_landing_page_design_preset";
+    private static final String PROMPT_MARKDOWN_FILE = "landing-page-design-preset.md";
 
     private final ObjectMapper objectMapper;
-    private final Resource schemaResource;
 
-    public MontaRequest(ObjectMapper objectMapper,
-                        @Value("classpath:prompts/geralanding/landing-page-design-preset-schema.json") Resource schemaResource) {
+    public MontaRequest(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.schemaResource = schemaResource;
     }
 
-    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema e parâmetros padrão. */
+    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
     public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
-        format.put("name", "experiment_pipeline_landing_page_design_preset");
-        format.put("schema", carregarSchema());
+        format.put("name", SCHEMA_NAME);
+        format.put("schema", MontaRequestSupport.carregarSchema(objectMapper, SCHEMA_RESOURCE_PATH));
         format.put("strict", true);
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", experiment.resolveText(null, DEFAULT_MODEL));
         body.put("input", List.of(
                 Map.of("role", "system", "content", "[" + DEFAULT_SYSTEM_NAME + "] " + DEFAULT_SYSTEM_MESSAGE),
-                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", montarPrompt(experiment))))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);
     }
 
-    /** Carrega e converte para mapa o schema JSON da etapa. */
-    private Map<String, Object> carregarSchema() throws JsonProcessingException {
-        try {
-            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
-        } catch (IOException ex) {
-            throw new JsonProcessingException("Falha ao carregar schema da etapa presetdesign") {
-            };
-        }
+    /** Retorna o nome do arquivo markdown da etapa. */
+    public String nomePromptMarkdown() {
+        return PROMPT_MARKDOWN_FILE;
+    }
+
+    /** Retorna o nome do arquivo schema json da etapa. */
+    public String nomeSchemaJson() {
+        return SCHEMA_RESOURCE_PATH.substring(SCHEMA_RESOURCE_PATH.lastIndexOf('/') + 1);
+    }
+
+    /** Carrega o markdown bruto da etapa usando o arquivo padrão declarado no montador. */
+    public String carregarPromptMarkdownCru() throws IOException {
+        return MontaRequestSupport.carregarPromptMarkdownCru(PROMPT_MARKDOWN_FILE);
+    }
+
+    /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
+    public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
+        return MontaRequestSupport.montarPrompt(nomePromptMarkdown().replace(".md", ""), PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
@@ -3,12 +3,11 @@ package com.marketinghub.worker.geralanding.wireframe;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import com.marketinghub.worker.geralanding.MontaRequestSupport;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -21,41 +20,51 @@ public class MontaRequest {
     private static final String DEFAULT_SYSTEM_NAME = "gera-landing-pipeline";
     private static final String DEFAULT_SYSTEM_MESSAGE =
             "Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet.";
+    private static final String SCHEMA_RESOURCE_PATH = "prompts/geralanding/landing-page-wireframe-schema.json";
+    private static final String SCHEMA_NAME = "experiment_pipeline_landing_page_wireframe";
+    private static final String PROMPT_MARKDOWN_FILE = "landing-page-wireframe.md";
 
     private final ObjectMapper objectMapper;
-    private final Resource schemaResource;
 
-    public MontaRequest(ObjectMapper objectMapper,
-                        @Value("classpath:prompts/geralanding/landing-page-wireframe-schema.json") Resource schemaResource) {
+    public MontaRequest(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.schemaResource = schemaResource;
     }
 
-    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema e parâmetros padrão. */
+    /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
     public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
-        format.put("name", "experiment_pipeline_landing_page_wireframe");
-        format.put("schema", carregarSchema());
+        format.put("name", SCHEMA_NAME);
+        format.put("schema", MontaRequestSupport.carregarSchema(objectMapper, SCHEMA_RESOURCE_PATH));
         format.put("strict", true);
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", experiment.resolveText(null, DEFAULT_MODEL));
         body.put("input", List.of(
                 Map.of("role", "system", "content", "[" + DEFAULT_SYSTEM_NAME + "] " + DEFAULT_SYSTEM_MESSAGE),
-                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", experiment.prompt())))
+                Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", montarPrompt(experiment))))
         ));
         body.put("text", Map.of("format", format));
         return objectMapper.writeValueAsString(body);
     }
 
-    /** Carrega e converte para mapa o schema JSON da etapa. */
-    private Map<String, Object> carregarSchema() throws JsonProcessingException {
-        try {
-            return objectMapper.readValue(schemaResource.getInputStream(), Map.class);
-        } catch (IOException ex) {
-            throw new JsonProcessingException("Falha ao carregar schema da etapa wireframe") {
-            };
-        }
+    /** Retorna o nome do arquivo markdown da etapa. */
+    public String nomePromptMarkdown() {
+        return PROMPT_MARKDOWN_FILE;
+    }
+
+    /** Retorna o nome do arquivo schema json da etapa. */
+    public String nomeSchemaJson() {
+        return SCHEMA_RESOURCE_PATH.substring(SCHEMA_RESOURCE_PATH.lastIndexOf('/') + 1);
+    }
+
+    /** Carrega o markdown bruto da etapa usando o arquivo padrão declarado no montador. */
+    public String carregarPromptMarkdownCru() throws IOException {
+        return MontaRequestSupport.carregarPromptMarkdownCru(PROMPT_MARKDOWN_FILE);
+    }
+
+    /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
+    public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
+        return MontaRequestSupport.montarPrompt(nomePromptMarkdown().replace(".md", ""), PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1542,3 +1542,15 @@
   - simplificação de `GeraLandingExperimentRequest` para conter apenas dados do experimento (`experimentId`, `prompt`);
   - cada `MontaRequest` passou a carregar o schema da própria etapa via resource classpath e montar o payload completo internamente;
   - `GeraLandingExecutionService` agora apenas repassa o objeto de experimento para o montador da etapa.
+
+## 2026-05-25 20:05:00 UTC
+- ajuste solicitado nos `MontaRequest` do GeraLanding para centralizar definição de nomes de schema/prompt e a montagem completa do prompt por etapa.
+- causa-raiz: parte da montagem do prompt (carregamento de markdown + ingestão de placeholders `dados-*` e `prompt-*`) permanecia fora dos montadores, no `GeraLandingService`/`GeraLandingExecutionService`.
+- correção aplicada:
+  - criação de `MontaRequestSupport` com utilitários de resolução de placeholders de prompt (`{prompt-*}`, `{dados-*}` e `{{mustache}}`) e carregamento de schema;
+  - `MontaRequest` de `wireframe`, `copy`, `imageplanning`, `presetdesign` e `deliverables` passaram a declarar internamente:
+    - nome do schema JSON da etapa;
+    - nome do markdown de prompt da etapa;
+    - montagem do prompt final e payload OpenAI;
+  - `GeraLandingExecutionService` foi ajustado para delegar a montagem do prompt e do markdown bruto diretamente aos `MontaRequest` por etapa.
+- impacto funcional: mantém o contrato final de request OpenAI, reduz acoplamento e centraliza a lógica de montagem por etapa.


### PR DESCRIPTION
### Motivation
- Remover o acoplamento da montagem de prompt fora dos montadores de etapa e fazer com que cada etapa declare seu próprio `schema.json` e arquivo markdown de prompt. 
- Centralizar a resolução de placeholders (`{prompt-*}`, `{dados-*}` e `{{mustache}}`) e o carregamento de schema para evitar duplicação e inconsistências entre etapas.

### Description
- Adiciona `MontaRequestSupport` com utilitários públicos `carregarSchema`, `carregarPromptMarkdownCru` e `montarPrompt` para resolver placeholders e formatar o prompt final. 
- Refatora as classes de montador por etapa (`wireframe`, `copy`, `imageplanning`, `presetdesign`, `deliverables`) para declarar `SCHEMA_RESOURCE_PATH`, `SCHEMA_NAME` e `PROMPT_MARKDOWN_FILE`, usar `MontaRequestSupport` e expor `montarPrompt` / `carregarPromptMarkdownCru` / `nomeSchemaJson` / `nomePromptMarkdown`. 
- Altera `GeraLandingExperimentRequest` para transportar `Map<String,Object> dados` (dados do experimento) em vez de uma `String prompt` para que os montadores montem localmente o prompt. 
- Ajusta `GeraLandingExecutionService` para carregar `dadosPrompt`, construir um `GeraLandingExperimentRequest`, delegar a montagem do prompt via `montarPromptPorEtapa(...)` e o carregamento do markdown com `carregarPromptMarkdownPorEtapa(...)`, e continuar delegando a montagem do payload OpenAI a `montarRequestPorEtapa(...)`.

### Testing
- Executado `mvn -Dtest=GeraLandingServiceTest test` no módulo `ai-worker`, que falhou devido à falha em resolver a dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` retornando `401 Unauthorized` do repositório GitHub Packages. 
- Tentativa de usar Gradle não foi aplicável porque o repositório não contém `./gradlew` no ambiente; portanto os testes unitários não foram concluídos localmente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149f11ed548321874965e295206125)