### PR TITLE
Restringe ingestão OPRM para Estabelecimentos e Simples

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -182,3 +182,4 @@
 
 - 2026-05-26 18:20:00 (UTC-3): ajuste solicitado para reagendar novamente a ingestão OPRM CNPJ/CNAE para **18:20** no fuso `America/Sao_Paulo`, com atualização do cron hardcoded de `runScheduledImport` para `0 20 18 * * *` e sincronização do cron padrão em `application.yml`.
 - 2026-05-27 00:07:22 (UTC): ajuste solicitado para agendar nova execução da ingestão OPRM CNPJ/CNAE para **23:10** no fuso `America/Sao_Paulo`, com atualização do cron hardcoded de `runScheduledImport` para `0 10 23 * * *` no `oprm-coletor-mei`.
+- 2026-05-27 00:00:00 (UTC): ajuste solicitado na ingestão de CNAEs do `oprm-coletor-mei` para processar **somente** os arquivos `Estabelecimentos1..9.zip` e `Simples.zip` na montagem da lista de arquivos da run, removendo o processamento de `Cnaes.zip`, `Empresas1..9.zip` e `Socios1..9.zip` neste momento.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/service/OprmMarketImportScheduler.java
@@ -508,14 +508,11 @@ public class OprmMarketImportScheduler {
         private long totalEmpresasSimples;
     }
 
-    /** Monta a lista padrão de arquivos da base CNPJ a serem processados na execução. */
+    /** Monta a lista de arquivos da base CNPJ considerando somente ESTABELECIMENTOS e SIMPLES. */
     private List<OprmImportFileSeedDto> buildFiles(String sourceUrl) {
         List<OprmImportFileSeedDto> files = new ArrayList<>();
-        files.add(file("Cnaes.zip", sourceUrl, "CNAE"));
-        for (int i = 1; i < 10; i++) files.add(file("Empresas" + i + ".zip", sourceUrl, "EMPRESAS"));
         for (int i = 1; i < 10; i++) files.add(file("Estabelecimentos" + i + ".zip", sourceUrl, "ESTABELECIMENTOS"));
         files.add(file("Simples.zip", sourceUrl, "SIMPLES"));
-        for (int i = 1; i < 10; i++) files.add(file("Socios" + i + ".zip", sourceUrl, "SOCIOS"));
         return files;
     }
 


### PR DESCRIPTION
### Motivation
- Reduzir o escopo da ingestão temporariamente para concentrar o diagnóstico no mapeamento `SIMPLES -> CNAE` processando apenas os arquivos de `Estabelecimentos` e `Simples`.

### Description
- Altera o método `buildFiles` em `OprmMarketImportScheduler` para montar a lista de arquivos incluindo somente `Estabelecimentos1..9.zip` e `Simples.zip`, removendo temporariamente `Cnaes.zip`, `Empresas1..9.zip` e `Socios1..9.zip`, e registra a alteração em `docs/registros/oprm1.md`.

### Testing
- Executado `mvn test -q` no módulo `oprm-coletor-mei` e os testes de unidade foram executados com sucesso; a tentativa de `./mvnw test -q` falhou devido à ausência do wrapper no ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16556165648321859a0c4ba6459e17)