### PR TITLE
Add startup and runId logs to OPRM scheduler and update scheduled cron to 16:45

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -156,3 +156,9 @@
 
 - 2026-05-23 05:20:00 (UTC): ajuste solicitado para o próximo agendamento da ingestão OPRM CNPJ/CNAE para **14:06 de 24/05/2026** (America/Sao_Paulo), com atualização do cron hardcoded de `runScheduledImport` para `0 6 14 24 5 *`, sincronização do cron padrão em `application.yml` e ajuste da mensagem de log para refletir 14:06.
 - 2026-05-23 00:00:00 (UTC): validação solicitada do módulo de logs no MCP confirmando nomenclatura operacional `module=oprm-coletor-receita` para consultar o serviço `oprm-coletor-mei`; em seguida, reagendado o coletor OPRM CNPJ/CNAE para **18:20 de hoje (23/05/2026)** no fuso `America/Sao_Paulo`, com atualização do cron hardcoded de `runScheduledImport` para `0 20 18 23 5 *`, sincronização do cron padrão em `application.yml` e ajuste do `snapshot-date` padrão para `2026-05-23`.
+
+- 2026-05-25 00:00:00 (UTC): ajuste solicitado para adicionar log imediatamente após criação da run no `runScheduledImport`, registrando `runId`, `snapshotDate`, `sourceUrl` e `filesTotal`; e alteração do agendamento hardcoded da ingestão OPRM CNPJ/CNAE para **16:45** (America/Sao_Paulo) com cron `0 45 16 * * *`, incluindo atualização da mensagem final de sucesso para refletir 16:45.
+
+- 2026-05-25 00:00:00 (UTC): ajuste complementar solicitado por revisão: adicionado log textual explícito com `runId` logo após a criação da run no `runScheduledImport` para facilitar buscas operacionais por `contains=runId=` nos logs do MCP.
+
+- 2026-05-25 00:00:00 (UTC): ajuste solicitado em revisão para inserir log no início do método `runScheduledImport` (primeira instrução), registrando disparo da rotina antes de qualquer validação de `enabled`.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
@@ -58,8 +58,9 @@ public class OprmMarketImportScheduler {
     }
 
     /** Executa a ingestão completa de arquivos CNPJ/CNAE no horário agendado para a execução operacional. */
-    @Scheduled(cron = "0 20 18 23 5 *", zone = "America/Sao_Paulo")
+    @Scheduled(cron = "0 45 16 * * *", zone = "America/Sao_Paulo")
     public void runScheduledImport() {
+        log.info("Iniciando runScheduledImport do OPRM CNPJ/CNAE.");
         if (!scheduleProperties.enabled()) {
             log.info("Scheduler OPRM market import desabilitado.");
             return;
@@ -102,6 +103,16 @@ public class OprmMarketImportScheduler {
         if (runResponse == null || runResponse.runId() == null || runResponse.fileIds() == null || runResponse.fileIds().size() != files.size()) {
             throw new IllegalStateException("Resposta inválida ao criar import run OPRM.");
         }
+        log.info("[run={}] Run OPRM criada e pronta para processamento de arquivos. snapshotDate={} sourceUrl={} filesTotal={}",
+                runResponse.runId(),
+                snapshotDate,
+                sourceUrl,
+                files.size());
+        log.info("runScheduledImport criado com sucesso: runId={} snapshotDate={} sourceUrl={} filesTotal={}",
+                runResponse.runId(),
+                snapshotDate,
+                sourceUrl,
+                files.size());
 
         Path runTempDir = Paths.get(collectorProperties.tempDir(), "run-" + runResponse.runId());
         long totalRowsRead = 0L;
@@ -203,7 +214,7 @@ public class OprmMarketImportScheduler {
             }
         }
 
-        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 14:06 ({}) com {} arquivos.",
+        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 16:45 ({}) com {} arquivos.",
                 snapshotDate,
                 scheduleProperties.timezone(),
                 files.size());


### PR DESCRIPTION
### Motivation

- Improve operational observability of the OPRM CNPJ/CNAE ingest run by surfacing early invocation and stable identifiers for searching and debugging. 
- Align the hardcoded scheduler execution time with recent operational requests and keep documentation in sync.

### Description

- Inserted an initial log at the start of `runScheduledImport` with the message `Iniciando runScheduledImport do OPRM CNPJ/CNAE.` to record routine triggers before validations. 
- Added detailed post-creation logs that include `runId`, `snapshotDate`, `sourceUrl` and `filesTotal` and a second explicit textual log containing `runId` to make `contains=runId=` searches reliable. 
- Updated the `@Scheduled` cron on `runScheduledImport` from `0 20 18 23 5 *` to `0 45 16 * * *` (zone `America/Sao_Paulo`) and adjusted the final success log to reflect execution at `16:45`. 
- Updated documentation entry `docs/registros/oprm1.md` to record the added logs and cron changes made to the scheduler.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1489d92c3c8321bd832489b2517528)