### PR TITLE
docs: documenta agendamento e busca de etapas Worker AI

### DIFF
--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -22,6 +22,49 @@ Backend<Etapa>Controller.pending -> List<Record<Etapa>Pending>
 
 Exemplo: `BackendWireframeController.pending` deve retornar `List<RecordWireframePending>`.
 
+## Etapa 2 — Agendamento e busca de novos itens para processamento
+
+A segunda etapa operacional de qualquer processamento assíncrono por Worker AI é o ciclo de
+agendamento e busca de novos itens aptos para processamento. O padrão canônico deve seguir o
+comportamento do scheduler de wireframe do Worker AI:
+
+1. o Worker AI deve possuir um scheduler específico da etapa, nomeado no padrão
+   `<Etapa>ExecutionScheduler`;
+2. o scheduler deve executar periodicamente via `@Scheduled` com cron explícito na anotação, sem
+   variável intermediária para o cron;
+3. a cada ciclo, o scheduler deve delegar a busca de pendências a um serviço específico da etapa,
+   nomeado no padrão `<Etapa>PendingJobsService`;
+4. o serviço de pendências deve consultar exclusivamente o endpoint interno `pending` da própria etapa
+   no backend, respeitando o isolamento por módulo/etapa;
+5. o endpoint `pending` deve retornar somente itens realmente aptos ao processamento da etapa,
+   preferencialmente com status `INICIADO`;
+6. o Worker AI pode aplicar um limite operacional de leitura/processamento, mas esse limite não pode
+   alterar o contrato semântico do item;
+7. falhas no ciclo agendado devem ser registradas em log com stack trace completo antes de serem
+   propagadas ou tratadas.
+
+Cada item retornado pelo `pending` deve vir completo como uma **unidade de trabalho fechada**. Isso
+significa que o item precisa carregar, no próprio payload da listagem, todos os identificadores, dados
+de contexto e artefatos necessários para executar a etapa sem depender de uma chamada adicional de
+detalhe antes do processamento. A unidade de trabalho fechada deve conter, no mínimo:
+
+- identificador único do job da etapa;
+- identificador do experimento ou entidade principal processada;
+- código da etapa;
+- status operacional que justifica a seleção para processamento;
+- dados completos da entidade principal necessários para montar o prompt ou executar a regra da etapa;
+- dados completos da hipótese, framework ou demais insumos de domínio exigidos pela etapa;
+- artefatos anteriores já produzidos e necessários para continuidade do fluxo, serializados como JSON
+  estruturado quando forem JSON válido;
+- metadados mínimos de ordenação/rastreabilidade quando existirem no backend.
+
+É proibido desenhar a busca de pendências como uma lista parcial que obrigue o Worker AI a buscar
+detalhes complementares por job antes de processar. Caso alguma etapa precise de dados adicionais para
+funcionar, a causa-raiz deve ser corrigida no contrato `pending` do backend para que o item continue
+sendo publicado como unidade de trabalho fechada. Esse padrão reduz acoplamento, evita inconsistência
+entre leituras em momentos diferentes, melhora rastreabilidade e mantém o backend como fonte única dos
+dados operacionais.
+
 ## GeraLanding — wireframe
 
 A etapa `landing-page-wireframe` expõe a fila interna pelo endpoint:

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -65,6 +65,52 @@ sendo publicado como unidade de trabalho fechada. Esse padrão reduz acoplamento
 entre leituras em momentos diferentes, melhora rastreabilidade e mantém o backend como fonte única dos
 dados operacionais.
 
+## Etapa 3 — Montagem do request OpenAI com prompt, schema e dados da solicitação
+
+A terceira etapa operacional de qualquer processamento assíncrono por Worker AI é transformar a
+unidade de trabalho fechada recebida do backend em um request completo para o endpoint da OpenAI. O
+padrão canônico deve seguir o comportamento da etapa wireframe do Worker AI:
+
+1. o serviço executor da etapa, nomeado no padrão `<Etapa>OpenAiExecutionService`, deve receber a
+   unidade de trabalho fechada produzida pela Etapa 2;
+2. antes de chamar a OpenAI, o executor deve obter os dados de prompt a partir do próprio item recebido
+   do backend, preservando o backend como fonte única da solicitação;
+3. o executor deve criar um record/DTO de request da própria etapa, no padrão `Record<Etapa>Request`,
+   contendo o identificador da entidade principal e o mapa de dados já estruturado;
+4. a montagem do payload da OpenAI deve ficar em um montador isolado da etapa, nomeado no padrão
+   `MontaRequest`, dentro do pacote da própria etapa;
+5. o `MontaRequest` deve carregar o arquivo markdown de prompt da etapa a partir de
+   `ai-worker/src/main/resources/prompts/<dominio>/<arquivo-da-etapa>.md`;
+6. o `MontaRequest` deve carregar o schema JSON da etapa a partir de
+   `ai-worker/src/main/resources/prompts/<dominio>/<arquivo-da-etapa>-schema.json`;
+7. os placeholders do prompt devem ser resolvidos usando os dados estruturados da unidade de trabalho,
+   sem inserir JSON serializado dentro de outro JSON textual quando o contrato permitir objeto/array;
+8. o body enviado à OpenAI deve conter, no mínimo, `model`, `input` com mensagens `system` e `user`, e
+   `text.format` com `type=json_schema`, `name`, `schema` e `strict=true`;
+9. antes do envio, o request deve ser convertido para mapa/objeto JSON validável e não pode permanecer
+   apenas como texto opaco;
+10. o executor deve registrar logs com contexto operacional (`jobId`, etapa, modelo e prévia segura do
+    payload) antes do envio e depois da resposta, preservando stack trace completo em falhas HTTP ou
+    inesperadas;
+11. a chamada à OpenAI deve ser feita pelo endpoint `/responses`, com `Content-Type: application/json`
+    e corpo JSON montado pelo `MontaRequest`;
+12. quando a etapa usar modo flex, o executor deve adicionar `service_tier=flex` ao corpo final antes de
+    enviar ao endpoint `/responses`.
+
+No exemplo de wireframe, o fluxo é: `GeraLandingWireframeOpenAiExecutionService` recebe a execução
+pendente, chama `backendClient.loadPromptData(execution)` para aproveitar os dados estruturados da
+solicitação, cria `RecordWireframeRequest`, solicita ao `MontaRequest` o prompt final e o request body,
+cria um `RecordJobDto`, converte o `requestBodyJson` em mapa, acrescenta `service_tier=flex` e envia o
+payload para `POST /responses`. O prompt markdown usado é
+`prompts/geralanding/landing-page-wireframe.md`, e o schema de saída estruturada usado é
+`prompts/geralanding/landing-page-wireframe-schema.json`.
+
+Essa etapa não deve buscar novamente detalhes operacionais no backend para completar a solicitação. Se
+o prompt ou o schema exigir algum dado que não veio na unidade de trabalho fechada, a correção deve ser
+feita na Etapa 2, ampliando o contrato `pending` do backend. A responsabilidade da Etapa 3 é apenas
+ingerir a solicitação já completa, combinar esses dados com os arquivos versionados de prompt/schema e
+enviar um request determinístico e rastreável para a OpenAI.
+
 ## GeraLanding — wireframe
 
 A etapa `landing-page-wireframe` expõe a fila interna pelo endpoint:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2306,3 +2306,19 @@
   - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframeExecutionScheduler.java
   - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframePendingJobsService.java
   - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
+
+## 2026-05-28 22:58:09 UTC-3
+- solicitação para complementar o cânone de arquitetura por etapas com a Etapa 3 do Worker AI: obtenção dos arquivos de prompt e schema, ingestão dos dados da solicitação recebida do backend e envio do request para o endpoint da OpenAI.
+- raciocínio aplicado: usar o wireframe como exemplo concreto para documentar que a unidade de trabalho fechada é transformada em `Record<Etapa>Request`, combinada com prompt markdown e schema JSON versionados, convertida em payload JSON validável e enviada ao endpoint `/responses` da OpenAI.
+- foi feito: inclusão da seção "Etapa 3 — Montagem do request OpenAI com prompt, schema e dados da solicitação" em `docs/canonical/arquitetura-etapas.md`, declarando responsabilidades do `<Etapa>OpenAiExecutionService`, do `MontaRequest`, dos arquivos `*.md`/`*-schema.json`, dos logs e da chamada `POST /responses`.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/canonical/arquitetura-etapas.md
+  - docs/registros/experimentos.md
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/MontaRequest.java
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/MontaRequestSupport.java
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/RecordWireframeRequest.java
+  - ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+  - ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2293,3 +2293,16 @@
   - removido o método `fetchWireframeStageExecutionDetail` do client de wireframe do Worker AI;
   - o cânone de arquitetura por etapa foi atualizado para declarar que o `pending` de wireframe é fonte suficiente para o Worker AI, sem chamada adicional de detalhe antes do processamento;
   - adicionados testes garantindo que o serviço usa apenas a lista pending estruturada e que o client faz somente uma requisição ao endpoint interno de pendências.
+
+## 2026-05-28 22:53:51 UTC-3
+- solicitação para documentar no cânone de arquitetura por etapas a segunda etapa operacional do Worker AI: agendamento e busca de novos itens para processamento.
+- raciocínio aplicado: usar o scheduler de wireframe como referência concreta para formalizar que cada ciclo agendado consulta apenas a fila interna `pending` da própria etapa e que cada item deve chegar completo como unidade de trabalho fechada.
+- foi feito: inclusão da seção "Etapa 2 — Agendamento e busca de novos itens para processamento" em `docs/canonical/arquitetura-etapas.md`, deixando explícito que o contrato `pending` deve carregar todos os identificadores, dados de contexto e artefatos necessários sem chamada adicional de detalhe antes do processamento.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/canonical/arquitetura-etapas.md
+  - docs/registros/experimentos.md
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframeExecutionScheduler.java
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframePendingJobsService.java
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java


### PR DESCRIPTION
### Motivation
- Formalizar a Etapa 2 do fluxo Worker AI (agendamento e busca de pendências) e garantir que o endpoint `pending` entregue cada item como uma unidade de trabalho fechada com todos os artefatos necessários, evitando chamadas adicionais de detalhe antes do processamento.

### Description
- Adiciona a seção "Etapa 2 — Agendamento e busca de novos itens para processamento" em `docs/canonical/arquitetura-etapas.md` definindo padrões de `<Etapa>ExecutionScheduler`, `<Etapa>PendingJobsService`, consulta exclusiva ao endpoint `pending`, requisitos mínimos do payload (`jobid`, `experiment`, `hypothesis`, artefatos JSON estruturados, metadados) e proibição de listas parciais; e registra a operação em `docs/registros/experimentos.md`.

### Testing
- Executado `git diff --check` sem erros e os arquivos foram commitados (commit: `docs: documenta agendamento de etapas worker`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18f172d1cc8321b7ee1ce3613f42e0)