### PR TITLE
Change Hotmart first-cycle schedule from 00:15 to 13:38

### DIFF
--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -34,9 +34,9 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos diariamente às 00:15.
+     * Executa o ciclo 1 de listagem de produtos diariamente às 13:38.
      */
-    @Scheduled(cron = "0 15 0 * * *")
+    @Scheduled(cron = "0 38 13 * * *")
     public void collectFirstCycleAtTen() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
@@ -44,7 +44,7 @@ public class HotmartCollectorScheduler {
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=00:15 ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=13:38 ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),
                 response.products().size(),


### PR DESCRIPTION
### Motivation
- Adjust the scheduled execution time for the Hotmart collector first cycle from midnight to early afternoon to match the new collection window.

### Description
- Updated the cron expression for `collectFirstCycleAtTen` from `0 15 0 * * *` to `0 38 13 * * *`, and updated the method javadoc and log message to reflect execution at 13:38 while leaving request construction and service invocation unchanged.

### Testing
- Ran the project unit tests with `./mvnw test` and the existing automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151cdd49648321aa90e500ff916496)