### PR TITLE
Fix ArchUnit rule to accept exact geralanding.comum package and document change

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/ArquiteturaTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/ArquiteturaTest.java
@@ -122,7 +122,7 @@ class ArquiteturaTest {
 
                     String targetPackage = dependency.getTargetClass().getPackageName();
                     boolean valid = targetPackage.contains(".geralanding." + ownSubpackage + ".")
-                            || targetPackage.contains(".geralanding.comum.");
+                            || targetPackage.contains(".geralanding.comum");
                     if (!valid) {
                         String message = "[ARQUITETURA] classe-origem=" + item.getName()
                                 + " possui dependência violadora: " + dependency.getDescription()

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2099,3 +2099,12 @@
   - atualizados imports/referências em `GeraLandingImagePlanningOpenAiExecutionService` e `ImagePlanningPendingJobsService`.
 - validação executada:
   - `mvn -q -DskipTests compile` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).
+
+## 2026-05-28 18:20:00 UTC
+- solicitação: retirar o ponto final da regra ArchUnit de `geralanding.wireframe` para corrigir falso-positivo.
+- causa-raiz identificada: a checagem permitia apenas pacote `geralanding.comum.` (com subpacote), mas a classe alvo estava no pacote exato `geralanding.comum`.
+- correção aplicada:
+  - ajustada a condição `targetPackage.contains(".geralanding.comum.")` para `targetPackage.contains(".geralanding.comum")` em `ArquiteturaTest`.
+- validação executada:
+  - inspeção estática da regra alterada com `nl -ba` para confirmar remoção do ponto final no matcher.
+  - execução de `mvn -q -Dtest=com.marketinghub.worker.geralanding.ArquiteturaTest test` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation
- Avoid a false-positive in the ArchUnit check that rejected classes located in the exact package `geralanding.comum` due to a trailing-dot matcher.

### Description
- Updated the ArchUnit condition in `ai-worker/src/test/java/com/marketinghub/worker/geralanding/ArquiteturaTest.java` by replacing `targetPackage.contains(".geralanding.comum.")` with `targetPackage.contains(".geralanding.comum")` and added an entry to `docs/registros/experimentos.md` recording the fix.

### Testing
- Performed a static inspection with `nl -ba` to confirm the matcher change and attempted to run `mvn -q -Dtest=com.marketinghub.worker.geralanding.ArquiteturaTest test`, which could not complete due to an external private dependency `com.marketinghub:ads-service:0.0.1-SNAPSHOT` returning HTTP 401.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1829c9d3c883218d297513493112fa)