### PR TITLE
Use deliverables-scoped GeraLandingJobDto in deliverables execution service

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/request/GeraLandingDeliverablesOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/request/GeraLandingDeliverablesOpenAiExecutionService.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.deliverables.request;
 
-import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.deliverables.dto.GeraLandingJobDto;
 import com.marketinghub.worker.geralanding.GeraLandingOpenAiFlexClient;
 import com.marketinghub.worker.geralanding.deliverables.GeraLandingDeliverablesBackendClient;
 import com.marketinghub.worker.geralanding.deliverables.GeraLandingExperimentDeliverablesRequest;


### PR DESCRIPTION
### Motivation
- Preserve stage isolation pattern used by the wireframe stage by ensuring the deliverables stage consumes its own `GeraLandingJobDto` type from the `deliverables` package instead of the shared `geralanding` DTO.

### Description
- Replaced the import in `ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/request/GeraLandingDeliverablesOpenAiExecutionService.java` to use `com.marketinghub.worker.geralanding.deliverables.dto.GeraLandingJobDto`, keeping the service implementation and job construction unchanged.

### Testing
- Attempted to run unit tests with `mvn -q -Dtest=GeraLandingServiceTest,GeraLandingOpenAiFlexClientTest test`, but the environment failed to resolve private Maven dependency `com.marketinghub:ads-service` (GitHub Packages) with a `401 Unauthorized`, so tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a182033b15883219531781ec00e812e)