### PR TITLE
Encapsulate initial execution registration in per-stage execution services

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionService.java
@@ -16,6 +16,13 @@ public class GeraLandingCopyStageExecutionService {
         this.delegate = delegate;
     }
 
+
+    /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
+    public GeraLandingCopyStartResponse registerInitialExecution(Long experimentId, String stageCode) {
+        var response = delegate.registerInitialExecution(experimentId, stageCode);
+        return new GeraLandingCopyStartResponse(response.idJob(), response.status());
+    }
+
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
     public List<GeraLandingCopyExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
         return delegate.listExperimentStageExecutions(experimentId, stageCode, includeCompleted).stream()

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageService.java
@@ -1,15 +1,14 @@
 package com.marketinghub.geralanding.copy.service;
 
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar a execução da etapa de copy do GeraLanding. */
 @Service
 public class GeraLandingCopyStageService {
   private static final String STAGE_NAME = "landing-page-copy";
-  private final GeraLandingStageExecutionService executionService;
+  private final GeraLandingCopyStageExecutionService executionService;
 
-  public GeraLandingCopyStageService(GeraLandingStageExecutionService executionService) {
+  public GeraLandingCopyStageService(GeraLandingCopyStageExecutionService executionService) {
     this.executionService = executionService;
   }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageExecutionService.java
@@ -16,6 +16,13 @@ public class GeraLandingDeliverablesStageExecutionService {
         this.delegate = delegate;
     }
 
+
+    /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
+    public GeraLandingDeliverablesStartResponse registerInitialExecution(Long experimentId, String stageCode) {
+        var response = delegate.registerInitialExecution(experimentId, stageCode);
+        return new GeraLandingDeliverablesStartResponse(response.idJob(), response.status());
+    }
+
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
     public List<GeraLandingDeliverablesExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
         return delegate.listExperimentStageExecutions(experimentId, stageCode, includeCompleted).stream()

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageService.java
@@ -1,6 +1,5 @@
 package com.marketinghub.geralanding.deliverables.service;
 
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar execuções da etapa landing-page-deliverables. */
@@ -8,9 +7,9 @@ import org.springframework.stereotype.Service;
 public class GeraLandingDeliverablesStageService {
   private static final String STAGE_NAME = "landing-page-deliverables";
 
-  private final GeraLandingStageExecutionService executionService;
+  private final GeraLandingDeliverablesStageExecutionService executionService;
 
-  public GeraLandingDeliverablesStageService(GeraLandingStageExecutionService executionService) {
+  public GeraLandingDeliverablesStageService(GeraLandingDeliverablesStageExecutionService executionService) {
     this.executionService = executionService;
   }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageExecutionService.java
@@ -16,6 +16,13 @@ public class GeraLandingDesignPresetStageExecutionService {
         this.delegate = delegate;
     }
 
+
+    /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
+    public GeraLandingDesignPresetStartResponse registerInitialExecution(Long experimentId, String stageCode) {
+        var response = delegate.registerInitialExecution(experimentId, stageCode);
+        return new GeraLandingDesignPresetStartResponse(response.idJob(), response.status());
+    }
+
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
     public List<GeraLandingDesignPresetExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
         return delegate.listExperimentStageExecutions(experimentId, stageCode, includeCompleted).stream()

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageService.java
@@ -1,15 +1,14 @@
 package com.marketinghub.geralanding.designpreset.service;
 
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar a execução da etapa de design preset do GeraLanding. */
 @Service
 public class GeraLandingDesignPresetStageService {
   private static final String STAGE_NAME = "landing-page-design-preset";
-  private final GeraLandingStageExecutionService executionService;
+  private final GeraLandingDesignPresetStageExecutionService executionService;
 
-  public GeraLandingDesignPresetStageService(GeraLandingStageExecutionService executionService) {
+  public GeraLandingDesignPresetStageService(GeraLandingDesignPresetStageExecutionService executionService) {
     this.executionService = executionService;
   }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageExecutionService.java
@@ -16,6 +16,13 @@ public class GeraLandingImagePlanningStageExecutionService {
         this.delegate = delegate;
     }
 
+
+    /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
+    public GeraLandingImagePlanningStartResponse registerInitialExecution(Long experimentId, String stageCode) {
+        var response = delegate.registerInitialExecution(experimentId, stageCode);
+        return new GeraLandingImagePlanningStartResponse(response.idJob(), response.status());
+    }
+
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
     public List<GeraLandingImagePlanningExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
         return delegate.listExperimentStageExecutions(experimentId, stageCode, includeCompleted).stream()

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageService.java
@@ -1,15 +1,14 @@
 package com.marketinghub.geralanding.imageplanning.service;
 
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar a execução da etapa de planejamento de imagens do GeraLanding. */
 @Service
 public class GeraLandingImagePlanningStageService {
   private static final String STAGE_NAME = "landing-page-image-planning";
-  private final GeraLandingStageExecutionService executionService;
+  private final GeraLandingImagePlanningStageExecutionService executionService;
 
-  public GeraLandingImagePlanningStageService(GeraLandingStageExecutionService executionService) {
+  public GeraLandingImagePlanningStageService(GeraLandingImagePlanningStageExecutionService executionService) {
     this.executionService = executionService;
   }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
@@ -16,6 +16,13 @@ public class GeraLandingWireframeStageExecutionService {
         this.delegate = delegate;
     }
 
+
+    /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
+    public GeraLandingWireframeStartResponse registerInitialExecution(Long experimentId, String stageCode) {
+        var response = delegate.registerInitialExecution(experimentId, stageCode);
+        return new GeraLandingWireframeStartResponse(response.idJob(), response.status());
+    }
+
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
     public List<GeraLandingWireframeExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
         return delegate.listExperimentStageExecutions(experimentId, stageCode, includeCompleted).stream()

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
@@ -1,15 +1,14 @@
 package com.marketinghub.geralanding.wireframe.service;
 
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
 import org.springframework.stereotype.Service;
 
 /** Responsável por iniciar a execução da etapa de wireframe do GeraLanding. */
 @Service
 public class GeraLandingWireframeStageService {
   private static final String STAGE_NAME = "landing-page-wireframe";
-  private final GeraLandingStageExecutionService executionService;
+  private final GeraLandingWireframeStageExecutionService executionService;
 
-  public GeraLandingWireframeStageService(GeraLandingStageExecutionService executionService) {
+  public GeraLandingWireframeStageService(GeraLandingWireframeStageExecutionService executionService) {
     this.executionService = executionService;
   }
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1872,3 +1872,11 @@
   - marcadas como obsoletas (`@Deprecated`) as classes transversais antigas: `GeraLandingExecutionSummaryResponse`, `GeraLandingStageExecutionDetailResponse` e `GeraLandingStageExecutionService`.
 - validação executada:
   - teste arquitetural `ArquiteturaTest` executado com sucesso após refatoração.
+
+## 2026-05-27 00:38:00 UTC
+- solicitação: nas classes do pacote `service`, usar a versão local do próprio pacote para iniciar execução de etapa.
+- correção aplicada no backend (`ads-service`):
+  - `GeraLanding*StageService` de `copy`, `designpreset`, `imageplanning`, `wireframe` e `deliverables` passaram a depender de `GeraLanding*StageExecutionService` local da etapa (em vez de depender direto do serviço transversal);
+  - adicionado método `registerInitialExecution(...)` em cada `GeraLanding*StageExecutionService` para encapsular a delegação e retornar `GeraLanding*StartResponse` local.
+- validação executada:
+  - `mvn -q -Dtest=ArquiteturaTest test` (ainda falha por dependências remanescentes dos `*StageExecutionService` para classes transversais legadas).


### PR DESCRIPTION
### Motivation
- Ensure controllers and stage services depend only on per-stage DTOs/services instead of the transversal `GeraLandingStageExecutionService` to respect package isolation rules. 
- Encapsulate the initial execution registration logic so each stage returns its local `StartResponse` DTO instead of exposing transversal response types. 
- Progress toward satisfying ArchUnit rules that prevent web packages from depending on cross-cutting `com.marketinghub.geralanding` types.

### Description
- Added `registerInitialExecution(Long experimentId, String stageCode)` to each per-stage execution adapter (`*StageExecutionService`) which delegates to the transversal service and maps the result into the stage-local `GeraLanding*StartResponse`. 
- Updated each `GeraLanding*StageService` (`copy`, `designpreset`, `imageplanning`, `wireframe`, `deliverables`) to depend on the corresponding per-stage execution service type and use `registerInitialExecution` when starting a stage. 
- Adjusted imports and constructors in the stage services to use the per-stage execution service types. 
- Updated `docs/registros/experimentos.md` with a record of the change and current validation notes.

### Testing
- Module `ads-service` compilation completed successfully after the code changes. 
- Ran the architectural test `ArquiteturaTest` with `mvn -q -Dtest=ArquiteturaTest test`, which still fails due to remaining references from `*StageExecutionService` implementations to legacy transversal classes. 
- No other automated tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1639b4a2508321b51148154e8dad07)