### PR TITLE
fix(ai-worker): alinhar IOException nos montadores do GeraLanding

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.geralanding.copy;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import com.marketinghub.worker.geralanding.comum.MontaRequestSupport;
@@ -31,7 +30,7 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
-    public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
+    public String montar(GeraLandingExperimentRequest experiment) throws IOException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.geralanding.deliverables;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import com.marketinghub.worker.geralanding.comum.MontaRequestSupport;
@@ -31,7 +30,7 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
-    public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
+    public String montar(GeraLandingExperimentRequest experiment) throws IOException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.geralanding.imageplanning;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import com.marketinghub.worker.geralanding.comum.MontaRequestSupport;
@@ -31,7 +30,7 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
-    public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
+    public String montar(GeraLandingExperimentRequest experiment) throws IOException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.geralanding.presetdesign;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import com.marketinghub.worker.geralanding.comum.MontaRequestSupport;
@@ -31,7 +30,7 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
-    public String montar(GeraLandingExperimentRequest experiment) throws JsonProcessingException {
+    public String montar(GeraLandingExperimentRequest experiment) throws IOException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1591,3 +1591,19 @@
 - correção aplicada:
   - atualização da assinatura de `montarRequestPorEtapa` para `throws IOException`, eliminando erro de compilação de exceção checada não declarada.
 - impacto funcional: sem mudança de comportamento de negócio; apenas correção de contrato de exceções para compilar com segurança.
+
+## 2026-05-25 21:20:00 UTC
+- correção de compilação na etapa de copy do GeraLanding.
+- causa-raiz: a classe `copy/MontaRequest` chamava `montarPrompt(...)` (que lança `IOException`) dentro de `montar(...)`, mas a assinatura de `montar` declarava apenas `JsonProcessingException`.
+- correção aplicada:
+  - remoção do import não utilizado `JsonProcessingException`;
+  - atualização da assinatura de `montar(...)` para `throws IOException`, alinhando com as exceções reais propagadas pelo fluxo.
+- impacto funcional: sem alteração de regra de negócio; apenas correção de contrato de exceção para eliminar o erro de compilação no CI.
+
+## 2026-05-25 21:24:00 UTC
+- correção complementar de compilação nos montadores de etapas adicionais do GeraLanding.
+- causa-raiz: o mesmo desalinhamento de exceção checada (`IOException`) também existia em `imageplanning`, `presetdesign` e `deliverables`.
+- correção aplicada:
+  - atualização das assinaturas `montar(...)` para `throws IOException` nesses três montadores;
+  - remoção dos imports `JsonProcessingException` não utilizados após o ajuste.
+- impacto funcional: correção de build sem alteração de comportamento funcional das etapas.


### PR DESCRIPTION
### Motivation
- Corrigir erro de compilação causado por exceção checada não declarada quando `montar(...)` chama `montarPrompt(...)`, que lança `IOException`.
- Restaurar a compilação do módulo `ai-worker` sem alterar comportamento de negócio das etapas do `GeraLanding`.

### Description
- Atualizada a assinatura de `montar(...)` para `throws IOException` em `copy/MontaRequest`, `imageplanning/MontaRequest`, `presetdesign/MontaRequest` e `deliverables/MontaRequest` para refletir as exceções reais do fluxo. 
- Removidos os imports não utilizados de `JsonProcessingException` nessas classes após o ajuste de assinatura. 
- Atualizado o registro de atividade em `docs/registros/experimentos.md` documentando a correção e sua causa-raiz. 
- Commit realizado com a mensagem `fix(ai-worker): alinhar IOException nos montadores do GeraLanding`.

### Testing
- Executado `mvn -f backend/ads-service/pom.xml -DskipTests install` para instalar a dependência local `ads-service` (sucesso). 
- Executado `mvn -f ai-worker/pom.xml -DskipTests compile` para compilar o módulo `ai-worker` após as correções (sucesso, build concluído com `BUILD SUCCESS`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14ac9786388321baa71993097d8da9)