### PR TITLE
Log prompt recebido no callback de wireframe

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -4,11 +4,12 @@ import com.marketinghub.geralanding.wireframe.service.BackendWireframeService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeExecutionSummaryResponse;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
 import com.marketinghub.geralanding.wireframe.service.RecordBackendWireframeDetalheDto;
-import com.marketinghub.geralanding.wireframe.service.RecordWireframePending;
-import com.marketinghub.geralanding.wireframe.service.recebeprompt.RecebePromptRequest;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframePending;
+import com.marketinghub.geralanding.wireframe.service.recebeprompt.RecebePromptRequest;
 import jakarta.validation.Valid;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 public class BackendWireframeController {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BackendWireframeController.class);
   private static final String STAGE_CODE = "landing-page-wireframe";
 
   private final BackendWireframeService executionService;
@@ -54,10 +56,15 @@ public class BackendWireframeController {
     return executionService.listPending(STAGE_CODE);
   }
 
-  /** Recebe o prompt enviado para IA e marca a execução como aguardando retorno da OpenAI. */
+  /** Recebe o prompt enviado para IA, registra o prompt e marca a execução como aguardando retorno da OpenAI. */
   @PostMapping("/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-prompt")
   public ResponseEntity<Void> recebePrompt(
       @PathVariable String idJob, @Valid @RequestBody RecebePromptRequest payload) {
+    LOGGER.info(
+        "[GeraLanding][Wireframe] Recebido prompt enviado para IA idJob={} jobidopenai={} prompt={}",
+        idJob,
+        payload.jobidopenai(),
+        payload.prompt());
     executionService.markWaitingOpenAiDispatch(idJob, payload.prompt(), payload.jobidopenai());
     return ResponseEntity.accepted().build();
   }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -10,16 +10,20 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.geralanding.wireframe.service.BackendWireframeService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
-import com.marketinghub.geralanding.wireframe.service.recebeprompt.RecebePromptRequest;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframeExperiment;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframeHypothesis;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframePending;
+import com.marketinghub.geralanding.wireframe.service.recebeprompt.RecebePromptRequest;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
 /** Valida o contrato do controller de backend da etapa wireframe. */
+@ExtendWith(OutputCaptureExtension.class)
 class BackendWireframeControllerTest {
 
     /** Deve delegar o início da etapa diretamente para o BackendWireframeService. */
@@ -60,7 +64,7 @@ class BackendWireframeControllerTest {
 
     /** Deve receber o prompt enviado para IA e delegar marcação de espera pelo retorno OpenAI. */
     @Test
-    void recebePromptShouldMarkExecutionWaitingOpenAiDispatch() {
+    void recebePromptShouldMarkExecutionWaitingOpenAiDispatch(CapturedOutput output) {
         BackendWireframeService executionService = mock(BackendWireframeService.class);
         BackendWireframeController controller = new BackendWireframeController(executionService);
         RecebePromptRequest payload = new RecebePromptRequest("Prompt para IA", "openai-job-1");
@@ -71,6 +75,7 @@ class BackendWireframeControllerTest {
         assertEquals("Prompt para IA", payload.prompt());
         assertEquals("openai-job-1", payload.jobidopenai());
         verify(executionService).markWaitingOpenAiDispatch("job-ia-1", "Prompt para IA", "openai-job-1");
+        assertTrue(output.getOut().contains("prompt=Prompt para IA"));
     }
 
     /** Deve serializar pending como lista com atributos experiment e jobid em cada item. */

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2404,3 +2404,10 @@
 - Correção aplicada:
   - `RecordWireframePending`, `RecordWireframeExperiment` e `RecordWireframeHypothesis` foram movidos para `com.marketinghub.geralanding.wireframe.service.pending`;
   - `BackendWireframeService`, `BackendWireframeController` e os testes relacionados foram atualizados para importar os records a partir do novo subpacote.
+
+## 2026-05-29 — Log do prompt recebido no callback de wireframe
+
+- Solicitação: no `BackendWireframeController`, registrar em log o campo `payload.prompt()` recebido pelo callback interno `recebe-prompt`.
+- Correção aplicada:
+  - `BackendWireframeController.recebePrompt` passou a registrar `idJob`, `jobidopenai` e o valor literal de `payload.prompt()` antes de delegar para `BackendWireframeService.markWaitingOpenAiDispatch`;
+  - o teste do controller foi atualizado para capturar o log e garantir que o prompt recebido aparece na saída de log.


### PR DESCRIPTION
### Motivation
- Registrar o valor do `payload.prompt()` no callback interno `recebe-prompt` para melhorar rastreabilidade e depuração do envio de prompts ao provedor de IA.

### Description
- Adicionado `Logger` (SLF4J) em `BackendWireframeController` e inclusão de `LOGGER.info(...)` em `recebePrompt` para registrar `idJob`, `jobidopenai` e `payload.prompt()` antes da delegação ao serviço.
- Atualizado o teste `BackendWireframeControllerTest` para capturar a saída de log (`OutputCaptureExtension`) e verificar que o prompt aparece na saída.
- Ajustados imports no controller e no teste para manter consistência após as mudanças de pacote de DTOs/records (`recebeprompt` e `pending`).
- Documentado o ajuste em `docs/registros/experimentos.md` sob o registro de experimentos.

### Testing
- PASS: Executado `mvn test -Dtest=BackendWireframeControllerTest` no módulo `backend/ads-service` e o teste do controller passou com sucesso.
- FAIL: Executado `mvn test` no módulo `backend/ads-service` e a build falhou devido a regras ArchUnit pré-existentes e a um teste com falha `BackendWireframeServiceTest.markWaitingOpenAiDispatchShouldPersistPromptOpenAiJobAndWaitingStatus` onde o `prompt` esperado não estava persistido (causa fora do escopo deste PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19765d93248321819b1cba4852c186)