### PR TITLE
Refatora executor da etapa wireframe para pacote comum

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/GeraLandingWireframeExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/GeraLandingWireframeExecutionService.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.comum;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
 import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/WireframeExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/WireframeExecutionScheduler.java
@@ -1,5 +1,5 @@
 package com.marketinghub.worker.geralanding.wireframe;
-
+import com.marketinghub.worker.geralanding.comum.GeraLandingWireframeExecutionService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
### Motivation
- Arquitetura de testes (ArchUnit) impede que classes do pacote `geralanding.wireframe` dependam diretamente de classes fora de `geralanding.wireframe` ou `geralanding.comum`, e a classe atual violava essa regra ao depender do executor raiz.

### Description
- Move `GeraLandingWireframeExecutionService` do pacote `com.marketinghub.worker.geralanding.wireframe` para `com.marketinghub.worker.geralanding.comum` preservando sua responsabilidade e comportamento (arquivo em `ai-worker/src/main/java/.../geralanding/comum/GeraLandingWireframeExecutionService.java`).
- Atualiza `WireframeExecutionScheduler` para importar `com.marketinghub.worker.geralanding.comum.GeraLandingWireframeExecutionService` sem alterar a lógica de agendamento ou processamento.

### Testing
- Executei `mvn -f ai-worker/pom.xml -Dtest=ArquiteturaTest test` para validar a regra de arquitetura, mas a execução falhou por erro de resolução de dependência externo (`com.marketinghub:ads-service:0.0.1-SNAPSHOT` retornando 401 do GitHub Packages).
- Tentei instalar a dependência localmente com `mvn -f backend/ads-service/pom.xml -DskipTests install`, mas esse build também falhou resolvendo `org.projectlombok:lombok:1.18.30` devido a um erro 502 no Maven Central, portanto os testes automatizados não puderam ser concluídos no ambiente atual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1693e382f08321b22dc42590e3c6d5)