### PR TITLE
Melhora visual do cabeçalho do pitch com badge MKTH

### DIFF
--- a/docs/pitch/marketing-hub-investidores.md
+++ b/docs/pitch/marketing-hub-investidores.md
@@ -14,22 +14,43 @@ style: |
       linear-gradient(135deg, #0f172a 0%, #111827 45%, #1e1b4b 100%);
     color: #e5e7eb;
   }
+  section::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 74px;
+    background: linear-gradient(90deg, rgba(8, 47, 73, 0.78) 0%, rgba(30, 64, 175, 0.42) 55%, rgba(15, 23, 42, 0.2) 100%);
+    border-bottom: 1px solid rgba(103, 232, 249, 0.35);
+    box-shadow: 0 12px 28px rgba(2, 6, 23, 0.4);
+    z-index: 0;
+  }
   section::after {
     content: "MKTH";
     position: absolute;
-    top: 18px;
+    top: 16px;
     right: 24px;
-    padding: 8px 12px;
-    border-radius: 999px;
-    font-weight: 800;
-    font-size: 0.8rem;
-    letter-spacing: 0.14em;
-    color: #0f172a;
-    background: linear-gradient(90deg, #22d3ee 0%, #38bdf8 100%);
-    box-shadow: 0 10px 30px rgba(56, 189, 248, 0.35);
+    padding: 9px 15px;
+    border-radius: 10px;
+    font-weight: 900;
+    font-size: 0.82rem;
+    letter-spacing: 0.18em;
+    color: #ecfeff;
+    border: 1px solid rgba(103, 232, 249, 0.65);
+    background: linear-gradient(135deg, rgba(8, 145, 178, 0.9) 0%, rgba(37, 99, 235, 0.9) 100%);
+    box-shadow: 0 12px 30px rgba(14, 116, 144, 0.45);
+    z-index: 2;
   }
   h1, h2, h3 {
     color: #f8fafc;
+  }
+  section > * {
+    position: relative;
+    z-index: 1;
+  }
+  h1 {
+    margin-top: 1.4rem;
   }
   strong {
     color: #67e8f9;


### PR DESCRIPTION
### Motivation
- Tornar o cabeçalho dos slides do pitch mais profissional e reforçar a identidade com a sigla `MKTH` visível em todos os slides mantendo legibilidade do conteúdo.

### Description
- Atualiza o tema Marp em `docs/pitch/marketing-hub-investidores.md` adicionando uma faixa superior (`section::before`), reestilizando a sigla `MKTH` como badge (`section::after`) e ajustando camadas/z-index e espaçamento de títulos para preservar legibilidade.

### Testing
- Não há testes automatizados aplicáveis para este ajuste visual em Markdown/Marp; nenhuma suíte automática foi executada para este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e2d1c7d88321804836bc60454170)