### PR TITLE
Fix MKTH badge rendering in pitch slides

### DIFF
--- a/docs/pitch/marketing-hub-investidores.md
+++ b/docs/pitch/marketing-hub-investidores.md
@@ -5,6 +5,7 @@ paginate: true
 size: 16:9
 title: Marketing Hub — Pitch para Investidores
 description: Apresentação institucional para captação de investimento.
+header: <span class="mkth-badge">MKTH</span>
 style: |
   section {
     font-family: "Inter", "Segoe UI", sans-serif;
@@ -26,11 +27,15 @@ style: |
     box-shadow: 0 12px 28px rgba(2, 6, 23, 0.4);
     z-index: 0;
   }
-  section::after {
-    content: "MKTH";
+  header {
     position: absolute;
     top: 16px;
     right: 24px;
+    margin: 0;
+    z-index: 2;
+  }
+  .mkth-badge {
+    display: inline-block;
     padding: 9px 15px;
     border-radius: 10px;
     font-weight: 900;
@@ -40,7 +45,6 @@ style: |
     border: 1px solid rgba(103, 232, 249, 0.65);
     background: linear-gradient(135deg, rgba(8, 145, 178, 0.9) 0%, rgba(37, 99, 235, 0.9) 100%);
     box-shadow: 0 12px 30px rgba(14, 116, 144, 0.45);
-    z-index: 2;
   }
   h1, h2, h3 {
     color: #f8fafc;


### PR DESCRIPTION
### Motivation
- The MKTH badge in the pitch slides was not appearing in some render/export paths because it used a CSS pseudo-element (`section::after`) that is not reliably preserved by Marp → PPTX/LibreOffice exports.
- The change aims to make the badge explicit in the slide metadata so exports render the symbol consistently.

### Description
- Replaced the `section::after` pseudo-element badge with a Marp `header` element containing `<span class="mkth-badge">MKTH</span>` and added styling for `header` and `.mkth-badge` to preserve the original visual appearance (position, padding, gradient, border and shadow).
- Added the `header` YAML field at the top of `docs/pitch/marketing-hub-investidores.md` and moved the badge styling into the stylesheet block to improve compatibility with export pipelines.
- No functional or runtime code was changed; this is a presentation/content update only in `docs/pitch/marketing-hub-investidores.md`.

### Testing
- No automated tests were applicable for this presentation-only change.
- The source diff was reviewed to confirm the `header` field and `.mkth-badge` styles are present and equivalent to the previous visual design.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f6db35e08321a72015c88e2152b3)