### PR TITLE
fix(ai-worker): update GeraLandingExecutionServiceTest to match constructor signature

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -44,6 +44,17 @@ class GeraLandingExecutionServiceTest {
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
+        com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService wireframePendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService.class);
+        com.marketinghub.worker.geralanding.copy.CopyPendingJobsService copyPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.CopyPendingJobsService.class);
+        com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService imagePlanningPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService.class);
+        com.marketinghub.worker.geralanding.presetdesign.PresetDesignPendingJobsService presetDesignPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.PresetDesignPendingJobsService.class);
+        com.marketinghub.worker.geralanding.deliverables.DeliverablesPendingJobsService deliverablesPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.DeliverablesPendingJobsService.class);
+
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
                 new GeraLandingStageExecutionDto(19L, "dd8a7dac-ce15-4858-99b4-45a7a18591fa", "landing-page-wireframe")));
@@ -87,6 +98,11 @@ class GeraLandingExecutionServiceTest {
                         imagePlanningRecebeResponse,
                         presetDesignRecebeResponse,
                         deliverablesRecebeResponse,
+                        wireframePendingJobsService,
+                        copyPendingJobsService,
+                        imagePlanningPendingJobsService,
+                        presetDesignPendingJobsService,
+                        deliverablesPendingJobsService,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
@@ -130,6 +146,17 @@ class GeraLandingExecutionServiceTest {
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
+        com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService wireframePendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService.class);
+        com.marketinghub.worker.geralanding.copy.CopyPendingJobsService copyPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.CopyPendingJobsService.class);
+        com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService imagePlanningPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService.class);
+        com.marketinghub.worker.geralanding.presetdesign.PresetDesignPendingJobsService presetDesignPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.PresetDesignPendingJobsService.class);
+        com.marketinghub.worker.geralanding.deliverables.DeliverablesPendingJobsService deliverablesPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.DeliverablesPendingJobsService.class);
+
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
                 new GeraLandingStageExecutionDto(19L, "dd8a7dac-ce15-4858-99b4-45a7a18591fa", "landing-page-wireframe")));
@@ -156,6 +183,11 @@ class GeraLandingExecutionServiceTest {
                         imagePlanningRecebeResponse,
                         presetDesignRecebeResponse,
                         deliverablesRecebeResponse,
+                        wireframePendingJobsService,
+                        copyPendingJobsService,
+                        imagePlanningPendingJobsService,
+                        presetDesignPendingJobsService,
+                        deliverablesPendingJobsService,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
@@ -194,6 +226,17 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.RecebeResponse.class);
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
+
+        com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService wireframePendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService.class);
+        com.marketinghub.worker.geralanding.copy.CopyPendingJobsService copyPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.CopyPendingJobsService.class);
+        com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService imagePlanningPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService.class);
+        com.marketinghub.worker.geralanding.presetdesign.PresetDesignPendingJobsService presetDesignPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.PresetDesignPendingJobsService.class);
+        com.marketinghub.worker.geralanding.deliverables.DeliverablesPendingJobsService deliverablesPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.DeliverablesPendingJobsService.class);
 
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
@@ -243,6 +286,11 @@ class GeraLandingExecutionServiceTest {
                         imagePlanningRecebeResponse,
                         presetDesignRecebeResponse,
                         deliverablesRecebeResponse,
+                        wireframePendingJobsService,
+                        copyPendingJobsService,
+                        imagePlanningPendingJobsService,
+                        presetDesignPendingJobsService,
+                        deliverablesPendingJobsService,
                         20,
                         new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                         new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
@@ -282,6 +330,17 @@ class GeraLandingExecutionServiceTest {
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
+        com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService wireframePendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService.class);
+        com.marketinghub.worker.geralanding.copy.CopyPendingJobsService copyPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.CopyPendingJobsService.class);
+        com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService imagePlanningPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService.class);
+        com.marketinghub.worker.geralanding.presetdesign.PresetDesignPendingJobsService presetDesignPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.PresetDesignPendingJobsService.class);
+        com.marketinghub.worker.geralanding.deliverables.DeliverablesPendingJobsService deliverablesPendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.deliverables.DeliverablesPendingJobsService.class);
+
         when(openAiClient.isEnabled()).thenReturn(true);
         when(backendClient.listPendingExecutions(20)).thenReturn(List.of(
                 new GeraLandingStageExecutionDto(19L, "dd8a7dac-ce15-4858-99b4-45a7a18591fa", "landing-page-design-preset")));
@@ -315,7 +374,8 @@ class GeraLandingExecutionServiceTest {
 
         GeraLandingExecutionService service = new GeraLandingExecutionService(
                 backendClient, geraLandingService, openAiClient, objectMapper, stageSchemaResolver, wireframeMontaRequest,
-                copyMontaRequest, imagePlanningMontaRequest, presetDesignMontaRequest, deliverablesMontaRequest, wireframeRecebeResponse, copyRecebeResponse, imagePlanningRecebeResponse, presetDesignRecebeResponse, deliverablesRecebeResponse, 20,
+                copyMontaRequest, imagePlanningMontaRequest, presetDesignMontaRequest, deliverablesMontaRequest, wireframeRecebeResponse, copyRecebeResponse, imagePlanningRecebeResponse, presetDesignRecebeResponse, deliverablesRecebeResponse,
+                wireframePendingJobsService, copyPendingJobsService, imagePlanningPendingJobsService, presetDesignPendingJobsService, deliverablesPendingJobsService, 20,
                 new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json"),
                 new ClassPathResource("prompts/geralanding/landing-page-copy-schema.json"),
                 new ClassPathResource("prompts/geralanding/landing-page-image-planning-schema.json"),


### PR DESCRIPTION
### Motivation
- The `GeraLandingExecutionService` constructor gained five `*PendingJobsService` dependencies which caused unit tests to fail compilation due to mismatched argument lists.
- Tests need to instantiate the service with the same dependencies as production code so compilation and behavior verification remain valid.

### Description
- Added mocks for the five pending-jobs services (`WireframePendingJobsService`, `CopyPendingJobsService`, `ImagePlanningPendingJobsService`, `PresetDesignPendingJobsService`, `DeliverablesPendingJobsService`) in each test case of `GeraLandingExecutionServiceTest`.
- Updated all `new GeraLandingExecutionService(...)` calls in `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` to pass the new mocks in the constructor before the `pendingLimit` and `Resource` args.
- File modified: `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` to align test instantiation with the production constructor signature.

### Testing
- Ran `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test`; compilation mismatch is resolved and the build progressed further but stopped during dependency resolution due to an external artifact authorization error for `com.marketinghub:ads-service:0.0.1-SNAPSHOT` (HTTP 401 from GitHub Packages), so tests could not be executed in this environment.
- Recommendation: re-run the module tests in CI or a dev environment with access to the private Maven registry (or install the missing `ads-service` artifact locally) to complete test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a166763483c83218550430318b846da)