### PR TITLE
Refatora serviços de execução do GeraLanding por pacote de etapa

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/CopyExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/CopyExecutionScheduler.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.geralanding.copy;
 
-import com.marketinghub.worker.geralanding.comum.GeraLandingCopyExecutionService;
 
 
 import org.slf4j.Logger;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyExecutionService.java
@@ -1,20 +1,20 @@
-package com.marketinghub.worker.geralanding.comum;
+package com.marketinghub.worker.geralanding.copy;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
 import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
-/** Centraliza a execução de jobs da etapa preset design usando o executor compartilhado. */
+/** Centraliza a execução de jobs da etapa copy usando o executor compartilhado. */
 @Service
-public class GeraLandingPresetDesignExecutionService {
+public class GeraLandingCopyExecutionService {
     private final GeraLandingExecutionService executionService;
 
-    public GeraLandingPresetDesignExecutionService(GeraLandingExecutionService executionService) {
+    public GeraLandingCopyExecutionService(GeraLandingExecutionService executionService) {
         this.executionService = executionService;
     }
 
-    /** Processa os jobs pendentes da etapa preset design. */
+    /** Processa os jobs pendentes da etapa copy. */
     public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionService.processExecutions(jobs);
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/DeliverablesExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/DeliverablesExecutionScheduler.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.geralanding.deliverables;
 
-import com.marketinghub.worker.geralanding.comum.GeraLandingDeliverablesExecutionService;
 
 
 import org.slf4j.Logger;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesExecutionService.java
@@ -1,20 +1,20 @@
-package com.marketinghub.worker.geralanding.comum;
+package com.marketinghub.worker.geralanding.deliverables;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
 import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
-/** Centraliza a execução de jobs da etapa image planning usando o executor compartilhado. */
+/** Centraliza a execução de jobs da etapa deliverables usando o executor compartilhado. */
 @Service
-public class GeraLandingImagePlanningExecutionService {
+public class GeraLandingDeliverablesExecutionService {
     private final GeraLandingExecutionService executionService;
 
-    public GeraLandingImagePlanningExecutionService(GeraLandingExecutionService executionService) {
+    public GeraLandingDeliverablesExecutionService(GeraLandingExecutionService executionService) {
         this.executionService = executionService;
     }
 
-    /** Processa os jobs pendentes da etapa image planning. */
+    /** Processa os jobs pendentes da etapa deliverables. */
     public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionService.processExecutions(jobs);
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningExecutionService.java
@@ -1,20 +1,20 @@
-package com.marketinghub.worker.geralanding.comum;
+package com.marketinghub.worker.geralanding.imageplanning;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
 import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
-/** Centraliza a execução de jobs da etapa wireframe usando o executor compartilhado. */
+/** Centraliza a execução de jobs da etapa image planning usando o executor compartilhado. */
 @Service
-public class GeraLandingWireframeExecutionService {
+public class GeraLandingImagePlanningExecutionService {
     private final GeraLandingExecutionService executionService;
 
-    public GeraLandingWireframeExecutionService(GeraLandingExecutionService executionService) {
+    public GeraLandingImagePlanningExecutionService(GeraLandingExecutionService executionService) {
         this.executionService = executionService;
     }
 
-    /** Processa os jobs pendentes da etapa wireframe. */
+    /** Processa os jobs pendentes da etapa image planning. */
     public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionService.processExecutions(jobs);
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/ImagePlanningExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/ImagePlanningExecutionScheduler.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.geralanding.imageplanning;
 
-import com.marketinghub.worker.geralanding.comum.GeraLandingImagePlanningExecutionService;
 
 
 import org.slf4j.Logger;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignExecutionService.java
@@ -1,20 +1,20 @@
-package com.marketinghub.worker.geralanding.comum;
+package com.marketinghub.worker.geralanding.presetdesign;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
 import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
-/** Centraliza a execução de jobs da etapa deliverables usando o executor compartilhado. */
+/** Centraliza a execução de jobs da etapa preset design usando o executor compartilhado. */
 @Service
-public class GeraLandingDeliverablesExecutionService {
+public class GeraLandingPresetDesignExecutionService {
     private final GeraLandingExecutionService executionService;
 
-    public GeraLandingDeliverablesExecutionService(GeraLandingExecutionService executionService) {
+    public GeraLandingPresetDesignExecutionService(GeraLandingExecutionService executionService) {
         this.executionService = executionService;
     }
 
-    /** Processa os jobs pendentes da etapa deliverables. */
+    /** Processa os jobs pendentes da etapa preset design. */
     public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionService.processExecutions(jobs);
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/PresetDesignExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/PresetDesignExecutionScheduler.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.geralanding.presetdesign;
 
-import com.marketinghub.worker.geralanding.comum.GeraLandingPresetDesignExecutionService;
 
 
 import org.slf4j.Logger;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeExecutionService.java
@@ -1,20 +1,20 @@
-package com.marketinghub.worker.geralanding.comum;
+package com.marketinghub.worker.geralanding.wireframe;
 
 import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
 import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
-/** Centraliza a execução de jobs da etapa copy usando o executor compartilhado. */
+/** Centraliza a execução de jobs da etapa wireframe usando o executor compartilhado. */
 @Service
-public class GeraLandingCopyExecutionService {
+public class GeraLandingWireframeExecutionService {
     private final GeraLandingExecutionService executionService;
 
-    public GeraLandingCopyExecutionService(GeraLandingExecutionService executionService) {
+    public GeraLandingWireframeExecutionService(GeraLandingExecutionService executionService) {
         this.executionService = executionService;
     }
 
-    /** Processa os jobs pendentes da etapa copy. */
+    /** Processa os jobs pendentes da etapa wireframe. */
     public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionService.processExecutions(jobs);
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/WireframeExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/WireframeExecutionScheduler.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.geralanding.wireframe;
 
-import com.marketinghub.worker.geralanding.comum.GeraLandingWireframeExecutionService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
### Motivation
- Isolar serviços de execução por etapa para reduzir acoplamento e colocar cada responsabilidade no pacote da sua etapa (copy, imageplanning, presetdesign, wireframe, deliverables). 
- Manter apenas utilitários compartilhados no pacote `comum` para preservar helpers reutilizáveis.

### Description
- Move as classes `GeraLandingCopyExecutionService`, `GeraLandingImagePlanningExecutionService`, `GeraLandingPresetDesignExecutionService`, `GeraLandingWireframeExecutionService` e `GeraLandingDeliverablesExecutionService` do pacote `com.marketinghub.worker.geralanding.comum` para seus respectivos pacotes de etapa (`copy`, `imageplanning`, `presetdesign`, `wireframe`, `deliverables`).
- Atualiza as declarações de `package` e ajusta os `Scheduler`s para dependerem dos serviços no pacote da etapa, removendo imports antigos do pacote `comum`.
- Mantém `MontaRequestSupport` em `com.marketinghub.worker.geralanding.comum` como único artefato compartilhado nesse pacote.

### Testing
- Executado: `mvn -f ai-worker/pom.xml test -DskipITs` para validar o módulo `ai-worker`.
- Resultado: falha de build por dependência externa não resolvida `com.marketinghub:ads-service:0.0.1-SNAPSHOT` devido a retorno `401 Unauthorized` no repositório GitHub Packages, impedindo execução completa dos testes unitários no ambiente atual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1714a4323083218a16216eced317b3)