### PR TITLE
Incluir path completo do prompt markdown nos MontaRequest do GeraLanding

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
@@ -65,6 +65,6 @@ public class MontaRequest {
 
     /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
     public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
-        return MontaRequestSupport.montarPrompt(nomePromptMarkdown().replace(".md", ""), PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
+        return MontaRequestSupport.montarPrompt("prompts/geralanding/" + PROMPT_MARKDOWN_FILE, PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
@@ -65,6 +65,6 @@ public class MontaRequest {
 
     /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
     public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
-        return MontaRequestSupport.montarPrompt(nomePromptMarkdown().replace(".md", ""), PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
+        return MontaRequestSupport.montarPrompt("prompts/geralanding/" + PROMPT_MARKDOWN_FILE, PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
@@ -65,6 +65,6 @@ public class MontaRequest {
 
     /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
     public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
-        return MontaRequestSupport.montarPrompt(nomePromptMarkdown().replace(".md", ""), PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
+        return MontaRequestSupport.montarPrompt("prompts/geralanding/" + PROMPT_MARKDOWN_FILE, PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
@@ -65,6 +65,6 @@ public class MontaRequest {
 
     /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
     public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
-        return MontaRequestSupport.montarPrompt(nomePromptMarkdown().replace(".md", ""), PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
+        return MontaRequestSupport.montarPrompt("prompts/geralanding/" + PROMPT_MARKDOWN_FILE, PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
@@ -65,6 +65,6 @@ public class MontaRequest {
 
     /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
     public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
-        return MontaRequestSupport.montarPrompt(nomePromptMarkdown().replace(".md", ""), PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
+        return MontaRequestSupport.montarPrompt("prompts/geralanding/" + PROMPT_MARKDOWN_FILE, PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }


### PR DESCRIPTION
### Motivation
- Garantir que o identificador/etapa embutido no prompt final contenha o caminho completo do arquivo markdown, evitando ambiguidade ao resolver prompts auxiliares.

### Description
- Alterado o comportamento de montagem do prompt em cinco montadores `MontaRequest` do GeraLanding (`wireframe`, `copy`, `imageplanning`, `presetdesign`, `deliverables`) para passar o path completo do markdown como primeiro argumento para `MontaRequestSupport.montarPrompt` (`"prompts/geralanding/<arquivo>.md"`).
- Arquivos modificados: `ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java`, `.../copy/MontaRequest.java`, `.../imageplanning/MontaRequest.java`, `.../presetdesign/MontaRequest.java`, `.../deliverables/MontaRequest.java`.
- Commit message: `Include full markdown prompt path in GeraLanding MontaRequest`.

### Testing
- Executed `mvn -f ai-worker/pom.xml -DskipTests compile` to validate compilation; the build failed due to inability to download private dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT` from GitHub Packages (HTTP 401), so a full compile/test run could not complete.
- No unit tests were executed in this environment because of the dependency resolution failure. Please run CI or a local build with access to the private Maven package registry to fully validate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a28aec948321b996b7c6f169191a)