### PR TITLE
Add missing `receiveDispatch` / `receiveResult` to GeraLanding stage backend clients

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java
@@ -17,6 +17,25 @@ public class GeraLandingDeliverablesBackendClient {
         return backendClient.listPendingExecutions(limit).stream().map(GeraLandingStageExecutionDeliverablesDto::fromBase).toList();
     }
 
+    /** Envia resultado da etapa para o backend principal com mapeamento para payload base. */
+    public void receiveResult(String idJob, Long experimentId, String stageCode, GeraLandingJobCompletionDeliverablesPayload payload) {
+        backendClient.receiveResult(idJob, experimentId, stageCode,
+                new com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload(
+                        payload != null ? payload.responseContent() : null,
+                        payload != null ? payload.rawResponse() : null,
+                        payload != null ? payload.requestBodyJson() : null,
+                        payload != null ? payload.openAiJobId() : null,
+                        payload != null ? payload.inputTokens() : null,
+                        payload != null ? payload.outputTokens() : null,
+                        payload != null ? payload.costUsd() : null));
+    }
+
+
+    /** Encaminha confirmação de despacho da etapa para o backend principal. */
+    public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) {
+        backendClient.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);
+    }
+
     /** Busca os detalhes de execução da etapa no backend. */
     public GeraLandingStageExecutionDetailDto fetchStageExecutionDetail(Long experimentId, String idJob) {
         return backendClient.fetchDeliverablesStageExecutionDetail(experimentId, idJob);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningBackendClient.java
@@ -17,6 +17,25 @@ public class GeraLandingImagePlanningBackendClient {
         return backendClient.listPendingExecutions(limit).stream().map(GeraLandingStageExecutionImagePlanningDto::fromBase).toList();
     }
 
+    /** Envia resultado da etapa para o backend principal com mapeamento para payload base. */
+    public void receiveResult(String idJob, Long experimentId, String stageCode, GeraLandingJobCompletionImagePlanningPayload payload) {
+        backendClient.receiveResult(idJob, experimentId, stageCode,
+                new com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload(
+                        payload != null ? payload.responseContent() : null,
+                        payload != null ? payload.rawResponse() : null,
+                        payload != null ? payload.requestBodyJson() : null,
+                        payload != null ? payload.openAiJobId() : null,
+                        payload != null ? payload.inputTokens() : null,
+                        payload != null ? payload.outputTokens() : null,
+                        payload != null ? payload.costUsd() : null));
+    }
+
+
+    /** Encaminha confirmação de despacho da etapa para o backend principal. */
+    public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) {
+        backendClient.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);
+    }
+
     /** Busca os detalhes de execução da etapa no backend. */
     public GeraLandingStageExecutionDetailDto fetchStageExecutionDetail(Long experimentId, String idJob) {
         return backendClient.fetchImagePlanningStageExecutionDetail(experimentId, idJob);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignBackendClient.java
@@ -17,6 +17,25 @@ public class GeraLandingPresetDesignBackendClient {
         return backendClient.listPendingExecutions(limit).stream().map(GeraLandingStageExecutionPresetDesignDto::fromBase).toList();
     }
 
+    /** Envia resultado da etapa para o backend principal com mapeamento para payload base. */
+    public void receiveResult(String idJob, Long experimentId, String stageCode, GeraLandingJobCompletionPresetDesignPayload payload) {
+        backendClient.receiveResult(idJob, experimentId, stageCode,
+                new com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload(
+                        payload != null ? payload.responseContent() : null,
+                        payload != null ? payload.rawResponse() : null,
+                        payload != null ? payload.requestBodyJson() : null,
+                        payload != null ? payload.openAiJobId() : null,
+                        payload != null ? payload.inputTokens() : null,
+                        payload != null ? payload.outputTokens() : null,
+                        payload != null ? payload.costUsd() : null));
+    }
+
+
+    /** Encaminha confirmação de despacho da etapa para o backend principal. */
+    public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) {
+        backendClient.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);
+    }
+
     /** Busca os detalhes de execução da etapa no backend. */
     public GeraLandingStageExecutionDetailDto fetchStageExecutionDetail(Long experimentId, String idJob) {
         return backendClient.fetchDesignPresetStageExecutionDetail(experimentId, idJob);

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2000,3 +2000,16 @@
 - validação executada:
   - `mvn -Dtest=ArquiteturaTest test -DskipITs` em `backend/ads-service` (sucesso);
   - `mvn -Dtest=ArquiteturaTest test -DskipITs` em `ai-worker` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).
+
+
+## 2026-05-27 18:20:00 UTC
+- solicitação: corrigir erro de compilação no `ai-worker` causado por métodos ausentes nos backend clients de etapa do GeraLanding (`imageplanning`, `presetdesign`, `deliverables`).
+- causa-raiz identificada: no refactor de isolamento por etapa, os `RecebeResponse` passaram a chamar `receiveDispatch` e `receiveResult` nos clients locais, mas esses métodos não foram implementados nas classes locais.
+- correção aplicada:
+  - adicionados `receiveDispatch` e `receiveResult` em `GeraLandingImagePlanningBackendClient`;
+  - adicionados `receiveDispatch` e `receiveResult` em `GeraLandingPresetDesignBackendClient`;
+  - adicionados `receiveDispatch` e `receiveResult` em `GeraLandingDeliverablesBackendClient`;
+  - os métodos `receiveResult` fazem mapeamento explícito dos payloads de etapa para `GeraLandingJobCompletionPayload` antes de delegar ao backend client base.
+- validação executada:
+  - `mvn -pl ai-worker -DskipTests compile` (falhou: projeto não encontrado no reactor).
+  - `mvn -DskipTests compile` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation
- A refactor to isolate GeraLanding logic by stage caused `RecebeResponse` classes to call `receiveDispatch` and `receiveResult` on stage-local backend clients that did not expose those methods, producing compile-time `cannot find symbol` errors. 
- The change restores the expected client API surface so stage handlers can delegate dispatch/result callbacks to the shared backend client while preserving per-stage isolation.

### Description
- Added `receiveResult(String idJob, Long experimentId, String stageCode, <Stage>Payload payload)` to `GeraLandingImagePlanningBackendClient`, `GeraLandingPresetDesignBackendClient` and `GeraLandingDeliverablesBackendClient`, each mapping the stage-specific completion payload into the shared `com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload` and delegating to the base client.
- Added `receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId)` to the three stage-local backend clients to forward dispatch confirmations to the base backend client.
- Updated `docs/registros/experimentos.md` with the root cause analysis, applied fix and validation notes to follow repository operational rules.

### Testing
- Attempted compile from repo root with `mvn -pl ai-worker -DskipTests compile`, which failed with “project not found in the reactor” in this invocation. 
- Ran `cd ai-worker && mvn -DskipTests compile`, which failed in this environment due to a private dependency access error (`com.marketinghub:ads-service:0.0.1-SNAPSHOT` returned HTTP 401 from GitHub Packages), so full compilation could not be validated here.
- No automated unit tests were executed as part of this rollout due to dependency resolution limitations; the changes are limited to adding the missing client methods and should resolve the prior `cannot find symbol` errors when the project dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17334399bc8321b2375cb4a8ece84b)