### PR TITLE
Rename GeraLanding stage classes to wireframe-specific names and update usages

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
@@ -13,13 +13,13 @@ import java.util.UUID;
 
 /** Responsável por registrar execuções iniciais da etapa de wireframe. */
 @Service("geraLandingWireframeStageExecutionService")
-public class GeraLandingStageExecutionService {
+public class GeraLandingWireframeStageExecutionService {
 
   private static final String STATUS_STARTED = "INICIADO";
   private final ExperimentRepository experimentRepository;
   private final GeraLandingStageExecutionRepository executionRepository;
 
-  public GeraLandingStageExecutionService(
+  public GeraLandingWireframeStageExecutionService(
       ExperimentRepository experimentRepository,
       GeraLandingStageExecutionRepository executionRepository) {
     this.experimentRepository = experimentRepository;
@@ -28,7 +28,7 @@ public class GeraLandingStageExecutionService {
 
   /** Registra a execução inicial da etapa e retorna o contrato local para o módulo wireframe. */
   @Transactional
-  public GeraLandingStartResponse registerInitialExecution(Long experimentId, String stageName) {
+  public GeraLandingWireframeStartExecutionResponse registerInitialExecution(Long experimentId, String stageName) {
     Instant now = Instant.now();
     Experiment experiment =
         experimentRepository
@@ -49,7 +49,7 @@ public class GeraLandingStageExecutionService {
             .build();
 
     GeraLandingStageExecution saved = executionRepository.save(execution);
-    return new GeraLandingStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    return new GeraLandingWireframeStartExecutionResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
   }
 
   /** Converte o identificador textual para formato binário persistido no banco. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
@@ -6,15 +6,15 @@ import org.springframework.stereotype.Service;
 @Service
 public class GeraLandingWireframeStageService {
   private static final String STAGE_NAME = "landing-page-wireframe";
-  private final GeraLandingStageExecutionService executionService;
+  private final GeraLandingWireframeStageExecutionService executionService;
 
-  public GeraLandingWireframeStageService(GeraLandingStageExecutionService executionService) {
+  public GeraLandingWireframeStageService(GeraLandingWireframeStageExecutionService executionService) {
     this.executionService = executionService;
   }
 
   /** Inicia a execução da etapa de wireframe para o experimento informado. */
   public GeraLandingWireframeStartResponse start(Long experimentId) {
-    GeraLandingStartResponse response = executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    GeraLandingWireframeStartExecutionResponse response = executionService.registerInitialExecution(experimentId, STAGE_NAME);
     return new GeraLandingWireframeStartResponse(response.idJob(), response.status());
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStartExecutionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStartExecutionResponse.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.wireframe.service;
 
 /** Responsável por representar o retorno inicial da execução da etapa de wireframe. */
-public record GeraLandingStartResponse(
+public record GeraLandingWireframeStartExecutionResponse(
         String idJob,
         String status) {
 }


### PR DESCRIPTION
### Motivation

- Clarify and scope types to the wireframe stage by replacing generic `GeraLandingStageExecutionService` and `GeraLandingStartResponse` names with wireframe-specific names to reduce ambiguity and improve readability.

### Description

- Renamed `GeraLandingStageExecutionService` to `GeraLandingWireframeStageExecutionService` and updated the constructor and filename accordingly.
- Renamed response record `GeraLandingStartResponse` to `GeraLandingWireframeStartExecutionResponse` and updated its file and usages.
- Updated `GeraLandingWireframeStageService` to use the new `GeraLandingWireframeStageExecutionService` type and to consume/return the renamed response type in `start`.
- Preserved existing behavior for job id encoding/decoding and execution creation while only changing type and filename identifiers.

### Testing

- Ran the project unit tests with `./mvnw test` and the test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a156827ed388321add8350c44f85d5b)