### PR TITLE
Reschedule Hotmart first collection cycle to 15:00 and update method/log

### DIFF
--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -34,17 +34,17 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos diariamente às 13:38.
+     * Executa o ciclo 1 de listagem de produtos diariamente às 15:00.
      */
-    @Scheduled(cron = "0 38 13 * * *")
-    public void collectFirstCycleAtTen() {
+    @Scheduled(cron = "0 0 15 * * *")
+    public void collectFirstCycleAtFifteen() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=13:38 ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=15:00 ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),
                 response.products().size(),


### PR DESCRIPTION
### Motivation
- Adjust the daily timing of the first Hotmart collection cycle from 13:38 to 15:00 to match updated scheduling requirements.

### Description
- Changed the first cycle cron from `0 38 13 * * *` to `0 0 15 * * *`, renamed the method `collectFirstCycleAtTen` to `collectFirstCycleAtFifteen`, and updated the log message to reflect `hora=15:00`, while leaving the second cycle unchanged.

### Testing
- Ran `mvn test` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d324ec188321b1d86cdcf49a7e37)