### PR TITLE
docs(ai-worker): reforça isolamento do GeraLanding por etapa

### DIFF
--- a/ai-worker/AGENTS.md
+++ b/ai-worker/AGENTS.md
@@ -33,3 +33,9 @@
   - envio para a OpenAI contendo **request cru** + **jobId do Marketing Hub**;
   - resposta da OpenAI contendo **resposta crua** + **jobId do Marketing Hub**;
   - envio para o backend contendo **payload enviado** + **jobId do Marketing Hub**.
+
+## Regra de isolamento do GeraLanding por etapa (obrigatória)
+- Todo código relacionado ao **GeraLanding** deve permanecer dentro do pacote específico da própria etapa/domínio (`geralanding.<etapa>`).
+- Evite mover classes, utilitários, DTOs, mappers, validadores e clientes para pacote comum/compartilhado quando forem usados pela etapa.
+- Se houver necessidade prática entre etapas, **prefira duplicar código** dentro de cada pacote de etapa ao invés de centralizar em pacote comum.
+- Objetivo: preservar isolamento arquitetural por etapa e evitar acoplamento transversal.


### PR DESCRIPTION
### Motivation
- Preservar o isolamento arquitetural entre etapas do GeraLanding evitando acoplamento transversal e centralização indevida de código.

### Description
- Adiciona no `ai-worker/AGENTS.md` a `Regra de isolamento do GeraLanding por etapa` instruindo que todo código do `geralanding` fique em `geralanding.<etapa>`, que não se mova artefatos para pacote comum e que, se necessário, prefira-se duplicar código por etapa em vez de centralizar.

### Testing
- No automated tests were run or are applicable for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1715678b308321b5dcd6680c994b9b)