### PR TITLE
Add missing delegation methods to GeraLanding stage backend clients

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java
@@ -30,6 +30,16 @@ public class GeraLandingDeliverablesBackendClient {
         backendClient.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);
     }
 
+
+    /** Carrega os dados de prompt necessários para execução da etapa. */
+    public java.util.Map<String, Object> loadPromptData(Long experimentId) {
+        return backendClient.loadPromptData(experimentId);
+    }
+
+    /** Encaminha falha de execução da etapa para o backend principal. */
+    public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) {
+        backendClient.receiveFailure(idJob, experimentId, stageCode, errorMessage, errorDetail);
+    }
     /** Busca os detalhes de execução da etapa no backend. */
     public GeraLandingStageExecutionDetailDto fetchStageExecutionDetail(Long experimentId, String idJob) {
         return backendClient.fetchDeliverablesStageExecutionDetail(experimentId, idJob);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningBackendClient.java
@@ -30,6 +30,16 @@ public class GeraLandingImagePlanningBackendClient {
         backendClient.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);
     }
 
+
+    /** Carrega os dados de prompt necessários para execução da etapa. */
+    public java.util.Map<String, Object> loadPromptData(Long experimentId) {
+        return backendClient.loadPromptData(experimentId);
+    }
+
+    /** Encaminha falha de execução da etapa para o backend principal. */
+    public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) {
+        backendClient.receiveFailure(idJob, experimentId, stageCode, errorMessage, errorDetail);
+    }
     /** Busca os detalhes de execução da etapa no backend. */
     public GeraLandingStageExecutionDetailDto fetchStageExecutionDetail(Long experimentId, String idJob) {
         return backendClient.fetchImagePlanningStageExecutionDetail(experimentId, idJob);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignBackendClient.java
@@ -30,6 +30,16 @@ public class GeraLandingPresetDesignBackendClient {
         backendClient.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);
     }
 
+
+    /** Carrega os dados de prompt necessários para execução da etapa. */
+    public java.util.Map<String, Object> loadPromptData(Long experimentId) {
+        return backendClient.loadPromptData(experimentId);
+    }
+
+    /** Encaminha falha de execução da etapa para o backend principal. */
+    public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) {
+        backendClient.receiveFailure(idJob, experimentId, stageCode, errorMessage, errorDetail);
+    }
     /** Busca os detalhes de execução da etapa no backend. */
     public GeraLandingStageExecutionDetailDto fetchStageExecutionDetail(Long experimentId, String idJob) {
         return backendClient.fetchDesignPresetStageExecutionDetail(experimentId, idJob);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
@@ -22,6 +22,16 @@ public class GeraLandingWireframeBackendClient {
                 .toList();
     }
 
+
+    /** Carrega os dados de prompt necessários para execução da etapa. */
+    public java.util.Map<String, Object> loadPromptData(Long experimentId) {
+        return backendClient.loadPromptData(experimentId);
+    }
+
+    /** Encaminha falha de execução da etapa para o backend principal. */
+    public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) {
+        backendClient.receiveFailure(idJob, experimentId, stageCode, errorMessage, errorDetail);
+    }
     /** Busca os detalhes de execução da etapa wireframe no backend. */
     public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) {
         backendClient.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);


### PR DESCRIPTION
### Motivation
- Several `GeraLanding*OpenAiExecutionService` classes failed to compile because their stage-specific backend clients did not expose `loadPromptData(Long)` and `receiveFailure(...)` methods that the execution services call.
- The change preserves stage isolation by delegating these calls to the existing `GeraLandingCopyBackendClient` which already implements the underlying contract.

### Description
- Added `public Map<String,Object> loadPromptData(Long experimentId)` delegation method to the backend clients for `imageplanning`, `deliverables`, `presetdesign` and `wireframe` that forwards to `backendClient.loadPromptData(...)`.
- Added `public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail)` delegation method to the same clients that forwards to `backendClient.receiveFailure(...)`.
- Files changed: `ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningBackendClient.java`, `ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java`, `ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/GeraLandingPresetDesignBackendClient.java`, and `ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java`.

### Testing
- Ran `mvn -DskipTests compile` for the `ai-worker` module, which progressed past the original missing-symbol compilation errors but failed during dependency resolution due to a private artifact (`com.marketinghub:ads-service`) returning `401 Unauthorized` in this environment, so a full build artifact could not be produced.
- Verified by source inspection that the previously missing method symbols referenced by the execution services are now present and delegated to `GeraLandingCopyBackendClient`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a179f97fb708321ae3b1d7b98e3bc82)