### PR TITLE
Refactor GeraLanding para usar GeraLandingExecutionService diretamente

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/GeraLandingExecutionService.java
@@ -39,7 +39,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 /**
  * Executa as etapas pendentes do GeraLanding, preparando prompts, schemas e payloads para a OpenAI.
  */
-public class GeraLandingExecutionService implements com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor {
+public class GeraLandingExecutionService {
     private static final Logger log = LoggerFactory.getLogger(GeraLandingExecutionService.class);
     private static final Pattern BANNED_COPY_TEXT_PATTERN = Pattern.compile(
             "(?i)(adCopy\\.|campaignAngle\\.|landingPageWireframe|uiTags|uiTextTags|copySlots|sectionId|slotId|CASE_DATA|OUTPUT_CONTRACT|template_id|artifact_target|\\bV[1-3]-|lorem ipsum|como funciona \\(passo)");

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/GeraLandingStageExecutionProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/GeraLandingStageExecutionProcessor.java
@@ -1,9 +1,0 @@
-package com.marketinghub.worker.geralanding.comum;
-
-import java.util.List;
-
-/** Define o contrato de processamento de execuções de etapas do GeraLanding. */
-public interface GeraLandingStageExecutionProcessor {
-    /** Processa as execuções recebidas. */
-    void processExecutions(List<GeraLandingStageExecutionRef> executions);
-}

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingExecutionService.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.geralanding.copy;
 
-import com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor;
 import com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionRef;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -8,15 +7,15 @@ import org.springframework.stereotype.Service;
 /** Responsabilidade: encapsular execução da etapa copy preservando isolamento de pacote. */
 @Service("geraLandingCopyExecutionStageService")
 public class GeraLandingExecutionService {
-    private final GeraLandingStageExecutionProcessor executionProcessor;
+    private final com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService executionService;
 
-    public GeraLandingExecutionService(GeraLandingStageExecutionProcessor executionProcessor) {
-        this.executionProcessor = executionProcessor;
+    public GeraLandingExecutionService(com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService executionService) {
+        this.executionService = executionService;
     }
 
     /** Processa as execuções da etapa copy convertendo para DTO base do pipeline. */
     public void processExecutions(List<GeraLandingStageExecutionDto> jobs) {
-        executionProcessor.processExecutions(jobs.stream()
+        executionService.processExecutions(jobs.stream()
                 .map(item -> new GeraLandingStageExecutionRef(item.experimentId(), item.idJob(), item.stageCode()))
                 .toList());
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesExecutionService.java
@@ -6,15 +6,15 @@ import org.springframework.stereotype.Service;
 /** Centraliza a execução de jobs da etapa deliverables usando o executor compartilhado. */
 @Service
 public class GeraLandingDeliverablesExecutionService {
-    private final com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor executionProcessor;
+    private final com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService executionService;
 
-    public GeraLandingDeliverablesExecutionService(com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor executionProcessor) {
-        this.executionProcessor = executionProcessor;
+    public GeraLandingDeliverablesExecutionService(com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService executionService) {
+        this.executionService = executionService;
     }
 
     /** Processa os jobs pendentes da etapa deliverables. */
     public void processExecutions(List<GeraLandingStageExecutionDeliverablesDto> jobs) {
-        executionProcessor.processExecutions(jobs.stream()
+        executionService.processExecutions(jobs.stream()
                 .map(item -> new com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionRef(item.experimentId(), item.idJob(), item.stageCode()))
                 .toList());
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningExecutionService.java
@@ -6,15 +6,15 @@ import org.springframework.stereotype.Service;
 /** Centraliza a execução de jobs da etapa image planning usando o executor compartilhado. */
 @Service
 public class GeraLandingImagePlanningExecutionService {
-    private final com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor executionProcessor;
+    private final com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService executionService;
 
-    public GeraLandingImagePlanningExecutionService(com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor executionProcessor) {
-        this.executionProcessor = executionProcessor;
+    public GeraLandingImagePlanningExecutionService(com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService executionService) {
+        this.executionService = executionService;
     }
 
     /** Processa os jobs pendentes da etapa image planning. */
     public void processExecutions(List<GeraLandingStageExecutionImagePlanningDto> jobs) {
-        executionProcessor.processExecutions(jobs.stream()
+        executionService.processExecutions(jobs.stream()
                 .map(item -> new com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionRef(item.experimentId(), item.idJob(), item.stageCode()))
                 .toList());
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignExecutionService.java
@@ -6,15 +6,15 @@ import org.springframework.stereotype.Service;
 /** Centraliza a execução de jobs da etapa preset design usando o executor compartilhado. */
 @Service
 public class GeraLandingPresetDesignExecutionService {
-    private final com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor executionProcessor;
+    private final com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService executionService;
 
-    public GeraLandingPresetDesignExecutionService(com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor executionProcessor) {
-        this.executionProcessor = executionProcessor;
+    public GeraLandingPresetDesignExecutionService(com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService executionService) {
+        this.executionService = executionService;
     }
 
     /** Processa os jobs pendentes da etapa preset design. */
     public void processExecutions(List<GeraLandingStageExecutionPresetDesignDto> jobs) {
-        executionProcessor.processExecutions(jobs.stream()
+        executionService.processExecutions(jobs.stream()
                 .map(item -> new com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionRef(item.experimentId(), item.idJob(), item.stageCode()))
                 .toList());
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/GeraLandingExecutionWireframeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/GeraLandingExecutionWireframeService.java
@@ -6,11 +6,11 @@ import org.springframework.stereotype.Service;
 /** Centraliza a execução de jobs da etapa wireframe usando o executor base. */
 @Service("geraLandingWireframeExecutionStageService")
 public class GeraLandingExecutionWireframeService {
-    private final com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor executionProcessor;
+    private final com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService executionService;
 
     public GeraLandingExecutionWireframeService(
-            com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor executionProcessor) {
-        this.executionProcessor = executionProcessor;
+            com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService executionService) {
+        this.executionService = executionService;
     }
 
     /** Processa os jobs pendentes já filtrados da etapa wireframe convertendo para o DTO base. */
@@ -18,6 +18,6 @@ public class GeraLandingExecutionWireframeService {
         List<com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionRef> mapped = jobs.stream()
                 .map(item -> new com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionRef(item.experimentId(), item.idJob(), item.stageCode()))
                 .toList();
-        executionProcessor.processExecutions(mapped);
+        executionService.processExecutions(mapped);
     }
 }


### PR DESCRIPTION
### Motivation
- Simplificar o fluxo de execução do GeraLanding eliminando uma abstração desnecessária e injetando o serviço comum diretamente. 
- Reduzir acoplamento entre serviços de etapa e o executor central mantendo a responsabilidade de conversão de DTOs por etapa. 

### Description
- Remove a interface `com.marketinghub.worker.geralanding.comum.GeraLandingStageExecutionProcessor` e sua implementação indireta. 
- Ajusta `com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService` para não `implements` mais a interface removida e manter a API pública `processExecutions(...)`. 
- Atualiza serviços por etapa para injetarem `com.marketinghub.worker.geralanding.comum.GeraLandingExecutionService` e delegarem a execução após mapear seus DTOs locais (arquivos alterados: `copy/GeraLandingExecutionService.java`, `imageplanning/GeraLandingImagePlanningExecutionService.java`, `presetdesign/GeraLandingPresetDesignExecutionService.java`, `deliverables/GeraLandingDeliverablesExecutionService.java`, `wireframe/monitor/GeraLandingExecutionWireframeService.java`, e `comum/GeraLandingExecutionService.java`). 

### Testing
- Tentativa de rodar o teste unitário específico com `./mvnw -Dtest=GeraLandingExecutionServiceTest test` falhou porque o wrapper `mvnw` não existe no módulo. 
- Executado `mvn -Dtest=GeraLandingExecutionServiceTest test`, que abortou na resolução de dependências por limitação de ambiente: o Maven não conseguiu baixar `com.marketinghub:ads-service:0.0.1-SNAPSHOT` do GitHub Packages retornando `401 Unauthorized`, portanto os testes automatizados não chegaram a ser executados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a176c293528832186bde11de3c53905)