### PR TITLE
Run architecture tests in CI and rename architecture test to ArquiteturaTest

### DIFF
--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -46,6 +46,8 @@ jobs:
           distribution: temurin
           java-version: 21
           cache: maven
+      - name: Run architecture tests
+        run: mvn -B -s settings.xml -Dtest='*ArchitectureTest,*ArquiteturaTest' test
       - name: Run tests
         run: mvn -B -s settings.xml test
       - name: Build

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/ArquiteturaTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/ArquiteturaTest.java
@@ -9,7 +9,7 @@ import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
 @AnalyzeClasses(packages = "com.marketinghub.worker", importOptions = ImportOption.DoNotIncludeTests.class)
-class GeraLandingArchitectureTest {
+class ArquiteturaTest {
 
     /** Garante que o módulo de geração de landing não dependa do pipeline legado de experimentos. */
     @ArchTest


### PR DESCRIPTION
### Motivation
- Ensure architecture rules are executed explicitly in CI to catch architectural violations early.
- Align the architecture test name with the new Portuguese class name for clarity and project localization.

### Description
- Added a CI step `Run architecture tests` that executes `mvn -B -s settings.xml -Dtest='*ArchitectureTest,*ArquiteturaTest' test` in `.github/workflows/ai-worker.yml`.
- Renamed `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingArchitectureTest.java` to `ai-worker/src/test/java/com/marketinghub/worker/geralanding/ArquiteturaTest.java` and updated the class name to `ArquiteturaTest`.
- Left the regular test and build steps unchanged so the full test suite and packaging continue to run as before.

### Testing
- CI now runs the architecture tests via `mvn -B -s settings.xml -Dtest='*ArchitectureTest,*ArquiteturaTest' test` as a separate step and it completed successfully.
- The regular test step `mvn -B -s settings.xml test` and the build step `mvn -B -s settings.xml package -DskipTests` were executed in the workflow and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a168ef139dc8321a1fcb64067e2da96)