### PR TITLE
Fix GeraLandingExecutionServiceTest to use stage processors and update experiment log

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -81,8 +81,9 @@ class GeraLandingExecutionServiceTest {
 
         verify(openAiClient).generate(any());
         verify(backendClient).receivePrompt(any(), any(), any(), any(), any(), any(), any(), any());
-        verify(backendClient).receiveDispatch(any(), any(), any(), any());
-        verify(backendClient).receiveResult(any(), any(), any(), any());
+        verify(wireframeRecebeResponse).processar(any(), any(), any(), any());
+        verify(backendClient, never()).receiveDispatch(any(), any(), any(), any());
+        verify(backendClient, never()).receiveResult(any(), any(), any(), any());
         verify(backendClient, never()).receiveFailure(any(), any(), any(), any(), any());
     }
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1807,3 +1807,11 @@
   - atualizado o `new GeraLandingExecutionService(...)` em todos os testes para enviar os novos argumentos na ordem correta.
 - impacto funcional: os testes voltam a compilar com a API atual do serviço, eliminando o erro de lista de argumentos divergente no `testCompile`.
 - 2026-05-26: Atualizados os diagramas canônicos de arquitetura do GeraLanding para refletir as regras ArchUnit vigentes no backend por camada/etapa (`web`, `provisorio` e `service`), incluindo as dependências explicitamente permitidas em `service` para `Experiment`, `ExperimentRepository`, `GeraLandingStageExecution` e `GeraLandingStageExecutionRepository`.
+
+## 2026-05-26 18:40:00 UTC
+- ajuste solicitado: corrigir falha do teste `GeraLandingExecutionServiceTest.processPendingExecutionsShouldSendPromptToOpenAiAndRegisterResult` que ainda esperava callback direto no `backendClient`.
+- causa-raiz: após a refatoração por etapa, `receiveDispatch`/`receiveResult` passaram a ocorrer dentro dos processadores `RecebeResponse`; no teste o `wireframeRecebeResponse` é mock e, portanto, não executa o callback real no backend.
+- correção aplicada:
+  - alterada a asserção principal para validar a delegação ao processador da etapa (`wireframeRecebeResponse.processar(...)`);
+  - removida expectativa de `receiveDispatch`/`receiveResult` no `backendClient` nesse cenário, mantendo validação de ausência de falha.
+- impacto funcional: o teste passa a validar o contrato correto do `GeraLandingExecutionService` (delegar o processamento da resposta para a etapa), eliminando falso negativo no surefire.


### PR DESCRIPTION
### Motivation
- Tests started failing to compile and one test produced a false negative after the `GeraLandingExecutionService` constructor and response flow were refactored to use per-stage `RecebeResponse` processors.
- The intent is to align tests with the new flow where `receiveDispatch`/`receiveResult` are invoked inside stage `RecebeResponse` processors instead of directly on the backend client.

### Description
- Updated `GeraLandingExecutionServiceTest` to pass mocked `RecebeResponse` processors for all stages into the `GeraLandingExecutionService` constructor so tests compile with the new signature.
- Adjusted assertions in `processPendingExecutionsShouldSendPromptToOpenAiAndRegisterResult` to verify delegation to the stage processor via `wireframeRecebeResponse.processar(...)` and assert that `backendClient.receiveDispatch` and `backendClient.receiveResult` are not directly called in that scenario.
- Kept verification that `openAiClient.generate(...)` and `backendClient.receivePrompt(...)` are invoked and that no failure callback is triggered.
- Updated `docs/registros/experimentos.md` to record the compilation fix and the behavioral test correction after the stage refactor.

### Testing
- Ran the unit test `GeraLandingExecutionServiceTest.processPendingExecutionsShouldSendPromptToOpenAiAndRegisterResult` which now passes after asserting delegation to `RecebeResponse`; the test succeeds.
- Recompiled the test suite to validate the updated constructor signature and mocks, and the compilation/test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f62e6f4c8321b22ce072423f588d)