### PR TITLE
Fix WebMvcTest by adding stage service mocks and updating tests

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingContollerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/GeraLandingContollerTest.java
@@ -1,10 +1,17 @@
 package com.marketinghub.geralanding;
 
+import com.marketinghub.geralanding.copy.service.GeraLandingCopyStageService;
+import com.marketinghub.geralanding.copy.service.GeraLandingCopyStartResponse;
 import com.marketinghub.geralanding.copy.web.GeraLandingCopyController;
 import com.marketinghub.geralanding.deliverables.web.GeraLandingDeliverablesController;
+import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStageService;
 import com.marketinghub.geralanding.designpreset.web.GeraLandingDesignPresetController;
 import com.marketinghub.geralanding.execution.web.GeraLandingExecutionController;
+import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStageService;
+import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStartResponse;
 import com.marketinghub.geralanding.imageplanning.web.GeraLandingImagePlanningController;
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
 import com.marketinghub.geralanding.wireframe.web.GeraLandingWireframeController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,45 +40,57 @@ class GeraLandingContollerTest {
     @MockBean
     private GeraLandingStageExecutionService executionService;
 
+    @MockBean
+    private GeraLandingCopyStageService copyStageService;
+
+    @MockBean
+    private GeraLandingWireframeStageService wireframeStageService;
+
+    @MockBean
+    private GeraLandingImagePlanningStageService imagePlanningStageService;
+
+    @MockBean
+    private GeraLandingDesignPresetStageService designPresetStageService;
+
     @Test
     void shouldCreateExecutionAndReturnCodeAndStatus() throws Exception {
-        when(executionService.registerInitialExecution(99L, "landing-page-wireframe"))
-                .thenReturn(new GeraLandingStartResponse("job-123", "INICIADO"));
+        when(wireframeStageService.start(99L))
+                .thenReturn(new GeraLandingWireframeStartResponse("job-123", "INICIADO"));
 
         mockMvc.perform(post("/api/experiments/{experimentId}/geralanding/wireframe/start", 99L))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.idJob").value("job-123"))
                 .andExpect(jsonPath("$.status").value("INICIADO"));
 
-        verify(executionService).registerInitialExecution(eq(99L), eq("landing-page-wireframe"));
+        verify(wireframeStageService).start(eq(99L));
     }
 
 
     @Test
     void shouldCreateCopyExecutionAndReturnCodeAndStatus() throws Exception {
-        when(executionService.registerInitialExecution(99L, "landing-page-copy"))
-                .thenReturn(new GeraLandingStartResponse("job-copy-1", "INICIADO"));
+        when(copyStageService.start(99L))
+                .thenReturn(new GeraLandingCopyStartResponse("job-copy-1", "INICIADO"));
 
         mockMvc.perform(post("/api/experiments/{experimentId}/geralanding/copy/start", 99L))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.idJob").value("job-copy-1"))
                 .andExpect(jsonPath("$.status").value("INICIADO"));
 
-        verify(executionService).registerInitialExecution(eq(99L), eq("landing-page-copy"));
+        verify(copyStageService).start(eq(99L));
     }
 
 
     @Test
     void shouldCreateImagePromptsExecutionAndReturnCodeAndStatus() throws Exception {
-        when(executionService.registerInitialExecution(99L, "landing-page-image-planning"))
-                .thenReturn(new GeraLandingStartResponse("job-image-1", "INICIADO"));
+        when(imagePlanningStageService.start(99L))
+                .thenReturn(new GeraLandingImagePlanningStartResponse("job-image-1", "INICIADO"));
 
         mockMvc.perform(post("/api/experiments/{experimentId}/geralanding/image-prompts/start", 99L))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.idJob").value("job-image-1"))
                 .andExpect(jsonPath("$.status").value("INICIADO"));
 
-        verify(executionService).registerInitialExecution(eq(99L), eq("landing-page-image-planning"));
+        verify(imagePlanningStageService).start(eq(99L));
     }
 
     @Test

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1715,3 +1715,11 @@
   - criação de responses por etapa (`GeraLanding*StartResponse`) dentro de `geralanding.<etapa>.service`;
   - atualização dos controllers de etapa para depender apenas das classes do próprio subpacote.
 - impacto funcional: mantém os endpoints e o contrato HTTP de início de etapa, com isolamento arquitetural por submódulo.
+
+## 2026-05-26 02:58:00 UTC
+- ajuste solicitado: corrigir falha de contexto em `GeraLandingContollerTest` durante `@WebMvcTest`.
+- causa-raiz: o controller `geralanding.copy.web.GeraLandingCopyController` passou a depender de `GeraLandingCopyStageService`, mas o teste não declarava `@MockBean` desse serviço, impedindo a criação do ApplicationContext.
+- correção aplicada:
+  - inclusão de `@MockBean GeraLandingCopyStageService` no teste;
+  - ajuste do cenário `shouldCreateCopyExecutionAndReturnCodeAndStatus` para mockar/verificar `copyStageService.start(...)` e `GeraLandingCopyStartResponse`.
+- impacto funcional: restaura a subida do contexto do teste MVC sem alterar contrato HTTP dos endpoints.


### PR DESCRIPTION
### Motivation
- Controllers for GeraLanding stages were refactored to depend on stage-specific services and responses, which broke the `@WebMvcTest` context when those dependencies were not mocked.
- Tests needed to exercise the new per-stage `start(...)` contracts instead of the old centralized execution service API.
- Documentation about the architecture and registration of changes required an entry explaining the test fix to keep the audit trail coherent.

### Description
- Added `@MockBean` entries for `GeraLandingCopyStageService`, `GeraLandingWireframeStageService`, `GeraLandingImagePlanningStageService`, and `GeraLandingDesignPresetStageService` in `GeraLandingContollerTest` to satisfy controller dependencies in the `@WebMvcTest` slice.
- Updated test scenarios to mock and verify stage-specific `start(...)` calls and to return stage-specific response types (`GeraLandingWireframeStartResponse`, `GeraLandingCopyStartResponse`, `GeraLandingImagePlanningStartResponse`).
- Updated `docs/registros/experimentos.md` with an entry describing the test-context fix and its rationale.

### Testing
- Executed the unit test class `GeraLandingContollerTest` under the project test suite via `mvn test`, and the modified tests passed. 
- Ran the full test suite via `mvn test` and no regressions were observed in automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a150a2028ec83219fa0ed11afc7125f)