### PR TITLE
Add wireframe stage service and local start response

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingStageExecutionService.java
@@ -1,0 +1,64 @@
+package com.marketinghub.geralanding.wireframe.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/** Responsável por registrar execuções iniciais da etapa de wireframe. */
+@Service
+public class GeraLandingStageExecutionService {
+
+  private static final String STATUS_STARTED = "INICIADO";
+  private final ExperimentRepository experimentRepository;
+  private final GeraLandingStageExecutionRepository executionRepository;
+
+  public GeraLandingStageExecutionService(
+      ExperimentRepository experimentRepository,
+      GeraLandingStageExecutionRepository executionRepository) {
+    this.experimentRepository = experimentRepository;
+    this.executionRepository = executionRepository;
+  }
+
+  /** Registra a execução inicial da etapa e retorna o contrato local para o módulo wireframe. */
+  @Transactional
+  public GeraLandingStartResponse registerInitialExecution(Long experimentId, String stageName) {
+    Instant now = Instant.now();
+    Experiment experiment =
+        experimentRepository
+            .findById(experimentId)
+            .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+
+    GeraLandingStageExecution execution =
+        GeraLandingStageExecution.builder()
+            .experimentId(experiment.getId())
+            .experiment(experiment)
+            .stageCode(stageName)
+            .executionRequestedAt(now)
+            .createdAt(now)
+            .promptTemplateId("manual/start")
+            .promptContent("Início manual via interface do experimento.")
+            .status(STATUS_STARTED)
+            .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+            .build();
+
+    GeraLandingStageExecution saved = executionRepository.save(execution);
+    return new GeraLandingStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+  }
+
+  /** Converte o identificador textual para formato binário persistido no banco. */
+  private byte[] toDatabaseIdJob(String jobId) {
+    return UUID.fromString(jobId).toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+  }
+
+  /** Converte o identificador binário persistido no banco para formato textual. */
+  private String fromDatabaseIdJob(byte[] idJob) {
+    return new String(idJob, java.nio.charset.StandardCharsets.UTF_8);
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingStartResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.geralanding.wireframe.service;
+
+/** Responsável por representar o retorno inicial da execução da etapa de wireframe. */
+public record GeraLandingStartResponse(
+        String idJob,
+        String status) {
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1723,3 +1723,19 @@
   - inclusão de `@MockBean GeraLandingCopyStageService` no teste;
   - ajuste do cenário `shouldCreateCopyExecutionAndReturnCodeAndStatus` para mockar/verificar `copyStageService.start(...)` e `GeraLandingCopyStartResponse`.
 - impacto funcional: restaura a subida do contexto do teste MVC sem alterar contrato HTTP dos endpoints.
+
+## 2026-05-26 03:45:00 UTC
+- ajuste solicitado: criar `GeraLandingStartResponse` e `GeraLandingStageExecutionService` dentro do pacote `com.marketinghub.geralanding.wireframe.service`.
+- causa-raiz: necessidade de disponibilizar contrato e serviço locais no subpacote `wireframe.service` para reduzir acoplamento direto no ponto de uso.
+- correção aplicada:
+  - criação de `GeraLandingStartResponse` local em `geralanding.wireframe.service`;
+  - criação de `GeraLandingStageExecutionService` local em `geralanding.wireframe.service`, com adaptação de retorno para o contrato local.
+- impacto funcional: mantém a API interna de início da etapa wireframe com tipos locais no próprio subpacote.
+
+## 2026-05-26 03:50:00 UTC
+- ajuste solicitado: remover o uso de `com.marketinghub.geralanding.GeraLandingStartResponse` no serviço local de wireframe.
+- causa-raiz: implementação anterior fazia adaptação por delegação ao serviço/response do pacote raiz, contrariando a orientação de manter a lógica dentro do pacote local neste momento.
+- correção aplicada:
+  - substituição da lógica delegada por implementação direta de `registerInitialExecution(...)` em `geralanding.wireframe.service.GeraLandingStageExecutionService`;
+  - remoção do uso explícito de `com.marketinghub.geralanding.GeraLandingStartResponse` no fluxo local.
+- impacto funcional: o retorno do start continua no contrato local `GeraLandingStartResponse`, agora com lógica executada localmente no serviço da etapa wireframe.


### PR DESCRIPTION
### Motivation

- Provide a local service and contract in the `wireframe` subpackage to register the initial execution of the wireframe stage and reduce cross-package coupling.

### Description

- Add `com.marketinghub.geralanding.wireframe.service.GeraLandingStageExecutionService` which looks up an `Experiment` via `ExperimentRepository`, creates and persists a `GeraLandingStageExecution` via `GeraLandingStageExecutionRepository`, and returns a local response contract. 
- Add `com.marketinghub.geralanding.wireframe.service.GeraLandingStartResponse` as a simple record to represent the start response containing `idJob` and `status`.
- Implement helper methods `toDatabaseIdJob` and `fromDatabaseIdJob` for converting the textual UUID to/from the byte[] representation used by the persisted `idJob`, and use a fixed status constant `INICIADO` and a default `promptTemplateId`/`promptContent` for manual starts. 
- Update documentation at `docs/registros/experimentos.md` to record the architectural change and the addition of the local service/response.

### Testing

- Ran module unit tests for the ads-service module (`mvn -pl backend/ads-service test`), and they completed successfully.
- Existing web MVC tests that mock stage services were kept compatible after introducing the local `GeraLanding...Service` and `GeraLandingStartResponse` and passed in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151530d4a88321ae3119dea3f84fa8)