### PR TITLE
Split GeraLanding scheduler into per-stage schedulers and add processExecutions API

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionScheduler.java
@@ -3,9 +3,6 @@ package com.marketinghub.worker.geralanding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-
-@Component
 public class GeraLandingExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(GeraLandingExecutionScheduler.class);
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -137,7 +137,18 @@ public class GeraLandingExecutionService {
         log.info("Stage pending jobs via stage controllers: wireframe={}, copy={}, imagePlanning={}, designPreset={}, deliverables={}",
                 wireframePending.size(), copyPending.size(), imagePlanningPending.size(), presetDesignPending.size(), deliverablesPending.size());
         log.info("GeraLanding execution worker found {} pending execution(s)", pending.size());
-        for (GeraLandingStageExecutionDto execution : pending) {
+        processExecutions(pending);
+    }
+
+    /**
+     * Processa uma lista de execuções já filtradas por uma etapa específica.
+     */
+    public void processExecutions(List<GeraLandingStageExecutionDto> executions) {
+        if (!openAiClient.isEnabled()) {
+            log.warn("GeraLanding generation skipped: OpenAI client is disabled");
+            return;
+        }
+        for (GeraLandingStageExecutionDto execution : executions) {
             processExecution(execution);
         }
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/CopyExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/CopyExecutionScheduler.java
@@ -1,0 +1,40 @@
+package com.marketinghub.worker.geralanding.copy;
+
+import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Agenda o processamento de jobs pendentes da etapa copy. */
+@Component
+public class CopyExecutionScheduler {
+    private static final Logger log = LoggerFactory.getLogger(CopyExecutionScheduler.class);
+
+    private final GeraLandingExecutionService executionService;
+    private final CopyPendingJobsService pendingJobsService;
+    private final int pendingLimit;
+
+    public CopyExecutionScheduler(GeraLandingExecutionService executionService,
+                                  CopyPendingJobsService pendingJobsService,
+                                  @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
+        this.executionService = executionService;
+        this.pendingJobsService = pendingJobsService;
+        this.pendingLimit = Math.max(1, pendingLimit);
+    }
+
+    /** Executa o ciclo da etapa copy consultando apenas o endpoint específico da etapa. */
+    @Scheduled(cron = "10 */1 * * * *")
+    public void run() {
+        long startedAt = System.currentTimeMillis();
+        try {
+            executionService.processExecutions(pendingJobsService.listPendingCopyJobs(pendingLimit));
+        } catch (Exception ex) {
+            log.error("CopyExecutionScheduler cycle failed", ex);
+            throw ex;
+        } finally {
+            log.info("CopyExecutionScheduler finished (elapsedMs={})", System.currentTimeMillis() - startedAt);
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/DeliverablesExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/DeliverablesExecutionScheduler.java
@@ -1,0 +1,40 @@
+package com.marketinghub.worker.geralanding.deliverables;
+
+import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Agenda o processamento de jobs pendentes da etapa deliverables. */
+@Component
+public class DeliverablesExecutionScheduler {
+    private static final Logger log = LoggerFactory.getLogger(DeliverablesExecutionScheduler.class);
+
+    private final GeraLandingExecutionService executionService;
+    private final DeliverablesPendingJobsService pendingJobsService;
+    private final int pendingLimit;
+
+    public DeliverablesExecutionScheduler(GeraLandingExecutionService executionService,
+                                          DeliverablesPendingJobsService pendingJobsService,
+                                          @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
+        this.executionService = executionService;
+        this.pendingJobsService = pendingJobsService;
+        this.pendingLimit = Math.max(1, pendingLimit);
+    }
+
+    /** Executa o ciclo da etapa deliverables consultando apenas o endpoint específico da etapa. */
+    @Scheduled(cron = "40 */1 * * * *")
+    public void run() {
+        long startedAt = System.currentTimeMillis();
+        try {
+            executionService.processExecutions(pendingJobsService.listPendingDeliverablesJobs(pendingLimit));
+        } catch (Exception ex) {
+            log.error("DeliverablesExecutionScheduler cycle failed", ex);
+            throw ex;
+        } finally {
+            log.info("DeliverablesExecutionScheduler finished (elapsedMs={})", System.currentTimeMillis() - startedAt);
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/ImagePlanningExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/ImagePlanningExecutionScheduler.java
@@ -1,0 +1,40 @@
+package com.marketinghub.worker.geralanding.imageplanning;
+
+import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Agenda o processamento de jobs pendentes da etapa image-planning. */
+@Component
+public class ImagePlanningExecutionScheduler {
+    private static final Logger log = LoggerFactory.getLogger(ImagePlanningExecutionScheduler.class);
+
+    private final GeraLandingExecutionService executionService;
+    private final ImagePlanningPendingJobsService pendingJobsService;
+    private final int pendingLimit;
+
+    public ImagePlanningExecutionScheduler(GeraLandingExecutionService executionService,
+                                           ImagePlanningPendingJobsService pendingJobsService,
+                                           @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
+        this.executionService = executionService;
+        this.pendingJobsService = pendingJobsService;
+        this.pendingLimit = Math.max(1, pendingLimit);
+    }
+
+    /** Executa o ciclo da etapa image-planning consultando apenas o endpoint específico da etapa. */
+    @Scheduled(cron = "20 */1 * * * *")
+    public void run() {
+        long startedAt = System.currentTimeMillis();
+        try {
+            executionService.processExecutions(pendingJobsService.listPendingImagePlanningJobs(pendingLimit));
+        } catch (Exception ex) {
+            log.error("ImagePlanningExecutionScheduler cycle failed", ex);
+            throw ex;
+        } finally {
+            log.info("ImagePlanningExecutionScheduler finished (elapsedMs={})", System.currentTimeMillis() - startedAt);
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/PresetDesignExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/PresetDesignExecutionScheduler.java
@@ -1,0 +1,40 @@
+package com.marketinghub.worker.geralanding.presetdesign;
+
+import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Agenda o processamento de jobs pendentes da etapa design-preset. */
+@Component
+public class PresetDesignExecutionScheduler {
+    private static final Logger log = LoggerFactory.getLogger(PresetDesignExecutionScheduler.class);
+
+    private final GeraLandingExecutionService executionService;
+    private final PresetDesignPendingJobsService pendingJobsService;
+    private final int pendingLimit;
+
+    public PresetDesignExecutionScheduler(GeraLandingExecutionService executionService,
+                                          PresetDesignPendingJobsService pendingJobsService,
+                                          @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
+        this.executionService = executionService;
+        this.pendingJobsService = pendingJobsService;
+        this.pendingLimit = Math.max(1, pendingLimit);
+    }
+
+    /** Executa o ciclo da etapa design-preset consultando apenas o endpoint específico da etapa. */
+    @Scheduled(cron = "30 */1 * * * *")
+    public void run() {
+        long startedAt = System.currentTimeMillis();
+        try {
+            executionService.processExecutions(pendingJobsService.listPendingPresetDesignJobs(pendingLimit));
+        } catch (Exception ex) {
+            log.error("PresetDesignExecutionScheduler cycle failed", ex);
+            throw ex;
+        } finally {
+            log.info("PresetDesignExecutionScheduler finished (elapsedMs={})", System.currentTimeMillis() - startedAt);
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/WireframeExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/WireframeExecutionScheduler.java
@@ -1,0 +1,40 @@
+package com.marketinghub.worker.geralanding.wireframe;
+
+import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Agenda o processamento de jobs pendentes da etapa wireframe. */
+@Component
+public class WireframeExecutionScheduler {
+    private static final Logger log = LoggerFactory.getLogger(WireframeExecutionScheduler.class);
+
+    private final GeraLandingExecutionService executionService;
+    private final WireframePendingJobsService pendingJobsService;
+    private final int pendingLimit;
+
+    public WireframeExecutionScheduler(GeraLandingExecutionService executionService,
+                                       WireframePendingJobsService pendingJobsService,
+                                       @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
+        this.executionService = executionService;
+        this.pendingJobsService = pendingJobsService;
+        this.pendingLimit = Math.max(1, pendingLimit);
+    }
+
+    /** Executa o ciclo da etapa wireframe consultando apenas o endpoint específico da etapa. */
+    @Scheduled(cron = "0 */1 * * * *")
+    public void run() {
+        long startedAt = System.currentTimeMillis();
+        try {
+            executionService.processExecutions(pendingJobsService.listPendingWireframeJobs(pendingLimit));
+        } catch (Exception ex) {
+            log.error("WireframeExecutionScheduler cycle failed", ex);
+            throw ex;
+        } finally {
+            log.info("WireframeExecutionScheduler finished (elapsedMs={})", System.currentTimeMillis() - startedAt);
+        }
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1926,3 +1926,20 @@
 - validação executada:
   - `npm run lint` (falhou: script inexistente no `package.json` do frontend);
   - `npm run build` (falhou: `vite: not found` no ambiente atual).
+
+## 2026-05-27 06:12:00 UTC
+- solicitação: desligar scheduler global `GeraLandingExecutionScheduler` no ai-worker e criar scheduler por etapa, usando endpoint exclusivo da etapa no backend.
+- ajustes aplicados no `ai-worker`:
+  - removida anotação `@Component` de `GeraLandingExecutionScheduler` para desativar a execução global;
+  - criada a API `processExecutions(List<GeraLandingStageExecutionDto>)` em `GeraLandingExecutionService` para processar listas já filtradas por etapa;
+  - criados schedulers dedicados por etapa, cada um chamando somente seu respectivo `*PendingJobsService`:
+    - `WireframeExecutionScheduler`;
+    - `CopyExecutionScheduler`;
+    - `ImagePlanningExecutionScheduler`;
+    - `PresetDesignExecutionScheduler`;
+    - `DeliverablesExecutionScheduler`.
+  - cada scheduler usa cron literal direto na anotação `@Scheduled`.
+- observação operacional:
+  - a confirmação de pendência por etapa continua sendo feita via endpoint exclusivo da etapa em cada `*PendingJobsService` (wireframe/copy/imageplanning/designpreset/deliverables).
+- validação executada:
+  - `mvn -f ai-worker/pom.xml -DskipTests compile` (falhou por dependência externa ausente/sem acesso: `com.marketinghub:ads-service:0.0.1-SNAPSHOT`, erro 401 no repositório GitHub Packages).


### PR DESCRIPTION
### Motivation
- Disable the monolithic `GeraLandingExecutionScheduler` and run stage-specific scheduling to query stage-scoped backend endpoints and avoid global contention. 
- Provide a public `processExecutions(List<GeraLandingStageExecutionDto>)` API to allow schedulers to submit already-filtered stage job lists to the existing processing logic. 

### Description
- Removed `@Component` from `GeraLandingExecutionScheduler` to stop the global scheduled cycle and extracted a new public `processExecutions(...)` method in `GeraLandingExecutionService`. 
- Added five dedicated scheduler components that invoke only their stage-specific pending-jobs service and call `processExecutions(...)`: `WireframeExecutionScheduler`, `CopyExecutionScheduler`, `ImagePlanningExecutionScheduler`, `PresetDesignExecutionScheduler`, and `DeliverablesExecutionScheduler`. 
- Each new scheduler uses a literal cron in `@Scheduled` and calls the corresponding `listPending*Jobs(pendingLimit)` before delegating to the service. 
- Updated `docs/registros/experimentos.md` with the operational notes describing the change. 

### Testing
- Ran architecture test with `cd backend/ads-service && ../../backend/mvnw -Dtest=ArquiteturaTest test -q`, which succeeded. 
- Attempted frontend validations with `npm run lint` and `npm run build`, where `npm run lint` failed due to a missing script and `npm run build` failed with `vite: not found` in the current environment. 
- Attempted to compile the `ai-worker` module with `mvn -f ai-worker/pom.xml -DskipTests compile`, which failed due to an external dependency resolution error for `com.marketinghub:ads-service:0.0.1-SNAPSHOT` (401 on GitHub Packages).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16897133648321ab3dbd5aaa78802b)