### PR TITLE
feat: add wireframe pending backend endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
+/** Repositório responsável por consultar e persistir execuções das etapas do GeraLanding. */
 public interface GeraLandingStageExecutionRepository extends JpaRepository<GeraLandingStageExecution, byte[]> {
     Optional<GeraLandingStageExecution> findTopByIdJobOrderByExecutionRequestedAtDesc(byte[] idJob);
 
@@ -17,6 +18,10 @@ public interface GeraLandingStageExecutionRepository extends JpaRepository<GeraL
     List<GeraLandingStageExecution> findTop20ByStatusOrderByExecutionRequestedAtAsc(String status);
 
     List<GeraLandingStageExecution> findTop20ByStatusInOrderByExecutionRequestedAtAsc(List<String> statuses);
+
+    /** Busca as execuções mais antigas de uma etapa com o status informado. */
+    List<GeraLandingStageExecution> findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(String stageCode,
+                                                                                                String status);
 
     List<GeraLandingStageExecution>
     findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(Long experimentId, String stageCode);

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframePendingExecutionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframePendingExecutionResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.geralanding.wireframe.service;
+
+/** Representa o item mínimo de pendência da etapa wireframe consumido pelo Worker AI. */
+public record GeraLandingWireframePendingExecutionResponse(
+        Long experimentId,
+        String idJob,
+        String stageCode
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
@@ -20,6 +20,7 @@ public class GeraLandingWireframeStageExecutionService {
     private final ExperimentRepository experimentRepository;
     private final GeraLandingStageExecutionRepository executionRepository;
 
+    /** Inicializa o serviço com os repositórios necessários para consultar execuções de wireframe. */
     public GeraLandingWireframeStageExecutionService(
             ExperimentRepository experimentRepository,
             GeraLandingStageExecutionRepository executionRepository) {
@@ -61,6 +62,18 @@ public class GeraLandingWireframeStageExecutionService {
                         STATUS_COMPLETED);
         return executions.stream()
                 .map(this::toSummaryResponse)
+                .toList();
+    }
+
+    /** Lista os jobs iniciados da etapa wireframe para processamento independente de experimento. */
+    @Transactional(readOnly = true)
+    public List<GeraLandingWireframePendingExecutionResponse> listPending(String stageCode) {
+        return executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(stageCode, STATUS_STARTED)
+                .stream()
+                .map(execution -> new GeraLandingWireframePendingExecutionResponse(
+                        execution.getExperimentId(),
+                        fromDatabaseIdJob(execution.getIdJob()),
+                        execution.getStageCode()))
                 .toList();
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -1,6 +1,7 @@
 package com.marketinghub.geralanding.wireframe.web;
 
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeExecutionSummaryResponse;
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframePendingExecutionResponse;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionDetailResponse;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
@@ -14,29 +15,32 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Responsável por iniciar a etapa landing-page-wireframe no GeraLanding e expor consultas das execuções da etapa. */
+/** Responsável por expor os endpoints de backend da etapa landing-page-wireframe no GeraLanding. */
 @RestController
-@RequestMapping("/api/experiments/{experimentId}/geralanding")
-public class GeraLandingWireframeController {
+@RequestMapping("/api")
+public class BackendWireframeController {
   private static final String STAGE_CODE = "landing-page-wireframe";
 
   private final GeraLandingWireframeStageService stageService;
   private final GeraLandingWireframeStageExecutionService executionService;
 
-  public GeraLandingWireframeController(GeraLandingWireframeStageService stageService, GeraLandingWireframeStageExecutionService executionService) {
+  /** Inicializa o controller com os serviços da etapa wireframe. */
+  public BackendWireframeController(
+      GeraLandingWireframeStageService stageService,
+      GeraLandingWireframeStageExecutionService executionService) {
     this.stageService = stageService;
     this.executionService = executionService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-wireframe. */
-  @PostMapping("/wireframe/start")
+  @PostMapping("/experiments/{experimentId}/geralanding/wireframe/start")
   public ResponseEntity<GeraLandingWireframeStartResponse> start(@PathVariable Long experimentId) {
     GeraLandingWireframeStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
   }
 
   /** Lista as execuções da etapa para o experimento. */
-  @GetMapping("/wireframe/stage-executions")
+  @GetMapping("/experiments/{experimentId}/geralanding/wireframe/stage-executions")
   public ResponseEntity<List<GeraLandingWireframeExecutionSummaryResponse>> listStageExecutions(
       @PathVariable Long experimentId,
       @RequestParam(defaultValue = "true") boolean includeCompleted) {
@@ -45,8 +49,16 @@ public class GeraLandingWireframeController {
     return ResponseEntity.ok(response);
   }
 
+  /** Lista os jobs pendentes iniciados da etapa wireframe para processamento pelo Worker AI. */
+  @GetMapping("/internal/geralanding/wireframe/stage-executions/pending")
+  public ResponseEntity<List<GeraLandingWireframePendingExecutionResponse>> pending() {
+    List<GeraLandingWireframePendingExecutionResponse> response =
+        executionService.listPending(STAGE_CODE);
+    return ResponseEntity.ok(response);
+  }
+
   /** Retorna os detalhes de uma execução específica da etapa. */
-  @GetMapping("/wireframe/stage-executions/{idJob}")
+  @GetMapping("/experiments/{experimentId}/geralanding/wireframe/stage-executions/{idJob}")
   public ResponseEntity<GeraLandingWireframeStageExecutionDetailResponse> detailStageExecution(
       @PathVariable Long experimentId, @PathVariable String idJob) {
     GeraLandingWireframeStageExecutionDetailResponse response =

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -88,6 +88,13 @@ class ArquiteturaTest {
                     .because("[ARQUITETURA][BACKEND][GeraLanding] serviços em geralanding.*.service só podem acessar classes permitidas dentro de com.marketinghub");
 
     @ArchTest
+    static final ArchRule backendStageControllersMustExposePendingMethod =
+            classes().that().resideInAPackage("com.marketinghub.geralanding.*.web..")
+                    .and().haveNameMatching(".*\\.Backend[A-Za-z0-9]+Controller")
+                    .should(havePendingMethod())
+                    .because("[ARQUITETURA] [BACKEND][GeraLanding] toda classe Backend<etapa>Controller deve expor o método pending para a fila interna da etapa");
+
+    @ArchTest
     static final ArchRule moisSalesLibraryWebShouldOnlyDependOnServiceLayer =
             classes().that(classesBelongingToLayer("web")).should(onlyDependOnLayer("service"));
 
@@ -205,6 +212,24 @@ class ArquiteturaTest {
             public boolean test(JavaClass input) {
                 String packageName = input.getPackageName();
                 return packageName.startsWith("com.marketinghub") && !packageName.startsWith(allowedPackagePrefix);
+            }
+        };
+    }
+
+    /**
+     * Garante que controllers internos por etapa exponham o método pending.
+     */
+    private static ArchCondition<JavaClass> havePendingMethod() {
+        return new ArchCondition<>("[ARQUITETURA] [BACKEND][GeraLanding] Backend<etapa>Controller has pending method") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                boolean hasPending = item.getMethods().stream()
+                        .anyMatch(method -> method.getName().equals("pending"));
+                if (!hasPending) {
+                    String message = "[ARQUITETURA] [BACKEND][GeraLanding] classe=" + item.getName()
+                            + " deve declarar método pending para expor a fila interna da etapa";
+                    events.add(SimpleConditionEvent.violated(item, message));
+                }
             }
         };
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionServiceTest.java
@@ -1,0 +1,44 @@
+package com.marketinghub.geralanding.wireframe.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Valida as consultas de execução específicas da etapa wireframe. */
+class GeraLandingWireframeStageExecutionServiceTest {
+
+    /** Deve buscar somente jobs iniciados da etapa wireframe para o endpoint interno pending. */
+    @Test
+    void listPendingShouldQueryStartedJobsForStage() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        GeraLandingWireframeStageExecutionService service =
+                new GeraLandingWireframeStageExecutionService(experimentRepository, executionRepository);
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(77L)
+                .stageCode("landing-page-wireframe")
+                .executionRequestedAt(Instant.parse("2026-05-28T10:00:00Z"))
+                .createdAt(Instant.parse("2026-05-28T10:00:00Z"))
+                .status("INICIADO")
+                .idJob("job-77".getBytes(StandardCharsets.UTF_8))
+                .build();
+        when(executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+                "landing-page-wireframe", "INICIADO"))
+                .thenReturn(List.of(execution));
+
+        List<GeraLandingWireframePendingExecutionResponse> response = service.listPending("landing-page-wireframe");
+
+        assertEquals(1, response.size());
+        assertEquals(77L, response.get(0).experimentId());
+        assertEquals("job-77", response.get(0).idJob());
+        assertEquals("landing-page-wireframe", response.get(0).stageCode());
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -1,0 +1,34 @@
+package com.marketinghub.geralanding.wireframe.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframePendingExecutionResponse;
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionService;
+import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+/** Valida o contrato do controller de backend da etapa wireframe. */
+class BackendWireframeControllerTest {
+
+    /** Deve delegar a listagem pendente para a etapa canônica de wireframe. */
+    @Test
+    void pendingShouldReturnStartedWireframeJobs() {
+        GeraLandingWireframeStageService stageService = mock(GeraLandingWireframeStageService.class);
+        GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
+        BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
+        List<GeraLandingWireframePendingExecutionResponse> pending = List.of(
+                new GeraLandingWireframePendingExecutionResponse(12L, "job-12", "landing-page-wireframe"));
+        when(executionService.listPending("landing-page-wireframe")).thenReturn(pending);
+
+        ResponseEntity<List<GeraLandingWireframePendingExecutionResponse>> response = controller.pending();
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(pending, response.getBody());
+        verify(executionService).listPending("landing-page-wireframe");
+    }
+}

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -1,1 +1,24 @@
+# Arquitetura canônica por etapa
 
+## Backend por etapa
+
+Todo controller interno de backend criado para uma etapa operacional deve seguir o padrão de nome
+`Backend<Etapa>Controller` e deve declarar um método público chamado `pending`.
+
+Esse método representa o contrato mínimo da fila interna da etapa para o Worker AI:
+
+- expor uma listagem independente de experimento;
+- filtrar a etapa específica do controller;
+- retornar apenas jobs com status `INICIADO`, salvo decisão canônica explícita em contrário;
+- manter endpoint interno no formato `/api/internal/<dominio>/<etapa>/stage-executions/pending` quando o domínio usar processamento assíncrono por worker.
+
+## GeraLanding — wireframe
+
+A etapa `landing-page-wireframe` expõe a fila interna pelo endpoint:
+
+```http
+GET /api/internal/geralanding/wireframe/stage-executions/pending
+```
+
+O endpoint fica no `BackendWireframeController`, usa o método `pending` e retorna os jobs da etapa
+`landing-page-wireframe` com status `INICIADO`, em ordem crescente de solicitação de execução.

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -7,14 +7,15 @@ info:
     `com.marketinghub.geralanding`, organizados por etapa operacional do GeraLanding.
 
     Fonte de verdade revisada em código:
-    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/GeraLandingWireframeController.java`
+    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java`
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java`
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java`
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java`
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java`
 
-    Todos os endpoints listados abaixo ficam sob o escopo de um experimento e usam o prefixo
-    `/api/experiments/{experimentId}/geralanding`.
+    Os endpoints públicos de acompanhamento ficam sob o escopo de um experimento e usam o prefixo
+    `/api/experiments/{experimentId}/geralanding`. Endpoints internos de fila por etapa usam
+    o prefixo `/api/internal/geralanding/<etapa>`.
 servers:
   - url: http://191.252.181.168
     description: Backend principal para acessos executados pelo Codex
@@ -87,6 +88,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StageExecutionDetail'
+  /api/internal/geralanding/wireframe/stage-executions/pending:
+    get:
+      tags:
+        - landing-page-wireframe
+      summary: Lista jobs pendentes internos da etapa landing-page-wireframe.
+      description: Retorna jobs de wireframe com status INICIADO, independente de experimento, para processamento pelo Worker AI.
+      operationId: pendingGeraLandingWireframeExecutions
+      responses:
+        '200':
+          description: Lista de jobs pendentes da etapa.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PendingStageExecution'
   /api/experiments/{experimentId}/geralanding/copy/start:
     post:
       tags:
@@ -344,6 +361,21 @@ components:
           description: Identificador do job criado para a etapa.
         status:
           $ref: '#/components/schemas/StageStatus'
+    PendingStageExecution:
+      type: object
+      additionalProperties: false
+      properties:
+        experimentId:
+          type: integer
+          format: int64
+        idJob:
+          type: string
+        stageCode:
+          type: string
+      required:
+        - experimentId
+        - idJob
+        - stageCode
     StageExecutionSummary:
       type: object
       required:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2199,3 +2199,14 @@
   - adicionado teste unitário garantindo que o client chama `/api/experiments/{experimentId}/geralanding/wireframe/stage-executions?includeCompleted=false`.
 - validação executada:
   - `mvn -q -Dtest=GeraLandingWireframeBackendClientTest test` em `ai-worker/` (bloqueado por dependência privada externa `com.marketinghub:ads-service:0.0.1-SNAPSHOT` com HTTP 401 no GitHub Packages).
+
+## 2026-05-28 21:30:00 UTC
+- solicitação: criar endpoint interno global de pendências para a etapa wireframe do GeraLanding e reforçar a arquitetura por etapa.
+- causa-raiz tratada: a etapa wireframe precisava de uma fila independente de experimento para o Worker AI consultar apenas jobs com status `INICIADO`, evitando varredura por experimento como substituto operacional.
+- correção aplicada:
+  - renomeado o controller Java de wireframe para `BackendWireframeController`;
+  - criado o endpoint `GET /api/internal/geralanding/wireframe/stage-executions/pending` no método `pending`;
+  - adicionada consulta por `stageCode` + status `INICIADO` no repositório e no serviço da etapa wireframe;
+  - registrado o padrão em `docs/canonical/arquitetura-etapas.md` e no Swagger canônico do GeraLanding;
+  - criada regra ArchUnit para exigir método `pending` em classes `Backend<Etapa>Controller` do GeraLanding;
+  - adicionados testes unitários do controller e serviço de wireframe.


### PR DESCRIPTION
### Motivation
- Provide a global, experiment-independent queue endpoint for the GeraLanding wireframe step so Worker AI can poll only `INICIADO` jobs without scanning per-experiment endpoints.
- Align backend controllers and architecture rules with a per-stage internal queue pattern and document the contract in canonical Swagger and architecture docs.

### Description
- Renamed `GeraLandingWireframeController` to `BackendWireframeController` and moved its mapping to the API root while preserving experiment-scoped endpoints at `/api/experiments/{experimentId}/geralanding/...`.
- Added `GET /api/internal/geralanding/wireframe/stage-executions/pending` exposed by the new `pending` method which returns pending wireframe jobs for the stage `landing-page-wireframe`.
- Introduced `GeraLandingWireframePendingExecutionResponse` DTO and `listPending(String stageCode)` service method which maps `GeraLandingStageExecution` entries to the pending DTO.
- Added repository query `findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(...)` to support stage+status lookups.
- Updated canonical docs (`docs/canonical/arquitetura-etapas.md`) and OpenAPI (`docs/canonical/geralanding-backend-swagger.v1.yaml`) to declare the internal pending endpoint and the per-stage controller pattern; added ArchUnit rule enforcing that `Backend<Etapa>Controller` classes expose a `pending` method.
- Added unit tests for the controller and service: `BackendWireframeControllerTest` and `GeraLandingWireframeStageExecutionServiceTest` and updated `ArquiteturaTest` accordingly.

### Testing
- Ran compilation: `cd backend/ads-service && ../mvnw -q -DskipTests compile` which succeeded.
- Executed targeted unit tests: `cd backend/ads-service && ../mvnw -q -Dtest=BackendWireframeControllerTest,GeraLandingWireframeStageExecutionServiceTest,ArquiteturaTest test` and the tests passed.
- Executed full test suite: `cd backend/ads-service && ../mvnw -q test` which completed (no test-suite failure observed for the modified areas).
- Style check `cd backend/ads-service && ../mvnw -q spotless:check` failed due to unavailable Spotless plugin prefix in this environment and is reported as an unrelated tooling configuration issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189d5c63088321a12f2056edd2b1c4)