### PR TITLE
Isolate imageplanning/presetdesign/deliverables stages with stage-specific DTOs and backend clients

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -251,9 +251,9 @@ public class GeraLandingExecutionService {
         switch (stage) {
             case WIREFRAME -> wireframeRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), toWireframePayload(payload));
             case COPY -> copyRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), toCopyPayload(payload));
-            case IMAGE_PLANNING -> imagePlanningRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), payload);
-            case DESIGN_PRESET -> presetDesignRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), payload);
-            case DELIVERABLES -> deliverablesRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), payload);
+            case IMAGE_PLANNING -> imagePlanningRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), toImagePlanningPayload(payload));
+            case DESIGN_PRESET -> presetDesignRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), toPresetDesignPayload(payload));
+            case DELIVERABLES -> deliverablesRecebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), toDeliverablesPayload(payload));
             default -> throw new IllegalStateException("Etapa não suportada para processamento de resposta: " + stage);
         }
     }
@@ -475,9 +475,9 @@ public class GeraLandingExecutionService {
         return switch (stage) {
             case WIREFRAME -> wireframeMontaRequest.montar(toWireframeExperiment(experiment));
             case COPY -> copyMontaRequest.montar(toCopyExperiment(experiment));
-            case IMAGE_PLANNING -> imagePlanningMontaRequest.montar(experiment);
-            case DESIGN_PRESET -> presetDesignMontaRequest.montar(experiment);
-            case DELIVERABLES -> deliverablesMontaRequest.montar(experiment);
+            case IMAGE_PLANNING -> imagePlanningMontaRequest.montar(toImagePlanningExperiment(experiment));
+            case DESIGN_PRESET -> presetDesignMontaRequest.montar(toPresetDesignExperiment(experiment));
+            case DELIVERABLES -> deliverablesMontaRequest.montar(toDeliverablesExperiment(experiment));
         };
     }
 
@@ -488,9 +488,9 @@ public class GeraLandingExecutionService {
         return switch (stage) {
             case WIREFRAME -> wireframeMontaRequest.montarPrompt(toWireframeExperiment(experiment));
             case COPY -> copyMontaRequest.montarPrompt(toCopyExperiment(experiment));
-            case IMAGE_PLANNING -> imagePlanningMontaRequest.montarPrompt(experiment);
-            case DESIGN_PRESET -> presetDesignMontaRequest.montarPrompt(experiment);
-            case DELIVERABLES -> deliverablesMontaRequest.montarPrompt(experiment);
+            case IMAGE_PLANNING -> imagePlanningMontaRequest.montarPrompt(toImagePlanningExperiment(experiment));
+            case DESIGN_PRESET -> presetDesignMontaRequest.montarPrompt(toPresetDesignExperiment(experiment));
+            case DELIVERABLES -> deliverablesMontaRequest.montarPrompt(toDeliverablesExperiment(experiment));
         };
     }
 
@@ -515,6 +515,21 @@ public class GeraLandingExecutionService {
         return new com.marketinghub.worker.geralanding.wireframe.GeraLandingExperimentWireframeRequest(experiment.experimentId(), experiment.dados());
     }
 
+    /** Converte o request comum para o tipo isolado da etapa imageplanning. */
+    private com.marketinghub.worker.geralanding.imageplanning.GeraLandingExperimentImagePlanningRequest toImagePlanningExperiment(GeraLandingExperimentRequest experiment) {
+        return new com.marketinghub.worker.geralanding.imageplanning.GeraLandingExperimentImagePlanningRequest(experiment.experimentId(), experiment.dados());
+    }
+
+    /** Converte o request comum para o tipo isolado da etapa presetdesign. */
+    private com.marketinghub.worker.geralanding.presetdesign.GeraLandingExperimentPresetDesignRequest toPresetDesignExperiment(GeraLandingExperimentRequest experiment) {
+        return new com.marketinghub.worker.geralanding.presetdesign.GeraLandingExperimentPresetDesignRequest(experiment.experimentId(), experiment.dados());
+    }
+
+    /** Converte o request comum para o tipo isolado da etapa deliverables. */
+    private com.marketinghub.worker.geralanding.deliverables.GeraLandingExperimentDeliverablesRequest toDeliverablesExperiment(GeraLandingExperimentRequest experiment) {
+        return new com.marketinghub.worker.geralanding.deliverables.GeraLandingExperimentDeliverablesRequest(experiment.experimentId(), experiment.dados());
+    }
+
     /** Converte o payload comum para o tipo isolado da etapa copy. */
     private com.marketinghub.worker.geralanding.copy.GeraLandingJobCompletionPayload toCopyPayload(GeraLandingJobCompletionPayload payload) {
         if (payload == null) {
@@ -536,6 +551,51 @@ public class GeraLandingExecutionService {
             return null;
         }
         return new com.marketinghub.worker.geralanding.wireframe.GeraLandingJobCompletionWireframePayload(
+                payload.responseContent(),
+                payload.rawResponse(),
+                payload.requestBodyJson(),
+                payload.openAiJobId(),
+                payload.inputTokens(),
+                payload.outputTokens(),
+                payload.costUsd());
+    }
+
+    /** Converte o payload comum para o tipo isolado da etapa imageplanning. */
+    private com.marketinghub.worker.geralanding.imageplanning.GeraLandingJobCompletionImagePlanningPayload toImagePlanningPayload(GeraLandingJobCompletionPayload payload) {
+        if (payload == null) {
+            return null;
+        }
+        return new com.marketinghub.worker.geralanding.imageplanning.GeraLandingJobCompletionImagePlanningPayload(
+                payload.responseContent(),
+                payload.rawResponse(),
+                payload.requestBodyJson(),
+                payload.openAiJobId(),
+                payload.inputTokens(),
+                payload.outputTokens(),
+                payload.costUsd());
+    }
+
+    /** Converte o payload comum para o tipo isolado da etapa presetdesign. */
+    private com.marketinghub.worker.geralanding.presetdesign.GeraLandingJobCompletionPresetDesignPayload toPresetDesignPayload(GeraLandingJobCompletionPayload payload) {
+        if (payload == null) {
+            return null;
+        }
+        return new com.marketinghub.worker.geralanding.presetdesign.GeraLandingJobCompletionPresetDesignPayload(
+                payload.responseContent(),
+                payload.rawResponse(),
+                payload.requestBodyJson(),
+                payload.openAiJobId(),
+                payload.inputTokens(),
+                payload.outputTokens(),
+                payload.costUsd());
+    }
+
+    /** Converte o payload comum para o tipo isolado da etapa deliverables. */
+    private com.marketinghub.worker.geralanding.deliverables.GeraLandingJobCompletionDeliverablesPayload toDeliverablesPayload(GeraLandingJobCompletionPayload payload) {
+        if (payload == null) {
+            return null;
+        }
+        return new com.marketinghub.worker.geralanding.deliverables.GeraLandingJobCompletionDeliverablesPayload(
                 payload.responseContent(),
                 payload.rawResponse(),
                 payload.requestBodyJson(),

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/MontaRequest.java
@@ -1,7 +1,6 @@
 package com.marketinghub.worker.geralanding.deliverables;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import com.marketinghub.worker.geralanding.comum.MontaRequestSupport;
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -30,7 +29,7 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
-    public String montar(GeraLandingExperimentRequest experiment) throws IOException {
+    public String montar(GeraLandingExperimentDeliverablesRequest experiment) throws IOException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);
@@ -63,7 +62,7 @@ public class MontaRequest {
     }
 
     /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
-    public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
+    public String montarPrompt(GeraLandingExperimentDeliverablesRequest experiment) throws IOException {
         return MontaRequestSupport.montarPrompt("prompts/geralanding/" + PROMPT_MARKDOWN_FILE, PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/RecebeResponse.java
@@ -1,7 +1,5 @@
 package com.marketinghub.worker.geralanding.deliverables;
 
-import com.marketinghub.worker.geralanding.GeraLandingBackendClient;
-import com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -15,16 +13,16 @@ public class RecebeResponse {
 
     private static final Logger log = LoggerFactory.getLogger(RecebeResponse.class);
 
-    private final GeraLandingBackendClient backendClient;
+    private final GeraLandingDeliverablesBackendClient backendClient;
 
-    public RecebeResponse(GeraLandingBackendClient backendClient) {
+    public RecebeResponse(GeraLandingDeliverablesBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 
     /**
      * Envia para o backend os dados de despacho e de resultado da etapa, incluindo a resposta crua da OpenAI.
      */
-    public void processar(Long experimentId, String stageCode, String idJob, GeraLandingJobCompletionPayload payload) {
+    public void processar(Long experimentId, String stageCode, String idJob, GeraLandingJobCompletionDeliverablesPayload payload) {
         if (payload != null && payload.openAiJobId() != null && !payload.openAiJobId().isBlank()) {
             backendClient.receiveDispatch(idJob, experimentId, stageCode, payload.openAiJobId());
         }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/MontaRequest.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.imageplanning;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import com.marketinghub.worker.geralanding.imageplanning.GeraLandingExperimentImagePlanningRequest;
 import com.marketinghub.worker.geralanding.comum.MontaRequestSupport;
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -30,7 +30,7 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
-    public String montar(GeraLandingExperimentRequest experiment) throws IOException {
+    public String montar(GeraLandingExperimentImagePlanningRequest experiment) throws IOException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);
@@ -63,7 +63,7 @@ public class MontaRequest {
     }
 
     /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
-    public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
+    public String montarPrompt(GeraLandingExperimentImagePlanningRequest experiment) throws IOException {
         return MontaRequestSupport.montarPrompt("prompts/geralanding/" + PROMPT_MARKDOWN_FILE, PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/RecebeResponse.java
@@ -1,7 +1,5 @@
 package com.marketinghub.worker.geralanding.imageplanning;
 
-import com.marketinghub.worker.geralanding.GeraLandingBackendClient;
-import com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -15,16 +13,16 @@ public class RecebeResponse {
 
     private static final Logger log = LoggerFactory.getLogger(RecebeResponse.class);
 
-    private final GeraLandingBackendClient backendClient;
+    private final GeraLandingImagePlanningBackendClient backendClient;
 
-    public RecebeResponse(GeraLandingBackendClient backendClient) {
+    public RecebeResponse(GeraLandingImagePlanningBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 
     /**
      * Envia para o backend os dados de despacho e de resultado da etapa, incluindo a resposta crua da OpenAI.
      */
-    public void processar(Long experimentId, String stageCode, String idJob, GeraLandingJobCompletionPayload payload) {
+    public void processar(Long experimentId, String stageCode, String idJob, GeraLandingJobCompletionImagePlanningPayload payload) {
         if (payload != null && payload.openAiJobId() != null && !payload.openAiJobId().isBlank()) {
             backendClient.receiveDispatch(idJob, experimentId, stageCode, payload.openAiJobId());
         }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/MontaRequest.java
@@ -1,7 +1,6 @@
 package com.marketinghub.worker.geralanding.presetdesign;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
 import com.marketinghub.worker.geralanding.comum.MontaRequestSupport;
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -30,7 +29,7 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
-    public String montar(GeraLandingExperimentRequest experiment) throws IOException {
+    public String montar(GeraLandingExperimentPresetDesignRequest experiment) throws IOException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);
@@ -63,7 +62,7 @@ public class MontaRequest {
     }
 
     /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
-    public String montarPrompt(GeraLandingExperimentRequest experiment) throws IOException {
+    public String montarPrompt(GeraLandingExperimentPresetDesignRequest experiment) throws IOException {
         return MontaRequestSupport.montarPrompt("prompts/geralanding/" + PROMPT_MARKDOWN_FILE, PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/RecebeResponse.java
@@ -1,7 +1,5 @@
 package com.marketinghub.worker.geralanding.presetdesign;
 
-import com.marketinghub.worker.geralanding.GeraLandingBackendClient;
-import com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -15,16 +13,16 @@ public class RecebeResponse {
 
     private static final Logger log = LoggerFactory.getLogger(RecebeResponse.class);
 
-    private final GeraLandingBackendClient backendClient;
+    private final GeraLandingPresetDesignBackendClient backendClient;
 
-    public RecebeResponse(GeraLandingBackendClient backendClient) {
+    public RecebeResponse(GeraLandingPresetDesignBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 
     /**
      * Envia para o backend os dados de despacho e de resultado da etapa, incluindo a resposta crua da OpenAI.
      */
-    public void processar(Long experimentId, String stageCode, String idJob, GeraLandingJobCompletionPayload payload) {
+    public void processar(Long experimentId, String stageCode, String idJob, GeraLandingJobCompletionPresetDesignPayload payload) {
         if (payload != null && payload.openAiJobId() != null && !payload.openAiJobId().isBlank()) {
             backendClient.receiveDispatch(idJob, experimentId, stageCode, payload.openAiJobId());
         }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1989,3 +1989,14 @@
   - atualizado `GeraLandingImagePlanningExecutionService`, `GeraLandingPresetDesignExecutionService` e `GeraLandingDeliverablesExecutionService` para aceitar DTOs locais e converter para DTO base no ponto de delegação.
 - validação executada:
   - `mvn -q -DskipTests compile` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).
+
+## 2026-05-27 00:00:00 UTC (varredura de isolamento por etapa no ai-worker)
+- solicitação: varrer os pacotes de etapas do GeraLanding no `ai-worker` e substituir usos de classes compartilhadas quando já existirem equivalentes dentro do próprio pacote da etapa.
+- causa-raiz identificada: as etapas `imageplanning`, `presetdesign` e `deliverables` ainda recebiam/enviavam tipos compartilhados (`GeraLandingExperimentRequest`, `GeraLandingJobCompletionPayload` e `GeraLandingBackendClient`) apesar de já existirem DTOs/clients locais por etapa.
+- correção aplicada:
+  - `MontaRequest` de `imageplanning`, `presetdesign` e `deliverables` passou a receber os requests locais de etapa;
+  - `RecebeResponse` dessas três etapas passou a depender do backend client local e dos payloads locais de etapa;
+  - `GeraLandingExecutionService` foi ajustado para converter request/payload comuns nos tipos locais de `imageplanning`, `presetdesign` e `deliverables` antes de chamar `MontaRequest` e `RecebeResponse`.
+- validação executada:
+  - `mvn -Dtest=ArquiteturaTest test -DskipITs` em `backend/ads-service` (sucesso);
+  - `mvn -Dtest=ArquiteturaTest test -DskipITs` em `ai-worker` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation
- Reduce cross-stage coupling by replacing usages of shared `GeraLandingExperimentRequest`, `GeraLandingJobCompletionPayload` and `GeraLandingBackendClient` with stage-local DTOs/clients for `imageplanning`, `presetdesign` and `deliverables` following the existing wireframe isolation pattern.
- Ensure each stage API surface accepts and emits its own typed request/payload to make stage implementations independent and safer to evolve.

### Description
- Updated `GeraLandingExecutionService` to convert common request/payload types to stage-specific types via new helpers `toImagePlanningExperiment`, `toPresetDesignExperiment`, `toDeliverablesExperiment`, and `toImagePlanningPayload`, `toPresetDesignPayload`, `toDeliverablesPayload`, and to call the stage-specific `MontaRequest`/`RecebeResponse` APIs. 
- Adjusted `montarRequestPorEtapa`, `montarPromptPorEtapa` and `encaminharRespostaDaEtapa` to use the stage-local types for `IMAGE_PLANNING`, `DESIGN_PRESET` and `DELIVERABLES` stages. 
- Changed `MontaRequest` signatures for `imageplanning`, `presetdesign` and `deliverables` to accept their respective `GeraLandingExperiment<Etapa>Request` types and their `montarPrompt` overloads accordingly. 
- Updated `RecebeResponse` implementations for those three stages to depend on stage-specific backend clients (`GeraLandingImagePlanningBackendClient`, `GeraLandingPresetDesignBackendClient`, `GeraLandingDeliverablesBackendClient`) and to accept the stage-specific `GeraLandingJobCompletion<Etapa>Payload` types; also updated constructors and `processar` method signatures. 
- Added corresponding conversion helpers and kept prompt/schema loading behavior unchanged; updated documentation `docs/registros/experimentos.md` describing the changes. 

### Testing
- Ran `mvn -q -Dtest=GeraLandingExecutionServiceTest,GeraLandingServiceTest test`, which failed because the private external dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT` could not be fetched (HTTP 401). 
- Ran `mvn -q -DskipTests compile` in `ai-worker`, which also failed due to the same private dependency resolution error. 
- Ran `mvn -Dtest=ArquiteturaTest test -DskipITs` in `backend/ads-service`, which succeeded; running the same command in `ai-worker` failed due to the private dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT` returning HTTP 401.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172fa7c68083218a7b47a8f9380618)