### PR TITLE
Adjust Hotmart first-cycle scheduler to 23:20 and update method/log

### DIFF
--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -34,17 +34,17 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos diariamente às 18:15.
+     * Executa o ciclo 1 de listagem de produtos diariamente às 23:20.
      */
-    @Scheduled(cron = "0 15 18 * * *")
-    public void collectFirstCycleAtFifteen() {
+    @Scheduled(cron = "0 20 23 * * *")
+    public void collectFirstCycleAtTwentyThreeTwenty() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=18:15 ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=23:20 ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),
                 response.products().size(),


### PR DESCRIPTION
### Motivation
- Change the timing for the Hotmart first collection cycle to run later at 23:20 instead of 18:15 to better align with collection windows.

### Description
- Updated the first cycle cron expression to `0 20 23 * * *`, renamed the method from `collectFirstCycleAtFifteen` to `collectFirstCycleAtTwentyThreeTwenty`, and updated the log message to reflect `hora=23:20` while keeping the request/response behavior unchanged.

### Testing
- Ran the automated unit test suite with `mvn test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a162f6725d48321a70b51920dd13e26)