### PR TITLE
Fix gera-landing stage execution service generic types

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyExecutionService.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.copy;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
-import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +15,7 @@ public class GeraLandingCopyExecutionService {
     }
 
     /** Processa os jobs pendentes da etapa copy. */
-    public void processExecutions(List<GeraLandingJobDto> jobs) {
+    public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionService.processExecutions(jobs);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesExecutionService.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.deliverables;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
-import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +15,7 @@ public class GeraLandingDeliverablesExecutionService {
     }
 
     /** Processa os jobs pendentes da etapa deliverables. */
-    public void processExecutions(List<GeraLandingJobDto> jobs) {
+    public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionService.processExecutions(jobs);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningExecutionService.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.imageplanning;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
-import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +15,7 @@ public class GeraLandingImagePlanningExecutionService {
     }
 
     /** Processa os jobs pendentes da etapa image planning. */
-    public void processExecutions(List<GeraLandingJobDto> jobs) {
+    public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionService.processExecutions(jobs);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignExecutionService.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.presetdesign;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
-import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +15,7 @@ public class GeraLandingPresetDesignExecutionService {
     }
 
     /** Processa os jobs pendentes da etapa preset design. */
-    public void processExecutions(List<GeraLandingJobDto> jobs) {
+    public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionService.processExecutions(jobs);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeExecutionService.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.wireframe;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
-import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +15,7 @@ public class GeraLandingWireframeExecutionService {
     }
 
     /** Processa os jobs pendentes da etapa wireframe. */
-    public void processExecutions(List<GeraLandingJobDto> jobs) {
+    public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionService.processExecutions(jobs);
     }
 }


### PR DESCRIPTION
### Motivation
- Fix compile-time generic type mismatches between stage-specific execution wrappers and `GeraLandingExecutionService.processExecutions(...)` so stage services accept the correct DTO type.

### Description
- Replaced `GeraLandingJobDto` with `GeraLandingStageExecutionDto` imports in the stage-specific execution services.
- Updated the `processExecutions(...)` method signatures in the stage wrappers to accept `List<GeraLandingStageExecutionDto>` instead of `List<GeraLandingJobDto>`.
- Files changed: `copy/GeraLandingCopyExecutionService.java`, `wireframe/GeraLandingWireframeExecutionService.java`, `imageplanning/GeraLandingImagePlanningExecutionService.java`, `presetdesign/GeraLandingPresetDesignExecutionService.java`, and `deliverables/GeraLandingDeliverablesExecutionService.java`.

### Testing
- Ran module compilation with `mvn -f ai-worker/pom.xml -DskipTests compile` to validate source-level issues; the source-level generic mismatch was addressed but the build failed during dependency resolution due to missing private artifact access (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`, HTTP 401 from GitHub Packages).
- No unit tests were executed because the compile step could not complete dependency resolution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1691207f088321a8f5794a38545831)