### PR TITLE
fix(ai-worker): declare IOException in GeraLandingExecutionService

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -237,7 +237,7 @@ public class GeraLandingExecutionService {
      * Direciona a montagem do request da OpenAI para o montador específico de cada etapa.
      */
     private String montarRequestPorEtapa(GeraLandingStageDefinition stage,
-                                         GeraLandingExperimentRequest experiment) throws JsonProcessingException {
+                                         GeraLandingExperimentRequest experiment) throws IOException {
         return switch (stage) {
             case WIREFRAME -> wireframeMontaRequest.montar(experiment);
             case COPY -> copyMontaRequest.montar(experiment);

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1569,3 +1569,10 @@
   - inclusão de regras ArchUnit para bloquear dependências cruzadas entre módulos `copy`, `presetdesign`, `stage`, `wireframe`, `deliverables` e `imageplanning`;
   - inclusão de regra ArchUnit para garantir que `geralanding.comum` não acesse módulos funcionais `geralanding.*`.
 - impacto funcional: reforço de fronteiras arquiteturais do domínio GeraLanding com validação automatizada em testes.
+
+## 2026-05-25 21:05:00 UTC
+- correção de compilação no `GeraLandingExecutionService` para alinhamento de assinatura com exceções reais dos montadores por etapa.
+- causa-raiz: o método `montarRequestPorEtapa` declarava apenas `JsonProcessingException`, mas os montadores (`montar`) podem propagar `IOException`.
+- correção aplicada:
+  - atualização da assinatura de `montarRequestPorEtapa` para `throws IOException`, eliminando erro de compilação de exceção checada não declarada.
+- impacto funcional: sem mudança de comportamento de negócio; apenas correção de contrato de exceções para compilar com segurança.


### PR DESCRIPTION
### Motivation
- Corrigir erro de compilação causado por exceção checada não declarada quando os montadores de etapa (`montar(...)`) propagam `IOException`.
- Alinhar a assinatura do `GeraLandingExecutionService` com o comportamento real dos `MontaRequest` para restaurar compilação do módulo `ai-worker`.

### Description
- Atualiza a assinatura de `montarRequestPorEtapa(...)` em `ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java` para `throws IOException` (antes declarava apenas `JsonProcessingException`).
- Registra a atividade e a justificativa em `docs/registros/experimentos.md` com a descrição da causa-raiz e da correção aplicada.

### Testing
- Executado `mvn -f ai-worker/pom.xml -DskipTests compile` para validar a compilação do módulo; o build falhou por resolução de dependência externa (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`) com erro 401 no Maven GitHub Packages, problema externo à mudança.
- Não foram executados testes unitários devido ao bloqueio de resolução de dependências durante a tentativa de compilação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a877a74083218a5f1e0c2e13a882)