### PR TITLE
Organize wireframe execution DTOs into subpackages and persist prompt on dispatch callback

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
@@ -7,6 +7,8 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import com.marketinghub.geralanding.wireframe.service.detailStageExecution.RecordBackendWireframeDetalheDto;
+import com.marketinghub.geralanding.wireframe.service.listStageExecutions.GeraLandingWireframeExecutionSummaryResponse;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframeExperiment;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframeHypothesis;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframePending;
@@ -110,6 +112,7 @@ public class BackendWireframeService {
                         "GeraLanding execution not found for idJob: " + idJob
                 ));
 
+        execution.setPrompt(prompt);
         execution.setOpenAiRequestBody(prompt);
         execution.setOpenAiJobId(openAiJobId);
         execution.setProcessingStartedAt(Instant.now());

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/detailStageExecution/RecordBackendWireframeDetalheDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/detailStageExecution/RecordBackendWireframeDetalheDto.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.wireframe.service;
+package com.marketinghub.geralanding.wireframe.service.detailStageExecution;
 
 import java.math.BigDecimal;
 import java.time.Instant;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/listStageExecutions/GeraLandingWireframeExecutionSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/listStageExecutions/GeraLandingWireframeExecutionSummaryResponse.java
@@ -1,4 +1,4 @@
-package com.marketinghub.geralanding.wireframe.service;
+package com.marketinghub.geralanding.wireframe.service.listStageExecutions;
 
 import java.math.BigDecimal;
 import java.time.Instant;

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -1,13 +1,12 @@
 package com.marketinghub.geralanding.wireframe.web;
 
 import com.marketinghub.geralanding.wireframe.service.BackendWireframeService;
-import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeExecutionSummaryResponse;
+import com.marketinghub.geralanding.wireframe.service.listStageExecutions.GeraLandingWireframeExecutionSummaryResponse;
 import com.marketinghub.geralanding.wireframe.service.GeraLandingWireframeStartResponse;
-import com.marketinghub.geralanding.wireframe.service.RecordBackendWireframeDetalheDto;
+import com.marketinghub.geralanding.wireframe.service.detailStageExecution.RecordBackendWireframeDetalheDto;
 import com.marketinghub.geralanding.wireframe.service.recebeprompt.RecebePromptRequest;
 import com.marketinghub.geralanding.wireframe.service.receberesposta.RecebeRespostaRequest;
 import com.marketinghub.geralanding.wireframe.service.pending.RecordWireframePending;
-import com.marketinghub.geralanding.wireframe.service.recebeprompt.RecebePromptRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.slf4j.Logger;

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2425,3 +2425,15 @@
 - Correção aplicada:
   - `BackendWireframeController.recebePrompt` passou a registrar `idJob`, `jobidopenai` e o valor literal de `payload.prompt()` antes de delegar para `BackendWireframeService.markWaitingOpenAiDispatch`;
   - o teste do controller foi atualizado para capturar o log e garantir que o prompt recebido aparece na saída de log.
+
+## 2026-05-29 — Records dos endpoints de listagem e detalhe do wireframe isolados
+
+- Solicitação: dentro de `geralanding.wireframe.service`, criar os pacotes `listStageExecutions` e `detailStageExecution` e mover para eles os records usados pelos endpoints correspondentes do controller.
+- Correção aplicada:
+  - `GeraLandingWireframeExecutionSummaryResponse` foi movido para `com.marketinghub.geralanding.wireframe.service.listStageExecutions`;
+  - `RecordBackendWireframeDetalheDto` foi movido para `com.marketinghub.geralanding.wireframe.service.detailStageExecution`;
+  - `BackendWireframeService` e `BackendWireframeController` passaram a importar os records a partir dos novos subpacotes.
+
+## 2026-05-29 — Persistência do prompt no callback de despacho do wireframe
+
+- Ajuste adicional validado por teste unitário: `BackendWireframeService.markWaitingOpenAiDispatch` também passou a preencher o campo `prompt` da execução ao receber o prompt despachado, mantendo `openAiRequestBody` preservado com o mesmo conteúdo para compatibilidade.


### PR DESCRIPTION
### Motivation
- Separate DTOs used by list/detail endpoints into dedicated subpackages to improve package organization and reduce coupling.
- Ensure the internal `recebe-prompt` callback persists the `prompt` field on the execution so the worker/trace contract is satisfied and tests reflect real behavior.

### Description
- Moved `GeraLandingWireframeExecutionSummaryResponse` into `com.marketinghub.geralanding.wireframe.service.listStageExecutions` and updated its `package` declaration.
- Moved `RecordBackendWireframeDetalheDto` into `com.marketinghub.geralanding.wireframe.service.detailStageExecution` and updated its `package` declaration.
- Updated `BackendWireframeController` and `BackendWireframeService` imports and usage to reference the new subpackages for the DTOs.
- Updated `BackendWireframeService.markWaitingOpenAiDispatch` to also set `execution.setPrompt(prompt)` while preserving `openAiRequestBody` and `openAiJobId`.
- Added an entry in `docs/registros/experimentos.md` documenting the package refactor and the prompt persistence change.

### Testing
- Ran `../mvnw test -Dtest=BackendWireframeServiceTest,BackendWireframeControllerTest` in `backend/ads-service` and addressed a failing assertion by persisting `prompt` in `markWaitingOpenAiDispatch`.
- After the fix the specified tests completed successfully with all assertions passing (test suite for these classes: 8 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197c9985948321ad4c28689086cf7c)