### PR TITLE
Fix GeraLanding stage execution DTO type mismatches

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -129,7 +129,9 @@ public class GeraLandingExecutionService implements com.marketinghub.worker.gera
             log.warn("GeraLanding generation skipped: OpenAI client is disabled");
             return;
         }
-        List<GeraLandingStageExecutionDto> pending = backendClient.listPendingExecutions(pendingLimit);
+        List<GeraLandingStageExecutionDto> pending = backendClient.listPendingExecutions(pendingLimit).stream()
+                .map(item -> new GeraLandingStageExecutionDto(item.experimentId(), item.idJob(), item.stageCode()))
+                .toList();
         List<com.marketinghub.worker.geralanding.wireframe.GeraLandingStageExecutionWireframeDto> wireframePending =
                 wireframePendingJobsService.listPendingWireframeJobs(pendingLimit);
         List<com.marketinghub.worker.geralanding.copy.GeraLandingStageExecutionDto> copyPending = copyPendingJobsService.listPendingCopyJobs(pendingLimit);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingStageExecutionDeliverablesDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingStageExecutionDeliverablesDto.java
@@ -7,7 +7,7 @@ public record GeraLandingStageExecutionDeliverablesDto(
         String stageCode) {
 
     /** Cria um DTO da etapa a partir do DTO base do GeraLanding. */
-    public static GeraLandingStageExecutionDeliverablesDto fromBase(com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto base) {
+    public static GeraLandingStageExecutionDeliverablesDto fromBase(com.marketinghub.worker.geralanding.copy.GeraLandingStageExecutionDto base) {
         return new GeraLandingStageExecutionDeliverablesDto(base.experimentId(), base.idJob(), base.stageCode());
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingStageExecutionImagePlanningDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingStageExecutionImagePlanningDto.java
@@ -7,7 +7,7 @@ public record GeraLandingStageExecutionImagePlanningDto(
         String stageCode) {
 
     /** Cria um DTO da etapa a partir do DTO base do GeraLanding. */
-    public static GeraLandingStageExecutionImagePlanningDto fromBase(com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto base) {
+    public static GeraLandingStageExecutionImagePlanningDto fromBase(com.marketinghub.worker.geralanding.copy.GeraLandingStageExecutionDto base) {
         return new GeraLandingStageExecutionImagePlanningDto(base.experimentId(), base.idJob(), base.stageCode());
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingStageExecutionPresetDesignDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingStageExecutionPresetDesignDto.java
@@ -7,7 +7,7 @@ public record GeraLandingStageExecutionPresetDesignDto(
         String stageCode) {
 
     /** Cria um DTO da etapa a partir do DTO base do GeraLanding. */
-    public static GeraLandingStageExecutionPresetDesignDto fromBase(com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto base) {
+    public static GeraLandingStageExecutionPresetDesignDto fromBase(com.marketinghub.worker.geralanding.copy.GeraLandingStageExecutionDto base) {
         return new GeraLandingStageExecutionPresetDesignDto(base.experimentId(), base.idJob(), base.stageCode());
     }
 }


### PR DESCRIPTION
### Motivation
- Resolve compilation errors caused by mismatched DTO types returned by the copy backend client vs. the base DTO used by the GeraLanding execution flow while keeping the existing architectural isolation per stage. 

### Description
- Convert the list returned by the backend client into the base `GeraLandingStageExecutionDto` inside `GeraLandingExecutionService` using `.stream().map(...).toList()` so processing uses the expected base DTO. 
- Update `fromBase(...)` signatures in `deliverables`, `imageplanning` and `presetdesign` stage DTOs to accept `com.marketinghub.worker.geralanding.copy.GeraLandingStageExecutionDto`, matching what the `GeraLandingCopyBackendClient` returns. 
- Changes are minimal and scoped to type alignment only, preserving stage package boundaries and behavior. 

### Testing
- Attempted `mvn -pl ai-worker test -DskipITs` but the reactor selector failed in this environment. 
- Ran `cd ai-worker && mvn test -DskipITs`; the build could not complete due to missing access to private dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT` from GitHub Packages (`401 Unauthorized`), so automated tests could not be fully executed here. 
- The edits address the previously reported compilation errors (type mismatches); full CI/build verification should be performed where GitHub Packages credentials are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17449b1f248321b84cbc30787895cd)