### PR TITLE
ci: reduzir ruído dos testes destacando erros do ArquiteturaTest

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,8 +53,15 @@ jobs:
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: maven-
 
-      - name: Rodar testes
-        run: mvn -B test
+      - name: Rodar testes (ArquiteturaTest: somente erros)
+        run: |
+          set -o pipefail
+          mvn -B -q test | tee /tmp/maven-test.log
+
+          if grep -q "ArquiteturaTest" /tmp/maven-test.log; then
+            echo "Resumo de erros do ArquiteturaTest:"
+            awk '/ArquiteturaTest/,/^$/' /tmp/maven-test.log | grep -E "^\[ERROR\]" || true
+          fi
 
       - name: Validar changelogs Liquibase
         run: |


### PR DESCRIPTION
### Motivation
- Reduzir o volume de logs no step de testes do workflow para facilitar a identificação rápida de falhas do `ArquiteturaTest` no GitHub Actions.

### Description
- Alterei `.github/workflows/ci-cd.yml` para executar `mvn -B -q test` redirecionando a saída para `/tmp/maven-test.log` e, quando houver trecho referente a `ArquiteturaTest`, imprimir apenas as linhas de `[ERROR]` desse bloco como resumo.

### Testing
- Não houve alteração em código fonte testado; validei a alteração do workflow localmente com `rg` e `nl -ba .github/workflows/ci-cd.yml | sed -n '50,85p'` para confirmar que o novo step está presente e formatado conforme esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a163a46368883219afaca3db9961254)