### PR TITLE
Add ArchUnit rule restricting geralanding service dependencies

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
@@ -26,6 +26,11 @@ class ModuleIsolationArchitectureTest {
     private static final String GERALANDING_COPY_PACKAGE = "com.marketinghub.geralanding.copy";
     private static final String GERALANDING_IMAGEPLANNING_PACKAGE = "com.marketinghub.geralanding.imageplanning";
     private static final String GERALANDING_PRESETDESIGN_PACKAGE = "com.marketinghub.geralanding.designpreset";
+    private static final String EXPERIMENT_CLASS = "com.marketinghub.experiment.Experiment";
+    private static final String EXPERIMENT_REPOSITORY_CLASS = "com.marketinghub.experiment.repository.ExperimentRepository";
+    private static final String GERALANDING_STAGE_EXECUTION_CLASS = "com.marketinghub.geralanding.GeraLandingStageExecution";
+    private static final String GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS =
+            "com.marketinghub.geralanding.GeraLandingStageExecutionRepository";
     private static final Pattern SALES_LIBRARY_LAYER_PATTERN = Pattern.compile(
             "^com\\.marketinghub\\.mois\\.bibliotecapaginavenda\\.([a-zA-Z0-9_]+)\\.(v\\d+)\\.(web|service|repository)(?:\\..*)?$");
 
@@ -85,6 +90,12 @@ class ModuleIsolationArchitectureTest {
             "[ARQUITETURA][BACKEND][GeraLandingDesignPresetStageService] o subpacote geralanding.designpreset deve ficar independente dos demais pacotes internos");
 
     @ArchTest
+    static final ArchRule geralandingServicePackagesShouldOnlyAccessAllowedMarketingHubClasses =
+            classes().that().resideInAPackage("com.marketinghub.geralanding..service..")
+                    .should(onlyDependOnAllowedMarketingHubClasses())
+                    .because("[ARQUITETURA][BACKEND][GeraLanding] serviços em geralanding.*.service só podem acessar classes permitidas dentro de com.marketinghub");
+
+    @ArchTest
     static final ArchRule moisSalesLibraryWebShouldOnlyDependOnServiceLayer =
             classes().that(classesBelongingToLayer("web")).should(onlyDependOnLayer("service"));
 
@@ -111,6 +122,38 @@ class ModuleIsolationArchitectureTest {
             public boolean test(JavaClass input) {
                 String packageName = input.getPackageName();
                 return packageName.startsWith("com.marketinghub") && !packageName.startsWith(allowedPackagePrefix);
+            }
+        };
+    }
+
+    /**
+     * Garante que serviços geralanding acessem apenas classes permitidas dentro de com.marketinghub.
+     */
+    private static ArchCondition<JavaClass> onlyDependOnAllowedMarketingHubClasses() {
+        return new ArchCondition<>("[ARQUITETURA][BACKEND][GeraLanding] depend only on explicit allowed classes") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                item.getDirectDependenciesFromSelf().forEach(dependency -> {
+                    JavaClass targetClass = dependency.getTargetClass();
+                    String targetName = targetClass.getName();
+                    if (!targetName.startsWith("com.marketinghub.")) {
+                        return;
+                    }
+                    if (targetName.equals(EXPERIMENT_CLASS)
+                            || targetName.equals(EXPERIMENT_REPOSITORY_CLASS)
+                            || targetName.equals(GERALANDING_STAGE_EXECUTION_CLASS)
+                            || targetName.equals(GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS)) {
+                        return;
+                    }
+                    String message = "[ARQUITETURA][BACKEND][GeraLanding] " + item.getName()
+                            + " depende de " + targetName
+                            + " mas serviços em geralanding.*.service só podem acessar "
+                            + EXPERIMENT_CLASS + ", "
+                            + EXPERIMENT_REPOSITORY_CLASS + ", "
+                            + GERALANDING_STAGE_EXECUTION_CLASS + " e "
+                            + GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS;
+                    events.add(SimpleConditionEvent.violated(item, message));
+                });
             }
         };
     }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1739,3 +1739,11 @@
   - substituição da lógica delegada por implementação direta de `registerInitialExecution(...)` em `geralanding.wireframe.service.GeraLandingStageExecutionService`;
   - remoção do uso explícito de `com.marketinghub.geralanding.GeraLandingStartResponse` no fluxo local.
 - impacto funcional: o retorno do start continua no contrato local `GeraLandingStartResponse`, agora com lógica executada localmente no serviço da etapa wireframe.
+
+## 2026-05-26 04:05:00 UTC
+- ajuste solicitado: adicionar regra de arquitetura no ArchUnit para restringir dependências de `geralanding.*.service`.
+- causa-raiz: ausência de guarda arquitetural explícita permitia que serviços do GeraLanding dependessem de classes internas fora da lista permitida.
+- correção aplicada:
+  - inclusão de regra `geralandingServicePackagesShouldOnlyAccessAllowedMarketingHubClasses` em `ModuleIsolationArchitectureTest`;
+  - lista de classes permitidas em `com.marketinghub`: `Experiment`, `ExperimentRepository`, `GeraLandingStageExecution`, `GeraLandingStageExecutionRepository`.
+- impacto funcional: prevenção automatizada de acoplamento indevido entre serviços `geralanding.*.service` e outros pacotes internos.


### PR DESCRIPTION
### Motivation
- Prevent unintended coupling by enforcing that classes in `com.marketinghub.geralanding..service..` only depend on a small, explicit set of internal domain types. 

### Description
- Added allowlist constants and a new ArchUnit test `geralandingServicePackagesShouldOnlyAccessAllowedMarketingHubClasses` in `backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java` to restrict dependencies. 
- Implemented the `onlyDependOnAllowedMarketingHubClasses()` `ArchCondition` which permits only `com.marketinghub.experiment.Experiment`, `com.marketinghub.experiment.repository.ExperimentRepository`, `com.marketinghub.geralanding.GeraLandingStageExecution` and `com.marketinghub.geralanding.GeraLandingStageExecutionRepository`. 
- Registered the change in `docs/registros/experimentos.md` to document the architectural guard. 

### Testing
- Ran `cd backend/ads-service && ../mvnw -Dtest=ModuleIsolationArchitectureTest test` and the test run executed but failed due to existing architectural violations in `geralanding` packages (tests run: 11, failures: 5). 
- A top-level attempt `cd backend && ./mvnw -pl ads-service -Dtest=ModuleIsolationArchitectureTest test` failed because the selected project was not found in that reactor context. 
- Conclusion: the new rule is in place and correctly detects disallowed dependencies, and current failures are pre-existing architecture violations that must be addressed separately; the change itself did not introduce compilation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151a8382988321af08b36375056e25)