### PR TITLE
Adjust Hotmart collector schedule (first cycle -> 00:15) and add scheduler docs

### DIFF
--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -9,6 +9,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
+/**
+ * Responsável por agendar e disparar os ciclos automáticos de coleta Hotmart.
+ */
 public class HotmartCollectorScheduler {
 
     private static final Logger log = LoggerFactory.getLogger(HotmartCollectorScheduler.class);
@@ -30,7 +33,10 @@ public class HotmartCollectorScheduler {
         this.maxProducts = maxProducts;
     }
 
-    @Scheduled(cron = "0 0 10 * * *")
+    /**
+     * Executa o ciclo 1 de listagem de produtos diariamente às 00:15.
+     */
+    @Scheduled(cron = "0 15 0 * * *")
     public void collectFirstCycleAtTen() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
@@ -38,13 +44,16 @@ public class HotmartCollectorScheduler {
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=10 ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=00:15 ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),
                 response.products().size(),
                 response.message());
     }
 
+    /**
+     * Executa o ciclo 2 de enriquecimento de detalhes diariamente às 17:00.
+     */
     @Scheduled(cron = "0 0 17 * * *")
     public void collectSecondCycleAtSeventeen() {
         if (!enabled) {


### PR DESCRIPTION
### Motivation
- Ensure the Hotmart collector first listing cycle runs at the intended early-hour window and make the scheduler behavior clearer through code documentation.

### Description
- Changed the first cycle cron from `0 0 10 * * *` to `0 15 0 * * *` so the listing cycle now runs daily at `00:15` instead of `10:00`.
- Updated the runtime log message to reflect the new execution time from `hora=10` to `hora=00:15` and retained existing details about cycle, status, product count and message.
- Added Portuguese JavaDoc comments to the `HotmartCollectorScheduler` class and its scheduled methods to document their responsibilities and schedules.
- Kept the second cycle scheduling and behavior intact and added a comment describing that it runs daily at `17:00`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14d2a11be4832182ea87d935c3d55a)