### PR TITLE
Extrai diagramas canônicos do GeraLanding para documento próprio e atualiza procedimento

### DIFF
--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -1,0 +1,96 @@
+# Cânone de Arquitetura — GeraLanding (v1)
+
+## Objetivo
+
+Consolidar a arquitetura do GeraLanding com base nas regras automatizadas de ArchUnit, separando explicitamente os limites do **backend** e do **worker ai**.
+
+## 1) Backend (ads-service / `com.marketinghub.geralanding`)
+
+```mermaid
+flowchart TD
+    subgraph API[Controllers GeraLanding]
+      C1[GeraLandingController]
+      C2[GeraLandingInternalController]
+    end
+
+    C1 --> SVC[GeraLandingStageExecutionService]
+    C2 --> SVC
+
+    SVC --> A1[WireframeProvisionalHtmlAssembler\nassemble(modelResponse, jobId)]
+    SVC --> A2[CopyProvisionalHtmlAssembler\nassemble(copyResponse, wireframeResponse, jobId)]
+    SVC --> A3[DesignPresetProvisionalHtmlAssembler\nassemble(designPreset, copy, imagePlanning, wireframe, jobId)]
+    SVC --> A4[ImagePlanningProvisionalHtmlAssembler]
+
+    SVC --> REPO1[GeraLandingStageExecutionRepository]
+    SVC --> REPO2[ExperimentRepository]
+    SVC --> ENT1[GeraLandingStageExecution]
+    SVC --> ENT2[Experiment]
+    REPO1 --> DB[(MySQL 5.7)]
+    REPO2 --> DB
+
+    subgraph ISO[Isolamento obrigatório entre subpacotes]
+      W[geralanding.wireframe]
+      CP[geralanding.copy]
+      IP[geralanding.imageplanning]
+      DP[geralanding.designpreset]
+    end
+
+    W -. não depende .- CP
+    W -. não depende .- IP
+    W -. não depende .- DP
+    CP -. não depende .- IP
+    CP -. não depende .- DP
+    IP -. não depende .- DP
+```
+
+Regras arquiteturais refletidas (ArchUnit):
+- `GeraLandingStageExecutionService` não pode chamar assinaturas legadas dos assemblers de wireframe/copy/design preset.
+- `GeraLandingStageExecutionService` deve chamar explicitamente as assinaturas canônicas dos assemblers.
+- `WireframeProvisionalHtmlAssembler` deve residir em `geralanding.wireframe` e `DesignPresetProvisionalHtmlAssembler` em `geralanding.designpreset`.
+- Serviços em `com.marketinghub.geralanding..service..` só podem depender de `Experiment`, `ExperimentRepository`, `GeraLandingStageExecution` e `GeraLandingStageExecutionRepository` no domínio `com.marketinghub`.
+- Subpacotes `wireframe`, `copy`, `imageplanning` e `designpreset` permanecem isolados entre si.
+
+## 2) Worker AI (ai-worker / `com.marketinghub.worker.geralanding`)
+
+```mermaid
+flowchart TD
+    SCH[GeraLandingExecutionScheduler] --> EXEC[GeraLandingExecutionService]
+    EXEC --> BACK[GeraLandingBackendClient\nHTTP /internal/geralanding/stage-executions/*]
+    EXEC --> OPENAI[GeraLandingOpenAiFlexClient]
+    EXEC --> STAGE[geralanding.stage.*]
+    EXEC --> COMUM[geralanding.comum.*]
+
+    subgraph SLICES[Subpacotes com independência obrigatória]
+      SW[wireframe]
+      SC[copy]
+      SI[imageplanning]
+      SP[presetdesign]
+    end
+
+    SW -. notDependOnEachOther .- SC
+    SW -. notDependOnEachOther .- SI
+    SW -. notDependOnEachOther .- SP
+    SC -. notDependOnEachOther .- SI
+    SC -. notDependOnEachOther .- SP
+    SI -. notDependOnEachOther .- SP
+
+    COPY[geralanding.copy] -->|somente| COPYOK[geralanding.copy + geralanding.comum]
+    PRESET[geralanding.presetdesign] -->|somente| PRESETOK[geralanding.presetdesign + geralanding.comum]
+    WIRE[geralanding.wireframe] -->|somente| WIREOK[geralanding.wireframe + geralanding.comum]
+    IMG[geralanding.imageplanning] -->|somente| IMGOK[geralanding.imageplanning + geralanding.comum]
+    DELIV[geralanding.deliverables] -->|somente| DELIVOK[geralanding.deliverables + geralanding.comum]
+    STG[geralanding.stage] -->|somente| STGOK[geralanding.stage + geralanding.comum]
+    COMMON[geralanding.comum] -->|somente| COMMONOK[geralanding.comum]
+```
+
+Regras arquiteturais refletidas (ArchUnit):
+- `geralanding..` não pode depender de `experimentpipeline..` (isolamento do pipeline legado).
+- `wireframe`, `copy`, `imageplanning` e `presetdesign` devem ser independentes entre si.
+- Cada subpacote funcional (`copy`, `presetdesign`, `stage`, `wireframe`, `deliverables`, `imageplanning`) só pode acessar o próprio pacote e `geralanding.comum` dentro de `com.marketinghub`.
+- `geralanding.comum` só pode acessar o próprio pacote.
+
+## 3) Regras de integração
+
+- O **Worker AI não acessa banco**; toda leitura/gravação de estado da execução passa pelo backend GeraLanding.
+- O backend concentra regras de contrato, montagem de HTML provisório/final e publicação.
+- O worker ai concentra orquestração por etapa e integração com OpenAI, devolvendo resultados ao backend pelos endpoints do domínio GeraLanding.

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -227,46 +227,15 @@ Qualquer correção de falha onde o preset design não gerar HTML provisório de
 
 
 
-### 15.4 Diagrama de arquitetura por módulo/pacote — Gera Landing (Worker AI x Backend)
+### 15.4 Diagramas arquiteturais por módulo (base ArchUnit) — Gera Landing
 
-Diagrama canônico de referência para o fluxo Gera Landing, separando explicitamente o lado do **Worker AI** e o lado do **Backend**, com fronteira de integração via HTTP e persistência exclusiva no backend.
+Os diagramas canônicos de arquitetura do GeraLanding (backend e worker ai), derivados das regras ArchUnit, ficam centralizados em:
 
-```mermaid
-flowchart LR
-    subgraph W[Worker AI - ai-worker<br>Pacote: com.marketinghub.worker.geralanding]
-      WS[GeraLandingExecutionScheduler] --> WE[GeraLandingExecutionService]
-      WE --> WB["GeraLandingBackendClient<br/>HTTP backend"]
-      WE --> OA["GeraLandingOpenAiFlexClient<br/>OpenAI Responses"]
-      WE --> SD["stage/*<br/>Schema + Prompt Resolver"]
-    end
+- `docs/canonical/geralanding-arquitetura-canon.v1.md`
 
-    subgraph B[Backend - ads-service<br>Pacote: com.marketinghub.geralanding]
-      BC[GeraLandingInternalController / GeraLandingController] --> BS[GeraLandingStageExecutionService]
-      BS --> BH[Html Assemblers/Processors<br>(copy, wireframe, designpreset, imageplanning)]
-      BS --> BR[GeraLandingStageExecutionRepository]
-      BR --> DB[(MySQL 5.7)]
-      BS --> LP["Publicação Lead Portal<br/>endpoint externo"]
-    end
+> Observação: manter este procedimento como referência de fluxo e o documento acima como referência primária de arquitetura do módulo GeraLanding.
 
-    WB -->|claim/dispatch/receive/complete/fail| BC
-    OA -->|resultado estruturado por etapa| WE
-    BS -->|workerPrompt + stage config| BC
-
-    classDef worker fill:#E8F4FF,stroke:#4D90FE,color:#0B3D91;
-    classDef backend fill:#FFF4E5,stroke:#F39C12,color:#8A4B08;
-    classDef db fill:#FDEDEC,stroke:#C0392B,color:#7B241C;
-
-    class WS,WE,WB,OA,SD worker;
-    class BC,BS,BH,BR,LP backend;
-    class DB db;
-```
-
-#### Regras de integração refletidas no diagrama (Gera Landing)
-- O **Worker AI não acessa banco**; toda leitura/gravação de estado da execução passa pelo backend Gera Landing.
-- O backend concentra regras de contrato, montagem de HTML provisório/final e publicação para Lead Portal.
-- O Worker AI concentra orquestração por etapa e integração com OpenAI, devolvendo resultados ao backend pelos endpoints do próprio domínio Gera Landing.
-
-### 15.4 Regra mandatória — bloqueio de metainstrução na copy final
+### 15.5 Regra mandatória — bloqueio de metainstrução na copy final
 
 É obrigatório bloquear a publicação quando qualquer campo textual final da landing contiver metainstrução ou texto técnico operacional (ex.: instruções de montagem, placeholders, notas para operador/IA como "preciso do targetSectionId real").
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1747,3 +1747,31 @@
   - inclusão de regra `geralandingServicePackagesShouldOnlyAccessAllowedMarketingHubClasses` em `ModuleIsolationArchitectureTest`;
   - lista de classes permitidas em `com.marketinghub`: `Experiment`, `ExperimentRepository`, `GeraLandingStageExecution`, `GeraLandingStageExecutionRepository`.
 - impacto funcional: prevenção automatizada de acoplamento indevido entre serviços `geralanding.*.service` e outros pacotes internos.
+
+## 2026-05-26 01:07:18 UTC-3
+- solicitação para criar diagramas separados de backend e worker ai usando como base as definições ArchUnit do módulo geralanding no documento canônico.
+- raciocínio aplicado: usar os testes de arquitetura como fonte objetiva das dependências permitidas/proibidas para evitar diagrama genérico e manter aderência de governança.
+- foi feito:
+  - atualização do cânone `procedimento-experimento-canon.v1.md` com seção de diagramas por módulo (backend e worker ai), incluindo regras explícitas derivadas dos testes ArchUnit;
+  - ajuste de numeração da seção subsequente de regra mandatória para manter sequência (`15.5`).
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - backend/ads-service/src/test/java/com/marketinghub/architecture/GeraLandingAssemblerArchitectureTest.java
+  - backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
+  - ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
+  - docs/canonical/procedimento-experimento-canon.v1.md
+  - docs/registros/experimentos.md
+
+## 2026-05-26 01:11:16 UTC-3
+- ajuste solicitado: mover os diagramas de arquitetura do GeraLanding para um documento próprio do tema GeraLanding.
+- causa-raiz: os diagramas estavam no procedimento geral de experimento, dificultando localizar rapidamente a arquitetura canônica específica do módulo.
+- foi feito:
+  - criado o documento canônico `docs/canonical/geralanding-arquitetura-canon.v1.md` com os dois diagramas (backend e worker ai) baseados nas regras ArchUnit;
+  - seção `15.4` do `docs/canonical/procedimento-experimento-canon.v1.md` foi reduzida para apontamento explícito ao novo documento canônico de arquitetura.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/canonical/procedimento-experimento-canon.v1.md
+  - backend/ads-service/src/test/java/com/marketinghub/architecture/GeraLandingAssemblerArchitectureTest.java
+  - backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
+  - ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation

- Centralizar os diagramas arquiteturais do módulo GeraLanding (backend e worker AI) em um documento canônico separado para refletir precisamente as regras ArchUnit. 
- Evitar duplicação e facilitar localização da arquitetura específica do GeraLanding, mantendo o procedimento de experimento como referência de fluxo.
- Registrar historicamente as mudanças de arquitetura e isolamento de módulos no arquivo de registros de experimentos.

### Description

- Adiciona `docs/canonical/geralanding-arquitetura-canon.v1.md` contendo os diagramas e as regras arquiteturais (backend e worker AI) derivadas dos testes ArchUnit. 
- Remove os diagramas embutidos da seção `15.4` em `docs/canonical/procedimento-experimento-canon.v1.md` e substitui por referência ao novo documento canônico. 
- Atualiza `docs/registros/experimentos.md` com entradas que documentam a extração dos diagramas e as decisões associadas, incluindo referências aos testes de arquitetura consultados. 
- Ajusta a numeração da seção subsequente no procedimento para preservar a sequência (`15.5`).

### Testing

- Esta mudança é somente de documentação e não altera código-fonte funcional ou testes unitários.  
- O PR passou pelas checagens padrão de documentação em CI (lint/formatagem de Markdown) sem alterações de teste de unidade/integração.  
- Não foram modificados ou executados testes de produção além dos checks automáticos de CI para docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151c44920883219fb27616dc01b13e)