### PR TITLE
docs: adicionar Swagger OpenAPI canônico do GeraLanding por etapa

### DIFF
--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -63,7 +63,12 @@ Regras arquiteturais refletidas (ArchUnit):
 - Cada subpacote funcional (`copy`, `presetdesign`, `stage`, `wireframe`, `deliverables`, `imageplanning`) só pode acessar o próprio pacote e `geralanding.comum` dentro de `com.marketinghub`.
 - `geralanding.comum` só pode acessar o próprio pacote.
 
-## 3) Regras de integração
+## 3) Contrato HTTP canônico
+
+- O Swagger/OpenAPI canônico dos endpoints HTTP do backend GeraLanding por etapa fica em `docs/canonical/geralanding-backend-swagger.v1.yaml`.
+- Qualquer criação, remoção ou mudança de endpoint em `com.marketinghub.geralanding.*.web` deve manter esse Swagger sincronizado no mesmo PR.
+
+## 4) Regras de integração
 
 - O **Worker AI não acessa banco**; toda leitura/gravação de estado da execução passa pelo backend GeraLanding.
 - O polling e os callbacks internos do GeraLanding no Worker AI devem consumir endpoints específicos por etapa: `/api/internal/geralanding/wireframe/stage-executions/*`, `/api/internal/geralanding/copy/stage-executions/*`, `/api/internal/geralanding/image-prompts/stage-executions/*`, `/api/internal/geralanding/design-preset/stage-executions/*` e `/api/internal/geralanding/deliverables/stage-executions/*`.

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -1,0 +1,458 @@
+openapi: 3.0.3
+info:
+  title: Marketing Hub Backend - GeraLanding por etapa
+  version: v1
+  description: |
+    Contrato canônico dos endpoints HTTP expostos pelo backend `ads-service` no pacote
+    `com.marketinghub.geralanding`, organizados por etapa operacional do GeraLanding.
+
+    Fonte de verdade revisada em código:
+    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java`
+    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java`
+    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java`
+    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java`
+    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java`
+
+    Todos os endpoints listados abaixo ficam sob o escopo de um experimento e usam o prefixo
+    `/api/experiments/{experimentId}/geralanding`.
+servers:
+  - url: http://191.252.181.168
+    description: Backend principal para acessos executados pelo Codex
+  - url: http://191.252.181.168:8000
+    description: Backend principal documentado para operação externa
+tags:
+  - name: landing-page-wireframe
+    description: Etapa de geração do wireframe da landing.
+  - name: landing-page-copy
+    description: Etapa de geração da copy da landing.
+  - name: landing-page-image-planning
+    description: Etapa de planejamento de imagens/prompts visuais da landing.
+  - name: landing-page-design-preset
+    description: Etapa de definição do preset visual e consolidação visual da landing.
+  - name: landing-page-deliverables
+    description: Etapa de geração dos entregáveis finais vinculados à landing/oferta.
+paths:
+  /api/experiments/{experimentId}/geralanding/wireframe/start:
+    post:
+      tags:
+        - landing-page-wireframe
+      summary: Inicia a etapa landing-page-wireframe.
+      description: Registra uma nova execução inicial da etapa de wireframe para o experimento informado.
+      operationId: startGeraLandingWireframe
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '202':
+          description: Execução da etapa registrada para processamento assíncrono.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageStartResponse'
+              example:
+                idJob: 7d3d1f3a-9f6f-41b7-9b4b-3f5c3f4d9a01
+                status: INICIADO
+  /api/experiments/{experimentId}/geralanding/wireframe/stage-executions:
+    get:
+      tags:
+        - landing-page-wireframe
+      summary: Lista execuções da etapa landing-page-wireframe.
+      description: Retorna os resumos das execuções de wireframe do experimento, com opção de incluir execuções concluídas.
+      operationId: listGeraLandingWireframeExecutions
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IncludeCompleted'
+      responses:
+        '200':
+          description: Lista de execuções da etapa.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StageExecutionSummary'
+  /api/experiments/{experimentId}/geralanding/wireframe/stage-executions/{idJob}:
+    get:
+      tags:
+        - landing-page-wireframe
+      summary: Detalha uma execução da etapa landing-page-wireframe.
+      description: Retorna todos os dados persistidos para o job de wireframe do experimento.
+      operationId: getGeraLandingWireframeExecution
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IdJob'
+      responses:
+        '200':
+          description: Detalhe da execução da etapa.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionDetail'
+  /api/experiments/{experimentId}/geralanding/copy/start:
+    post:
+      tags:
+        - landing-page-copy
+      summary: Inicia a etapa landing-page-copy.
+      description: Registra uma nova execução inicial da etapa de copy para o experimento informado.
+      operationId: startGeraLandingCopy
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '202':
+          description: Execução da etapa registrada para processamento assíncrono.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageStartResponse'
+  /api/experiments/{experimentId}/geralanding/copy/stage-executions:
+    get:
+      tags:
+        - landing-page-copy
+      summary: Lista execuções da etapa landing-page-copy.
+      description: Retorna os resumos das execuções de copy do experimento, com opção de incluir execuções concluídas.
+      operationId: listGeraLandingCopyExecutions
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IncludeCompleted'
+      responses:
+        '200':
+          description: Lista de execuções da etapa.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StageExecutionSummary'
+  /api/experiments/{experimentId}/geralanding/copy/stage-executions/{idJob}:
+    get:
+      tags:
+        - landing-page-copy
+      summary: Detalha uma execução da etapa landing-page-copy.
+      description: Retorna todos os dados persistidos para o job de copy do experimento.
+      operationId: getGeraLandingCopyExecution
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IdJob'
+      responses:
+        '200':
+          description: Detalhe da execução da etapa.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionDetail'
+  /api/experiments/{experimentId}/geralanding/image-prompts/start:
+    post:
+      tags:
+        - landing-page-image-planning
+      summary: Inicia a etapa landing-page-image-planning.
+      description: Registra uma nova execução inicial da etapa de planejamento de imagens para o experimento informado.
+      operationId: startGeraLandingImagePlanning
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '202':
+          description: Execução da etapa registrada para processamento assíncrono.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageStartResponse'
+  /api/experiments/{experimentId}/geralanding/image-prompts/stage-executions:
+    get:
+      tags:
+        - landing-page-image-planning
+      summary: Lista execuções da etapa landing-page-image-planning.
+      description: Retorna os resumos das execuções de planejamento de imagens do experimento, com opção de incluir execuções concluídas.
+      operationId: listGeraLandingImagePlanningExecutions
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IncludeCompleted'
+      responses:
+        '200':
+          description: Lista de execuções da etapa.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StageExecutionSummary'
+  /api/experiments/{experimentId}/geralanding/image-prompts/stage-executions/{idJob}:
+    get:
+      tags:
+        - landing-page-image-planning
+      summary: Detalha uma execução da etapa landing-page-image-planning.
+      description: Retorna todos os dados persistidos para o job de planejamento de imagens do experimento.
+      operationId: getGeraLandingImagePlanningExecution
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IdJob'
+      responses:
+        '200':
+          description: Detalhe da execução da etapa.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionDetail'
+  /api/experiments/{experimentId}/geralanding/design-preset/start:
+    post:
+      tags:
+        - landing-page-design-preset
+      summary: Inicia a etapa landing-page-design-preset.
+      description: Registra uma nova execução inicial da etapa de preset visual para o experimento informado.
+      operationId: startGeraLandingDesignPreset
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '202':
+          description: Execução da etapa registrada para processamento assíncrono.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageStartResponse'
+  /api/experiments/{experimentId}/geralanding/design-preset/stage-executions:
+    get:
+      tags:
+        - landing-page-design-preset
+      summary: Lista execuções da etapa landing-page-design-preset.
+      description: Retorna os resumos das execuções de preset visual do experimento, com opção de incluir execuções concluídas.
+      operationId: listGeraLandingDesignPresetExecutions
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IncludeCompleted'
+      responses:
+        '200':
+          description: Lista de execuções da etapa.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StageExecutionSummary'
+  /api/experiments/{experimentId}/geralanding/design-preset/stage-executions/{idJob}:
+    get:
+      tags:
+        - landing-page-design-preset
+      summary: Detalha uma execução da etapa landing-page-design-preset.
+      description: Retorna todos os dados persistidos para o job de preset visual do experimento.
+      operationId: getGeraLandingDesignPresetExecution
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IdJob'
+      responses:
+        '200':
+          description: Detalhe da execução da etapa.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionDetail'
+  /api/experiments/{experimentId}/geralanding/deliverables/start:
+    post:
+      tags:
+        - landing-page-deliverables
+      summary: Inicia a etapa landing-page-deliverables.
+      description: Registra uma nova execução inicial da etapa de entregáveis para o experimento informado.
+      operationId: startGeraLandingDeliverables
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '202':
+          description: Execução da etapa registrada para processamento assíncrono.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageStartResponse'
+  /api/experiments/{experimentId}/geralanding/deliverables/stage-executions:
+    get:
+      tags:
+        - landing-page-deliverables
+      summary: Lista execuções da etapa landing-page-deliverables.
+      description: Retorna os resumos das execuções de entregáveis do experimento, com opção de incluir execuções concluídas.
+      operationId: listGeraLandingDeliverablesExecutions
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IncludeCompleted'
+      responses:
+        '200':
+          description: Lista de execuções da etapa.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StageExecutionSummary'
+  /api/experiments/{experimentId}/geralanding/deliverables/stage-executions/{idJob}:
+    get:
+      tags:
+        - landing-page-deliverables
+      summary: Detalha uma execução da etapa landing-page-deliverables.
+      description: Retorna todos os dados persistidos para o job de entregáveis do experimento.
+      operationId: getGeraLandingDeliverablesExecution
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IdJob'
+      responses:
+        '200':
+          description: Detalhe da execução da etapa.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionDetail'
+components:
+  parameters:
+    ExperimentId:
+      name: experimentId
+      in: path
+      required: true
+      description: Identificador numérico do experimento dono da execução GeraLanding.
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+    IdJob:
+      name: idJob
+      in: path
+      required: true
+      description: Identificador textual do job da execução da etapa.
+      schema:
+        type: string
+        minLength: 1
+    IncludeCompleted:
+      name: includeCompleted
+      in: query
+      required: false
+      description: Quando `true`, inclui execuções com status `CONCLUIDO`; o padrão do backend é `true`.
+      schema:
+        type: boolean
+        default: true
+  schemas:
+    StageStatus:
+      type: string
+      description: Status operacional persistido para a execução da etapa.
+      enum:
+        - INICIADO
+        - AGUARDANDO_RETORNO_OPENAI
+        - EM_PROCESSAMENTO
+        - CONCLUIDO
+        - FALHA
+    StageStartResponse:
+      type: object
+      required:
+        - idJob
+        - status
+      additionalProperties: false
+      properties:
+        idJob:
+          type: string
+          description: Identificador do job criado para a etapa.
+        status:
+          $ref: '#/components/schemas/StageStatus'
+    StageExecutionSummary:
+      type: object
+      required:
+        - idJob
+        - status
+        - executionRequestedAt
+      additionalProperties: false
+      properties:
+        idJob:
+          type: string
+          description: Identificador do job da etapa.
+        status:
+          $ref: '#/components/schemas/StageStatus'
+        executionRequestedAt:
+          type: string
+          format: date-time
+          description: Momento em que a execução foi solicitada.
+        costUsd:
+          type: number
+          format: double
+          nullable: true
+          description: Custo estimado/persistido da execução em dólar, quando disponível.
+    StageExecutionDetail:
+      type: object
+      required:
+        - idJob
+        - experimentId
+        - stageCode
+        - status
+      additionalProperties: false
+      properties:
+        idJob:
+          type: string
+        experimentId:
+          type: integer
+          format: int64
+        stageCode:
+          type: string
+          enum:
+            - landing-page-wireframe
+            - landing-page-copy
+            - landing-page-image-planning
+            - landing-page-design-preset
+            - landing-page-deliverables
+        executionRequestedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+        processingStartedAt:
+          type: string
+          format: date-time
+          nullable: true
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+        promptTemplateId:
+          type: string
+          nullable: true
+        promptContent:
+          type: string
+          nullable: true
+        prompt:
+          type: string
+          nullable: true
+        openAiRequestBody:
+          type: string
+          nullable: true
+          description: Corpo bruto enviado para a OpenAI quando persistido para rastreabilidade.
+        openAiModel:
+          type: string
+          nullable: true
+        schemaJson:
+          type: string
+          nullable: true
+        promptMarkdownContent:
+          type: string
+          nullable: true
+        status:
+          $ref: '#/components/schemas/StageStatus'
+        openAiJobId:
+          type: string
+          nullable: true
+        modelResponse:
+          type: string
+          nullable: true
+        provisionalHtml:
+          type: string
+          nullable: true
+          description: HTML provisório produzido pela etapa quando aplicável.
+        errorMessage:
+          type: string
+          nullable: true
+        errorDetail:
+          type: string
+          nullable: true
+        inputTokens:
+          type: integer
+          format: int32
+          nullable: true
+        outputTokens:
+          type: integer
+          format: int32
+          nullable: true
+        costUsd:
+          type: number
+          format: double
+          nullable: true

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2163,3 +2163,18 @@
 - validação executada:
   - inspeção estática com `rg` para garantir ausência do nome antigo no código Java do `ai-worker`;
   - `mvn -q -DskipTests compile` em `ai-worker/` (bloqueado por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).
+
+## 2026-05-28 14:08:18 UTC-3
+- solicitação para criar um Swagger canônico com os endpoints existentes no backend do GeraLanding organizados por etapa.
+- raciocínio aplicado: verificar diretamente os controllers do pacote `com.marketinghub.geralanding` para documentar apenas contratos realmente expostos pelo backend e evitar inventar endpoints inexistentes.
+- registro do que foi feito: criado o OpenAPI canônico `docs/canonical/geralanding-backend-swagger.v1.yaml` com endpoints de start, listagem e detalhe das etapas wireframe, copy, image planning, design preset e deliverables; também foi adicionada referência ao Swagger no cânone de arquitetura do GeraLanding.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/canonical/geralanding-arquitetura-canon.v1.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java


### PR DESCRIPTION
### Motivation
- Padronizar e publicar o contrato HTTP dos endpoints do domínio `com.marketinghub.geralanding` para evitar divergência entre código e documentação. 
- Tornar explícitos os endpoints consumidos pelo Worker AI (por etapa) e evitar documentar endpoints inexistentes. 
- Garantir que futuras alterações em controllers do GeraLanding atualizem o artefato canônico de API. 

### Description
- Adicionado o arquivo `docs/canonical/geralanding-backend-swagger.v1.yaml` contendo um OpenAPI 3.0.3 com os endpoints por etapa (`wireframe`, `copy`, `image-prompts`, `design-preset`, `deliverables`) incluindo operações de `start`, listagem de `stage-executions` e detalhe por `idJob`, além de componentes reutilizáveis para parâmetros e schemas de resposta/status. 
- Atualizada a arquitetura canônica `docs/canonical/geralanding-arquitetura-canon.v1.md` para referenciar o Swagger como o contrato HTTP canônico e exigir sincronização quando endpoints forem alterados. 
- Registrado o trabalho no log operacional `docs/registros/experimentos.md` com referência aos controllers usados como fonte de verdade. 
- Arquivos modificados/criados: `docs/canonical/geralanding-backend-swagger.v1.yaml`, `docs/canonical/geralanding-arquitetura-canon.v1.md`, `docs/registros/experimentos.md`. 

### Testing
- Executada validação de sintaxe/estrutura do YAML com Ruby carregando o arquivo: `ruby -e "require 'yaml'; doc=YAML.load_file('docs/canonical/geralanding-backend-swagger.v1.yaml'); raise 'no openapi' unless doc['openapi']=='3.0.3'; raise 'paths missing' unless doc['paths'].size == 15; puts \"openapi ok: #{doc['paths'].size} paths\""` which concluiu com sucesso. 
- Verificada ausência de problemas de diff/whitespace com `git diff --check`, sem erros reportados. 
- Nenhum teste unitário de aplicação foi modificado; as verificações foram focadas na validade do artefato OpenAPI e na atualização dos documentos canônicos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1875f30dc4832190bb4c52797f67a7)