### PR TITLE
refactor(ai-worker): alinhar imageplanning ao padrão wireframe

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/backend/GeraLandingImagePlanningBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/backend/GeraLandingImagePlanningBackendClient.java
@@ -1,5 +1,6 @@
-package com.marketinghub.worker.geralanding.imageplanning;
+package com.marketinghub.worker.geralanding.imageplanning.backend;
 
+import com.marketinghub.worker.geralanding.imageplanning.GeraLandingJobCompletionImagePlanningPayload;
 import com.marketinghub.worker.geralanding.imageplanning.dto.GeraLandingStageExecutionDetailDto;
 import java.util.List;
 import org.springframework.stereotype.Component;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/monitor/ImagePlanningPendingJobsService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/monitor/ImagePlanningPendingJobsService.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.imageplanning.monitor;
 
-import com.marketinghub.worker.geralanding.imageplanning.GeraLandingImagePlanningBackendClient;
+import com.marketinghub.worker.geralanding.imageplanning.backend.GeraLandingImagePlanningBackendClient;
 import com.marketinghub.worker.geralanding.imageplanning.dto.GeraLandingStageExecutionDetailDto;
 import java.util.List;
 import java.util.Locale;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/request/GeraLandingImagePlanningOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/request/GeraLandingImagePlanningOpenAiExecutionService.java
@@ -2,11 +2,11 @@ package com.marketinghub.worker.geralanding.imageplanning.request;
 
 import com.marketinghub.worker.geralanding.GeraLandingJobDto;
 import com.marketinghub.worker.geralanding.GeraLandingOpenAiFlexClient;
-import com.marketinghub.worker.geralanding.imageplanning.GeraLandingImagePlanningBackendClient;
+import com.marketinghub.worker.geralanding.imageplanning.backend.GeraLandingImagePlanningBackendClient;
 import com.marketinghub.worker.geralanding.imageplanning.GeraLandingExperimentImagePlanningRequest;
 import com.marketinghub.worker.geralanding.imageplanning.GeraLandingJobCompletionImagePlanningPayload;
 import com.marketinghub.worker.geralanding.imageplanning.dto.GeraLandingStageExecutionDetailDto;
-import com.marketinghub.worker.geralanding.imageplanning.RecebeResponse;
+import com.marketinghub.worker.geralanding.imageplanning.response.RecebeResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -22,9 +22,9 @@ public class GeraLandingImagePlanningOpenAiExecutionService {
     private static final Logger log = LoggerFactory.getLogger(GeraLandingImagePlanningOpenAiExecutionService.class);
     private final GeraLandingImagePlanningBackendClient backendClient;
     private final GeraLandingOpenAiFlexClient openAiClient;
-    private final com.marketinghub.worker.geralanding.imageplanning.MontaRequest montaRequest;
+    private final com.marketinghub.worker.geralanding.imageplanning.request.MontaRequest montaRequest;
     private final RecebeResponse recebeResponse;
-    public GeraLandingImagePlanningOpenAiExecutionService(GeraLandingImagePlanningBackendClient backendClient, GeraLandingOpenAiFlexClient openAiClient, com.marketinghub.worker.geralanding.imageplanning.MontaRequest montaRequest, RecebeResponse recebeResponse) {
+    public GeraLandingImagePlanningOpenAiExecutionService(GeraLandingImagePlanningBackendClient backendClient, GeraLandingOpenAiFlexClient openAiClient, com.marketinghub.worker.geralanding.imageplanning.request.MontaRequest montaRequest, RecebeResponse recebeResponse) {
         this.backendClient = backendClient; this.openAiClient = openAiClient; this.montaRequest = montaRequest; this.recebeResponse = recebeResponse;
     }
     /** Processa os jobs pendentes da etapa imageplanning. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/request/MontaRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/request/MontaRequest.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.geralanding.imageplanning;
+package com.marketinghub.worker.geralanding.imageplanning.request;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.imageplanning.GeraLandingExperimentImagePlanningRequest;

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/response/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/response/RecebeResponse.java
@@ -1,5 +1,7 @@
-package com.marketinghub.worker.geralanding.imageplanning;
+package com.marketinghub.worker.geralanding.imageplanning.response;
 
+import com.marketinghub.worker.geralanding.imageplanning.GeraLandingJobCompletionImagePlanningPayload;
+import com.marketinghub.worker.geralanding.imageplanning.backend.GeraLandingImagePlanningBackendClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2088,3 +2088,14 @@
   - referências ajustadas em `GeraLandingWireframeOpenAiExecutionService` e `MontaRequest`.
 - validação executada:
   - inspeção estática das referências com `rg` para garantir ausência do nome antigo em código Java da etapa wireframe.
+
+## 2026-05-28 18:00:00 UTC
+- solicitação: usar a mesma estrutura do wireframe no worker ai para replicar na etapa `geralanding.imageplanning`.
+- causa-raiz identificada: `imageplanning` ainda mantinha classes `MontaRequest`, `RecebeResponse` e `GeraLandingImagePlanningBackendClient` no pacote raiz da etapa, divergindo do padrão por responsabilidade aplicado em `wireframe`.
+- correção aplicada:
+  - movida integração backend para `geralanding.imageplanning.backend.GeraLandingImagePlanningBackendClient`;
+  - movido callback de resposta para `geralanding.imageplanning.response.RecebeResponse`;
+  - movido montador de request OpenAI para `geralanding.imageplanning.request.MontaRequest`;
+  - atualizados imports/referências em `GeraLandingImagePlanningOpenAiExecutionService` e `ImagePlanningPendingJobsService`.
+- validação executada:
+  - `mvn -q -DskipTests compile` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation
- A etapa `geralanding.imageplanning` mantinha classes no pacote raiz, divergindo do padrão por responsabilidade consolidado na etapa `wireframe`, o que dificultava manutenção por etapa.

### Description
- Movi a integração com o backend para `geralanding.imageplanning.backend.GeraLandingImagePlanningBackendClient` (arquivo `ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/backend/GeraLandingImagePlanningBackendClient.java`).
- Movi o montador de request OpenAI para `geralanding.imageplanning.request.MontaRequest` (arquivo `ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/request/MontaRequest.java`).
- Movi o callback de resposta para `geralanding.imageplanning.response.RecebeResponse` (arquivo `ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/response/RecebeResponse.java`).
- Atualizei imports e referências em `GeraLandingImagePlanningOpenAiExecutionService` e `ImagePlanningPendingJobsService` para usar os novos pacotes e registrei a operação em `docs/registros/experimentos.md`.

### Testing
- Executado `./mvnw -q -DskipTests compile` em `ai-worker/` falhou porque o wrapper `mvnw` não existe no ambiente (erro local de invocação). (failed)
- Executado `mvn -q -DskipTests compile` em `ai-worker/` falhou devido a dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` retornando `401 Unauthorized` ao buscar no GitHub Packages, impedindo a validação de build (failed).
- Inspeção estática de referências/imports com `rg` foi usada para validar que não ficaram referências ao layout antigo (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181ff169d08321bee408a1e4d686ea)