### PR TITLE
Remove wireframe detail fetch from pending flow

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
@@ -25,6 +25,7 @@ public class GeraLandingWireframeBackendClient {
     private final String apiPrefix;
     private final ObjectMapper objectMapper;
 
+    /** Inicializa o client HTTP com a URL base do backend e o mapper usado para reidratar artefatos JSON. */
     public GeraLandingWireframeBackendClient(
             WebClient.Builder builder,
             @Value("${backend.base-url:http://191.252.181.168:8000}") String backendBaseUrl,
@@ -155,15 +156,6 @@ public class GeraLandingWireframeBackendClient {
         body.put("costUsd", payload != null ? payload.costUsd() : null);
         body.put("openAiJobId", payload != null ? payload.openAiJobId() : null);
         webClient.post().uri(baseUrl + "/{idJob}/receive-result", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block();
-    }
-
-    /** Busca os detalhes de uma execução específica da etapa wireframe. */
-    public GeraLandingStageExecutionDetailDto fetchWireframeStageExecutionDetail(Long experimentId, String idJob) {
-        String uri = UrlUtils.joinPath(
-                backendBaseUrl,
-                apiPrefix,
-                "/experiments/" + experimentId + "/geralanding/wireframe/stage-executions/" + idJob);
-        return webClient.get().uri(uri).retrieve().bodyToMono(GeraLandingStageExecutionDetailDto.class).onErrorReturn(null).block();
     }
 
     /** Preenche no payload dados de hipótese usados para montar o prompt da etapa. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframePendingJobsService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframePendingJobsService.java
@@ -19,18 +19,18 @@ public class WireframePendingJobsService {
 
     private final GeraLandingWireframeBackendClient backendClient;
 
+    /** Recebe o client responsável pelo contrato HTTP da fila interna de wireframe. */
     public WireframePendingJobsService(GeraLandingWireframeBackendClient backendClient) {
         this.backendClient = backendClient;
     }
 
     /**
-     * Busca execuções pendentes da etapa wireframe e confirma o estado via controller wireframe.web.
+     * Busca execuções pendentes da etapa wireframe usando exclusivamente a lista pending estruturada.
      */
     public List<GeraLandingStageExecutionDetailDto> listPendingWireframeJobs(int limit) {
         List<GeraLandingStageExecutionDetailDto> pendingExecutions = backendClient.listPendingExecutions(limit);
         List<GeraLandingStageExecutionDetailDto> wireframeJobs = pendingExecutions.stream()
                 .filter(this::isWireframeStage)
-                .filter(this::isPendingOnWireframeController)
                 .toList();
         log.info("Wireframe pending jobs fetched: {} (from total pending={})", wireframeJobs.size(), pendingExecutions.size());
         return wireframeJobs;
@@ -45,16 +45,4 @@ public class WireframePendingJobsService {
                 && WIREFRAME_STAGE_CODE.equals(execution.stageCode().trim().toLowerCase(Locale.ROOT));
     }
 
-    /**
-     * Consulta o endpoint wireframe.web para confirmar que o job segue pendente.
-     */
-    private boolean isPendingOnWireframeController(GeraLandingStageExecutionDetailDto execution) {
-        if (execution == null || execution.experimentId() == null || !StringUtils.hasText(execution.idJob())) {
-            return false;
-        }
-        GeraLandingStageExecutionDetailDto detail = backendClient.fetchWireframeStageExecutionDetail(
-                execution.experimentId(),
-                execution.idJob());
-        return detail != null && "INICIADO".equalsIgnoreCase(detail.status());
-    }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClientTest.java
@@ -14,20 +14,26 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
+/**
+ * Responsável por validar o contrato HTTP do client backend da etapa wireframe.
+ */
 class GeraLandingWireframeBackendClientTest {
     private MockWebServer server;
 
+    /** Inicializa o servidor HTTP simulado usado nos testes do client. */
     @BeforeEach
     void setUp() throws Exception {
         server = new MockWebServer();
         server.start();
     }
 
+    /** Encerra o servidor HTTP simulado ao final de cada teste. */
     @AfterEach
     void tearDown() throws Exception {
         server.shutdown();
     }
 
+    /** Deve consultar apenas a fila interna pending de wireframe e preservar JSON estruturado. */
     @Test
     void listPendingExecutionsCallsInternalWireframeQueueAndKeepsStructuredJson() throws Exception {
         server.enqueue(jsonResponse("["
@@ -67,9 +73,19 @@ class GeraLandingWireframeBackendClientTest {
         assertThat(pending.getFirst().idJob()).isEqualTo("ef92d7d2-7d84-4b1e-a5a5-ccf3034da4bd");
         assertThat(pending.getFirst().status()).isEqualTo("INICIADO");
         assertThat(pending.getFirst().promptData())
-                .containsKeys("campaignAngle", "adCopy", "adImageBriefing", "landingPageWireframe", "NICHE_NAME", "PAIN_JSON", "RESULT_JSON");
+                .containsKeys(
+                        "campaignAngle",
+                        "adCopy",
+                        "adImageBriefing",
+                        "landingPageWireframe",
+                        "NICHE_NAME",
+                        "PAIN_JSON",
+                        "RESULT_JSON");
         assertThat(pending.getFirst().promptData().get("campaignAngle"))
-                .isInstanceOfSatisfying(java.util.Map.class, value -> assertThat(value).containsEntry("primaryPromise", "Agenda cheia"));
+                .isInstanceOfSatisfying(
+                        java.util.Map.class,
+                        value -> assertThat(value).containsEntry("primaryPromise", "Agenda cheia"));
+        assertThat(server.getRequestCount()).isEqualTo(1);
     }
 
     /** Cria resposta JSON para simular os endpoints reais do backend. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframePendingJobsServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframePendingJobsServiceTest.java
@@ -1,0 +1,60 @@
+package com.marketinghub.worker.geralanding.wireframe.monitor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.worker.geralanding.wireframe.backend.GeraLandingWireframeBackendClient;
+import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Responsável por validar o consumo da fila pending estruturada da etapa wireframe.
+ */
+@ExtendWith(MockitoExtension.class)
+class WireframePendingJobsServiceTest {
+    @Mock
+    private GeraLandingWireframeBackendClient backendClient;
+
+    /**
+     * Deve usar apenas a lista pending estruturada e filtrar a etapa wireframe sem chamadas adicionais de detalhe.
+     */
+    @Test
+    void listPendingWireframeJobsShouldUseOnlyStructuredPendingList() {
+        GeraLandingStageExecutionDetailDto wireframe = new GeraLandingStageExecutionDetailDto(
+                34L,
+                "landing-page-wireframe",
+                "job-wireframe",
+                "INICIADO",
+                null,
+                null,
+                null,
+                null,
+                Map.of("campaignAngle", Map.of("primaryPromise", "Agenda cheia")));
+        GeraLandingStageExecutionDetailDto copy = new GeraLandingStageExecutionDetailDto(
+                35L,
+                "landing-page-copy",
+                "job-copy",
+                "INICIADO",
+                null,
+                null,
+                null,
+                null,
+                Map.of());
+        when(backendClient.listPendingExecutions(20)).thenReturn(List.of(wireframe, copy));
+        WireframePendingJobsService service = new WireframePendingJobsService(backendClient);
+
+        List<GeraLandingStageExecutionDetailDto> jobs = service.listPendingWireframeJobs(20);
+
+        assertThat(jobs).containsExactly(wireframe);
+        assertThat(jobs.getFirst().promptData()).containsKey("campaignAngle");
+        verify(backendClient).listPendingExecutions(20);
+        verifyNoMoreInteractions(backendClient);
+    }
+}

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -44,7 +44,10 @@ serializados no contrato `pending` como JSON estruturado sempre que o conteúdo 
 como string contendo JSON escapado. Apenas conteúdo realmente textual ou JSON inválido pode permanecer
 como string bruta, com log de diagnóstico no caso inválido. O atributo `hypothesis` deve expor `id`,
 `title` e `framework` com todos os itens canônicos do framework Dor → Resultado → Mecanismo → Prova →
-Oferta: `pain`, `result`, `mechanism`, `proof`, `offer` e `checklist`.
+Oferta: `pain`, `result`, `mechanism`, `proof`, `offer` e `checklist`. Como esse contrato `pending`
+carrega todos os dados necessários para processamento da etapa, o Worker AI de wireframe deve consumir a
+lista como fonte suficiente e não deve fazer chamada adicional de detalhe da execução antes de processar o
+job.
 
 ## Regra global — JSON estruturado em contratos internos
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2267,3 +2267,13 @@
 - Ajustado o client do Worker AI da etapa `landing-page-wireframe` para consumir diretamente o endpoint interno `/api/internal/geralanding/wireframe/stage-executions/pending`, preservando os artefatos JSON estruturados enviados pelo backend (`experiment` e `hypothesis.framework`) sem voltar a depender da varredura por experimento.
 - A montagem dos dados de prompt passou a preferir o JSON já entregue na fila pending, mantendo fallback legado por `experimentId` quando o backend não enviar dados embutidos.
 - Adicionado teste unitário cobrindo o contrato `jobid`, `experiment`, `hypothesis.framework` e a preservação do JSON estruturado no DTO consumido pelo scheduler de wireframe.
+
+## 2026-05-29 — Worker AI wireframe sem consulta adicional de detalhe
+
+- Solicitação: remover a necessidade de `fetchWireframeStageExecutionDetail` no fluxo de wireframe, porque tudo que a etapa precisa já vem na lista de pendentes.
+- Causa-raiz tratada: o serviço de pendências ainda confirmava cada job com uma chamada extra ao endpoint de detalhe, apesar de o contrato `pending` já carregar status, experimento, hipótese e artefatos estruturados suficientes para processamento.
+- Correção aplicada:
+  - `WireframePendingJobsService` passou a usar exclusivamente `listPendingExecutions` e filtrar apenas o código da etapa `landing-page-wireframe`;
+  - removido o método `fetchWireframeStageExecutionDetail` do client de wireframe do Worker AI;
+  - o cânone de arquitetura por etapa foi atualizado para declarar que o `pending` de wireframe é fonte suficiente para o Worker AI, sem chamada adicional de detalhe antes do processamento;
+  - adicionados testes garantindo que o serviço usa apenas a lista pending estruturada e que o client faz somente uma requisição ao endpoint interno de pendências.


### PR DESCRIPTION
### Motivation
- The wireframe worker already receives all necessary data in the structured `pending` list, so per-job calls to fetch execution detail are redundant and cause extra latency and coupling.
- Simplify the Worker AI flow by relying on the canonical internal pending queue as the single source of truth for wireframe jobs.

### Description
- `WireframePendingJobsService` now uses only `listPendingExecutions` and filters by `stageCode` (`landing-page-wireframe`) without calling execution-detail: removed the detail-confirmation step in `listPendingWireframeJobs`.
- Removed the unused `fetchWireframeStageExecutionDetail` method from `GeraLandingWireframeBackendClient` and kept the client focused on the internal `/api/internal/geralanding/wireframe/stage-executions/pending` contract.
- Updated canonical architecture docs (`docs/canonical/arquitetura-etapas.md`) to state that the wireframe `pending` payload is sufficient and must be consumed directly by the Worker AI.
- Added unit test `WireframePendingJobsServiceTest` to verify the service calls only `listPendingExecutions`, and strengthened `GeraLandingWireframeBackendClientTest` to assert a single pending endpoint request and preservation of structured prompt data; added experiment log entry in `docs/registros/experimentos.md` describing the change.

### Testing
- Built and installed backend artifact with `cd backend/ads-service && ../mvnw -DskipTests install`, which succeeded and populated the local Maven repository for downstream tests.
- Ran unit tests for the AI worker with `cd ai-worker && mvn -Dtest=GeraLandingWireframeBackendClientTest,WireframePendingJobsServiceTest test`, and both tests passed.
- The new `WireframePendingJobsServiceTest` verifies that only the pending endpoint is used and that no additional backend interactions occur, and the client test verifies the pending payload shape and single-request behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18e1fca3ac832182eefe6ebc7f7113)