### PR TITLE
Ajusta callback recebePrompt do wireframe (adiciona payload prompt + jobidopenai)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -6,11 +6,14 @@ import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageE
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
 import com.marketinghub.geralanding.wireframe.service.RecordWireframePending;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -55,11 +58,15 @@ public class BackendWireframeController {
     return executionService.listPending(STAGE_CODE);
   }
 
-  /** Recebe o job enviado para IA sem alterar estado persistido nesta primeira versão. */
-  @PostMapping("/internal/geralanding/wireframe/stage-executions/{idJob}/enviado-para-ia")
-  public ResponseEntity<Void> enviadoParaIA(@PathVariable String idJob) {
+  /** Recebe o prompt enviado para IA sem alterar estado persistido nesta primeira versão. */
+  @PostMapping("/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-prompt")
+  public ResponseEntity<Void> recebePrompt(
+      @PathVariable String idJob, @Valid @RequestBody RecebePromptRequest payload) {
     return ResponseEntity.accepted().build();
   }
+
+  /** Payload interno com o prompt enviado ao provedor de IA e o job aberto no OpenAI. */
+  public record RecebePromptRequest(@NotBlank String prompt, @NotBlank String jobidopenai) {}
 
   /** Retorna os detalhes de uma execução específica da etapa. */
   @GetMapping("/experiments/{experimentId}/geralanding/wireframe/stage-executions/{idJob}")

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -99,11 +99,11 @@ class ArquiteturaTest {
                     .because("[ARQUITETURA] [BACKEND][GeraLanding] toda classe Backend<Etapa>Controller deve expor pending retornando List<Record<Etapa>Pending> para a fila interna da etapa");
 
     @ArchTest
-    static final ArchRule backendWireframeControllerMustExposeEnviadoParaIAMethod = classes()
+    static final ArchRule backendWireframeControllerMustExposeRecebePromptMethod = classes()
             .that()
             .haveFullyQualifiedName("com.marketinghub.geralanding.wireframe.web.BackendWireframeController")
-            .should(haveEnviadoParaIAMethod())
-            .because("[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] BackendWireframeController deve expor enviadoParaIA(String idJob) para o callback interno de envio à IA");
+            .should(haveRecebePromptMethod())
+            .because("[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] BackendWireframeController deve expor recebePrompt(String idJob, RecebePromptRequest payload) para receber o prompt enviado à IA");
 
     @ArchTest
     static final ArchRule moisSalesLibraryWebShouldOnlyDependOnServiceLayer =
@@ -261,28 +261,31 @@ class ArquiteturaTest {
     }
 
     /**
-     * Garante que BackendWireframeController exponha o método interno enviadoParaIA recebendo jobId.
+     * Garante que BackendWireframeController exponha o método interno recebePrompt recebendo jobId e payload.
      */
-    private static ArchCondition<JavaClass> haveEnviadoParaIAMethod() {
+    private static ArchCondition<JavaClass> haveRecebePromptMethod() {
         return new ArchCondition<>(
-                "[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] BackendWireframeController.enviadoParaIA(String)") {
+                "[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] BackendWireframeController.recebePrompt(String, RecebePromptRequest)") {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
                 Optional<JavaMethod> method = item.getMethods().stream()
-                        .filter(candidate -> candidate.getName().equals("enviadoParaIA"))
+                        .filter(candidate -> candidate.getName().equals("recebePrompt"))
                         .findFirst();
                 if (method.isEmpty()) {
                     String message = "[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] classe=" + item.getName()
-                            + " deve declarar método enviadoParaIA para receber o job enviado à IA";
+                            + " deve declarar método recebePrompt para receber o prompt enviado à IA";
                     events.add(SimpleConditionEvent.violated(item, message));
                     return;
                 }
 
                 Class<?>[] parameterTypes = method.get().reflect().getParameterTypes();
-                boolean validSignature = parameterTypes.length == 1 && String.class.equals(parameterTypes[0]);
+                boolean validSignature = parameterTypes.length == 2
+                        && String.class.equals(parameterTypes[0])
+                        && "com.marketinghub.geralanding.wireframe.web.BackendWireframeController$RecebePromptRequest"
+                                .equals(parameterTypes[1].getName());
                 if (!validSignature) {
                     String message = "[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] classe=" + item.getName()
-                            + " método=enviadoParaIA deve receber exatamente um parâmetro String idJob";
+                            + " método=recebePrompt deve receber exatamente String idJob e RecebePromptRequest payload";
                     events.add(SimpleConditionEvent.violated(item, message));
                 }
             }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -43,16 +43,20 @@ class BackendWireframeControllerTest {
         verify(executionService).listPending("landing-page-wireframe");
     }
 
-    /** Deve receber confirmação de envio para IA sem alterar estado nesta primeira versão. */
+    /** Deve receber o prompt enviado para IA sem alterar estado nesta primeira versão. */
     @Test
-    void enviadoParaIAShouldAcceptJobWithoutSideEffects() {
+    void recebePromptShouldAcceptPromptPayloadWithoutSideEffects() {
         GeraLandingWireframeStageService stageService = mock(GeraLandingWireframeStageService.class);
         GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
         BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
+        BackendWireframeController.RecebePromptRequest payload =
+                new BackendWireframeController.RecebePromptRequest("Prompt para IA", "openai-job-1");
 
-        var response = controller.enviadoParaIA("job-ia-1");
+        var response = controller.recebePrompt("job-ia-1", payload);
 
         assertEquals(202, response.getStatusCode().value());
+        assertEquals("Prompt para IA", payload.prompt());
+        assertEquals("openai-job-1", payload.jobidopenai());
         verifyNoInteractions(stageService, executionService);
     }
 

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -142,6 +142,23 @@ carrega todos os dados necessários para processamento da etapa, o Worker AI de 
 lista como fonte suficiente e não deve fazer chamada adicional de detalhe da execução antes de processar o
 job.
 
+Após montar e enviar o prompt para IA, o Worker AI deve chamar o callback interno:
+
+```http
+POST /api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-prompt
+Content-Type: application/json
+
+{
+  "prompt": "...",
+  "jobidopenai": "..."
+}
+```
+
+O endpoint fica no `BackendWireframeController`, usa o método `recebePrompt` e recebe o payload com os
+campos obrigatórios `prompt` e `jobidopenai`. Nesta primeira versão o backend apenas aceita a chamada
+com `202 Accepted`, sem alterar estado persistido, mantendo rastreabilidade contratual do prompt e do
+job aberto na OpenAI para evolução posterior.
+
 ## Regra global — JSON estruturado em contratos internos
 
 Sempre que um endpoint interno expuser dados que são artefatos JSON persistidos em colunas textuais, a

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -10,7 +10,7 @@ info:
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java`
 
     Este Swagger mantém somente os endpoints internos necessários para o Worker AI consumir jobs
-    pendentes de wireframe e informar o envio do job para IA.
+    pendentes de wireframe e informar o prompt enviado para IA.
 servers:
   - url: http://191.252.181.168
     description: Backend principal para acessos executados pelo Codex
@@ -36,18 +36,24 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PendingStageExecution'
-  /api/internal/geralanding/wireframe/stage-executions/{idJob}/enviado-para-ia:
+  /api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-prompt:
     post:
       tags:
         - landing-page-wireframe
-      summary: Recebe confirmação interna de envio do job de wireframe para IA.
-      description: Endpoint inicial para o Worker AI informar o job enviado para IA; nesta versão o backend apenas aceita a chamada sem alterar estado persistido.
-      operationId: enviadoParaIAGeraLandingWireframeExecution
+      summary: Recebe o prompt interno enviado para IA no job de wireframe.
+      description: Endpoint inicial para o Worker AI informar o prompt enviado para IA e o identificador do job aberto na OpenAI; nesta versão o backend apenas aceita a chamada sem alterar estado persistido.
+      operationId: recebePromptGeraLandingWireframeExecution
       parameters:
         - $ref: '#/components/parameters/IdJob'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecebePromptRequest'
       responses:
         '202':
-          description: Confirmação aceita sem alteração operacional nesta versão.
+          description: Prompt aceito sem alteração operacional nesta versão.
 components:
   parameters:
     IdJob:
@@ -59,6 +65,22 @@ components:
         type: string
         minLength: 1
   schemas:
+    RecebePromptRequest:
+      type: object
+      additionalProperties: false
+      description: Payload do prompt enviado para IA pelo Worker AI.
+      properties:
+        prompt:
+          type: string
+          minLength: 1
+          description: Prompt final enviado ao provedor de IA.
+        jobidopenai:
+          type: string
+          minLength: 1
+          description: Identificador do job aberto na OpenAI para rastreabilidade.
+      required:
+        - prompt
+        - jobidopenai
     PendingStageExecution:
       type: object
       additionalProperties: false

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2344,3 +2344,12 @@
 - Correção aplicada:
   - `docs/canonical/geralanding-backend-swagger.v1.yaml` passou a documentar somente `GET /api/internal/geralanding/wireframe/stage-executions/pending` e `POST /api/internal/geralanding/wireframe/stage-executions/{idJob}/enviado-para-ia`;
   - foram removidas do Swagger as entradas públicas de start/list/detail das etapas e as tags/componentes que ficaram sem uso no contrato reduzido.
+
+## 2026-05-29 — Callback recebePrompt do wireframe com payload OpenAI
+
+- Solicitação: renomear o método `enviadoParaIA` do `BackendWireframeController` para `recebePrompt` e exigir no POST os dados `prompt` e `jobidopenai`.
+- Correção aplicada:
+  - `BackendWireframeController` passou a expor o callback interno `/api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-prompt` pelo método `recebePrompt(String idJob, RecebePromptRequest payload)`, mantendo `202 Accepted` sem efeitos colaterais nesta primeira versão;
+  - o payload `RecebePromptRequest` documenta os campos contratuais `prompt` e `jobidopenai` para rastrear o prompt enviado à IA e o job aberto na OpenAI;
+  - o Swagger canônico e o cânone de arquitetura por etapas foram atualizados com o novo nome, endpoint e corpo JSON;
+  - os testes unitários e o `ArquiteturaTest` passaram a validar o método `recebePrompt` e sua assinatura com payload.


### PR DESCRIPTION
### Motivation
- Substituir o callback genérico de confirmação de envio à IA por um callback que receba explicitamente o `prompt` e o `jobidopenai` para garantir rastreabilidade e permitir evolução do fluxo de processamento do Worker AI.
- Manter comportamento sem efeitos colaterais nesta primeira versão, mas formalizar contrato HTTP, testes e validações arquiteturais para suportar integração com OpenAI.

### Description
- Renomeia o endpoint para `POST /api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-prompt` e altera o método do controller para `recebePrompt(String idJob, RecebePromptRequest payload)` em `BackendWireframeController`.
- Adiciona o `record` interno `RecebePromptRequest(String prompt, String jobidopenai)` com validação `@NotBlank` e anotações `@Valid`/`@RequestBody` para o payload.
- Atualiza o teste unitário do controller `BackendWireframeControllerTest` para validar a nova assinatura, o conteúdo do payload e a ausência de interações com os serviços nesta versão.
- Atualiza a regra arquitetural `ArquiteturaTest` para exigir a nova assinatura `recebePrompt(String idJob, RecebePromptRequest payload)` em vez do método antigo `enviadoParaIA`.
- Altera o Swagger canônico `docs/canonical/geralanding-backend-swagger.v1.yaml`, o documento de etapas `docs/canonical/arquitetura-etapas.md` e o registro de alterações `docs/registros/experimentos.md` para documentar o novo endpoint e schema `RecebePromptRequest`.

### Testing
- Executei `cd backend/ads-service && ../../backend/mvnw -Dtest=BackendWireframeControllerTest,ArquiteturaTest test` e os testes unitários e de arquitetura passaram com sucesso (`BUILD SUCCESS`, todos os testes executados tiveram 0 falhas).
- Tentei `cd backend/ads-service && ../../backend/mvnw spotless:check`, que falhou por não encontrar o plugin `spotless` no ambiente (`NoPluginFoundForPrefixException`), portanto a verificação de formatação não pôde ser concluída aqui.
- Todos os arquivos modificados foram commitados sob a mensagem `Ajusta callback recebePrompt do wireframe` e a mudança inclui código, testes e documentação canônica atualizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18fbac39a08321b2d6781c97f4d53a)