### PR TITLE
Expose experiment summary in wireframe pending endpoint and update DTO/contract

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionRepository.java
@@ -1,5 +1,6 @@
 package com.marketinghub.geralanding;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -19,7 +20,8 @@ public interface GeraLandingStageExecutionRepository extends JpaRepository<GeraL
 
     List<GeraLandingStageExecution> findTop20ByStatusInOrderByExecutionRequestedAtAsc(List<String> statuses);
 
-    /** Busca as execuções mais antigas de uma etapa com o status informado. */
+    /** Busca as execuções mais antigas de uma etapa com o status informado e experimento carregado. */
+    @EntityGraph(attributePaths = "experiment")
     List<GeraLandingStageExecution> findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(String stageCode,
                                                                                                 String status);
 

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.geralanding.wireframe.service;
 
+import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
@@ -73,8 +74,27 @@ public class GeraLandingWireframeStageExecutionService {
                 .map(execution -> new RecordWireframePending(
                         execution.getExperimentId(),
                         fromDatabaseIdJob(execution.getIdJob()),
-                        execution.getStageCode()))
+                        execution.getStageCode(),
+                        toPendingExperiment(execution.getExperiment())))
                 .toList();
+    }
+
+    /** Converte o experimento da execução para o resumo mínimo exposto na fila pending. */
+    private RecordWireframeExperiment toPendingExperiment(Experiment experiment) {
+        if (experiment == null) {
+            return null;
+        }
+        return new RecordWireframeExperiment(
+                experiment.getId(),
+                experiment.getName(),
+                experiment.getHypothesis(),
+                enumValueToText(experiment.getStatus()),
+                enumValueToText(experiment.getStage()));
+    }
+
+    /** Converte um enum de experimento para texto sem acoplar o serviço às classes concretas do enum. */
+    private String enumValueToText(Object value) {
+        return value != null ? String.valueOf(value) : null;
     }
 
     @Transactional(readOnly = true)

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframeExperiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframeExperiment.java
@@ -1,0 +1,11 @@
+package com.marketinghub.geralanding.wireframe.service;
+
+/** Representa os dados mínimos do experimento expostos na fila interna da etapa wireframe. */
+public record RecordWireframeExperiment(
+        Long id,
+        String name,
+        String hypothesis,
+        String status,
+        String stage
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframePending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframePending.java
@@ -3,7 +3,8 @@ package com.marketinghub.geralanding.wireframe.service;
 /** Representa o item mínimo de pendência da etapa wireframe consumido pelo Worker AI. */
 public record RecordWireframePending(
         Long experimentId,
-        String idJob,
-        String stageCode
+        String jobid,
+        String stageCode,
+        RecordWireframeExperiment experiment
 ) {
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionServiceTest.java
@@ -1,9 +1,11 @@
 package com.marketinghub.geralanding.wireframe.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
@@ -22,8 +24,13 @@ class GeraLandingWireframeStageExecutionServiceTest {
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         GeraLandingWireframeStageExecutionService service =
                 new GeraLandingWireframeStageExecutionService(experimentRepository, executionRepository);
+        Experiment experiment = mock(Experiment.class);
+        when(experiment.getId()).thenReturn(77L);
+        when(experiment.getName()).thenReturn("Experimento Wireframe");
+        when(experiment.getHypothesis()).thenReturn("Hipótese de valor");
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .experimentId(77L)
+                .experiment(experiment)
                 .stageCode("landing-page-wireframe")
                 .executionRequestedAt(Instant.parse("2026-05-28T10:00:00Z"))
                 .createdAt(Instant.parse("2026-05-28T10:00:00Z"))
@@ -38,7 +45,11 @@ class GeraLandingWireframeStageExecutionServiceTest {
 
         assertEquals(1, response.size());
         assertEquals(77L, response.get(0).experimentId());
-        assertEquals("job-77", response.get(0).idJob());
+        assertEquals("job-77", response.get(0).jobid());
         assertEquals("landing-page-wireframe", response.get(0).stageCode());
+        assertNotNull(response.get(0).experiment());
+        assertEquals(77L, response.get(0).experiment().id());
+        assertEquals("Experimento Wireframe", response.get(0).experiment().name());
+        assertEquals("Hipótese de valor", response.get(0).experiment().hypothesis());
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -1,12 +1,16 @@
 package com.marketinghub.geralanding.wireframe.web;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
+import com.marketinghub.geralanding.wireframe.service.RecordWireframeExperiment;
 import com.marketinghub.geralanding.wireframe.service.RecordWireframePending;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -21,12 +25,39 @@ class BackendWireframeControllerTest {
         GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
         BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
         List<RecordWireframePending> pending = List.of(
-                new RecordWireframePending(12L, "job-12", "landing-page-wireframe"));
+                new RecordWireframePending(
+                        12L,
+                        "job-12",
+                        "landing-page-wireframe",
+                        new RecordWireframeExperiment(12L, "Experimento 12", "Hipótese", "PLANNED", "LANDING")));
         when(executionService.listPending("landing-page-wireframe")).thenReturn(pending);
 
         List<RecordWireframePending> response = controller.pending();
 
         assertEquals(pending, response);
         verify(executionService).listPending("landing-page-wireframe");
+    }
+
+    /** Deve serializar pending como lista com atributos experiment e jobid em cada item. */
+    @Test
+    void pendingShouldSerializeListItemsWithExperimentAndJobid() throws Exception {
+        GeraLandingWireframeStageService stageService = mock(GeraLandingWireframeStageService.class);
+        GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
+        BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
+        when(executionService.listPending("landing-page-wireframe")).thenReturn(List.of(
+                new RecordWireframePending(
+                        33L,
+                        "bbed57d0-dcc7-40ab-b936-20a19e21c7fe",
+                        "landing-page-wireframe",
+                        new RecordWireframeExperiment(33L, "Experimento 33", "Hipótese 33", "PLANNED", "LANDING"))));
+
+        JsonNode json = new ObjectMapper().valueToTree(controller.pending());
+
+        assertTrue(json.isArray());
+        assertEquals(1, json.size());
+        assertTrue(json.get(0).has("experiment"));
+        assertTrue(json.get(0).has("jobid"));
+        assertEquals("bbed57d0-dcc7-40ab-b936-20a19e21c7fe", json.get(0).get("jobid").asText());
+        assertEquals(33L, json.get(0).get("experiment").get("id").asLong());
     }
 }

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -32,4 +32,6 @@ GET /api/internal/geralanding/wireframe/stage-executions/pending
 
 O endpoint fica no `BackendWireframeController`, usa o método `pending` e retorna uma lista de
 `RecordWireframePending` com os jobs da etapa `landing-page-wireframe` com status `INICIADO`, em ordem
-crescente de solicitação de execução.
+crescente de solicitação de execução. Cada item da lista deve conter, no mínimo, os atributos `jobid`
+e `experiment`. O atributo `experiment` deve ser um objeto resumido com os dados mínimos necessários
+para o consumidor da fila identificar o experimento sem expor a entidade completa.

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -368,14 +368,40 @@ components:
         experimentId:
           type: integer
           format: int64
-        idJob:
+        jobid:
           type: string
+          description: Identificador do job pendente na etapa wireframe.
         stageCode:
           type: string
+        experiment:
+          $ref: '#/components/schemas/PendingStageExperiment'
       required:
         - experimentId
-        - idJob
+        - jobid
         - stageCode
+        - experiment
+    PendingStageExperiment:
+      type: object
+      additionalProperties: false
+      description: Resumo mínimo do experimento associado ao job pendente.
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          nullable: true
+        hypothesis:
+          type: string
+          nullable: true
+        status:
+          type: string
+          nullable: true
+        stage:
+          type: string
+          nullable: true
+      required:
+        - id
     StageExecutionSummary:
       type: object
       required:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2217,3 +2217,14 @@
 - Ajustado `BackendWireframeController.pending` para retornar diretamente `List<RecordWireframePending>`.
 - Registrada no cânone de arquitetura por etapa a regra `Backend<Etapa>Controller.pending -> List<Record<Etapa>Pending>`.
 - Atualizado `ArquiteturaTest` para validar o contrato genérico do método `pending` por etapa.
+
+## 2026-05-28 21:55:00 UTC
+- solicitação: incluir o experimento junto aos itens pendentes da etapa `landing-page-wireframe` e garantir teste para atributos `experiment` e `jobid` no retorno de `pending`.
+- causa-raiz tratada: o contrato interno global de pendências expunha apenas identificadores mínimos (`experimentId`, `idJob`/etapa), obrigando consumidores a buscar o experimento em chamada separada para identificar contexto básico do job.
+- correção aplicada:
+  - o record `RecordWireframePending` passou a expor `jobid`, `stageCode`, `experimentId` e o resumo `experiment`;
+  - criado `RecordWireframeExperiment` com os campos mínimos do experimento necessários para identificação do job pendente;
+  - o serviço de execução de wireframe passou a montar o resumo do experimento a partir da execução carregada;
+  - a consulta de pendências no repositório passou a carregar o relacionamento `experiment` via `EntityGraph` para evitar consulta adicional por item;
+  - o cânone de arquitetura por etapa e o Swagger canônico do GeraLanding foram atualizados com o novo contrato de pending;
+  - adicionados testes garantindo os dados do experimento no service e a serialização da resposta como lista contendo `experiment` e `jobid`.


### PR DESCRIPTION
### Motivation

- Provide a minimal experiment summary alongside pending wireframe jobs so workers can identify job context without extra calls.
- Standardize the internal pending contract for the `landing-page-wireframe` stage to include `jobid` and an experiment summary.

### Description

- Updated `GeraLandingStageExecutionRepository` to eagerly load the `experiment` relationship on pending queries using `@EntityGraph(attributePaths = "experiment")` for `findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc`.
- Extended the wireframe pending contract by renaming `idJob` to `jobid` and adding a new `experiment` field in `RecordWireframePending`, and added a new `RecordWireframeExperiment` record holding minimal experiment attributes (`id`, `name`, `hypothesis`, `status`, `stage`).
- Enhanced `GeraLandingWireframeStageExecutionService` to map the loaded `experiment` into the `RecordWireframeExperiment` via the new `toPendingExperiment` helper and a generic `enumValueToText` converter, and amended `listPending` to include the experiment summary when building `RecordWireframePending`.
- Updated docs and OpenAPI spec: `docs/canonical/arquitetura-etapas.md` and `docs/canonical/geralanding-backend-swagger.v1.yaml` now reflect the new `jobid` and `experiment` fields and include `PendingStageExperiment` schema.

### Testing

- Ran `GeraLandingWireframeStageExecutionServiceTest` which asserts mapping of execution -> `RecordWireframePending` and it succeeded.
- Ran `BackendWireframeControllerTest` including the new serialization assertions for `jobid` and `experiment`, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a9b06fa08321b1ad7a9f974c9264)