### PR TITLE
docs: sincroniza regras canônicas de arquitetura (ArquiteturaTest)

### DIFF
--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -1,5 +1,9 @@
 # Arquitetura canônica por etapa
 
+Este documento consolida as regras canônicas de arquitetura por etapa que são protegidas pelos testes
+`ArquiteturaTest` do backend e do Worker AI. Toda alteração estrutural deve preservar estas regras ou alterar
+primeiro este cânone e, em seguida, sincronizar os testes de arquitetura correspondentes.
+
 ## Backend por etapa
 
 Todo controller interno de backend criado para uma etapa operacional deve seguir o padrão de nome
@@ -21,6 +25,115 @@ Backend<Etapa>Controller.pending -> List<Record<Etapa>Pending>
 ```
 
 Exemplo: `BackendWireframeController.pending` deve retornar `List<RecordWireframePending>`.
+
+## Backend — regras globais de isolamento de módulos
+
+As regras abaixo valem para classes analisadas no pacote `com.marketinghub` do backend:
+
+- **MOIS isolado**: classes em `com.marketinghub.mois..` não podem depender de outros pacotes internos
+  `com.marketinghub`, exceto o próprio prefixo `com.marketinghub.mois`.
+- **OPRM isolado**: classes em `com.marketinghub.oprm..` não podem depender de outros pacotes internos
+  `com.marketinghub`, exceto o próprio prefixo `com.marketinghub.oprm`.
+- **Biblioteca de páginas de venda MOIS isolada**: classes em
+  `com.marketinghub.mois.bibliotecapaginavenda.worker.v1..` não podem depender de outros pacotes internos
+  `com.marketinghub`, exceto o próprio pacote da biblioteca.
+- **Demais pacotes não consomem a biblioteca MOIS**: qualquer classe em `com.marketinghub..` fora de
+  `com.marketinghub.mois.bibliotecapaginavenda.worker.v1..` não pode depender da biblioteca de páginas de
+  venda MOIS.
+
+## Backend — biblioteca de páginas de venda MOIS
+
+A biblioteca de páginas de venda do MOIS usa pacotes no padrão:
+
+```text
+com.marketinghub.mois.bibliotecapaginavenda.<namespace>.<versao>.<layer>
+```
+
+Onde:
+
+- `<namespace>` é um identificador alfanumérico ou com `_`;
+- `<versao>` segue o padrão `vN`, por exemplo `v1`;
+- `<layer>` deve ser `web`, `service` ou `repository`.
+
+As dependências entre layers devem respeitar o mesmo `<namespace>` e a mesma `<versao>`:
+
+- classes do layer `web` podem depender apenas de classes do próprio layer `web` ou do layer `service` no
+  mesmo `<namespace>/<versao>`;
+- classes do layer `service` podem depender apenas de classes do próprio layer `service` ou do layer
+  `repository` no mesmo `<namespace>/<versao>`;
+- dependências para classes fora desse padrão de pacote não são tratadas por esta regra específica, mas
+  continuam sujeitas às demais regras globais de isolamento.
+
+## Backend — GeraLanding por etapa
+
+As regras abaixo valem para dependências internas sob `com.marketinghub.geralanding..`:
+
+- **Web por etapa**: classes em `com.marketinghub.geralanding.<etapa>.web..` só podem depender de classes
+  `com.marketinghub.geralanding.<etapa>.web..` ou
+  `com.marketinghub.geralanding.<etapa>.service..` da mesma `<etapa>`.
+- **Provisório por etapa**: classes em `com.marketinghub.geralanding.<etapa>.provisorio..` só podem depender
+  de classes `com.marketinghub.geralanding.<etapa>.provisorio..` da mesma `<etapa>`.
+- **Service com whitelist explícita**: classes em `com.marketinghub.geralanding..service..` só podem depender,
+  dentro de `com.marketinghub`, de classes do próprio pacote ou dos tipos canonicamente permitidos:
+  - `com.marketinghub.experiment.Experiment`;
+  - `com.marketinghub.experiment.repository.ExperimentRepository`;
+  - `com.marketinghub.geralanding.GeraLandingStageExecution`;
+  - `com.marketinghub.geralanding.GeraLandingStageExecutionRepository`;
+  - `com.marketinghub.geralanding.GeraLandingStageExecution$GeraLandingStageExecutionBuilder`.
+- **Controllers internos por etapa**: toda classe em `com.marketinghub.geralanding.<etapa>.web..` com nome
+  `Backend<Etapa>Controller` deve declarar método `pending` retornando exatamente
+  `List<Record<Etapa>Pending>`.
+
+## Backend — GeraLandingStageExecutionService e assemblers canônicos
+
+O serviço `com.marketinghub.geralanding.GeraLandingStageExecutionService` deve usar apenas os contratos
+canônicos atuais dos assemblers provisórios:
+
+- **Design preset**:
+  - é proibido chamar `DesignPresetProvisionalHtmlAssembler.assemble(String, String)`;
+  - é obrigatório chamar `DesignPresetProvisionalHtmlAssembler.assemble(String, String, String, String, String)`
+    quando `STAGE_DESIGN_PRESET` for processado.
+- **Wireframe**:
+  - é proibido chamar `WireframeProvisionalHtmlAssembler.assemble(String)`;
+  - é obrigatório chamar `WireframeProvisionalHtmlAssembler.assemble(String, String)` quando
+    `STAGE_WIREFRAME` for processado.
+- **Copy**:
+  - é proibido chamar `CopyProvisionalHtmlAssembler.assemble(String, String)`;
+  - é obrigatório chamar `CopyProvisionalHtmlAssembler.assemble(String, String, String)` quando `STAGE_COPY`
+    for processado.
+
+Os tipos canônicos de assembler também devem permanecer estáveis:
+
+- qualquer classe com nome simples `WireframeProvisionalHtmlAssembler` deve residir em pacote
+  `..geralanding.wireframe..`;
+- qualquer classe com nome simples `DesignPresetProvisionalHtmlAssembler` deve residir em pacote
+  `..geralanding.designpreset..`;
+- o tipo `WireframeProvisionalHtmlAssembler` deve continuar existindo como tipo canônico atribuível à classe
+  `com.marketinghub.geralanding.wireframe.provisorio.WireframeProvisionalHtmlAssembler`.
+
+## Worker AI — GeraLanding
+
+As regras abaixo valem para classes analisadas no pacote `com.marketinghub.worker` do Worker AI:
+
+- **Sem dependência do pipeline legado**: qualquer classe em `..geralanding..` não pode depender de classes em
+  `..experimentpipeline..`.
+- **Independência entre subpacotes principais**: os subpacotes
+  `com.marketinghub.worker.geralanding.wireframe..`, `copy..`, `imageplanning..` e `presetdesign..` não devem
+  depender uns dos outros.
+- **Acesso por subpacote ou comum**: dentro de dependências `com.marketinghub..`, cada subpacote do
+  GeraLanding só pode acessar classes do próprio subpacote ou de `..geralanding.comum..`:
+  - `..geralanding.copy..` só pode acessar `..geralanding.copy..` ou `..geralanding.comum..`;
+  - `..geralanding.presetdesign..` só pode acessar `..geralanding.presetdesign..` ou
+    `..geralanding.comum..`;
+  - `..geralanding.stage..` só pode acessar `..geralanding.stage..` ou `..geralanding.comum..`;
+  - `..geralanding.wireframe..` só pode acessar `..geralanding.wireframe..` ou
+    `..geralanding.comum..`;
+  - `..geralanding.deliverables..` só pode acessar `..geralanding.deliverables..` ou
+    `..geralanding.comum..`;
+  - `..geralanding.imageplanning..` só pode acessar `..geralanding.imageplanning..` ou
+    `..geralanding.comum..`.
+- **Comum isolado**: classes em `..geralanding.comum..` só podem acessar outras classes do próprio pacote
+  `..geralanding.comum..` dentro de `com.marketinghub..`.
 
 ## GeraLanding — wireframe
 


### PR DESCRIPTION
### Motivation
- Consolidar no cânone as regras de arquitetura que estão implementadas nos testes `ArquiteturaTest` do backend e do Worker AI para garantir alinhamento entre documentação e validações automatizadas.
- Tornar explícitos contratos por etapa (p.ex. `Backend<Etapa>Controller.pending`) e as restrições de dependência aplicadas a MOIS, OPRM, biblioteca MOIS e GeraLanding.

### Description
- Atualiza `docs/canonical/arquitetura-etapas.md` para incluir as regras verificadas pelos testes do backend: isolamento MOIS/OPRM, padrão e regras de layers da biblioteca MOIS e regras de dependência/whitelist do `geralanding` (web/service/provisorio) e contratos de `GeraLandingStageExecutionService`/assemblers.
- Adiciona as regras do Worker AI para `com.marketinghub.worker.geralanding`: bloqueio de dependência no pipeline legado, slices/isolamento entre subpacotes (wireframe, copy, imageplanning, presetdesign) e regras de acesso ao pacote `geralanding.comum`.
- Documenta o contrato canônico `Backend<Etapa>Controller.pending -> List<Record<Etapa>Pending>` e a exigência de serializar JSON persistido em colunas textuais como JSON estruturado nos contratos internos.

### Testing
- Executado `git diff --check` e a verificação está limpa.
- Executado `cd backend/ads-service && ../mvnw -Dtest=com.marketinghub.architecture.ArquiteturaTest test` e todos os testes do `ArquiteturaTest` do backend passaram (`Tests run: 19, Failures: 0`).
- Executado `cd backend/ads-service && ../mvnw -DskipTests install` para disponibilizar o artefato localmente e a instalação local completou com sucesso.
- Executado `cd ai-worker && mvn -Dtest=com.marketinghub.worker.geralanding.ArquiteturaTest test`, observando uma falha inicial por resolução de dependência em GitHub Packages (401) que foi resolvida ao instalar o backend localmente, e em seguida os testes do Worker AI passaram (`Tests run: 9, Failures: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18f1e7eb3c832180985e4d25b61f8b)