### PR TITLE
ai-worker: consume fila interna de pending de wireframe e preservar JSON de prompt

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
@@ -5,8 +5,6 @@ import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecuti
 import com.marketinghub.worker.geralanding.wireframe.response.RecordWireframeResponse;
 import com.marketinghub.worker.util.UrlUtils;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,71 +36,39 @@ public class GeraLandingWireframeBackendClient {
         this.objectMapper = objectMapper;
     }
 
-    /** Lista execuções pendentes da etapa wireframe usando os endpoints de experimento expostos pelo backend. */
+    /** Lista execuções pendentes da etapa wireframe usando a fila interna canônica do backend. */
     public List<GeraLandingStageExecutionDetailDto> listPendingExecutions(int limit) {
         int effectiveLimit = Math.max(1, limit);
-        List<Map<String, Object>> experiments = listExperiments();
-        List<GeraLandingStageExecutionDetailDto> pending = new ArrayList<>();
-        for (Map<String, Object> experiment : experiments) {
-            Long experimentId = asLong(experiment.get("id"));
-            if (experimentId == null) {
-                continue;
-            }
-            pending.addAll(listPendingExecutionsForExperiment(experimentId));
-        }
-        return pending.stream()
-                .sorted(Comparator.comparing(
-                        GeraLandingStageExecutionDetailDto::executionRequestedAt,
-                        Comparator.nullsLast(Comparator.naturalOrder())))
-                .limit(effectiveLimit)
-                .toList();
-    }
-
-    /** Lista os experimentos para descobrir os ids necessários ao endpoint de wireframe por experimento. */
-    private List<Map<String, Object>> listExperiments() {
-        String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/experiments");
+        String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/wireframe/stage-executions/pending");
         List<Map<String, Object>> payload = webClient.get()
                 .uri(uri)
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
-                .doOnError(err -> log.error("Falha ao buscar experimentos para pendências wireframe. uri={}", uri, err))
-                .onErrorReturn(List.of())
-                .block();
-        return payload != null ? payload : List.of();
-    }
-
-    /** Lista as execuções abertas de wireframe de um experimento usando a URL canônica atual do backend. */
-    private List<GeraLandingStageExecutionDetailDto> listPendingExecutionsForExperiment(Long experimentId) {
-        String uri = UrlUtils.joinPath(
-                backendBaseUrl,
-                apiPrefix,
-                "/experiments/" + experimentId + "/geralanding/wireframe/stage-executions") + "?includeCompleted=false";
-        List<Map<String, Object>> payload = webClient.get()
-                .uri(uri)
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
-                .doOnError(err -> log.error("Falha ao buscar execuções pendentes wireframe por experimento. uri={}", uri, err))
+                .doOnError(err -> log.error("Falha ao buscar fila interna de pendências wireframe. uri={}", uri, err))
                 .onErrorReturn(List.of())
                 .block();
         if (payload == null || payload.isEmpty()) {
             return List.of();
         }
         return payload.stream()
-                .map(item -> toPendingExecutionDto(experimentId, item))
+                .map(this::toPendingExecutionDto)
+                .filter(item -> item.experimentId() != null && item.idJob() != null)
+                .limit(effectiveLimit)
                 .toList();
     }
 
-    /** Converte o resumo da listagem pública de wireframe para o DTO consumido pelo scheduler da etapa. */
-    private GeraLandingStageExecutionDetailDto toPendingExecutionDto(Long experimentId, Map<String, Object> item) {
+    /** Converte o item da fila interna de wireframe para o DTO consumido pelo scheduler da etapa. */
+    private GeraLandingStageExecutionDetailDto toPendingExecutionDto(Map<String, Object> item) {
         return new GeraLandingStageExecutionDetailDto(
-                experimentId,
-                "landing-page-wireframe",
-                asString(item.get("idJob")),
-                asString(item.get("status")),
-                asInstant(item.get("executionRequestedAt")),
+                asLong(item.get("experimentId")),
+                asString(item.get("stageCode")),
+                asString(item.get("jobid")),
+                "INICIADO",
                 null,
                 null,
-                asString(item.get("openAiJobId")));
+                null,
+                null,
+                buildPromptDataFromPending(item));
     }
 
     /** Carrega os dados de prompt para a geração wireframe a partir do experimento. */
@@ -128,6 +94,31 @@ public class GeraLandingWireframeBackendClient {
         payload.put("landingPageWireframe", parseJsonField(experiment.get("landingPageWireframe")));
         payload.put("NICHE_NAME", resolveNicheName(experiment.get("nicheId")));
         populateHypothesisFields(payload, experiment.get("nicheId"), experiment.get("hypothesisId"));
+        return payload;
+    }
+
+    /** Carrega os dados de prompt preferindo o JSON estruturado recebido da fila interna pending. */
+    public Map<String, Object> loadPromptData(GeraLandingStageExecutionDetailDto execution) {
+        if (execution != null && execution.promptData() != null && !execution.promptData().isEmpty()) {
+            return execution.promptData();
+        }
+        return execution != null ? loadPromptData(execution.experimentId()) : Map.of();
+    }
+
+    /** Monta os dados de prompt a partir do contrato PendingStageExecution enviado pelo backend. */
+    private Map<String, Object> buildPromptDataFromPending(Map<String, Object> pending) {
+        Map<String, Object> experiment = asMap(pending.get("experiment"));
+        Map<String, Object> hypothesis = asMap(pending.get("hypothesis"));
+        Map<String, Object> framework = asMap(hypothesis.get("framework"));
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("campaignAngle", normalizeJsonArtifact(experiment.get("campaignAngle")));
+        payload.put("adCopy", normalizeJsonArtifact(experiment.get("adCopy")));
+        payload.put("adImageBriefing", normalizeJsonArtifact(experiment.get("adImageBriefing")));
+        payload.put("landingPageWireframe", normalizeJsonArtifact(experiment.get("landingPageWireframe")));
+        payload.put("NICHE_NAME", firstText(experiment.get("nicheName"), experiment.get("niche"), experiment.get("name")));
+        payload.put("PAIN_JSON", framework.getOrDefault("pain", Map.of()));
+        payload.put("RESULT_JSON", framework.getOrDefault("result", Map.of()));
         return payload;
     }
 
@@ -218,6 +209,38 @@ public class GeraLandingWireframeBackendClient {
         String nicheUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/niches/" + nicheId);
         Map<String, Object> niche = webClient.get().uri(nicheUrl).retrieve().bodyToMono(Map.class).onErrorReturn(Map.of()).block();
         return niche != null && niche.get("name") != null ? String.valueOf(niche.get("name")) : "";
+    }
+
+    /** Converte objetos genéricos de JSON em mapa quando possível, ou retorna mapa vazio. */
+    private Map<String, Object> asMap(Object value) {
+        if (value instanceof Map<?, ?> rawMap) {
+            Map<String, Object> converted = new LinkedHashMap<>();
+            rawMap.forEach((key, rawValue) -> {
+                if (key != null) {
+                    converted.put(String.valueOf(key), rawValue);
+                }
+            });
+            return converted;
+        }
+        return Map.of();
+    }
+
+    /** Normaliza artefatos recebidos da fila pending preservando JSON estruturado e convertendo strings JSON legadas. */
+    private Object normalizeJsonArtifact(Object value) {
+        if (value instanceof String text) {
+            return parseJsonField(text);
+        }
+        return value != null ? value : Map.of();
+    }
+
+    /** Retorna o primeiro valor textual preenchido entre possíveis nomes vindos do contrato do backend. */
+    private String firstText(Object... values) {
+        for (Object value : values) {
+            if (value != null && !value.toString().isBlank()) {
+                return value.toString();
+            }
+        }
+        return "";
     }
 
     /** Tenta converter campos JSON serializados para mapa, mantendo texto cru quando inválido. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/dto/GeraLandingStageExecutionDetailDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/dto/GeraLandingStageExecutionDetailDto.java
@@ -1,6 +1,9 @@
 package com.marketinghub.worker.geralanding.wireframe.dto;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Responsável por representar os detalhes retornados pelo backend para uma execução de etapa do GeraLanding.
@@ -13,5 +16,26 @@ public record GeraLandingStageExecutionDetailDto(
         Instant executionRequestedAt,
         Instant processingStartedAt,
         Instant completedAt,
-        String openAiJobId) {
+        String openAiJobId,
+        Map<String, Object> promptData) {
+
+    /** Mantém compatibilidade com respostas antigas do backend que não enviam dados de prompt embutidos. */
+    public GeraLandingStageExecutionDetailDto(
+            Long experimentId,
+            String stageCode,
+            String idJob,
+            String status,
+            Instant executionRequestedAt,
+            Instant processingStartedAt,
+            Instant completedAt,
+            String openAiJobId) {
+        this(experimentId, stageCode, idJob, status, executionRequestedAt, processingStartedAt, completedAt, openAiJobId, Map.of());
+    }
+
+    /** Normaliza dados de prompt nulos para um mapa seguro e imutável. */
+    public GeraLandingStageExecutionDetailDto {
+        promptData = promptData != null
+                ? Collections.unmodifiableMap(new LinkedHashMap<>(promptData))
+                : Map.of();
+    }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
@@ -81,7 +81,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
             return;
         }
         try {
-            Map<String, Object> dadosPrompt = backendClient.loadPromptData(execution.experimentId());
+            Map<String, Object> dadosPrompt = backendClient.loadPromptData(execution);
             RecordWireframeRequest requestData = new RecordWireframeRequest(execution.experimentId(), dadosPrompt);
             String prompt = montaRequest.montarPrompt(requestData);
             String requestBody = montaRequest.montar(requestData);

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClientTest.java
@@ -29,13 +29,26 @@ class GeraLandingWireframeBackendClientTest {
     }
 
     @Test
-    void listPendingExecutionsCallsExperimentScopedWireframeUrl() throws Exception {
-        server.enqueue(jsonResponse("[{\"id\":34,\"name\":\"Experimento 34\"}]"));
+    void listPendingExecutionsCallsInternalWireframeQueueAndKeepsStructuredJson() throws Exception {
         server.enqueue(jsonResponse("["
-                + "{\"idJob\":\"ef92d7d2-7d84-4b1e-a5a5-ccf3034da4bd\","
-                + "\"status\":\"INICIADO\","
-                + "\"executionRequestedAt\":\"2026-05-28T16:21:35.330Z\","
-                + "\"costUsd\":null}"
+                + "{\"experimentId\":34,"
+                + "\"jobid\":\"ef92d7d2-7d84-4b1e-a5a5-ccf3034da4bd\","
+                + "\"stageCode\":\"landing-page-wireframe\","
+                + "\"experiment\":{"
+                + "\"id\":34,"
+                + "\"name\":\"Personal trainers\","
+                + "\"campaignAngle\":{\"primaryPromise\":\"Agenda cheia\"},"
+                + "\"adCopy\":{\"headline\":\"Sem desconto\"},"
+                + "\"adImageBriefing\":{\"concept\":\"Calendário lotado\"},"
+                + "\"landingPageWireframe\":null"
+                + "},"
+                + "\"hypothesis\":{"
+                + "\"framework\":{"
+                + "\"pain\":{\"summary\":\"agenda vazia\"},"
+                + "\"result\":{\"summary\":\"agenda cheia\"}"
+                + "}"
+                + "}"
+                + "}"
                 + "]"));
 
         GeraLandingWireframeBackendClient client = new GeraLandingWireframeBackendClient(
@@ -46,14 +59,17 @@ class GeraLandingWireframeBackendClientTest {
 
         List<GeraLandingStageExecutionDetailDto> pending = client.listPendingExecutions(20);
 
-        assertThat(server.takeRequest().getPath()).isEqualTo("/api/experiments");
         assertThat(server.takeRequest().getPath())
-                .isEqualTo("/api/experiments/34/geralanding/wireframe/stage-executions?includeCompleted=false");
+                .isEqualTo("/api/internal/geralanding/wireframe/stage-executions/pending");
         assertThat(pending).hasSize(1);
         assertThat(pending.getFirst().experimentId()).isEqualTo(34L);
         assertThat(pending.getFirst().stageCode()).isEqualTo("landing-page-wireframe");
         assertThat(pending.getFirst().idJob()).isEqualTo("ef92d7d2-7d84-4b1e-a5a5-ccf3034da4bd");
         assertThat(pending.getFirst().status()).isEqualTo("INICIADO");
+        assertThat(pending.getFirst().promptData())
+                .containsKeys("campaignAngle", "adCopy", "adImageBriefing", "landingPageWireframe", "NICHE_NAME", "PAIN_JSON", "RESULT_JSON");
+        assertThat(pending.getFirst().promptData().get("campaignAngle"))
+                .isInstanceOfSatisfying(java.util.Map.class, value -> assertThat(value).containsEntry("primaryPromise", "Agenda cheia"));
     }
 
     /** Cria resposta JSON para simular os endpoints reais do backend. */

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2261,3 +2261,9 @@
   - testes do service e do controller foram atualizados para validar `campaignAngle` e demais artefatos como JSON estruturado no pending.
 - validação executada:
   - `./../mvnw -Dtest=GeraLandingWireframeStageExecutionServiceTest,BackendWireframeControllerTest test` em `backend/ads-service/`.
+
+## 2026-05-29 — Worker AI preparado para fila pending estruturada do wireframe
+
+- Ajustado o client do Worker AI da etapa `landing-page-wireframe` para consumir diretamente o endpoint interno `/api/internal/geralanding/wireframe/stage-executions/pending`, preservando os artefatos JSON estruturados enviados pelo backend (`experiment` e `hypothesis.framework`) sem voltar a depender da varredura por experimento.
+- A montagem dos dados de prompt passou a preferir o JSON já entregue na fila pending, mantendo fallback legado por `experimentId` quando o backend não enviar dados embutidos.
+- Adicionado teste unitário cobrindo o contrato `jobid`, `experiment`, `hypothesis.framework` e a preservação do JSON estruturado no DTO consumido pelo scheduler de wireframe.


### PR DESCRIPTION
### Motivation

- Garantir que o Worker AI da etapa `landing-page-wireframe` consuma a fila interna do backend (`/api/internal/geralanding/wireframe/stage-executions/pending`) em vez de varrer experiments, preservando artefatos JSON estruturados para o prompt. 

### Description

- Alterado `GeraLandingWireframeBackendClient` para chamar diretamente `/api/internal/geralanding/wireframe/stage-executions/pending` e mapear cada item da fila para `GeraLandingStageExecutionDetailDto` em vez de fazer varredura por experimentos. 
- Implementado parsing de `pending` para montar `promptData` (campo `campaignAngle`, `adCopy`, `adImageBriefing`, `landingPageWireframe`, `NICHE_NAME`, `PAIN_JSON`, `RESULT_JSON`) com normalização de JSON/string e helpers (`asMap`, `normalizeJsonArtifact`, `firstText`). 
- Estendido `GeraLandingStageExecutionDetailDto` para incluir `promptData` com construtor de compatibilidade (mantém suporte a payloads legados). 
- Atualizado `GeraLandingWireframeOpenAiExecutionService` para usar `backendClient.loadPromptData(execution)` (preferindo `promptData` embutido no item da fila) em vez de buscar por `experimentId`. 
- Atualizado teste `GeraLandingWireframeBackendClientTest` para validar consumo do endpoint interno e preservação do JSON estruturado no `promptData`. 
- Adicionado registro em `docs/registros/experimentos.md` documentando a adaptação do worker ao contrato da fila `pending`.

### Testing

- Instalado e buildado o backend localmente com `mvn -q -DskipTests install` em `backend/ads-service` para disponibilizar o artefato necessário ao módulo `ai-worker`. (sucesso) 
- Executado o teste unitário focado `GeraLandingWireframeBackendClientTest` em `ai-worker` com `mvn -Dtest=GeraLandingWireframeBackendClientTest test` após instalar o backend; o teste confirmou chamada ao endpoint interno e preservação de `promptData` (sucesso). 
- Executado suíte de testes do `ai-worker` com `mvn test` (após instalação do backend) sem falhas reportadas na saída observada (nenhuma falha de teste detectada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18dbd48b6483219edc1bad8e5f5004)