### PR TITLE
Fix Mermaid parsing in GeraLanding architecture canon

### DIFF
--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -16,9 +16,9 @@ flowchart TD
     C1 --> SVC[GeraLandingStageExecutionService]
     C2 --> SVC
 
-    SVC --> A1[WireframeProvisionalHtmlAssembler\nassemble(modelResponse, jobId)]
-    SVC --> A2[CopyProvisionalHtmlAssembler\nassemble(copyResponse, wireframeResponse, jobId)]
-    SVC --> A3[DesignPresetProvisionalHtmlAssembler\nassemble(designPreset, copy, imagePlanning, wireframe, jobId)]
+    SVC --> A1[WireframeProvisionalHtmlAssembler<br/>assemble(modelResponse, jobId)]
+    SVC --> A2[CopyProvisionalHtmlAssembler<br/>assemble(copyResponse, wireframeResponse, jobId)]
+    SVC --> A3[DesignPresetProvisionalHtmlAssembler<br/>assemble(designPreset, copy, imagePlanning, wireframe, jobId)]
     SVC --> A4[ImagePlanningProvisionalHtmlAssembler]
 
     SVC --> REPO1[GeraLandingStageExecutionRepository]
@@ -55,7 +55,7 @@ Regras arquiteturais refletidas (ArchUnit):
 ```mermaid
 flowchart TD
     SCH[GeraLandingExecutionScheduler] --> EXEC[GeraLandingExecutionService]
-    EXEC --> BACK[GeraLandingBackendClient\nHTTP /internal/geralanding/stage-executions/*]
+    EXEC --> BACK[GeraLandingBackendClient<br/>HTTP /internal/geralanding/stage-executions/*]
     EXEC --> OPENAI[GeraLandingOpenAiFlexClient]
     EXEC --> STAGE[geralanding.stage.*]
     EXEC --> COMUM[geralanding.comum.*]


### PR DESCRIPTION
### Motivation
- Resolve a GitHub Mermaid render error caused by literal `\n` line breaks inside node labels so the architecture diagrams display correctly.

### Description
- Replaced embedded `\n` line breaks with HTML `<br/>` in the affected Mermaid node labels in `docs/canonical/geralanding-arquitetura-canon.v1.md`, covering the backend assemblers and the backend client label in the worker AI section.

### Testing
- Validated the edit with `rg --line-number "Backend Ads Service|assemble\\(modelResponse" docs/canonical/geralanding-arquitetura-canon.v1.md`, `sed -n '1,80p' docs/canonical/geralanding-arquitetura-canon.v1.md`, and `nl -ba docs/canonical/geralanding-arquitetura-canon.v1.md | sed -n '12,70p'`, which show the updated labels as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c1c4cd7c8321b735c2d52e763c8c)