### PR TITLE
docs: register GeraLanding endpoint verification

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2178,3 +2178,14 @@
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java
+
+## 2026-05-28 20:45:00 UTC
+- solicitação: verificar se todos os acessos dos pacotes do Worker AI `geralanding.<etapa>` usam endpoints declarados no Swagger canônico em `docs/canonical`.
+- causa-raiz identificada: o Swagger canônico atual documenta apenas endpoints públicos por experimento (`start`, listagem e detalhe), enquanto os clients do Worker AI ainda consomem endpoints operacionais internos por etapa (`pending`, `receive-result`, `receive-dispatch` e, no caso de copy, `receive-prompt`) e endpoints auxiliares de experimento/nicho que não aparecem nesse Swagger.
+- resultado da verificação:
+  - acessos compatíveis: consultas de detalhe por etapa em `/api/experiments/{experimentId}/geralanding/<etapa>/stage-executions/{idJob}`;
+  - acessos não declarados no Swagger canônico: `/api/internal/geralanding/<etapa>/stage-executions/pending`, `/receive-result`, `/receive-dispatch`, `/receive-prompt`, `/api/experiments/{experimentId}`, `/api/niches/{nicheId}` e `/api/niches/{nicheId}/hypotheses`.
+- validação executada:
+  - `find docs/canonical -type f` para confirmar que o único Swagger canônico YAML é `docs/canonical/geralanding-backend-swagger.v1.yaml`;
+  - `rg`/script Python sobre `ai-worker/src/main/java/com/marketinghub/worker/geralanding` para enumerar chamadas HTTP montadas com `UrlUtils.joinPath` e `.uri(...)`;
+  - `rg` nos controllers do backend em `backend/ads-service/src/main/java/com/marketinghub/geralanding` para comparar os endpoints expostos pelo pacote `com.marketinghub.geralanding` com o Swagger.


### PR DESCRIPTION
### Motivation
- Verificar se os pacotes do Worker AI `geralanding.<etapa>` consomem apenas endpoints documentados no Swagger canônico em `docs/canonical` e registrar as discrepâncias encontradas.
- Registrar evidências e comandos usados para validação para orientar alinhamento futuro entre backend canônico e clients do Worker AI.

### Description
- Adicionada entrada em `docs/registros/experimentos.md` descrevendo a verificação dos acessos do Worker AI contra o Swagger canônico `docs/canonical/geralanding-backend-swagger.v1.yaml` e a conclusão da análise.
- Documentei os pontos verificados e o resultado: consultas de detalhe por etapa (`/api/experiments/{experimentId}/geralanding/<etapa>/stage-executions/{idJob}`) estão no Swagger, enquanto endpoints operacionais internos por etapa (`/api/internal/geralanding/<etapa>/stage-executions/pending`, `/receive-result`, `/receive-dispatch`, `/receive-prompt`) e endpoints auxiliares (`/api/experiments/{experimentId}`, `/api/niches/{nicheId}`, `/api/niches/{nicheId}/hypotheses`) não constam do YAML canônico.
- Incluí os comandos e a metodologia de varredura estática usada para identificar os call-sites nos clients do `ai-worker` (`UrlUtils.joinPath`, `.uri(...)`) e a comparação com os controllers do backend.

### Testing
- Executado `find docs/canonical -type f \( -name '*swagger*' -o -name '*.yaml' -o -name '*.yml' \) -print` para confirmar o Swagger canônico existente, e o comando concluiu com sucesso.
- Executado o script Python de varredura estática sobre `ai-worker/src/main/java/com/marketinghub/worker/geralanding` (busca por `UrlUtils.joinPath` e `.uri(...)`) e a análise completou com sucesso produzindo os locais de chamada HTTP.
- Executado `rg` para verificar controllers e padrões relevantes em `backend/ads-service/src/main/java/com/marketinghub/geralanding` e em `docs/canonical/geralanding-backend-swagger.v1.yaml`, e o comando retornou os mapeamentos usados na comparação com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1879185dbc83218797bc3b708e0f98)