### PR TITLE
Add GeraLanding stage-executions list/detail endpoints to etapa web controllers

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java
@@ -1,26 +1,56 @@
 package com.marketinghub.geralanding.copy.web;
 
+import com.marketinghub.geralanding.GeraLandingExecutionSummaryResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionDetailResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import com.marketinghub.geralanding.copy.service.GeraLandingCopyStageService;
 import com.marketinghub.geralanding.copy.service.GeraLandingCopyStartResponse;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Responsável por iniciar a etapa landing-page-copy no GeraLanding. */
+/** Responsável por iniciar a etapa landing-page-copy no GeraLanding e expor consultas das execuções da etapa. */
 @RestController
 @RequestMapping("/api/experiments/{experimentId}/geralanding")
 public class GeraLandingCopyController {
-  private final GeraLandingCopyStageService stageService;
+  private static final String STAGE_CODE = "landing-page-copy";
 
-  public GeraLandingCopyController(GeraLandingCopyStageService stageService) {
+  private final GeraLandingCopyStageService stageService;
+  private final GeraLandingStageExecutionService executionService;
+
+  public GeraLandingCopyController(GeraLandingCopyStageService stageService, GeraLandingStageExecutionService executionService) {
     this.stageService = stageService;
+    this.executionService = executionService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-copy. */
   @PostMapping("/copy/start")
-  public ResponseEntity<GeraLandingCopyStartResponse> start(@PathVariable Long experimentId) {    GeraLandingCopyStartResponse response = stageService.start(experimentId);
+  public ResponseEntity<GeraLandingCopyStartResponse> start(@PathVariable Long experimentId) {
+    GeraLandingCopyStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
+  }
+
+  /** Lista as execuções da etapa para o experimento. */
+  @GetMapping("/copy/stage-executions")
+  public ResponseEntity<List<GeraLandingExecutionSummaryResponse>> listStageExecutions(
+      @PathVariable Long experimentId,
+      @RequestParam(defaultValue = "true") boolean includeCompleted) {
+    List<GeraLandingExecutionSummaryResponse> response =
+        executionService.listExperimentStageExecutions(experimentId, STAGE_CODE, includeCompleted);
+    return ResponseEntity.ok(response);
+  }
+
+  /** Retorna os detalhes de uma execução específica da etapa. */
+  @GetMapping("/copy/stage-executions/{idJob}")
+  public ResponseEntity<GeraLandingStageExecutionDetailResponse> detailStageExecution(
+      @PathVariable Long experimentId, @PathVariable String idJob) {
+    GeraLandingStageExecutionDetailResponse response =
+        executionService.getStageExecutionDetail(experimentId, idJob);
+    return ResponseEntity.ok(response);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java
@@ -1,21 +1,31 @@
 package com.marketinghub.geralanding.deliverables.web;
 
+import com.marketinghub.geralanding.GeraLandingExecutionSummaryResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionDetailResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStageService;
 import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStartResponse;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Responsável por iniciar a etapa landing-page-deliverables no GeraLanding. */
+/** Responsável por iniciar a etapa landing-page-deliverables no GeraLanding e expor consultas das execuções da etapa. */
 @RestController
 @RequestMapping("/api/experiments/{experimentId}/geralanding")
 public class GeraLandingDeliverablesController {
-  private final GeraLandingDeliverablesStageService stageService;
+  private static final String STAGE_CODE = "landing-page-deliverables";
 
-  public GeraLandingDeliverablesController(GeraLandingDeliverablesStageService stageService) {
+  private final GeraLandingDeliverablesStageService stageService;
+  private final GeraLandingStageExecutionService executionService;
+
+  public GeraLandingDeliverablesController(GeraLandingDeliverablesStageService stageService, GeraLandingStageExecutionService executionService) {
     this.stageService = stageService;
+    this.executionService = executionService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-deliverables. */
@@ -23,5 +33,24 @@ public class GeraLandingDeliverablesController {
   public ResponseEntity<GeraLandingDeliverablesStartResponse> start(@PathVariable Long experimentId) {
     GeraLandingDeliverablesStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
+  }
+
+  /** Lista as execuções da etapa para o experimento. */
+  @GetMapping("/deliverables/stage-executions")
+  public ResponseEntity<List<GeraLandingExecutionSummaryResponse>> listStageExecutions(
+      @PathVariable Long experimentId,
+      @RequestParam(defaultValue = "true") boolean includeCompleted) {
+    List<GeraLandingExecutionSummaryResponse> response =
+        executionService.listExperimentStageExecutions(experimentId, STAGE_CODE, includeCompleted);
+    return ResponseEntity.ok(response);
+  }
+
+  /** Retorna os detalhes de uma execução específica da etapa. */
+  @GetMapping("/deliverables/stage-executions/{idJob}")
+  public ResponseEntity<GeraLandingStageExecutionDetailResponse> detailStageExecution(
+      @PathVariable Long experimentId, @PathVariable String idJob) {
+    GeraLandingStageExecutionDetailResponse response =
+        executionService.getStageExecutionDetail(experimentId, idJob);
+    return ResponseEntity.ok(response);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java
@@ -1,26 +1,56 @@
 package com.marketinghub.geralanding.designpreset.web;
 
+import com.marketinghub.geralanding.GeraLandingExecutionSummaryResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionDetailResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStageService;
 import com.marketinghub.geralanding.designpreset.service.GeraLandingDesignPresetStartResponse;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Responsável por iniciar a etapa landing-page-design-preset no GeraLanding. */
+/** Responsável por iniciar a etapa landing-page-design-preset no GeraLanding e expor consultas das execuções da etapa. */
 @RestController
 @RequestMapping("/api/experiments/{experimentId}/geralanding")
 public class GeraLandingDesignPresetController {
-  private final GeraLandingDesignPresetStageService stageService;
+  private static final String STAGE_CODE = "landing-page-design-preset";
 
-  public GeraLandingDesignPresetController(GeraLandingDesignPresetStageService stageService) {
+  private final GeraLandingDesignPresetStageService stageService;
+  private final GeraLandingStageExecutionService executionService;
+
+  public GeraLandingDesignPresetController(GeraLandingDesignPresetStageService stageService, GeraLandingStageExecutionService executionService) {
     this.stageService = stageService;
+    this.executionService = executionService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-design-preset. */
   @PostMapping("/design-preset/start")
-  public ResponseEntity<GeraLandingDesignPresetStartResponse> start(@PathVariable Long experimentId) {    GeraLandingDesignPresetStartResponse response = stageService.start(experimentId);
+  public ResponseEntity<GeraLandingDesignPresetStartResponse> start(@PathVariable Long experimentId) {
+    GeraLandingDesignPresetStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
+  }
+
+  /** Lista as execuções da etapa para o experimento. */
+  @GetMapping("/design-preset/stage-executions")
+  public ResponseEntity<List<GeraLandingExecutionSummaryResponse>> listStageExecutions(
+      @PathVariable Long experimentId,
+      @RequestParam(defaultValue = "true") boolean includeCompleted) {
+    List<GeraLandingExecutionSummaryResponse> response =
+        executionService.listExperimentStageExecutions(experimentId, STAGE_CODE, includeCompleted);
+    return ResponseEntity.ok(response);
+  }
+
+  /** Retorna os detalhes de uma execução específica da etapa. */
+  @GetMapping("/design-preset/stage-executions/{idJob}")
+  public ResponseEntity<GeraLandingStageExecutionDetailResponse> detailStageExecution(
+      @PathVariable Long experimentId, @PathVariable String idJob) {
+    GeraLandingStageExecutionDetailResponse response =
+        executionService.getStageExecutionDetail(experimentId, idJob);
+    return ResponseEntity.ok(response);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java
@@ -1,26 +1,56 @@
 package com.marketinghub.geralanding.imageplanning.web;
 
+import com.marketinghub.geralanding.GeraLandingExecutionSummaryResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionDetailResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStageService;
 import com.marketinghub.geralanding.imageplanning.service.GeraLandingImagePlanningStartResponse;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Responsável por iniciar a etapa landing-page-image-planning no GeraLanding. */
+/** Responsável por iniciar a etapa landing-page-image-planning no GeraLanding e expor consultas das execuções da etapa. */
 @RestController
 @RequestMapping("/api/experiments/{experimentId}/geralanding")
 public class GeraLandingImagePlanningController {
-  private final GeraLandingImagePlanningStageService stageService;
+  private static final String STAGE_CODE = "landing-page-image-planning";
 
-  public GeraLandingImagePlanningController(GeraLandingImagePlanningStageService stageService) {
+  private final GeraLandingImagePlanningStageService stageService;
+  private final GeraLandingStageExecutionService executionService;
+
+  public GeraLandingImagePlanningController(GeraLandingImagePlanningStageService stageService, GeraLandingStageExecutionService executionService) {
     this.stageService = stageService;
+    this.executionService = executionService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-image-planning. */
   @PostMapping("/image-prompts/start")
-  public ResponseEntity<GeraLandingImagePlanningStartResponse> start(@PathVariable Long experimentId) {    GeraLandingImagePlanningStartResponse response = stageService.start(experimentId);
+  public ResponseEntity<GeraLandingImagePlanningStartResponse> start(@PathVariable Long experimentId) {
+    GeraLandingImagePlanningStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
+  }
+
+  /** Lista as execuções da etapa para o experimento. */
+  @GetMapping("/image-prompts/stage-executions")
+  public ResponseEntity<List<GeraLandingExecutionSummaryResponse>> listStageExecutions(
+      @PathVariable Long experimentId,
+      @RequestParam(defaultValue = "true") boolean includeCompleted) {
+    List<GeraLandingExecutionSummaryResponse> response =
+        executionService.listExperimentStageExecutions(experimentId, STAGE_CODE, includeCompleted);
+    return ResponseEntity.ok(response);
+  }
+
+  /** Retorna os detalhes de uma execução específica da etapa. */
+  @GetMapping("/image-prompts/stage-executions/{idJob}")
+  public ResponseEntity<GeraLandingStageExecutionDetailResponse> detailStageExecution(
+      @PathVariable Long experimentId, @PathVariable String idJob) {
+    GeraLandingStageExecutionDetailResponse response =
+        executionService.getStageExecutionDetail(experimentId, idJob);
+    return ResponseEntity.ok(response);
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java
@@ -1,26 +1,56 @@
 package com.marketinghub.geralanding.wireframe.web;
 
+import com.marketinghub.geralanding.GeraLandingExecutionSummaryResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionDetailResponse;
+import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Responsável por iniciar a etapa landing-page-wireframe no GeraLanding. */
+/** Responsável por iniciar a etapa landing-page-wireframe no GeraLanding e expor consultas das execuções da etapa. */
 @RestController
 @RequestMapping("/api/experiments/{experimentId}/geralanding")
 public class GeraLandingWireframeController {
-  private final GeraLandingWireframeStageService stageService;
+  private static final String STAGE_CODE = "landing-page-wireframe";
 
-  public GeraLandingWireframeController(GeraLandingWireframeStageService stageService) {
+  private final GeraLandingWireframeStageService stageService;
+  private final GeraLandingStageExecutionService executionService;
+
+  public GeraLandingWireframeController(GeraLandingWireframeStageService stageService, GeraLandingStageExecutionService executionService) {
     this.stageService = stageService;
+    this.executionService = executionService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-wireframe. */
   @PostMapping("/wireframe/start")
-  public ResponseEntity<GeraLandingWireframeStartResponse> start(@PathVariable Long experimentId) {    GeraLandingWireframeStartResponse response = stageService.start(experimentId);
+  public ResponseEntity<GeraLandingWireframeStartResponse> start(@PathVariable Long experimentId) {
+    GeraLandingWireframeStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
+  }
+
+  /** Lista as execuções da etapa para o experimento. */
+  @GetMapping("/wireframe/stage-executions")
+  public ResponseEntity<List<GeraLandingExecutionSummaryResponse>> listStageExecutions(
+      @PathVariable Long experimentId,
+      @RequestParam(defaultValue = "true") boolean includeCompleted) {
+    List<GeraLandingExecutionSummaryResponse> response =
+        executionService.listExperimentStageExecutions(experimentId, STAGE_CODE, includeCompleted);
+    return ResponseEntity.ok(response);
+  }
+
+  /** Retorna os detalhes de uma execução específica da etapa. */
+  @GetMapping("/wireframe/stage-executions/{idJob}")
+  public ResponseEntity<GeraLandingStageExecutionDetailResponse> detailStageExecution(
+      @PathVariable Long experimentId, @PathVariable String idJob) {
+    GeraLandingStageExecutionDetailResponse response =
+        executionService.getStageExecutionDetail(experimentId, idJob);
+    return ResponseEntity.ok(response);
   }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1847,3 +1847,14 @@
   - docs/registros/experimentos.md
   - frontend/src/api/experiment/useGeraLandingStageExecutions.ts
   - frontend/src/pages/experiment/ExperimentDetailPage.tsx
+
+## 2026-05-26 21:20:00 UTC
+- solicitação: disponibilizar endpoints de listagem/detalhe de execuções dentro dos pacotes `geralanding.<etapa>.web`, incluindo `GET /api/experiments/{experimentId}/geralanding/deliverables/stage-executions?includeCompleted=false`.
+- causa-raiz: os controllers por etapa possuíam apenas endpoint `start`, sem endpoints HTTP para consultar histórico e detalhe de execuções, apesar do serviço `GeraLandingStageExecutionService` já suportar essas consultas.
+- correção aplicada no backend:
+  - adicionados endpoints por etapa (`wireframe`, `copy`, `image-prompts`, `design-preset`, `deliverables`) para:
+    - `GET /<etapa>/stage-executions`
+    - `GET /<etapa>/stage-executions/{idJob}`
+  - mantido filtro `includeCompleted` com default `true`, delegando ao `GeraLandingStageExecutionService` com `stageCode` fixo por controller.
+- validação executada:
+  - compilação do módulo `ads-service` concluída com sucesso após alterações.


### PR DESCRIPTION
### Motivation
- The frontend requires per-stage endpoints to list and inspect GeraLanding executions (e.g. `/api/experiments/{experimentId}/geralanding/deliverables/stage-executions?includeCompleted=false`) instead of a generic endpoint with `stageCode` query param. 
- The service `GeraLandingStageExecutionService` already implements the query logic but the per-`<etapa>.web` controllers only exposed `start` endpoints, so controllers needed HTTP endpoints to surface history and details.

### Description
- Added `GET /{etapa}/stage-executions` and `GET /{etapa}/stage-executions/{idJob}` endpoints to the five controllers `wireframe`, `copy`, `image-prompts`, `design-preset`, and `deliverables` in `backend/ads-service/src/main/java/com/marketinghub/geralanding/*/web`. 
- Introduced a `STAGE_CODE` constant per controller and injected `GeraLandingStageExecutionService` into each controller to delegate listing and detail queries to existing service methods. 
- Preserved existing `POST .../start` endpoints and added imports/response types (`GeraLandingExecutionSummaryResponse`, `GeraLandingStageExecutionDetailResponse`) for the new endpoints. 
- Recorded the change and rationale in `docs/registros/experimentos.md`.

### Testing
- Attempted targeted test runs with `-Dtest=GeraLandingDeliverablesControllerTest` which failed because no matching test or incorrect reactor selection was used. 
- Verified module build by running `cd backend/ads-service && ../../backend/mvnw -DskipTests compile`, which completed successfully and confirms the code compiles. 
- Changes were committed and registered in the experiments log; no additional automated controller/unit tests were added in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a160d506564832186b933ca3bcf2038)