### PR TITLE
Move stage services and start-response records into .service packages and update controller imports

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageService.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.copy;
+package com.marketinghub.geralanding.copy.service;
 
 import com.marketinghub.geralanding.copy.service.GeraLandingCopyStageExecutionService;
 import java.nio.charset.StandardCharsets;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStartResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.copy;
+package com.marketinghub.geralanding.copy.service;
 
 /** Representa a resposta de início da etapa de copy do GeraLanding. */
 public record GeraLandingCopyStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.copy.web;
 
-import com.marketinghub.geralanding.copy.GeraLandingCopyStageService;
-import com.marketinghub.geralanding.copy.GeraLandingCopyStartResponse;
+import com.marketinghub.geralanding.copy.service.GeraLandingCopyStageService;
+import com.marketinghub.geralanding.copy.service.GeraLandingCopyStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageService.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.deliverables;
+package com.marketinghub.geralanding.deliverables.service;
 
 import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStageExecutionService;
 import java.nio.charset.StandardCharsets;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStartResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.deliverables;
+package com.marketinghub.geralanding.deliverables.service;
 
 /** Resposta de início da etapa landing-page-deliverables. */
 public record GeraLandingDeliverablesStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.deliverables.web;
 
-import com.marketinghub.geralanding.deliverables.GeraLandingDeliverablesStageService;
-import com.marketinghub.geralanding.deliverables.GeraLandingDeliverablesStartResponse;
+import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStageService;
+import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageService.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.designpreset;
+package com.marketinghub.geralanding.designpreset.service;
 
 import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStageExecutionService;
 import java.nio.charset.StandardCharsets;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStartResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.designpreset;
+package com.marketinghub.geralanding.designpreset.service;
 
 /** Representa a resposta de início da etapa de design preset do GeraLanding. */
 public record GeraLandingDesignPresetStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.designpreset.web;
 
-import com.marketinghub.geralanding.designpreset.GeraLandingDesignPresetStageService;
-import com.marketinghub.geralanding.designpreset.GeraLandingDesignPresetStartResponse;
+import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStageService;
+import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageService.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.imageplanning;
+package com.marketinghub.geralanding.imageplanning.service;
 
 import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStageExecutionService;
 import java.nio.charset.StandardCharsets;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStartResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.imageplanning;
+package com.marketinghub.geralanding.imageplanning.service;
 
 /** Representa a resposta de início da etapa de planejamento de imagens do GeraLanding. */
 public record GeraLandingImagePlanningStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.imageplanning.web;
 
-import com.marketinghub.geralanding.imageplanning.GeraLandingImagePlanningStageService;
-import com.marketinghub.geralanding.imageplanning.GeraLandingImagePlanningStartResponse;
+import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStageService;
+import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.wireframe;
+package com.marketinghub.geralanding.wireframe.service;
 
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionService;
 import java.nio.charset.StandardCharsets;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStartResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.wireframe;
+package com.marketinghub.geralanding.wireframe.service;
 
 /** Representa a resposta de início da etapa de wireframe do GeraLanding. */
 public record GeraLandingWireframeStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.wireframe.web;
 
-import com.marketinghub.geralanding.wireframe.GeraLandingWireframeStageService;
-import com.marketinghub.geralanding.wireframe.GeraLandingWireframeStartResponse;
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;


### PR DESCRIPTION
### Motivation
- Organize stage-related service classes and response records under a dedicated `.service` package to improve package structure and clarity.

### Description
- Changed package declarations for multiple stage service classes and their start-response records from `com.marketinghub.geralanding.<stage>` to `com.marketinghub.geralanding.<stage>.service` for the following areas: `copy`, `deliverables`, `designpreset`, `imageplanning`, and `wireframe`.
- Updated controller imports to reference the relocated classes under the new `.service` packages.
- Kept existing behavior: services still call `registerInitialExecution` and convert `idJob` bytes to `String` using `StandardCharsets.UTF_8`.

### Testing
- Built the project and ran unit tests with `./gradlew build`, and the build and automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d6bd8bc083218540d1088bb3e25e)