### PR TITLE
Expose internal wireframe callback `enviado-para-ia` and update canonical docs and architecture rule

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -55,6 +55,12 @@ public class BackendWireframeController {
     return executionService.listPending(STAGE_CODE);
   }
 
+  /** Recebe o job enviado para IA sem alterar estado persistido nesta primeira versão. */
+  @PostMapping("/internal/geralanding/wireframe/stage-executions/{idJob}/enviado-para-ia")
+  public ResponseEntity<Void> enviadoParaIA(@PathVariable String idJob) {
+    return ResponseEntity.accepted().build();
+  }
+
   /** Retorna os detalhes de uma execução específica da etapa. */
   @GetMapping("/experiments/{experimentId}/geralanding/wireframe/stage-executions/{idJob}")
   public ResponseEntity<GeraLandingWireframeStageExecutionDetailResponse> detailStageExecution(

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -99,6 +99,13 @@ class ArquiteturaTest {
                     .because("[ARQUITETURA] [BACKEND][GeraLanding] toda classe Backend<Etapa>Controller deve expor pending retornando List<Record<Etapa>Pending> para a fila interna da etapa");
 
     @ArchTest
+    static final ArchRule backendWireframeControllerMustExposeEnviadoParaIAMethod = classes()
+            .that()
+            .haveFullyQualifiedName("com.marketinghub.geralanding.wireframe.web.BackendWireframeController")
+            .should(haveEnviadoParaIAMethod())
+            .because("[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] BackendWireframeController deve expor enviadoParaIA(String idJob) para o callback interno de envio à IA");
+
+    @ArchTest
     static final ArchRule moisSalesLibraryWebShouldOnlyDependOnServiceLayer =
             classes().that(classesBelongingToLayer("web")).should(onlyDependOnLayer("service"));
 
@@ -247,6 +254,35 @@ class ArquiteturaTest {
                             + " método=pending deve retornar List<" + expectedRecordName + ">"
                             + " conforme o padrão Backend<Etapa>Controller.pending -> List<Record<Etapa>Pending>"
                             + "; retorno atual=" + returnType.getTypeName();
+                    events.add(SimpleConditionEvent.violated(item, message));
+                }
+            }
+        };
+    }
+
+    /**
+     * Garante que BackendWireframeController exponha o método interno enviadoParaIA recebendo jobId.
+     */
+    private static ArchCondition<JavaClass> haveEnviadoParaIAMethod() {
+        return new ArchCondition<>(
+                "[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] BackendWireframeController.enviadoParaIA(String)") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                Optional<JavaMethod> method = item.getMethods().stream()
+                        .filter(candidate -> candidate.getName().equals("enviadoParaIA"))
+                        .findFirst();
+                if (method.isEmpty()) {
+                    String message = "[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] classe=" + item.getName()
+                            + " deve declarar método enviadoParaIA para receber o job enviado à IA";
+                    events.add(SimpleConditionEvent.violated(item, message));
+                    return;
+                }
+
+                Class<?>[] parameterTypes = method.get().reflect().getParameterTypes();
+                boolean validSignature = parameterTypes.length == 1 && String.class.equals(parameterTypes[0]);
+                if (!validSignature) {
+                    String message = "[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] classe=" + item.getName()
+                            + " método=enviadoParaIA deve receber exatamente um parâmetro String idJob";
                     events.add(SimpleConditionEvent.violated(item, message));
                 }
             }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -40,6 +41,19 @@ class BackendWireframeControllerTest {
 
         assertEquals(pending, response);
         verify(executionService).listPending("landing-page-wireframe");
+    }
+
+    /** Deve receber confirmação de envio para IA sem alterar estado nesta primeira versão. */
+    @Test
+    void enviadoParaIAShouldAcceptJobWithoutSideEffects() {
+        GeraLandingWireframeStageService stageService = mock(GeraLandingWireframeStageService.class);
+        GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
+        BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
+
+        var response = controller.enviadoParaIA("job-ia-1");
+
+        assertEquals(202, response.getStatusCode().value());
+        verifyNoInteractions(stageService, executionService);
     }
 
     /** Deve serializar pending como lista com atributos experiment e jobid em cada item. */

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -1,21 +1,16 @@
 openapi: 3.0.3
 info:
-  title: Marketing Hub Backend - GeraLanding por etapa
+  title: Marketing Hub Backend - GeraLanding wireframe interno
   version: v1
   description: |
-    Contrato canônico dos endpoints HTTP expostos pelo backend `ads-service` no pacote
-    `com.marketinghub.geralanding`, organizados por etapa operacional do GeraLanding.
+    Contrato canônico dos endpoints HTTP internos do backend `ads-service` para a fila da etapa
+    `landing-page-wireframe` do GeraLanding.
 
     Fonte de verdade revisada em código:
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java`
-    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java`
-    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java`
-    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/web/GeraLandingDesignPresetController.java`
-    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java`
 
-    Os endpoints públicos de acompanhamento ficam sob o escopo de um experimento e usam o prefixo
-    `/api/experiments/{experimentId}/geralanding`. Endpoints internos de fila por etapa usam
-    o prefixo `/api/internal/geralanding/<etapa>`.
+    Este Swagger mantém somente os endpoints internos necessários para o Worker AI consumir jobs
+    pendentes de wireframe e informar o envio do job para IA.
 servers:
   - url: http://191.252.181.168
     description: Backend principal para acessos executados pelo Codex
@@ -24,70 +19,7 @@ servers:
 tags:
   - name: landing-page-wireframe
     description: Etapa de geração do wireframe da landing.
-  - name: landing-page-copy
-    description: Etapa de geração da copy da landing.
-  - name: landing-page-image-planning
-    description: Etapa de planejamento de imagens/prompts visuais da landing.
-  - name: landing-page-design-preset
-    description: Etapa de definição do preset visual e consolidação visual da landing.
-  - name: landing-page-deliverables
-    description: Etapa de geração dos entregáveis finais vinculados à landing/oferta.
 paths:
-  /api/experiments/{experimentId}/geralanding/wireframe/start:
-    post:
-      tags:
-        - landing-page-wireframe
-      summary: Inicia a etapa landing-page-wireframe.
-      description: Registra uma nova execução inicial da etapa de wireframe para o experimento informado.
-      operationId: startGeraLandingWireframe
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-      responses:
-        '202':
-          description: Execução da etapa registrada para processamento assíncrono.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StageStartResponse'
-              example:
-                idJob: 7d3d1f3a-9f6f-41b7-9b4b-3f5c3f4d9a01
-                status: INICIADO
-  /api/experiments/{experimentId}/geralanding/wireframe/stage-executions:
-    get:
-      tags:
-        - landing-page-wireframe
-      summary: Lista execuções da etapa landing-page-wireframe.
-      description: Retorna os resumos das execuções de wireframe do experimento, com opção de incluir execuções concluídas.
-      operationId: listGeraLandingWireframeExecutions
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-        - $ref: '#/components/parameters/IncludeCompleted'
-      responses:
-        '200':
-          description: Lista de execuções da etapa.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/StageExecutionSummary'
-  /api/experiments/{experimentId}/geralanding/wireframe/stage-executions/{idJob}:
-    get:
-      tags:
-        - landing-page-wireframe
-      summary: Detalha uma execução da etapa landing-page-wireframe.
-      description: Retorna todos os dados persistidos para o job de wireframe do experimento.
-      operationId: getGeraLandingWireframeExecution
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-        - $ref: '#/components/parameters/IdJob'
-      responses:
-        '200':
-          description: Detalhe da execução da etapa.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StageExecutionDetail'
   /api/internal/geralanding/wireframe/stage-executions/pending:
     get:
       tags:
@@ -104,225 +36,20 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PendingStageExecution'
-  /api/experiments/{experimentId}/geralanding/copy/start:
+  /api/internal/geralanding/wireframe/stage-executions/{idJob}/enviado-para-ia:
     post:
       tags:
-        - landing-page-copy
-      summary: Inicia a etapa landing-page-copy.
-      description: Registra uma nova execução inicial da etapa de copy para o experimento informado.
-      operationId: startGeraLandingCopy
+        - landing-page-wireframe
+      summary: Recebe confirmação interna de envio do job de wireframe para IA.
+      description: Endpoint inicial para o Worker AI informar o job enviado para IA; nesta versão o backend apenas aceita a chamada sem alterar estado persistido.
+      operationId: enviadoParaIAGeraLandingWireframeExecution
       parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-      responses:
-        '202':
-          description: Execução da etapa registrada para processamento assíncrono.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StageStartResponse'
-  /api/experiments/{experimentId}/geralanding/copy/stage-executions:
-    get:
-      tags:
-        - landing-page-copy
-      summary: Lista execuções da etapa landing-page-copy.
-      description: Retorna os resumos das execuções de copy do experimento, com opção de incluir execuções concluídas.
-      operationId: listGeraLandingCopyExecutions
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-        - $ref: '#/components/parameters/IncludeCompleted'
-      responses:
-        '200':
-          description: Lista de execuções da etapa.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/StageExecutionSummary'
-  /api/experiments/{experimentId}/geralanding/copy/stage-executions/{idJob}:
-    get:
-      tags:
-        - landing-page-copy
-      summary: Detalha uma execução da etapa landing-page-copy.
-      description: Retorna todos os dados persistidos para o job de copy do experimento.
-      operationId: getGeraLandingCopyExecution
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
         - $ref: '#/components/parameters/IdJob'
       responses:
-        '200':
-          description: Detalhe da execução da etapa.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StageExecutionDetail'
-  /api/experiments/{experimentId}/geralanding/image-prompts/start:
-    post:
-      tags:
-        - landing-page-image-planning
-      summary: Inicia a etapa landing-page-image-planning.
-      description: Registra uma nova execução inicial da etapa de planejamento de imagens para o experimento informado.
-      operationId: startGeraLandingImagePlanning
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-      responses:
         '202':
-          description: Execução da etapa registrada para processamento assíncrono.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StageStartResponse'
-  /api/experiments/{experimentId}/geralanding/image-prompts/stage-executions:
-    get:
-      tags:
-        - landing-page-image-planning
-      summary: Lista execuções da etapa landing-page-image-planning.
-      description: Retorna os resumos das execuções de planejamento de imagens do experimento, com opção de incluir execuções concluídas.
-      operationId: listGeraLandingImagePlanningExecutions
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-        - $ref: '#/components/parameters/IncludeCompleted'
-      responses:
-        '200':
-          description: Lista de execuções da etapa.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/StageExecutionSummary'
-  /api/experiments/{experimentId}/geralanding/image-prompts/stage-executions/{idJob}:
-    get:
-      tags:
-        - landing-page-image-planning
-      summary: Detalha uma execução da etapa landing-page-image-planning.
-      description: Retorna todos os dados persistidos para o job de planejamento de imagens do experimento.
-      operationId: getGeraLandingImagePlanningExecution
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-        - $ref: '#/components/parameters/IdJob'
-      responses:
-        '200':
-          description: Detalhe da execução da etapa.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StageExecutionDetail'
-  /api/experiments/{experimentId}/geralanding/design-preset/start:
-    post:
-      tags:
-        - landing-page-design-preset
-      summary: Inicia a etapa landing-page-design-preset.
-      description: Registra uma nova execução inicial da etapa de preset visual para o experimento informado.
-      operationId: startGeraLandingDesignPreset
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-      responses:
-        '202':
-          description: Execução da etapa registrada para processamento assíncrono.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StageStartResponse'
-  /api/experiments/{experimentId}/geralanding/design-preset/stage-executions:
-    get:
-      tags:
-        - landing-page-design-preset
-      summary: Lista execuções da etapa landing-page-design-preset.
-      description: Retorna os resumos das execuções de preset visual do experimento, com opção de incluir execuções concluídas.
-      operationId: listGeraLandingDesignPresetExecutions
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-        - $ref: '#/components/parameters/IncludeCompleted'
-      responses:
-        '200':
-          description: Lista de execuções da etapa.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/StageExecutionSummary'
-  /api/experiments/{experimentId}/geralanding/design-preset/stage-executions/{idJob}:
-    get:
-      tags:
-        - landing-page-design-preset
-      summary: Detalha uma execução da etapa landing-page-design-preset.
-      description: Retorna todos os dados persistidos para o job de preset visual do experimento.
-      operationId: getGeraLandingDesignPresetExecution
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-        - $ref: '#/components/parameters/IdJob'
-      responses:
-        '200':
-          description: Detalhe da execução da etapa.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StageExecutionDetail'
-  /api/experiments/{experimentId}/geralanding/deliverables/start:
-    post:
-      tags:
-        - landing-page-deliverables
-      summary: Inicia a etapa landing-page-deliverables.
-      description: Registra uma nova execução inicial da etapa de entregáveis para o experimento informado.
-      operationId: startGeraLandingDeliverables
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-      responses:
-        '202':
-          description: Execução da etapa registrada para processamento assíncrono.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StageStartResponse'
-  /api/experiments/{experimentId}/geralanding/deliverables/stage-executions:
-    get:
-      tags:
-        - landing-page-deliverables
-      summary: Lista execuções da etapa landing-page-deliverables.
-      description: Retorna os resumos das execuções de entregáveis do experimento, com opção de incluir execuções concluídas.
-      operationId: listGeraLandingDeliverablesExecutions
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-        - $ref: '#/components/parameters/IncludeCompleted'
-      responses:
-        '200':
-          description: Lista de execuções da etapa.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/StageExecutionSummary'
-  /api/experiments/{experimentId}/geralanding/deliverables/stage-executions/{idJob}:
-    get:
-      tags:
-        - landing-page-deliverables
-      summary: Detalha uma execução da etapa landing-page-deliverables.
-      description: Retorna todos os dados persistidos para o job de entregáveis do experimento.
-      operationId: getGeraLandingDeliverablesExecution
-      parameters:
-        - $ref: '#/components/parameters/ExperimentId'
-        - $ref: '#/components/parameters/IdJob'
-      responses:
-        '200':
-          description: Detalhe da execução da etapa.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StageExecutionDetail'
+          description: Confirmação aceita sem alteração operacional nesta versão.
 components:
   parameters:
-    ExperimentId:
-      name: experimentId
-      in: path
-      required: true
-      description: Identificador numérico do experimento dono da execução GeraLanding.
-      schema:
-        type: integer
-        format: int64
-        minimum: 1
     IdJob:
       name: idJob
       in: path
@@ -331,36 +58,7 @@ components:
       schema:
         type: string
         minLength: 1
-    IncludeCompleted:
-      name: includeCompleted
-      in: query
-      required: false
-      description: Quando `true`, inclui execuções com status `CONCLUIDO`; o padrão do backend é `true`.
-      schema:
-        type: boolean
-        default: true
   schemas:
-    StageStatus:
-      type: string
-      description: Status operacional persistido para a execução da etapa.
-      enum:
-        - INICIADO
-        - AGUARDANDO_RETORNO_OPENAI
-        - EM_PROCESSAMENTO
-        - CONCLUIDO
-        - FALHA
-    StageStartResponse:
-      type: object
-      required:
-        - idJob
-        - status
-      additionalProperties: false
-      properties:
-        idJob:
-          type: string
-          description: Identificador do job criado para a etapa.
-        status:
-          $ref: '#/components/schemas/StageStatus'
     PendingStageExecution:
       type: object
       additionalProperties: false
@@ -488,115 +186,3 @@ components:
         - proof
         - offer
         - checklist
-    StageExecutionSummary:
-      type: object
-      required:
-        - idJob
-        - status
-        - executionRequestedAt
-      additionalProperties: false
-      properties:
-        idJob:
-          type: string
-          description: Identificador do job da etapa.
-        status:
-          $ref: '#/components/schemas/StageStatus'
-        executionRequestedAt:
-          type: string
-          format: date-time
-          description: Momento em que a execução foi solicitada.
-        costUsd:
-          type: number
-          format: double
-          nullable: true
-          description: Custo estimado/persistido da execução em dólar, quando disponível.
-    StageExecutionDetail:
-      type: object
-      required:
-        - idJob
-        - experimentId
-        - stageCode
-        - status
-      additionalProperties: false
-      properties:
-        idJob:
-          type: string
-        experimentId:
-          type: integer
-          format: int64
-        stageCode:
-          type: string
-          enum:
-            - landing-page-wireframe
-            - landing-page-copy
-            - landing-page-image-planning
-            - landing-page-design-preset
-            - landing-page-deliverables
-        executionRequestedAt:
-          type: string
-          format: date-time
-          nullable: true
-        createdAt:
-          type: string
-          format: date-time
-          nullable: true
-        processingStartedAt:
-          type: string
-          format: date-time
-          nullable: true
-        completedAt:
-          type: string
-          format: date-time
-          nullable: true
-        promptTemplateId:
-          type: string
-          nullable: true
-        promptContent:
-          type: string
-          nullable: true
-        prompt:
-          type: string
-          nullable: true
-        openAiRequestBody:
-          type: string
-          nullable: true
-          description: Corpo bruto enviado para a OpenAI quando persistido para rastreabilidade.
-        openAiModel:
-          type: string
-          nullable: true
-        schemaJson:
-          type: string
-          nullable: true
-        promptMarkdownContent:
-          type: string
-          nullable: true
-        status:
-          $ref: '#/components/schemas/StageStatus'
-        openAiJobId:
-          type: string
-          nullable: true
-        modelResponse:
-          type: string
-          nullable: true
-        provisionalHtml:
-          type: string
-          nullable: true
-          description: HTML provisório produzido pela etapa quando aplicável.
-        errorMessage:
-          type: string
-          nullable: true
-        errorDetail:
-          type: string
-          nullable: true
-        inputTokens:
-          type: integer
-          format: int32
-          nullable: true
-        outputTokens:
-          type: integer
-          format: int32
-          nullable: true
-        costUsd:
-          type: number
-          format: double
-          nullable: true

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2299,3 +2299,20 @@
 - Solicitação: tornar `docs/canonical/openai-informacoes-tratadas-canon.v1.md` completamente focado no modelo de dados onde ficam as informações tratadas pelos modelos de IA.
 - Correção aplicada: o cânone foi reescrito para conter somente a visão de persistência, tabelas, colunas, relacionamentos, cardinalidades e regras de localização dos dados de IA.
 - Escopo documentado: `hypothesis`, `hypothesis_framework_generation_job`, `experiment`, `experiment_pipeline_generation_job`, `framework_image_generation_job` e `ai_worker_generation`.
+
+## 2026-05-29 — Endpoint interno de envio para IA no wireframe
+
+- Solicitação: criar um endpoint na etapa `landing-page-wireframe` que receba o `jobId` quando o job for enviado para IA, inicialmente sem alterar estado persistido.
+- Correção aplicada:
+  - `BackendWireframeController` passou a expor o método `enviadoParaIA(String idJob)` no endpoint interno `/api/internal/geralanding/wireframe/stage-executions/{idJob}/enviado-para-ia`, retornando `202 Accepted` sem efeitos colaterais nesta primeira versão;
+  - o Swagger canônico do GeraLanding foi atualizado com o novo contrato;
+  - a regra ArchUnit passou a exigir a existência do método `enviadoParaIA` no controller de wireframe;
+  - teste unitário do controller valida que a chamada é aceita e não interage com os serviços enquanto o comportamento operacional ainda não for implementado.
+
+
+## 2026-05-29 — Swagger GeraLanding reduzido aos endpoints internos do wireframe
+
+- Solicitação: retirar do Swagger canônico todos os endpoints, deixando apenas a fila `pending` e o callback `enviado-para-ia` da etapa `landing-page-wireframe`.
+- Correção aplicada:
+  - `docs/canonical/geralanding-backend-swagger.v1.yaml` passou a documentar somente `GET /api/internal/geralanding/wireframe/stage-executions/pending` e `POST /api/internal/geralanding/wireframe/stage-executions/{idJob}/enviado-para-ia`;
+  - foram removidas do Swagger as entradas públicas de start/list/detail das etapas e as tags/componentes que ficaram sem uso no contrato reduzido.


### PR DESCRIPTION
### Motivation
- Add a minimal internal callback so the Worker AI can notify the backend when a `landing-page-wireframe` job has been sent to the IA without changing persisted state in this first iteration.
- Keep the canonical API focused on the internal wireframe queue consumed by the Worker AI and remove unrelated public endpoints from the reduced contract.
- Enforce architecture expectations for the wireframe backend controller via ArchUnit so the new callback method is part of the code contract.

### Description
- Added `enviadoParaIA(String idJob)` to `BackendWireframeController` at `POST /api/internal/geralanding/wireframe/stage-executions/{idJob}/enviado-para-ia` which returns `202 Accepted` without side effects.
- Updated `docs/canonical/geralanding-backend-swagger.v1.yaml` to document only the internal `pending` and the new `enviado-para-ia` endpoints for the wireframe stage.
- Introduced a new ArchUnit condition `haveEnviadoParaIAMethod()` and an `ArchTest` that requires `BackendWireframeController` to expose `enviadoParaIA(String)` in `ArquiteturaTest`.
- Added a unit test `enviadoParaIAShouldAcceptJobWithoutSideEffects` to `BackendWireframeControllerTest` and updated experiment records in `docs/registros/experimentos.md` to document the change.

### Testing
- Ran unit tests including `BackendWireframeControllerTest` which asserts `enviadoParaIA` returns `202` and performs no interactions with services, and the test succeeded.
- Ran architecture tests in `ArquiteturaTest` that validate the new ArchUnit rule for `BackendWireframeController`, and those tests succeeded.
- Executed the project's test suite (`mvn test`) and the automated tests related to these changes passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18f3e56be483218561636dcea6dacf)