### PR TITLE
Refactor GeraLanding common classes into `comum` package and update usages

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingExecutionScheduler.java
@@ -1,5 +1,6 @@
 package com.marketinghub.worker.geralanding;
 
+import com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/GeraLandingExecutionService.java
@@ -1,9 +1,15 @@
-package com.marketinghub.worker.geralanding;
+package com.marketinghub.worker.geralanding.comum;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
+import com.marketinghub.worker.geralanding.GeraLandingExperimentRequest;
+import com.marketinghub.worker.geralanding.GeraLandingJobCompletionPayload;
+import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.GeraLandingOpenAiFlexClient;
+import com.marketinghub.worker.geralanding.GeraLandingService;
+import com.marketinghub.worker.geralanding.GeraLandingStageExecutionDto;
 import com.marketinghub.worker.geralanding.stage.GeraLandingStageDefinition;
 import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
 import com.marketinghub.worker.geralanding.wireframe.monitor.WireframePendingJobsService;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingExecutionService.java
@@ -1,21 +1,23 @@
 package com.marketinghub.worker.geralanding.copy;
 
+import com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor;
+import com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionRef;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 /** Responsabilidade: encapsular execução da etapa copy preservando isolamento de pacote. */
 @Service("geraLandingCopyExecutionStageService")
 public class GeraLandingExecutionService {
-    private final com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor executionProcessor;
+    private final GeraLandingStageExecutionProcessor executionProcessor;
 
-    public GeraLandingExecutionService(com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor executionProcessor) {
+    public GeraLandingExecutionService(GeraLandingStageExecutionProcessor executionProcessor) {
         this.executionProcessor = executionProcessor;
     }
 
     /** Processa as execuções da etapa copy convertendo para DTO base do pipeline. */
     public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
         executionProcessor.processExecutions(jobs.stream()
-                .map(item -> new com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionRef(item.experimentId(), item.idJob(), item.stageCode()))
+                .map(item -> new GeraLandingStageExecutionRef(item.experimentId(), item.idJob(), item.stageCode()))
                 .toList());
     }
 }


### PR DESCRIPTION
### Motivation
- Consolidate shared GeraLanding execution types and processors into a `comum` package to improve encapsulation and reuse across stage implementations.
- Reduce package coupling so stage-specific services can depend on common execution abstractions instead of package-internal classes.

### Description
- Moved `GeraLandingExecutionService` into `com.marketinghub.worker.geralanding.comum` and updated its package declaration and imports.
- Updated `GeraLandingExecutionScheduler` to import `GeraLandingExecutionService` from the new `comum` package.
- Updated the copy stage service to import and use `GeraLandingStageExecutionProcessor` and `GeraLandingStageExecutionRef` from the `comum` package and adjusted the constructor and mapping code accordingly.
- Added/adjusted DTO and service imports referenced by the relocated service without changing the execution logic or scheduled cron behavior.

### Testing
- Ran the project unit test suite with `mvn test` and all tests passed.
- Verified the project builds successfully with `mvn -DskipTests=true package`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1763c53098832187bd14437f4ea725)