### PR TITLE
Rename wireframe payload record to RecordWireframeResponse

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyBackendClient.java
@@ -242,7 +242,7 @@ public class GeraLandingCopyBackendClient {
 
     /** Recebe resultado da etapa wireframe usando o payload tipado da etapa. */
     public void receiveResult(String idJob, Long experimentId, String stageCode,
-                              com.marketinghub.worker.geralanding.wireframe.response.GeraLandingJobCompletionWireframePayload payload) {
+                              com.marketinghub.worker.geralanding.wireframe.response.RecordWireframeResponse payload) {
         String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix,
                 "/internal/geralanding/stage-executions");
         Map<String, Object> body = new java.util.LinkedHashMap<>();

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
@@ -2,7 +2,7 @@ package com.marketinghub.worker.geralanding.wireframe.backend;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto;
-import com.marketinghub.worker.geralanding.wireframe.response.GeraLandingJobCompletionWireframePayload;
+import com.marketinghub.worker.geralanding.wireframe.response.RecordWireframeResponse;
 import com.marketinghub.worker.util.UrlUtils;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -100,7 +100,7 @@ public class GeraLandingWireframeBackendClient {
     }
 
     /** Envia ao backend o resultado final da etapa wireframe. */
-    public void receiveResult(String idJob, Long experimentId, String stageCode, GeraLandingJobCompletionWireframePayload payload) {
+    public void receiveResult(String idJob, Long experimentId, String stageCode, RecordWireframeResponse payload) {
         String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions");
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("experimentId", experimentId);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingJobDto;
 import com.marketinghub.worker.geralanding.wireframe.backend.GeraLandingWireframeBackendClient;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto;
-import com.marketinghub.worker.geralanding.wireframe.response.GeraLandingJobCompletionWireframePayload;
+import com.marketinghub.worker.geralanding.wireframe.response.RecordWireframeResponse;
 import com.marketinghub.worker.geralanding.wireframe.response.RecebeResponse;
 import com.marketinghub.worker.openai.OpenAiCostEstimator;
 import com.marketinghub.worker.openai.OpenAiResponse;
@@ -86,7 +86,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
             String prompt = montaRequest.montarPrompt(requestData);
             String requestBody = montaRequest.montar(requestData);
             GeraLandingJobDto openAiJob = new GeraLandingJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), "gpt-5.2", requestBody, prompt, null);
-            GeraLandingJobCompletionWireframePayload payload = generate(openAiJob);
+            RecordWireframeResponse payload = generate(openAiJob);
             recebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), payload);
         } catch (Exception ex) {
             log.error("Falha ao processar etapa wireframe para executionId={} (experimentId={})", execution.idJob(), execution.experimentId(), ex);
@@ -95,7 +95,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
     }
 
     /** Executa a geração no endpoint /responses da OpenAI e devolve o payload final da etapa wireframe. */
-    private GeraLandingJobCompletionWireframePayload generate(GeraLandingJobDto job) throws Exception {
+    private RecordWireframeResponse generate(GeraLandingJobDto job) throws Exception {
         log.info("Iniciando geração gera-landing wireframe via OpenAI flex [jobId={}, stage={}, model={}, requestBodyLength={}]", job.id(), job.section(), job.model(), safeLength(job.requestBodyJson()));
         log.info("Payload requestBodyJson do gera-landing wireframe [jobId={}, stage={}, requestBodyPreview={}]", job.id(), job.section(), preview(job.requestBodyJson()));
         OpenAiResponse response = createFlexResponse(job);
@@ -110,7 +110,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
         Integer inputTokens = response.usage() != null ? response.usage().effectiveInputTokens() : null;
         Integer outputTokens = response.usage() != null ? response.usage().effectiveOutputTokens() : null;
         log.info("Finalizando geração gera-landing wireframe [jobId={}, stage={}, responseId={}, inputTokens={}, outputTokens={}]", job.id(), job.section(), response.id(), inputTokens, outputTokens);
-        return new GeraLandingJobCompletionWireframePayload(modelResponse, rawOutput, job.requestBodyJson(), response.id(), inputTokens, outputTokens, OpenAiCostEstimator.estimateUsd(job.model(), response.usage()));
+        return new RecordWireframeResponse(modelResponse, rawOutput, job.requestBodyJson(), response.id(), inputTokens, outputTokens, OpenAiCostEstimator.estimateUsd(job.model(), response.usage()));
     }
 
     /** Prepara e executa a chamada flex da OpenAI para a etapa wireframe. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/response/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/response/RecebeResponse.java
@@ -23,7 +23,7 @@ public class RecebeResponse {
     /**
      * Envia para o backend os dados de despacho e de resultado da etapa, incluindo a resposta crua da OpenAI.
      */
-    public void processar(Long experimentId, String stageCode, String idJob, GeraLandingJobCompletionWireframePayload payload) {
+    public void processar(Long experimentId, String stageCode, String idJob, RecordWireframeResponse payload) {
         if (payload != null && payload.openAiJobId() != null && !payload.openAiJobId().isBlank()) {
             backendClient.receiveDispatch(idJob, experimentId, stageCode, payload.openAiJobId());
         }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/response/RecordWireframeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/response/RecordWireframeResponse.java
@@ -3,7 +3,7 @@ package com.marketinghub.worker.geralanding.wireframe.response;
 import java.math.BigDecimal;
 
 /** Guarda a resposta final da OpenAI para a etapa wireframe. */
-public record GeraLandingJobCompletionWireframePayload(
+public record RecordWireframeResponse(
         String responseContent,
         String rawResponse,
         String requestBodyJson,

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -3,7 +3,7 @@ package com.marketinghub.worker.geralanding;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.marketinghub.worker.geralanding.deliverables.GeraLandingJobCompletionDeliverablesPayload;
-import com.marketinghub.worker.geralanding.wireframe.callback.GeraLandingJobCompletionWireframePayload;
+import com.marketinghub.worker.geralanding.wireframe.callback.RecordWireframeResponse;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
@@ -120,7 +120,7 @@ class GeraLandingExecutionServiceTest {
         verify(wireframeRecebeResponse).processar(any(), any(), any(), any());
         verify(backendClient, never()).receiveDispatch(any(), any(), any(), any());
         verify(backendClient, never())
-                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionWireframePayload.class));
+                .receiveResult(any(), any(), any(), any(RecordWireframeResponse.class));
         verify(backendClient, never())
                 .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionDeliverablesPayload.class));
         verify(backendClient, never()).receiveFailure(any(), any(), any(), any(), any());
@@ -205,7 +205,7 @@ class GeraLandingExecutionServiceTest {
 
         verify(backendClient).receiveFailure(any(), any(), any(), any(), any());
         verify(backendClient, never())
-                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionWireframePayload.class));
+                .receiveResult(any(), any(), any(), any(RecordWireframeResponse.class));
         verify(backendClient, never())
                 .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionDeliverablesPayload.class));
     }
@@ -311,7 +311,7 @@ class GeraLandingExecutionServiceTest {
 
         verify(backendClient).receiveFailure(any(), any(), any(), any(), any());
         verify(backendClient, never())
-                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionWireframePayload.class));
+                .receiveResult(any(), any(), any(), any(RecordWireframeResponse.class));
         verify(backendClient, never())
                 .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionDeliverablesPayload.class));
     }
@@ -398,7 +398,7 @@ class GeraLandingExecutionServiceTest {
 
         verify(backendClient).receiveFailure(any(), any(), any(), any(), any());
         verify(backendClient, never())
-                .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionWireframePayload.class));
+                .receiveResult(any(), any(), any(), any(RecordWireframeResponse.class));
         verify(backendClient, never())
                 .receiveResult(any(), any(), any(), any(GeraLandingJobCompletionDeliverablesPayload.class));
     }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2058,3 +2058,12 @@
   - atualizado cada scheduler para orquestrar apenas `PendingJobsService` + `ExecutionProcessor` da própria etapa.
 - validação executada:
   - `mvn -q -DskipTests compile` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).
+
+## 2026-05-28 16:10:00 UTC
+- solicitação: renomear `GeraLandingJobCompletionWireframePayload` para `RecordWireframeResponse` na etapa `geralanding.wireframe` do `ai-worker`.
+- causa-raiz identificada: nome anterior longo e inconsistente com o padrão desejado para objeto de resposta da etapa wireframe.
+- correção aplicada:
+  - classe record renomeada para `RecordWireframeResponse`;
+  - atualizadas todas as referências/importações no fluxo wireframe (backend client, execução OpenAI e receive response) e no teste de execução.
+- validação executada:
+  - `mvn -q -Dtest=GeraLandingExecutionServiceTest test` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation
- Reduzir o nome longo e inconsistente do payload de resposta da etapa wireframe para um identificador claro e uniforme (`RecordWireframeResponse`) e alinhar referências em todo o fluxo da etapa.

### Description
- Renomeado o record de `GeraLandingJobCompletionWireframePayload` para `RecordWireframeResponse` em `ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/response/RecordWireframeResponse.java` e movido o arquivo com o novo nome.
- Atualizadas todas as importações e usos no fluxo wireframe, incluindo `GeraLandingWireframeBackendClient.receiveResult(...)`, `GeraLandingWireframeOpenAiExecutionService.generate(...)`, `RecebeResponse.processar(...)` e o adaptador de copy `GeraLandingCopyBackendClient.receiveResult(...)` para usar o novo tipo.
- Atualizados os testes em `ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java` para esperar `RecordWireframeResponse` e registrado o ajuste em `docs/registros/experimentos.md`.
- Mudança aplicada via rename + substituição de referências (commit afetou múltiplos arquivos — rename detectado e importações corrigidas).

### Testing
- Executado: `mvn -q -Dtest=GeraLandingExecutionServiceTest test` em `ai-worker/` como verificação de integração unitária.
- Resultado: falhou por limitação de ambiente ao resolver dependência privada (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`) retornando HTTP 401 do GitHub Packages, portanto os testes não puderam ser concluídos com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e5ba4f28832187247842e053e87f)