### PR TITLE
docs: simplifica diagrama de pacotes do GeraLanding (caixas + setas explícitas)

### DIFF
--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -7,42 +7,23 @@ Consolidar a arquitetura do GeraLanding com base nas regras automatizadas de Arc
 ## 1) Backend (ads-service / `com.marketinghub.geralanding`)
 
 ```mermaid
-flowchart TD
-    subgraph API[Controllers GeraLanding]
-      C1[GeraLandingController]
-      C2[GeraLandingInternalController]
-    end
+flowchart LR
+    WEB["Pacote: geralanding.<etapa>.web"]
+    SERV["Pacote: geralanding.<etapa>.service"]
+    PROV["Pacote: geralanding.<etapa>.provisorio"]
+    EXP["Pacote: com.marketinghub.experiment (Experiment + ExperimentRepository)"]
+    EXEC["Pacote: com.marketinghub.geralanding.execution (GeraLandingStageExecution + GeraLandingStageExecutionRepository)"]
 
-    C1 --> SVC[GeraLandingStageExecutionService]
-    C2 --> SVC
-
-    SVC --> A1[WireframeProvisionalHtmlAssembler<br/>assemble(modelResponse, jobId)]
-    SVC --> A2[CopyProvisionalHtmlAssembler<br/>assemble(copyResponse, wireframeResponse, jobId)]
-    SVC --> A3[DesignPresetProvisionalHtmlAssembler<br/>assemble(designPreset, copy, imagePlanning, wireframe, jobId)]
-    SVC --> A4[ImagePlanningProvisionalHtmlAssembler]
-
-    SVC --> REPO1[GeraLandingStageExecutionRepository]
-    SVC --> REPO2[ExperimentRepository]
-    SVC --> ENT1[GeraLandingStageExecution]
-    SVC --> ENT2[Experiment]
-    REPO1 --> DB[(MySQL 5.7)]
-    REPO2 --> DB
-
-    subgraph STAGES[Etapas do GeraLanding no backend]
-      WEB[geralanding.<etapa>.web]
-      PROV[geralanding.<etapa>.provisorio]
-      SERV[geralanding.<etapa>.service]
-    end
-
-    WEB -->|somente mesma etapa| WEB
-    WEB -->|somente mesma etapa| SERV
-    PROV -->|somente mesma etapa| PROV
-    SERV -->|somente mesmas classes service da etapa| SERV
-    SERV -->|permitido| ENT2
-    SERV -->|permitido| REPO2
-    SERV -->|permitido| ENT1
-    SERV -->|permitido| REPO1
+    WEB -->|pode usar| WEB
+    WEB -->|pode usar| SERV
+    PROV -->|pode usar| PROV
+    SERV -->|pode usar| SERV
+    SERV -->|pode usar| EXP
+    SERV -->|pode usar| EXEC
 ```
+
+> Leitura do diagrama: cada caixa é um pacote. Só existe seta quando há dependência permitida. Sem seta = não pode usar diretamente.
+
 
 Regras arquiteturais refletidas (ArchUnit):
 - `GeraLandingStageExecutionService` não pode chamar assinaturas legadas dos assemblers de wireframe/copy/design preset.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1847,3 +1847,4 @@
   - docs/registros/experimentos.md
   - frontend/src/api/experiment/useGeraLandingStageExecutions.ts
   - frontend/src/pages/experiment/ExperimentDetailPage.tsx
+- 2026-05-26 21:12:16 UTC — Simplificado o diagrama do documento `docs/canonical/geralanding-arquitetura-canon.v1.md` para reduzir confusão: os pacotes passaram a ser exibidos como caixas únicas e as dependências aparecem somente com setas quando permitidas (sem seta = acesso não permitido).


### PR DESCRIPTION
### Motivation
- O diagrama de arquitetura do GeraLanding estava confuso e misturava muitos elementos, dificultando a leitura das dependências permitidas entre pacotes.
- Objetivo: apresentar os pacotes como caixas e mostrar setas apenas quando a dependência é explicitamente permitida, tornando a política arquitetural mais clara visualmente.

### Description
- Atualizado o diagrama Mermaid em `docs/canonical/geralanding-arquitetura-canon.v1.md` para exibir cada pacote como uma caixa (`geralanding.<etapa>.web`, `geralanding.<etapa>.service`, `geralanding.<etapa>.provisorio`, `com.marketinghub.experiment`, `com.marketinghub.geralanding.execution`) e manter setas somente para dependências permitidas.
- Mantida a seção de regras ArchUnit logo abaixo do diagrama para preservar o contrato arquitetural textual sem alterar regras técnicas.
- Acrescentado registro em `docs/registros/experimentos.md` documentando a alteração do diagrama.

### Testing
- Validação de conteúdo com `rg -n "landing-page-image-planning|stage-executions|pacotes|caixas|seta|geralanding" docs -S` completada com sucesso.
- Inspeção do arquivo atualizado com `sed -n '1,220p' docs/canonical/geralanding-arquitetura-canon.v1.md` e verificação de linhas com `nl -ba docs/canonical/geralanding-arquitetura-canon.v1.md | sed -n '1,140p'` foram executadas com sucesso.
- Como se trata de mudança puramente documental, não houve alteração de código ou execução de testes unitários.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a160c76564c8321bb82622515db8428)