### PR TITLE
Fix invalid method reference in wireframe backend client

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeBackendClient.java
@@ -15,9 +15,7 @@ public class GeraLandingWireframeBackendClient {
 
     /** Lista execuções pendentes convertendo para o DTO específico da etapa wireframe. */
     public List<GeraLandingStageExecutionWireframeDto> listPendingExecutions(int limit) {
-        return backendClient.listPendingExecutions(limit).stream()
-                .map(GeraLandingStageExecutionWireframeDto::fromBase)
-                .toList();
+        return backendClient.listPendingExecutions(limit);
     }
 
     /** Busca os detalhes de execução da etapa wireframe no backend. */


### PR DESCRIPTION
### Motivation
- Resolve a compilation error in `GeraLandingWireframeBackendClient#listPendingExecutions` caused by an invalid and unnecessary method reference `GeraLandingStageExecutionWireframeDto::fromBase`.

### Description
- Replace the stream mapping with a direct return of `backendClient.listPendingExecutions(limit)` in `ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeBackendClient.java`, removing the invalid `fromBase` usage.

### Testing
- Ran `mvn -q test` in the `ai-worker` module but the build could not complete because Maven failed to resolve `com.marketinghub:ads-service:0.0.1-SNAPSHOT` from GitHub Packages due to `401 Unauthorized`, so automated tests did not run to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172a3b4398832193f52673404e3922)