### PR TITLE
Adicionar regras ArchUnit para isolar módulos geralanding no ai-worker

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
@@ -27,4 +27,103 @@ class GeraLandingArchitectureTest {
             .should()
             .notDependOnEachOther()
             .allowEmptyShould(true);
+
+    /** Garante que o módulo copy só acesse o próprio pacote e geralanding.comum dentro do domínio geralanding. */
+    @ArchTest
+    static final ArchRule geralanding_copy_must_not_depend_on_other_modules = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.copy..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "..geralanding.presetdesign..",
+                    "..geralanding.stage..",
+                    "..geralanding.wireframe..",
+                    "..geralanding.deliverables..",
+                    "..geralanding.imageplanning..");
+
+    /** Garante que o módulo presetdesign só acesse o próprio pacote e geralanding.comum dentro do domínio geralanding. */
+    @ArchTest
+    static final ArchRule geralanding_presetdesign_must_not_depend_on_other_modules = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.presetdesign..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "..geralanding.copy..",
+                    "..geralanding.stage..",
+                    "..geralanding.wireframe..",
+                    "..geralanding.deliverables..",
+                    "..geralanding.imageplanning..");
+
+    /** Garante que o módulo stage só acesse o próprio pacote e geralanding.comum dentro do domínio geralanding. */
+    @ArchTest
+    static final ArchRule geralanding_stage_must_not_depend_on_other_modules = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.stage..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "..geralanding.copy..",
+                    "..geralanding.presetdesign..",
+                    "..geralanding.wireframe..",
+                    "..geralanding.deliverables..",
+                    "..geralanding.imageplanning..");
+
+    /** Garante que o módulo wireframe só acesse o próprio pacote e geralanding.comum dentro do domínio geralanding. */
+    @ArchTest
+    static final ArchRule geralanding_wireframe_must_not_depend_on_other_modules = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.wireframe..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "..geralanding.copy..",
+                    "..geralanding.presetdesign..",
+                    "..geralanding.stage..",
+                    "..geralanding.deliverables..",
+                    "..geralanding.imageplanning..");
+
+    /** Garante que o módulo deliverables só acesse o próprio pacote e geralanding.comum dentro do domínio geralanding. */
+    @ArchTest
+    static final ArchRule geralanding_deliverables_must_not_depend_on_other_modules = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.deliverables..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "..geralanding.copy..",
+                    "..geralanding.presetdesign..",
+                    "..geralanding.stage..",
+                    "..geralanding.wireframe..",
+                    "..geralanding.imageplanning..");
+
+    /** Garante que o módulo imageplanning só acesse o próprio pacote e geralanding.comum dentro do domínio geralanding. */
+    @ArchTest
+    static final ArchRule geralanding_imageplanning_must_not_depend_on_other_modules = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.imageplanning..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "..geralanding.copy..",
+                    "..geralanding.presetdesign..",
+                    "..geralanding.stage..",
+                    "..geralanding.wireframe..",
+                    "..geralanding.deliverables..");
+
+    /** Garante que geralanding.comum só acesse classes do próprio pacote dentro do domínio geralanding. */
+    @ArchTest
+    static final ArchRule geralanding_comum_must_not_depend_on_other_modules = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.comum..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                    "..geralanding.copy..",
+                    "..geralanding.presetdesign..",
+                    "..geralanding.stage..",
+                    "..geralanding.wireframe..",
+                    "..geralanding.deliverables..",
+                    "..geralanding.imageplanning..");
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1561,3 +1561,11 @@
   - `MontaRequestSupport` movido para `com.marketinghub.worker.geralanding.comum`;
   - atualização dos imports nas classes `MontaRequest` das etapas (`wireframe`, `copy`, `imageplanning`, `presetdesign`, `deliverables`).
 - impacto funcional: sem alteração de comportamento, apenas organização de pacote para melhor separação de responsabilidades.
+
+## 2026-05-25 20:30:00 UTC
+- ajuste solicitado: criação de regras de arquitetura com ArchUnit para isolamento dos módulos `geralanding.*` no AI Worker.
+- causa-raiz: ausência de validação automatizada explícita para impedir acoplamento entre módulos irmãos e para restringir dependências do pacote `geralanding.comum`.
+- correção aplicada:
+  - inclusão de regras ArchUnit para bloquear dependências cruzadas entre módulos `copy`, `presetdesign`, `stage`, `wireframe`, `deliverables` e `imageplanning`;
+  - inclusão de regra ArchUnit para garantir que `geralanding.comum` não acesse módulos funcionais `geralanding.*`.
+- impacto funcional: reforço de fronteiras arquiteturais do domínio GeraLanding com validação automatizada em testes.


### PR DESCRIPTION
### Motivation
- Reforçar fronteiras arquiteturais do domínio GeraLanding para evitar acoplamento entre módulos irmãos e proteger utilitários compartilhados.
- Garantir que cada módulo `geralanding.*` só acesse seu próprio pacote ou o pacote compartilhado `geralanding.comum`, conforme a orientação de arquitetura do projeto.

### Description
- Adicionadas regras ArchUnit em `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java` que bloqueiam dependências cruzadas entre os módulos `copy`, `presetdesign`, `stage`, `wireframe`, `deliverables` e `imageplanning`.
- Incluída regra que impede `geralanding.comum` de depender de quaisquer módulos funcionais `geralanding.*` e preservadas as regras existentes (não depender de `experimentpipeline` e verificação de slices).
- Documentado o trabalho em `docs/registros/experimentos.md` com descrição da mudança e causa-raiz conforme política de registros do projeto.

### Testing
- Executado o comando de validação `mvn -f ai-worker/pom.xml -Dtest=GeraLandingArchitectureTest test` para rodar o teste de arquitetura; a execução falhou devido a resolução de dependência privada (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`) apontada para GitHub Packages retornando `401 Unauthorized` no ambiente de CI local.
- Observação: as regras ArchUnit foram adicionadas como testes automatizados no módulo de testes; a falha apresentada é de resolução de dependência externa e não de compilação/semântica das regras em si.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a671b9388321825fa85102c1a2d0)