### PR TITLE
Wireframe pending: include experiment summary and hypothesis framework in pending payload

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -17,6 +17,7 @@ import com.marketinghub.sampleemail.SampleEmail;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.UUID;
 
 /**
  * Experiment grouping ad sets and creatives.
@@ -85,6 +86,21 @@ public class Experiment {
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "hypothesis_id", nullable = false)
     private com.marketinghub.hypothesis.Hypothesis hypothesisRef;
+
+    /** Retorna o identificador da hipótese associada para contratos operacionais internos. */
+    public UUID getHypothesisRefIdForPending() {
+        return hypothesisRef != null ? hypothesisRef.getId() : null;
+    }
+
+    /** Retorna o título da hipótese associada para contratos operacionais internos. */
+    public String getHypothesisRefTitleForPending() {
+        return hypothesisRef != null ? hypothesisRef.getTitle() : null;
+    }
+
+    /** Retorna o JSON do framework da hipótese associada para contratos operacionais internos. */
+    public String getHypothesisFrameworkJsonForPending() {
+        return hypothesisRef != null ? hypothesisRef.getFrameworkJson() : null;
+    }
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "metric_preset_id")

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionRepository.java
@@ -1,5 +1,6 @@
 package com.marketinghub.geralanding;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -19,7 +20,8 @@ public interface GeraLandingStageExecutionRepository extends JpaRepository<GeraL
 
     List<GeraLandingStageExecution> findTop20ByStatusInOrderByExecutionRequestedAtAsc(List<String> statuses);
 
-    /** Busca as execuções mais antigas de uma etapa com o status informado. */
+    /** Busca as execuções mais antigas de uma etapa com experimento e hipótese carregados. */
+    @EntityGraph(attributePaths = {"experiment", "experiment.hypothesisRef"})
     List<GeraLandingStageExecution> findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(String stageCode,
                                                                                                 String status);
 

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
@@ -1,13 +1,21 @@
 package com.marketinghub.geralanding.wireframe.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,17 +23,22 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class GeraLandingWireframeStageExecutionService {
 
+    private static final Logger log = LoggerFactory.getLogger(GeraLandingWireframeStageExecutionService.class);
+    private static final TypeReference<LinkedHashMap<String, Object>> FRAMEWORK_TYPE = new TypeReference<>() {};
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private final ExperimentRepository experimentRepository;
     private final GeraLandingStageExecutionRepository executionRepository;
+    private final ObjectMapper objectMapper;
 
     /** Inicializa o serviço com os repositórios necessários para consultar execuções de wireframe. */
     public GeraLandingWireframeStageExecutionService(
             ExperimentRepository experimentRepository,
-            GeraLandingStageExecutionRepository executionRepository) {
+            GeraLandingStageExecutionRepository executionRepository,
+            ObjectMapper objectMapper) {
         this.experimentRepository = experimentRepository;
         this.executionRepository = executionRepository;
+        this.objectMapper = objectMapper;
     }
 
 
@@ -73,8 +86,74 @@ public class GeraLandingWireframeStageExecutionService {
                 .map(execution -> new RecordWireframePending(
                         execution.getExperimentId(),
                         fromDatabaseIdJob(execution.getIdJob()),
-                        execution.getStageCode()))
+                        execution.getStageCode(),
+                        toPendingExperiment(execution.getExperiment()),
+                        toPendingHypothesis(execution.getExperiment())))
                 .toList();
+    }
+
+    /** Converte o experimento da execução para os dados expostos na fila pending. */
+    private RecordWireframeExperiment toPendingExperiment(Experiment experiment) {
+        if (experiment == null) {
+            return null;
+        }
+        return new RecordWireframeExperiment(
+                experiment.getId(),
+                experiment.getName(),
+                experiment.getHypothesis(),
+                enumValueToText(experiment.getStatus()),
+                enumValueToText(experiment.getStage()),
+                experiment.getCreativeTextPrompt(),
+                experiment.getCreativeImagePrompt(),
+                experiment.getCampaignAngle(),
+                experiment.getAdCopy(),
+                experiment.getAdImageBriefing(),
+                experiment.getLandingPageCopy(),
+                experiment.getLandingPageWireframe(),
+                experiment.getLandingPageImagePlanning(),
+                experiment.getLandingPageDesignPreset(),
+                experiment.getLandingPageDeliverables(),
+                experiment.getHtmlGeraLanding());
+    }
+
+    /** Converte a hipótese associada ao experimento para o framework exposto na fila pending. */
+    private RecordWireframeHypothesis toPendingHypothesis(Experiment experiment) {
+        if (experiment == null) {
+            return null;
+        }
+        return new RecordWireframeHypothesis(
+                experiment.getHypothesisRefIdForPending(),
+                experiment.getHypothesisRefTitleForPending(),
+                resolveFramework(experiment.getId(), experiment.getHypothesisFrameworkJsonForPending()));
+    }
+
+    /** Resolve o JSON do framework da hipótese como objeto estruturado com todos os blocos canônicos. */
+    private Map<String, Object> resolveFramework(Long experimentId, String frameworkJson) {
+        Map<String, Object> framework = new LinkedHashMap<>();
+        if (frameworkJson != null && !frameworkJson.isBlank()) {
+            try {
+                framework.putAll(objectMapper.readValue(frameworkJson, FRAMEWORK_TYPE));
+            } catch (JsonProcessingException ex) {
+                log.warn("Falha ao ler framework da hipótese no pending wireframe. experimentId={}", experimentId, ex);
+            }
+        }
+        ensureFrameworkSections(framework);
+        return framework;
+    }
+
+    /** Garante presença dos itens canônicos Dor, Resultado, Mecanismo, Prova, Oferta e checklist. */
+    private void ensureFrameworkSections(Map<String, Object> framework) {
+        framework.putIfAbsent("pain", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("result", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("mechanism", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("proof", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("offer", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("checklist", new LinkedHashMap<String, Object>());
+    }
+
+    /** Converte um enum de experimento para texto sem acoplar o serviço às classes concretas do enum. */
+    private String enumValueToText(Object value) {
+        return value != null ? String.valueOf(value) : null;
     }
 
     @Transactional(readOnly = true)

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframeExperiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframeExperiment.java
@@ -1,0 +1,22 @@
+package com.marketinghub.geralanding.wireframe.service;
+
+/** Representa os dados do experimento expostos na fila interna da etapa wireframe. */
+public record RecordWireframeExperiment(
+        Long id,
+        String name,
+        String hypothesis,
+        String status,
+        String stage,
+        String creativeTextPrompt,
+        String creativeImagePrompt,
+        String campaignAngle,
+        String adCopy,
+        String adImageBriefing,
+        String landingPageCopy,
+        String landingPageWireframe,
+        String landingPageImagePlanning,
+        String landingPageDesignPreset,
+        String landingPageDeliverables,
+        String htmlGeraLanding
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframeHypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframeHypothesis.java
@@ -1,0 +1,12 @@
+package com.marketinghub.geralanding.wireframe.service;
+
+import java.util.Map;
+import java.util.UUID;
+
+/** Representa a hipótese e o framework usados na fila interna da etapa wireframe. */
+public record RecordWireframeHypothesis(
+        UUID id,
+        String title,
+        Map<String, Object> framework
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframePending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframePending.java
@@ -3,7 +3,9 @@ package com.marketinghub.geralanding.wireframe.service;
 /** Representa o item mínimo de pendência da etapa wireframe consumido pelo Worker AI. */
 public record RecordWireframePending(
         Long experimentId,
-        String idJob,
-        String stageCode
+        String jobid,
+        String stageCode,
+        RecordWireframeExperiment experiment,
+        RecordWireframeHypothesis hypothesis
 ) {
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionServiceTest.java
@@ -1,15 +1,21 @@
 package com.marketinghub.geralanding.wireframe.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 /** Valida as consultas de execução específicas da etapa wireframe. */
@@ -21,9 +27,39 @@ class GeraLandingWireframeStageExecutionServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         GeraLandingWireframeStageExecutionService service =
-                new GeraLandingWireframeStageExecutionService(experimentRepository, executionRepository);
+                new GeraLandingWireframeStageExecutionService(experimentRepository, executionRepository, new ObjectMapper());
+        Experiment experiment = mock(Experiment.class);
+        when(experiment.getId()).thenReturn(77L);
+        when(experiment.getName()).thenReturn("Experimento Wireframe");
+        when(experiment.getHypothesis()).thenReturn("Hipótese de valor");
+        when(experiment.getCreativeTextPrompt()).thenReturn("Prompt texto");
+        when(experiment.getCreativeImagePrompt()).thenReturn("Prompt imagem");
+        when(experiment.getCampaignAngle()).thenReturn("Ângulo campanha");
+        when(experiment.getAdCopy()).thenReturn("Copy anúncio");
+        when(experiment.getAdImageBriefing()).thenReturn("Briefing imagem");
+        when(experiment.getLandingPageCopy()).thenReturn("Copy landing");
+        when(experiment.getLandingPageWireframe()).thenReturn("Wireframe landing");
+        when(experiment.getLandingPageImagePlanning()).thenReturn("Planejamento imagem");
+        when(experiment.getLandingPageDesignPreset()).thenReturn("Preset design");
+        when(experiment.getLandingPageDeliverables()).thenReturn("Entregáveis landing");
+        when(experiment.getHtmlGeraLanding()).thenReturn("<html>GeraLanding</html>");
+        UUID hypothesisId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        when(experiment.getHypothesisRefIdForPending()).thenReturn(hypothesisId);
+        when(experiment.getHypothesisRefTitleForPending()).thenReturn("Hipótese Framework");
+        when(experiment.getHypothesisFrameworkJsonForPending()).thenReturn("""
+                {
+                  "version": "v1",
+                  "pain": {"surface": "Dor superficial", "root": "Dor raiz"},
+                  "result": {"desiredResult": "Resultado desejado"},
+                  "mechanism": {"core": "Mecanismo central"},
+                  "proof": {"type": "Prova"},
+                  "offer": {"name": "Oferta"},
+                  "checklist": {"painReady": true}
+                }
+                """);
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .experimentId(77L)
+                .experiment(experiment)
                 .stageCode("landing-page-wireframe")
                 .executionRequestedAt(Instant.parse("2026-05-28T10:00:00Z"))
                 .createdAt(Instant.parse("2026-05-28T10:00:00Z"))
@@ -38,7 +74,32 @@ class GeraLandingWireframeStageExecutionServiceTest {
 
         assertEquals(1, response.size());
         assertEquals(77L, response.get(0).experimentId());
-        assertEquals("job-77", response.get(0).idJob());
+        assertEquals("job-77", response.get(0).jobid());
         assertEquals("landing-page-wireframe", response.get(0).stageCode());
+        assertNotNull(response.get(0).experiment());
+        assertEquals(77L, response.get(0).experiment().id());
+        assertEquals("Experimento Wireframe", response.get(0).experiment().name());
+        assertEquals("Hipótese de valor", response.get(0).experiment().hypothesis());
+        assertEquals("Prompt texto", response.get(0).experiment().creativeTextPrompt());
+        assertEquals("Prompt imagem", response.get(0).experiment().creativeImagePrompt());
+        assertEquals("Ângulo campanha", response.get(0).experiment().campaignAngle());
+        assertEquals("Copy anúncio", response.get(0).experiment().adCopy());
+        assertEquals("Briefing imagem", response.get(0).experiment().adImageBriefing());
+        assertEquals("Copy landing", response.get(0).experiment().landingPageCopy());
+        assertEquals("Wireframe landing", response.get(0).experiment().landingPageWireframe());
+        assertEquals("Planejamento imagem", response.get(0).experiment().landingPageImagePlanning());
+        assertEquals("Preset design", response.get(0).experiment().landingPageDesignPreset());
+        assertEquals("Entregáveis landing", response.get(0).experiment().landingPageDeliverables());
+        assertEquals("<html>GeraLanding</html>", response.get(0).experiment().htmlGeraLanding());
+        assertNotNull(response.get(0).hypothesis());
+        assertEquals(hypothesisId, response.get(0).hypothesis().id());
+        assertEquals("Hipótese Framework", response.get(0).hypothesis().title());
+        assertEquals("v1", response.get(0).hypothesis().framework().get("version"));
+        assertEquals("Dor superficial", ((Map<?, ?>) response.get(0).hypothesis().framework().get("pain")).get("surface"));
+        assertEquals("Resultado desejado", ((Map<?, ?>) response.get(0).hypothesis().framework().get("result")).get("desiredResult"));
+        assertTrue(response.get(0).hypothesis().framework().containsKey("mechanism"));
+        assertTrue(response.get(0).hypothesis().framework().containsKey("proof"));
+        assertTrue(response.get(0).hypothesis().framework().containsKey("offer"));
+        assertTrue(response.get(0).hypothesis().framework().containsKey("checklist"));
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -1,14 +1,21 @@
 package com.marketinghub.geralanding.wireframe.web;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
+import com.marketinghub.geralanding.wireframe.service.RecordWireframeExperiment;
+import com.marketinghub.geralanding.wireframe.service.RecordWireframeHypothesis;
 import com.marketinghub.geralanding.wireframe.service.RecordWireframePending;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 /** Valida o contrato do controller de backend da etapa wireframe. */
@@ -21,12 +28,86 @@ class BackendWireframeControllerTest {
         GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
         BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
         List<RecordWireframePending> pending = List.of(
-                new RecordWireframePending(12L, "job-12", "landing-page-wireframe"));
+                new RecordWireframePending(
+                        12L,
+                        "job-12",
+                        "landing-page-wireframe",
+                        pendingExperiment(12L, "Experimento 12", "Hipótese"),
+                        pendingHypothesis()));
         when(executionService.listPending("landing-page-wireframe")).thenReturn(pending);
 
         List<RecordWireframePending> response = controller.pending();
 
         assertEquals(pending, response);
         verify(executionService).listPending("landing-page-wireframe");
+    }
+
+    /** Deve serializar pending como lista com atributos experiment e jobid em cada item. */
+    @Test
+    void pendingShouldSerializeListItemsWithExperimentAndJobid() throws Exception {
+        GeraLandingWireframeStageService stageService = mock(GeraLandingWireframeStageService.class);
+        GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
+        BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
+        when(executionService.listPending("landing-page-wireframe")).thenReturn(List.of(
+                new RecordWireframePending(
+                        33L,
+                        "bbed57d0-dcc7-40ab-b936-20a19e21c7fe",
+                        "landing-page-wireframe",
+                        pendingExperiment(33L, "Experimento 33", "Hipótese 33"),
+                        pendingHypothesis())));
+
+        JsonNode json = new ObjectMapper().valueToTree(controller.pending());
+
+        assertTrue(json.isArray());
+        assertEquals(1, json.size());
+        assertTrue(json.get(0).has("experiment"));
+        assertTrue(json.get(0).has("jobid"));
+        assertEquals("bbed57d0-dcc7-40ab-b936-20a19e21c7fe", json.get(0).get("jobid").asText());
+        assertEquals(33L, json.get(0).get("experiment").get("id").asLong());
+        assertEquals("Prompt texto", json.get(0).get("experiment").get("creativeTextPrompt").asText());
+        assertEquals("<html>GeraLanding</html>", json.get(0).get("experiment").get("htmlGeraLanding").asText());
+        assertTrue(json.get(0).has("hypothesis"));
+        assertEquals("Hipótese Framework", json.get(0).get("hypothesis").get("title").asText());
+        assertEquals("Dor superficial", json.get(0).get("hypothesis").get("framework").get("pain").get("surface").asText());
+        assertTrue(json.get(0).get("hypothesis").get("framework").has("result"));
+        assertTrue(json.get(0).get("hypothesis").get("framework").has("mechanism"));
+        assertTrue(json.get(0).get("hypothesis").get("framework").has("proof"));
+        assertTrue(json.get(0).get("hypothesis").get("framework").has("offer"));
+        assertTrue(json.get(0).get("hypothesis").get("framework").has("checklist"));
+    }
+
+    /** Cria a hipótese usada pelos testes de contrato pending. */
+    private RecordWireframeHypothesis pendingHypothesis() {
+        return new RecordWireframeHypothesis(
+                UUID.fromString("11111111-1111-1111-1111-111111111111"),
+                "Hipótese Framework",
+                Map.of(
+                        "pain", Map.of("surface", "Dor superficial"),
+                        "result", Map.of("desiredResult", "Resultado desejado"),
+                        "mechanism", Map.of("core", "Mecanismo central"),
+                        "proof", Map.of("type", "Prova"),
+                        "offer", Map.of("name", "Oferta"),
+                        "checklist", Map.of("painReady", true)));
+    }
+
+    /** Cria o resumo de experimento usado pelos testes de contrato pending. */
+    private RecordWireframeExperiment pendingExperiment(Long id, String name, String hypothesis) {
+        return new RecordWireframeExperiment(
+                id,
+                name,
+                hypothesis,
+                "PLANNED",
+                "LANDING",
+                "Prompt texto",
+                "Prompt imagem",
+                "Ângulo campanha",
+                "Copy anúncio",
+                "Briefing imagem",
+                "Copy landing",
+                "Wireframe landing",
+                "Planejamento imagem",
+                "Preset design",
+                "Entregáveis landing",
+                "<html>GeraLanding</html>");
     }
 }

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -32,4 +32,11 @@ GET /api/internal/geralanding/wireframe/stage-executions/pending
 
 O endpoint fica no `BackendWireframeController`, usa o método `pending` e retorna uma lista de
 `RecordWireframePending` com os jobs da etapa `landing-page-wireframe` com status `INICIADO`, em ordem
-crescente de solicitação de execução.
+crescente de solicitação de execução. Cada item da lista deve conter, no mínimo, os atributos `jobid`,
+`experiment` e `hypothesis`. O atributo `experiment` deve expor os dados necessários para o consumidor
+da fila identificar o experimento e usar os artefatos já gerados: `id`, `name`, `hypothesis`, `status`,
+`stage`, `creativeTextPrompt`, `creativeImagePrompt`, `campaignAngle`, `adCopy`, `adImageBriefing`,
+`landingPageCopy`, `landingPageWireframe`, `landingPageImagePlanning`, `landingPageDesignPreset`,
+`landingPageDeliverables` e `htmlGeraLanding`. O atributo `hypothesis` deve expor `id`, `title` e
+`framework` com todos os itens canônicos do framework Dor → Resultado → Mecanismo → Prova → Oferta:
+`pain`, `result`, `mechanism`, `proof`, `offer` e `checklist`.

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -368,14 +368,125 @@ components:
         experimentId:
           type: integer
           format: int64
-        idJob:
+        jobid:
           type: string
+          description: Identificador do job pendente na etapa wireframe.
         stageCode:
           type: string
+        experiment:
+          $ref: '#/components/schemas/PendingStageExperiment'
+        hypothesis:
+          $ref: '#/components/schemas/PendingStageHypothesis'
       required:
         - experimentId
-        - idJob
+        - jobid
         - stageCode
+        - experiment
+        - hypothesis
+    PendingStageExperiment:
+      type: object
+      additionalProperties: false
+      description: Dados do experimento associados ao job pendente de wireframe.
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          nullable: true
+        hypothesis:
+          type: string
+          nullable: true
+        status:
+          type: string
+          nullable: true
+        stage:
+          type: string
+          nullable: true
+        creativeTextPrompt:
+          type: string
+          nullable: true
+        creativeImagePrompt:
+          type: string
+          nullable: true
+        campaignAngle:
+          type: string
+          nullable: true
+        adCopy:
+          type: string
+          nullable: true
+        adImageBriefing:
+          type: string
+          nullable: true
+        landingPageCopy:
+          type: string
+          nullable: true
+        landingPageWireframe:
+          type: string
+          nullable: true
+        landingPageImagePlanning:
+          type: string
+          nullable: true
+        landingPageDesignPreset:
+          type: string
+          nullable: true
+        landingPageDeliverables:
+          type: string
+          nullable: true
+        htmlGeraLanding:
+          type: string
+          nullable: true
+      required:
+        - id
+    PendingStageHypothesis:
+      type: object
+      additionalProperties: false
+      description: Hipótese e framework canônico associados ao job pendente de wireframe.
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        framework:
+          $ref: '#/components/schemas/PendingStageHypothesisFramework'
+      required:
+        - framework
+    PendingStageHypothesisFramework:
+      type: object
+      additionalProperties: true
+      description: Framework Dor → Resultado → Mecanismo → Prova → Oferta da hipótese.
+      properties:
+        version:
+          type: string
+          nullable: true
+        pain:
+          type: object
+          additionalProperties: true
+        result:
+          type: object
+          additionalProperties: true
+        mechanism:
+          type: object
+          additionalProperties: true
+        proof:
+          type: object
+          additionalProperties: true
+        offer:
+          type: object
+          additionalProperties: true
+        checklist:
+          type: object
+          additionalProperties: true
+      required:
+        - pain
+        - result
+        - mechanism
+        - proof
+        - offer
+        - checklist
     StageExecutionSummary:
       type: object
       required:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2217,3 +2217,35 @@
 - Ajustado `BackendWireframeController.pending` para retornar diretamente `List<RecordWireframePending>`.
 - Registrada no cânone de arquitetura por etapa a regra `Backend<Etapa>Controller.pending -> List<Record<Etapa>Pending>`.
 - Atualizado `ArquiteturaTest` para validar o contrato genérico do método `pending` por etapa.
+
+## 2026-05-28 21:55:00 UTC
+- solicitação: incluir o experimento junto aos itens pendentes da etapa `landing-page-wireframe` e garantir teste para atributos `experiment` e `jobid` no retorno de `pending`.
+- causa-raiz tratada: o contrato interno global de pendências expunha apenas identificadores mínimos (`experimentId`, `idJob`/etapa), obrigando consumidores a buscar o experimento em chamada separada para identificar contexto básico do job.
+- correção aplicada:
+  - o record `RecordWireframePending` passou a expor `jobid`, `stageCode`, `experimentId` e o resumo `experiment`;
+  - criado `RecordWireframeExperiment` com os campos mínimos do experimento necessários para identificação do job pendente;
+  - o serviço de execução de wireframe passou a montar o resumo do experimento a partir da execução carregada;
+  - a consulta de pendências no repositório passou a carregar o relacionamento `experiment` via `EntityGraph` para evitar consulta adicional por item;
+  - o cânone de arquitetura por etapa e o Swagger canônico do GeraLanding foram atualizados com o novo contrato de pending;
+  - adicionados testes garantindo os dados do experimento no service e a serialização da resposta como lista contendo `experiment` e `jobid`.
+
+## 2026-05-28 22:20:00 UTC
+- solicitação: ampliar o objeto `experiment` retornado pelo pending de `landing-page-wireframe` com artefatos de criação usados no fluxo e levantar os campos existentes de hipótese.
+- causa-raiz tratada: o resumo anterior do experimento ainda era insuficiente para consumidores da fila reaproveitarem contexto de prompts, anúncios e etapas já geradas sem novas chamadas ao backend.
+- correção aplicada:
+  - `RecordWireframeExperiment` passou a incluir `creativeTextPrompt`, `creativeImagePrompt`, `campaignAngle`, `adCopy`, `adImageBriefing`, `landingPageCopy`, `landingPageWireframe`, `landingPageImagePlanning`, `landingPageDesignPreset`, `landingPageDeliverables` e `htmlGeraLanding`;
+  - o mapeamento de pending da etapa wireframe passou a preencher esses campos a partir da entidade `Experiment` carregada pela execução;
+  - os testes do service e do controller foram atualizados para validar os novos campos serializados no objeto `experiment`;
+  - o cânone de arquitetura por etapa e o Swagger canônico do GeraLanding foram atualizados com os novos campos do contrato;
+  - os campos da tabela/entidade/DTO de hipótese foram levantados para orientar a próxima decisão de contrato.
+
+## 2026-05-28 22:45:00 UTC
+- solicitação: incluir `hypothesis.framework` com todos os itens canônicos no retorno da lista de pendentes da etapa `landing-page-wireframe`.
+- causa-raiz tratada: o payload de pending já carregava o experimento, mas ainda não entregava o framework da hipótese no mesmo contrato, obrigando consumidores da fila a buscar a hipótese separadamente para obter Dor → Resultado → Mecanismo → Prova → Oferta.
+- correção aplicada:
+  - `RecordWireframePending` passou a incluir o atributo `hypothesis` além de `experiment`;
+  - criado `RecordWireframeHypothesis` com `id`, `title` e `framework`;
+  - o serviço de wireframe passou a resolver `hypothesis.framework` a partir do JSON da hipótese e garantir presença dos blocos `pain`, `result`, `mechanism`, `proof`, `offer` e `checklist`;
+  - a entidade `Experiment` passou a expor métodos operacionais para acessar id, título e framework JSON da hipótese associada sem acoplar o serviço da etapa ao pacote de hipótese;
+  - a consulta de pending passou a carregar `experiment.hypothesisRef` junto com o experimento;
+  - testes do service/controller, cânone de arquitetura por etapa e Swagger canônico foram atualizados para o novo contrato.


### PR DESCRIPTION
### Motivation
- Provide a global, experiment-independent pending queue for the GeraLanding wireframe stage that contains enough context for the Worker AI to process jobs without additional backend calls. 
- Avoid extra lookups by exposing a compact experiment summary and the hypothesis framework alongside the job identifier in the pending endpoint.

### Description
- Added three new record types: `RecordWireframePending` now includes `jobid`, `stageCode`, `RecordWireframeExperiment experiment` and `RecordWireframeHypothesis hypothesis`, and new records `RecordWireframeExperiment` and `RecordWireframeHypothesis` model the payload. 
- Extended `GeraLandingWireframeStageExecutionService` to populate the `experiment` summary and resolve `hypothesis.framework` JSON into a canonical map while ensuring canonical sections (`pain`, `result`, `mechanism`, `proof`, `offer`, `checklist`), and added an `ObjectMapper` and logging for JSON parsing. 
- Updated `GeraLandingStageExecutionRepository` to eagerly load `experiment` and `experiment.hypothesisRef` via `@EntityGraph` to avoid N+1 queries. 
- Exposed lightweight hypothesis accessors on `Experiment` (`getHypothesisRefIdForPending`, `getHypothesisRefTitleForPending`, `getHypothesisFrameworkJsonForPending`) to avoid coupling the wireframe service to the hypothesis package. 
- Updated controller contract, canonical docs, and Swagger schema to reflect the new pending payload fields and added/updated unit tests for service and controller behavior.

### Testing
- Ran `GeraLandingWireframeStageExecutionServiceTest` which asserts mapping of pending job to `RecordWireframePending` with `experiment` and `hypothesis` populated, and it passed. 
- Ran `BackendWireframeControllerTest` which verifies the controller returns a JSON array with `experiment` and `jobid` attributes and it passed. 
- Project compiles and unit tests covering the modified classes succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a9b06fa08321b1ad7a9f974c9264)