### PR TITLE
Renomeia DTO de detalhe do wireframe para RecordBackendWireframeDetalheDto

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
@@ -184,7 +184,7 @@ public class BackendWireframeService {
 
     @Transactional(readOnly = true)
     /** Retorna o detalhe da execução convertido para o DTO local da etapa. */
-    public GeraLandingWireframeStageExecutionDetailResponse getStageExecutionDetail(Long experimentId, String idJob) {
+    public RecordBackendWireframeDetalheDto getStageExecutionDetail(Long experimentId, String idJob) {
         GeraLandingStageExecution execution = executionRepository
                 .findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(experimentId, toDatabaseIdJob(idJob))
                 .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
@@ -201,8 +201,8 @@ public class BackendWireframeService {
     }
 
     /** Converte o detalhe transversal para o detalhe local da etapa. */
-    private GeraLandingWireframeStageExecutionDetailResponse toDetailResponse(GeraLandingStageExecution execution) {
-        return new GeraLandingWireframeStageExecutionDetailResponse(
+    private RecordBackendWireframeDetalheDto toDetailResponse(GeraLandingStageExecution execution) {
+        return new RecordBackendWireframeDetalheDto(
                 fromDatabaseIdJob(execution.getIdJob()),
                 execution.getExperimentId(),
                 execution.getStageCode(),

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordBackendWireframeDetalheDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/RecordBackendWireframeDetalheDto.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 
 /** Responsável por representar os detalhes de uma execução da etapa wireframe. */
-public record GeraLandingWireframeStageExecutionDetailResponse(
+public record RecordBackendWireframeDetalheDto(
         String idJob,
         Long experimentId,
         String stageCode,

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -2,8 +2,8 @@ package com.marketinghub.geralanding.wireframe.web;
 
 import com.marketinghub.geralanding.wireframe.service.BackendWireframeService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeExecutionSummaryResponse;
-import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStageExecutionDetailResponse;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
+import com.marketinghub.geralanding.wireframe.service.RecordBackendWireframeDetalheDto;
 import com.marketinghub.geralanding.wireframe.service.RecordWireframePending;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -65,9 +65,9 @@ public class BackendWireframeController {
 
   /** Retorna os detalhes de uma execução específica da etapa. */
   @GetMapping("/experiments/{experimentId}/geralanding/wireframe/stage-executions/{idJob}")
-  public ResponseEntity<GeraLandingWireframeStageExecutionDetailResponse> detailStageExecution(
+  public ResponseEntity<RecordBackendWireframeDetalheDto> detailStageExecution(
       @PathVariable Long experimentId, @PathVariable String idJob) {
-    GeraLandingWireframeStageExecutionDetailResponse response =
+    RecordBackendWireframeDetalheDto response =
         executionService.getStageExecutionDetail(experimentId, idJob);
     return ResponseEntity.ok(response);
   }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2373,3 +2373,11 @@
   - `BackendWireframeController` passou a depender somente de `BackendWireframeService` para iniciar, listar, detalhar e expor callbacks da etapa;
   - a classe intermediária `GeraLandingWireframeStageService` foi removida;
   - os testes unitários do controller e do service foram atualizados para validar a delegação direta e o registro inicial da etapa.
+
+## 2026-05-29 — DTO de detalhe do wireframe renomeado
+
+- Solicitação: alterar o nome de `GeraLandingWireframeStageExecutionDetailResponse` para `RecordBackendWireframeDetalheDto`.
+- Correção aplicada:
+  - o record Java de detalhe da execução da etapa `landing-page-wireframe` foi renomeado para `RecordBackendWireframeDetalheDto`;
+  - `BackendWireframeService` e `BackendWireframeController` foram atualizados para usar o novo nome no retorno do detalhe da execução;
+  - este registro documenta a alteração para manter rastreabilidade do tema Experimentos.


### PR DESCRIPTION
### Motivation
- Padronizar o nome do DTO de detalhe da etapa `landing-page-wireframe` por clareza e rastreabilidade no histórico de alterações.

### Description
- Renomeia o `record` Java `GeraLandingWireframeStageExecutionDetailResponse` para `RecordBackendWireframeDetalheDto` e atualiza as referências e imports em `BackendWireframeService` e `BackendWireframeController`, além de registrar a mudança em `docs/registros/experimentos.md`.

### Testing
- Executei `mvn -Dtest=BackendWireframeControllerTest,BackendWireframeServiceTest test` e os testes específicos passaram com sucesso.
- Compilei com `mvn -DskipTests compile` e a compilação concluiu com sucesso.
- Rodei `mvn test` completo; a execução falhou por um erro de integridade referencial em `FacebookPageControllerTest.shouldCreateListAndDeletePages` (dados de teste `lead_portal_flow -> market_niche`), que não está relacionado à renomeação do DTO.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196c28c9e8832183f102c9ffe8f54b)