### PR TITLE
Isolate GeraLanding copy package: add local DTOs and delegate services

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/CopyPendingJobsService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/CopyPendingJobsService.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.copy;
 
-import com.marketinghub.worker.geralanding.GeraLandingBackendClient;
-import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
+import com.marketinghub.worker.geralanding.copy.GeraLandingBackendClient;
+import com.marketinghub.worker.geralanding.copy.GeraLandingStageExecutionDto;
 import java.util.List;
 import java.util.Locale;
 import org.springframework.stereotype.Service;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingBackendClient.java
@@ -1,0 +1,44 @@
+package com.marketinghub.worker.geralanding.copy;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Responsabilidade: encapsular o cliente de backend da etapa copy mantendo isolamento por pacote. */
+@Component("geraLandingCopyBackendClient")
+public class GeraLandingBackendClient {
+    private final com.marketinghub.worker.geralanding.GeraLandingBackendClient delegate;
+
+    public GeraLandingBackendClient(com.marketinghub.worker.geralanding.GeraLandingBackendClient delegate) {
+        this.delegate = delegate;
+    }
+
+    /** Lista execuções pendentes e converte para o DTO local da etapa copy. */
+    public List<GeraLandingStageExecutionDto> listPendingExecutions(int limit) {
+        return delegate.listPendingExecutions(limit).stream()
+                .map(item -> new GeraLandingStageExecutionDto(item.experimentId(), item.idJob(), item.stageCode()))
+                .toList();
+    }
+
+    /** Encaminha confirmação de despacho do job da etapa copy para o backend principal. */
+    public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) {
+        delegate.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);
+    }
+
+    /** Envia resultado da etapa copy ao backend principal. */
+    public void receiveResult(String idJob, Long experimentId, String stageCode, GeraLandingJobCompletionPayload payload) {
+        delegate.receiveResult(idJob, experimentId, stageCode,
+                new com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload(
+                        payload.responseContent(),
+                        payload.rawResponse(),
+                        payload.requestBodyJson(),
+                        payload.openAiJobId(),
+                        payload.inputTokens(),
+                        payload.outputTokens(),
+                        payload.costUsd()));
+    }
+
+    /** Busca detalhes da execução da etapa copy no endpoint dedicado da etapa. */
+    public GeraLandingStageExecutionDetailDto fetchCopyStageExecutionDetail(Long experimentId, String idJob) {
+        return delegate.fetchCopyStageExecutionDetail(experimentId, idJob);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyExecutionService.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.copy;
 
-import com.marketinghub.worker.geralanding.GeraLandingExecutionService;
-import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
+import com.marketinghub.worker.geralanding.copy.GeraLandingExecutionService;
+import com.marketinghub.worker.geralanding.copy.GeraLandingStageExecutionDto;
 import java.util.List;
 import org.springframework.stereotype.Service;
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingExecutionService.java
@@ -1,0 +1,23 @@
+package com.marketinghub.worker.geralanding.copy;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Responsabilidade: encapsular execução da etapa copy preservando isolamento de pacote. */
+@Service("geraLandingCopyExecutionStageService")
+public class GeraLandingExecutionService {
+    private final com.marketinghub.worker.geralanding.GeraLandingExecutionService delegate;
+
+    public GeraLandingExecutionService(com.marketinghub.worker.geralanding.GeraLandingExecutionService delegate) {
+        this.delegate = delegate;
+    }
+
+    /** Processa as execuções da etapa copy convertendo para DTO base do pipeline. */
+    public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
+        List<com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto> mapped = jobs.stream()
+                .map(item -> new com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto(
+                        item.experimentId(), item.idJob(), item.stageCode()))
+                .toList();
+        delegate.processExecutions(mapped);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingExperimentRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingExperimentRequest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.worker.geralanding.copy;
+
+import java.util.Map;
+
+/** Responsabilidade: concentrar os dados do experimento para montagem de request da etapa copy. */
+public record GeraLandingExperimentRequest(
+        Long experimentId,
+        Map<String, Object> dados
+) {
+    /** Retorna fallback textual quando valor estiver nulo ou em branco. */
+    public String resolveText(String value, String fallback) {
+        if (value == null || value.trim().isEmpty()) {
+            return fallback;
+        }
+        return value.trim();
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingJobCompletionPayload.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingJobCompletionPayload.java
@@ -1,0 +1,14 @@
+package com.marketinghub.worker.geralanding.copy;
+
+import java.math.BigDecimal;
+
+/** Responsabilidade: transportar resultado da OpenAI para conclusão da etapa de copy. */
+public record GeraLandingJobCompletionPayload(
+        String responseContent,
+        String rawResponse,
+        String requestBodyJson,
+        String openAiJobId,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd) {
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingStageExecutionDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingStageExecutionDto.java
@@ -1,0 +1,9 @@
+package com.marketinghub.worker.geralanding.copy;
+
+/** Responsabilidade: representar a execução pendente da etapa de copy no GeraLanding. */
+public record GeraLandingStageExecutionDto(
+        Long experimentId,
+        String idJob,
+        String stageCode
+) {
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/MontaRequest.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.copy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import com.marketinghub.worker.geralanding.copy.GeraLandingExperimentRequest;
 import com.marketinghub.worker.geralanding.comum.MontaRequestSupport;
 import java.io.IOException;
 import java.util.LinkedHashMap;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/RecebeResponse.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.copy;
 
-import com.marketinghub.worker.geralanding.GeraLandingBackendClient;
-import com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload;
+import com.marketinghub.worker.geralanding.copy.GeraLandingBackendClient;
+import com.marketinghub.worker.geralanding.copy.GeraLandingJobCompletionPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1956,3 +1956,12 @@
   - atualizado cada `*ExecutionScheduler` de etapa para depender do serviço da própria etapa, removendo o import direto do executor compartilhado.
 - validação executada:
   - `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test` (falhou por dependência externa sem autenticação: `com.marketinghub:ads-service:0.0.1-SNAPSHOT`, erro 401 no GitHub Packages).
+
+## 2026-05-27 13:37:00 UTC-3
+- solicitação: mover dependências de GeraLanding para pacote de etapa no AI Worker, aceitando duplicação para isolamento arquitetural.
+- causa-raiz identificada: pacote `copy` dependia de classes-base em `com.marketinghub.worker.geralanding`, contrariando a regra de isolamento por etapa do `ai-worker/AGENTS.md`.
+- correção aplicada: criadas seis classes locais no pacote `copy` (`GeraLandingExecutionService`, `GeraLandingStageExecutionDto`, `GeraLandingExperimentRequest`, `GeraLandingBackendClient`, `GeraLandingJobCompletionPayload`) com delegação/mapeamento para as classes base, e atualização dos imports do pacote `copy` para usar apenas as classes locais.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Enforce package-level isolation for the `copy` stage by avoiding direct imports from `com.marketinghub.worker.geralanding` as required by the AI Worker architecture and `AGENTS.md`.
- Prevent cross-package coupling so stage-specific schedulers and services only depend on local stage types and adapters.

### Description
- Introduced stage-local abstractions for `copy`: `GeraLandingBackendClient`, `GeraLandingExecutionService`, `GeraLandingStageExecutionDto`, `GeraLandingExperimentRequest`, and `GeraLandingJobCompletionPayload`, each delegating or mapping to the existing shared implementations.
- Updated `CopyPendingJobsService`, `GeraLandingCopyExecutionService`, `MontaRequest`, and `RecebeResponse` to import and use the new local `copy` package types instead of the base package types.
- Implemented adapter methods in `GeraLandingBackendClient` to translate requests/responses to/from the shared backend client and payload DTOs.
- Recorded the change and rationale in `docs/registros/experimentos.md` under the 2026-05-27 entries.

### Testing
- Ran `mvn -f ai-worker/pom.xml -DskipTests compile`, which failed due to an external dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT` being unavailable (HTTP 401) in the GitHub Packages repository.
- Ran `mvn -f ai-worker/pom.xml -Dtest=GeraLandingExecutionServiceTest test`, which also failed for the same external dependency authentication issue (HTTP 401).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171c98676c83219544d64cef951613)