### PR TITLE
Ajusta consulta de status de job do GeraLanding por etapa no frontend

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1916,3 +1916,13 @@
   - atualizada mensagem da regra para listar explicitamente as 5 exceções permitidas.
 - validação executada:
   - `cd backend/ads-service && ../../backend/mvnw -Dtest=ArquiteturaTest test -q` (sucesso).
+
+## 2026-05-27 02:55:00 UTC
+- solicitação: ajustar frontend para consultar status de job no endpoint segmentado por etapa (GeraLanding stage-executions).
+- ajuste aplicado no frontend:
+  - `useGeraLandingStageExecutionDetail(...)` passou a receber `stageCode` e montar URL por etapa (`/geralanding/{stage}/stage-executions/{jobId}`) reaproveitando o resolvedor já existente;
+  - tela `ExperimentGeraLandingExecutionDetailPage` passou a ler `stageCode` da querystring e repassar para o hook de detalhe;
+  - links de Job ID na página do experimento foram atualizados para incluir `?stageCode=...` correto por etapa (wireframe, copy, image-planning, design-preset, deliverables), garantindo consulta no endpoint certo.
+- validação executada:
+  - `npm run lint` (falhou: script inexistente no `package.json` do frontend);
+  - `npm run build` (falhou: `vite: not found` no ambiente atual).

--- a/frontend/src/api/experiment/useGeraLandingStageExecutions.ts
+++ b/frontend/src/api/experiment/useGeraLandingStageExecutions.ts
@@ -65,15 +65,17 @@ export function useGeraLandingStageExecutions(
 export function useGeraLandingStageExecutionDetail(
   experimentId?: string,
   jobId?: string,
+  stageCode = "landing-page-wireframe",
   options?: { enabled?: boolean; refetchInterval?: number | false },
 ) {
   return useQuery({
-    queryKey: ["geralanding-stage-execution-detail", experimentId, jobId],
+    queryKey: ["geralanding-stage-execution-detail", experimentId, jobId, stageCode],
     enabled: options?.enabled ?? Boolean(experimentId && jobId),
     refetchInterval: options?.refetchInterval,
     queryFn: async () => {
+      const stageSegment = resolveStageExecutionsEndpointSegment(stageCode);
       const { data } = await axios.get<GeraLandingStageExecutionDetail>(
-        `/api/experiments/${experimentId}/geralanding/stage-executions/${jobId}`,
+        `/api/experiments/${experimentId}/geralanding/${stageSegment}/stage-executions/${jobId}`,
       );
       return data;
     },

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -2094,7 +2094,7 @@ export default function ExperimentDetailPage() {
                               <tr key={execution.idJob}>
                                 <td>
                                   <Link
-                                    to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                    to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}?stageCode=landing-page-wireframe`}
                                     className="fw-semibold text-decoration-none"
                                   >
                                     {execution.idJob}
@@ -2141,7 +2141,7 @@ export default function ExperimentDetailPage() {
                                 <tr key={execution.idJob}>
                                   <td>
                                     <Link
-                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}?stageCode=landing-page-wireframe`}
                                       className="fw-semibold text-decoration-none"
                                     >
                                       {execution.idJob}
@@ -2224,7 +2224,7 @@ export default function ExperimentDetailPage() {
                                 <tr key={execution.idJob}>
                                   <td>
                                     <Link
-                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}?stageCode=landing-page-copy`}
                                       className="fw-semibold text-decoration-none"
                                     >
                                       {execution.idJob}
@@ -2272,7 +2272,7 @@ export default function ExperimentDetailPage() {
                                   <tr key={execution.idJob}>
                                     <td>
                                       <Link
-                                        to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                        to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}?stageCode=landing-page-copy`}
                                         className="fw-semibold text-decoration-none"
                                       >
                                         {execution.idJob}
@@ -2369,7 +2369,7 @@ export default function ExperimentDetailPage() {
                                 <tr key={execution.idJob}>
                                   <td>
                                     <Link
-                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}?stageCode=landing-page-image-planning`}
                                       className="fw-semibold text-decoration-none"
                                     >
                                       {execution.idJob}
@@ -2420,7 +2420,7 @@ export default function ExperimentDetailPage() {
                                 <tr key={execution.idJob}>
                                   <td>
                                     <Link
-                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}?stageCode=landing-page-image-planning`}
                                       className="fw-semibold text-decoration-none"
                                     >
                                       {execution.idJob}
@@ -2630,7 +2630,7 @@ export default function ExperimentDetailPage() {
                                 <tr key={execution.idJob}>
                                   <td>
                                     <Link
-                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}?stageCode=landing-page-design-preset`}
                                       className="fw-semibold text-decoration-none"
                                     >
                                       {execution.idJob}
@@ -2679,7 +2679,7 @@ export default function ExperimentDetailPage() {
                                   <tr key={execution.idJob}>
                                     <td>
                                       <Link
-                                        to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                        to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}?stageCode=landing-page-design-preset`}
                                         className="fw-semibold text-decoration-none"
                                       >
                                         {execution.idJob}
@@ -2769,7 +2769,7 @@ export default function ExperimentDetailPage() {
                               <tr key={execution.idJob}>
                                 <td>
                                   <Link
-                                    to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                    to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}?stageCode=landing-page-deliverables`}
                                     className="fw-semibold text-decoration-none"
                                   >
                                     {execution.idJob}
@@ -2816,7 +2816,7 @@ export default function ExperimentDetailPage() {
                                 <tr key={execution.idJob}>
                                   <td>
                                     <Link
-                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}`}
+                                      to={`/experiments/${expId}/geralanding/stage-executions/${execution.idJob}?stageCode=landing-page-deliverables`}
                                       className="fw-semibold text-decoration-none"
                                     >
                                       {execution.idJob}

--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
 import { useGeraLandingStageExecutionDetail } from "../../api/experiment/useGeraLandingStageExecutions";
@@ -81,7 +81,14 @@ function extractErrorFileContent(raw?: string) {
 export default function ExperimentGeraLandingExecutionDetailPage() {
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const { id: experimentId, jobId } = useParams();
-  const detailQuery = useGeraLandingStageExecutionDetail(experimentId, jobId);
+  const [searchParams] = useSearchParams();
+  const stageCode =
+    searchParams.get("stageCode")?.trim() || "landing-page-wireframe";
+  const detailQuery = useGeraLandingStageExecutionDetail(
+    experimentId,
+    jobId,
+    stageCode,
+  );
   const modelUsed = extractModelFromRequestBody(
     detailQuery.data?.openAiRequestBody,
   );


### PR DESCRIPTION
### Motivation
- O backend passou a expor os detalhes de execução segmentados por etapa, portanto o frontend não deve mais consultar a rota genérica sem o segmento de `stage`. 
- Para garantir que o detalhe do job seja buscado no endpoint correto é necessário incluir a etapa (`stageCode`) na URL de consulta.

### Description
- Atualiza o hook `useGeraLandingStageExecutionDetail(...)` para receber `stageCode`, incluir `stageCode` no `queryKey` e montar a URL `/api/experiments/{experimentId}/geralanding/{stage}/stage-executions/{jobId}` via o resolvedor existente. 
- Modifica `ExperimentGeraLandingExecutionDetailPage` para ler `stageCode` da query string (`useSearchParams`) e repassar ao hook de detalhe. 
- Atualiza os links de Job ID em `ExperimentDetailPage` para incluir `?stageCode=...` nas seções: wireframe, copy, image-planning, design-preset e deliverables. 
- Registra a alteração em `docs/registros/experimentos.md` com resumo da mudança.

### Testing
- Executado `npm run lint` em `frontend`, que falhou porque o script `lint` não existe no `package.json` do frontend (falha). 
- Executado `npm run build` em `frontend`, que falhou no ambiente atual com `vite: not found` (falha). 
- Nenhum outro teste automatizado (unit/integration) foi executado neste ambiente após as alterações.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165c650c3c832186b9b2c09d028ba9)