### PR TITLE
fix: corrigir sintaxe YAML no workflow CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,7 @@ jobs:
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: maven-
 
-      - name: Rodar testes (ArquiteturaTest: somente erros)
+      - name: "Rodar testes (ArquiteturaTest: somente erros)"
         run: |
           set -o pipefail
           mvn -B -q test | tee /tmp/maven-test.log


### PR DESCRIPTION
### Motivation
- Evitar falha no parser do GitHub Actions causada pelo caractere `:` não escapado no `name` de um step do workflow.

### Description
- Envolve o valor do `name` do step `Rodar testes (ArquiteturaTest: somente erros)` em aspas no arquivo `.github/workflows/ci-cd.yml` para escapar o `:` corretamente.

### Testing
- Validado o YAML com `ruby -ryaml -e "YAML.load_file('.github/workflows/ci-cd.yml'); puts 'YAML OK'"`, que retornou `YAML OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1653ea6f748321864de13120b09a21)