### PR TITLE
fix(ai-worker): corrige import do GeraLandingJobDto no wireframe

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
@@ -2,7 +2,7 @@ package com.marketinghub.worker.geralanding.wireframe.request;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingJobDto;
 import com.marketinghub.worker.geralanding.wireframe.backend.GeraLandingWireframeBackendClient;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto;
 import com.marketinghub.worker.geralanding.wireframe.response.GeraLandingJobCompletionWireframePayload;


### PR DESCRIPTION
### Motivation
- Corrigir o import do DTO usado pela etapa wireframe para manter isolamento do pacote `geralanding.wireframe` e evitar dependência do DTO global da etapa.

### Description
- Atualiza o import em `GeraLandingWireframeOpenAiExecutionService` de `com.marketinghub.worker.geralanding.GeraLandingJobDto` para `com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingJobDto` no arquivo `ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java`.

### Testing
- Executando `./mvnw -q -DskipITs test` não foi possível porque o wrapper `./mvnw` não existe no módulo; em seguida `mvn -q -DskipITs test` foi executado e falhou por resolução de dependência privada (`com.marketinghub:ads-service`) devido a `401 Unauthorized` no repositório GitHub Packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17dfdb0c788321aa1b515f98147f4f)