### PR TITLE
Fix ai-worker geralanding compilation imports

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding;
 
-import com.marketinghub.worker.request.OpenAiCostEstimator;
-import com.marketinghub.worker.request.OpenAiResponse;
+import com.marketinghub.worker.openai.OpenAiCostEstimator;
+import com.marketinghub.worker.openai.OpenAiResponse;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
@@ -1,5 +1,6 @@
 package com.marketinghub.worker.geralanding.wireframe.backend;
 
+import com.marketinghub.worker.geralanding.wireframe.response.GeraLandingJobCompletionWireframePayload;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionWireframeDto;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto;
 import java.util.List;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframePendingJobsService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframePendingJobsService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.worker.geralanding.wireframe.monitor;
 
+import com.marketinghub.worker.geralanding.wireframe.backend.GeraLandingWireframeBackendClient;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionWireframeDto;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto;
 import java.util.List;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/response/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/response/RecebeResponse.java
@@ -1,5 +1,6 @@
 package com.marketinghub.worker.geralanding.wireframe.response;
 
+import com.marketinghub.worker.geralanding.wireframe.backend.GeraLandingWireframeBackendClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;


### PR DESCRIPTION
### Motivation

- Corrigir erros de compilação no módulo `ai-worker` originados por imports para pacotes/símbolos inexistentes e manter o isolamento obrigatório do domínio `geralanding.<etapa>.*`.

### Description

- Atualizados os imports em `GeraLandingOpenAiFlexClient` para usar `com.marketinghub.worker.openai.OpenAiCostEstimator` e `com.marketinghub.worker.openai.OpenAiResponse` em vez do pacote inexistente `com.marketinghub.worker.request`.
- Adicionados imports faltantes em `RecebeResponse`, `GeraLandingWireframeBackendClient` e `WireframePendingJobsService` para referenciar corretamente tipos do pacote `geralanding.wireframe` (por exemplo `GeraLandingJobCompletionWireframePayload` e `GeraLandingWireframeBackendClient`).
- Alterações realizadas nos arquivos `GeraLandingOpenAiFlexClient.java`, `RecebeResponse.java`, `GeraLandingWireframeBackendClient.java` e `WireframePendingJobsService.java` e limitadas ao escopo `geralanding.<etapa>.*` sem criar novas classes fora desse padrão.

### Testing

- Tentei executar `mvn -pl ai-worker test -DskipITs`, que falhou porque o seletor de projeto não foi resolvido no reactor do workspace.
- Executei `cd ai-worker && mvn test -DskipITs`, mas a execução não concluiu devido a erro de resolução da dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` (401 no repositório GitHub Packages), impedindo a conclusão da compilação/testes automáticos.
- Devido à falha de resolução externa, não foi possível confirmar a compilação final na CI, entretanto os ajustes de import resolvem os símbolos e pacotes ausentes relatados inicialmente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17841775248321a8e9dab6b20fd749)