### PR TITLE
Add empty wireframe response callback

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/receberesposta/RecebeRespostaRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/receberesposta/RecebeRespostaRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.geralanding.wireframe.service.receberesposta;
+
+/** Representa o payload inicial para receber a resposta da IA na etapa wireframe. */
+public record RecebeRespostaRequest() {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -4,8 +4,8 @@ import com.marketinghub.geralanding.wireframe.service.BackendWireframeService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeExecutionSummaryResponse;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
 import com.marketinghub.geralanding.wireframe.service.RecordBackendWireframeDetalheDto;
-import com.marketinghub.geralanding.wireframe.service.RecordWireframePending;
 import com.marketinghub.geralanding.wireframe.service.recebeprompt.RecebePromptRequest;
+import com.marketinghub.geralanding.wireframe.service.receberesposta.RecebeRespostaRequest;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframePending;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -59,6 +59,13 @@ public class BackendWireframeController {
   public ResponseEntity<Void> recebePrompt(
       @PathVariable String idJob, @Valid @RequestBody RecebePromptRequest payload) {
     executionService.markWaitingOpenAiDispatch(idJob, payload.prompt(), payload.jobidopenai());
+    return ResponseEntity.accepted().build();
+  }
+
+  /** Recebe a resposta da IA para a etapa wireframe sem processá-la nesta versão inicial. */
+  @PostMapping("/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-resposta")
+  public ResponseEntity<Void> recebeResposta(
+      @PathVariable String idJob, @Valid @RequestBody RecebeRespostaRequest payload) {
     return ResponseEntity.accepted().build();
   }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -11,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.geralanding.wireframe.service.BackendWireframeService;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
 import com.marketinghub.geralanding.wireframe.service.recebeprompt.RecebePromptRequest;
+import com.marketinghub.geralanding.wireframe.service.receberesposta.RecebeRespostaRequest;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframeExperiment;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframeHypothesis;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframePending;
@@ -71,6 +73,19 @@ class BackendWireframeControllerTest {
         assertEquals("Prompt para IA", payload.prompt());
         assertEquals("openai-job-1", payload.jobidopenai());
         verify(executionService).markWaitingOpenAiDispatch("job-ia-1", "Prompt para IA", "openai-job-1");
+    }
+
+    /** Deve receber a resposta da IA sem acionar processamento nesta versão inicial. */
+    @Test
+    void recebeRespostaShouldAcceptPayloadWithoutProcessing() {
+        BackendWireframeService executionService = mock(BackendWireframeService.class);
+        BackendWireframeController controller = new BackendWireframeController(executionService);
+        RecebeRespostaRequest payload = new RecebeRespostaRequest();
+
+        var response = controller.recebeResposta("job-ia-1", payload);
+
+        assertEquals(202, response.getStatusCode().value());
+        verifyNoInteractions(executionService);
     }
 
     /** Deve serializar pending como lista com atributos experiment e jobid em cada item. */

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -155,9 +155,21 @@ Content-Type: application/json
 ```
 
 O endpoint fica no `BackendWireframeController`, usa o método `recebePrompt` e recebe o payload com os
-campos obrigatórios `prompt` e `jobidopenai`. Nesta primeira versão o backend apenas aceita a chamada
-com `202 Accepted`, sem alterar estado persistido, mantendo rastreabilidade contratual do prompt e do
-job aberto na OpenAI para evolução posterior.
+campos obrigatórios `prompt` e `jobidopenai`, mantendo rastreabilidade contratual do prompt e do job
+aberto na OpenAI.
+
+Após receber a resposta da IA, o Worker AI deve chamar o callback interno inicial:
+
+```http
+POST /api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-resposta
+Content-Type: application/json
+
+{}
+```
+
+O endpoint fica no `BackendWireframeController`, usa o método `recebeResposta` e recebe o payload
+`RecebeRespostaRequest`. Nesta primeira versão o backend apenas aceita a chamada com `202 Accepted`,
+sem processar a resposta, para reservar o contrato antes da definição do payload definitivo.
 
 ## Regra global — JSON estruturado em contratos internos
 

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -10,7 +10,7 @@ info:
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java`
 
     Este Swagger mantém somente os endpoints internos necessários para o Worker AI consumir jobs
-    pendentes de wireframe e informar o prompt enviado para IA.
+    pendentes de wireframe, informar o prompt enviado para IA e, em seguida, informar a resposta recebida da IA.
 servers:
   - url: http://191.252.181.168
     description: Backend principal para acessos executados pelo Codex
@@ -41,7 +41,7 @@ paths:
       tags:
         - landing-page-wireframe
       summary: Recebe o prompt interno enviado para IA no job de wireframe.
-      description: Endpoint inicial para o Worker AI informar o prompt enviado para IA e o identificador do job aberto na OpenAI; nesta versão o backend apenas aceita a chamada sem alterar estado persistido.
+      description: Endpoint para o Worker AI informar o prompt enviado para IA e o identificador do job aberto na OpenAI, preservando rastreabilidade do envio.
       operationId: recebePromptGeraLandingWireframeExecution
       parameters:
         - $ref: '#/components/parameters/IdJob'
@@ -53,7 +53,25 @@ paths:
               $ref: '#/components/schemas/RecebePromptRequest'
       responses:
         '202':
-          description: Prompt aceito sem alteração operacional nesta versão.
+          description: Prompt aceito para rastreabilidade do envio à IA.
+  /api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-resposta:
+    post:
+      tags:
+        - landing-page-wireframe
+      summary: Recebe a resposta interna retornada pela IA no job de wireframe.
+      description: Endpoint inicial para o Worker AI informar a resposta da IA; nesta primeira versão o backend apenas aceita a chamada sem processar o payload.
+      operationId: recebeRespostaGeraLandingWireframeExecution
+      parameters:
+        - $ref: '#/components/parameters/IdJob'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecebeRespostaRequest'
+      responses:
+        '202':
+          description: Resposta aceita sem processamento operacional nesta versão.
 components:
   parameters:
     IdJob:
@@ -81,6 +99,10 @@ components:
       required:
         - prompt
         - jobidopenai
+    RecebeRespostaRequest:
+      type: object
+      description: Payload inicial da resposta da IA pelo Worker AI; campos definitivos serão especificados na próxima evolução do contrato.
+      additionalProperties: true
     PendingStageExecution:
       type: object
       additionalProperties: false

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2404,3 +2404,12 @@
 - Correção aplicada:
   - `RecordWireframePending`, `RecordWireframeExperiment` e `RecordWireframeHypothesis` foram movidos para `com.marketinghub.geralanding.wireframe.service.pending`;
   - `BackendWireframeService`, `BackendWireframeController` e os testes relacionados foram atualizados para importar os records a partir do novo subpacote.
+
+## 2026-05-29 — Callback recebeResposta vazio do wireframe
+
+- Solicitação: criar no `BackendWireframeController` um endpoint POST `recebeResposta`, semelhante ao `recebePrompt`, mas com payload próprio e inicialmente sem processamento.
+- Correção aplicada:
+  - criado o payload `RecebeRespostaRequest` em `com.marketinghub.geralanding.wireframe.service.receberesposta`;
+  - `BackendWireframeController` passou a expor `/api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-resposta`, retornando `202 Accepted` sem acionar serviço nesta primeira versão;
+  - o contrato canônico do GeraLanding foi atualizado para registrar o novo callback inicial;
+  - teste unitário do controller valida que o endpoint aceita o payload vazio sem efeitos colaterais.


### PR DESCRIPTION
### Motivation
- Reservar o contrato interno para que o Worker AI informe a resposta retornada pela IA na etapa `landing-page-wireframe` antes de implementar o processamento, mantendo simetria com o callback `recebePrompt` e garantindo rastreabilidade.
- Registrar a nova rota e o payload inicial no Swagger e na documentação canônica para evitar divergências contratuais posteriores.

### Description
- Adiciona o endpoint `POST /api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-resposta` implementado por `BackendWireframeController.recebeResposta` que retorna `202 Accepted` sem efeitos colaterais nesta versão inicial.
- Cria o record DTO `com.marketinghub.geralanding.wireframe.service.receberesposta.RecebeRespostaRequest` como payload inicial vazio para o novo callback.
- Inclui o teste unitário `BackendWireframeControllerTest.recebeRespostaShouldAcceptPayloadWithoutProcessing` que valida `202 Accepted` e que o `BackendWireframeService` não é acionado.
- Atualiza os artefatos canônicos `docs/canonical/geralanding-backend-swagger.v1.yaml`, `docs/canonical/arquitetura-etapas.md` e `docs/registros/experimentos.md` para documentar o novo callback.

### Testing
- Executado `../mvnw test -Dtest=BackendWireframeControllerTest`, que rodou 5 testes com 0 falhas e terminou com `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19787052648321b5957ee89bdc0402)