### PR TITLE
Improve ArchUnit failure messages with violating class and import details

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java
@@ -145,9 +145,10 @@ class ModuleIsolationArchitectureTest {
                             || targetName.equals(GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS)) {
                         return;
                     }
-                    String message = "[ARQUITETURA][BACKEND][GeraLanding] " + item.getName()
-                            + " depende de " + targetName
-                            + " mas serviços em geralanding.*.service só podem acessar "
+                    String message = "[ARQUITETURA] [BACKEND][GeraLanding] classe " + item.getName()
+                            + " possui import/dependência violadora: " + dependency.getDescription()
+                            + " (alvo: " + targetName + ")"
+                            + " | regra: serviços em geralanding.*.service só podem acessar "
                             + EXPERIMENT_CLASS + ", "
                             + EXPERIMENT_REPOSITORY_CLASS + ", "
                             + GERALANDING_STAGE_EXECUTION_CLASS + " e "
@@ -194,8 +195,10 @@ class ModuleIsolationArchitectureTest {
                     boolean allowedLayer = targetInfo.get().layer().equals(allowedTargetLayer)
                             || targetInfo.get().layer().equals(sourceInfo.get().layer());
                     if (!sameNamespace || !allowedLayer) {
-                        String message = "[ARQUITETURA][MOIS] " + item.getName() + " depende de " + dependency.getTargetClass().getName()
-                                + " mas só pode depender de pacote ." + allowedTargetLayer
+                        String message = "[ARQUITETURA] [MOIS] classe " + item.getName()
+                                + " possui import/dependência violadora: " + dependency.getDescription()
+                                + " (alvo: " + dependency.getTargetClass().getName() + ")"
+                                + " | regra: só pode depender de pacote ." + allowedTargetLayer
                                 + " com mesmo x/vN";
                         events.add(SimpleConditionEvent.violated(item, message));
                     }


### PR DESCRIPTION
### Motivation
- Make architecture test failures immediately actionable by exposing which source class and which specific import/dependency triggered the ArchUnit violation.

### Description
- Updated `ModuleIsolationArchitectureTest` custom `ArchCondition` messages to include the source class (`item.getName()`), the dependency description (`dependency.getDescription()`), and the resolved target class name (`dependency.getTargetClass().getName()`).
- Kept the mandated message prefix `[ARQUITETURA]` to comply with the project's ArchUnit message conventions.
- Change location: `backend/ads-service/src/test/java/com/marketinghub/architecture/ModuleIsolationArchitectureTest.java`.

### Testing
- Ran `./mvnw -pl ads-service -Dtest=ModuleIsolationArchitectureTest test`, which failed due to incorrect project selection in the reactor (project selection issue).
- Ran `cd backend/ads-service && ../mvnw -Dtest=ModuleIsolationArchitectureTest test`, which compiled and executed the modified test but the suite reported existing architecture violations (5 failing rules); the updated messages were produced by the running ArchUnit checks.
- Result: change compiles and ArchUnit checks run, and failure output now contains richer diagnostics to locate the violating class and import.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a156eea75a88321a41ab5d842c391ae)