### PR TITLE
Validate canonical style references for wireframe and design-preset; update prompts and tests

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -8,9 +8,11 @@ import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
 import com.marketinghub.worker.geralanding.wireframe.MontaRequest;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -148,6 +150,8 @@ public class GeraLandingExecutionService {
                     null);
             log.info("Enviando gera-landing executionId={} para OpenAI em modo flex", execution.idJob());
             GeraLandingJobCompletionPayload payload = openAiClient.generate(openAiJob);
+            validateWireframeStyleReferences(stage, payload);
+            validateDesignPresetStyleReferences(stage, payload);
             validateCopyPayloadText(stage, payload);
             log.info(
                     "Resposta OpenAI recebida para gera-landing executionId={} (experimentId={}, openAiJobId={}, inputTokens={}, outputTokens={}, costUsd={}, responseContentLength={}, rawResponseLength={})",
@@ -201,6 +205,166 @@ public class GeraLandingExecutionService {
             }
         } catch (JsonProcessingException ex) {
             throw new IllegalStateException("Copy inválida: resposta não é JSON parseável para validação textual", ex);
+        }
+    }
+
+    /**
+     * Valida se o preset design referencia em pagina.estilos somente classes definidas em definicoes.
+     */
+    private void validateDesignPresetStyleReferences(GeraLandingStageDefinition stage, GeraLandingJobCompletionPayload payload) {
+        if (stage != GeraLandingStageDefinition.DESIGN_PRESET || payload == null || !StringUtils.hasText(payload.responseContent())) {
+            return;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(payload.responseContent());
+            Set<String> allowedStyleNames = collectAllowedStyleNamesFromDesignPreset(root.path("definicoes"));
+            if (allowedStyleNames.isEmpty()) {
+                throw new IllegalStateException("Preset design inválido: bloco 'definicoes' sem estilos válidos para referência.");
+            }
+            List<String> violations = new ArrayList<>();
+            collectInvalidStyleReferenceList(root.path("pagina").path("body").path("estilos"), "pagina.body.estilos", allowedStyleNames, violations);
+            collectInvalidStyleReferenceList(root.path("pagina").path("corpo").path("estilos"), "pagina.corpo.estilos", allowedStyleNames, violations);
+            collectInvalidDesignPresetNodeStyles(root.path("pagina").path("corpo").path("secoes"), "pagina.corpo.secoes", allowedStyleNames, violations);
+            if (!violations.isEmpty()) {
+                throw new IllegalStateException("Preset design inválido: estilos inexistentes nas definições canônicas. " + String.join("; ", violations));
+            }
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Preset design inválido: resposta não é JSON parseável para validação de estilos", ex);
+        }
+    }
+
+    /**
+     * Coleta nomes de estilos permitidos de todos os grupos de definicoes da etapa preset design.
+     */
+    private Set<String> collectAllowedStyleNamesFromDesignPreset(JsonNode definicoesNode) {
+        Set<String> names = new HashSet<>();
+        if (!definicoesNode.isObject()) {
+            return names;
+        }
+        definicoesNode.fieldNames().forEachRemaining(groupName ->
+                collectStyleNamesFromDeviceBucket(definicoesNode.path(groupName), names));
+        return names;
+    }
+
+    /**
+     * Valida estilos em secoes e elementos do preset design recursivamente.
+     */
+    private void collectInvalidDesignPresetNodeStyles(JsonNode nodes, String path, Set<String> allowedStyleNames, List<String> violations) {
+        if (!nodes.isArray()) {
+            return;
+        }
+        for (int i = 0; i < nodes.size(); i++) {
+            JsonNode node = nodes.get(i);
+            String nodePath = path + "[" + i + "]";
+            collectInvalidStyleReferenceList(node.path("estilos"), nodePath + ".estilos", allowedStyleNames, violations);
+            collectInvalidDesignPresetNodeStyles(node.path("elementosSeccao"), nodePath + ".elementosSeccao", allowedStyleNames, violations);
+            collectInvalidDesignPresetNodeStyles(node.path("elementosInternos"), nodePath + ".elementosInternos", allowedStyleNames, violations);
+        }
+    }
+
+    /**
+     * Valida se os estilos referenciados no wireframe existem no bloco de definições do próprio artefato.
+     */
+    private void validateWireframeStyleReferences(GeraLandingStageDefinition stage, GeraLandingJobCompletionPayload payload) {
+        if (stage != GeraLandingStageDefinition.WIREFRAME || payload == null || !StringUtils.hasText(payload.responseContent())) {
+            return;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(payload.responseContent());
+            Set<String> allowedStyleNames = collectAllowedStyleNames(root.path("definicoes"));
+            if (allowedStyleNames.isEmpty()) {
+                throw new IllegalStateException("Wireframe inválido: bloco 'definicoes' sem estilos válidos para referência.");
+            }
+            List<String> violations = new ArrayList<>();
+            collectInvalidStyleReferences(root.path("pagina").path("corpo").path("secoes"), allowedStyleNames, violations);
+            if (!violations.isEmpty()) {
+                throw new IllegalStateException("Wireframe inválido: estilos inexistentes nas definições canônicas. " + String.join("; ", violations));
+            }
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Wireframe inválido: resposta não é JSON parseável para validação de estilos", ex);
+        }
+    }
+
+    /**
+     * Coleta todos os nomes de estilos permitidos por categoria e dispositivo.
+     */
+    private Set<String> collectAllowedStyleNames(JsonNode definicoesNode) {
+        Set<String> names = new HashSet<>();
+        collectStyleNamesFromDeviceBucket(definicoesNode.path("estrutura"), names);
+        collectStyleNamesFromDeviceBucket(definicoesNode.path("posicao"), names);
+        collectStyleNamesFromDeviceBucket(definicoesNode.path("layout"), names);
+        collectStyleNamesFromDeviceBucket(definicoesNode.path("mistas"), names);
+        return names;
+    }
+
+    /**
+     * Extrai nomes de estilos para desktop e mobile de uma categoria de definições.
+     */
+    private void collectStyleNamesFromDeviceBucket(JsonNode categoryNode, Set<String> collector) {
+        collectStyleNames(categoryNode.path("desktop"), collector);
+        collectStyleNames(categoryNode.path("mobile"), collector);
+    }
+
+    /**
+     * Adiciona ao coletor os nomes válidos encontrados na lista de definições.
+     */
+    private void collectStyleNames(JsonNode definitionsNode, Set<String> collector) {
+        if (!definitionsNode.isArray()) {
+            return;
+        }
+        for (JsonNode definition : definitionsNode) {
+            JsonNode nameNode = definition.path("nome");
+            if (nameNode.isTextual() && StringUtils.hasText(nameNode.asText())) {
+                collector.add(nameNode.asText());
+            }
+        }
+    }
+
+    /**
+     * Verifica estilos inválidos no nível das seções e delega a validação recursiva dos elementos.
+     */
+    private void collectInvalidStyleReferences(JsonNode secoesNode, Set<String> allowedStyleNames, List<String> violations) {
+        if (!secoesNode.isArray()) {
+            return;
+        }
+        for (int i = 0; i < secoesNode.size(); i++) {
+            JsonNode secaoNode = secoesNode.get(i);
+            collectInvalidStyleReferenceList(secaoNode.path("estilos"), "pagina.corpo.secoes[" + i + "].estilos", allowedStyleNames, violations);
+            collectInvalidElementStyles(secaoNode.path("elementosSeccao"), "pagina.corpo.secoes[" + i + "].elementosSeccao", allowedStyleNames, violations);
+        }
+    }
+
+    /**
+     * Valida de forma recursiva estilos inválidos em elementos e elementos internos.
+     */
+    private void collectInvalidElementStyles(JsonNode elementsNode, String path, Set<String> allowedStyleNames, List<String> violations) {
+        if (!elementsNode.isArray()) {
+            return;
+        }
+        for (int i = 0; i < elementsNode.size(); i++) {
+            JsonNode elementNode = elementsNode.get(i);
+            String elementPath = path + "[" + i + "]";
+            collectInvalidStyleReferenceList(elementNode.path("estilos"), elementPath + ".estilos", allowedStyleNames, violations);
+            collectInvalidElementStyles(elementNode.path("elementosInternos"), elementPath + ".elementosInternos", allowedStyleNames, violations);
+        }
+    }
+
+    /**
+     * Registra violações para cada referência de estilo ausente no conjunto permitido.
+     */
+    private void collectInvalidStyleReferenceList(JsonNode styleRefsNode, String path, Set<String> allowedStyleNames, List<String> violations) {
+        if (!styleRefsNode.isArray()) {
+            return;
+        }
+        for (int i = 0; i < styleRefsNode.size(); i++) {
+            JsonNode refNode = styleRefsNode.get(i);
+            if (!refNode.isTextual()) {
+                continue;
+            }
+            String styleRef = refNode.asText();
+            if (!allowedStyleNames.contains(styleRef)) {
+                violations.add(path + "[" + i + "]='" + styleRef + "'");
+            }
         }
     }
 

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
@@ -63,6 +63,7 @@ Regras obrigatórias:
 3. Aplique variação `desktop/mobile` somente em `definicoes`; em `pagina` use classes diretas sem separar por device.
 4. Em `pagina.body`, incluir obrigatoriamente a lista `estilos` com classes globais do body.
 5. Em cada elemento de `pagina` (`secoes`, `elementosSeccao`, `elementosInternos`), usar `estilos` como lista simples de classes (array de string), sem objetos `desktop/mobile`.
+5.1. Em qualquer `estilos[]` de `pagina` (`body`, `corpo`, `secoes`, `elementosSeccao`, `elementosInternos`), usar exclusivamente nomes existentes em `definicoes.*.desktop[].nome` ou `definicoes.*.mobile[].nome`.
 6. Cada item de `definicoes.desktop/mobile` deve seguir exatamente:
    - `nome`: nome da classe utilitária
    - `atributoCss`: propriedade CSS

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -53,6 +53,7 @@ Regras fixas da etapa (Gera Landing, contrato v3):
 - Cada item de definição deve conter somente: `nome`, `atributoCss`, `valor`.
 - Em `pagina`/`secoes`, usar somente referências por `nome` já definido em `definicoes`.
 - Em `pagina`/`secoes`, usar referências simples por nome de classe (sem separar por `desktop` e `mobile`).
+- Em `estilos[]` (seção e elementos internos), use exclusivamente nomes existentes em `definicoes.*.desktop[].nome` ou `definicoes.*.mobile[].nome`; qualquer nome fora disso viola contrato.
 - É proibido repetir `atributoCss`/`valor` fora de `definicoes`.
 - Não invente campos fora do schema.
 - Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -120,4 +120,138 @@ class GeraLandingExecutionServiceTest {
         verify(backendClient).receiveFailure(any(), any(), any(), any(), any());
         verify(backendClient, never()).receiveResult(any(), any(), any(), any());
     }
+
+    @Test
+    void processPendingExecutionsShouldRegisterFailureWhenWireframeUsesUndefinedStyle() throws Exception {
+        GeraLandingBackendClient backendClient = Mockito.mock(GeraLandingBackendClient.class);
+        GeraLandingService geraLandingService = Mockito.mock(GeraLandingService.class);
+        GeraLandingOpenAiFlexClient openAiClient = Mockito.mock(GeraLandingOpenAiFlexClient.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        GeraLandingStageSchemaResolver stageSchemaResolver = Mockito.mock(GeraLandingStageSchemaResolver.class);
+        MontaRequest wireframeMontaRequest = Mockito.mock(MontaRequest.class);
+        com.marketinghub.worker.geralanding.copy.MontaRequest copyMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.MontaRequest.class);
+        com.marketinghub.worker.geralanding.imageplanning.MontaRequest imagePlanningMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.MontaRequest.class);
+        com.marketinghub.worker.geralanding.presetdesign.MontaRequest presetDesignMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
+        com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
+
+        when(openAiClient.isEnabled()).thenReturn(true);
+        when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
+                new GeraLandingStageExecutionDto(19L, "dd8a7dac-ce15-4858-99b4-45a7a18591fa", "landing-page-wireframe")));
+        when(backendClient.loadPromptData(19L)).thenReturn(Map.of());
+        when(wireframeMontaRequest.montarPrompt(any())).thenReturn("prompt-content");
+        when(wireframeMontaRequest.carregarPromptMarkdownCru()).thenReturn("prompt-markdown");
+        when(wireframeMontaRequest.montar(any())).thenReturn("{\"model\":\"gpt-5.2\"}");
+        when(openAiClient.generate(any())).thenReturn(new GeraLandingJobCompletionPayload(
+                """
+                {
+                  "definicoes": {
+                    "estrutura": {"desktop":[{"nome":"wFull","atributoCss":"width","valor":"100%"}],"mobile":[{"nome":"wFull","atributoCss":"width","valor":"100%"}]},
+                    "posicao": {"desktop":[{"nome":"posRelative","atributoCss":"position","valor":"relative"}],"mobile":[{"nome":"posRelative","atributoCss":"position","valor":"relative"}]},
+                    "layout": {"desktop":[{"nome":"displayFlex","atributoCss":"display","valor":"flex"}],"mobile":[{"nome":"displayFlex","atributoCss":"display","valor":"flex"}]},
+                    "mistas": {"desktop":[{"nome":"noneTransform","atributoCss":"transform","valor":"none"}],"mobile":[{"nome":"noneTransform","atributoCss":"transform","valor":"none"}]}
+                  },
+                  "pagina": {
+                    "head":{"texto":""},
+                    "body":{"classes":["bgBody","fontBase","textPrimary","marginReset"]},
+                    "corpo":{
+                      "secoes":[
+                        {"nome":"hero","objetivo":"x","id":"s1","estrutura":["wFull"],"posicao":["posRelative"],"layout":["displayFlex"],"mistas":["noneTransform"],"estilos":["naoExiste"],"oQueQuerProvocarNoUsuario":"x","papelComercial":"x","fasePersuasao":"x","objeçãoQueRemove":"x","prioridadeConversao":1,"acaoEsperada":"x","fonteContexto":["x"],"elementosSeccao":[]},
+                        {"nome":"proof","objetivo":"x","id":"s2","estrutura":["wFull"],"posicao":["posRelative"],"layout":["displayFlex"],"mistas":["noneTransform"],"estilos":["wFull"],"oQueQuerProvocarNoUsuario":"x","papelComercial":"x","fasePersuasao":"x","objeçãoQueRemove":"x","prioridadeConversao":2,"acaoEsperada":"x","fonteContexto":["x"],"elementosSeccao":[]},
+                        {"nome":"faq","objetivo":"x","id":"s3","estrutura":["wFull"],"posicao":["posRelative"],"layout":["displayFlex"],"mistas":["noneTransform"],"estilos":["wFull"],"oQueQuerProvocarNoUsuario":"x","papelComercial":"x","fasePersuasao":"x","objeçãoQueRemove":"x","prioridadeConversao":3,"acaoEsperada":"x","fonteContexto":["x"],"elementosSeccao":[]},
+                        {"nome":"cta","objetivo":"x","id":"s4","estrutura":["wFull"],"posicao":["posRelative"],"layout":["displayFlex"],"mistas":["noneTransform"],"estilos":["wFull"],"oQueQuerProvocarNoUsuario":"x","papelComercial":"x","fasePersuasao":"x","objeçãoQueRemove":"x","prioridadeConversao":4,"acaoEsperada":"x","fonteContexto":["x"],"elementosSeccao":[]}
+                      ]
+                    }
+                  }
+                }
+                """, "raw", "request", "openai-job", 10, 20, BigDecimal.ONE));
+
+        GeraLandingExecutionService service =
+                new GeraLandingExecutionService(
+                        backendClient,
+                        geraLandingService,
+                        openAiClient,
+                        objectMapper,
+                        stageSchemaResolver,
+                        wireframeMontaRequest,
+                        copyMontaRequest,
+                        imagePlanningMontaRequest,
+                        presetDesignMontaRequest,
+                        deliverablesMontaRequest,
+                        20,
+                        new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json"),
+                        new ClassPathResource("prompts/geralanding/landing-page-deliverables-schema.json"));
+        service.processPendingExecutions();
+
+        verify(backendClient).receiveFailure(any(), any(), any(), any(), any());
+        verify(backendClient, never()).receiveResult(any(), any(), any(), any());
+    }
+
+    @Test
+    void processPendingExecutionsShouldRegisterFailureWhenDesignPresetUsesUndefinedStyle() throws Exception {
+        GeraLandingBackendClient backendClient = Mockito.mock(GeraLandingBackendClient.class);
+        GeraLandingService geraLandingService = Mockito.mock(GeraLandingService.class);
+        GeraLandingOpenAiFlexClient openAiClient = Mockito.mock(GeraLandingOpenAiFlexClient.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        GeraLandingStageSchemaResolver stageSchemaResolver = Mockito.mock(GeraLandingStageSchemaResolver.class);
+        MontaRequest wireframeMontaRequest = Mockito.mock(MontaRequest.class);
+        com.marketinghub.worker.geralanding.copy.MontaRequest copyMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.MontaRequest.class);
+        com.marketinghub.worker.geralanding.imageplanning.MontaRequest imagePlanningMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.MontaRequest.class);
+        com.marketinghub.worker.geralanding.presetdesign.MontaRequest presetDesignMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
+        com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
+
+        when(openAiClient.isEnabled()).thenReturn(true);
+        when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
+                new GeraLandingStageExecutionDto(19L, "dd8a7dac-ce15-4858-99b4-45a7a18591fa", "landing-page-design-preset")));
+        when(backendClient.loadPromptData(19L)).thenReturn(Map.of());
+        when(presetDesignMontaRequest.montarPrompt(any())).thenReturn("prompt-content");
+        when(presetDesignMontaRequest.carregarPromptMarkdownCru()).thenReturn("prompt-markdown");
+        when(presetDesignMontaRequest.montar(any())).thenReturn("{\"model\":\"gpt-5.2\"}");
+        when(openAiClient.generate(any())).thenReturn(new GeraLandingJobCompletionPayload(
+                """
+                {
+                  "definicoes": {
+                    "cores-fundo": {"desktop":[{"nome":"bgBody","atributoCss":"background-color","valor":"#fff"}],"mobile":[]},
+                    "tipografia": {"desktop":[{"nome":"fontBase","atributoCss":"font-family","valor":"Inter"}],"mobile":[]},
+                    "texto": {"desktop":[{"nome":"textPrimary","atributoCss":"color","valor":"#111"}],"mobile":[]},
+                    "bordas": {"desktop":[],"mobile":[]},
+                    "contorno": {"desktop":[],"mobile":[]},
+                    "sombras-transparencia": {"desktop":[],"mobile":[]},
+                    "filtro-efeitos": {"desktop":[],"mobile":[]},
+                    "cursor": {"desktop":[],"mobile":[]},
+                    "listas": {"desktop":[],"mobile":[]},
+                    "imagens": {"desktop":[],"mobile":[]},
+                    "transições": {"desktop":[],"mobile":[]},
+                    "animações": {"desktop":[],"mobile":[]}
+                  },
+                  "pagina": {
+                    "body": {"estilos": ["bgBody", "naoExistePreset"]},
+                    "corpo": {"estilos": ["fontBase"], "secoes": []}
+                  }
+                }
+                """, "raw", "request", "openai-job", 10, 20, BigDecimal.ONE));
+
+        GeraLandingExecutionService service = new GeraLandingExecutionService(
+                backendClient, geraLandingService, openAiClient, objectMapper, stageSchemaResolver, wireframeMontaRequest,
+                copyMontaRequest, imagePlanningMontaRequest, presetDesignMontaRequest, deliverablesMontaRequest, 20,
+                new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
+                new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
+                new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"),
+                new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json"),
+                new ClassPathResource("prompts/geralanding/landing-page-deliverables-schema.json"));
+        service.processPendingExecutions();
+
+        verify(backendClient).receiveFailure(any(), any(), any(), any(), any());
+        verify(backendClient, never()).receiveResult(any(), any(), any(), any());
+    }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
@@ -45,9 +45,26 @@ class GeraLandingServiceTest {
         assertThat(prompt).contains("Nicho: E-commerce");
         assertThat(prompt).contains("Baixa conversão");
         assertThat(prompt).contains("Mais vendas");
+        assertThat(prompt).contains("Em `estilos[]` (seção e elementos internos), use exclusivamente nomes existentes em `definicoes.*.desktop[].nome` ou `definicoes.*.mobile[].nome`");
         assertThat(prompt).doesNotContain("{{NICHE_NAME}}");
         assertThat(prompt).doesNotContain("{{PAIN_JSON}}");
         assertThat(prompt).doesNotContain("{{RESULT_JSON}}");
+    }
+
+    @Test
+    void deveConterRegraDeEstilosCanonicosNoPromptDeDesignPreset() throws Exception {
+        GeraLandingPromptContext context = new GeraLandingPromptContext(
+                10L,
+                "id-job-original",
+                "landing-page-design-preset",
+                Map.of(
+                        "NICHE_NAME", "E-commerce",
+                        "PAIN_JSON", Map.of("title", "Baixa conversão"),
+                        "RESULT_JSON", Map.of("title", "Mais vendas")));
+
+        String prompt = service.montarPromptEtapa(context, "landing-page-design-preset");
+
+        assertThat(prompt).contains("Em qualquer `estilos[]` de `pagina` (`body`, `corpo`, `secoes`, `elementosSeccao`, `elementosInternos`), usar exclusivamente nomes existentes em `definicoes.*.desktop[].nome` ou `definicoes.*.mobile[].nome`");
     }
 
     @Disabled("Teste desligado: validação textual extensa de pipeline não é mais necessária para o fluxo atual")

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -36,6 +36,7 @@
 11. **Exceções capturadas preservam ponto de falha.** Todo tratamento de exceção que captura, converte ou relança erro deve registrar log com contexto operacional e a exceção completa para manter stack trace e permitir diagnóstico de causa-raiz. Mensagens resumidas de causa raiz podem ser retornadas ao usuário/API, mas não substituem o log completo no ponto da captura.
 
 12. **Sem metainstrução no artefato final.** Qualquer texto técnico/operacional vazado em conteúdo final ao usuário (copy, CTA, FAQ, HTML publicado) deve bloquear publicação com erro explícito de contrato e apontamento do campo literal rejeitado.
+13. **Wireframe só aceita estilos existentes em definições canônicas.** O artefato de wireframe não pode introduzir `style`, `surfaceStyle`, `contrastMode`, `layoutPreset` ou variação visual fora do conjunto previsto nas definições canônicas vigentes. Qualquer estilo inexistente nas definições deve ser rejeitado em validação de contrato com indicação literal do valor inválido e da definição esperada.
 
 ## 3.1 Regra global de exclusividade de artefatos (todo o sistema)
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1640,3 +1640,29 @@
   - atualização de `DesignPresetProvisionalHtmlProcessor.applyTokenizedPresetStyles` para inserir estilos em `<style>` sem `id`;
   - atualização do teste `shouldApplyLegacyTokenizedPresetFormat` para validar ausência do id legado e manter as validações de CSS/classes.
 - impacto funcional: mantém os estilos de wireframe + preset design no HTML final, agora sem atributo `id` na tag `<style>`.
+
+## 2026-05-25 22:55:00 UTC
+- ajuste solicitado: aplicar a regra de estilos canônicos no fluxo real (código), e não apenas no documento.
+- causa-raiz: o worker aceitava wireframe com referências em `estilos[]` que não existiam em `definicoes`, permitindo drift de contrato mesmo com schema sintático válido.
+- correção aplicada:
+  - adição de validação pós-resposta da OpenAI na etapa `landing-page-wireframe` para garantir que cada item de `pagina.corpo.secoes[*].estilos` e `elementosSeccao[*].estilos` exista no conjunto `definicoes.*.(desktop|mobile)[].nome`;
+  - rejeição explícita com caminho literal do campo inválido quando houver estilo inexistente;
+  - inclusão de teste unitário cobrindo falha e callback `receiveFailure` quando o wireframe retorna estilo não definido.
+- impacto funcional: bloqueia na origem a publicação de wireframe com estilos fora das definições canônicas, reduzindo retrabalho nas etapas seguintes.
+
+## 2026-05-25 23:10:00 UTC
+- ajuste solicitado: reforçar a mesma regra também no prompt da etapa wireframe.
+- causa-raiz: somente validar no pós-resposta reduz risco técnico, mas não orienta preventivamente o modelo durante geração.
+- correção aplicada:
+  - atualização de `landing-page-wireframe.md` com regra explícita proibindo nomes em `estilos[]` fora de `definicoes.*.(desktop|mobile)[].nome`;
+  - atualização de teste do `GeraLandingServiceTest` para garantir presença literal da nova instrução no prompt montado.
+- impacto funcional: aumenta aderência já na geração do JSON e reduz incidência de retorno inválido antes da validação de runtime.
+
+## 2026-05-25 23:30:00 UTC
+- ajuste solicitado: aplicar a mesma proteção de estilos canônicos também na etapa `landing-page-design-preset`.
+- causa-raiz: o preset design ainda podia referenciar classes em `pagina.estilos[]` sem correspondência no bloco `definicoes`, gerando deriva de contrato visual.
+- correção aplicada:
+  - validação de runtime no `GeraLandingExecutionService` para `DESIGN_PRESET`, cobrindo `pagina.body.estilos`, `pagina.corpo.estilos`, `secoes[]`, `elementosSeccao[]` e `elementosInternos[]`;
+  - atualização do prompt `landing-page-design-preset.md` com regra explícita de referência exclusiva a `definicoes.*.(desktop|mobile)[].nome`;
+  - novos testes unitários para falha da execução quando houver estilo indefinido no preset e para presença da regra no prompt de design preset.
+- impacto funcional: bloqueia preset inválido antes de persistência e orienta o modelo a produzir saída aderente já na geração.


### PR DESCRIPTION
### Motivation
- Evitar drift de contrato visual ao aceitar artefatos que referenciam classes que não existem no bloco `definicoes`, bloqueando publicações com referências inválidas nas etapas de `WIREFRAME` e `DESIGN_PRESET`.
- Reforçar orientação ao modelo durante geração adicionando regra explícita nos prompts para reduzir retornos inválidos já na produção do JSON.
- Tornar a validação determinística no worker para proteger etapas subsequentes do pipeline e reduzir retrabalho humano.

### Description
- Adicionada validação pós-resposta em `GeraLandingExecutionService` para `WIREFRAME` e `DESIGN_PRESET` que verifica se todos os valores em `estilos[]` existem nas definições canônicas `definicoes.*.(desktop|mobile)[].nome` e lança `IllegalStateException` com caminho literal em caso de violação, com novos métodos utilitários (`collectAllowedStyleNames`, `collectStyleNamesFromDeviceBucket`, `collectInvalidStyleReferenceList`, etc.).
- Atualizados prompts `landing-page-wireframe.md` e `landing-page-design-preset.md` para incluir a regra obrigatória que exige uso exclusivo de nomes presentes em `definicoes.*.desktop[].nome` ou `definicoes.*.mobile[].nome` dentro de `estilos[]`.
- Incluídos testes unitários em `GeraLandingExecutionServiceTest` cobrindo falha quando `WIREFRAME` ou `DESIGN_PRESET` retornam estilos indefinidos e adicionado asserção em `GeraLandingServiceTest` para garantir presença literal da nova instrução no prompt de `design-preset`.
- Atualizados docs canônicos e registro de mudanças (`docs/canonical/...` e `docs/registros/experimentos.md`) para descrever a nova regra e histórico de correções.

### Testing
- Executados testes unitários alterados/adicionados: `GeraLandingExecutionServiceTest#processPendingExecutionsShouldRegisterFailureWhenWireframeUsesUndefinedStyle`, `GeraLandingExecutionServiceTest#processPendingExecutionsShouldRegisterFailureWhenDesignPresetUsesUndefinedStyle` e `GeraLandingServiceTest#deveConterRegraDeEstilosCanonicosNoPromptDeDesignPreset`, e eles passaram com sucesso.
- Suíte de testes do módulo `ai-worker` foi executada localmente e não apresentou regressões nas asserções existentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14d157210883219a3332b949b824f7)