### PR TITLE
Rename GeraLandingExperimentWireframeRequest to RecordWireframeRequest

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
@@ -82,7 +82,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
         }
         try {
             Map<String, Object> dadosPrompt = backendClient.loadPromptData(execution.experimentId());
-            GeraLandingExperimentWireframeRequest requestData = new GeraLandingExperimentWireframeRequest(execution.experimentId(), dadosPrompt);
+            RecordWireframeRequest requestData = new RecordWireframeRequest(execution.experimentId(), dadosPrompt);
             String prompt = montaRequest.montarPrompt(requestData);
             String requestBody = montaRequest.montar(requestData);
             GeraLandingJobDto openAiJob = new GeraLandingJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), "gpt-5.2", requestBody, prompt, null);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/MontaRequest.java
@@ -29,7 +29,7 @@ public class MontaRequest {
     }
 
     /** Monta o payload da Responses API para a etapa, resolvendo internamente schema, markdown e placeholders. */
-    public String montar(GeraLandingExperimentWireframeRequest experiment) throws IOException {
+    public String montar(RecordWireframeRequest experiment) throws IOException {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);
@@ -62,7 +62,7 @@ public class MontaRequest {
     }
 
     /** Monta o prompt final da etapa resolvendo placeholders de dados e prompts auxiliares. */
-    public String montarPrompt(GeraLandingExperimentWireframeRequest experiment) throws IOException {
+    public String montarPrompt(RecordWireframeRequest experiment) throws IOException {
         return MontaRequestSupport.montarPrompt("prompts/geralanding/" + PROMPT_MARKDOWN_FILE, PROMPT_MARKDOWN_FILE, experiment.dados(), objectMapper);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/RecordWireframeRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/RecordWireframeRequest.java
@@ -3,7 +3,7 @@ package com.marketinghub.worker.geralanding.wireframe.request;
 import java.util.Map;
 
 /** Concentra os dados do experimento usados na geração de wireframe. */
-public record GeraLandingExperimentWireframeRequest(
+public record RecordWireframeRequest(
         Long experimentId,
         Map<String, Object> dados) {
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2078,3 +2078,13 @@
   - atualizadas referências/importações nos fluxos de monitor/request e no backend client compartilhado.
 - validação executada:
   - `mvn -q -Dtest=GeraLandingExecutionServiceTest test` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).
+
+## 2026-05-28 17:30:00 UTC
+- solicitação: renomear `GeraLandingExperimentWireframeRequest` para `RecordWireframeRequest` na etapa `geralanding.wireframe` do `ai-worker`.
+- causa-raiz identificada: nome anterior não seguia o padrão curto de records adotado nas classes de request/response do fluxo wireframe.
+- correção aplicada:
+  - arquivo `GeraLandingExperimentWireframeRequest.java` renomeado para `RecordWireframeRequest.java`;
+  - record atualizado para `RecordWireframeRequest`;
+  - referências ajustadas em `GeraLandingWireframeOpenAiExecutionService` e `MontaRequest`.
+- validação executada:
+  - inspeção estática das referências com `rg` para garantir ausência do nome antigo em código Java da etapa wireframe.


### PR DESCRIPTION
### Motivation

- Padronizar o nome do `record` usado na etapa wireframe para seguir o padrão curto adotado para objetos de request/response.
- Melhorar legibilidade e consistência do pacote `geralanding.wireframe` reduzindo nomes longos e redundantes.

### Description

- Renomeado o `record` `GeraLandingExperimentWireframeRequest` para `RecordWireframeRequest` e o arquivo correspondente em `ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request`.
- Atualizadas as referências de criação do request em `GeraLandingWireframeOpenAiExecutionService` para instanciar `RecordWireframeRequest`.
- Atualizadas as assinaturas de `MontaRequest` (`montar` e `montarPrompt`) para receber `RecordWireframeRequest` em vez do nome antigo.
- Registrada a mudança em `docs/registros/experimentos.md` com descrição da solicitação, causa-raiz e correção aplicada.

### Testing

- Executado `rg -n "GeraLandingExperimentWireframeRequest" ai-worker docs/registros/experimentos.md` e verificado que não há referências restantes no código, apenas menções históricas na documentação (sucesso).
- A execução completa de `mvn`/testes não pôde ser realizada no ambiente local porque a build falha devido à dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` retornando HTTP 401, impedindo validação por `mvn` (falha externa).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e8b302d48321b18fe62446a0858b)