### PR TITLE
Per-stage GeraLanding execution services: replace transversal delegate with repository-backed implementations

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionService.java
@@ -1,74 +1,122 @@
 package com.marketinghub.geralanding.copy.service;
 
-import com.marketinghub.geralanding.GeraLandingExecutionSummaryResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionDetailResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Responsável por adaptar consultas de execução para o contrato da etapa copy. */
 @Service
 public class GeraLandingCopyStageExecutionService {
 
-    private final GeraLandingStageExecutionService delegate;
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private final ExperimentRepository experimentRepository;
+    private final GeraLandingStageExecutionRepository executionRepository;
 
-    public GeraLandingCopyStageExecutionService(GeraLandingStageExecutionService delegate) {
-        this.delegate = delegate;
+    public GeraLandingCopyStageExecutionService(
+            ExperimentRepository experimentRepository,
+            GeraLandingStageExecutionRepository executionRepository) {
+        this.experimentRepository = experimentRepository;
+        this.executionRepository = executionRepository;
     }
 
 
+    @Transactional
     /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
     public GeraLandingCopyStartResponse registerInitialExecution(Long experimentId, String stageCode) {
-        var response = delegate.registerInitialExecution(experimentId, stageCode);
-        return new GeraLandingCopyStartResponse(response.idJob(), response.status());
+        Instant now = Instant.now();
+        var experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(stageCode)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("manual/start")
+                .promptContent("Início manual via interface do experimento.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        GeraLandingStageExecution saved = executionRepository.save(execution);
+        return new GeraLandingCopyStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
     }
 
+    @Transactional(readOnly = true)
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
     public List<GeraLandingCopyExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
-        return delegate.listExperimentStageExecutions(experimentId, stageCode, includeCompleted).stream()
+        List<GeraLandingStageExecution> executions = includeCompleted
+                ? executionRepository.findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode)
+                : executionRepository.findTop20ByExperimentIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
+                        experimentId,
+                        stageCode,
+                        STATUS_COMPLETED);
+        return executions.stream()
                 .map(this::toSummaryResponse)
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     /** Retorna o detalhe da execução convertido para o DTO local da etapa. */
     public GeraLandingCopyStageExecutionDetailResponse getStageExecutionDetail(Long experimentId, String idJob) {
-        return toDetailResponse(delegate.getStageExecutionDetail(experimentId, idJob));
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(experimentId, toDatabaseIdJob(idJob))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+        return toDetailResponse(execution);
     }
 
     /** Converte o resumo transversal para o resumo local da etapa. */
-    private GeraLandingCopyExecutionSummaryResponse toSummaryResponse(GeraLandingExecutionSummaryResponse response) {
+    private GeraLandingCopyExecutionSummaryResponse toSummaryResponse(GeraLandingStageExecution execution) {
         return new GeraLandingCopyExecutionSummaryResponse(
-                response.idJob(),
-                response.status(),
-                response.executionRequestedAt(),
-                response.costUsd());
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getStatus(),
+                execution.getExecutionRequestedAt(),
+                execution.getCostUsd());
     }
 
     /** Converte o detalhe transversal para o detalhe local da etapa. */
-    private GeraLandingCopyStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecutionDetailResponse response) {
+    private GeraLandingCopyStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecution execution) {
         return new GeraLandingCopyStageExecutionDetailResponse(
-                response.idJob(),
-                response.experimentId(),
-                response.stageCode(),
-                response.executionRequestedAt(),
-                response.createdAt(),
-                response.processingStartedAt(),
-                response.completedAt(),
-                response.promptTemplateId(),
-                response.promptContent(),
-                response.prompt(),
-                response.openAiRequestBody(),
-                response.openAiModel(),
-                response.schemaJson(),
-                response.promptMarkdownContent(),
-                response.status(),
-                response.openAiJobId(),
-                response.modelResponse(),
-                response.provisionalHtml(),
-                response.errorMessage(),
-                response.errorDetail(),
-                response.inputTokens(),
-                response.outputTokens(),
-                response.costUsd());
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getExperimentId(),
+                execution.getStageCode(),
+                execution.getExecutionRequestedAt(),
+                execution.getCreatedAt(),
+                execution.getProcessingStartedAt(),
+                execution.getCompletedAt(),
+                execution.getPromptTemplateId(),
+                execution.getPromptContent(),
+                execution.getPrompt(),
+                execution.getOpenAiRequestBody(),
+                execution.getOpenAiModel(),
+                execution.getSchemaJson(),
+                execution.getPromptMarkdownContent(),
+                execution.getStatus(),
+                execution.getOpenAiJobId(),
+                execution.getModelResponse(),
+                execution.getProvisionalHtml(),
+                execution.getErrorMessage(),
+                execution.getErrorDetail(),
+                execution.getInputTokens(),
+                execution.getOutputTokens(),
+                execution.getCostUsd());
+    }
+
+    /** Converte o id_job textual para o formato persistido em banco. */
+    private byte[] toDatabaseIdJob(String idJob) {
+        return idJob.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Converte o id_job persistido em banco para texto. */
+    private String fromDatabaseIdJob(byte[] idJob) {
+        return new String(idJob, StandardCharsets.UTF_8);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageExecutionService.java
@@ -1,74 +1,122 @@
 package com.marketinghub.geralanding.deliverables.service;
 
-import com.marketinghub.geralanding.GeraLandingExecutionSummaryResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionDetailResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Responsável por adaptar consultas de execução para o contrato da etapa deliverables. */
 @Service
 public class GeraLandingDeliverablesStageExecutionService {
 
-    private final GeraLandingStageExecutionService delegate;
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private final ExperimentRepository experimentRepository;
+    private final GeraLandingStageExecutionRepository executionRepository;
 
-    public GeraLandingDeliverablesStageExecutionService(GeraLandingStageExecutionService delegate) {
-        this.delegate = delegate;
+    public GeraLandingDeliverablesStageExecutionService(
+            ExperimentRepository experimentRepository,
+            GeraLandingStageExecutionRepository executionRepository) {
+        this.experimentRepository = experimentRepository;
+        this.executionRepository = executionRepository;
     }
 
 
+    @Transactional
     /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
     public GeraLandingDeliverablesStartResponse registerInitialExecution(Long experimentId, String stageCode) {
-        var response = delegate.registerInitialExecution(experimentId, stageCode);
-        return new GeraLandingDeliverablesStartResponse(response.idJob(), response.status());
+        Instant now = Instant.now();
+        var experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(stageCode)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("manual/start")
+                .promptContent("Início manual via interface do experimento.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        GeraLandingStageExecution saved = executionRepository.save(execution);
+        return new GeraLandingDeliverablesStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
     }
 
+    @Transactional(readOnly = true)
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
     public List<GeraLandingDeliverablesExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
-        return delegate.listExperimentStageExecutions(experimentId, stageCode, includeCompleted).stream()
+        List<GeraLandingStageExecution> executions = includeCompleted
+                ? executionRepository.findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode)
+                : executionRepository.findTop20ByExperimentIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
+                        experimentId,
+                        stageCode,
+                        STATUS_COMPLETED);
+        return executions.stream()
                 .map(this::toSummaryResponse)
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     /** Retorna o detalhe da execução convertido para o DTO local da etapa. */
     public GeraLandingDeliverablesStageExecutionDetailResponse getStageExecutionDetail(Long experimentId, String idJob) {
-        return toDetailResponse(delegate.getStageExecutionDetail(experimentId, idJob));
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(experimentId, toDatabaseIdJob(idJob))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+        return toDetailResponse(execution);
     }
 
     /** Converte o resumo transversal para o resumo local da etapa. */
-    private GeraLandingDeliverablesExecutionSummaryResponse toSummaryResponse(GeraLandingExecutionSummaryResponse response) {
+    private GeraLandingDeliverablesExecutionSummaryResponse toSummaryResponse(GeraLandingStageExecution execution) {
         return new GeraLandingDeliverablesExecutionSummaryResponse(
-                response.idJob(),
-                response.status(),
-                response.executionRequestedAt(),
-                response.costUsd());
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getStatus(),
+                execution.getExecutionRequestedAt(),
+                execution.getCostUsd());
     }
 
     /** Converte o detalhe transversal para o detalhe local da etapa. */
-    private GeraLandingDeliverablesStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecutionDetailResponse response) {
+    private GeraLandingDeliverablesStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecution execution) {
         return new GeraLandingDeliverablesStageExecutionDetailResponse(
-                response.idJob(),
-                response.experimentId(),
-                response.stageCode(),
-                response.executionRequestedAt(),
-                response.createdAt(),
-                response.processingStartedAt(),
-                response.completedAt(),
-                response.promptTemplateId(),
-                response.promptContent(),
-                response.prompt(),
-                response.openAiRequestBody(),
-                response.openAiModel(),
-                response.schemaJson(),
-                response.promptMarkdownContent(),
-                response.status(),
-                response.openAiJobId(),
-                response.modelResponse(),
-                response.provisionalHtml(),
-                response.errorMessage(),
-                response.errorDetail(),
-                response.inputTokens(),
-                response.outputTokens(),
-                response.costUsd());
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getExperimentId(),
+                execution.getStageCode(),
+                execution.getExecutionRequestedAt(),
+                execution.getCreatedAt(),
+                execution.getProcessingStartedAt(),
+                execution.getCompletedAt(),
+                execution.getPromptTemplateId(),
+                execution.getPromptContent(),
+                execution.getPrompt(),
+                execution.getOpenAiRequestBody(),
+                execution.getOpenAiModel(),
+                execution.getSchemaJson(),
+                execution.getPromptMarkdownContent(),
+                execution.getStatus(),
+                execution.getOpenAiJobId(),
+                execution.getModelResponse(),
+                execution.getProvisionalHtml(),
+                execution.getErrorMessage(),
+                execution.getErrorDetail(),
+                execution.getInputTokens(),
+                execution.getOutputTokens(),
+                execution.getCostUsd());
+    }
+
+    /** Converte o id_job textual para o formato persistido em banco. */
+    private byte[] toDatabaseIdJob(String idJob) {
+        return idJob.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Converte o id_job persistido em banco para texto. */
+    private String fromDatabaseIdJob(byte[] idJob) {
+        return new String(idJob, StandardCharsets.UTF_8);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/service/GeraLandingDesignPresetStageExecutionService.java
@@ -1,74 +1,122 @@
 package com.marketinghub.geralanding.designpreset.service;
 
-import com.marketinghub.geralanding.GeraLandingExecutionSummaryResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionDetailResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Responsável por adaptar consultas de execução para o contrato da etapa designpreset. */
 @Service
 public class GeraLandingDesignPresetStageExecutionService {
 
-    private final GeraLandingStageExecutionService delegate;
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private final ExperimentRepository experimentRepository;
+    private final GeraLandingStageExecutionRepository executionRepository;
 
-    public GeraLandingDesignPresetStageExecutionService(GeraLandingStageExecutionService delegate) {
-        this.delegate = delegate;
+    public GeraLandingDesignPresetStageExecutionService(
+            ExperimentRepository experimentRepository,
+            GeraLandingStageExecutionRepository executionRepository) {
+        this.experimentRepository = experimentRepository;
+        this.executionRepository = executionRepository;
     }
 
 
+    @Transactional
     /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
     public GeraLandingDesignPresetStartResponse registerInitialExecution(Long experimentId, String stageCode) {
-        var response = delegate.registerInitialExecution(experimentId, stageCode);
-        return new GeraLandingDesignPresetStartResponse(response.idJob(), response.status());
+        Instant now = Instant.now();
+        var experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(stageCode)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("manual/start")
+                .promptContent("Início manual via interface do experimento.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        GeraLandingStageExecution saved = executionRepository.save(execution);
+        return new GeraLandingDesignPresetStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
     }
 
+    @Transactional(readOnly = true)
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
     public List<GeraLandingDesignPresetExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
-        return delegate.listExperimentStageExecutions(experimentId, stageCode, includeCompleted).stream()
+        List<GeraLandingStageExecution> executions = includeCompleted
+                ? executionRepository.findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode)
+                : executionRepository.findTop20ByExperimentIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
+                        experimentId,
+                        stageCode,
+                        STATUS_COMPLETED);
+        return executions.stream()
                 .map(this::toSummaryResponse)
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     /** Retorna o detalhe da execução convertido para o DTO local da etapa. */
     public GeraLandingDesignPresetStageExecutionDetailResponse getStageExecutionDetail(Long experimentId, String idJob) {
-        return toDetailResponse(delegate.getStageExecutionDetail(experimentId, idJob));
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(experimentId, toDatabaseIdJob(idJob))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+        return toDetailResponse(execution);
     }
 
     /** Converte o resumo transversal para o resumo local da etapa. */
-    private GeraLandingDesignPresetExecutionSummaryResponse toSummaryResponse(GeraLandingExecutionSummaryResponse response) {
+    private GeraLandingDesignPresetExecutionSummaryResponse toSummaryResponse(GeraLandingStageExecution execution) {
         return new GeraLandingDesignPresetExecutionSummaryResponse(
-                response.idJob(),
-                response.status(),
-                response.executionRequestedAt(),
-                response.costUsd());
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getStatus(),
+                execution.getExecutionRequestedAt(),
+                execution.getCostUsd());
     }
 
     /** Converte o detalhe transversal para o detalhe local da etapa. */
-    private GeraLandingDesignPresetStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecutionDetailResponse response) {
+    private GeraLandingDesignPresetStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecution execution) {
         return new GeraLandingDesignPresetStageExecutionDetailResponse(
-                response.idJob(),
-                response.experimentId(),
-                response.stageCode(),
-                response.executionRequestedAt(),
-                response.createdAt(),
-                response.processingStartedAt(),
-                response.completedAt(),
-                response.promptTemplateId(),
-                response.promptContent(),
-                response.prompt(),
-                response.openAiRequestBody(),
-                response.openAiModel(),
-                response.schemaJson(),
-                response.promptMarkdownContent(),
-                response.status(),
-                response.openAiJobId(),
-                response.modelResponse(),
-                response.provisionalHtml(),
-                response.errorMessage(),
-                response.errorDetail(),
-                response.inputTokens(),
-                response.outputTokens(),
-                response.costUsd());
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getExperimentId(),
+                execution.getStageCode(),
+                execution.getExecutionRequestedAt(),
+                execution.getCreatedAt(),
+                execution.getProcessingStartedAt(),
+                execution.getCompletedAt(),
+                execution.getPromptTemplateId(),
+                execution.getPromptContent(),
+                execution.getPrompt(),
+                execution.getOpenAiRequestBody(),
+                execution.getOpenAiModel(),
+                execution.getSchemaJson(),
+                execution.getPromptMarkdownContent(),
+                execution.getStatus(),
+                execution.getOpenAiJobId(),
+                execution.getModelResponse(),
+                execution.getProvisionalHtml(),
+                execution.getErrorMessage(),
+                execution.getErrorDetail(),
+                execution.getInputTokens(),
+                execution.getOutputTokens(),
+                execution.getCostUsd());
+    }
+
+    /** Converte o id_job textual para o formato persistido em banco. */
+    private byte[] toDatabaseIdJob(String idJob) {
+        return idJob.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Converte o id_job persistido em banco para texto. */
+    private String fromDatabaseIdJob(byte[] idJob) {
+        return new String(idJob, StandardCharsets.UTF_8);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/GeraLandingImagePlanningStageExecutionService.java
@@ -1,74 +1,122 @@
 package com.marketinghub.geralanding.imageplanning.service;
 
-import com.marketinghub.geralanding.GeraLandingExecutionSummaryResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionDetailResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Responsável por adaptar consultas de execução para o contrato da etapa imageplanning. */
 @Service
 public class GeraLandingImagePlanningStageExecutionService {
 
-    private final GeraLandingStageExecutionService delegate;
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private final ExperimentRepository experimentRepository;
+    private final GeraLandingStageExecutionRepository executionRepository;
 
-    public GeraLandingImagePlanningStageExecutionService(GeraLandingStageExecutionService delegate) {
-        this.delegate = delegate;
+    public GeraLandingImagePlanningStageExecutionService(
+            ExperimentRepository experimentRepository,
+            GeraLandingStageExecutionRepository executionRepository) {
+        this.experimentRepository = experimentRepository;
+        this.executionRepository = executionRepository;
     }
 
 
+    @Transactional
     /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
     public GeraLandingImagePlanningStartResponse registerInitialExecution(Long experimentId, String stageCode) {
-        var response = delegate.registerInitialExecution(experimentId, stageCode);
-        return new GeraLandingImagePlanningStartResponse(response.idJob(), response.status());
+        Instant now = Instant.now();
+        var experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(stageCode)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("manual/start")
+                .promptContent("Início manual via interface do experimento.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        GeraLandingStageExecution saved = executionRepository.save(execution);
+        return new GeraLandingImagePlanningStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
     }
 
+    @Transactional(readOnly = true)
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
     public List<GeraLandingImagePlanningExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
-        return delegate.listExperimentStageExecutions(experimentId, stageCode, includeCompleted).stream()
+        List<GeraLandingStageExecution> executions = includeCompleted
+                ? executionRepository.findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode)
+                : executionRepository.findTop20ByExperimentIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
+                        experimentId,
+                        stageCode,
+                        STATUS_COMPLETED);
+        return executions.stream()
                 .map(this::toSummaryResponse)
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     /** Retorna o detalhe da execução convertido para o DTO local da etapa. */
     public GeraLandingImagePlanningStageExecutionDetailResponse getStageExecutionDetail(Long experimentId, String idJob) {
-        return toDetailResponse(delegate.getStageExecutionDetail(experimentId, idJob));
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(experimentId, toDatabaseIdJob(idJob))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+        return toDetailResponse(execution);
     }
 
     /** Converte o resumo transversal para o resumo local da etapa. */
-    private GeraLandingImagePlanningExecutionSummaryResponse toSummaryResponse(GeraLandingExecutionSummaryResponse response) {
+    private GeraLandingImagePlanningExecutionSummaryResponse toSummaryResponse(GeraLandingStageExecution execution) {
         return new GeraLandingImagePlanningExecutionSummaryResponse(
-                response.idJob(),
-                response.status(),
-                response.executionRequestedAt(),
-                response.costUsd());
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getStatus(),
+                execution.getExecutionRequestedAt(),
+                execution.getCostUsd());
     }
 
     /** Converte o detalhe transversal para o detalhe local da etapa. */
-    private GeraLandingImagePlanningStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecutionDetailResponse response) {
+    private GeraLandingImagePlanningStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecution execution) {
         return new GeraLandingImagePlanningStageExecutionDetailResponse(
-                response.idJob(),
-                response.experimentId(),
-                response.stageCode(),
-                response.executionRequestedAt(),
-                response.createdAt(),
-                response.processingStartedAt(),
-                response.completedAt(),
-                response.promptTemplateId(),
-                response.promptContent(),
-                response.prompt(),
-                response.openAiRequestBody(),
-                response.openAiModel(),
-                response.schemaJson(),
-                response.promptMarkdownContent(),
-                response.status(),
-                response.openAiJobId(),
-                response.modelResponse(),
-                response.provisionalHtml(),
-                response.errorMessage(),
-                response.errorDetail(),
-                response.inputTokens(),
-                response.outputTokens(),
-                response.costUsd());
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getExperimentId(),
+                execution.getStageCode(),
+                execution.getExecutionRequestedAt(),
+                execution.getCreatedAt(),
+                execution.getProcessingStartedAt(),
+                execution.getCompletedAt(),
+                execution.getPromptTemplateId(),
+                execution.getPromptContent(),
+                execution.getPrompt(),
+                execution.getOpenAiRequestBody(),
+                execution.getOpenAiModel(),
+                execution.getSchemaJson(),
+                execution.getPromptMarkdownContent(),
+                execution.getStatus(),
+                execution.getOpenAiJobId(),
+                execution.getModelResponse(),
+                execution.getProvisionalHtml(),
+                execution.getErrorMessage(),
+                execution.getErrorDetail(),
+                execution.getInputTokens(),
+                execution.getOutputTokens(),
+                execution.getCostUsd());
+    }
+
+    /** Converte o id_job textual para o formato persistido em banco. */
+    private byte[] toDatabaseIdJob(String idJob) {
+        return idJob.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Converte o id_job persistido em banco para texto. */
+    private String fromDatabaseIdJob(byte[] idJob) {
+        return new String(idJob, StandardCharsets.UTF_8);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
@@ -1,74 +1,122 @@
 package com.marketinghub.geralanding.wireframe.service;
 
-import com.marketinghub.geralanding.GeraLandingExecutionSummaryResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionDetailResponse;
-import com.marketinghub.geralanding.GeraLandingStageExecutionService;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Responsável por adaptar consultas de execução para o contrato da etapa wireframe. */
 @Service
 public class GeraLandingWireframeStageExecutionService {
 
-    private final GeraLandingStageExecutionService delegate;
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private final ExperimentRepository experimentRepository;
+    private final GeraLandingStageExecutionRepository executionRepository;
 
-    public GeraLandingWireframeStageExecutionService(GeraLandingStageExecutionService delegate) {
-        this.delegate = delegate;
+    public GeraLandingWireframeStageExecutionService(
+            ExperimentRepository experimentRepository,
+            GeraLandingStageExecutionRepository executionRepository) {
+        this.experimentRepository = experimentRepository;
+        this.executionRepository = executionRepository;
     }
 
 
+    @Transactional
     /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
     public GeraLandingWireframeStartResponse registerInitialExecution(Long experimentId, String stageCode) {
-        var response = delegate.registerInitialExecution(experimentId, stageCode);
-        return new GeraLandingWireframeStartResponse(response.idJob(), response.status());
+        Instant now = Instant.now();
+        var experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(stageCode)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("manual/start")
+                .promptContent("Início manual via interface do experimento.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        GeraLandingStageExecution saved = executionRepository.save(execution);
+        return new GeraLandingWireframeStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
     }
 
+    @Transactional(readOnly = true)
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
     public List<GeraLandingWireframeExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
-        return delegate.listExperimentStageExecutions(experimentId, stageCode, includeCompleted).stream()
+        List<GeraLandingStageExecution> executions = includeCompleted
+                ? executionRepository.findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode)
+                : executionRepository.findTop20ByExperimentIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
+                        experimentId,
+                        stageCode,
+                        STATUS_COMPLETED);
+        return executions.stream()
                 .map(this::toSummaryResponse)
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     /** Retorna o detalhe da execução convertido para o DTO local da etapa. */
     public GeraLandingWireframeStageExecutionDetailResponse getStageExecutionDetail(Long experimentId, String idJob) {
-        return toDetailResponse(delegate.getStageExecutionDetail(experimentId, idJob));
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(experimentId, toDatabaseIdJob(idJob))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+        return toDetailResponse(execution);
     }
 
     /** Converte o resumo transversal para o resumo local da etapa. */
-    private GeraLandingWireframeExecutionSummaryResponse toSummaryResponse(GeraLandingExecutionSummaryResponse response) {
+    private GeraLandingWireframeExecutionSummaryResponse toSummaryResponse(GeraLandingStageExecution execution) {
         return new GeraLandingWireframeExecutionSummaryResponse(
-                response.idJob(),
-                response.status(),
-                response.executionRequestedAt(),
-                response.costUsd());
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getStatus(),
+                execution.getExecutionRequestedAt(),
+                execution.getCostUsd());
     }
 
     /** Converte o detalhe transversal para o detalhe local da etapa. */
-    private GeraLandingWireframeStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecutionDetailResponse response) {
+    private GeraLandingWireframeStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecution execution) {
         return new GeraLandingWireframeStageExecutionDetailResponse(
-                response.idJob(),
-                response.experimentId(),
-                response.stageCode(),
-                response.executionRequestedAt(),
-                response.createdAt(),
-                response.processingStartedAt(),
-                response.completedAt(),
-                response.promptTemplateId(),
-                response.promptContent(),
-                response.prompt(),
-                response.openAiRequestBody(),
-                response.openAiModel(),
-                response.schemaJson(),
-                response.promptMarkdownContent(),
-                response.status(),
-                response.openAiJobId(),
-                response.modelResponse(),
-                response.provisionalHtml(),
-                response.errorMessage(),
-                response.errorDetail(),
-                response.inputTokens(),
-                response.outputTokens(),
-                response.costUsd());
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getExperimentId(),
+                execution.getStageCode(),
+                execution.getExecutionRequestedAt(),
+                execution.getCreatedAt(),
+                execution.getProcessingStartedAt(),
+                execution.getCompletedAt(),
+                execution.getPromptTemplateId(),
+                execution.getPromptContent(),
+                execution.getPrompt(),
+                execution.getOpenAiRequestBody(),
+                execution.getOpenAiModel(),
+                execution.getSchemaJson(),
+                execution.getPromptMarkdownContent(),
+                execution.getStatus(),
+                execution.getOpenAiJobId(),
+                execution.getModelResponse(),
+                execution.getProvisionalHtml(),
+                execution.getErrorMessage(),
+                execution.getErrorDetail(),
+                execution.getInputTokens(),
+                execution.getOutputTokens(),
+                execution.getCostUsd());
+    }
+
+    /** Converte o id_job textual para o formato persistido em banco. */
+    private byte[] toDatabaseIdJob(String idJob) {
+        return idJob.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Converte o id_job persistido em banco para texto. */
+    private String fromDatabaseIdJob(byte[] idJob) {
+        return new String(idJob, StandardCharsets.UTF_8);
     }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1880,3 +1880,16 @@
   - adicionado método `registerInitialExecution(...)` em cada `GeraLanding*StageExecutionService` para encapsular a delegação e retornar `GeraLanding*StartResponse` local.
 - validação executada:
   - `mvn -q -Dtest=ArquiteturaTest test` (ainda falha por dependências remanescentes dos `*StageExecutionService` para classes transversais legadas).
+
+## 2026-05-27 01:15:00 UTC
+- solicitação: "faça o mesmo nas demais etapas além da copy" para remover dependência dos `*StageExecutionService` por etapa do serviço transversal legado.
+- correção aplicada no backend (`ads-service`):
+  - refatorados `GeraLandingWireframeStageExecutionService`, `GeraLandingImagePlanningStageExecutionService`, `GeraLandingDesignPresetStageExecutionService` e `GeraLandingDeliverablesStageExecutionService`;
+  - removida a dependência de `GeraLandingStageExecutionService`, `GeraLandingExecutionSummaryResponse` e `GeraLandingStageExecutionDetailResponse` nas etapas acima;
+  - implementada lógica local com `ExperimentRepository` + `GeraLandingStageExecutionRepository` para:
+    - `registerInitialExecution(...)`;
+    - `listExperimentStageExecutions(...)`;
+    - `getStageExecutionDetail(...)`;
+  - mantidas conversões de `idJob` (`String` <-> `byte[]`) em cada serviço por etapa para aderir ao repositório e ao contrato de resposta da etapa.
+- validação executada:
+  - `mvn -Dtest=ArquiteturaTest test -q` (ainda falha por violações arquiteturais remanescentes, inclusive chamadas ao tipo interno `GeraLandingStageExecution$GeraLandingStageExecutionBuilder` e outras classes fora do escopo permitido).


### PR DESCRIPTION
### Motivation
- Remove per-stage dependencies on the transversal `GeraLandingStageExecutionService` to respect package isolation and use local per-stage DTOs and services.
- Provide repository-backed implementations so each stage can register, list and retrieve executions without depending on legacy transversal types.

### Description
- Replaced the delegate with `ExperimentRepository` and `GeraLandingStageExecutionRepository` in `GeraLanding*StageExecutionService` for `copy`, `wireframe`, `imageplanning`, `designpreset`, and `deliverables` and removed reliance on transversal DTOs/services.
- Implemented `registerInitialExecution(...)` to create and persist a `GeraLandingStageExecution` using a `UUID` `idJob` stored as `byte[]` and exposed as `String`, and added `toDatabaseIdJob`/`fromDatabaseIdJob` helpers.
- Implemented `listExperimentStageExecutions(...)` and `getStageExecutionDetail(...)` using repository queries and mapping `GeraLandingStageExecution` to the per-stage summary/detail response DTOs, and added `EntityNotFoundException` handling and `@Transactional` annotations.
- Updated the experiments registry document `docs/registros/experimentos.md` to record the refactor and its scope.

### Testing
- The `ads-service` module compiled successfully after the changes with `mvn` build validation of the module completing without compilation errors.
- The architectural test `mvn -Dtest=ArquiteturaTest test -q` was executed and still fails due to remaining architectural violations and references to internal/transversal types.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a163e7b2b788321be4cd8cdd1d76b0e)