### PR TITLE
Disambiguate overloaded `receiveResult` verification in GeraLandingExecutionServiceTest

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -1,6 +1,9 @@
 package com.marketinghub.worker.geralanding;
 
 import static org.mockito.ArgumentMatchers.any;
+
+import com.marketinghub.worker.geralanding.deliverables.GeraLandingJobCompletionDeliverablesPayload;
+import com.marketinghub.worker.geralanding.wireframe.GeraLandingJobCompletionWireframePayload;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
@@ -115,7 +118,10 @@ class GeraLandingExecutionServiceTest {
         verify(backendClient).receivePrompt(any(), any(), any(), any(), any(), any(), any(), any());
         verify(wireframeRecebeResponse).processar(any(), any(), any(), any());
         verify(backendClient, never()).receiveDispatch(any(), any(), any(), any());
-        verify(backendClient, never()).receiveResult(any(), any(), any(), any());
+        verify(backendClient, never())
+                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionWireframePayload.class));
+        verify(backendClient, never())
+                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionDeliverablesPayload.class));
         verify(backendClient, never()).receiveFailure(any(), any(), any(), any(), any());
     }
 
@@ -197,7 +203,10 @@ class GeraLandingExecutionServiceTest {
         service.processPendingExecutions();
 
         verify(backendClient).receiveFailure(any(), any(), any(), any(), any());
-        verify(backendClient, never()).receiveResult(any(), any(), any(), any());
+        verify(backendClient, never())
+                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionWireframePayload.class));
+        verify(backendClient, never())
+                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionDeliverablesPayload.class));
     }
 
     @Test
@@ -300,7 +309,10 @@ class GeraLandingExecutionServiceTest {
         service.processPendingExecutions();
 
         verify(backendClient).receiveFailure(any(), any(), any(), any(), any());
-        verify(backendClient, never()).receiveResult(any(), any(), any(), any());
+        verify(backendClient, never())
+                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionWireframePayload.class));
+        verify(backendClient, never())
+                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionDeliverablesPayload.class));
     }
 
     @Test
@@ -384,6 +396,9 @@ class GeraLandingExecutionServiceTest {
         service.processPendingExecutions();
 
         verify(backendClient).receiveFailure(any(), any(), any(), any(), any());
-        verify(backendClient, never()).receiveResult(any(), any(), any(), any());
+        verify(backendClient, never())
+                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionWireframePayload.class));
+        verify(backendClient, never())
+                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionDeliverablesPayload.class));
     }
 }


### PR DESCRIPTION
### Motivation
- Fix a compilation failure in `GeraLandingExecutionServiceTest` caused by an ambiguous Mockito verification of the overloaded `receiveResult(...)` methods in `GeraLandingBackendClient` after the new overload was introduced.

### Description
- In `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` added imports for `GeraLandingJobCompletionWireframePayload` and `GeraLandingJobCompletionDeliverablesPayload` and replaced the generic fourth-argument `any()` in `verify(...).receiveResult(...)` with typed matchers `any(GeraLandingJobCompletionWireframePayload.class)` and `any(GeraLandingJobCompletionDeliverablesPayload.class)` to remove overload ambiguity.

### Testing
- Ran `mvn -Dtest=GeraLandingExecutionServiceTest test` in `ai-worker`, but the run failed to collect dependencies due to an external private artifact resolution error for `com.marketinghub:ads-service:0.0.1-SNAPSHOT` from GitHub Packages (HTTP 401), so the unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a173b3326e883219bf0995bf0da7f9c)