### PR TITLE
refactor(ai-worker): alinhar estrutura da etapa copy com wireframe

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
@@ -2,7 +2,7 @@ package com.marketinghub.worker.geralanding;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
+import com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient;
 import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.AdCopy;
 import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.AdImageBriefing;
 import com.marketinghub.worker.creative.pipeline.AdImagePayloadBuilder.CampaignAngle;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/backend/GeraLandingCopyBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/backend/GeraLandingCopyBackendClient.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.copy;
+package com.marketinghub.worker.geralanding.copy.backend;
 
 import com.marketinghub.worker.geralanding.copy.dto.GeraLandingStageExecutionDetailDto;
 import com.marketinghub.worker.util.UrlUtils;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/monitor/CopyPendingJobsService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/monitor/CopyPendingJobsService.java
@@ -1,7 +1,7 @@
 package com.marketinghub.worker.geralanding.copy.monitor;
 
 import com.marketinghub.worker.geralanding.copy.dto.GeraLandingStageExecutionDetailDto;
-import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
+import com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient;
 import java.util.List;
 import java.util.Locale;
 import org.springframework.stereotype.Service;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/request/GeraLandingCopyOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/request/GeraLandingCopyOpenAiExecutionService.java
@@ -2,10 +2,10 @@ package com.marketinghub.worker.geralanding.copy.request;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
+import com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient;
 import com.marketinghub.worker.geralanding.copy.GeraLandingExperimentRequest;
 import com.marketinghub.worker.geralanding.copy.GeraLandingJobCompletionPayload;
-import com.marketinghub.worker.geralanding.copy.RecebeResponse;
+import com.marketinghub.worker.geralanding.copy.response.RecebeResponse;
 import com.marketinghub.worker.geralanding.copy.dto.GeraLandingJobDto;
 import com.marketinghub.worker.geralanding.copy.dto.GeraLandingStageExecutionDetailDto;
 import com.marketinghub.worker.openai.OpenAiCostEstimator;
@@ -33,7 +33,7 @@ public class GeraLandingCopyOpenAiExecutionService {
     private static final Logger log = LoggerFactory.getLogger(GeraLandingCopyOpenAiExecutionService.class);
     private static final int LOG_PREVIEW_LIMIT = 1200;
     private final GeraLandingCopyBackendClient backendClient;
-    private final com.marketinghub.worker.geralanding.copy.MontaRequest montaRequest;
+    private final com.marketinghub.worker.geralanding.copy.request.MontaRequest montaRequest;
     private final RecebeResponse recebeResponse;
     private final ObjectMapper objectMapper;
     private final WebClient webClient;
@@ -44,7 +44,7 @@ public class GeraLandingCopyOpenAiExecutionService {
                                                  @Value("${openai.api-key:}") String apiKey,
                                                  @Value("${openai.base-url:https://api.request.com/v1}") String baseUrl,
                                                  @Value("${openai.flex-timeout:${openai.batch-timeout:PT30M}}") Duration flexTimeout,
-                                                 com.marketinghub.worker.geralanding.copy.MontaRequest montaRequest, RecebeResponse recebeResponse) {
+                                                 com.marketinghub.worker.geralanding.copy.request.MontaRequest montaRequest, RecebeResponse recebeResponse) {
         this.backendClient = backendClient;
         this.montaRequest = montaRequest;
         this.recebeResponse = recebeResponse;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/request/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/request/MontaRequest.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.copy;
+package com.marketinghub.worker.geralanding.copy.request;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.copy.GeraLandingExperimentRequest;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/response/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/response/RecebeResponse.java
@@ -1,6 +1,6 @@
-package com.marketinghub.worker.geralanding.copy;
+package com.marketinghub.worker.geralanding.copy.response;
 
-import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
+import com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient;
 import com.marketinghub.worker.geralanding.copy.GeraLandingJobCompletionPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/GeraLandingDeliverablesBackendClient.java
@@ -7,9 +7,9 @@ import org.springframework.stereotype.Component;
 /** Encapsula o acesso ao backend para operações da etapa deliverables. */
 @Component
 public class GeraLandingDeliverablesBackendClient {
-    private final com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient backendClient;
+    private final com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient backendClient;
 
-    public GeraLandingDeliverablesBackendClient(com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient backendClient) {
+    public GeraLandingDeliverablesBackendClient(com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/GeraLandingImagePlanningBackendClient.java
@@ -7,9 +7,9 @@ import org.springframework.stereotype.Component;
 /** Encapsula o acesso ao backend para operações da etapa imageplanning. */
 @Component
 public class GeraLandingImagePlanningBackendClient {
-    private final com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient backendClient;
+    private final com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient backendClient;
 
-    public GeraLandingImagePlanningBackendClient(com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient backendClient) {
+    public GeraLandingImagePlanningBackendClient(com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/backend/GeraLandingPresetDesignBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/backend/GeraLandingPresetDesignBackendClient.java
@@ -8,9 +8,9 @@ import org.springframework.stereotype.Component;
 /** Encapsula o acesso ao backend para operações da etapa presetdesign. */
 @Component
 public class GeraLandingPresetDesignBackendClient {
-    private final com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient backendClient;
+    private final com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient backendClient;
 
-    public GeraLandingPresetDesignBackendClient(com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient backendClient) {
+    public GeraLandingPresetDesignBackendClient(com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingExecutionServiceTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
+import com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient;
 import com.marketinghub.worker.geralanding.stage.GeraLandingStageSchemaResolver;
 import com.marketinghub.worker.geralanding.wireframe.openai.MontaRequest;
 import java.math.BigDecimal;
@@ -29,8 +29,8 @@ class GeraLandingExecutionServiceTest {
         ObjectMapper objectMapper = new ObjectMapper();
         GeraLandingStageSchemaResolver stageSchemaResolver = Mockito.mock(GeraLandingStageSchemaResolver.class);
         MontaRequest wireframeMontaRequest = Mockito.mock(MontaRequest.class);
-        com.marketinghub.worker.geralanding.copy.MontaRequest copyMontaRequest =
-                Mockito.mock(com.marketinghub.worker.geralanding.copy.MontaRequest.class);
+        com.marketinghub.worker.geralanding.copy.request.MontaRequest copyMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.request.MontaRequest.class);
         com.marketinghub.worker.geralanding.imageplanning.MontaRequest imagePlanningMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.MontaRequest.class);
         com.marketinghub.worker.geralanding.presetdesign.MontaRequest presetDesignMontaRequest =
@@ -39,8 +39,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
         com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse wireframeRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse.class);
-        com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.copy.response.RecebeResponse copyRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.response.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
         com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse presetDesignRecebeResponse =
@@ -134,8 +134,8 @@ class GeraLandingExecutionServiceTest {
         ObjectMapper objectMapper = new ObjectMapper();
         GeraLandingStageSchemaResolver stageSchemaResolver = Mockito.mock(GeraLandingStageSchemaResolver.class);
         MontaRequest wireframeMontaRequest = Mockito.mock(MontaRequest.class);
-        com.marketinghub.worker.geralanding.copy.MontaRequest copyMontaRequest =
-                Mockito.mock(com.marketinghub.worker.geralanding.copy.MontaRequest.class);
+        com.marketinghub.worker.geralanding.copy.request.MontaRequest copyMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.request.MontaRequest.class);
         com.marketinghub.worker.geralanding.imageplanning.MontaRequest imagePlanningMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.MontaRequest.class);
         com.marketinghub.worker.geralanding.presetdesign.MontaRequest presetDesignMontaRequest =
@@ -144,8 +144,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
         com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse wireframeRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse.class);
-        com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.copy.response.RecebeResponse copyRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.response.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
         com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse presetDesignRecebeResponse =
@@ -218,8 +218,8 @@ class GeraLandingExecutionServiceTest {
         ObjectMapper objectMapper = new ObjectMapper();
         GeraLandingStageSchemaResolver stageSchemaResolver = Mockito.mock(GeraLandingStageSchemaResolver.class);
         MontaRequest wireframeMontaRequest = Mockito.mock(MontaRequest.class);
-        com.marketinghub.worker.geralanding.copy.MontaRequest copyMontaRequest =
-                Mockito.mock(com.marketinghub.worker.geralanding.copy.MontaRequest.class);
+        com.marketinghub.worker.geralanding.copy.request.MontaRequest copyMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.request.MontaRequest.class);
         com.marketinghub.worker.geralanding.imageplanning.MontaRequest imagePlanningMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.MontaRequest.class);
         com.marketinghub.worker.geralanding.presetdesign.MontaRequest presetDesignMontaRequest =
@@ -228,8 +228,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
         com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse wireframeRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse.class);
-        com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.copy.response.RecebeResponse copyRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.response.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
         com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse presetDesignRecebeResponse =
@@ -324,8 +324,8 @@ class GeraLandingExecutionServiceTest {
         ObjectMapper objectMapper = new ObjectMapper();
         GeraLandingStageSchemaResolver stageSchemaResolver = Mockito.mock(GeraLandingStageSchemaResolver.class);
         MontaRequest wireframeMontaRequest = Mockito.mock(MontaRequest.class);
-        com.marketinghub.worker.geralanding.copy.MontaRequest copyMontaRequest =
-                Mockito.mock(com.marketinghub.worker.geralanding.copy.MontaRequest.class);
+        com.marketinghub.worker.geralanding.copy.request.MontaRequest copyMontaRequest =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.request.MontaRequest.class);
         com.marketinghub.worker.geralanding.imageplanning.MontaRequest imagePlanningMontaRequest =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.MontaRequest.class);
         com.marketinghub.worker.geralanding.presetdesign.MontaRequest presetDesignMontaRequest =
@@ -334,8 +334,8 @@ class GeraLandingExecutionServiceTest {
                 Mockito.mock(com.marketinghub.worker.geralanding.deliverables.MontaRequest.class);
         com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse wireframeRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.wireframe.callback.RecebeResponse.class);
-        com.marketinghub.worker.geralanding.copy.RecebeResponse copyRecebeResponse =
-                Mockito.mock(com.marketinghub.worker.geralanding.copy.RecebeResponse.class);
+        com.marketinghub.worker.geralanding.copy.response.RecebeResponse copyRecebeResponse =
+                Mockito.mock(com.marketinghub.worker.geralanding.copy.response.RecebeResponse.class);
         com.marketinghub.worker.geralanding.imageplanning.RecebeResponse imagePlanningRecebeResponse =
                 Mockito.mock(com.marketinghub.worker.geralanding.imageplanning.RecebeResponse.class);
         com.marketinghub.worker.geralanding.presetdesign.response.RecebeResponse presetDesignRecebeResponse =

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.copy.GeraLandingCopyBackendClient;
+import com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Disabled;


### PR DESCRIPTION
### Motivation
- Padronizar a organização do código entre os estágios do pipeline GeraLanding para facilitar manutenção e previsibilidade.
- Isolar responsabilidades de integração, montagem de request e processamento de resposta na etapa `copy` tal como já existe em `wireframe`.

### Description
- Moved core `copy` classes into subpackages by responsibility: `copy.backend.GeraLandingCopyBackendClient`, `copy.request.MontaRequest` and `copy.response.RecebeResponse` to mirror `wireframe` layout.
- Updated imports and references across the `ai-worker` module (including `GeraLandingService`, stage backend clients, monitors and execution services) to use the new package paths.
- Adjusted unit tests to mock the relocated types (`com.marketinghub.worker.geralanding.copy.request.MontaRequest` and `com.marketinghub.worker.geralanding.copy.response.RecebeResponse`).
- This change is structural/organizational only and preserves existing runtime behavior and public APIs.

### Testing
- Attempted to run targeted unit tests with `mvn -Dtest=GeraLandingExecutionServiceTest,GeraLandingServiceTest test` against the `ai-worker` module.
- Test execution failed due to Maven dependency resolution error (401 Unauthorized) when fetching a private artifact from `maven.pkg.github.com`, preventing full test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e9e1cc0c8321a684e893da0a9de6)