### PR TITLE
Annotate ArchUnit rule reasons with module and backend context

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/GeraLandingAssemblerArchitectureTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/GeraLandingAssemblerArchitectureTest.java
@@ -25,7 +25,7 @@ class GeraLandingAssemblerArchitectureTest {
                     "assemble",
                     String.class,
                     String.class)
-            .because("[ARQUITETURA] o serviço deve usar o contrato padronizado com os novos parâmetros do design-preset");
+            .because("[ARQUITETURA][BACKEND][GeraLandingStageExecutionService] o serviço deve usar o contrato padronizado com os novos parâmetros do design-preset");
 
 
     @ArchTest
@@ -37,7 +37,7 @@ class GeraLandingAssemblerArchitectureTest {
                     WireframeProvisionalHtmlAssembler.class,
                     "assemble",
                     String.class)
-            .because("[ARQUITETURA] o serviço deve usar o contrato padronizado assemble(modelResponse, jobId) para wireframe");
+            .because("[ARQUITETURA][BACKEND][GeraLandingStageExecutionService] o serviço deve usar o contrato padronizado assemble(modelResponse, jobId) para wireframe");
 
     @ArchTest
     static final ArchRule stageExecutionServiceMustNotCallLegacyTwoArgCopyAssembler = noClasses()
@@ -49,7 +49,7 @@ class GeraLandingAssemblerArchitectureTest {
                     "assemble",
                     String.class,
                     String.class)
-            .because("[ARQUITETURA] o serviço deve usar o contrato padronizado assemble(copyModelResponse, wireframeModelResponse, jobId) para copy");
+            .because("[ARQUITETURA][BACKEND][GeraLandingStageExecutionService] o serviço deve usar o contrato padronizado assemble(copyModelResponse, wireframeModelResponse, jobId) para copy");
 
 
 
@@ -63,7 +63,7 @@ class GeraLandingAssemblerArchitectureTest {
                     "assemble",
                     String.class,
                     String.class)
-            .because("[ARQUITETURA] quando STAGE_WIREFRAME for processado, o assembler canônico de wireframe deve ser usado");
+            .because("[ARQUITETURA][BACKEND][GeraLandingStageExecutionService] quando STAGE_WIREFRAME for processado, o assembler canônico de wireframe deve ser usado");
 
     @ArchTest
     static final ArchRule stageExecutionServiceMustCallStandardDesignPresetAssembler = classes()
@@ -78,7 +78,7 @@ class GeraLandingAssemblerArchitectureTest {
                     String.class,
                     String.class,
                     String.class)
-            .because("[ARQUITETURA] quando STAGE_DESIGN_PRESET for processado, o assembler canônico de design preset com novos parâmetros deve ser usado");
+            .because("[ARQUITETURA][BACKEND][GeraLandingStageExecutionService] quando STAGE_DESIGN_PRESET for processado, o assembler canônico de design preset com novos parâmetros deve ser usado");
 
     @ArchTest
     static final ArchRule stageExecutionServiceMustCallStandardCopyAssembler = classes()
@@ -91,7 +91,7 @@ class GeraLandingAssemblerArchitectureTest {
                     String.class,
                     String.class,
                     String.class)
-            .because("[ARQUITETURA] quando STAGE_COPY for processado, o assembler canônico de copy deve ser usado");
+            .because("[ARQUITETURA][BACKEND][GeraLandingStageExecutionService] quando STAGE_COPY for processado, o assembler canônico de copy deve ser usado");
 
     @ArchTest
     static final ArchRule wireframeAssemblerMustResideInWireframePackage = classes()
@@ -99,7 +99,7 @@ class GeraLandingAssemblerArchitectureTest {
             .haveSimpleName("WireframeProvisionalHtmlAssembler")
             .should()
             .resideInAPackage("..geralanding.wireframe..")
-            .because("[ARQUITETURA] o assembler de wireframe deve ficar no pacote geralanding.wireframe");
+            .because("[ARQUITETURA][BACKEND][WireframeProvisionalHtmlAssembler] o assembler de wireframe deve ficar no pacote geralanding.wireframe");
 
     @ArchTest
     static final ArchRule designPresetAssemblerMustResideInDesignPresetPackage = classes()
@@ -107,7 +107,7 @@ class GeraLandingAssemblerArchitectureTest {
             .haveSimpleName("DesignPresetProvisionalHtmlAssembler")
             .should()
             .resideInAPackage("..geralanding.designpreset..")
-            .because("[ARQUITETURA] o assembler de design preset deve ficar no pacote geralanding.designpreset");
+            .because("[ARQUITETURA][BACKEND][DesignPresetProvisionalHtmlAssembler] o assembler de design preset deve ficar no pacote geralanding.designpreset");
 
     @ArchTest
     static final ArchRule wireframePackageMustContainCanonicalAssemblerType = classes()
@@ -115,5 +115,5 @@ class GeraLandingAssemblerArchitectureTest {
             .haveNameMatching(".*WireframeProvisionalHtmlAssembler")
             .should()
             .beAssignableTo(WireframeProvisionalHtmlAssembler.class)
-            .because("[ARQUITETURA] o tipo canônico do assembler de wireframe deve existir e permanecer estável");
+            .because("[ARQUITETURA][BACKEND][WireframeProvisionalHtmlAssembler] o tipo canônico do assembler de wireframe deve existir e permanecer estável");
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
@@ -35,7 +35,7 @@ class ModuleIsolationArchitectureTest {
             .resideInAPackage("com.marketinghub.mois..")
             .should()
             .dependOnClassesThat(otherMarketingHubPackagesExcept("com.marketinghub.mois"))
-            .because("[ARQUITETURA] o módulo MOIS não deve depender de outros pacotes internos do sistema");
+            .because("[ARQUITETURA][MOIS] o módulo MOIS não deve depender de outros pacotes internos do sistema");
 
     @ArchTest
     static final ArchRule oprmMustNotDependOnOtherMarketingHubPackages = noClasses()
@@ -43,7 +43,7 @@ class ModuleIsolationArchitectureTest {
             .resideInAPackage("com.marketinghub.oprm..")
             .should()
             .dependOnClassesThat(otherMarketingHubPackagesExcept("com.marketinghub.oprm"))
-            .because("[ARQUITETURA] o módulo OPRM não deve depender de outros pacotes internos do sistema");
+            .because("[ARQUITETURA][OPRM] o módulo OPRM não deve depender de outros pacotes internos do sistema");
 
     @ArchTest
     static final ArchRule moisSalesLibraryPackageMustNotDependOnOtherMarketingHubPackages = noClasses()
@@ -51,7 +51,7 @@ class ModuleIsolationArchitectureTest {
             .resideInAPackage(MOIS_SALES_LIBRARY_PACKAGE + "..")
             .should()
             .dependOnClassesThat(otherMarketingHubPackagesExcept(MOIS_SALES_LIBRARY_PACKAGE))
-            .because("[ARQUITETURA] o pacote de biblioteca de páginas de vendas do MOIS deve ficar isolado dos demais pacotes internos");
+            .because("[ARQUITETURA][MOIS] o pacote de biblioteca de páginas de vendas do MOIS deve ficar isolado dos demais pacotes internos");
 
     @ArchTest
     static final ArchRule otherMarketingHubPackagesMustNotDependOnMoisSalesLibraryPackage = noClasses()
@@ -62,27 +62,27 @@ class ModuleIsolationArchitectureTest {
             .should()
             .dependOnClassesThat()
             .resideInAPackage(MOIS_SALES_LIBRARY_PACKAGE + "..")
-            .because("[ARQUITETURA] nenhum outro pacote interno deve depender da biblioteca de páginas de vendas do MOIS");
+            .because("[ARQUITETURA][MOIS] nenhum outro pacote interno deve depender da biblioteca de páginas de vendas do MOIS");
 
     @ArchTest
     static final ArchRule geralandingWireframeMustBeIsolated = isolatedFromOtherMarketingHubPackages(
             GERALANDING_WIREFRAME_PACKAGE,
-            "[ARQUITETURA] o subpacote geralanding.wireframe deve ficar independente dos demais pacotes internos");
+            "[ARQUITETURA][BACKEND][GeraLandingWireframeStageService] o subpacote geralanding.wireframe deve ficar independente dos demais pacotes internos");
 
     @ArchTest
     static final ArchRule geralandingCopyMustBeIsolated = isolatedFromOtherMarketingHubPackages(
             GERALANDING_COPY_PACKAGE,
-            "[ARQUITETURA] o subpacote geralanding.copy deve ficar independente dos demais pacotes internos");
+            "[ARQUITETURA][BACKEND][GeraLandingCopyStageService] o subpacote geralanding.copy deve ficar independente dos demais pacotes internos");
 
     @ArchTest
     static final ArchRule geralandingImagePlanningMustBeIsolated = isolatedFromOtherMarketingHubPackages(
             GERALANDING_IMAGEPLANNING_PACKAGE,
-            "[ARQUITETURA] o subpacote geralanding.imageplanning deve ficar independente dos demais pacotes internos");
+            "[ARQUITETURA][BACKEND][GeraLandingImagePlanningStageService] o subpacote geralanding.imageplanning deve ficar independente dos demais pacotes internos");
 
     @ArchTest
     static final ArchRule geralandingPresetDesignMustBeIsolated = isolatedFromOtherMarketingHubPackages(
             GERALANDING_PRESETDESIGN_PACKAGE,
-            "[ARQUITETURA] o subpacote geralanding.designpreset deve ficar independente dos demais pacotes internos");
+            "[ARQUITETURA][BACKEND][GeraLandingDesignPresetStageService] o subpacote geralanding.designpreset deve ficar independente dos demais pacotes internos");
 
     @ArchTest
     static final ArchRule moisSalesLibraryWebShouldOnlyDependOnServiceLayer =
@@ -133,7 +133,7 @@ class ModuleIsolationArchitectureTest {
      * Valida que classes de um layer dependem apenas do layer permitido com mesmo x e vN.
      */
     private static ArchCondition<JavaClass> onlyDependOnLayer(String allowedTargetLayer) {
-        return new ArchCondition<>("[ARQUITETURA] depend only on " + allowedTargetLayer + " in same x/vN") {
+        return new ArchCondition<>("[ARQUITETURA][MOIS] depend only on " + allowedTargetLayer + " in same x/vN") {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
                 Optional<SalesLibraryPackageInfo> sourceInfo = extractSalesLibraryPackageInfo(item.getPackageName());
@@ -151,7 +151,7 @@ class ModuleIsolationArchitectureTest {
                     boolean allowedLayer = targetInfo.get().layer().equals(allowedTargetLayer)
                             || targetInfo.get().layer().equals(sourceInfo.get().layer());
                     if (!sameNamespace || !allowedLayer) {
-                        String message = "[ARQUITETURA] " + item.getName() + " depende de " + dependency.getTargetClass().getName()
+                        String message = "[ARQUITETURA][MOIS] " + item.getName() + " depende de " + dependency.getTargetClass().getName()
                                 + " mas só pode depender de pacote ." + allowedTargetLayer
                                 + " com mesmo x/vN";
                         events.add(SimpleConditionEvent.violated(item, message));


### PR DESCRIPTION
### Motivation
- Make architectural rule messages more explicit by adding module and backend context tags to help identify failing rules and their owning services.

### Description
- Updated reason strings in `GeraLandingAssemblerArchitectureTest` to include `[BACKEND]` and specific service/type context in the `.because(...)` messages.
- Updated reason strings in `ModuleIsolationArchitectureTest` to include `[MOIS]` and `[BACKEND]` context tags and service identifiers for several isolation rules.
- Adjusted the `onlyDependOnLayer` `ArchCondition` message to include the `[MOIS]` tag for clearer violation output.
- No logic or rule semantics were changed; only the human-readable `.because(...)` and violation message text were modified.

### Testing
- Ran the test suite with `./gradlew test` which includes the ArchUnit architecture tests, and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1515b627e083218c14d14c80431942)