### PR TITLE
Allow GeraLandingStageExecutionBuilder in ArchUnit allowlist and document reproduction/fix

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -29,6 +29,8 @@ class ArquiteturaTest {
     private static final String GERALANDING_STAGE_EXECUTION_CLASS = "com.marketinghub.geralanding.GeraLandingStageExecution";
     private static final String GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS =
             "com.marketinghub.geralanding.GeraLandingStageExecutionRepository";
+    private static final String GERALANDING_STAGE_EXECUTION_BUILDER_CLASS =
+            "com.marketinghub.geralanding.GeraLandingStageExecution$GeraLandingStageExecutionBuilder";
     private static final Pattern SALES_LIBRARY_LAYER_PATTERN = Pattern.compile(
             "^com\\.marketinghub\\.mois\\.bibliotecapaginavenda\\.([a-zA-Z0-9_]+)\\.(v\\d+)\\.(web|service|repository)(?:\\..*)?$");
 
@@ -287,7 +289,8 @@ class ArquiteturaTest {
                             || targetName.equals(EXPERIMENT_CLASS)
                             || targetName.equals(EXPERIMENT_REPOSITORY_CLASS)
                             || targetName.equals(GERALANDING_STAGE_EXECUTION_CLASS)
-                            || targetName.equals(GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS)) {
+                            || targetName.equals(GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS)
+                            || targetName.equals(GERALANDING_STAGE_EXECUTION_BUILDER_CLASS)) {
                         return;
                     }
                     String message = "[ARQUITETURA] [BACKEND][GeraLanding] classe-origem=" + item.getName()
@@ -296,8 +299,9 @@ class ArquiteturaTest {
                             + " | regra: serviços em geralanding.*.service só podem acessar "
                             + EXPERIMENT_CLASS + ", "
                             + EXPERIMENT_REPOSITORY_CLASS + ", "
-                            + GERALANDING_STAGE_EXECUTION_CLASS + " e "
-                            + GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS;
+                            + GERALANDING_STAGE_EXECUTION_CLASS + ", "
+                            + GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS + " e "
+                            + GERALANDING_STAGE_EXECUTION_BUILDER_CLASS;
                     events.add(SimpleConditionEvent.violated(item, message));
                 });
             }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1893,3 +1893,26 @@
   - mantidas conversões de `idJob` (`String` <-> `byte[]`) em cada serviço por etapa para aderir ao repositório e ao contrato de resposta da etapa.
 - validação executada:
   - `mvn -Dtest=ArquiteturaTest test -q` (ainda falha por violações arquiteturais remanescentes, inclusive chamadas ao tipo interno `GeraLandingStageExecution$GeraLandingStageExecutionBuilder` e outras classes fora do escopo permitido).
+
+## 2026-05-27 01:40:00 UTC
+- solicitação: "pegue uma situação que tem esse erro" para a violação ArchUnit em `geralanding..service..`.
+- situação capturada (reprodução real):
+  - teste executado: `mvn -Dtest=ArquiteturaTest test -q` no módulo `backend/ads-service`;
+  - falha observada: regra `geralandingServicePackagesShouldOnlyAccessAllowedMarketingHubClasses` com **50 violações**;
+  - exemplo concreto da violação:
+    - classe origem: `com.marketinghub.geralanding.copy.service.GeraLandingCopyStageExecutionService`;
+    - operação: método `registerInitialExecution(Long, String)`;
+    - dependência proibida: chamadas para `com.marketinghub.geralanding.GeraLandingStageExecution$GeraLandingStageExecutionBuilder` (`experimentId(...)`, `stageCode(...)`, `executionRequestedAt(...)`, `build()`, entre outras).
+- causa-raiz identificada:
+  - a regra arquitetural permite explicitamente `GeraLandingStageExecution` e `GeraLandingStageExecutionRepository`, porém as chamadas do builder (`GeraLandingStageExecution$GeraLandingStageExecutionBuilder`) são contabilizadas pelo ArchUnit como dependência para uma classe **não incluída** na allowlist.
+- ação aplicada nesta tarefa:
+  - registrado o cenário com evidência objetiva para orientar o próximo ajuste da regra/implementação e evitar análise por consequência.
+
+## 2026-05-27 01:50:00 UTC
+- solicitação: adicionar como 5ª exceção permitida na regra ArchUnit de `geralanding..service..` a classe interna do builder de `GeraLandingStageExecution`.
+- ajuste aplicado em `backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java`:
+  - criada constante `GERALANDING_STAGE_EXECUTION_BUILDER_CLASS` com valor `com.marketinghub.geralanding.GeraLandingStageExecution$GeraLandingStageExecutionBuilder`;
+  - incluída essa constante na allowlist da condição `onlyDependOnAllowedMarketingHubClasses()`;
+  - atualizada mensagem da regra para listar explicitamente as 5 exceções permitidas.
+- validação executada:
+  - `cd backend/ads-service && ../../backend/mvnw -Dtest=ArquiteturaTest test -q` (sucesso).


### PR DESCRIPTION
### Motivation
- ArchUnit rule for `geralanding..service..` was failing because calls to the internal builder `GeraLandingStageExecution$GeraLandingStageExecutionBuilder` were reported as violations even though `GeraLandingStageExecution` itself is allowed. 
- A reproducible failure was observed when running the architectural test `ArquiteturaTest`, producing many violations originating from usages of the builder in stage services. 
- The change makes the intended exception explicit so stage services that use the builder no longer trigger the rule.

### Description
- Added a constant `GERALANDING_STAGE_EXECUTION_BUILDER_CLASS` with value `com.marketinghub.geralanding.GeraLandingStageExecution$GeraLandingStageExecutionBuilder` to `ArquiteturaTest`. 
- Included the builder class in the allowlist inside the `onlyDependOnAllowedMarketingHubClasses()` ArchUnit condition and updated the rule message to list the five permitted types. 
- Recorded the reproduction details and the applied fix in `docs/registros/experimentos.md` to capture the failure context and the remediation steps.

### Testing
- Reproduced the original failure by running `mvn -Dtest=ArquiteturaTest test -q` which exhibited ArchUnit violations related to the builder (failure). 
- Verified the fix by running `cd backend/ads-service && ../../backend/mvnw -Dtest=ArquiteturaTest test -q`, and the `ArquiteturaTest` execution completed successfully (pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1646eaa0dc83219886e793d4a65e29)