### PR TITLE
Refatora estrutura interna da etapa wireframe no AI Worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionService.java
@@ -6,12 +6,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
 import com.marketinghub.worker.geralanding.stage.GeraLandingStageDefinition;
 import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
-import com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService;
+import com.marketinghub.worker.geralanding.wireframe.monitor.WireframePendingJobsService;
 import com.marketinghub.worker.geralanding.copy.CopyPendingJobsService;
 import com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService;
 import com.marketinghub.worker.geralanding.presetdesign.PresetDesignPendingJobsService;
 import com.marketinghub.worker.geralanding.deliverables.DeliverablesPendingJobsService;
-import com.marketinghub.worker.geralanding.wireframe.MontaRequest;
+import com.marketinghub.worker.geralanding.wireframe.openai.MontaRequest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -48,7 +48,7 @@ public class GeraLandingExecutionService implements com.marketinghub.worker.gera
     private final com.marketinghub.worker.geralanding.imageplanning.MontaRequest imagePlanningMontaRequest;
     private final com.marketinghub.worker.geralanding.presetdesign.MontaRequest presetDesignMontaRequest;
     private final com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest;
-    private final com.marketinghub.worker.geralanding.wireframe.RecebeResponse wireframeRecebeResponse;
+    private final com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse wireframeRecebeResponse;
     private final com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse;
     private final com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse;
     private final com.marketinghub.worker.geralanding.presetdesign.RecebeResponse presetDesignRecebeResponse;
@@ -75,7 +75,7 @@ public class GeraLandingExecutionService implements com.marketinghub.worker.gera
                                        com.marketinghub.worker.geralanding.imageplanning.MontaRequest imagePlanningMontaRequest,
                                        com.marketinghub.worker.geralanding.presetdesign.MontaRequest presetDesignMontaRequest,
                                        com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest,
-                                       com.marketinghub.worker.geralanding.wireframe.RecebeResponse wireframeRecebeResponse,
+                                       com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse wireframeRecebeResponse,
                                        com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse,
                                        com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse,
                                        com.marketinghub.worker.geralanding.presetdesign.RecebeResponse presetDesignRecebeResponse,
@@ -132,7 +132,7 @@ public class GeraLandingExecutionService implements com.marketinghub.worker.gera
         List<GeraLandingStageExecutionDto> pending = backendClient.listPendingExecutions(pendingLimit).stream()
                 .map(item -> new GeraLandingStageExecutionDto(item.experimentId(), item.idJob(), item.stageCode()))
                 .toList();
-        List<com.marketinghub.worker.geralanding.wireframe.GeraLandingStageExecutionWireframeDto> wireframePending =
+        List<com.marketinghub.worker.geralanding.wireframe.backend.GeraLandingStageExecutionWireframeDto> wireframePending =
                 wireframePendingJobsService.listPendingWireframeJobs(pendingLimit);
         List<com.marketinghub.worker.geralanding.copy.GeraLandingStageExecutionDto> copyPending = copyPendingJobsService.listPendingCopyJobs(pendingLimit);
         List<com.marketinghub.worker.geralanding.imageplanning.GeraLandingStageExecutionImagePlanningDto> imagePlanningPending =
@@ -522,8 +522,8 @@ public class GeraLandingExecutionService implements com.marketinghub.worker.gera
     }
 
     /** Converte o request comum para o tipo isolado da etapa wireframe. */
-    private com.marketinghub.worker.geralanding.wireframe.GeraLandingExperimentWireframeRequest toWireframeExperiment(GeraLandingExperimentRequest experiment) {
-        return new com.marketinghub.worker.geralanding.wireframe.GeraLandingExperimentWireframeRequest(experiment.experimentId(), experiment.dados());
+    private com.marketinghub.worker.geralanding.wireframe.openai.GeraLandingExperimentWireframeRequest toWireframeExperiment(GeraLandingExperimentRequest experiment) {
+        return new com.marketinghub.worker.geralanding.wireframe.openai.GeraLandingExperimentWireframeRequest(experiment.experimentId(), experiment.dados());
     }
 
     /** Converte o request comum para o tipo isolado da etapa imageplanning. */
@@ -557,11 +557,11 @@ public class GeraLandingExecutionService implements com.marketinghub.worker.gera
     }
 
     /** Converte o payload comum para o tipo isolado da etapa wireframe. */
-    private com.marketinghub.worker.geralanding.wireframe.GeraLandingJobCompletionWireframePayload toWireframePayload(GeraLandingJobCompletionPayload payload) {
+    private com.marketinghub.worker.geralanding.wireframe.callback.GeraLandingJobCompletionWireframePayload toWireframePayload(GeraLandingJobCompletionPayload payload) {
         if (payload == null) {
             return null;
         }
-        return new com.marketinghub.worker.geralanding.wireframe.GeraLandingJobCompletionWireframePayload(
+        return new com.marketinghub.worker.geralanding.wireframe.callback.GeraLandingJobCompletionWireframePayload(
                 payload.responseContent(),
                 payload.rawResponse(),
                 payload.requestBodyJson(),

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyBackendClient.java
@@ -2,7 +2,7 @@ package com.marketinghub.worker.geralanding.copy;
 
 import com.marketinghub.worker.util.UrlUtils;
 import com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload;
-import com.marketinghub.worker.geralanding.wireframe.GeraLandingStageExecutionDetailDto;
+import com.marketinghub.worker.geralanding.wireframe.backend.GeraLandingStageExecutionDetailDto;
 import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
@@ -242,7 +242,7 @@ public class GeraLandingCopyBackendClient {
 
     /** Recebe resultado da etapa wireframe usando o payload tipado da etapa. */
     public void receiveResult(String idJob, Long experimentId, String stageCode,
-                              com.marketinghub.worker.geralanding.wireframe.GeraLandingJobCompletionWireframePayload payload) {
+                              com.marketinghub.worker.geralanding.wireframe.callback.GeraLandingJobCompletionWireframePayload payload) {
         String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix,
                 "/internal/geralanding/stage-executions");
         Map<String, Object> body = new java.util.LinkedHashMap<>();

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingStageExecutionDetailDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingStageExecutionDetailDto.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.backend;
 
 import java.time.Instant;
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingStageExecutionWireframeDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingStageExecutionWireframeDto.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.backend;
 
 /** Representa uma execução pendente da etapa wireframe. */
 public record GeraLandingStageExecutionWireframeDto(

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.backend;
 
 import java.util.List;
 import org.springframework.stereotype.Component;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/callback/GeraLandingJobCompletionWireframePayload.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/callback/GeraLandingJobCompletionWireframePayload.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.callback;
 
 import java.math.BigDecimal;
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/callback/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/callback/RecebeResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.callback;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/GeraLandingExecutionWireframeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/GeraLandingExecutionWireframeService.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.monitor;
 
 import java.util.List;
 import org.springframework.stereotype.Service;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/GeraLandingWireframeExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/GeraLandingWireframeExecutionService.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.monitor;
 
 import java.util.List;
 import org.springframework.stereotype.Service;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframeExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframeExecutionScheduler.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.monitor;
 
 
 import org.slf4j.Logger;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframePendingJobsService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframePendingJobsService.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.monitor;
 
 import java.util.List;
 import java.util.Locale;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/openai/GeraLandingExperimentWireframeRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/openai/GeraLandingExperimentWireframeRequest.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.openai;
 
 import java.util.Map;
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/openai/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/openai/MontaRequest.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.wireframe;
+package com.marketinghub.worker.geralanding.wireframe.openai;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.comum.MontaRequestSupport;

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -3,7 +3,7 @@ package com.marketinghub.worker.geralanding;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.marketinghub.worker.geralanding.deliverables.GeraLandingJobCompletionDeliverablesPayload;
-import com.marketinghub.worker.geralanding.wireframe.GeraLandingJobCompletionWireframePayload;
+import com.marketinghub.worker.geralanding.wireframe.callback.GeraLandingJobCompletionWireframePayload;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.never;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
 import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
-import com.marketinghub.worker.geralanding.wireframe.MontaRequest;
+import com.marketinghub.worker.geralanding.wireframe.openai.MontaRequest;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
@@ -37,8 +37,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
         com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
-        com.marketinghub.worker.geralanding.wireframe.RecebeResponse wireframeRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse wireframeRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse.class);
         com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
@@ -48,8 +48,8 @@ class GeraLandingExecutionServiceTest {
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
-        com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService wireframePendingJobsService =
-                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService.class);
+        com.marketinghub.worker.geralanding.wireframe.monitor.WireframePendingJobsService wireframePendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.monitor.WireframePendingJobsService.class);
         com.marketinghub.worker.geralanding.copy.CopyPendingJobsService copyPendingJobsService =
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.CopyPendingJobsService.class);
         com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService imagePlanningPendingJobsService =
@@ -142,8 +142,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
         com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
-        com.marketinghub.worker.geralanding.wireframe.RecebeResponse wireframeRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse wireframeRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse.class);
         com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
@@ -153,8 +153,8 @@ class GeraLandingExecutionServiceTest {
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
-        com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService wireframePendingJobsService =
-                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService.class);
+        com.marketinghub.worker.geralanding.wireframe.monitor.WireframePendingJobsService wireframePendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.monitor.WireframePendingJobsService.class);
         com.marketinghub.worker.geralanding.copy.CopyPendingJobsService copyPendingJobsService =
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.CopyPendingJobsService.class);
         com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService imagePlanningPendingJobsService =
@@ -226,8 +226,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
         com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
-        com.marketinghub.worker.geralanding.wireframe.RecebeResponse wireframeRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse wireframeRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse.class);
         com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
@@ -237,8 +237,8 @@ class GeraLandingExecutionServiceTest {
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
-        com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService wireframePendingJobsService =
-                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService.class);
+        com.marketinghub.worker.geralanding.wireframe.monitor.WireframePendingJobsService wireframePendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.monitor.WireframePendingJobsService.class);
         com.marketinghub.worker.geralanding.copy.CopyPendingJobsService copyPendingJobsService =
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.CopyPendingJobsService.class);
         com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService imagePlanningPendingJobsService =
@@ -332,8 +332,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.MontaRequest.class);
         com.marketinghub.worker.geralanding.deliverables.MontaRequest deliverablesMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
-        com.marketinghub.worker.geralanding.wireframe.RecebeResponse wireframeRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse wireframeRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse.class);
         com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
@@ -343,8 +343,8 @@ class GeraLandingExecutionServiceTest {
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
-        com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService wireframePendingJobsService =
-                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.WireframePendingJobsService.class);
+        com.marketinghub.worker.geralanding.wireframe.monitor.WireframePendingJobsService wireframePendingJobsService =
+                Mockito.mock(com.marketinghub.worker.geralanding.wireframe.monitor.WireframePendingJobsService.class);
         com.marketinghub.worker.geralanding.copy.CopyPendingJobsService copyPendingJobsService =
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.CopyPendingJobsService.class);
         com.marketinghub.worker.geralanding.imageplanning.ImagePlanningPendingJobsService imagePlanningPendingJobsService =

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2025,3 +2025,15 @@
 - validação executada:
   - inspeção estática via `rg` para confirmar remoção de `toBase()` nas etapas ajustadas;
   - tentativa de execução de testes/maven permanece bloqueada por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` (HTTP 401 no GitHub Packages).
+
+## 2026-05-27 20:10:00 UTC
+- solicitação: subdividir os pacotes da etapa `geralanding.wireframe` no `ai-worker` em `monitor`, `openai`, `callback` e `backend`.
+- causa-raiz identificada: as classes da etapa wireframe estavam concentradas em um único pacote, reduzindo isolamento interno por responsabilidade e dificultando manutenção por contexto da etapa.
+- correção aplicada:
+  - movidas classes de execução/monitoramento para `geralanding.wireframe.monitor`;
+  - movidas classes de request OpenAI para `geralanding.wireframe.openai`;
+  - movidas classes de callback/result payload para `geralanding.wireframe.callback`;
+  - movidas classes de integração backend e DTOs para `geralanding.wireframe.backend`;
+  - atualizadas importações e referências em `GeraLandingExecutionService`, `GeraLandingCopyBackendClient` e `GeraLandingExecutionServiceTest` para os novos pacotes.
+- validação executada:
+  - `mvn -q -Dtest=GeraLandingExecutionServiceTest test` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation
- Melhorar o isolamento por responsabilidade da etapa `geralanding.wireframe` separando monitoramento, montagem de requests OpenAI, callbacks e integração backend para facilitar manutenção e leitura.

### Description
- Subdividido o pacote `com.marketinghub.worker.geralanding.wireframe` em quatro subpacotes: `monitor`, `openai`, `callback` e `backend`, movendo as classes correspondentes para cada contexto. 
- Atualizadas as importações e referências nos consumidores afetados, incluindo `GeraLandingExecutionService`, `GeraLandingCopyBackendClient` e `GeraLandingExecutionServiceTest`. 
- Ajustados tipos de DTO/payload onde necessário (ex.: `GeraLandingJobCompletionWireframePayload` e `RecebeResponse` movidos para `callback`, DTOs e backend client para `backend`).
- Registrado o trabalho em `docs/registros/experimentos.md` com resumo da mudança.

### Testing
- Tentativa de executar os testes unitários com `./mvnw -q -Dtest=GeraLandingExecutionServiceTest test` falhou localmente por ausência do wrapper script. 
- Em seguida `mvn -q -Dtest=GeraLandingExecutionServiceTest test` foi executado e falhou na resolução de dependências devido à dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` retornando HTTP 401 no GitHub Packages, impedindo a conclusão dos testes automatizados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a176102aee88321a98b13656a6a0b1a)