### PR TITLE
Refactor GeraLanding stage execution flows and unify start responses/packages

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionService.java
@@ -28,28 +28,25 @@ public class GeraLandingCopyStageExecutionService {
 
   /** Registra a execução inicial da etapa e devolve os dados para acompanhamento. */
   @Transactional
-  public GeraLandingCopyStartResponse registerInitialExecution(Long experimentId, String stageCode) {
+  public GeraLandingStageExecution registerInitialExecution(Long experimentId, String stageCode) {
     Instant now = Instant.now();
     Experiment experiment =
         experimentRepository
             .findById(experimentId)
             .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
 
-    GeraLandingStageExecution execution =
-        GeraLandingStageExecution.builder()
-            .experimentId(experiment.getId())
-            .experiment(experiment)
-            .stageCode(stageCode)
-            .executionRequestedAt(now)
-            .createdAt(now)
-            .promptTemplateId("manual/start")
-            .promptContent("Início manual via interface do experimento.")
-            .status(STATUS_STARTED)
-            .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
-            .build();
+    GeraLandingStageExecution execution = new GeraLandingStageExecution();
+    execution.setExperimentId(experiment.getId());
+    execution.setExperiment(experiment);
+    execution.setStageCode(stageCode);
+    execution.setExecutionRequestedAt(now);
+    execution.setCreatedAt(now);
+    execution.setPromptTemplateId("manual/start");
+    execution.setPromptContent("Início manual via interface do experimento.");
+    execution.setStatus(STATUS_STARTED);
+    execution.setIdJob(toDatabaseIdJob(UUID.randomUUID().toString()));
 
-    GeraLandingStageExecution saved = executionRepository.save(execution);
-    return new GeraLandingCopyStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    return executionRepository.save(execution);
   }
 
   /** Remove prefixo interno de jobId antes de expor o valor para os clientes. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageService.java
@@ -1,5 +1,7 @@
-package com.marketinghub.geralanding.copy.service;
+package com.marketinghub.geralanding.copy;
 
+import com.marketinghub.geralanding.copy.service.GeraLandingCopyStageExecutionService;
+import java.nio.charset.StandardCharsets;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar a execução da etapa de copy do GeraLanding. */
@@ -14,6 +16,13 @@ public class GeraLandingCopyStageService {
 
   /** Inicia a execução da etapa de copy para o experimento informado. */
   public GeraLandingCopyStartResponse start(Long experimentId) {
-    return executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    var execution = executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    return new GeraLandingCopyStartResponse(fromDatabaseIdJob(execution.getIdJob()), execution.getStatus());
+  }
+
+
+  /** Converte o id do formato persistido para o formato textual da API. */
+  private String fromDatabaseIdJob(byte[] idJob) {
+    return new String(idJob, StandardCharsets.UTF_8);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStartResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.copy.service;
+package com.marketinghub.geralanding.copy;
 
 /** Representa a resposta de início da etapa de copy do GeraLanding. */
 public record GeraLandingCopyStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.copy.web;
 
-import com.marketinghub.geralanding.copy.service.GeraLandingCopyStageService;
-import com.marketinghub.geralanding.copy.service.GeraLandingCopyStartResponse;
+import com.marketinghub.geralanding.copy.GeraLandingCopyStageService;
+import com.marketinghub.geralanding.copy.GeraLandingCopyStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageExecutionService.java
@@ -28,28 +28,25 @@ public class GeraLandingDeliverablesStageExecutionService {
 
   /** Registra a execução inicial da etapa e devolve os dados para acompanhamento. */
   @Transactional
-  public GeraLandingDeliverablesStartResponse registerInitialExecution(Long experimentId, String stageCode) {
+  public GeraLandingStageExecution registerInitialExecution(Long experimentId, String stageCode) {
     Instant now = Instant.now();
     Experiment experiment =
         experimentRepository
             .findById(experimentId)
             .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
 
-    GeraLandingStageExecution execution =
-        GeraLandingStageExecution.builder()
-            .experimentId(experiment.getId())
-            .experiment(experiment)
-            .stageCode(stageCode)
-            .executionRequestedAt(now)
-            .createdAt(now)
-            .promptTemplateId("manual/start")
-            .promptContent("Início manual via interface do experimento.")
-            .status(STATUS_STARTED)
-            .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
-            .build();
+    GeraLandingStageExecution execution = new GeraLandingStageExecution();
+    execution.setExperimentId(experiment.getId());
+    execution.setExperiment(experiment);
+    execution.setStageCode(stageCode);
+    execution.setExecutionRequestedAt(now);
+    execution.setCreatedAt(now);
+    execution.setPromptTemplateId("manual/start");
+    execution.setPromptContent("Início manual via interface do experimento.");
+    execution.setStatus(STATUS_STARTED);
+    execution.setIdJob(toDatabaseIdJob(UUID.randomUUID().toString()));
 
-    GeraLandingStageExecution saved = executionRepository.save(execution);
-    return new GeraLandingDeliverablesStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    return executionRepository.save(execution);
   }
 
   /** Remove prefixo interno de jobId antes de expor o valor para os clientes. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageService.java
@@ -1,5 +1,7 @@
-package com.marketinghub.geralanding.deliverables.service;
+package com.marketinghub.geralanding.deliverables;
 
+import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStageExecutionService;
+import java.nio.charset.StandardCharsets;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar execuções da etapa landing-page-deliverables. */
@@ -15,6 +17,13 @@ public class GeraLandingDeliverablesStageService {
 
   /** Registra a execução inicial da etapa e retorna identificadores para acompanhamento. */
   public GeraLandingDeliverablesStartResponse start(Long experimentId) {
-    return executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    var execution = executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    return new GeraLandingDeliverablesStartResponse(fromDatabaseIdJob(execution.getIdJob()), execution.getStatus());
+  }
+
+
+  /** Converte o id do formato persistido para o formato textual da API. */
+  private String fromDatabaseIdJob(byte[] idJob) {
+    return new String(idJob, StandardCharsets.UTF_8);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStartResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.deliverables.service;
+package com.marketinghub.geralanding.deliverables;
 
 /** Resposta de início da etapa landing-page-deliverables. */
 public record GeraLandingDeliverablesStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.deliverables.web;
 
-import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStageService;
-import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStartResponse;
+import com.marketinghub.geralanding.deliverables.GeraLandingDeliverablesStageService;
+import com.marketinghub.geralanding.deliverables.GeraLandingDeliverablesStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageExecutionService.java
@@ -28,28 +28,25 @@ public class GeraLandingDesignPresetStageExecutionService {
 
   /** Registra a execução inicial da etapa e devolve os dados para acompanhamento. */
   @Transactional
-  public GeraLandingDesignPresetStartResponse registerInitialExecution(Long experimentId, String stageCode) {
+  public GeraLandingStageExecution registerInitialExecution(Long experimentId, String stageCode) {
     Instant now = Instant.now();
     Experiment experiment =
         experimentRepository
             .findById(experimentId)
             .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
 
-    GeraLandingStageExecution execution =
-        GeraLandingStageExecution.builder()
-            .experimentId(experiment.getId())
-            .experiment(experiment)
-            .stageCode(stageCode)
-            .executionRequestedAt(now)
-            .createdAt(now)
-            .promptTemplateId("manual/start")
-            .promptContent("Início manual via interface do experimento.")
-            .status(STATUS_STARTED)
-            .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
-            .build();
+    GeraLandingStageExecution execution = new GeraLandingStageExecution();
+    execution.setExperimentId(experiment.getId());
+    execution.setExperiment(experiment);
+    execution.setStageCode(stageCode);
+    execution.setExecutionRequestedAt(now);
+    execution.setCreatedAt(now);
+    execution.setPromptTemplateId("manual/start");
+    execution.setPromptContent("Início manual via interface do experimento.");
+    execution.setStatus(STATUS_STARTED);
+    execution.setIdJob(toDatabaseIdJob(UUID.randomUUID().toString()));
 
-    GeraLandingStageExecution saved = executionRepository.save(execution);
-    return new GeraLandingDesignPresetStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    return executionRepository.save(execution);
   }
 
   /** Remove prefixo interno de jobId antes de expor o valor para os clientes. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageService.java
@@ -1,5 +1,7 @@
-package com.marketinghub.geralanding.designpreset.service;
+package com.marketinghub.geralanding.designpreset;
 
+import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStageExecutionService;
+import java.nio.charset.StandardCharsets;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar a execução da etapa de design preset do GeraLanding. */
@@ -14,6 +16,13 @@ public class GeraLandingDesignPresetStageService {
 
   /** Inicia a execução da etapa de design preset para o experimento informado. */
   public GeraLandingDesignPresetStartResponse start(Long experimentId) {
-    return executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    var execution = executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    return new GeraLandingDesignPresetStartResponse(fromDatabaseIdJob(execution.getIdJob()), execution.getStatus());
+  }
+
+
+  /** Converte o id do formato persistido para o formato textual da API. */
+  private String fromDatabaseIdJob(byte[] idJob) {
+    return new String(idJob, StandardCharsets.UTF_8);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStartResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.designpreset.service;
+package com.marketinghub.geralanding.designpreset;
 
 /** Representa a resposta de início da etapa de design preset do GeraLanding. */
 public record GeraLandingDesignPresetStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.designpreset.web;
 
-import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStageService;
-import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStartResponse;
+import com.marketinghub.geralanding.designpreset.GeraLandingDesignPresetStageService;
+import com.marketinghub.geralanding.designpreset.GeraLandingDesignPresetStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageExecutionService.java
@@ -28,28 +28,25 @@ public class GeraLandingImagePlanningStageExecutionService {
 
   /** Registra a execução inicial da etapa e devolve os dados para acompanhamento. */
   @Transactional
-  public GeraLandingImagePlanningStartResponse registerInitialExecution(Long experimentId, String stageCode) {
+  public GeraLandingStageExecution registerInitialExecution(Long experimentId, String stageCode) {
     Instant now = Instant.now();
     Experiment experiment =
         experimentRepository
             .findById(experimentId)
             .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
 
-    GeraLandingStageExecution execution =
-        GeraLandingStageExecution.builder()
-            .experimentId(experiment.getId())
-            .experiment(experiment)
-            .stageCode(stageCode)
-            .executionRequestedAt(now)
-            .createdAt(now)
-            .promptTemplateId("manual/start")
-            .promptContent("Início manual via interface do experimento.")
-            .status(STATUS_STARTED)
-            .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
-            .build();
+    GeraLandingStageExecution execution = new GeraLandingStageExecution();
+    execution.setExperimentId(experiment.getId());
+    execution.setExperiment(experiment);
+    execution.setStageCode(stageCode);
+    execution.setExecutionRequestedAt(now);
+    execution.setCreatedAt(now);
+    execution.setPromptTemplateId("manual/start");
+    execution.setPromptContent("Início manual via interface do experimento.");
+    execution.setStatus(STATUS_STARTED);
+    execution.setIdJob(toDatabaseIdJob(UUID.randomUUID().toString()));
 
-    GeraLandingStageExecution saved = executionRepository.save(execution);
-    return new GeraLandingImagePlanningStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    return executionRepository.save(execution);
   }
 
   /** Remove prefixo interno de jobId antes de expor o valor para os clientes. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageService.java
@@ -1,5 +1,7 @@
-package com.marketinghub.geralanding.imageplanning.service;
+package com.marketinghub.geralanding.imageplanning;
 
+import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStageExecutionService;
+import java.nio.charset.StandardCharsets;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar a execução da etapa de planejamento de imagens do GeraLanding. */
@@ -14,6 +16,13 @@ public class GeraLandingImagePlanningStageService {
 
   /** Inicia a execução da etapa de planejamento de imagens para o experimento informado. */
   public GeraLandingImagePlanningStartResponse start(Long experimentId) {
-    return executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    var execution = executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    return new GeraLandingImagePlanningStartResponse(fromDatabaseIdJob(execution.getIdJob()), execution.getStatus());
+  }
+
+
+  /** Converte o id do formato persistido para o formato textual da API. */
+  private String fromDatabaseIdJob(byte[] idJob) {
+    return new String(idJob, StandardCharsets.UTF_8);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStartResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.imageplanning.service;
+package com.marketinghub.geralanding.imageplanning;
 
 /** Representa a resposta de início da etapa de planejamento de imagens do GeraLanding. */
 public record GeraLandingImagePlanningStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.imageplanning.web;
 
-import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStageService;
-import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStartResponse;
+import com.marketinghub.geralanding.imageplanning.GeraLandingImagePlanningStageService;
+import com.marketinghub.geralanding.imageplanning.GeraLandingImagePlanningStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
@@ -29,28 +29,25 @@ public class GeraLandingWireframeStageExecutionService {
 
   /** Registra a execução inicial da etapa e retorna o contrato local para o módulo wireframe. */
   @Transactional
-  public GeraLandingWireframeStartExecutionResponse registerInitialExecution(Long experimentId, String stageName) {
+  public GeraLandingStageExecution registerInitialExecution(Long experimentId, String stageName) {
     Instant now = Instant.now();
     Experiment experiment =
         experimentRepository
             .findById(experimentId)
             .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
 
-    GeraLandingStageExecution execution =
-        GeraLandingStageExecution.builder()
-            .experimentId(experiment.getId())
-            .experiment(experiment)
-            .stageCode(stageName)
-            .executionRequestedAt(now)
-            .createdAt(now)
-            .promptTemplateId("manual/start")
-            .promptContent("Início manual via interface do experimento.")
-            .status(STATUS_STARTED)
-            .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
-            .build();
+    GeraLandingStageExecution execution = new GeraLandingStageExecution();
+    execution.setExperimentId(experiment.getId());
+    execution.setExperiment(experiment);
+    execution.setStageCode(stageName);
+    execution.setExecutionRequestedAt(now);
+    execution.setCreatedAt(now);
+    execution.setPromptTemplateId("manual/start");
+    execution.setPromptContent("Início manual via interface do experimento.");
+    execution.setStatus(STATUS_STARTED);
+    execution.setIdJob(toDatabaseIdJob(UUID.randomUUID().toString()));
 
-    GeraLandingStageExecution saved = executionRepository.save(execution);
-    return new GeraLandingWireframeStartExecutionResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    return executionRepository.save(execution);
   }
 
   /** Converte o identificador textual para formato binário persistido no banco. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
@@ -1,5 +1,7 @@
-package com.marketinghub.geralanding.wireframe.service;
+package com.marketinghub.geralanding.wireframe;
 
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionService;
+import java.nio.charset.StandardCharsets;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar a execução da etapa de wireframe do GeraLanding. */
@@ -14,7 +16,13 @@ public class GeraLandingWireframeStageService {
 
   /** Inicia a execução da etapa de wireframe para o experimento informado. */
   public GeraLandingWireframeStartResponse start(Long experimentId) {
-    GeraLandingWireframeStartExecutionResponse response = executionService.registerInitialExecution(experimentId, STAGE_NAME);
-    return new GeraLandingWireframeStartResponse(response.idJob(), response.status());
+    var execution = executionService.registerInitialExecution(experimentId, STAGE_NAME);
+    return new GeraLandingWireframeStartResponse(fromDatabaseIdJob(execution.getIdJob()), execution.getStatus());
+  }
+
+
+  /** Converte o id do formato persistido para o formato textual da API. */
+  private String fromDatabaseIdJob(byte[] idJob) {
+    return new String(idJob, StandardCharsets.UTF_8);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStartExecutionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStartExecutionResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.wireframe.service;
+package com.marketinghub.geralanding.wireframe;
 
 /** Responsável por representar o retorno inicial da execução da etapa de wireframe. */
 public record GeraLandingWireframeStartExecutionResponse(

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStartResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.wireframe.service;
+package com.marketinghub.geralanding.wireframe;
 
 /** Representa a resposta de início da etapa de wireframe do GeraLanding. */
 public record GeraLandingWireframeStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.wireframe.web;
 
-import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
-import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
+import com.marketinghub.geralanding.wireframe.GeraLandingWireframeStageService;
+import com.marketinghub.geralanding.wireframe.GeraLandingWireframeStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;


### PR DESCRIPTION
### Motivation
- Simplify stage execution APIs by returning the persisted `GeraLandingStageExecution` entity from execution services so callers can compose start responses centrally.
- Standardize identifier encoding/decoding between services and controllers and reduce duplicated builder code across multiple stage implementations.
- Reorganize small DTO/service classes into their feature packages to align package structure with runtime usage.

### Description
- Changed several `*StageExecutionService.registerInitialExecution` methods to return `GeraLandingStageExecution` instead of feature-specific start response types and replaced builder usage with a mutable `GeraLandingStageExecution` instance that is saved and returned.
- Updated stage services (e.g., `GeraLandingCopyStageService`, `GeraLandingDeliverablesStageService`, `GeraLandingDesignPresetStageService`, `GeraLandingImagePlanningStageService`, `GeraLandingWireframeStageService`) to call the new execution service return value and build their `*StartResponse` objects from the returned entity using a local `fromDatabaseIdJob` helper that decodes `byte[]` to `String`.
- Moved several small types and service classes out of `.service` subpackages into feature root packages (for example `com.marketinghub.geralanding.copy`, `com.marketinghub.geralanding.deliverables`, etc.) and adjusted imports across controllers and services accordingly.
- Kept the low-level `toDatabaseIdJob` implementation in execution services (encoding to `byte[]`) and removed the older intermediate response types from execution services where applicable.

### Testing
- Project build and the test suite were executed with `mvn -DskipTests=false test` and completed successfully with all unit tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d2ea4df48321a272d4a6252fc787)