### PR TITLE
Isolate wireframe stage DTOs and adapters; route wireframe requests/payloads through stage-specific wrappers

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -249,7 +249,7 @@ public class GeraLandingExecutionService {
                                            GeraLandingStageExecutionDto execution,
                                            GeraLandingJobCompletionPayload payload) {
         switch (stage) {
-            case WIREFRAME -> wireframeRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), payload);
+            case WIREFRAME -> wireframeRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), toWireframePayload(payload));
             case COPY -> copyRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), toCopyPayload(payload));
             case IMAGE_PLANNING -> imagePlanningRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), payload);
             case DESIGN_PRESET -> presetDesignRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), payload);
@@ -473,7 +473,7 @@ public class GeraLandingExecutionService {
     private String montarRequestPorEtapa(GeraLandingStageDefinition stage,
                                          GeraLandingExperimentRequest experiment) throws IOException {
         return switch (stage) {
-            case WIREFRAME -> wireframeMontaRequest.montar(experiment);
+            case WIREFRAME -> wireframeMontaRequest.montar(toWireframeExperiment(experiment));
             case COPY -> copyMontaRequest.montar(toCopyExperiment(experiment));
             case IMAGE_PLANNING -> imagePlanningMontaRequest.montar(experiment);
             case DESIGN_PRESET -> presetDesignMontaRequest.montar(experiment);
@@ -486,7 +486,7 @@ public class GeraLandingExecutionService {
     private String montarPromptPorEtapa(GeraLandingStageDefinition stage,
                                         GeraLandingExperimentRequest experiment) throws IOException {
         return switch (stage) {
-            case WIREFRAME -> wireframeMontaRequest.montarPrompt(experiment);
+            case WIREFRAME -> wireframeMontaRequest.montarPrompt(toWireframeExperiment(experiment));
             case COPY -> copyMontaRequest.montarPrompt(toCopyExperiment(experiment));
             case IMAGE_PLANNING -> imagePlanningMontaRequest.montarPrompt(experiment);
             case DESIGN_PRESET -> presetDesignMontaRequest.montarPrompt(experiment);
@@ -510,12 +510,32 @@ public class GeraLandingExecutionService {
         return new com.marketinghub.worker.geralanding.copy.GeraLandingExperimentRequest(experiment.experimentId(), experiment.dados());
     }
 
+    /** Converte o request comum para o tipo isolado da etapa wireframe. */
+    private com.marketinghub.worker.geralanding.wireframe.GeraLandingExperimentWireframeRequest toWireframeExperiment(GeraLandingExperimentRequest experiment) {
+        return new com.marketinghub.worker.geralanding.wireframe.GeraLandingExperimentWireframeRequest(experiment.experimentId(), experiment.dados());
+    }
+
     /** Converte o payload comum para o tipo isolado da etapa copy. */
     private com.marketinghub.worker.geralanding.copy.GeraLandingJobCompletionPayload toCopyPayload(GeraLandingJobCompletionPayload payload) {
         if (payload == null) {
             return null;
         }
         return new com.marketinghub.worker.geralanding.copy.GeraLandingJobCompletionPayload(
+                payload.responseContent(),
+                payload.rawResponse(),
+                payload.requestBodyJson(),
+                payload.openAiJobId(),
+                payload.inputTokens(),
+                payload.outputTokens(),
+                payload.costUsd());
+    }
+
+    /** Converte o payload comum para o tipo isolado da etapa wireframe. */
+    private com.marketinghub.worker.geralanding.wireframe.GeraLandingJobCompletionWireframePayload toWireframePayload(GeraLandingJobCompletionPayload payload) {
+        if (payload == null) {
+            return null;
+        }
+        return new com.marketinghub.worker.geralanding.wireframe.GeraLandingJobCompletionWireframePayload(
                 payload.responseContent(),
                 payload.rawResponse(),
                 payload.requestBodyJson(),

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingBackendClient.java
@@ -1,0 +1,37 @@
+package com.marketinghub.worker.geralanding.wireframe;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Responsabilidade: encapsular o cliente de backend da etapa wireframe mantendo isolamento por pacote. */
+@Component("geraLandingWireframeBackendClient")
+public class GeraLandingBackendClient {
+    private final com.marketinghub.worker.geralanding.GeraLandingBackendClient delegate;
+
+    public GeraLandingBackendClient(com.marketinghub.worker.geralanding.GeraLandingBackendClient delegate) {
+        this.delegate = delegate;
+    }
+
+    /** Lista execuções pendentes e converte para o DTO local da etapa wireframe. */
+    public List<GeraLandingStageExecutionWireframeDto> listPendingExecutions(int limit) {
+        return delegate.listPendingExecutions(limit).stream()
+                                .map(item -> new GeraLandingStageExecutionWireframeDto(
+                        item.experimentId(), item.idJob(), item.stageCode()))
+                .toList();
+    }
+
+    /** Encaminha confirmação de despacho do job da etapa wireframe para o backend principal. */
+    public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) {
+        delegate.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);
+    }
+
+    /** Envia resultado da etapa wireframe ao backend principal. */
+    public void receiveResult(String idJob, Long experimentId, String stageCode, GeraLandingJobCompletionWireframePayload payload) {
+        delegate.receiveResult(idJob, experimentId, stageCode, payload.toBase());
+    }
+
+    /** Busca detalhes da execução da etapa wireframe no endpoint dedicado da etapa. */
+    public GeraLandingStageExecutionDetailDto fetchWireframeStageExecutionDetail(Long experimentId, String idJob) {
+        return delegate.fetchWireframeStageExecutionDetail(experimentId, idJob);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingExecutionService.java
@@ -1,0 +1,23 @@
+package com.marketinghub.worker.geralanding.wireframe;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Responsabilidade: encapsular execução da etapa wireframe preservando isolamento de pacote. */
+@Service("geraLandingWireframeExecutionStageService")
+public class GeraLandingExecutionService {
+    private final com.marketinghub.worker.geralanding.GeraLandingExecutionService delegate;
+
+    public GeraLandingExecutionService(com.marketinghub.worker.geralanding.GeraLandingExecutionService delegate) {
+        this.delegate = delegate;
+    }
+
+    /** Processa as execuções da etapa wireframe convertendo para DTO base do pipeline. */
+    public void processExecutions(List<GeraLandingStageExecutionWireframeDto> jobs) {
+        List<com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto> mapped = jobs.stream()
+                                .map(item -> new com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto(
+                        item.experimentId(), item.idJob(), item.stageCode()))
+                .toList();
+        delegate.processExecutions(mapped);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingExecutionWireframeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingExecutionWireframeService.java
@@ -6,14 +6,14 @@ import org.springframework.stereotype.Service;
 /** Centraliza a execução de jobs da etapa wireframe usando o executor base. */
 @Service
 public class GeraLandingExecutionWireframeService {
-    private final com.marketinghub.worker.geralanding.GeraLandingExecutionService executionService;
+    private final GeraLandingExecutionService executionService;
 
-    public GeraLandingExecutionWireframeService(com.marketinghub.worker.geralanding.GeraLandingExecutionService executionService) {
+    public GeraLandingExecutionWireframeService(GeraLandingExecutionService executionService) {
         this.executionService = executionService;
     }
 
     /** Processa os jobs pendentes já filtrados da etapa wireframe. */
     public void processExecutions(List<GeraLandingStageExecutionWireframeDto> jobs) {
-        executionService.processExecutions(jobs.stream().map(GeraLandingStageExecutionWireframeDto::toBase).toList());
+        executionService.processExecutions(jobs);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingStageExecutionWireframeDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingStageExecutionWireframeDto.java
@@ -5,15 +5,4 @@ public record GeraLandingStageExecutionWireframeDto(
         Long experimentId,
         String idJob,
         String stageCode) {
-
-    /** Converte o DTO específico de wireframe para o DTO base do GeraLanding. */
-    public com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto toBase() {
-        return new com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto(experimentId, idJob, stageCode);
-    }
-
-    /** Cria um DTO wireframe a partir do DTO base do GeraLanding. */
-    public static GeraLandingStageExecutionWireframeDto fromBase(
-            com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto base) {
-        return new GeraLandingStageExecutionWireframeDto(base.experimentId(), base.idJob(), base.stageCode());
-    }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeBackendClient.java
@@ -5,10 +5,11 @@ import org.springframework.stereotype.Component;
 
 /** Encapsula o acesso ao backend para operações da etapa wireframe. */
 @Component
+@Deprecated
 public class GeraLandingWireframeBackendClient {
-    private final com.marketinghub.worker.geralanding.GeraLandingBackendClient backendClient;
+    private final GeraLandingBackendClient backendClient;
 
-    public GeraLandingWireframeBackendClient(com.marketinghub.worker.geralanding.GeraLandingBackendClient backendClient) {
+    public GeraLandingWireframeBackendClient(GeraLandingBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/MontaRequest.java
@@ -1,7 +1,6 @@
 package com.marketinghub.worker.geralanding.wireframe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import com.marketinghub.worker.geralanding.comum.MontaRequestSupport;
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -30,7 +29,7 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
-    public String montar(GeraLandingExperimentRequest experiment) throws IOException {
+    public String montar(GeraLandingExperimentWireframeRequest experiment) throws IOException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);
@@ -63,7 +62,7 @@ public class MontaRequest {
     }
 
     /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
-    public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
+    public String montarPrompt(GeraLandingExperimentWireframeRequest experiment) throws IOException {
         return MontaRequestSupport.montarPrompt("prompts/geralanding/" + PROMPT_MARKDOWN_FILE, PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/RecebeResponse.java
@@ -1,7 +1,5 @@
 package com.marketinghub.worker.geralanding.wireframe;
 
-import com.marketinghub.worker.geralanding.GeraLandingBackendClient;
-import com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -24,7 +22,7 @@ public class RecebeResponse {
     /**
      * Envia para o backend os dados de despacho e de resultado da etapa, incluindo a resposta crua da OpenAI.
      */
-    public void processar(Long experimentId, String stageCode, String idJob, GeraLandingJobCompletionPayload payload) {
+    public void processar(Long experimentId, String stageCode, String idJob, GeraLandingJobCompletionWireframePayload payload) {
         if (payload != null && payload.openAiJobId() != null && !payload.openAiJobId().isBlank()) {
             backendClient.receiveDispatch(idJob, experimentId, stageCode, payload.openAiJobId());
         }


### PR DESCRIPTION
### Motivation

- Encapsulate wireframe-stage specific DTOs and backend interactions to avoid leaking stage-specific types into the core pipeline and to enable stage-focused request/payload handling.
- Allow the core execution flow to remain generic while providing type-safe montadores/receivers for the wireframe stage.

### Description

- Added a new `wireframe` package containing `GeraLandingBackendClient`, `GeraLandingExecutionService`, `RecebeResponse`, `MontaRequest` and `GeraLandingStageExecutionWireframeDto` to isolate wireframe-specific logic and DTOs.
- Updated core `GeraLandingExecutionService` to convert base experiment and payload objects into wireframe-specific types via `toWireframeExperiment` and `toWireframePayload`, and to route WIREFRAME stage calls through those converters when building requests, prompts and when forwarding responses.
- Modified `GeraLandingExecutionWireframeService` to use the new package-level `GeraLandingExecutionService` wrapper and simplified the processing call to pass wireframe DTOs directly.
- Left a thin compatibility wrapper `GeraLandingWireframeBackendClient` annotated `@Deprecated` that delegates to the new `GeraLandingBackendClient` adapter.

### Testing

- Ran project build and unit tests using the standard test suite (`mvn test`), and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172741b5808321b93b084bf2641212)