### PR TITLE
Fix ai-worker test failures from GeraLanding MontaRequest bean conflicts

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 /**
  * Responsabilidade: montar o request da OpenAI para a etapa de copy do GeraLanding.
  */
-@Component
+@Component("geraLandingCopyMontaRequest")
 public class MontaRequest {
 
     private static final String DEFAULT_MODEL = "gpt-5.2";

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 /**
  * Responsabilidade: montar o request da OpenAI para a etapa de deliverables do GeraLanding.
  */
-@Component
+@Component("geraLandingDeliverablesMontaRequest")
 public class MontaRequest {
 
     private static final String DEFAULT_MODEL = "gpt-5.2";

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 /**
  * Responsabilidade: montar o request da OpenAI para a etapa de imageplanning do GeraLanding.
  */
-@Component
+@Component("geraLandingImageplanningMontaRequest")
 public class MontaRequest {
 
     private static final String DEFAULT_MODEL = "gpt-5.2";

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 /**
  * Responsabilidade: montar o request da OpenAI para a etapa de presetdesign do GeraLanding.
  */
-@Component
+@Component("geraLandingPresetdesignMontaRequest")
 public class MontaRequest {
 
     private static final String DEFAULT_MODEL = "gpt-5.2";

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 /**
  * Responsabilidade: montar o request da OpenAI para a etapa de wireframe do GeraLanding.
  */
-@Component
+@Component("geraLandingWireframeMontaRequest")
 public class MontaRequest {
 
     private static final String DEFAULT_MODEL = "gpt-5.2";

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -10,6 +10,7 @@ import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
 import com.marketinghub.worker.geralanding.wireframe.MontaRequest;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.core.io.ClassPathResource;
@@ -36,7 +37,10 @@ class GeraLandingExecutionServiceTest {
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
                 new GeraLandingStageExecutionDto(19L, "dd8a7dac-ce15-4858-99b4-45a7a18591fa", "landing-page-wireframe")));
-        when(geraLandingService.montarERegistrarPromptEtapa(any(), any())).thenReturn("prompt-content");
+        when(backendClient.loadPromptData(19L)).thenReturn(Map.of());
+        when(wireframeMontaRequest.montarPrompt(any())).thenReturn("prompt-content");
+        when(wireframeMontaRequest.carregarPromptMarkdownCru()).thenReturn("prompt-markdown");
+        when(wireframeMontaRequest.montar(any())).thenReturn("{\"model\":\"gpt-5.2\"}");
         when(openAiClient.generate(any())).thenReturn(new GeraLandingJobCompletionPayload(
                 "{\"ok\":true}", "raw", "request", "openai-job", 10, 20, BigDecimal.ONE));
 
@@ -87,7 +91,10 @@ class GeraLandingExecutionServiceTest {
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
                 new GeraLandingStageExecutionDto(19L, "dd8a7dac-ce15-4858-99b4-45a7a18591fa", "landing-page-wireframe")));
-        when(geraLandingService.montarERegistrarPromptEtapa(any(), any())).thenReturn("prompt-content");
+        when(backendClient.loadPromptData(19L)).thenReturn(Map.of());
+        when(wireframeMontaRequest.montarPrompt(any())).thenReturn("prompt-content");
+        when(wireframeMontaRequest.carregarPromptMarkdownCru()).thenReturn("prompt-markdown");
+        when(wireframeMontaRequest.montar(any())).thenReturn("{\"model\":\"gpt-5.2\"}");
         when(openAiClient.generate(any())).thenThrow(new IllegalStateException("OpenAI erro de flex"));
 
         GeraLandingExecutionService service =


### PR DESCRIPTION
### Motivation
- Multiple classes named `MontaRequest` under `geralanding/*` were annotated with plain `@Component`, producing duplicate default bean names and causing `ConflictingBeanDefinitionException` during Spring test startup. 
- `GeraLandingExecutionServiceTest` mocked an older flow and did not stub the current prompt-building path, so the service returned early and never reached the `openAiClient.generate(...)` call under test.

### Description
- Added explicit Spring bean names to each `geralanding/*/MontaRequest` component (`@Component("geraLandingWireframeMontaRequest")`, `@Component("geraLandingCopyMontaRequest")`, `@Component("geraLandingImageplanningMontaRequest")`, `@Component("geraLandingPresetdesignMontaRequest")`, `@Component("geraLandingDeliverablesMontaRequest")`) to eliminate bean-name collisions. 
- Updated `GeraLandingExecutionServiceTest` to mock the current execution path by stubbing `backendClient.loadPromptData(...)`, `wireframeMontaRequest.montarPrompt(...)`, `wireframeMontaRequest.carregarPromptMarkdownCru()` and `wireframeMontaRequest.montar(...)` so the test reaches and verifies `openAiClient.generate(...)`. 
- Ensured local module dependency was available by installing `backend/ads-service` into the local Maven repository so `ai-worker` can build and run tests.

### Testing
- Installed local dependency with `mvn -f backend/ads-service/pom.xml -DskipTests install -q`, which completed successfully. 
- Ran targeted unit tests with `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest,NicheHypothesisServiceTest,SuccessProductNicheHypothesisServiceTest test -q`, and the targeted tests passed. 
- Test logs contained non-blocking scheduler network warnings from background components, but these did not affect the unit test results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b7f5bd6483218b8ecfaeb082e982)