### PR TITLE
Add per-stage GeraLanding services and start responses; update controllers to use them

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageService.java
@@ -1,0 +1,22 @@
+package com.marketinghub.geralanding.copy.service;
+
+import com.marketinghub.geralanding.GeraLandingStartResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionService;
+import org.springframework.stereotype.Service;
+
+/** Responsável por iniciar a execução da etapa de copy do GeraLanding. */
+@Service
+public class GeraLandingCopyStageService {
+  private static final String STAGE_NAME = "landing-page-copy";
+  private final GeraLandingStageExecutionService executionService;
+
+  public GeraLandingCopyStageService(GeraLandingStageExecutionService executionService) {
+    this.executionService = executionService;
+  }
+
+  /** Inicia a execução da etapa de copy para o experimento informado. */
+  public GeraLandingCopyStartResponse start(Long experimentId) {
+    GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    return new GeraLandingCopyStartResponse(response.idJob(), response.status());
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStartResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.geralanding.copy.service;
+
+/** Representa a resposta de início da etapa de copy do GeraLanding. */
+public record GeraLandingCopyStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.copy.web;
 
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
-import com.marketinghub.geralanding.GeraLandingStartResponse;
+import com.marketinghub.geralanding.copy.service.GeraLandingCopyStageService;
+import com.marketinghub.geralanding.copy.service.GeraLandingCopyStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,16 +12,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/experiments/{experimentId}/geralanding")
 public class GeraLandingCopyController {
-  private final GeraLandingStageExecutionService executionService;
+  private final GeraLandingCopyStageService stageService;
 
-  public GeraLandingCopyController(GeraLandingStageExecutionService executionService) {
-    this.executionService = executionService;
+  public GeraLandingCopyController(GeraLandingCopyStageService stageService) {
+    this.stageService = stageService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-copy. */
   @PostMapping("/copy/start")
-  public ResponseEntity<GeraLandingStartResponse> start(@PathVariable Long experimentId) {
-    GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, "landing-page-copy");
+  public ResponseEntity<GeraLandingCopyStartResponse> start(@PathVariable Long experimentId) {    GeraLandingCopyStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageService.java
@@ -1,0 +1,22 @@
+package com.marketinghub.geralanding.designpreset.service;
+
+import com.marketinghub.geralanding.GeraLandingStartResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionService;
+import org.springframework.stereotype.Service;
+
+/** Responsável por iniciar a execução da etapa de design preset do GeraLanding. */
+@Service
+public class GeraLandingDesignPresetStageService {
+  private static final String STAGE_NAME = "landing-page-design-preset";
+  private final GeraLandingStageExecutionService executionService;
+
+  public GeraLandingDesignPresetStageService(GeraLandingStageExecutionService executionService) {
+    this.executionService = executionService;
+  }
+
+  /** Inicia a execução da etapa de design preset para o experimento informado. */
+  public GeraLandingDesignPresetStartResponse start(Long experimentId) {
+    GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    return new GeraLandingDesignPresetStartResponse(response.idJob(), response.status());
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStartResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.geralanding.designpreset.service;
+
+/** Representa a resposta de início da etapa de design preset do GeraLanding. */
+public record GeraLandingDesignPresetStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.designpreset.web;
 
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
-import com.marketinghub.geralanding.GeraLandingStartResponse;
+import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStageService;
+import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,16 +12,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/experiments/{experimentId}/geralanding")
 public class GeraLandingDesignPresetController {
-  private final GeraLandingStageExecutionService executionService;
+  private final GeraLandingDesignPresetStageService stageService;
 
-  public GeraLandingDesignPresetController(GeraLandingStageExecutionService executionService) {
-    this.executionService = executionService;
+  public GeraLandingDesignPresetController(GeraLandingDesignPresetStageService stageService) {
+    this.stageService = stageService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-design-preset. */
   @PostMapping("/design-preset/start")
-  public ResponseEntity<GeraLandingStartResponse> start(@PathVariable Long experimentId) {
-    GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, "landing-page-design-preset");
+  public ResponseEntity<GeraLandingDesignPresetStartResponse> start(@PathVariable Long experimentId) {    GeraLandingDesignPresetStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageService.java
@@ -1,0 +1,22 @@
+package com.marketinghub.geralanding.imageplanning.service;
+
+import com.marketinghub.geralanding.GeraLandingStartResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionService;
+import org.springframework.stereotype.Service;
+
+/** Responsável por iniciar a execução da etapa de planejamento de imagens do GeraLanding. */
+@Service
+public class GeraLandingImagePlanningStageService {
+  private static final String STAGE_NAME = "landing-page-image-planning";
+  private final GeraLandingStageExecutionService executionService;
+
+  public GeraLandingImagePlanningStageService(GeraLandingStageExecutionService executionService) {
+    this.executionService = executionService;
+  }
+
+  /** Inicia a execução da etapa de planejamento de imagens para o experimento informado. */
+  public GeraLandingImagePlanningStartResponse start(Long experimentId) {
+    GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    return new GeraLandingImagePlanningStartResponse(response.idJob(), response.status());
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStartResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.geralanding.imageplanning.service;
+
+/** Representa a resposta de início da etapa de planejamento de imagens do GeraLanding. */
+public record GeraLandingImagePlanningStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.imageplanning.web;
 
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
-import com.marketinghub.geralanding.GeraLandingStartResponse;
+import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStageService;
+import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,16 +12,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/experiments/{experimentId}/geralanding")
 public class GeraLandingImagePlanningController {
-  private final GeraLandingStageExecutionService executionService;
+  private final GeraLandingImagePlanningStageService stageService;
 
-  public GeraLandingImagePlanningController(GeraLandingStageExecutionService executionService) {
-    this.executionService = executionService;
+  public GeraLandingImagePlanningController(GeraLandingImagePlanningStageService stageService) {
+    this.stageService = stageService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-image-planning. */
   @PostMapping("/image-prompts/start")
-  public ResponseEntity<GeraLandingStartResponse> start(@PathVariable Long experimentId) {
-    GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, "landing-page-image-planning");
+  public ResponseEntity<GeraLandingImagePlanningStartResponse> start(@PathVariable Long experimentId) {    GeraLandingImagePlanningStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
@@ -1,0 +1,22 @@
+package com.marketinghub.geralanding.wireframe.service;
+
+import com.marketinghub.geralanding.GeraLandingStartResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionService;
+import org.springframework.stereotype.Service;
+
+/** Responsável por iniciar a execução da etapa de wireframe do GeraLanding. */
+@Service
+public class GeraLandingWireframeStageService {
+  private static final String STAGE_NAME = "landing-page-wireframe";
+  private final GeraLandingStageExecutionService executionService;
+
+  public GeraLandingWireframeStageService(GeraLandingStageExecutionService executionService) {
+    this.executionService = executionService;
+  }
+
+  /** Inicia a execução da etapa de wireframe para o experimento informado. */
+  public GeraLandingWireframeStartResponse start(Long experimentId) {
+    GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    return new GeraLandingWireframeStartResponse(response.idJob(), response.status());
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStartResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.geralanding.wireframe.service;
+
+/** Representa a resposta de início da etapa de wireframe do GeraLanding. */
+public record GeraLandingWireframeStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.wireframe.web;
 
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
-import com.marketinghub.geralanding.GeraLandingStartResponse;
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,16 +12,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/experiments/{experimentId}/geralanding")
 public class GeraLandingWireframeController {
-  private final GeraLandingStageExecutionService executionService;
+  private final GeraLandingWireframeStageService stageService;
 
-  public GeraLandingWireframeController(GeraLandingStageExecutionService executionService) {
-    this.executionService = executionService;
+  public GeraLandingWireframeController(GeraLandingWireframeStageService stageService) {
+    this.stageService = stageService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-wireframe. */
   @PostMapping("/wireframe/start")
-  public ResponseEntity<GeraLandingStartResponse> start(@PathVariable Long experimentId) {
-    GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, "landing-page-wireframe");
+  public ResponseEntity<GeraLandingWireframeStartResponse> start(@PathVariable Long experimentId) {    GeraLandingWireframeStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
   }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1706,3 +1706,12 @@
 - correção aplicada:
   - adição de nomes explícitos em `@Component` para cada etapa (`wireframe`, `copy`, `imageplanning`, `presetdesign`, `deliverables`).
 - impacto funcional: mantém a injeção estável e elimina ambiguidades de identificação de bean por nome.
+
+## 2026-05-26 02:20:00 UTC
+- ajuste solicitado: criar pacote `service` em cada etapa do GeraLanding e mover o início de execução para classes específicas por etapa.
+- causa-raiz: os controllers de `wireframe`, `copy`, `imageplanning` e `designpreset` dependiam diretamente de classes do pacote raiz `com.marketinghub.geralanding`, violando o teste de isolamento arquitetural por subpacote.
+- correção aplicada:
+  - criação de serviços por etapa (`GeraLanding*StageService`) dentro de `geralanding.<etapa>.service`;
+  - criação de responses por etapa (`GeraLanding*StartResponse`) dentro de `geralanding.<etapa>.service`;
+  - atualização dos controllers de etapa para depender apenas das classes do próprio subpacote.
+- impacto funcional: mantém os endpoints e o contrato HTTP de início de etapa, com isolamento arquitetural por submódulo.


### PR DESCRIPTION
### Motivation
- Enforce architectural isolation by moving start-of-execution logic out of the root package and into per-stage packages.
- Reduce controller coupling to `com.marketinghub.geralanding` and ensure each GeraLanding stage handles its own startup flow.
- Preserve existing HTTP contracts while making stage responsibilities explicit for future evolution and testability.

### Description
- Added per-stage service classes `GeraLandingWireframeStageService`, `GeraLandingCopyStageService`, `GeraLandingImagePlanningStageService`, and `GeraLandingDesignPresetStageService` that call `GeraLandingStageExecutionService.registerInitialExecution` with stage-specific names. 
- Introduced corresponding response records `GeraLandingWireframeStartResponse`, `GeraLandingCopyStartResponse`, `GeraLandingImagePlanningStartResponse`, and `GeraLandingDesignPresetStartResponse` to return `idJob` and `status`. 
- Updated controllers in each stage package to depend on the new stage services and to return the new stage-specific response types instead of the root `GeraLandingStartResponse`. 
- Updated documentation `docs/registros/experimentos.md` to record the architectural change and the new per-stage service/responses.

### Testing
- Built the module and executed the project test suite with `mvn test`, and the build and tests completed successfully. 
- Exercised the updated WebMvc tests that validate the start endpoints and they passed against the modified controllers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1500028c9883219c76ea19cea9733b)