### PR TITLE
Enforce geralanding package isolation with ArchUnit and update experiment logs

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
@@ -27,4 +27,81 @@ class GeraLandingArchitectureTest {
             .should()
             .notDependOnEachOther()
             .allowEmptyShould(true);
+
+    /** Garante que copy só acesse classes do próprio pacote ou geralanding.comum dentro da aplicação. */
+    @ArchTest
+    static final ArchRule geralanding_copy_must_only_access_own_or_comum = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.copy..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("com.marketinghub..")
+            .andShould()
+            .resideOutsideOfPackages("..geralanding.copy..", "..geralanding.comum..");
+
+    /** Garante que presetdesign só acesse classes do próprio pacote ou geralanding.comum dentro da aplicação. */
+    @ArchTest
+    static final ArchRule geralanding_presetdesign_must_only_access_own_or_comum = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.presetdesign..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("com.marketinghub..")
+            .andShould()
+            .resideOutsideOfPackages("..geralanding.presetdesign..", "..geralanding.comum..");
+
+    /** Garante que stage só acesse classes do próprio pacote ou geralanding.comum dentro da aplicação. */
+    @ArchTest
+    static final ArchRule geralanding_stage_must_only_access_own_or_comum = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.stage..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("com.marketinghub..")
+            .andShould()
+            .resideOutsideOfPackages("..geralanding.stage..", "..geralanding.comum..");
+
+    /** Garante que wireframe só acesse classes do próprio pacote ou geralanding.comum dentro da aplicação. */
+    @ArchTest
+    static final ArchRule geralanding_wireframe_must_only_access_own_or_comum = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.wireframe..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("com.marketinghub..")
+            .andShould()
+            .resideOutsideOfPackages("..geralanding.wireframe..", "..geralanding.comum..");
+
+    /** Garante que deliverables só acesse classes do próprio pacote ou geralanding.comum dentro da aplicação. */
+    @ArchTest
+    static final ArchRule geralanding_deliverables_must_only_access_own_or_comum = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.deliverables..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("com.marketinghub..")
+            .andShould()
+            .resideOutsideOfPackages("..geralanding.deliverables..", "..geralanding.comum..");
+
+    /** Garante que imageplanning só acesse classes do próprio pacote ou geralanding.comum dentro da aplicação. */
+    @ArchTest
+    static final ArchRule geralanding_imageplanning_must_only_access_own_or_comum = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.imageplanning..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("com.marketinghub..")
+            .andShould()
+            .resideOutsideOfPackages("..geralanding.imageplanning..", "..geralanding.comum..");
+
+    /** Garante que geralanding.comum só acesse classes do próprio pacote dentro da aplicação. */
+    @ArchTest
+    static final ArchRule geralanding_comum_must_only_access_its_own_package = noClasses()
+            .that()
+            .resideInAPackage("..geralanding.comum..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("com.marketinghub..")
+            .andShould()
+            .resideOutsideOfPackages("..geralanding.comum..");
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1561,3 +1561,27 @@
   - `MontaRequestSupport` movido para `com.marketinghub.worker.geralanding.comum`;
   - atualização dos imports nas classes `MontaRequest` das etapas (`wireframe`, `copy`, `imageplanning`, `presetdesign`, `deliverables`).
 - impacto funcional: sem alteração de comportamento, apenas organização de pacote para melhor separação de responsabilidades.
+
+## 2026-05-25 20:30:00 UTC
+- ajuste solicitado: criação de regras de arquitetura com ArchUnit para isolamento dos módulos `geralanding.*` no AI Worker.
+- causa-raiz: ausência de validação automatizada explícita para impedir acoplamento entre módulos irmãos e para restringir dependências do pacote `geralanding.comum`.
+- correção aplicada:
+  - inclusão de regras ArchUnit para bloquear dependências cruzadas entre módulos `copy`, `presetdesign`, `stage`, `wireframe`, `deliverables` e `imageplanning`;
+  - inclusão de regra ArchUnit para garantir que `geralanding.comum` não acesse módulos funcionais `geralanding.*`.
+- impacto funcional: reforço de fronteiras arquiteturais do domínio GeraLanding com validação automatizada em testes.
+
+## 2026-05-25 20:50:00 UTC
+- ajuste de refinamento: endurecimento das regras ArchUnit do GeraLanding para restringir dependências também contra outros pacotes da aplicação (`com.marketinghub.worker..`).
+- causa-raiz: versão anterior bloqueava módulos irmãos, mas ainda permitia dependências para outros pacotes da aplicação fora de `geralanding`.
+- correção aplicada:
+  - regras por módulo alteradas para proibir dependências em `com.marketinghub.worker..` fora do próprio pacote e de `geralanding.comum`;
+  - regra de `geralanding.comum` ajustada para permitir apenas dependências no próprio pacote dentro da aplicação.
+- impacto funcional: validação arquitetural agora confirma que `geralanding.*` só acessa próprio pacote/comum e nenhum outro ponto da aplicação.
+
+## 2026-05-25 21:10:00 UTC
+- ajuste solicitado em revisão: ampliar o escopo das restrições ArchUnit de `com.marketinghub.worker..` para `com.marketinghub..`.
+- causa-raiz: regra anterior cobria apenas dependências internas do worker e não todo o namespace da aplicação.
+- correção aplicada:
+  - atualização das regras por módulo para filtrar dependências em `com.marketinghub..`;
+  - manutenção das mesmas exceções permitidas (próprio pacote e `geralanding.comum`).
+- impacto funcional: o isolamento de `geralanding.*` passa a considerar todo o domínio `com.marketinghub`.


### PR DESCRIPTION
### Motivation
- Prevent accidental coupling between `geralanding` feature modules and the legacy experiment pipeline by adding automated architecture checks.
- Ensure each `geralanding.*` subpackage only depends on itself or on the shared `geralanding.comum` utilities to keep boundaries clear.

### Description
- Added multiple ArchUnit rules in `GeraLandingArchitectureTest` to forbid cross-dependencies between `geralanding.copy`, `presetdesign`, `stage`, `wireframe`, `deliverables` and `imageplanning` and to restrict their dependencies to their own package or `geralanding.comum` within `com.marketinghub..`.
- Introduced a rule that ensures `geralanding.comum` only depends on its own package to avoid it becoming a backdoor to other application areas.
- Updated `docs/registros/experimentos.md` with entries describing the addition and subsequent refinements of these ArchUnit rules and the rationale for tightening the scope from `com.marketinghub.worker..` to `com.marketinghub..`.

### Testing
- Executed the project's unit test suite including the ArchUnit tests, and `GeraLandingArchitectureTest` passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a671b9388321825fa85102c1a2d0)