### PR TITLE
GeraLandingWireframeStageService: use local wireframe types

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
@@ -1,7 +1,5 @@
 package com.marketinghub.geralanding.wireframe.service;
 
-import com.marketinghub.geralanding.GeraLandingStartResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar a execução da etapa de wireframe do GeraLanding. */

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1775,3 +1775,5 @@
   - backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
   - ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java
   - docs/registros/experimentos.md
+
+- 2026-05-26: Ajustado `GeraLandingWireframeStageService` para usar as cópias locais de service/response no pacote `geralanding.wireframe.service`, removendo dependência direta de `com.marketinghub.geralanding.GeraLandingStageExecutionService` e `GeraLandingStartResponse`.


### PR DESCRIPTION
### Motivation
- Decouple the wireframe stage service from the broader `com.marketinghub.geralanding` package by using local copies of the service/response types in `geralanding.wireframe.service`.

### Description
- Removed imports of `com.marketinghub.geralanding.GeraLandingStartResponse` and `com.marketinghub.geralanding.GeraLandingStageExecutionService` so the class uses the local `GeraLandingStageExecutionService` and the package-local `GeraLandingWireframeStartResponse` instead.

### Testing
- Ran the backend ads-service unit tests via `./gradlew :backend:ads-service:test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151e30e870832185b810cb9dc36c08)