### PR TITLE
refactor(ai-worker): replicar estrutura wireframe para etapa presetdesign

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/GeraLandingCopyBackendClient.java
@@ -216,7 +216,7 @@ public class GeraLandingCopyBackendClient {
 
     /** Recebe resultado da etapa preset design usando o payload tipado da etapa. */
     public void receiveResult(String idJob, Long experimentId, String stageCode,
-                              com.marketinghub.worker.geralanding.presetdesign.GeraLandingJobCompletionPresetDesignPayload payload) {
+                              com.marketinghub.worker.geralanding.presetdesign.response.RecordPresetDesignResponse payload) {
         receiveResult(idJob, experimentId, stageCode, new GeraLandingJobCompletionPayload(
                 payload != null ? payload.responseContent() : null,
                 payload != null ? payload.rawResponse() : null,

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/backend/GeraLandingPresetDesignBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/backend/GeraLandingPresetDesignBackendClient.java
@@ -1,6 +1,7 @@
-package com.marketinghub.worker.geralanding.presetdesign;
+package com.marketinghub.worker.geralanding.presetdesign.backend;
 
 import com.marketinghub.worker.geralanding.presetdesign.dto.GeraLandingStageExecutionDetailDto;
+import com.marketinghub.worker.geralanding.presetdesign.response.RecordPresetDesignResponse;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -19,7 +20,7 @@ public class GeraLandingPresetDesignBackendClient {
     }
 
     /** Envia resultado da etapa para o backend principal com mapeamento para payload base. */
-    public void receiveResult(String idJob, Long experimentId, String stageCode, GeraLandingJobCompletionPresetDesignPayload payload) {
+    public void receiveResult(String idJob, Long experimentId, String stageCode, RecordPresetDesignResponse payload) {
         backendClient.receiveResult(idJob, experimentId, stageCode, payload);
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/monitor/PresetDesignPendingJobsService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/monitor/PresetDesignPendingJobsService.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.presetdesign.monitor;
 
-import com.marketinghub.worker.geralanding.presetdesign.GeraLandingPresetDesignBackendClient;
+import com.marketinghub.worker.geralanding.presetdesign.backend.GeraLandingPresetDesignBackendClient;
 import com.marketinghub.worker.geralanding.presetdesign.dto.GeraLandingStageExecutionDetailDto;
 import java.util.List;
 import java.util.Locale;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/request/GeraLandingPresetDesignOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/request/GeraLandingPresetDesignOpenAiExecutionService.java
@@ -2,11 +2,11 @@ package com.marketinghub.worker.geralanding.presetdesign.request;
 
 import com.marketinghub.worker.geralanding.GeraLandingJobDto;
 import com.marketinghub.worker.geralanding.GeraLandingOpenAiFlexClient;
-import com.marketinghub.worker.geralanding.presetdesign.GeraLandingPresetDesignBackendClient;
+import com.marketinghub.worker.geralanding.presetdesign.backend.GeraLandingPresetDesignBackendClient;
 import com.marketinghub.worker.geralanding.presetdesign.GeraLandingExperimentPresetDesignRequest;
-import com.marketinghub.worker.geralanding.presetdesign.GeraLandingJobCompletionPresetDesignPayload;
+import com.marketinghub.worker.geralanding.presetdesign.response.RecordPresetDesignResponse;
 import com.marketinghub.worker.geralanding.presetdesign.dto.GeraLandingStageExecutionDetailDto;
-import com.marketinghub.worker.geralanding.presetdesign.RecebeResponse;
+import com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -38,7 +38,7 @@ public class GeraLandingPresetDesignOpenAiExecutionService {
             String prompt = montaRequest.montarPrompt(requestData); String requestBody = montaRequest.montar(requestData);
             GeraLandingJobDto openAiJob = new GeraLandingJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), "gpt-5.2", requestBody, prompt, null);
             var basePayload = openAiClient.generate(openAiJob);
-            GeraLandingJobCompletionPresetDesignPayload pl = new GeraLandingJobCompletionPresetDesignPayload(basePayload.responseContent(), basePayload.rawResponse(), basePayload.requestBodyJson(), basePayload.openAiJobId(), basePayload.inputTokens(), basePayload.outputTokens(), basePayload.costUsd());
+            RecordPresetDesignResponse pl = new RecordPresetDesignResponse(basePayload.responseContent(), basePayload.rawResponse(), basePayload.requestBodyJson(), basePayload.openAiJobId(), basePayload.inputTokens(), basePayload.outputTokens(), basePayload.costUsd());
             recebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), pl);
         } catch (Exception ex) {
             log.error("Falha ao processar etapa presetdesign para executionId={} (experimentId={})", execution.idJob(), execution.experimentId(), ex);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/response/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/response/RecebeResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.presetdesign;
+package com.marketinghub.worker.geralanding.presetdesign.response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,16 +13,16 @@ public class RecebeResponse {
 
     private static final Logger log = LoggerFactory.getLogger(RecebeResponse.class);
 
-    private final GeraLandingPresetDesignBackendClient backendClient;
+    private final com.marketinghub.worker.geralanding.presetdesign.backend.GeraLandingPresetDesignBackendClient backendClient;
 
-    public RecebeResponse(GeraLandingPresetDesignBackendClient backendClient) {
+    public RecebeResponse(com.marketinghub.worker.geralanding.presetdesign.backend.GeraLandingPresetDesignBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 
     /**
      * Envia para o backend os dados de despacho e de resultado da etapa, incluindo a resposta crua da OpenAI.
      */
-    public void processar(Long experimentId, String stageCode, String idJob, GeraLandingJobCompletionPresetDesignPayload payload) {
+    public void processar(Long experimentId, String stageCode, String idJob, RecordPresetDesignResponse payload) {
         if (payload != null && payload.openAiJobId() != null && !payload.openAiJobId().isBlank()) {
             backendClient.receiveDispatch(idJob, experimentId, stageCode, payload.openAiJobId());
         }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/response/RecordPresetDesignResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/response/RecordPresetDesignResponse.java
@@ -1,0 +1,13 @@
+package com.marketinghub.worker.geralanding.presetdesign.response;
+
+import java.math.BigDecimal;
+
+/** Responsabilidade: representar o payload de resposta da OpenAI para conclusão da etapa presetdesign. */
+public record RecordPresetDesignResponse(
+        String responseContent,
+        String rawResponse,
+        String requestBodyJson,
+        String openAiJobId,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd) {}

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -43,8 +43,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
-        com.marketinghub.worker.geralanding.presetdesign.RecebeResponse presetDesignRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse presetDesignRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse.class);
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
@@ -148,8 +148,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
-        com.marketinghub.worker.geralanding.presetdesign.RecebeResponse presetDesignRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse presetDesignRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse.class);
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
@@ -232,8 +232,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
-        com.marketinghub.worker.geralanding.presetdesign.RecebeResponse presetDesignRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse presetDesignRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse.class);
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 
@@ -338,8 +338,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
-        com.marketinghub.worker.geralanding.presetdesign.RecebeResponse presetDesignRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse presetDesignRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse.class);
         com.marketinghub.worker.geralanding.deliverables.RecebeResponse deliverablesRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.RecebeResponse.class);
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2067,3 +2067,14 @@
   - atualizadas todas as referências/importações no fluxo wireframe (backend client, execução OpenAI e receive response) e no teste de execução.
 - validação executada:
   - `mvn -q -Dtest=GeraLandingExecutionServiceTest test` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).
+
+## 2026-05-28 17:05:00 UTC
+- solicitação: replicar para `geralanding.presetdesign` a mesma estrutura de pacotes consolidada na etapa `geralanding.wireframe`.
+- causa-raiz identificada: a etapa `presetdesign` ainda mantinha classes centrais em pacote raiz da etapa, diferente da organização por responsabilidade usada em `wireframe`.
+- correção aplicada:
+  - movida a integração com backend para `geralanding.presetdesign.backend.GeraLandingPresetDesignBackendClient`;
+  - movida a classe de callback para `geralanding.presetdesign.response.RecebeResponse`;
+  - criado o record `geralanding.presetdesign.response.RecordPresetDesignResponse` para alinhar payload de retorno ao padrão de resposta por etapa;
+  - atualizadas referências/importações nos fluxos de monitor/request e no backend client compartilhado.
+- validação executada:
+  - `mvn -q -Dtest=GeraLandingExecutionServiceTest test` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation

- Unificar a organização da etapa `geralanding.presetdesign` com o padrão aplicado em `geralanding.wireframe` para melhorar isolamento por responsabilidade. 
- Reduzir acoplamento e facilitar manutenção ao separar integrações backend, callback/response e DTOs dentro do próprio pacote da etapa. 
- Padronizar o formato de payload de resposta por etapa para manter consistência no pipeline de entrega.

### Description

- Movido `GeraLandingPresetDesignBackendClient` para o pacote `geralanding.presetdesign.backend` e ajustadas suas assinaturas para usar o novo record de resposta. 
- Movida a classe de callback `RecebeResponse` para `geralanding.presetdesign.response` e atualizada para receber o backend client no novo pacote. 
- Criado o record `geralanding.presetdesign.response.RecordPresetDesignResponse` para representar o payload de retorno da OpenAI da etapa `presetdesign`. 
- Atualizadas referências/importações em `GeraLandingPresetDesignOpenAiExecutionService`, `PresetDesignPendingJobsService`, `GeraLandingCopyBackendClient` (sobrecarga `receiveResult`) e testes (`GeraLandingExecutionServiceTest`) para refletir os novos pacotes/tipos; e registrado o trabalho em `docs/registros/experimentos.md`.

### Testing

- Executado `./mvnw -q -Dtest=GeraLandingExecutionServiceTest test` (não foi encontrado `./mvnw` no ambiente de execução). 
- Executado `mvn -q -Dtest=GeraLandingExecutionServiceTest test` em `ai-worker/`, que falhou devido a resolução de dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` retornando `401 Unauthorized` no GitHub Packages. 
- Código reorganizado e commit realizado (`refactor(ai-worker): replica estrutura wireframe na etapa presetdesign`), porém testes automatizados não puderam concluir por limitação de ambiente/depêndencia externa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e6ebd3b88321bcdeb49c259526b0)