### PR TITLE
Fix GeraLandingExecutionService pending stage DTO list types

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -129,11 +129,15 @@ public class GeraLandingExecutionService {
             return;
         }
         List<GeraLandingStageExecutionDto> pending = backendClient.listPendingExecutions(pendingLimit);
-        List<GeraLandingStageExecutionDto> wireframePending = wireframePendingJobsService.listPendingWireframeJobs(pendingLimit);
+        List<com.marketinghub.worker.geralanding.wireframe.GeraLandingStageExecutionWireframeDto> wireframePending =
+                wireframePendingJobsService.listPendingWireframeJobs(pendingLimit);
         List<com.marketinghub.worker.geralanding.copy.GeraLandingStageExecutionDto> copyPending = copyPendingJobsService.listPendingCopyJobs(pendingLimit);
-        List<GeraLandingStageExecutionDto> imagePlanningPending = imagePlanningPendingJobsService.listPendingImagePlanningJobs(pendingLimit);
-        List<GeraLandingStageExecutionDto> presetDesignPending = presetDesignPendingJobsService.listPendingPresetDesignJobs(pendingLimit);
-        List<GeraLandingStageExecutionDto> deliverablesPending = deliverablesPendingJobsService.listPendingDeliverablesJobs(pendingLimit);
+        List<com.marketinghub.worker.geralanding.imageplanning.GeraLandingStageExecutionImagePlanningDto> imagePlanningPending =
+                imagePlanningPendingJobsService.listPendingImagePlanningJobs(pendingLimit);
+        List<com.marketinghub.worker.geralanding.presetdesign.GeraLandingStageExecutionPresetDesignDto> presetDesignPending =
+                presetDesignPendingJobsService.listPendingPresetDesignJobs(pendingLimit);
+        List<com.marketinghub.worker.geralanding.deliverables.GeraLandingStageExecutionDeliverablesDto> deliverablesPending =
+                deliverablesPendingJobsService.listPendingDeliverablesJobs(pendingLimit);
         log.info("Stage pending jobs via stage controllers: wireframe={}, copy={}, imagePlanning={}, designPreset={}, deliverables={}",
                 wireframePending.size(), copyPending.size(), imagePlanningPending.size(), presetDesignPending.size(), deliverablesPending.size());
         log.info("GeraLanding execution worker found {} pending execution(s)", pending.size());


### PR DESCRIPTION
### Motivation
- Resolve compilation errors caused by incorrect generic list types in `GeraLandingExecutionService.processPendingExecutions` where stage-specific pending job services return stage-scoped DTO types rather than the base `GeraLandingStageExecutionDto`.

### Description
- Adjusted the local variable declarations in `ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java` to use the stage-specific DTO list types for `wireframe`, `imageplanning`, `presetdesign` and `deliverables`, preserving existing behavior (only used for logging/counts).

### Testing
- Ran `mvn -f ai-worker/pom.xml -DskipTests compile`, which confirmed dependency resolution in this environment is blocked by a private package authentication error (`com.marketinghub:ads-service:0.0.1-SNAPSHOT` returned 401), but the source-level generic incompatibility reported by CI is addressed by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1724f770748321bd5e1e5058be0d0d)