### PR TITLE
Update GeraLandingExecutionServiceTest to mock and inject MontaRequest dependencies

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
+import com.marketinghub.worker.geralanding.wireframe.MontaRequest;
 import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,15 @@ class GeraLandingExecutionServiceTest {
         GeraLandingOpenAiFlexClient openAiClient = Mockito.mock(GeraLandingOpenAiFlexClient.class);
         ObjectMapper objectMapper = new ObjectMapper();
         GeraLandingStageSchemaResolver stageSchemaResolver = Mockito.mock(GeraLandingStageSchemaResolver.class);
+        MontaRequest wireframeMontaRequest = Mockito.mock(MontaRequest.class);
+        com.marketinghub.worker.geralanding.copy.MontaRequest copyMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.MontaRequest.class);
+        com.marketinghub.worker.geralanding.imageplanning.MontaRequest imagePlanningMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.MontaRequest.class);
+        com.marketinghub.worker.geralanding.presetdesign.MontaRequest presetDesignMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
+        com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
 
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
@@ -37,6 +47,11 @@ class GeraLandingExecutionServiceTest {
                         openAiClient,
                         objectMapper,
                         stageSchemaResolver,
+                        wireframeMontaRequest,
+                        copyMontaRequest,
+                        imagePlanningMontaRequest,
+                        presetDesignMontaRequest,
+                        deliverablesMontaRequest,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
@@ -59,6 +74,15 @@ class GeraLandingExecutionServiceTest {
         GeraLandingOpenAiFlexClient openAiClient = Mockito.mock(GeraLandingOpenAiFlexClient.class);
         ObjectMapper objectMapper = new ObjectMapper();
         GeraLandingStageSchemaResolver stageSchemaResolver = Mockito.mock(GeraLandingStageSchemaResolver.class);
+        MontaRequest wireframeMontaRequest = Mockito.mock(MontaRequest.class);
+        com.marketinghub.worker.geralanding.copy.MontaRequest copyMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.MontaRequest.class);
+        com.marketinghub.worker.geralanding.imageplanning.MontaRequest imagePlanningMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.MontaRequest.class);
+        com.marketinghub.worker.geralanding.presetdesign.MontaRequest presetDesignMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
+        com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
 
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
@@ -73,6 +97,11 @@ class GeraLandingExecutionServiceTest {
                         openAiClient,
                         objectMapper,
                         stageSchemaResolver,
+                        wireframeMontaRequest,
+                        copyMontaRequest,
+                        imagePlanningMontaRequest,
+                        presetDesignMontaRequest,
+                        deliverablesMontaRequest,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),


### PR DESCRIPTION
### Motivation
- The service constructor was extended to require MontaRequest dependencies for multiple stages, so tests needed updating to satisfy the new constructor signature.

### Description
- Added an import for the wireframe `MontaRequest` and created mocks for the wireframe, copy, image-planning, preset-design, and deliverables `MontaRequest` types in the test.
- Injected the mocked `MontaRequest` instances into `GeraLandingExecutionService` construction in both tests and adjusted the test setup accordingly.
- Kept existing verifications for OpenAI invocation, backend result/dispatch/failure handling unchanged.

### Testing
- Ran the unit tests in `GeraLandingExecutionServiceTest` via `mvn -Dtest=GeraLandingExecutionServiceTest test` and the updated tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14af489f648321938baa31fdc29bfe)