### PR TITLE
Renomeia GeraLandingJobDto para RecordJobDto no ai-worker (geralanding)

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingOpenAiFlexClient.java
@@ -60,14 +60,28 @@ public class GeraLandingOpenAiFlexClient {
     /**
      * Executa a geração no endpoint /responses da OpenAI para DTO da etapa deliverables.
      */
-    public GeraLandingJobCompletionPayload generate(com.marketinghub.worker.geralanding.deliverables.dto.GeraLandingJobDto job) {
+    public GeraLandingJobCompletionPayload generate(com.marketinghub.worker.geralanding.deliverables.dto.RecordJobDto job) {
+        return generateFromValues(job.id(), job.section(), job.model(), job.requestBodyJson(), job.prompt());
+    }
+
+    /**
+     * Executa a geração no endpoint /responses da OpenAI para DTO da etapa imageplanning.
+     */
+    public GeraLandingJobCompletionPayload generate(com.marketinghub.worker.geralanding.imageplanning.dto.RecordJobDto job) {
+        return generateFromValues(job.id(), job.section(), job.model(), job.requestBodyJson(), job.prompt());
+    }
+
+    /**
+     * Executa a geração no endpoint /responses da OpenAI para DTO da etapa presetdesign.
+     */
+    public GeraLandingJobCompletionPayload generate(com.marketinghub.worker.geralanding.presetdesign.dto.RecordJobDto job) {
         return generateFromValues(job.id(), job.section(), job.model(), job.requestBodyJson(), job.prompt());
     }
 
     /**
      * Executa a geração no endpoint /responses da OpenAI e devolve o payload final da etapa.
      */
-    public GeraLandingJobCompletionPayload generate(GeraLandingJobDto job) {
+    public GeraLandingJobCompletionPayload generate(RecordJobDto job) {
         return generateFromValues(job.id(), job.section(), job.model(), job.requestBodyJson(), job.prompt());
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/RecordJobDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/RecordJobDto.java
@@ -3,7 +3,8 @@ package com.marketinghub.worker.geralanding;
 import java.time.Instant;
 import java.util.UUID;
 
-public record GeraLandingJobDto(
+/** Responsabilidade: representar os dados do job OpenAI do fluxo geral do GeraLanding. */
+public record RecordJobDto(
         UUID id,
         Long experimentId,
         String section,

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/dto/RecordJobDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/dto/RecordJobDto.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 /** Responsabilidade: representar os dados do job OpenAI da etapa copy. */
-public record GeraLandingJobDto(
+public record RecordJobDto(
         UUID id,
         Long experimentId,
         String section,

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/request/GeraLandingCopyOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/request/GeraLandingCopyOpenAiExecutionService.java
@@ -6,7 +6,7 @@ import com.marketinghub.worker.geralanding.copy.backend.GeraLandingCopyBackendCl
 import com.marketinghub.worker.geralanding.copy.GeraLandingExperimentRequest;
 import com.marketinghub.worker.geralanding.copy.GeraLandingJobCompletionPayload;
 import com.marketinghub.worker.geralanding.copy.response.RecebeResponse;
-import com.marketinghub.worker.geralanding.copy.dto.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.copy.dto.RecordJobDto;
 import com.marketinghub.worker.geralanding.copy.dto.GeraLandingStageExecutionDetailDto;
 import com.marketinghub.worker.openai.OpenAiCostEstimator;
 import com.marketinghub.worker.openai.OpenAiResponse;
@@ -72,7 +72,7 @@ public class GeraLandingCopyOpenAiExecutionService {
             String prompt = montaRequest.montarPrompt(requestData);
             String requestBody = montaRequest.montar(requestData);
             String openAiModel = "gpt-5.2";
-            GeraLandingJobDto openAiJob = new GeraLandingJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), openAiModel, requestBody, prompt, null);
+            RecordJobDto openAiJob = new RecordJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), openAiModel, requestBody, prompt, null);
             var payload = generate(openAiJob);
             recebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), payload);
         } catch (Exception ex) {
@@ -82,7 +82,7 @@ public class GeraLandingCopyOpenAiExecutionService {
     }
 
     /** Executa a geração no endpoint /responses da OpenAI e devolve o payload final da etapa. */
-    private GeraLandingJobCompletionPayload generate(GeraLandingJobDto job) { /* shortened by parity */
+    private GeraLandingJobCompletionPayload generate(RecordJobDto job) { /* shortened by parity */
         try {
             OpenAiResponse response = createFlexResponse(job);
             String rawOutput = objectMapper.writeValueAsString(response);
@@ -101,9 +101,9 @@ public class GeraLandingCopyOpenAiExecutionService {
         }
     }
 
-    private OpenAiResponse createFlexResponse(GeraLandingJobDto job) throws Exception { Map<String, Object> requestBody = prepareRequestBodyForFlex(job); requestBody.put("service_tier", "flex"); OpenAiResponse response = webClient.post().uri("/responses").contentType(MediaType.APPLICATION_JSON).bodyValue(requestBody).retrieve().bodyToMono(OpenAiResponse.class).block(flexTimeout); if (response == null) throw new IllegalStateException("OpenAI flex retornou resposta vazia para gera-landing"); if (StringUtils.hasText(response.errorMessage())) throw new IllegalStateException("OpenAI flex retornou erro para gera-landing: " + response.errorMessage()); return response; }
-    private Map<String, Object> prepareRequestBodyForFlex(GeraLandingJobDto job) throws Exception { String requestBodyJson = job.requestBodyJson(); if (StringUtils.hasText(requestBodyJson)) { String trimmed = requestBodyJson.trim(); if (trimmed.startsWith("{") || trimmed.startsWith("[")) return objectMapper.readValue(trimmed, new TypeReference<>() {}); return buildRequestBodyFromPrompt(job, trimmed);} return buildRequestBodyFromPrompt(job, job.prompt()); }
-    private String sanitizeModelResponse(String modelResponse, GeraLandingJobDto job) { if (!StringUtils.hasText(modelResponse)) return modelResponse; String trimmed = modelResponse.trim(); if (!trimmed.startsWith("```json")) return modelResponse; String withoutPrefix = trimmed.substring("```json".length()).trim(); if (withoutPrefix.endsWith("```")) withoutPrefix = withoutPrefix.substring(0, withoutPrefix.length() - 3).trim(); log.warn("Model response veio com code fence JSON; removendo cercas markdown [jobId={}, stage={}]", job.id(), job.section()); return withoutPrefix; }
-    private Map<String, Object> buildRequestBodyFromPrompt(GeraLandingJobDto job, String promptText) { if (!StringUtils.hasText(promptText)) throw new IllegalStateException("Payload da OpenAI ausente: requestBodyJson e prompt vazios para gera-landing"); Map<String, Object> requestBody = new LinkedHashMap<>(); requestBody.put("model", StringUtils.hasText(job.model()) ? job.model() : "gpt-5.2"); requestBody.put("input", List.of(Map.of("role", "system", "content", "[gera-landing-pipeline] Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet."), Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", promptText))))); return requestBody; }
+    private OpenAiResponse createFlexResponse(RecordJobDto job) throws Exception { Map<String, Object> requestBody = prepareRequestBodyForFlex(job); requestBody.put("service_tier", "flex"); OpenAiResponse response = webClient.post().uri("/responses").contentType(MediaType.APPLICATION_JSON).bodyValue(requestBody).retrieve().bodyToMono(OpenAiResponse.class).block(flexTimeout); if (response == null) throw new IllegalStateException("OpenAI flex retornou resposta vazia para gera-landing"); if (StringUtils.hasText(response.errorMessage())) throw new IllegalStateException("OpenAI flex retornou erro para gera-landing: " + response.errorMessage()); return response; }
+    private Map<String, Object> prepareRequestBodyForFlex(RecordJobDto job) throws Exception { String requestBodyJson = job.requestBodyJson(); if (StringUtils.hasText(requestBodyJson)) { String trimmed = requestBodyJson.trim(); if (trimmed.startsWith("{") || trimmed.startsWith("[")) return objectMapper.readValue(trimmed, new TypeReference<>() {}); return buildRequestBodyFromPrompt(job, trimmed);} return buildRequestBodyFromPrompt(job, job.prompt()); }
+    private String sanitizeModelResponse(String modelResponse, RecordJobDto job) { if (!StringUtils.hasText(modelResponse)) return modelResponse; String trimmed = modelResponse.trim(); if (!trimmed.startsWith("```json")) return modelResponse; String withoutPrefix = trimmed.substring("```json".length()).trim(); if (withoutPrefix.endsWith("```")) withoutPrefix = withoutPrefix.substring(0, withoutPrefix.length() - 3).trim(); log.warn("Model response veio com code fence JSON; removendo cercas markdown [jobId={}, stage={}]", job.id(), job.section()); return withoutPrefix; }
+    private Map<String, Object> buildRequestBodyFromPrompt(RecordJobDto job, String promptText) { if (!StringUtils.hasText(promptText)) throw new IllegalStateException("Payload da OpenAI ausente: requestBodyJson e prompt vazios para gera-landing"); Map<String, Object> requestBody = new LinkedHashMap<>(); requestBody.put("model", StringUtils.hasText(job.model()) ? job.model() : "gpt-5.2"); requestBody.put("input", List.of(Map.of("role", "system", "content", "[gera-landing-pipeline] Você é um Especialista em Marketing focado em vendas de produtos digitais pela Internet."), Map.of("role", "user", "content", List.of(Map.of("type", "input_text", "text", promptText))))); return requestBody; }
     private String preview(String value) { if (!StringUtils.hasText(value)) return "<empty>"; String normalized = value.replace("\n", "\\n").replace("\r", "\\r"); if (normalized.length() <= LOG_PREVIEW_LIMIT) return normalized; return normalized.substring(0, LOG_PREVIEW_LIMIT) + "...(truncated)"; }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/dto/RecordJobDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/dto/RecordJobDto.java
@@ -1,10 +1,10 @@
-package com.marketinghub.worker.geralanding.wireframe.dto;
+package com.marketinghub.worker.geralanding.deliverables.dto;
 
 import java.time.Instant;
 import java.util.UUID;
 
-/** Responsabilidade: representar os dados do job OpenAI da etapa wireframe. */
-public record GeraLandingJobDto(
+/** Responsabilidade: representar os dados do job OpenAI da etapa deliverables. */
+public record RecordJobDto(
         UUID id,
         Long experimentId,
         String section,

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/request/GeraLandingDeliverablesOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/request/GeraLandingDeliverablesOpenAiExecutionService.java
@@ -7,7 +7,7 @@ import com.marketinghub.worker.geralanding.deliverables.GeraLandingExperimentDel
 import com.marketinghub.worker.geralanding.deliverables.GeraLandingJobCompletionDeliverablesPayload;
 import com.marketinghub.worker.geralanding.deliverables.MontaRequest;
 import com.marketinghub.worker.geralanding.deliverables.RecebeResponse;
-import com.marketinghub.worker.geralanding.deliverables.dto.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.deliverables.dto.RecordJobDto;
 import com.marketinghub.worker.geralanding.deliverables.dto.GeraLandingStageExecutionDetailDto;
 import com.marketinghub.worker.openai.OpenAiCostEstimator;
 import com.marketinghub.worker.openai.OpenAiResponse;
@@ -88,7 +88,7 @@ public class GeraLandingDeliverablesOpenAiExecutionService {
                     new GeraLandingExperimentDeliverablesRequest(execution.experimentId(), dadosPrompt);
             String prompt = montaRequest.montarPrompt(requestData);
             String requestBody = montaRequest.montar(requestData);
-            GeraLandingJobDto openAiJob = new GeraLandingJobDto(
+            RecordJobDto openAiJob = new RecordJobDto(
                     UUID.fromString(execution.idJob()),
                     execution.experimentId(),
                     execution.stageCode(),
@@ -105,7 +105,7 @@ public class GeraLandingDeliverablesOpenAiExecutionService {
     }
 
     /** Executa a geração no endpoint /responses da OpenAI e devolve o payload final da etapa deliverables. */
-    private GeraLandingJobCompletionDeliverablesPayload generate(GeraLandingJobDto job) throws Exception {
+    private GeraLandingJobCompletionDeliverablesPayload generate(RecordJobDto job) throws Exception {
         log.info("Iniciando geração gera-landing deliverables via OpenAI flex [jobId={}, stage={}, model={}, requestBodyLength={}]", job.id(), job.section(), job.model(), safeLength(job.requestBodyJson()));
         log.info("Payload requestBodyJson do gera-landing deliverables [jobId={}, stage={}, requestBodyPreview={}]", job.id(), job.section(), preview(job.requestBodyJson()));
         OpenAiResponse response = createFlexResponse(job);
@@ -131,7 +131,7 @@ public class GeraLandingDeliverablesOpenAiExecutionService {
     }
 
     /** Prepara e executa a chamada flex da OpenAI para a etapa deliverables. */
-    private OpenAiResponse createFlexResponse(GeraLandingJobDto job) throws Exception {
+    private OpenAiResponse createFlexResponse(RecordJobDto job) throws Exception {
         try {
             log.info("Iniciando preparação do request para flex deliverables [jobId={}, stage={}, requestBodyJsonPreview={}]", job.id(), job.section(), preview(job.requestBodyJson()));
             Map<String, Object> requestBody = prepareRequestBodyForFlex(job);
@@ -164,7 +164,7 @@ public class GeraLandingDeliverablesOpenAiExecutionService {
     }
 
     /** Converte o requestBodyJson em mapa ou aplica fallback usando prompt textual. */
-    private Map<String, Object> prepareRequestBodyForFlex(GeraLandingJobDto job) throws Exception {
+    private Map<String, Object> prepareRequestBodyForFlex(RecordJobDto job) throws Exception {
         String requestBodyJson = job.requestBodyJson();
         if (StringUtils.hasText(requestBodyJson)) {
             String trimmed = requestBodyJson.trim();
@@ -178,7 +178,7 @@ public class GeraLandingDeliverablesOpenAiExecutionService {
     }
 
     /** Remove cercas markdown de JSON (```json ... ```) para manter conteúdo parseável no pipeline. */
-    private String sanitizeModelResponse(String modelResponse, GeraLandingJobDto job) {
+    private String sanitizeModelResponse(String modelResponse, RecordJobDto job) {
         if (!StringUtils.hasText(modelResponse)) {
             return modelResponse;
         }
@@ -196,7 +196,7 @@ public class GeraLandingDeliverablesOpenAiExecutionService {
     }
 
     /** Cria um corpo mínimo de requisição quando apenas o prompt textual está disponível. */
-    private Map<String, Object> buildRequestBodyFromPrompt(GeraLandingJobDto job, String promptText) {
+    private Map<String, Object> buildRequestBodyFromPrompt(RecordJobDto job, String promptText) {
         if (!StringUtils.hasText(promptText)) {
             throw new IllegalStateException("Payload da OpenAI ausente: requestBodyJson e prompt vazios para gera-landing deliverables");
         }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/dto/RecordJobDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/dto/RecordJobDto.java
@@ -1,10 +1,10 @@
-package com.marketinghub.worker.geralanding.deliverables.dto;
+package com.marketinghub.worker.geralanding.imageplanning.dto;
 
 import java.time.Instant;
 import java.util.UUID;
 
-/** Responsabilidade: representar os dados do job OpenAI da etapa deliverables. */
-public record GeraLandingJobDto(
+/** Responsabilidade: representar os dados do job OpenAI da etapa imageplanning. */
+public record RecordJobDto(
         UUID id,
         Long experimentId,
         String section,

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/request/GeraLandingImagePlanningOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/request/GeraLandingImagePlanningOpenAiExecutionService.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.imageplanning.request;
 
-import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.imageplanning.dto.RecordJobDto;
 import com.marketinghub.worker.geralanding.GeraLandingOpenAiFlexClient;
 import com.marketinghub.worker.geralanding.imageplanning.backend.GeraLandingImagePlanningBackendClient;
 import com.marketinghub.worker.geralanding.imageplanning.GeraLandingExperimentImagePlanningRequest;
@@ -36,7 +36,7 @@ public class GeraLandingImagePlanningOpenAiExecutionService {
             Map<String, Object> dadosPrompt = backendClient.loadPromptData(execution.experimentId());
             GeraLandingExperimentImagePlanningRequest requestData = new GeraLandingExperimentImagePlanningRequest(execution.experimentId(), dadosPrompt);
             String prompt = montaRequest.montarPrompt(requestData); String requestBody = montaRequest.montar(requestData);
-            GeraLandingJobDto openAiJob = new GeraLandingJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), "gpt-5.2", requestBody, prompt, null);
+            RecordJobDto openAiJob = new RecordJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), "gpt-5.2", requestBody, prompt, null);
             var basePayload = openAiClient.generate(openAiJob);
             GeraLandingJobCompletionImagePlanningPayload pl = new GeraLandingJobCompletionImagePlanningPayload(basePayload.responseContent(), basePayload.rawResponse(), basePayload.requestBodyJson(), basePayload.openAiJobId(), basePayload.inputTokens(), basePayload.outputTokens(), basePayload.costUsd());
             recebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), pl);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/dto/RecordJobDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/dto/RecordJobDto.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 /** Responsabilidade: representar os dados do job OpenAI da etapa presetdesign. */
-public record GeraLandingJobDto(
+public record RecordJobDto(
         UUID id,
         Long experimentId,
         String section,

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/request/GeraLandingPresetDesignOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/request/GeraLandingPresetDesignOpenAiExecutionService.java
@@ -1,6 +1,6 @@
 package com.marketinghub.worker.geralanding.presetdesign.request;
 
-import com.marketinghub.worker.geralanding.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.presetdesign.dto.RecordJobDto;
 import com.marketinghub.worker.geralanding.GeraLandingOpenAiFlexClient;
 import com.marketinghub.worker.geralanding.presetdesign.backend.GeraLandingPresetDesignBackendClient;
 import com.marketinghub.worker.geralanding.presetdesign.GeraLandingExperimentPresetDesignRequest;
@@ -36,7 +36,7 @@ public class GeraLandingPresetDesignOpenAiExecutionService {
             Map<String, Object> dadosPrompt = backendClient.loadPromptData(execution.experimentId());
             GeraLandingExperimentPresetDesignRequest requestData = new GeraLandingExperimentPresetDesignRequest(execution.experimentId(), dadosPrompt);
             String prompt = montaRequest.montarPrompt(requestData); String requestBody = montaRequest.montar(requestData);
-            GeraLandingJobDto openAiJob = new GeraLandingJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), "gpt-5.2", requestBody, prompt, null);
+            RecordJobDto openAiJob = new RecordJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), "gpt-5.2", requestBody, prompt, null);
             var basePayload = openAiClient.generate(openAiJob);
             RecordPresetDesignResponse pl = new RecordPresetDesignResponse(basePayload.responseContent(), basePayload.rawResponse(), basePayload.requestBodyJson(), basePayload.openAiJobId(), basePayload.inputTokens(), basePayload.outputTokens(), basePayload.costUsd());
             recebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), pl);

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/dto/RecordJobDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/dto/RecordJobDto.java
@@ -1,10 +1,10 @@
-package com.marketinghub.worker.geralanding.imageplanning.dto;
+package com.marketinghub.worker.geralanding.wireframe.dto;
 
 import java.time.Instant;
 import java.util.UUID;
 
-/** Responsabilidade: representar os dados do job OpenAI da etapa imageplanning. */
-public record GeraLandingJobDto(
+/** Responsabilidade: representar os dados do job OpenAI da etapa wireframe. */
+public record RecordJobDto(
         UUID id,
         Long experimentId,
         String section,

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
@@ -2,7 +2,7 @@ package com.marketinghub.worker.geralanding.wireframe.request;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingJobDto;
+import com.marketinghub.worker.geralanding.wireframe.dto.RecordJobDto;
 import com.marketinghub.worker.geralanding.wireframe.backend.GeraLandingWireframeBackendClient;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto;
 import com.marketinghub.worker.geralanding.wireframe.response.RecordWireframeResponse;
@@ -85,7 +85,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
             RecordWireframeRequest requestData = new RecordWireframeRequest(execution.experimentId(), dadosPrompt);
             String prompt = montaRequest.montarPrompt(requestData);
             String requestBody = montaRequest.montar(requestData);
-            GeraLandingJobDto openAiJob = new GeraLandingJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), "gpt-5.2", requestBody, prompt, null);
+            RecordJobDto openAiJob = new RecordJobDto(UUID.fromString(execution.idJob()), execution.experimentId(), execution.stageCode(), "gpt-5.2", requestBody, prompt, null);
             RecordWireframeResponse payload = generate(openAiJob);
             recebeResponse.processar(execution.experimentId(), execution.stageCode(), execution.idJob(), payload);
         } catch (Exception ex) {
@@ -95,7 +95,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
     }
 
     /** Executa a geração no endpoint /responses da OpenAI e devolve o payload final da etapa wireframe. */
-    private RecordWireframeResponse generate(GeraLandingJobDto job) throws Exception {
+    private RecordWireframeResponse generate(RecordJobDto job) throws Exception {
         log.info("Iniciando geração gera-landing wireframe via OpenAI flex [jobId={}, stage={}, model={}, requestBodyLength={}]", job.id(), job.section(), job.model(), safeLength(job.requestBodyJson()));
         log.info("Payload requestBodyJson do gera-landing wireframe [jobId={}, stage={}, requestBodyPreview={}]", job.id(), job.section(), preview(job.requestBodyJson()));
         OpenAiResponse response = createFlexResponse(job);
@@ -114,7 +114,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
     }
 
     /** Prepara e executa a chamada flex da OpenAI para a etapa wireframe. */
-    private OpenAiResponse createFlexResponse(GeraLandingJobDto job) throws Exception {
+    private OpenAiResponse createFlexResponse(RecordJobDto job) throws Exception {
         try {
             log.info("Iniciando preparação do request para flex wireframe [jobId={}, stage={}, requestBodyJsonPreview={}]", job.id(), job.section(), preview(job.requestBodyJson()));
             Map<String, Object> requestBody = prepareRequestBodyForFlex(job);
@@ -147,7 +147,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
     }
 
     /** Converte o requestBodyJson em mapa ou aplica fallback usando prompt textual. */
-    private Map<String, Object> prepareRequestBodyForFlex(GeraLandingJobDto job) throws Exception {
+    private Map<String, Object> prepareRequestBodyForFlex(RecordJobDto job) throws Exception {
         String requestBodyJson = job.requestBodyJson();
         if (StringUtils.hasText(requestBodyJson)) {
             String trimmed = requestBodyJson.trim();
@@ -161,7 +161,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
     }
 
     /** Remove cercas markdown de JSON (```json ... ```) para manter conteúdo parseável no pipeline. */
-    private String sanitizeModelResponse(String modelResponse, GeraLandingJobDto job) {
+    private String sanitizeModelResponse(String modelResponse, RecordJobDto job) {
         if (!StringUtils.hasText(modelResponse)) {
             return modelResponse;
         }
@@ -179,7 +179,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
     }
 
     /** Cria um corpo mínimo de requisição quando apenas o prompt textual está disponível. */
-    private Map<String, Object> buildRequestBodyFromPrompt(GeraLandingJobDto job, String promptText) {
+    private Map<String, Object> buildRequestBodyFromPrompt(RecordJobDto job, String promptText) {
         if (!StringUtils.hasText(promptText)) {
             throw new IllegalStateException("Payload da OpenAI ausente: requestBodyJson e prompt vazios para gera-landing wireframe");
         }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2118,3 +2118,14 @@
   - reescrito `presetdesign.backend.GeraLandingPresetDesignBackendClient` no mesmo padrão de isolamento por etapa.
 - validação executada:
   - `mvn -q -Dtest=ArquiteturaTest test` em `ai-worker/` (bloqueado por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).
+
+## 2026-05-28 20:15:00 UTC
+- solicitação: renomear `GeraLandingJobDto` para `RecordJobDto` em todas as etapas do `geralanding` no `ai-worker`.
+- causa-raiz identificada: o nome anterior mantinha o prefixo legado do módulo e não seguia o padrão curto de records adotado nas etapas do GeraLanding.
+- correção aplicada:
+  - records de job OpenAI renomeados para `RecordJobDto` nos pacotes geral, `copy`, `deliverables`, `imageplanning`, `presetdesign` e `wireframe`;
+  - imports, assinaturas e instanciações atualizados nos serviços de execução OpenAI do GeraLanding;
+  - cliente flex geral atualizado para aceitar `RecordJobDto` do fluxo geral e das etapas `deliverables`, `imageplanning` e `presetdesign`.
+- validação executada:
+  - inspeção estática com `rg` para garantir ausência do nome antigo no código Java do `ai-worker`;
+  - `mvn -q -DskipTests compile` em `ai-worker/` (bloqueado por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation
- Padronizar nomes de records do fluxo GeraLanding usando o estilo curto adotado nas etapas (remover prefixo legado `GeraLanding`).
- Reduzir ambiguidade e unificar o DTO de job usado pelas etapas que consomem o cliente OpenAI flex.

### Description
- Renomeia o record `GeraLandingJobDto` para `RecordJobDto` no pacote raiz `com.marketinghub.worker.geralanding` e em cada subpacote das etapas `copy`, `deliverables`, `imageplanning`, `presetdesign` e `wireframe` (arquivos `*RecordJobDto.java`).
- Atualiza imports, construtores/instanciações e assinaturas de métodos nas classes de execução OpenAI das etapas para usar `RecordJobDto` em lugar do nome antigo.
- Ajusta o `GeraLandingOpenAiFlexClient` adicionando overloads para aceitar `RecordJobDto` das etapas que o utilizam e altera a assinatura que antes referenciava `GeraLandingJobDto`.
- Registra a alteração em `docs/registros/experimentos.md` explicando a motivação e as validações realizadas.

### Testing
- Verificação estática com `rg -n "GeraLandingJobDto" ai-worker` retornou sem ocorrências remanescentes, indicando referência substituída com sucesso.
- Checagem rápida de problemas de diff com `git diff --check` foi executada sem avisos automáticos de espaço/whitespace.
- Tentativa de compilação com `mvn -q -DskipTests compile` em `ai-worker/` foi executada mas bloqueada por dependência privada externa (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`) retornando HTTP 401 no repositório (compilação não concluída por esse motivo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186ce5c288832197c80ab586a05180)