### PR TITLE
Use public experiment-scoped wireframe endpoints and add unit test

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto;
 import com.marketinghub.worker.geralanding.wireframe.response.RecordWireframeResponse;
 import com.marketinghub.worker.util.UrlUtils;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -11,12 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 /** Responsabilidade: encapsular as integrações HTTP da etapa wireframe com o backend sem dependências cruzadas de outras etapas. */
 @Component
@@ -39,17 +38,71 @@ public class GeraLandingWireframeBackendClient {
         this.objectMapper = objectMapper;
     }
 
-    /** Lista execuções pendentes da etapa wireframe no backend. */
+    /** Lista execuções pendentes da etapa wireframe usando os endpoints de experimento expostos pelo backend. */
     public List<GeraLandingStageExecutionDetailDto> listPendingExecutions(int limit) {
-        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/wireframe/stage-executions/pending");
-        String uri = url + "?limit=" + Math.max(1, limit);
-        List<GeraLandingStageExecutionDetailDto> payload = webClient.get()
+        int effectiveLimit = Math.max(1, limit);
+        List<Map<String, Object>> experiments = listExperiments();
+        List<GeraLandingStageExecutionDetailDto> pending = new ArrayList<>();
+        for (Map<String, Object> experiment : experiments) {
+            Long experimentId = asLong(experiment.get("id"));
+            if (experimentId == null) {
+                continue;
+            }
+            pending.addAll(listPendingExecutionsForExperiment(experimentId));
+        }
+        return pending.stream()
+                .sorted(Comparator.comparing(
+                        GeraLandingStageExecutionDetailDto::executionRequestedAt,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
+                .limit(effectiveLimit)
+                .toList();
+    }
+
+    /** Lista os experimentos para descobrir os ids necessários ao endpoint de wireframe por experimento. */
+    private List<Map<String, Object>> listExperiments() {
+        String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments");
+        List<Map<String, Object>> payload = webClient.get()
                 .uri(uri)
-                .exchangeToFlux(response -> handleListResponse(uri, response.statusCode(), response))
-                .collectList()
-                .doOnError(err -> log.error("Falha ao buscar execuções pendentes wireframe. uri={}", uri, err))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
+                .doOnError(err -> log.error("Falha ao buscar experimentos para pendências wireframe. uri={}", uri, err))
+                .onErrorReturn(List.of())
                 .block();
         return payload != null ? payload : List.of();
+    }
+
+    /** Lista as execuções abertas de wireframe de um experimento usando a URL canônica atual do backend. */
+    private List<GeraLandingStageExecutionDetailDto> listPendingExecutionsForExperiment(Long experimentId) {
+        String uri = UrlUtils.joinPath(
+                backendBaseUrl,
+                apiPrefix,
+                "/experiments/" + experimentId + "/geralanding/wireframe/stage-executions") + "?includeCompleted=false";
+        List<Map<String, Object>> payload = webClient.get()
+                .uri(uri)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
+                .doOnError(err -> log.error("Falha ao buscar execuções pendentes wireframe por experimento. uri={}", uri, err))
+                .onErrorReturn(List.of())
+                .block();
+        if (payload == null || payload.isEmpty()) {
+            return List.of();
+        }
+        return payload.stream()
+                .map(item -> toPendingExecutionDto(experimentId, item))
+                .toList();
+    }
+
+    /** Converte o resumo da listagem pública de wireframe para o DTO consumido pelo scheduler da etapa. */
+    private GeraLandingStageExecutionDetailDto toPendingExecutionDto(Long experimentId, Map<String, Object> item) {
+        return new GeraLandingStageExecutionDetailDto(
+                experimentId,
+                "landing-page-wireframe",
+                asString(item.get("idJob")),
+                asString(item.get("status")),
+                asInstant(item.get("executionRequestedAt")),
+                null,
+                null,
+                asString(item.get("openAiJobId")));
     }
 
     /** Carrega os dados de prompt para a geração wireframe a partir do experimento. */
@@ -175,18 +228,35 @@ public class GeraLandingWireframeBackendClient {
         try {
             return objectMapper.readValue(raw, Map.class);
         } catch (Exception ex) {
+            log.warn("Falha ao converter campo JSON de prompt wireframe; mantendo valor textual bruto (length={})", raw.length(), ex);
             return raw;
         }
     }
 
-    /** Trata resposta de listagem pendente e converte erros HTTP em exceção contextual. */
-    private Flux<GeraLandingStageExecutionDetailDto> handleListResponse(String uri, HttpStatusCode status, ClientResponse response) {
-        if (status.isError()) {
-            return response.bodyToMono(String.class)
-                    .defaultIfEmpty("")
-                    .flatMapMany(body -> Mono.error(new IllegalStateException(
-                            "GET %s failed with status %s: %s".formatted(uri, status, body))));
+    /** Converte valores numéricos vindos de payloads genéricos em Long. */
+    private Long asLong(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
         }
-        return response.bodyToFlux(GeraLandingStageExecutionDetailDto.class);
+        if (value instanceof String text && !text.isBlank()) {
+            return Long.parseLong(text.trim());
+        }
+        return null;
+    }
+
+    /** Converte valores textuais vindos de payloads genéricos em String segura. */
+    private String asString(Object value) {
+        return value != null ? value.toString() : null;
+    }
+
+    /** Converte valores de data/hora vindos de payloads genéricos em Instant. */
+    private Instant asInstant(Object value) {
+        if (value instanceof Instant instant) {
+            return instant;
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            return Instant.parse(text.trim());
+        }
+        return null;
     }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClientTest.java
@@ -1,0 +1,66 @@
+package com.marketinghub.worker.geralanding.wireframe.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+class GeraLandingWireframeBackendClientTest {
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void listPendingExecutionsCallsExperimentScopedWireframeUrl() throws Exception {
+        server.enqueue(jsonResponse("[{\"id\":34,\"name\":\"Experimento 34\"}]"));
+        server.enqueue(jsonResponse("["
+                + "{\"idJob\":\"ef92d7d2-7d84-4b1e-a5a5-ccf3034da4bd\","
+                + "\"status\":\"INICIADO\","
+                + "\"executionRequestedAt\":\"2026-05-28T16:21:35.330Z\","
+                + "\"costUsd\":null}"
+                + "]"));
+
+        GeraLandingWireframeBackendClient client = new GeraLandingWireframeBackendClient(
+                WebClient.builder(),
+                server.url("/").toString(),
+                "/api",
+                new ObjectMapper());
+
+        List<GeraLandingStageExecutionDetailDto> pending = client.listPendingExecutions(20);
+
+        assertThat(server.takeRequest().getPath()).isEqualTo("/api/experiments");
+        assertThat(server.takeRequest().getPath())
+                .isEqualTo("/api/experiments/34/geralanding/wireframe/stage-executions?includeCompleted=false");
+        assertThat(pending).hasSize(1);
+        assertThat(pending.getFirst().experimentId()).isEqualTo(34L);
+        assertThat(pending.getFirst().stageCode()).isEqualTo("landing-page-wireframe");
+        assertThat(pending.getFirst().idJob()).isEqualTo("ef92d7d2-7d84-4b1e-a5a5-ccf3034da4bd");
+        assertThat(pending.getFirst().status()).isEqualTo("INICIADO");
+    }
+
+    /** Cria resposta JSON para simular os endpoints reais do backend. */
+    private MockResponse jsonResponse(String body) {
+        return new MockResponse()
+                .setResponseCode(200)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(body);
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2189,3 +2189,13 @@
   - `find docs/canonical -type f` para confirmar que o único Swagger canônico YAML é `docs/canonical/geralanding-backend-swagger.v1.yaml`;
   - `rg`/script Python sobre `ai-worker/src/main/java/com/marketinghub/worker/geralanding` para enumerar chamadas HTTP montadas com `UrlUtils.joinPath` e `.uri(...)`;
   - `rg` nos controllers do backend em `backend/ads-service/src/main/java/com/marketinghub/geralanding` para comparar os endpoints expostos pelo pacote `com.marketinghub.geralanding` com o Swagger.
+
+## 2026-05-28 19:10:00 UTC
+- solicitação: ajustar o Worker AI para buscar pendências de `landing-page-wireframe` usando a URL realmente exposta pelo backend atual.
+- causa-raiz identificada: `GeraLandingWireframeBackendClient.listPendingExecutions(...)` chamava `/api/internal/geralanding/wireframe/stage-executions/pending`, endpoint inexistente no backend; o controller atual expõe a listagem por experimento em `/api/experiments/{experimentId}/geralanding/wireframe/stage-executions?includeCompleted=false`.
+- correção aplicada:
+  - o client de wireframe passou a listar experimentos via `/api/experiments` e, para cada experimento, consultar a URL correta de execuções abertas de wireframe por experimento;
+  - os resumos retornados pelo backend são convertidos para `GeraLandingStageExecutionDetailDto` com `experimentId` e `stageCode` preenchidos para manter o fluxo do scheduler;
+  - adicionado teste unitário garantindo que o client chama `/api/experiments/{experimentId}/geralanding/wireframe/stage-executions?includeCompleted=false`.
+- validação executada:
+  - `mvn -q -Dtest=GeraLandingWireframeBackendClientTest test` em `ai-worker/` (bloqueado por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).


### PR DESCRIPTION
### Motivation
- The previous implementation called a non-existent internal `/api/internal/geralanding/.../pending` endpoint, so the worker could not discover pending wireframe executions.
- Align the Worker AI client with the canonical backend contracts which expose public experiment-scoped list endpoints.
- Ensure the scheduler receives consistent `GeraLandingStageExecutionDetailDto` entries populated with `experimentId` and `stageCode` so downstream logic remains intact.

### Description
- Reworked `GeraLandingWireframeBackendClient.listPendingExecutions` to fetch `/api/experiments` and then call `/api/experiments/{experimentId}/geralanding/wireframe/stage-executions?includeCompleted=false` per experiment and aggregate/sort results.
- Added helpers `listExperiments`, `listPendingExecutionsForExperiment`, `toPendingExecutionDto`, and parsing utilities `asLong`, `asString`, and `asInstant` to convert generic payloads into typed DTOs.
- Replaced reactive `Flux`-style handling with `retrieve().bodyToMono(...)` calls and added a warning log in `parseJsonField` on JSON parse failure to keep raw text.
- Added a unit test `GeraLandingWireframeBackendClientTest` using `MockWebServer` that asserts the client calls `/api/experiments` and the per-experiment wireframe URL and validates DTO fields, and updated `docs/registros/experimentos.md` with the change rationale.

### Testing
- Added `GeraLandingWireframeBackendClientTest` which exercises `listPendingExecutions` via `MockWebServer` and asserts request paths and DTO contents.
- Attempted to run `mvn -q -Dtest=GeraLandingWireframeBackendClientTest test`, but execution was blocked by a private build dependency (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`) returning HTTP 401, so the full test run did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a188ccc7f888321abd058ac17f5172e)