### PR TITLE
Rename GeraLandingWireframeStageExecutionService to BackendWireframeService

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
@@ -21,9 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** Responsável por adaptar consultas de execução para o contrato da etapa wireframe. */
 @Service
-public class GeraLandingWireframeStageExecutionService {
+public class BackendWireframeService {
 
-    private static final Logger log = LoggerFactory.getLogger(GeraLandingWireframeStageExecutionService.class);
+    private static final Logger log = LoggerFactory.getLogger(BackendWireframeService.class);
     private static final TypeReference<LinkedHashMap<String, Object>> FRAMEWORK_TYPE = new TypeReference<>() {};
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
@@ -32,7 +32,7 @@ public class GeraLandingWireframeStageExecutionService {
     private final ObjectMapper objectMapper;
 
     /** Inicializa o serviço com os repositórios necessários para consultar execuções de wireframe. */
-    public GeraLandingWireframeStageExecutionService(
+    public BackendWireframeService(
             ExperimentRepository experimentRepository,
             GeraLandingStageExecutionRepository executionRepository,
             ObjectMapper objectMapper) {
@@ -41,9 +41,8 @@ public class GeraLandingWireframeStageExecutionService {
         this.objectMapper = objectMapper;
     }
 
-
-    @Transactional
     /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
+    @Transactional
     public GeraLandingWireframeStartResponse registerInitialExecution(Long experimentId, String stageCode) {
         Instant now = Instant.now();
         var experiment = experimentRepository.findById(experimentId)
@@ -64,8 +63,8 @@ public class GeraLandingWireframeStageExecutionService {
         return new GeraLandingWireframeStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
     }
 
-    @Transactional(readOnly = true)
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
+    @Transactional(readOnly = true)
     public List<GeraLandingWireframeExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
         List<GeraLandingStageExecution> executions = includeCompleted
                 ? executionRepository.findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode)

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/GeraLandingWireframeStageService.java
@@ -6,9 +6,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class GeraLandingWireframeStageService {
   private static final String STAGE_NAME = "landing-page-wireframe";
-  private final GeraLandingWireframeStageExecutionService executionService;
+  private final BackendWireframeService executionService;
 
-  public GeraLandingWireframeStageService(GeraLandingWireframeStageExecutionService executionService) {
+  /** Inicializa o serviço com o executor backend da etapa wireframe. */
+  public GeraLandingWireframeStageService(BackendWireframeService executionService) {
     this.executionService = executionService;
   }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -1,8 +1,8 @@
 package com.marketinghub.geralanding.wireframe.web;
 
+import com.marketinghub.geralanding.wireframe.service.BackendWireframeService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeExecutionSummaryResponse;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionDetailResponse;
-import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
 import com.marketinghub.geralanding.wireframe.service.RecordWireframePending;
@@ -25,12 +25,12 @@ public class BackendWireframeController {
   private static final String STAGE_CODE = "landing-page-wireframe";
 
   private final GeraLandingWireframeStageService stageService;
-  private final GeraLandingWireframeStageExecutionService executionService;
+  private final BackendWireframeService executionService;
 
   /** Inicializa o controller com os serviços da etapa wireframe. */
   public BackendWireframeController(
       GeraLandingWireframeStageService stageService,
-      GeraLandingWireframeStageExecutionService executionService) {
+      BackendWireframeService executionService) {
     this.stageService = stageService;
     this.executionService = executionService;
   }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
@@ -19,15 +19,15 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 /** Valida as consultas de execução específicas da etapa wireframe. */
-class GeraLandingWireframeStageExecutionServiceTest {
+class BackendWireframeServiceTest {
 
     /** Deve buscar somente jobs iniciados da etapa wireframe para o endpoint interno pending. */
     @Test
     void listPendingShouldQueryStartedJobsForStage() {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
-        GeraLandingWireframeStageExecutionService service =
-                new GeraLandingWireframeStageExecutionService(experimentRepository, executionRepository, new ObjectMapper());
+        BackendWireframeService service =
+                new BackendWireframeService(experimentRepository, executionRepository, new ObjectMapper());
         Experiment experiment = mock(Experiment.class);
         when(experiment.getId()).thenReturn(77L);
         when(experiment.getName()).thenReturn("Experimento Wireframe");

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionService;
+import com.marketinghub.geralanding.wireframe.service.BackendWireframeService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageService;
 import com.marketinghub.geralanding.wireframe.service.RecordWireframeExperiment;
 import com.marketinghub.geralanding.wireframe.service.RecordWireframeHypothesis;
@@ -26,7 +26,7 @@ class BackendWireframeControllerTest {
     @Test
     void pendingShouldReturnStartedWireframeJobs() {
         GeraLandingWireframeStageService stageService = mock(GeraLandingWireframeStageService.class);
-        GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
+        BackendWireframeService executionService = mock(BackendWireframeService.class);
         BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
         List<RecordWireframePending> pending = List.of(
                 new RecordWireframePending(
@@ -47,7 +47,7 @@ class BackendWireframeControllerTest {
     @Test
     void recebePromptShouldAcceptPromptPayloadWithoutSideEffects() {
         GeraLandingWireframeStageService stageService = mock(GeraLandingWireframeStageService.class);
-        GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
+        BackendWireframeService executionService = mock(BackendWireframeService.class);
         BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
         BackendWireframeController.RecebePromptRequest payload =
                 new BackendWireframeController.RecebePromptRequest("Prompt para IA", "openai-job-1");
@@ -64,7 +64,7 @@ class BackendWireframeControllerTest {
     @Test
     void pendingShouldSerializeListItemsWithExperimentAndJobid() throws Exception {
         GeraLandingWireframeStageService stageService = mock(GeraLandingWireframeStageService.class);
-        GeraLandingWireframeStageExecutionService executionService = mock(GeraLandingWireframeStageExecutionService.class);
+        BackendWireframeService executionService = mock(BackendWireframeService.class);
         BackendWireframeController controller = new BackendWireframeController(stageService, executionService);
         when(executionService.listPending("landing-page-wireframe")).thenReturn(List.of(
                 new RecordWireframePending(

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2353,3 +2353,10 @@
   - o payload `RecebePromptRequest` documenta os campos contratuais `prompt` e `jobidopenai` para rastrear o prompt enviado à IA e o job aberto na OpenAI;
   - o Swagger canônico e o cânone de arquitetura por etapas foram atualizados com o novo nome, endpoint e corpo JSON;
   - os testes unitários e o `ArquiteturaTest` passaram a validar o método `recebePrompt` e sua assinatura com payload.
+
+## 2026-05-29 — Serviço backend de wireframe renomeado
+
+- Solicitação: alterar o nome de `GeraLandingWireframeStageExecutionService` para `BackendWireframeService`.
+- Correção aplicada:
+  - classe principal, construtor, logger, imports, injeções e testes foram renomeados para `BackendWireframeService`;
+  - este registro documenta a alteração para manter rastreabilidade do tema Experimentos.


### PR DESCRIPTION
### Motivation
- Padronizar e simplificar o nome do serviço de execução da etapa wireframe para um identificador mais genérico e legível (`BackendWireframeService`).
- Manter consistência nas injeções e contratos usados pelo controller e pelos testes, facilitando futuras refatorações transversais da lógica de execução. 

### Description
- Renomeia a classe e arquivo `GeraLandingWireframeStageExecutionService` para `BackendWireframeService` e atualiza o `Logger` e o construtor para o novo nome. 
- Atualiza todas as referências de injeção e imports em `GeraLandingWireframeStageService` e `BackendWireframeController` para usar `BackendWireframeService`. 
- Renomeia e adapta os testes correspondentes para `BackendWireframeServiceTest` e atualiza `BackendWireframeControllerTest` para mockar o novo tipo. 
- Registra a alteração no log de experimentos em `docs/registros/experimentos.md` para manter rastreabilidade do histórico. 

### Testing
- Executei os testes unitários com `./../mvnw -Dtest=BackendWireframeServiceTest,BackendWireframeControllerTest test` e todos os testes indicados passaram (4 testes, 0 falhas). 
- Tentei executar `./../mvnw spotless:check`, que falhou devido à ausência/configuração do plugin Spotless no ambiente Maven (`No plugin found for prefix 'spotless'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196511f0a08321ae081dea42bfe3f8)