### PR TITLE
Preserva JSON estruturado no pending do wireframe

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionService.java
@@ -105,15 +105,36 @@ public class GeraLandingWireframeStageExecutionService {
                 enumValueToText(experiment.getStage()),
                 experiment.getCreativeTextPrompt(),
                 experiment.getCreativeImagePrompt(),
-                experiment.getCampaignAngle(),
-                experiment.getAdCopy(),
-                experiment.getAdImageBriefing(),
-                experiment.getLandingPageCopy(),
-                experiment.getLandingPageWireframe(),
-                experiment.getLandingPageImagePlanning(),
-                experiment.getLandingPageDesignPreset(),
-                experiment.getLandingPageDeliverables(),
+                resolveJsonArtifact(experiment.getId(), "campaignAngle", experiment.getCampaignAngle()),
+                resolveJsonArtifact(experiment.getId(), "adCopy", experiment.getAdCopy()),
+                resolveJsonArtifact(experiment.getId(), "adImageBriefing", experiment.getAdImageBriefing()),
+                resolveJsonArtifact(experiment.getId(), "landingPageCopy", experiment.getLandingPageCopy()),
+                resolveJsonArtifact(experiment.getId(), "landingPageWireframe", experiment.getLandingPageWireframe()),
+                resolveJsonArtifact(experiment.getId(), "landingPageImagePlanning", experiment.getLandingPageImagePlanning()),
+                resolveJsonArtifact(experiment.getId(), "landingPageDesignPreset", experiment.getLandingPageDesignPreset()),
+                resolveJsonArtifact(experiment.getId(), "landingPageDeliverables", experiment.getLandingPageDeliverables()),
                 experiment.getHtmlGeraLanding());
+    }
+
+    /** Preserva artefatos JSON como objetos estruturados na fila pending, mantendo textos não JSON intactos. */
+    private Object resolveJsonArtifact(Long experimentId, String fieldName, String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return rawValue;
+        }
+        String trimmed = rawValue.trim();
+        if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+            return rawValue;
+        }
+        try {
+            return objectMapper.readValue(trimmed, Object.class);
+        } catch (JsonProcessingException ex) {
+            log.warn(
+                    "Falha ao ler artefato JSON no pending wireframe; mantendo texto bruto. experimentId={} fieldName={}",
+                    experimentId,
+                    fieldName,
+                    ex);
+            return rawValue;
+        }
     }
 
     /** Converte a hipótese associada ao experimento para o framework exposto na fila pending. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframeExperiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframeExperiment.java
@@ -9,14 +9,14 @@ public record RecordWireframeExperiment(
         String stage,
         String creativeTextPrompt,
         String creativeImagePrompt,
-        String campaignAngle,
-        String adCopy,
-        String adImageBriefing,
-        String landingPageCopy,
-        String landingPageWireframe,
-        String landingPageImagePlanning,
-        String landingPageDesignPreset,
-        String landingPageDeliverables,
+        Object campaignAngle,
+        Object adCopy,
+        Object adImageBriefing,
+        Object landingPageCopy,
+        Object landingPageWireframe,
+        Object landingPageImagePlanning,
+        Object landingPageDesignPreset,
+        Object landingPageDeliverables,
         String htmlGeraLanding
 ) {
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageExecutionServiceTest.java
@@ -34,11 +34,11 @@ class GeraLandingWireframeStageExecutionServiceTest {
         when(experiment.getHypothesis()).thenReturn("Hipótese de valor");
         when(experiment.getCreativeTextPrompt()).thenReturn("Prompt texto");
         when(experiment.getCreativeImagePrompt()).thenReturn("Prompt imagem");
-        when(experiment.getCampaignAngle()).thenReturn("Ângulo campanha");
-        when(experiment.getAdCopy()).thenReturn("Copy anúncio");
+        when(experiment.getCampaignAngle()).thenReturn("{\"campaignAngle\":{\"singleMindedPromise\":\"Promessa clara\"}}");
+        when(experiment.getAdCopy()).thenReturn("{\"adCopy\":{\"headline\":\"Headline\"}}");
         when(experiment.getAdImageBriefing()).thenReturn("Briefing imagem");
-        when(experiment.getLandingPageCopy()).thenReturn("Copy landing");
-        when(experiment.getLandingPageWireframe()).thenReturn("Wireframe landing");
+        when(experiment.getLandingPageCopy()).thenReturn("{\"landingPageCopy\":{\"hero\":{\"headline\":\"Hero\"}}}");
+        when(experiment.getLandingPageWireframe()).thenReturn("{\"landingPageWireframe\":{\"sectionOrder\":[\"hero\"]}}");
         when(experiment.getLandingPageImagePlanning()).thenReturn("Planejamento imagem");
         when(experiment.getLandingPageDesignPreset()).thenReturn("Preset design");
         when(experiment.getLandingPageDeliverables()).thenReturn("Entregáveis landing");
@@ -82,11 +82,17 @@ class GeraLandingWireframeStageExecutionServiceTest {
         assertEquals("Hipótese de valor", response.get(0).experiment().hypothesis());
         assertEquals("Prompt texto", response.get(0).experiment().creativeTextPrompt());
         assertEquals("Prompt imagem", response.get(0).experiment().creativeImagePrompt());
-        assertEquals("Ângulo campanha", response.get(0).experiment().campaignAngle());
-        assertEquals("Copy anúncio", response.get(0).experiment().adCopy());
+        Map<?, ?> campaignAngle = (Map<?, ?>) response.get(0).experiment().campaignAngle();
+        assertEquals("Promessa clara", ((Map<?, ?>) campaignAngle.get("campaignAngle")).get("singleMindedPromise"));
+        Map<?, ?> adCopy = (Map<?, ?>) response.get(0).experiment().adCopy();
+        assertEquals("Headline", ((Map<?, ?>) adCopy.get("adCopy")).get("headline"));
         assertEquals("Briefing imagem", response.get(0).experiment().adImageBriefing());
-        assertEquals("Copy landing", response.get(0).experiment().landingPageCopy());
-        assertEquals("Wireframe landing", response.get(0).experiment().landingPageWireframe());
+        Map<?, ?> landingPageCopy = (Map<?, ?>) response.get(0).experiment().landingPageCopy();
+        assertEquals(
+                "Hero",
+                ((Map<?, ?>) ((Map<?, ?>) landingPageCopy.get("landingPageCopy")).get("hero")).get("headline"));
+        Map<?, ?> landingPageWireframe = (Map<?, ?>) response.get(0).experiment().landingPageWireframe();
+        assertEquals(List.of("hero"), ((Map<?, ?>) landingPageWireframe.get("landingPageWireframe")).get("sectionOrder"));
         assertEquals("Planejamento imagem", response.get(0).experiment().landingPageImagePlanning());
         assertEquals("Preset design", response.get(0).experiment().landingPageDesignPreset());
         assertEquals("Entregáveis landing", response.get(0).experiment().landingPageDeliverables());

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -65,6 +65,10 @@ class BackendWireframeControllerTest {
         assertEquals("bbed57d0-dcc7-40ab-b936-20a19e21c7fe", json.get(0).get("jobid").asText());
         assertEquals(33L, json.get(0).get("experiment").get("id").asLong());
         assertEquals("Prompt texto", json.get(0).get("experiment").get("creativeTextPrompt").asText());
+        assertTrue(json.get(0).get("experiment").get("campaignAngle").isObject());
+        assertEquals(
+                "Promessa clara",
+                json.get(0).get("experiment").get("campaignAngle").get("campaignAngle").get("singleMindedPromise").asText());
         assertEquals("<html>GeraLanding</html>", json.get(0).get("experiment").get("htmlGeraLanding").asText());
         assertTrue(json.get(0).has("hypothesis"));
         assertEquals("Hipótese Framework", json.get(0).get("hypothesis").get("title").asText());
@@ -100,8 +104,8 @@ class BackendWireframeControllerTest {
                 "LANDING",
                 "Prompt texto",
                 "Prompt imagem",
-                "Ângulo campanha",
-                "Copy anúncio",
+                Map.of("campaignAngle", Map.of("singleMindedPromise", "Promessa clara")),
+                Map.of("adCopy", Map.of("headline", "Headline")),
                 "Briefing imagem",
                 "Copy landing",
                 "Wireframe landing",

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -37,6 +37,21 @@ crescente de solicitação de execução. Cada item da lista deve conter, no mí
 da fila identificar o experimento e usar os artefatos já gerados: `id`, `name`, `hypothesis`, `status`,
 `stage`, `creativeTextPrompt`, `creativeImagePrompt`, `campaignAngle`, `adCopy`, `adImageBriefing`,
 `landingPageCopy`, `landingPageWireframe`, `landingPageImagePlanning`, `landingPageDesignPreset`,
-`landingPageDeliverables` e `htmlGeraLanding`. O atributo `hypothesis` deve expor `id`, `title` e
-`framework` com todos os itens canônicos do framework Dor → Resultado → Mecanismo → Prova → Oferta:
-`pain`, `result`, `mechanism`, `proof`, `offer` e `checklist`.
+`landingPageDeliverables` e `htmlGeraLanding`. Campos de artefato que armazenam JSON textual no banco
+(`campaignAngle`, `adCopy`, `adImageBriefing`, `landingPageCopy`, `landingPageWireframe`,
+`landingPageImagePlanning`, `landingPageDesignPreset` e `landingPageDeliverables`) devem ser
+serializados no contrato `pending` como JSON estruturado sempre que o conteúdo for JSON válido, e não
+como string contendo JSON escapado. Apenas conteúdo realmente textual ou JSON inválido pode permanecer
+como string bruta, com log de diagnóstico no caso inválido. O atributo `hypothesis` deve expor `id`,
+`title` e `framework` com todos os itens canônicos do framework Dor → Resultado → Mecanismo → Prova →
+Oferta: `pain`, `result`, `mechanism`, `proof`, `offer` e `checklist`.
+
+## Regra global — JSON estruturado em contratos internos
+
+Sempre que um endpoint interno expuser dados que são artefatos JSON persistidos em colunas textuais, a
+camada de contrato deve reidratar o conteúdo para objeto/array JSON antes de serializar a resposta. É
+proibido publicar JSON dentro de string em listas `pending`, callbacks de worker ou payloads de etapa,
+pois isso quebra o contrato semântico do consumidor, dificulta validação por schema e pode causar perda
+de estrutura em campos como `campaignAngle`. O padrão obrigatório é: detectar conteúdo JSON válido,
+converter com `ObjectMapper`/parser equivalente, manter campos textuais como texto e registrar log com
+contexto operacional quando um campo aparentemente JSON não puder ser convertido.

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -410,34 +410,35 @@ components:
           type: string
           nullable: true
         campaignAngle:
-          type: string
-          nullable: true
+          $ref: '#/components/schemas/JsonBackedArtifact'
         adCopy:
-          type: string
-          nullable: true
+          $ref: '#/components/schemas/JsonBackedArtifact'
         adImageBriefing:
-          type: string
-          nullable: true
+          $ref: '#/components/schemas/JsonBackedArtifact'
         landingPageCopy:
-          type: string
-          nullable: true
+          $ref: '#/components/schemas/JsonBackedArtifact'
         landingPageWireframe:
-          type: string
-          nullable: true
+          $ref: '#/components/schemas/JsonBackedArtifact'
         landingPageImagePlanning:
-          type: string
-          nullable: true
+          $ref: '#/components/schemas/JsonBackedArtifact'
         landingPageDesignPreset:
-          type: string
-          nullable: true
+          $ref: '#/components/schemas/JsonBackedArtifact'
         landingPageDeliverables:
-          type: string
-          nullable: true
+          $ref: '#/components/schemas/JsonBackedArtifact'
         htmlGeraLanding:
           type: string
           nullable: true
       required:
         - id
+    JsonBackedArtifact:
+      description: Artefato persistido em coluna textual, mas exposto como JSON estruturado quando o conteúdo armazenado for JSON válido; texto bruto só é aceito para conteúdo realmente textual ou fallback de diagnóstico.
+      nullable: true
+      oneOf:
+        - type: object
+          additionalProperties: true
+        - type: array
+          items: {}
+        - type: string
     PendingStageHypothesis:
       type: object
       additionalProperties: false

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2249,3 +2249,15 @@
   - a entidade `Experiment` passou a expor métodos operacionais para acessar id, título e framework JSON da hipótese associada sem acoplar o serviço da etapa ao pacote de hipótese;
   - a consulta de pending passou a carregar `experiment.hypothesisRef` junto com o experimento;
   - testes do service/controller, cânone de arquitetura por etapa e Swagger canônico foram atualizados para o novo contrato.
+
+## 2026-05-29 00:05:00 UTC
+- solicitação: ajustar a lista `pending` da etapa `landing-page-wireframe` para não serializar artefatos JSON como strings escapadas, evitando perda de estrutura em `campaignAngle` e campos equivalentes.
+- causa-raiz tratada: artefatos persistidos em colunas textuais eram repassados diretamente pelo contrato interno de pending, gerando JSON dentro de string e obrigando consumidores a reparsear campos que deveriam chegar estruturados.
+- correção aplicada:
+  - `RecordWireframeExperiment` passou a aceitar artefatos como `Object` nos campos JSON-backed;
+  - o serviço de wireframe passou a reidratar JSON válido de `campaignAngle`, `adCopy`, `adImageBriefing`, `landingPageCopy`, `landingPageWireframe`, `landingPageImagePlanning`, `landingPageDesignPreset` e `landingPageDeliverables` antes de serializar a resposta;
+  - conteúdo textual real permanece como string e JSON aparentemente inválido gera log com `experimentId` e nome do campo;
+  - o cânone de arquitetura por etapa e o Swagger canônico do GeraLanding foram atualizados para proibir JSON dentro de string nos contratos internos;
+  - testes do service e do controller foram atualizados para validar `campaignAngle` e demais artefatos como JSON estruturado no pending.
+- validação executada:
+  - `./../mvnw -Dtest=GeraLandingWireframeStageExecutionServiceTest,BackendWireframeControllerTest test` em `backend/ads-service/`.


### PR DESCRIPTION
### Motivation
- Corrigir perda de estrutura quando artefatos JSON armazenados em colunas textuais (ex.: `campaignAngle`) eram servidos como string com JSON escapado no endpoint interno `pending`. 
- Garantir que consumidores da fila (`Worker AI`) recebam objetos/arrays JSON válidos em vez de JSON serializado dentro de `String`, facilitando validação por schema e evitando reparse/destruição de campos.

### Description
- Ajusta o resumo `RecordWireframeExperiment` para expor campos JSON-backed como `Object` em vez de `String` para permitir envio de JSON estruturado (`backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordWireframeExperiment.java`).
- Adiciona a função `resolveJsonArtifact(...)` que tenta reidratar texto JSON válido com `ObjectMapper` e retorna o texto bruto apenas quando não for JSON ou ocorrer erro, com log contextual (`GeraLandingWireframeStageExecutionService.java`).
- Atualiza o mapeamento do `pending` para usar `resolveJsonArtifact(...)` em `campaignAngle`, `adCopy`, `landingPageWireframe` e demais campos JSON-backed, preservando textos realmente textuais (`GeraLandingWireframeStageExecutionService.java`).
- Sincroniza documentação e contratos: atualiza o cânone de arquitetura por etapa (`docs/canonical/arquitetura-etapas.md`) com a regra de reidratar JSON em contratos internos e atualiza o Swagger canônico (`docs/canonical/geralanding-backend-swagger.v1.yaml`) adicionando o schema `JsonBackedArtifact`; também registra a alteração em `docs/registros/experimentos.md`.
- Ajusta e estende testes unitários do serviço e do controller para validar que `campaignAngle`, `adCopy`, `landingPageCopy` e `landingPageWireframe` chegam como JSON estruturado no `pending` (testes modificados: `GeraLandingWireframeStageExecutionServiceTest` e `BackendWireframeControllerTest`).

### Testing
- Executado `./../mvnw -Dtest=GeraLandingWireframeStageExecutionServiceTest,BackendWireframeControllerTest test` em `backend/ads-service` e todos os testes selecionados passaram (3 tests, 0 failures). 
- Validado o Swagger/YAML com `ruby -e "require 'yaml'; YAML.load_file('docs/canonical/geralanding-backend-swagger.v1.yaml'); puts 'ok'"` que retornou `ok` indicando YAML válido. 
- Resultado: testes automatizados executados com sucesso e documentação sincronizada。」}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d70fcb408321a0c2f8cade293240)