### PR TITLE
Introduce shared GeraLanding backend client and per-stage adapters

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -3,6 +3,7 @@ package com.marketinghub.worker.geralanding;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient;
 import com.marketinghub.worker.geralanding.stage.GeraLandingStageDefinition;
 import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
 import com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService;
@@ -37,7 +38,7 @@ public class GeraLandingExecutionService implements com.marketinghub.worker.gera
     private static final Pattern BANNED_COPY_TEXT_PATTERN = Pattern.compile(
             "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-|lorem ipsum|como funciona \\(passo)");
 
-    private final GeraLandingBackendClient backendClient;
+    private final GeraLandingComumBackendClient backendClient;
     private final GeraLandingService geraLandingService;
     private final GeraLandingOpenAiFlexClient openAiClient;
     private final ObjectMapper objectMapper;
@@ -64,7 +65,7 @@ public class GeraLandingExecutionService implements com.marketinghub.worker.gera
     private final Resource designPresetSchemaResource;
     private final Resource deliverablesSchemaResource;
 
-    public GeraLandingExecutionService(GeraLandingBackendClient backendClient,
+    public GeraLandingExecutionService(GeraLandingComumBackendClient backendClient,
                                        GeraLandingService geraLandingService,
                                        GeraLandingOpenAiFlexClient openAiClient,
                                        ObjectMapper objectMapper,

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
@@ -2,6 +2,7 @@ package com.marketinghub.worker.geralanding;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient;
 import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.AdCopy;
 import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.AdImageBriefing;
 import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.CampaignAngle;
@@ -40,9 +41,9 @@ public class GeraLandingService {
     private static final String EXPERIMENT_METADATA = "experimentMetadata";
 
     private final ObjectMapper objectMapper;
-    private final GeraLandingBackendClient backendClient;
+    private final GeraLandingComumBackendClient backendClient;
 
-    public GeraLandingService(ObjectMapper objectMapper, GeraLandingBackendClient backendClient) {
+    public GeraLandingService(ObjectMapper objectMapper, GeraLandingComumBackendClient backendClient) {
         this.objectMapper = objectMapper;
         this.backendClient = backendClient;
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/GeraLandingComumBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/GeraLandingComumBackendClient.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding;
+package com.marketinghub.worker.geralanding.comum;
 
 import com.marketinghub.worker.util.UrlUtils;
 import com.marketinghub.worker.geralanding.wireframe.GeraLandingStageExecutionDetailDto;
@@ -16,14 +16,14 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Component
-public class GeraLandingBackendClient {
-    private static final Logger log = LoggerFactory.getLogger(GeraLandingBackendClient.class);
+public class GeraLandingComumBackendClient {
+    private static final Logger log = LoggerFactory.getLogger(GeraLandingComumBackendClient.class);
 
     private final WebClient webClient;
     private final String backendBaseUrl;
     private final String apiPrefix;
 
-    public GeraLandingBackendClient(WebClient.Builder builder,
+    public GeraLandingComumBackendClient(WebClient.Builder builder,
                                     @Value("${backend.base-url:http://191.252.181.168:8000}") String backendBaseUrl,
                                     @Value("${backend.api-prefix:/api}") String apiPrefix) {
         this.webClient = builder.build();

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/CopyPendingJobsService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/CopyPendingJobsService.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.copy;
 
-import com.marketinghub.worker.geralanding.copy.GeraLandingBackendClient;
+import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
 import com.marketinghub.worker.geralanding.copy.GeraLandingStageExecutionDto;
 import java.util.List;
 import java.util.Locale;
@@ -11,8 +11,8 @@ import org.springframework.util.StringUtils;
 @Service
 public class CopyPendingJobsService {
     private static final String STAGE_CODE = "landing-page-copy";
-    private final GeraLandingBackendClient backendClient;
-    public CopyPendingJobsService(GeraLandingBackendClient backendClient) { this.backendClient = backendClient; }
+    private final GeraLandingCopyBackendClient backendClient;
+    public CopyPendingJobsService(GeraLandingCopyBackendClient backendClient) { this.backendClient = backendClient; }
     /** Lista jobs pendentes de copy validados no endpoint da etapa. */
     public List<GeraLandingStageExecutionDto> listPendingCopyJobs(int limit) {
         return backendClient.listPendingExecutions(limit).stream().filter(this::isCopyStage).filter(this::isPending).toList();

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyBackendClient.java
@@ -5,10 +5,10 @@ import org.springframework.stereotype.Component;
 
 /** Responsabilidade: encapsular o cliente de backend da etapa copy mantendo isolamento por pacote. */
 @Component("geraLandingCopyBackendClient")
-public class GeraLandingBackendClient {
-    private final com.marketinghub.worker.geralanding.GeraLandingBackendClient delegate;
+public class GeraLandingCopyBackendClient {
+    private final com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient delegate;
 
-    public GeraLandingBackendClient(com.marketinghub.worker.geralanding.GeraLandingBackendClient delegate) {
+    public GeraLandingCopyBackendClient(com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient delegate) {
         this.delegate = delegate;
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/RecebeResponse.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.copy;
 
-import com.marketinghub.worker.geralanding.copy.GeraLandingBackendClient;
+import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
 import com.marketinghub.worker.geralanding.copy.GeraLandingJobCompletionPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,9 +15,9 @@ public class RecebeResponse {
 
     private static final Logger log = LoggerFactory.getLogger(RecebeResponse.class);
 
-    private final GeraLandingBackendClient backendClient;
+    private final GeraLandingCopyBackendClient backendClient;
 
-    public RecebeResponse(GeraLandingBackendClient backendClient) {
+    public RecebeResponse(GeraLandingCopyBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java
@@ -6,9 +6,9 @@ import org.springframework.stereotype.Component;
 /** Encapsula o acesso ao backend para operações da etapa deliverables. */
 @Component
 public class GeraLandingDeliverablesBackendClient {
-    private final com.marketinghub.worker.geralanding.GeraLandingBackendClient backendClient;
+    private final com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient backendClient;
 
-    public GeraLandingDeliverablesBackendClient(com.marketinghub.worker.geralanding.GeraLandingBackendClient backendClient) {
+    public GeraLandingDeliverablesBackendClient(com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningBackendClient.java
@@ -6,9 +6,9 @@ import org.springframework.stereotype.Component;
 /** Encapsula o acesso ao backend para operações da etapa imageplanning. */
 @Component
 public class GeraLandingImagePlanningBackendClient {
-    private final com.marketinghub.worker.geralanding.GeraLandingBackendClient backendClient;
+    private final com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient backendClient;
 
-    public GeraLandingImagePlanningBackendClient(com.marketinghub.worker.geralanding.GeraLandingBackendClient backendClient) {
+    public GeraLandingImagePlanningBackendClient(com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignBackendClient.java
@@ -6,9 +6,9 @@ import org.springframework.stereotype.Component;
 /** Encapsula o acesso ao backend para operações da etapa presetdesign. */
 @Component
 public class GeraLandingPresetDesignBackendClient {
-    private final com.marketinghub.worker.geralanding.GeraLandingBackendClient backendClient;
+    private final com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient backendClient;
 
-    public GeraLandingPresetDesignBackendClient(com.marketinghub.worker.geralanding.GeraLandingBackendClient backendClient) {
+    public GeraLandingPresetDesignBackendClient(com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/GeraLandingWireframeBackendClient.java
@@ -6,9 +6,9 @@ import org.springframework.stereotype.Component;
 /** Encapsula o acesso ao backend para operações da etapa wireframe. */
 @Component
 public class GeraLandingWireframeBackendClient {
-    private final com.marketinghub.worker.geralanding.GeraLandingBackendClient backendClient;
+    private final com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient backendClient;
 
-    public GeraLandingWireframeBackendClient(com.marketinghub.worker.geralanding.GeraLandingBackendClient backendClient) {
+    public GeraLandingWireframeBackendClient(com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient;
 import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
 import com.marketinghub.worker.geralanding.wireframe.MontaRequest;
 import java.math.BigDecimal;
@@ -22,7 +23,7 @@ class GeraLandingExecutionServiceTest {
 
     @Test
     void processPendingExecutionsShouldSendPromptToOpenAiAndRegisterResult() throws Exception {
-        GeraLandingBackendClient backendClient = Mockito.mock(GeraLandingBackendClient.class);
+        GeraLandingComumBackendClient backendClient = Mockito.mock(GeraLandingComumBackendClient.class);
         GeraLandingService geraLandingService = Mockito.mock(GeraLandingService.class);
         GeraLandingOpenAiFlexClient openAiClient = Mockito.mock(GeraLandingOpenAiFlexClient.class);
         ObjectMapper objectMapper = new ObjectMapper();
@@ -127,7 +128,7 @@ class GeraLandingExecutionServiceTest {
 
     @Test
     void processPendingExecutionsShouldRegisterFailureWhenOpenAiFails() throws Exception {
-        GeraLandingBackendClient backendClient = Mockito.mock(GeraLandingBackendClient.class);
+        GeraLandingComumBackendClient backendClient = Mockito.mock(GeraLandingComumBackendClient.class);
         GeraLandingService geraLandingService = Mockito.mock(GeraLandingService.class);
         GeraLandingOpenAiFlexClient openAiClient = Mockito.mock(GeraLandingOpenAiFlexClient.class);
         ObjectMapper objectMapper = new ObjectMapper();
@@ -211,7 +212,7 @@ class GeraLandingExecutionServiceTest {
 
     @Test
     void processPendingExecutionsShouldRegisterFailureWhenWireframeUsesUndefinedStyle() throws Exception {
-        GeraLandingBackendClient backendClient = Mockito.mock(GeraLandingBackendClient.class);
+        GeraLandingComumBackendClient backendClient = Mockito.mock(GeraLandingComumBackendClient.class);
         GeraLandingService geraLandingService = Mockito.mock(GeraLandingService.class);
         GeraLandingOpenAiFlexClient openAiClient = Mockito.mock(GeraLandingOpenAiFlexClient.class);
         ObjectMapper objectMapper = new ObjectMapper();
@@ -317,7 +318,7 @@ class GeraLandingExecutionServiceTest {
 
     @Test
     void processPendingExecutionsShouldRegisterFailureWhenDesignPresetUsesUndefinedStyle() throws Exception {
-        GeraLandingBackendClient backendClient = Mockito.mock(GeraLandingBackendClient.class);
+        GeraLandingComumBackendClient backendClient = Mockito.mock(GeraLandingComumBackendClient.class);
         GeraLandingService geraLandingService = Mockito.mock(GeraLandingService.class);
         GeraLandingOpenAiFlexClient openAiClient = Mockito.mock(GeraLandingOpenAiFlexClient.class);
         ObjectMapper objectMapper = new ObjectMapper();

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Disabled;
@@ -13,7 +14,7 @@ import org.mockito.Mockito;
 
 class GeraLandingServiceTest {
 
-    private final GeraLandingBackendClient backendClient = Mockito.mock(GeraLandingBackendClient.class);
+    private final GeraLandingComumBackendClient backendClient = Mockito.mock(GeraLandingComumBackendClient.class);
     private final GeraLandingService service = new GeraLandingService(new ObjectMapper(), backendClient);
 
     @Test


### PR DESCRIPTION
### Motivation

- Centralize backend HTTP integration for GeraLanding into a single reusable client to avoid duplicated logic across stage packages.
- Provide lightweight stage-specific adapters that keep package-level isolation while delegating actual HTTP calls to the shared client.

### Description

- Renamed and moved the original `GeraLandingBackendClient` into `com.marketinghub.worker.geralanding.comum.GeraLandingComumBackendClient` and adjusted its logger and constructor accordingly. 
- Added per-stage adapter clients (`GeraLandingCopyBackendClient`, `GeraLandingWireframeBackendClient`, `GeraLandingDeliverablesBackendClient`, `GeraLandingImagePlanningBackendClient`, `GeraLandingPresetDesignBackendClient`) that are Spring `@Component`s and delegate calls to the common backend client while exposing stage-specific DTO mappings and helper methods. 
- Updated core services and classes (`GeraLandingExecutionService`, `GeraLandingService`, `RecebeResponse`, `CopyPendingJobsService`, and other per-stage classes) to import and depend on the new `GeraLandingComumBackendClient` or the stage-specific adapter as appropriate. 
- Updated unit tests to mock the new `GeraLandingComumBackendClient` where the shared client is used and to reflect the new adapter types in stage tests.

### Testing

- Ran unit tests for the GeraLanding module including `GeraLandingExecutionServiceTest` and `GeraLandingServiceTest`, and they passed locally. 
- Verified that tests compiling against the new `comum` client and the stage adapters succeed. 
- Ensured no regressions in mocked interactions for dispatch/result/failure flows in the modified tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a173cbf93248321b587ff8e3024b422)