### PR TITLE
fix: correct GeraLanding detail hook call signature in experiment page

### DIFF
--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1129,10 +1129,15 @@ export default function ExperimentDetailPage() {
       0,
     );
   const { data: runningGeraLandingJobDetail } =
-    useGeraLandingStageExecutionDetail(expId, runningGeraLandingJobId, {
-      enabled: Boolean(runningGeraLandingJobId),
-      refetchInterval: 10000,
-    });
+    useGeraLandingStageExecutionDetail(
+      expId,
+      runningGeraLandingJobId,
+      undefined,
+      {
+        enabled: Boolean(runningGeraLandingJobId),
+        refetchInterval: 10000,
+      },
+    );
 
   useEffect(() => {
     if (!runningGeraLandingJobId || !runningGeraLandingJobDetail) return;


### PR DESCRIPTION
### Motivation
- Fix a TypeScript type error (`TS2345`) caused by passing the query `options` as the third parameter to `useGeraLandingStageExecutionDetail` where a `stageCode` (string) was expected.

### Description
- Updated the call site in `frontend/src/pages/experiment/ExperimentDetailPage.tsx` to call `useGeraLandingStageExecutionDetail(expId, runningGeraLandingJobId, undefined, { enabled, refetchInterval })` so `stageCode` is left as default and `options` is passed as the 4th argument.

### Testing
- Ran `cd frontend && npm run typecheck` and confirmed the original `TS2345` at `ExperimentDetailPage.tsx` is resolved; overall typecheck still reports unrelated environment/dependency issues (missing type definitions `@testing-library/jest-dom`, `vite/client`, `vitest/globals` and deprecation enforcement from `tsconfig.json`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165f1d5e288321b3af8038a82d24b5)