### PR TITLE
Encapsula execução do GeraLanding por etapa e remove import direto do executor compartilhado

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/CopyExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/CopyExecutionScheduler.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.copy;
 
-import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Component;
 public class CopyExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(CopyExecutionScheduler.class);
 
-    private final GeraLandingExecutionService executionService;
+    private final GeraLandingCopyExecutionService executionService;
     private final CopyPendingJobsService pendingJobsService;
     private final int pendingLimit;
 
-    public CopyExecutionScheduler(GeraLandingExecutionService executionService,
+    public CopyExecutionScheduler(GeraLandingCopyExecutionService executionService,
                                   CopyPendingJobsService pendingJobsService,
                                   @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
         this.executionService = executionService;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyExecutionService.java
@@ -1,0 +1,21 @@
+package com.marketinghub.worker.geralanding.copy;
+
+import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Centraliza a execução de jobs da etapa copy usando o executor compartilhado. */
+@Service
+public class GeraLandingCopyExecutionService {
+    private final GeraLandingExecutionService executionService;
+
+    public GeraLandingCopyExecutionService(GeraLandingExecutionService executionService) {
+        this.executionService = executionService;
+    }
+
+    /** Processa os jobs pendentes da etapa copy. */
+    public void processExecutions(List<GeraLandingJobDto> jobs) {
+        executionService.processExecutions(jobs);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/DeliverablesExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/DeliverablesExecutionScheduler.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.deliverables;
 
-import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Component;
 public class DeliverablesExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(DeliverablesExecutionScheduler.class);
 
-    private final GeraLandingExecutionService executionService;
+    private final GeraLandingDeliverablesExecutionService executionService;
     private final DeliverablesPendingJobsService pendingJobsService;
     private final int pendingLimit;
 
-    public DeliverablesExecutionScheduler(GeraLandingExecutionService executionService,
+    public DeliverablesExecutionScheduler(GeraLandingDeliverablesExecutionService executionService,
                                           DeliverablesPendingJobsService pendingJobsService,
                                           @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
         this.executionService = executionService;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesExecutionService.java
@@ -1,0 +1,21 @@
+package com.marketinghub.worker.geralanding.deliverables;
+
+import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Centraliza a execução de jobs da etapa deliverables usando o executor compartilhado. */
+@Service
+public class GeraLandingDeliverablesExecutionService {
+    private final GeraLandingExecutionService executionService;
+
+    public GeraLandingDeliverablesExecutionService(GeraLandingExecutionService executionService) {
+        this.executionService = executionService;
+    }
+
+    /** Processa os jobs pendentes da etapa deliverables. */
+    public void processExecutions(List<GeraLandingJobDto> jobs) {
+        executionService.processExecutions(jobs);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningExecutionService.java
@@ -1,0 +1,21 @@
+package com.marketinghub.worker.geralanding.imageplanning;
+
+import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Centraliza a execução de jobs da etapa image planning usando o executor compartilhado. */
+@Service
+public class GeraLandingImagePlanningExecutionService {
+    private final GeraLandingExecutionService executionService;
+
+    public GeraLandingImagePlanningExecutionService(GeraLandingExecutionService executionService) {
+        this.executionService = executionService;
+    }
+
+    /** Processa os jobs pendentes da etapa image planning. */
+    public void processExecutions(List<GeraLandingJobDto> jobs) {
+        executionService.processExecutions(jobs);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/ImagePlanningExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/ImagePlanningExecutionScheduler.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.imageplanning;
 
-import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Component;
 public class ImagePlanningExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(ImagePlanningExecutionScheduler.class);
 
-    private final GeraLandingExecutionService executionService;
+    private final GeraLandingImagePlanningExecutionService executionService;
     private final ImagePlanningPendingJobsService pendingJobsService;
     private final int pendingLimit;
 
-    public ImagePlanningExecutionScheduler(GeraLandingExecutionService executionService,
+    public ImagePlanningExecutionScheduler(GeraLandingImagePlanningExecutionService executionService,
                                            ImagePlanningPendingJobsService pendingJobsService,
                                            @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
         this.executionService = executionService;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignExecutionService.java
@@ -1,0 +1,21 @@
+package com.marketinghub.worker.geralanding.presetdesign;
+
+import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Centraliza a execução de jobs da etapa preset design usando o executor compartilhado. */
+@Service
+public class GeraLandingPresetDesignExecutionService {
+    private final GeraLandingExecutionService executionService;
+
+    public GeraLandingPresetDesignExecutionService(GeraLandingExecutionService executionService) {
+        this.executionService = executionService;
+    }
+
+    /** Processa os jobs pendentes da etapa preset design. */
+    public void processExecutions(List<GeraLandingJobDto> jobs) {
+        executionService.processExecutions(jobs);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/PresetDesignExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/PresetDesignExecutionScheduler.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.presetdesign;
 
-import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Component;
 public class PresetDesignExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(PresetDesignExecutionScheduler.class);
 
-    private final GeraLandingExecutionService executionService;
+    private final GeraLandingPresetDesignExecutionService executionService;
     private final PresetDesignPendingJobsService pendingJobsService;
     private final int pendingLimit;
 
-    public PresetDesignExecutionScheduler(GeraLandingExecutionService executionService,
+    public PresetDesignExecutionScheduler(GeraLandingPresetDesignExecutionService executionService,
                                           PresetDesignPendingJobsService pendingJobsService,
                                           @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
         this.executionService = executionService;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeExecutionService.java
@@ -1,0 +1,21 @@
+package com.marketinghub.worker.geralanding.wireframe;
+
+import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Centraliza a execução de jobs da etapa wireframe usando o executor compartilhado. */
+@Service
+public class GeraLandingWireframeExecutionService {
+    private final GeraLandingExecutionService executionService;
+
+    public GeraLandingWireframeExecutionService(GeraLandingExecutionService executionService) {
+        this.executionService = executionService;
+    }
+
+    /** Processa os jobs pendentes da etapa wireframe. */
+    public void processExecutions(List<GeraLandingJobDto> jobs) {
+        executionService.processExecutions(jobs);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/WireframeExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/WireframeExecutionScheduler.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.wireframe;
 
-import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Component;
 public class WireframeExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(WireframeExecutionScheduler.class);
 
-    private final GeraLandingExecutionService executionService;
+    private final GeraLandingWireframeExecutionService executionService;
     private final WireframePendingJobsService pendingJobsService;
     private final int pendingLimit;
 
-    public WireframeExecutionScheduler(GeraLandingExecutionService executionService,
+    public WireframeExecutionScheduler(GeraLandingWireframeExecutionService executionService,
                                        WireframePendingJobsService pendingJobsService,
                                        @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
         this.executionService = executionService;

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1943,3 +1943,16 @@
   - a confirmação de pendência por etapa continua sendo feita via endpoint exclusivo da etapa em cada `*PendingJobsService` (wireframe/copy/imageplanning/designpreset/deliverables).
 - validação executada:
   - `mvn -f ai-worker/pom.xml -DskipTests compile` (falhou por dependência externa ausente/sem acesso: `com.marketinghub:ads-service:0.0.1-SNAPSHOT`, erro 401 no repositório GitHub Packages).
+
+## 2026-05-27 06:23:00 UTC
+- solicitação: no ai-worker, dentro de `*.geralanding.<etapa>`, criar `GeraLanding<Etapa>ExecutionService` para evitar import direto de `com.marketinghub.worker.geralanding.GeraLandingExecutionService` nos schedulers de etapa.
+- ajustes aplicados no `ai-worker`:
+  - criados serviços por etapa para encapsular a execução compartilhada:
+    - `GeraLandingWireframeExecutionService`;
+    - `GeraLandingCopyExecutionService`;
+    - `GeraLandingImagePlanningExecutionService`;
+    - `GeraLandingPresetDesignExecutionService`;
+    - `GeraLandingDeliverablesExecutionService`.
+  - atualizado cada `*ExecutionScheduler` de etapa para depender do serviço da própria etapa, removendo o import direto do executor compartilhado.
+- validação executada:
+  - `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test` (falhou por dependência externa sem autenticação: `com.marketinghub:ads-service:0.0.1-SNAPSHOT`, erro 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation
- Evitar que os schedulers em `com.marketinghub.worker.geralanding.<etapa>` importem diretamente `com.marketinghub.worker.geralanding.GeraLandingExecutionService`, reduzindo acoplamento entre pacotes. 
- Encapsular a lógica de execução por etapa para seguir o padrão de responsabilidade única por pacote/etapa. 

### Description
- Criados serviços por etapa no `ai-worker` para encapsular o executor compartilhado: `GeraLandingWireframeExecutionService`, `GeraLandingCopyExecutionService`, `GeraLandingImagePlanningExecutionService`, `GeraLandingPresetDesignExecutionService` e `GeraLandingDeliverablesExecutionService` (em `com.marketinghub.worker.geralanding.<etapa>`). 
- Atualizados os schedulers de cada etapa (`WireframeExecutionScheduler`, `CopyExecutionScheduler`, `ImagePlanningExecutionScheduler`, `PresetDesignExecutionScheduler`, `DeliverablesExecutionScheduler`) para depender do respectivo `GeraLanding<Etapa>ExecutionService` e removido o `import com.marketinghub.worker.geralanding.GeraLandingExecutionService`. 
- Registrado o ajuste em `docs/registros/experimentos.md`. 

### Testing
- Executado `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test`, que falhou por não conseguir resolver a dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` (HTTP 401 no repositório de packages). 
- Executado `mvn -f ai-worker/pom.xml -DskipTests compile`, que também falhou pela mesma dependência não resolvida em ambiente atual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a168d4ffd5483219655256a052a186b)