### PR TITLE
Padroniza retorno pending do wireframe por etapa

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
@@ -67,10 +67,10 @@ public class GeraLandingWireframeStageExecutionService {
 
     /** Lista os jobs iniciados da etapa wireframe para processamento independente de experimento. */
     @Transactional(readOnly = true)
-    public List<GeraLandingWireframePendingExecutionResponse> listPending(String stageCode) {
+    public List<RecordWireframePending> listPending(String stageCode) {
         return executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(stageCode, STATUS_STARTED)
                 .stream()
-                .map(execution -> new GeraLandingWireframePendingExecutionResponse(
+                .map(execution -> new RecordWireframePending(
                         execution.getExperimentId(),
                         fromDatabaseIdJob(execution.getIdJob()),
                         execution.getStageCode()))

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframePending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframePending.java
@@ -1,7 +1,7 @@
 package com.marketinghub.geralanding.wireframe.service;
 
 /** Representa o item mínimo de pendência da etapa wireframe consumido pelo Worker AI. */
-public record GeraLandingWireframePendingExecutionResponse(
+public record RecordWireframePending(
         Long experimentId,
         String idJob,
         String stageCode

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -1,11 +1,11 @@
 package com.marketinghub.geralanding.wireframe.web;
 
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeExecutionSummaryResponse;
-import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframePendingExecutionResponse;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionDetailResponse;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
+import com.marketinghub.geralanding.wireframe.service.RecordWireframePending;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -51,10 +51,8 @@ public class BackendWireframeController {
 
   /** Lista os jobs pendentes iniciados da etapa wireframe para processamento pelo Worker AI. */
   @GetMapping("/internal/geralanding/wireframe/stage-executions/pending")
-  public ResponseEntity<List<GeraLandingWireframePendingExecutionResponse>> pending() {
-    List<GeraLandingWireframePendingExecutionResponse> response =
-        executionService.listPending(STAGE_CODE);
-    return ResponseEntity.ok(response);
+  public List<RecordWireframePending> pending() {
+    return executionService.listPending(STAGE_CODE);
   }
 
   /** Retorna os detalhes de uma execução específica da etapa. */

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -7,12 +7,16 @@ import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAsse
 import com.marketinghub.geralanding.wireframe.provisorio.WireframeProvisionalHtmlAssembler;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -91,8 +95,8 @@ class ArquiteturaTest {
     static final ArchRule backendStageControllersMustExposePendingMethod =
             classes().that().resideInAPackage("com.marketinghub.geralanding.*.web..")
                     .and().haveNameMatching(".*\\.Backend[A-Za-z0-9]+Controller")
-                    .should(havePendingMethod())
-                    .because("[ARQUITETURA] [BACKEND][GeraLanding] toda classe Backend<etapa>Controller deve expor o método pending para a fila interna da etapa");
+                    .should(havePendingMethodReturningStagePendingRecord())
+                    .because("[ARQUITETURA] [BACKEND][GeraLanding] toda classe Backend<Etapa>Controller deve expor pending retornando List<Record<Etapa>Pending> para a fila interna da etapa");
 
     @ArchTest
     static final ArchRule moisSalesLibraryWebShouldOnlyDependOnServiceLayer =
@@ -217,21 +221,65 @@ class ArquiteturaTest {
     }
 
     /**
-     * Garante que controllers internos por etapa exponham o método pending.
+     * Garante que controllers internos por etapa exponham pending com o record canônico da etapa.
      */
-    private static ArchCondition<JavaClass> havePendingMethod() {
-        return new ArchCondition<>("[ARQUITETURA] [BACKEND][GeraLanding] Backend<etapa>Controller has pending method") {
+    private static ArchCondition<JavaClass> havePendingMethodReturningStagePendingRecord() {
+        return new ArchCondition<>(
+                "[ARQUITETURA] [BACKEND][GeraLanding] Backend<Etapa>Controller.pending returns List<Record<Etapa>Pending>") {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
-                boolean hasPending = item.getMethods().stream()
-                        .anyMatch(method -> method.getName().equals("pending"));
-                if (!hasPending) {
+                Optional<JavaMethod> pendingMethod = item.getMethods().stream()
+                        .filter(method -> method.getName().equals("pending"))
+                        .findFirst();
+                if (pendingMethod.isEmpty()) {
                     String message = "[ARQUITETURA] [BACKEND][GeraLanding] classe=" + item.getName()
                             + " deve declarar método pending para expor a fila interna da etapa";
+                    events.add(SimpleConditionEvent.violated(item, message));
+                    return;
+                }
+
+                String stageName = extractBackendStageName(item);
+                String expectedRecordName = "Record" + stageName + "Pending";
+                Type returnType = pendingMethod.get().reflect().getGenericReturnType();
+                boolean validReturnType = isListOfExpectedRecord(returnType, expectedRecordName);
+                if (!validReturnType) {
+                    String message = "[ARQUITETURA] [BACKEND][GeraLanding] classe=" + item.getName()
+                            + " método=pending deve retornar List<" + expectedRecordName + ">"
+                            + " conforme o padrão Backend<Etapa>Controller.pending -> List<Record<Etapa>Pending>"
+                            + "; retorno atual=" + returnType.getTypeName();
                     events.add(SimpleConditionEvent.violated(item, message));
                 }
             }
         };
+    }
+
+    /**
+     * Extrai o nome da etapa do controller Backend<Etapa>Controller.
+     */
+    private static String extractBackendStageName(JavaClass item) {
+        Matcher matcher = Pattern.compile("^Backend([A-Za-z0-9]+)Controller$").matcher(item.getSimpleName());
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+        return "";
+    }
+
+    /**
+     * Verifica se o tipo de retorno é exatamente List<Record<Etapa>Pending>.
+     */
+    private static boolean isListOfExpectedRecord(Type returnType, String expectedRecordName) {
+        if (!(returnType instanceof ParameterizedType parameterizedType)) {
+            return false;
+        }
+        if (!List.class.equals(parameterizedType.getRawType())) {
+            return false;
+        }
+        Type[] typeArguments = parameterizedType.getActualTypeArguments();
+        if (typeArguments.length != 1) {
+            return false;
+        }
+        String actualTypeName = typeArguments[0].getTypeName();
+        return actualTypeName.endsWith("." + expectedRecordName);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionServiceTest.java
@@ -34,7 +34,7 @@ class GeraLandingWireframeStageExecutionServiceTest {
                 "landing-page-wireframe", "INICIADO"))
                 .thenReturn(List.of(execution));
 
-        List<GeraLandingWireframePendingExecutionResponse> response = service.listPending("landing-page-wireframe");
+        List<RecordWireframePending> response = service.listPending("landing-page-wireframe");
 
         assertEquals(1, response.size());
         assertEquals(77L, response.get(0).experimentId());

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -5,12 +5,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframePendingExecutionResponse;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
+import com.marketinghub.geralanding.wireframe.service.RecordWireframePending;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ResponseEntity;
 
 /** Valida o contrato do controller de backend da etapa wireframe. */
 class BackendWireframeControllerTest {
@@ -21,14 +20,13 @@ class BackendWireframeControllerTest {
         GeraLandingWireframeStageService stageService = mock(GeraLandingWireframeStageService.class);
         GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
         BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
-        List<GeraLandingWireframePendingExecutionResponse> pending = List.of(
-                new GeraLandingWireframePendingExecutionResponse(12L, "job-12", "landing-page-wireframe"));
+        List<RecordWireframePending> pending = List.of(
+                new RecordWireframePending(12L, "job-12", "landing-page-wireframe"));
         when(executionService.listPending("landing-page-wireframe")).thenReturn(pending);
 
-        ResponseEntity<List<GeraLandingWireframePendingExecutionResponse>> response = controller.pending();
+        List<RecordWireframePending> response = controller.pending();
 
-        assertEquals(200, response.getStatusCode().value());
-        assertEquals(pending, response.getBody());
+        assertEquals(pending, response);
         verify(executionService).listPending("landing-page-wireframe");
     }
 }

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -10,7 +10,17 @@ Esse método representa o contrato mínimo da fila interna da etapa para o Worke
 - expor uma listagem independente de experimento;
 - filtrar a etapa específica do controller;
 - retornar apenas jobs com status `INICIADO`, salvo decisão canônica explícita em contrário;
+- retornar diretamente uma lista tipada no padrão `List<Record<Etapa>Pending>`;
+- usar um record de resposta nomeado no padrão `Record<Etapa>Pending`, onde `<Etapa>` é o mesmo sufixo do controller `Backend<Etapa>Controller`;
 - manter endpoint interno no formato `/api/internal/<dominio>/<etapa>/stage-executions/pending` quando o domínio usar processamento assíncrono por worker.
+
+A regra genérica obrigatória é:
+
+```java
+Backend<Etapa>Controller.pending -> List<Record<Etapa>Pending>
+```
+
+Exemplo: `BackendWireframeController.pending` deve retornar `List<RecordWireframePending>`.
 
 ## GeraLanding — wireframe
 
@@ -20,5 +30,6 @@ A etapa `landing-page-wireframe` expõe a fila interna pelo endpoint:
 GET /api/internal/geralanding/wireframe/stage-executions/pending
 ```
 
-O endpoint fica no `BackendWireframeController`, usa o método `pending` e retorna os jobs da etapa
-`landing-page-wireframe` com status `INICIADO`, em ordem crescente de solicitação de execução.
+O endpoint fica no `BackendWireframeController`, usa o método `pending` e retorna uma lista de
+`RecordWireframePending` com os jobs da etapa `landing-page-wireframe` com status `INICIADO`, em ordem
+crescente de solicitação de execução.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2210,3 +2210,10 @@
   - registrado o padrão em `docs/canonical/arquitetura-etapas.md` e no Swagger canônico do GeraLanding;
   - criada regra ArchUnit para exigir método `pending` em classes `Backend<Etapa>Controller` do GeraLanding;
   - adicionados testes unitários do controller e serviço de wireframe.
+
+## 2026-05-28 — Padronização de retorno pending por etapa
+
+- Renomeado o record de pendência da etapa wireframe para `RecordWireframePending`.
+- Ajustado `BackendWireframeController.pending` para retornar diretamente `List<RecordWireframePending>`.
+- Registrada no cânone de arquitetura por etapa a regra `Backend<Etapa>Controller.pending -> List<Record<Etapa>Pending>`.
+- Atualizado `ArquiteturaTest` para validar o contrato genérico do método `pending` por etapa.


### PR DESCRIPTION
### Motivation

- Garantir contrato canônico entre controllers backend por etapa e o Worker AI especificando que `Backend<Etapa>Controller.pending` devolva uma lista tipada e estável para processamento assíncrono.
- Facilitar validação arquitetural automatizada e evitar varreduras por experimento ao expor uma fila global de jobs com status `INICIADO` por etapa.

### Description

- Renomeado o record de pendência `GeraLandingWireframePendingExecutionResponse` para `RecordWireframePending` mantendo os campos `experimentId`, `idJob` e `stageCode`.
- Atualizado `GeraLandingWireframeStageExecutionService.listPending` para retornar `List<RecordWireframePending>` e mapear as execuções para o novo record.
- Ajustado `BackendWireframeController.pending` para retornar diretamente `List<RecordWireframePending>` ao invés de `ResponseEntity<...>` para simplificar o contrato interno.
- Atualizada a regra canônica em `docs/canonical/arquitetura-etapas.md`, adicionada entrada em `docs/registros/experimentos.md` e ampliado `ArquiteturaTest` para validar genericamente que `Backend<Etapa>Controller.pending` retorne `List<Record<Etapa>Pending>`.

### Testing

- Executado `mvn -Dtest=GeraLandingWireframeStageExecutionServiceTest,BackendWireframeControllerTest,ArquiteturaTest test` no módulo `ads-service`, com `BUILD SUCCESS` e todos os testes passando (`Tests run: 21, Failures: 0, Errors: 0`).
- Verificada compila e integridade dos testes unitrios relevantes para wireframe e regras de arquitetura; nenhuma falha encontrada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a59b3e108321987f7e51eb020912)