### PR TITLE
Fix Spring bean name collision in GeraLanding stage execution service

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingStageExecutionService.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 /** Responsável por registrar execuções iniciais da etapa de wireframe. */
-@Service
+@Service("geraLandingWireframeStageExecutionService")
 public class GeraLandingStageExecutionService {
 
   private static final String STATUS_STARTED = "INICIADO";


### PR DESCRIPTION
### Motivation
- Prevent an `ApplicationContext` startup failure caused by two classes with the same simple name `GeraLandingStageExecutionService` being registered as Spring beans with the same default name.

### Description
- Assign an explicit bean name to the wireframe service by changing `@Service` to `@Service("geraLandingWireframeStageExecutionService")` in `backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingStageExecutionService.java` to avoid the naming conflict.

### Testing
- Ran the targeted controller tests with `mvn -Dtest=CampaignControllerTest,FacebookAccountControllerTest test` in `backend/ads-service`, and they passed (`Tests run: 13, Failures: 0, Errors: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151b590e088321975a38119eec7915)