### PR TITLE
Adjust OPRM ingest schedule to 17:45, enforce canonical fixed snapshot, and update docs/logs

### DIFF
--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -47,6 +47,17 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - As diretrizes gerais do sistema permanecem em `docs/canonical/system-governance-canon.v2.md`.
 
 
+
+## Regra obrigatória — snapshot canônico fixo para operação
+- Para operação atual da ingestão OPRM CNPJ/CNAE, o `snapshotDate` canônico deve permanecer **fixo em `2026-05-10`**.
+- É proibido alterar automaticamente a data do snapshot para diretórios mais novos durante execução agendada ou manual sem decisão explícita do usuário.
+- Qualquer tentativa de execução com `snapshotDate` diferente de `2026-05-10` deve ser tratada como não conformidade operacional e registrada em log com causa-raiz.
+
+## Critério de efetividade — snapshot fixo
+- Logs de criação de run devem mostrar explicitamente `snapshotDate=2026-05-10`.
+- A base de download deve ser explicitamente `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-05-10/` enquanto essa regra estiver vigente.
+- Antes de iniciar a execução agendada/manual, deve haver validação de acesso HTTP (ex.: `HEAD`) para os arquivos de referência do snapshot (mínimo: `Cnaes.zip`, `Empresas1.zip`, `Estabelecimentos1.zip`) com retorno `200`.
+
 ## Regra obrigatória — ranking de CNAEs por quantidade com paginação
 - A listagem de ranking de CNAEs por volume (`/oprm/cnaes-volume`) deve ser sempre ordenada por **Quantidade** em ordem decrescente (maior para menor).
 - O endpoint de leitura do ranking deve suportar paginação explícita (parâmetros de página e tamanho), evitando retorno massivo em uma única resposta.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -168,3 +168,5 @@
 - 2026-05-25 17:25:00 (UTC-3): ajuste solicitado no cânone OPRM para explicitar a URL completa de download do snapshot fixo (`https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-05-10/`) e tornar obrigatória a validação prévia de acesso HTTP 200 (HEAD) dos arquivos de referência (`Cnaes.zip`, `Empresas1.zip`, `Estabelecimentos1.zip`) antes da execução.
 
 - 2026-05-25 17:35:00 (UTC-3): ajuste solicitado no `oprm-coletor-mei` para reagendar a execução da ingestão OPRM CNPJ/CNAE para **17:45** no fuso `America/Sao_Paulo`, com atualização do cron hardcoded de `runScheduledImport` para `0 45 17 * * *`, sincronização do cron padrão em `application.yml` e ajuste da mensagem de log final para refletir 17:45.
+
+- 2026-05-25 17:45:00 (UTC-3): correção solicitada no `oprm-coletor-mei` para remover dependência de data atual no diretório da fonte e fixar o `snapshot-date` padrão em `2026-05-10` no `application.yml`, mantendo o diretório de ingestão alinhado ao cânone OPRM.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -162,3 +162,9 @@
 - 2026-05-25 00:00:00 (UTC): ajuste complementar solicitado por revisão: adicionado log textual explícito com `runId` logo após a criação da run no `runScheduledImport` para facilitar buscas operacionais por `contains=runId=` nos logs do MCP.
 
 - 2026-05-25 00:00:00 (UTC): ajuste solicitado em revisão para inserir log no início do método `runScheduledImport` (primeira instrução), registrando disparo da rotina antes de qualquer validação de `enabled`.
+
+- 2026-05-25 17:20:00 (UTC-3): atualização canônica solicitada no OPRM para deixar explícito que o `snapshotDate` da ingestão CNPJ/CNAE deve permanecer fixo em `2026-05-10`, proibindo troca automática para datas mais novas sem decisão explícita do usuário; documento atualizado em `docs/canonical/oprm-canon.v1.md`.
+
+- 2026-05-25 17:25:00 (UTC-3): ajuste solicitado no cânone OPRM para explicitar a URL completa de download do snapshot fixo (`https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-05-10/`) e tornar obrigatória a validação prévia de acesso HTTP 200 (HEAD) dos arquivos de referência (`Cnaes.zip`, `Empresas1.zip`, `Estabelecimentos1.zip`) antes da execução.
+
+- 2026-05-25 17:35:00 (UTC-3): ajuste solicitado no `oprm-coletor-mei` para reagendar a execução da ingestão OPRM CNPJ/CNAE para **17:45** no fuso `America/Sao_Paulo`, com atualização do cron hardcoded de `runScheduledImport` para `0 45 17 * * *`, sincronização do cron padrão em `application.yml` e ajuste da mensagem de log final para refletir 17:45.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
@@ -58,7 +58,7 @@ public class OprmMarketImportScheduler {
     }
 
     /** Executa a ingestão completa de arquivos CNPJ/CNAE no horário agendado para a execução operacional. */
-    @Scheduled(cron = "0 45 16 * * *", zone = "America/Sao_Paulo")
+    @Scheduled(cron = "0 45 17 * * *", zone = "America/Sao_Paulo")
     public void runScheduledImport() {
         log.info("Iniciando runScheduledImport do OPRM CNPJ/CNAE.");
         if (!scheduleProperties.enabled()) {
@@ -214,7 +214,7 @@ public class OprmMarketImportScheduler {
             }
         }
 
-        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 16:45 ({}) com {} arquivos.",
+        log.info("Import run OPRM CNPJ agendado com sucesso para snapshotDate={} às 17:45 ({}) com {} arquivos.",
                 snapshotDate,
                 scheduleProperties.timezone(),
                 files.size());

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -24,7 +24,7 @@ oprm:
       enabled: ${OPRM_MARKET_IMPORT_SCHEDULE_ENABLED:true}
       cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 45 17 * * *}
       timezone: ${OPRM_MARKET_IMPORT_SCHEDULE_TIMEZONE:America/Sao_Paulo}
-      snapshot-date: ${OPRM_MARKET_IMPORT_SNAPSHOT_DATE:2026-05-23}
+      snapshot-date: ${OPRM_MARKET_IMPORT_SNAPSHOT_DATE:2026-05-10}
       source-base-url: ${OPRM_MARKET_IMPORT_SOURCE_BASE_URL:https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos}
 
 logging:

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -22,7 +22,7 @@ oprm:
       temp-dir: ${OPRM_MARKET_IMPORT_TEMP_DIR:/tmp/oprm-cnpj-import}
     schedule:
       enabled: ${OPRM_MARKET_IMPORT_SCHEDULE_ENABLED:true}
-      cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 20 18 23 5 *}
+      cron: ${OPRM_MARKET_IMPORT_SCHEDULE_CRON:0 45 17 * * *}
       timezone: ${OPRM_MARKET_IMPORT_SCHEDULE_TIMEZONE:America/Sao_Paulo}
       snapshot-date: ${OPRM_MARKET_IMPORT_SNAPSHOT_DATE:2026-05-23}
       source-base-url: ${OPRM_MARKET_IMPORT_SOURCE_BASE_URL:https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos}


### PR DESCRIPTION
### Motivation
- Change the scheduled execution time for the OPRM CNPJ/CNAE ingest to align with new operational requirements and update the default cron across code and config. 
- Make the canonical policy explicit that the ingest `snapshotDate` must remain fixed to a known snapshot for current operations and forbid automatic switching to newer snapshots. 
- Record the scheduling and governance updates in operational registro files for traceability.

### Description
- Updated the scheduled cron in `OprmMarketImportScheduler` from `0 45 16 * * *` to `0 45 17 * * *` and adjusted the corresponding log message to mention `17:45`. 
- Updated `application.yml` default schedule cron to `0 45 17 * * *` to match the code change. 
- Expanded the canonical document `docs/canonical/oprm-canon.v1.md` to add a mandatory rule that the `snapshotDate` is fixed to `2026-05-10`, require the explicit snapshot download base URL `https://dados-abertos-rf-cnpj.casadosdados.com.br/arquivos/2026-05-10/`, and require HTTP `HEAD` validation for key files before execution. 
- Added registro entries in `docs/registros/oprm1.md` documenting the canonical snapshot rule and the scheduling changes.

### Testing
- Ran the project test suite with `./mvnw test` and the existing unit tests completed successfully. 
- Performed a build with `./mvnw package` to ensure compilation and resource processing succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a8a17e748321b7ed70e1725b9fa3)