### PR TITLE
Refatora clientes GeraLanding para isolar dependências entre etapas

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/backend/GeraLandingCopyBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/backend/GeraLandingCopyBackendClient.java
@@ -201,32 +201,6 @@ public class GeraLandingCopyBackendClient {
                 payload != null ? payload.costUsd() : null));
     }
 
-    /** Recebe resultado da etapa image planning usando o payload tipado da etapa. */
-    public void receiveResult(String idJob, Long experimentId, String stageCode,
-                              com.marketinghub.worker.geralanding.imageplanning.GeraLandingJobCompletionImagePlanningPayload payload) {
-        receiveResult(idJob, experimentId, stageCode, new GeraLandingJobCompletionPayload(
-                payload != null ? payload.responseContent() : null,
-                payload != null ? payload.rawResponse() : null,
-                payload != null ? payload.requestBodyJson() : null,
-                payload != null ? payload.openAiJobId() : null,
-                payload != null ? payload.inputTokens() : null,
-                payload != null ? payload.outputTokens() : null,
-                payload != null ? payload.costUsd() : null));
-    }
-
-    /** Recebe resultado da etapa preset design usando o payload tipado da etapa. */
-    public void receiveResult(String idJob, Long experimentId, String stageCode,
-                              com.marketinghub.worker.geralanding.presetdesign.response.RecordPresetDesignResponse payload) {
-        receiveResult(idJob, experimentId, stageCode, new GeraLandingJobCompletionPayload(
-                payload != null ? payload.responseContent() : null,
-                payload != null ? payload.rawResponse() : null,
-                payload != null ? payload.requestBodyJson() : null,
-                payload != null ? payload.openAiJobId() : null,
-                payload != null ? payload.inputTokens() : null,
-                payload != null ? payload.outputTokens() : null,
-                payload != null ? payload.costUsd() : null));
-    }
-
     /** Recebe resultado da etapa deliverables usando o payload tipado da etapa. */
     public void receiveResult(String idJob, Long experimentId, String stageCode,
                               com.marketinghub.worker.geralanding.deliverables.GeraLandingJobCompletionDeliverablesPayload payload) {
@@ -238,22 +212,6 @@ public class GeraLandingCopyBackendClient {
                 payload != null ? payload.inputTokens() : null,
                 payload != null ? payload.outputTokens() : null,
                 payload != null ? payload.costUsd() : null));
-    }
-
-    /** Recebe resultado da etapa wireframe usando o payload tipado da etapa. */
-    public void receiveResult(String idJob, Long experimentId, String stageCode,
-                              com.marketinghub.worker.geralanding.wireframe.response.RecordWireframeResponse payload) {
-        String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix,
-                "/internal/geralanding/stage-executions");
-        Map<String, Object> body = new java.util.LinkedHashMap<>();
-        body.put("experimentId", experimentId);
-        body.put("stageCode", stageCode);
-        body.put("modelResponse", payload != null ? payload.responseContent() : null);
-        body.put("inputTokens", payload != null ? payload.inputTokens() : null);
-        body.put("outputTokens", payload != null ? payload.outputTokens() : null);
-        body.put("costUsd", payload != null ? payload.costUsd() : null);
-        body.put("openAiJobId", payload != null ? payload.openAiJobId() : null);
-        webClient.post().uri(baseUrl + "/{idJob}/receive-result", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block();
     }
 
     public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) {
@@ -287,40 +245,12 @@ public class GeraLandingCopyBackendClient {
                 .block();
     }
 
-    /**
-     * Consulta o controller wireframe.web para obter os detalhes de um job específico da etapa wireframe.
-     */
-    public com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto fetchWireframeStageExecutionDetail(Long experimentId, String idJob) {
-        String uri = UrlUtils.joinPath(
-                backendBaseUrl,
-                apiPrefix,
-                "/experiments/" + experimentId + "/geralanding/wireframe/stage-executions/" + idJob);
-        return webClient.get()
-                .uri(uri)
-                .retrieve()
-                .bodyToMono(com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto.class)
-                .onErrorReturn(null)
-                .block();
-    }
-
 
 
     /** Consulta detalhes da execução da etapa copy no controller copy.web. */
     public com.marketinghub.worker.geralanding.copy.dto.GeraLandingStageExecutionDetailDto fetchCopyStageExecutionDetail(Long experimentId, String idJob) {
         String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/geralanding/copy/stage-executions/" + idJob);
         return webClient.get().uri(uri).retrieve().bodyToMono(com.marketinghub.worker.geralanding.copy.dto.GeraLandingStageExecutionDetailDto.class).onErrorReturn(null).block();
-    }
-
-    /** Consulta detalhes da execução da etapa image-planning no controller imageplanning.web. */
-    public com.marketinghub.worker.geralanding.imageplanning.dto.GeraLandingStageExecutionDetailDto fetchImagePlanningStageExecutionDetail(Long experimentId, String idJob) {
-        String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/geralanding/image-prompts/stage-executions/" + idJob);
-        return webClient.get().uri(uri).retrieve().bodyToMono(com.marketinghub.worker.geralanding.imageplanning.dto.GeraLandingStageExecutionDetailDto.class).onErrorReturn(null).block();
-    }
-
-    /** Consulta detalhes da execução da etapa design-preset no controller designpreset.web. */
-    public com.marketinghub.worker.geralanding.presetdesign.dto.GeraLandingStageExecutionDetailDto fetchDesignPresetStageExecutionDetail(Long experimentId, String idJob) {
-        String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/geralanding/design-preset/stage-executions/" + idJob);
-        return webClient.get().uri(uri).retrieve().bodyToMono(com.marketinghub.worker.geralanding.presetdesign.dto.GeraLandingStageExecutionDetailDto.class).onErrorReturn(null).block();
     }
 
     /** Consulta detalhes da execução da etapa deliverables no controller deliverables.web. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/backend/GeraLandingImagePlanningBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/backend/GeraLandingImagePlanningBackendClient.java
@@ -1,47 +1,56 @@
 package com.marketinghub.worker.geralanding.imageplanning.backend;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.imageplanning.GeraLandingJobCompletionImagePlanningPayload;
 import com.marketinghub.worker.geralanding.imageplanning.dto.GeraLandingStageExecutionDetailDto;
+import com.marketinghub.worker.util.UrlUtils;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-/** Encapsula o acesso ao backend para operações da etapa imageplanning. */
+/** Responsabilidade: encapsular integrações HTTP da etapa imageplanning sem dependências de outras etapas. */
 @Component
 public class GeraLandingImagePlanningBackendClient {
-    private final com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient backendClient;
+    private static final Logger log = LoggerFactory.getLogger(GeraLandingImagePlanningBackendClient.class);
+    private final WebClient webClient;
+    private final String backendBaseUrl;
+    private final String apiPrefix;
+    private final ObjectMapper objectMapper;
 
-    public GeraLandingImagePlanningBackendClient(com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient backendClient) {
-        this.backendClient = backendClient;
+    public GeraLandingImagePlanningBackendClient(WebClient.Builder builder,
+            @Value("${backend.base-url:http://191.252.181.168:8000}") String backendBaseUrl,
+            @Value("${backend.api-prefix:/api}") String apiPrefix,
+            ObjectMapper objectMapper) {
+        this.webClient = builder.build();
+        this.backendBaseUrl = backendBaseUrl;
+        this.apiPrefix = apiPrefix;
+        this.objectMapper = objectMapper;
     }
 
-    /** Lista execuções pendentes convertendo para o DTO específico da etapa. */
-    public List<GeraLandingStageExecutionDetailDto> listPendingExecutions(int limit) {
-        return backendClient.listPendingExecutions(limit).stream().map(item -> new GeraLandingStageExecutionDetailDto(item.experimentId(), item.stageCode(), item.idJob(), item.status(), item.executionRequestedAt(), item.processingStartedAt(), item.completedAt(), item.openAiJobId())).toList();
-    }
-
-    /** Envia resultado da etapa para o backend principal com mapeamento para payload base. */
-    public void receiveResult(String idJob, Long experimentId, String stageCode, GeraLandingJobCompletionImagePlanningPayload payload) {
-        backendClient.receiveResult(idJob, experimentId, stageCode, payload);
-    }
-
-
+    /** Lista execuções pendentes da etapa no backend. */
+    public List<GeraLandingStageExecutionDetailDto> listPendingExecutions(int limit) { String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions/pending") + "?limit=" + Math.max(1, limit); List<GeraLandingStageExecutionDetailDto> payload = webClient.get().uri(uri).exchangeToFlux(response -> handleListResponse(uri, response.statusCode(), response)).collectList().doOnError(err -> log.error("Falha ao buscar execuções pendentes imageplanning. uri={}", uri, err)).block(); return payload != null ? payload : List.of(); }
+    /** Envia resultado da etapa para o backend principal. */
+    public void receiveResult(String idJob, Long experimentId, String stageCode, GeraLandingJobCompletionImagePlanningPayload payload) { String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions"); Map<String, Object> body = new LinkedHashMap<>(); body.put("experimentId", experimentId); body.put("stageCode", stageCode); body.put("modelResponse", payload != null ? payload.responseContent() : null); body.put("inputTokens", payload != null ? payload.inputTokens() : null); body.put("outputTokens", payload != null ? payload.outputTokens() : null); body.put("costUsd", payload != null ? payload.costUsd() : null); body.put("openAiJobId", payload != null ? payload.openAiJobId() : null); webClient.post().uri(baseUrl + "/{idJob}/receive-result", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block(); }
     /** Encaminha confirmação de despacho da etapa para o backend principal. */
-    public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) {
-        backendClient.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);
-    }
-
-
+    public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) { String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions"); Map<String, Object> body = new LinkedHashMap<>(); body.put("experimentId", experimentId); body.put("stageCode", stageCode); body.put("openAiJobId", openAiJobId); webClient.post().uri(baseUrl + "/{idJob}/receive-dispatch", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block(); }
     /** Carrega os dados de prompt necessários para execução da etapa. */
-    public java.util.Map<String, Object> loadPromptData(Long experimentId) {
-        return backendClient.loadPromptData(experimentId);
-    }
-
+    public Map<String, Object> loadPromptData(Long experimentId) { if (experimentId == null) { return Map.of(); } String experimentUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId); Map<String, Object> experiment = webClient.get().uri(experimentUrl).retrieve().bodyToMono(Map.class).onErrorReturn(Map.of()).block(); if (experiment == null || experiment.isEmpty()) { return Map.of(); } Map<String, Object> payload = new LinkedHashMap<>(); payload.put("campaignAngle", parseJsonField(experiment.get("campaignAngle"))); payload.put("adCopy", parseJsonField(experiment.get("adCopy"))); payload.put("adImageBriefing", parseJsonField(experiment.get("adImageBriefing"))); payload.put("landingPageWireframe", parseJsonField(experiment.get("landingPageWireframe"))); payload.put("NICHE_NAME", resolveNicheName(experiment.get("nicheId"))); populateHypothesisFields(payload, experiment.get("nicheId"), experiment.get("hypothesisId")); return payload; }
     /** Encaminha falha de execução da etapa para o backend principal. */
-    public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) {
-        backendClient.receiveFailure(idJob, experimentId, stageCode, errorMessage, errorDetail);
-    }
+    public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) { String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions"); Map<String, Object> body = new LinkedHashMap<>(); body.put("experimentId", experimentId); body.put("stageCode", stageCode); body.put("errorMessage", errorMessage); body.put("errorDetail", errorDetail); webClient.post().uri(baseUrl + "/{idJob}/receive-result", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block(); }
     /** Busca os detalhes de execução da etapa no backend. */
-    public GeraLandingStageExecutionDetailDto fetchStageExecutionDetail(Long experimentId, String idJob) {
-        return backendClient.fetchImagePlanningStageExecutionDetail(experimentId, idJob);
-    }
+    public GeraLandingStageExecutionDetailDto fetchStageExecutionDetail(Long experimentId, String idJob) { String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/geralanding/image-prompts/stage-executions/" + idJob); return webClient.get().uri(uri).retrieve().bodyToMono(GeraLandingStageExecutionDetailDto.class).onErrorReturn(null).block(); }
+    private void populateHypothesisFields(Map<String, Object> payload, Object nicheId, Object hypothesisId) { if (nicheId == null || hypothesisId == null) { return; } String hypothesesUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/niches/" + nicheId + "/hypotheses"); List<Map<String, Object>> hypotheses = webClient.get().uri(hypothesesUrl).retrieve().bodyToFlux(new ParameterizedTypeReference<Map<String, Object>>() {}).collectList().onErrorReturn(List.of()).block(); if (hypotheses == null || hypotheses.isEmpty()) { return; } String hypothesisIdText = String.valueOf(hypothesisId); hypotheses.stream().filter(item -> hypothesisIdText.equalsIgnoreCase(String.valueOf(item.get("id")))).findFirst().ifPresent(hypothesis -> { Object framework = hypothesis.get("framework"); if (framework instanceof Map<?, ?> map) { Object pain = map.get("pain"); Object result = map.get("result"); if (pain != null) { payload.put("PAIN_JSON", pain); } if (result != null) { payload.put("RESULT_JSON", result); } } }); }
+    private String resolveNicheName(Object nicheId) { if (nicheId == null) { return ""; } String nicheUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/niches/" + nicheId); Map<String, Object> niche = webClient.get().uri(nicheUrl).retrieve().bodyToMono(Map.class).onErrorReturn(Map.of()).block(); return niche != null && niche.get("name") != null ? String.valueOf(niche.get("name")) : ""; }
+    private Object parseJsonField(Object value) { if (!(value instanceof String raw) || raw.isBlank()) { return Map.of(); } try { return objectMapper.readValue(raw, Map.class); } catch (Exception ex) { return raw; } }
+    private Flux<GeraLandingStageExecutionDetailDto> handleListResponse(String uri, HttpStatusCode status, ClientResponse response) { if (status.isError()) { return response.bodyToMono(String.class).defaultIfEmpty("").flatMapMany(body -> Mono.error(new IllegalStateException("GET %s failed with status %s: %s".formatted(uri, status, body)))); } return response.bodyToFlux(GeraLandingStageExecutionDetailDto.class); }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/backend/GeraLandingPresetDesignBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/backend/GeraLandingPresetDesignBackendClient.java
@@ -1,47 +1,53 @@
 package com.marketinghub.worker.geralanding.presetdesign.backend;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.presetdesign.dto.GeraLandingStageExecutionDetailDto;
 import com.marketinghub.worker.geralanding.presetdesign.response.RecordPresetDesignResponse;
+import com.marketinghub.worker.util.UrlUtils;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-/** Encapsula o acesso ao backend para operações da etapa presetdesign. */
+/** Responsabilidade: encapsular integrações HTTP da etapa presetdesign sem dependências de outras etapas. */
 @Component
 public class GeraLandingPresetDesignBackendClient {
-    private final com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient backendClient;
+    private static final Logger log = LoggerFactory.getLogger(GeraLandingPresetDesignBackendClient.class);
+    private final WebClient webClient;
+    private final String backendBaseUrl;
+    private final String apiPrefix;
+    private final ObjectMapper objectMapper;
 
-    public GeraLandingPresetDesignBackendClient(com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendClient backendClient) {
-        this.backendClient = backendClient;
+    public GeraLandingPresetDesignBackendClient(WebClient.Builder builder,
+            @Value("${backend.base-url:http://191.252.181.168:8000}") String backendBaseUrl,
+            @Value("${backend.api-prefix:/api}") String apiPrefix,
+            ObjectMapper objectMapper) {
+        this.webClient = builder.build(); this.backendBaseUrl = backendBaseUrl; this.apiPrefix = apiPrefix; this.objectMapper = objectMapper;
     }
 
-    /** Lista execuções pendentes convertendo para o DTO específico da etapa. */
-    public List<GeraLandingStageExecutionDetailDto> listPendingExecutions(int limit) {
-        return backendClient.listPendingExecutions(limit).stream().map(item -> new GeraLandingStageExecutionDetailDto(item.experimentId(), item.stageCode(), item.idJob(), item.status(), item.executionRequestedAt(), item.processingStartedAt(), item.completedAt(), item.openAiJobId())).toList();
-    }
-
-    /** Envia resultado da etapa para o backend principal com mapeamento para payload base. */
-    public void receiveResult(String idJob, Long experimentId, String stageCode, RecordPresetDesignResponse payload) {
-        backendClient.receiveResult(idJob, experimentId, stageCode, payload);
-    }
-
-
+    /** Lista execuções pendentes da etapa no backend. */
+    public List<GeraLandingStageExecutionDetailDto> listPendingExecutions(int limit) { String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions/pending") + "?limit=" + Math.max(1, limit); List<GeraLandingStageExecutionDetailDto> payload = webClient.get().uri(uri).exchangeToFlux(response -> handleListResponse(uri, response.statusCode(), response)).collectList().doOnError(err -> log.error("Falha ao buscar execuções pendentes presetdesign. uri={}", uri, err)).block(); return payload != null ? payload : List.of(); }
+    /** Envia resultado da etapa para o backend principal. */
+    public void receiveResult(String idJob, Long experimentId, String stageCode, RecordPresetDesignResponse payload) { String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions"); Map<String, Object> body = new LinkedHashMap<>(); body.put("experimentId", experimentId); body.put("stageCode", stageCode); body.put("modelResponse", payload != null ? payload.responseContent() : null); body.put("inputTokens", payload != null ? payload.inputTokens() : null); body.put("outputTokens", payload != null ? payload.outputTokens() : null); body.put("costUsd", payload != null ? payload.costUsd() : null); body.put("openAiJobId", payload != null ? payload.openAiJobId() : null); webClient.post().uri(baseUrl + "/{idJob}/receive-result", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block(); }
     /** Encaminha confirmação de despacho da etapa para o backend principal. */
-    public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) {
-        backendClient.receiveDispatch(idJob, experimentId, stageCode, openAiJobId);
-    }
-
-
+    public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) { String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions"); Map<String, Object> body = new LinkedHashMap<>(); body.put("experimentId", experimentId); body.put("stageCode", stageCode); body.put("openAiJobId", openAiJobId); webClient.post().uri(baseUrl + "/{idJob}/receive-dispatch", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block(); }
     /** Carrega os dados de prompt necessários para execução da etapa. */
-    public java.util.Map<String, Object> loadPromptData(Long experimentId) {
-        return backendClient.loadPromptData(experimentId);
-    }
-
+    public Map<String, Object> loadPromptData(Long experimentId) { if (experimentId == null) { return Map.of(); } String experimentUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId); Map<String, Object> experiment = webClient.get().uri(experimentUrl).retrieve().bodyToMono(Map.class).onErrorReturn(Map.of()).block(); if (experiment == null || experiment.isEmpty()) { return Map.of(); } Map<String, Object> payload = new LinkedHashMap<>(); payload.put("campaignAngle", parseJsonField(experiment.get("campaignAngle"))); payload.put("adCopy", parseJsonField(experiment.get("adCopy"))); payload.put("adImageBriefing", parseJsonField(experiment.get("adImageBriefing"))); payload.put("landingPageWireframe", parseJsonField(experiment.get("landingPageWireframe"))); payload.put("NICHE_NAME", resolveNicheName(experiment.get("nicheId"))); populateHypothesisFields(payload, experiment.get("nicheId"), experiment.get("hypothesisId")); return payload; }
     /** Encaminha falha de execução da etapa para o backend principal. */
-    public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) {
-        backendClient.receiveFailure(idJob, experimentId, stageCode, errorMessage, errorDetail);
-    }
+    public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) { String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions"); Map<String, Object> body = new LinkedHashMap<>(); body.put("experimentId", experimentId); body.put("stageCode", stageCode); body.put("errorMessage", errorMessage); body.put("errorDetail", errorDetail); webClient.post().uri(baseUrl + "/{idJob}/receive-result", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block(); }
     /** Busca os detalhes de execução da etapa no backend. */
-    public GeraLandingStageExecutionDetailDto fetchStageExecutionDetail(Long experimentId, String idJob) {
-        return backendClient.fetchDesignPresetStageExecutionDetail(experimentId, idJob);
-    }
+    public GeraLandingStageExecutionDetailDto fetchStageExecutionDetail(Long experimentId, String idJob) { String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments/" + experimentId + "/geralanding/design-preset/stage-executions/" + idJob); return webClient.get().uri(uri).retrieve().bodyToMono(GeraLandingStageExecutionDetailDto.class).onErrorReturn(null).block(); }
+    private void populateHypothesisFields(Map<String, Object> payload, Object nicheId, Object hypothesisId) { if (nicheId == null || hypothesisId == null) { return; } String hypothesesUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/niches/" + nicheId + "/hypotheses"); List<Map<String, Object>> hypotheses = webClient.get().uri(hypothesesUrl).retrieve().bodyToFlux(new ParameterizedTypeReference<Map<String, Object>>() {}).collectList().onErrorReturn(List.of()).block(); if (hypotheses == null || hypotheses.isEmpty()) { return; } String hypothesisIdText = String.valueOf(hypothesisId); hypotheses.stream().filter(item -> hypothesisIdText.equalsIgnoreCase(String.valueOf(item.get("id")))).findFirst().ifPresent(hypothesis -> { Object framework = hypothesis.get("framework"); if (framework instanceof Map<?, ?> map) { Object pain = map.get("pain"); Object result = map.get("result"); if (pain != null) { payload.put("PAIN_JSON", pain); } if (result != null) { payload.put("RESULT_JSON", result); } } }); }
+    private String resolveNicheName(Object nicheId) { if (nicheId == null) { return ""; } String nicheUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/niches/" + nicheId); Map<String, Object> niche = webClient.get().uri(nicheUrl).retrieve().bodyToMono(Map.class).onErrorReturn(Map.of()).block(); return niche != null && niche.get("name") != null ? String.valueOf(niche.get("name")) : ""; }
+    private Object parseJsonField(Object value) { if (!(value instanceof String raw) || raw.isBlank()) { return Map.of(); } try { return objectMapper.readValue(raw, Map.class); } catch (Exception ex) { return raw; } }
+    private Flux<GeraLandingStageExecutionDetailDto> handleListResponse(String uri, HttpStatusCode status, ClientResponse response) { if (status.isError()) { return response.bodyToMono(String.class).defaultIfEmpty("").flatMapMany(body -> Mono.error(new IllegalStateException("GET %s failed with status %s: %s".formatted(uri, status, body)))); } return response.bodyToFlux(GeraLandingStageExecutionDetailDto.class); }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2108,3 +2108,13 @@
 - validação executada:
   - inspeção estática da regra alterada com `nl -ba` para confirmar remoção do ponto final no matcher.
   - execução de `mvn -q -Dtest=com.marketinghub.worker.geralanding.ArquiteturaTest test` em `ai-worker/` (falhou por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).
+
+## 2026-05-28 19:05:00 UTC
+- solicitação: usar `geralanding.wireframe` como referência para remover dependências cruzadas entre slices do Worker AI e corrigir falhas do `ArquiteturaTest`.
+- causa-raiz identificada: `copy.backend.GeraLandingCopyBackendClient` concentrava contratos e métodos de `imageplanning`, `presetdesign` e `wireframe`, e `imageplanning/presetdesign` dependiam diretamente de `copy.backend`.
+- correção aplicada:
+  - removidas, em `copy.backend.GeraLandingCopyBackendClient`, as APIs tipadas e consultas específicas de `imageplanning`, `presetdesign` e `wireframe`;
+  - reescrito `imageplanning.backend.GeraLandingImagePlanningBackendClient` para encapsular seu próprio fluxo HTTP com DTO e payload da própria etapa, sem depender de `copy`;
+  - reescrito `presetdesign.backend.GeraLandingPresetDesignBackendClient` no mesmo padrão de isolamento por etapa.
+- validação executada:
+  - `mvn -q -Dtest=ArquiteturaTest test` em `ai-worker/` (bloqueado por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation
- Eliminar violações de arquitetura em `ai-worker` causadas por acoplamento entre slices `geralanding` (copy, imageplanning, presetdesign, wireframe). 
- Seguir o padrão de isolamento já aplicado em `geralanding.wireframe` para garantir que cada etapa gerencie suas integrações HTTP e DTOs.

### Description
- Removidas de `GeraLandingCopyBackendClient` as APIs tipadas e consultas específicas que expunham classes de `imageplanning`, `presetdesign` e `wireframe`, mantendo o client focado em `copy`/`deliverables` e no contrato comum de callback.
- Reescrito `GeraLandingImagePlanningBackendClient` para encapsular seu próprio fluxo HTTP com `WebClient`, `ObjectMapper`, DTOs e mapeamento de payloads sem depender de `copy.backend`.
- Reescrito `GeraLandingPresetDesignBackendClient` no mesmo padrão de isolamento por etapa, com métodos de listagem, leitura de prompt, envio de resultado/dispatch/failure e parsing de campos JSON.
- Atualizado registro operacional em `docs/registros/experimentos.md` documentando causa-raiz e alterações realizadas.

### Testing
- Execução estática e inspeções locais (`nl`, `rg`) para validar alterações de código e remoção de referencias cruzadas — concluídas com sucesso.
- Tentativa de rodar `mvn -q -Dtest=ArquiteturaTest test` no módulo `ai-worker` foi bloqueada por dependência privada externa ausente (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`) retornando HTTP 401 no GitHub Packages, impedindo validação automatizada da regra ArchUnit.
- Tentativa de aplicar `spotless` via `./mvnw`/`mvn -DskipTests spotless:apply` não concluiu no ambiente (a integração `spotless`/`mvnw` não estava disponível), portanto formatação automática não foi aplicada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a182d9ddb5c83218b9a963ca27c06f7)