### PR TITLE
Fix GeraLandingExecutionServiceTest constructor mismatch after RecebeResponse injection

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -33,6 +33,16 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
         com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
+        com.marketinghub.worker.geralanding.wireframe.RecebeResponse wireframeRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.presetdesign.RecebeResponse presetDesignRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
@@ -56,6 +66,11 @@ class GeraLandingExecutionServiceTest {
                         imagePlanningMontaRequest,
                         presetDesignMontaRequest,
                         deliverablesMontaRequest,
+                        wireframeRecebeResponse,
+                        copyRecebeResponse,
+                        imagePlanningRecebeResponse,
+                        presetDesignRecebeResponse,
+                        deliverablesRecebeResponse,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
@@ -87,6 +102,16 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
         com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
+        com.marketinghub.worker.geralanding.wireframe.RecebeResponse wireframeRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.presetdesign.RecebeResponse presetDesignRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
@@ -109,6 +134,11 @@ class GeraLandingExecutionServiceTest {
                         imagePlanningMontaRequest,
                         presetDesignMontaRequest,
                         deliverablesMontaRequest,
+                        wireframeRecebeResponse,
+                        copyRecebeResponse,
+                        imagePlanningRecebeResponse,
+                        presetDesignRecebeResponse,
+                        deliverablesRecebeResponse,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
@@ -137,6 +167,16 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
         com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
+        com.marketinghub.worker.geralanding.wireframe.RecebeResponse wireframeRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.presetdesign.RecebeResponse presetDesignRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
@@ -181,6 +221,11 @@ class GeraLandingExecutionServiceTest {
                         imagePlanningMontaRequest,
                         presetDesignMontaRequest,
                         deliverablesMontaRequest,
+                        wireframeRecebeResponse,
+                        copyRecebeResponse,
+                        imagePlanningRecebeResponse,
+                        presetDesignRecebeResponse,
+                        deliverablesRecebeResponse,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
@@ -209,6 +254,16 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
         com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
+        com.marketinghub.worker.geralanding.wireframe.RecebeResponse wireframeRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.presetdesign.RecebeResponse presetDesignRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
@@ -243,7 +298,7 @@ class GeraLandingExecutionServiceTest {
 
         GeraLandingExecutionService service = new GeraLandingExecutionService(
                 backendClient, geraLandingService, openAiClient, objectMapper, stageSchemaResolver, wireframeMontaRequest,
-                copyMontaRequest, imagePlanningMontaRequest, presetDesignMontaRequest, deliverablesMontaRequest, 20,
+                copyMontaRequest, imagePlanningMontaRequest, presetDesignMontaRequest, deliverablesMontaRequest, wireframeRecebeResponse, copyRecebeResponse, imagePlanningRecebeResponse, presetDesignRecebeResponse, deliverablesRecebeResponse, 20,
                 new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                 new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
                 new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"),

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1798,3 +1798,11 @@
 - 2026-05-26: Atualizada a regra arquitetural de GeraLanding para permitir dependência entre classes do próprio pacote `service` (mesma etapa), mantendo as dependências explícitas já permitidas (`Experiment`, `ExperimentRepository`, `GeraLandingStageExecution`, `GeraLandingStageExecutionRepository`). Ajustados teste ArchUnit e cânone para aderência.
 
 - 2026-05-26: Ajustado `docs/pitch/marketing-hub-investidores.md` com identidade visual (logo MKTH no canto dos slides, gradientes de fundo e destaque tipográfico) para melhorar apresentação do pitch.
+
+## 2026-05-26 18:15:00 UTC
+- ajuste solicitado: corrigir falha de compilação em `GeraLandingExecutionServiceTest` após mudança de assinatura do construtor de `GeraLandingExecutionService`.
+- causa-raiz: o construtor passou a exigir cinco dependências adicionais de processadores `RecebeResponse` por etapa (`wireframe`, `copy`, `imageplanning`, `presetdesign`, `deliverables`) e os testes continuavam instanciando o serviço com a assinatura antiga.
+- correção aplicada:
+  - adicionados mocks de `RecebeResponse` para todas as etapas em cada cenário do teste;
+  - atualizado o `new GeraLandingExecutionService(...)` em todos os testes para enviar os novos argumentos na ordem correta.
+- impacto funcional: os testes voltam a compilar com a API atual do serviço, eliminando o erro de lista de argumentos divergente no `testCompile`.


### PR DESCRIPTION
### Motivation
- O construtor de `GeraLandingExecutionService` foi alterado para receber cinco processadores `RecebeResponse` por etapa, o que quebrou a instanciação existente nos testes e gerou falha de `testCompile` por mismatch de argumentos.
- É necessário alinhar os testes à nova API do serviço e registrar a intervenção no registro de experimentos conforme as diretrizes do projeto.

### Description
- Atualizado `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` para adicionar mocks de `RecebeResponse` para as etapas `wireframe`, `copy`, `imageplanning`, `presetdesign` e `deliverables` em todos os cenários de teste.
- Alteradas todas as chamadas `new GeraLandingExecutionService(...)` nos testes para incluir os novos mocks na ordem correta, correspondendo à assinatura atual do construtor.
- Registrada a correção em `docs/registros/experimentos.md` com data, causa-raiz e a ação aplicada, seguindo o procedimento operacional do projeto.

### Testing
- Executado o comando `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test` para validar os testes unitários, porém a execução parou durante a resolução de dependências devido a `401 Unauthorized` ao acessar o pacote privado `com.marketinghub:ads-service:0.0.1-SNAPSHOT` no GitHub Packages.
- A falha reportada originalmente (mismatch de parâmetros no `testCompile`) foi tratada no código dos testes, e os testes devem compilar com sucesso quando as dependências privadas estiverem acessíveis no ambiente de build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e231076c83219e3420dd36842a71)