### PR TITLE
Allow GeraLanding service subpackage dependencies

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -89,7 +89,7 @@ class ArquiteturaTest {
     static final ArchRule geralandingServicePackagesShouldOnlyAccessAllowedMarketingHubClasses =
             classes().that().resideInAPackage("com.marketinghub.geralanding..service..")
                     .should(onlyDependOnAllowedMarketingHubClasses())
-                    .because("[ARQUITETURA][BACKEND][GeraLanding] serviços em geralanding.*.service só podem acessar classes permitidas dentro de com.marketinghub");
+                    .because("[ARQUITETURA] [BACKEND][GeraLanding] serviços em geralanding.*.service só podem acessar classes permitidas dentro de com.marketinghub");
 
     @ArchTest
     static final ArchRule backendStageControllersMustExposePendingMethod =
@@ -281,7 +281,7 @@ class ArquiteturaTest {
                 Class<?>[] parameterTypes = method.get().reflect().getParameterTypes();
                 boolean validSignature = parameterTypes.length == 2
                         && String.class.equals(parameterTypes[0])
-                        && "com.marketinghub.geralanding.wireframe.web.BackendWireframeController$RecebePromptRequest"
+                        && "com.marketinghub.geralanding.wireframe.service.recebeprompt.RecebePromptRequest"
                                 .equals(parameterTypes[1].getName());
                 if (!validSignature) {
                     String message = "[ARQUITETURA] [BACKEND][GeraLanding][Wireframe] classe=" + item.getName()
@@ -385,10 +385,10 @@ class ArquiteturaTest {
     }
 
     /**
-     * Garante que serviços geralanding acessem apenas classes permitidas dentro de com.marketinghub.
+     * Garante que serviços geralanding acessem serviços internos da mesma etapa e classes compartilhadas permitidas.
      */
     private static ArchCondition<JavaClass> onlyDependOnAllowedMarketingHubClasses() {
-        return new ArchCondition<>("[ARQUITETURA][BACKEND][GeraLanding] depend only on explicit allowed classes") {
+        return new ArchCondition<>("[ARQUITETURA] [BACKEND][GeraLanding] depend only on same-stage service packages and explicit allowed classes") {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
                 item.getDirectDependenciesFromSelf().forEach(dependency -> {
@@ -397,7 +397,7 @@ class ArquiteturaTest {
                     if (!targetName.startsWith("com.marketinghub.")) {
                         return;
                     }
-                    if (targetClass.getPackageName().equals(item.getPackageName())
+                    if (isSameStageServiceDependency(item, targetClass)
                             || targetName.equals(EXPERIMENT_CLASS)
                             || targetName.equals(EXPERIMENT_REPOSITORY_CLASS)
                             || targetName.equals(GERALANDING_STAGE_EXECUTION_CLASS)
@@ -409,6 +409,7 @@ class ArquiteturaTest {
                             + " possui import/dependência violadora: " + dependency.getDescription()
                             + " (alvo: " + targetName + ")"
                             + " | regra: serviços em geralanding.*.service só podem acessar "
+                            + "pacotes internos geralanding.<etapa>.service.* da mesma etapa, "
                             + EXPERIMENT_CLASS + ", "
                             + EXPERIMENT_REPOSITORY_CLASS + ", "
                             + GERALANDING_STAGE_EXECUTION_CLASS + ", "
@@ -418,6 +419,16 @@ class ArquiteturaTest {
                 });
             }
         };
+    }
+
+    /**
+     * Verifica se a dependência alvo pertence à árvore service da mesma etapa GeraLanding.
+     */
+    private static boolean isSameStageServiceDependency(JavaClass sourceClass, JavaClass targetClass) {
+        String sourceStage = extractGeraLandingStage(sourceClass.getPackageName());
+        String targetStage = extractGeraLandingStage(targetClass.getPackageName());
+        String targetLayer = extractGeraLandingLayer(targetClass.getPackageName());
+        return sourceStage != null && sourceStage.equals(targetStage) && "service".equals(targetLayer);
     }
 
     /**

--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -10,13 +10,19 @@ Consolidar a arquitetura do GeraLanding com base nas regras automatizadas de Arc
 flowchart LR
     WEB["Pacote: geralanding.<etapa>.web"]
     SERV["Pacote: geralanding.<etapa>.service"]
+    SERV_INT["Pacotes internos: geralanding.<etapa>.service.*"]
     PROV["Pacote: geralanding.<etapa>.provisorio"]
     EXP["Pacote: com.marketinghub.experiment (Experiment + ExperimentRepository)"]
     EXEC["Pacote: com.marketinghub.geralanding.execution (GeraLandingStageExecution + GeraLandingStageExecutionRepository)"]
 
     WEB -->|pode usar| SERV
+    SERV -->|pode usar| SERV_INT
+    SERV_INT -->|pode usar| SERV
+    SERV_INT -->|pode usar| SERV_INT
     SERV -->|pode usar| EXP
     SERV -->|pode usar| EXEC
+    SERV_INT -->|pode usar| EXP
+    SERV_INT -->|pode usar| EXEC
 ```
 
 > Leitura do diagrama: cada caixa é um pacote. Só existe seta quando há dependência permitida. Sem seta = não pode usar diretamente.
@@ -26,10 +32,10 @@ Regras arquiteturais refletidas (ArchUnit):
 - `GeraLandingStageExecutionService` não pode chamar assinaturas legadas dos assemblers de wireframe/copy/design preset.
 - `GeraLandingStageExecutionService` deve chamar explicitamente as assinaturas canônicas dos assemblers.
 - `WireframeProvisionalHtmlAssembler` deve residir em `geralanding.wireframe` e `DesignPresetProvisionalHtmlAssembler` em `geralanding.designpreset`.
-- Serviços em `com.marketinghub.geralanding..service..` podem depender de classes do próprio pacote de serviço (mesma etapa) e de `Experiment`, `ExperimentRepository`, `GeraLandingStageExecution` e `GeraLandingStageExecutionRepository` no domínio `com.marketinghub`.
+- Serviços em `com.marketinghub.geralanding..service..` podem depender de classes da árvore interna de serviço da mesma etapa (`geralanding.<etapa>.service` e `geralanding.<etapa>.service.*`) e de `Experiment`, `ExperimentRepository`, `GeraLandingStageExecution`, `GeraLandingStageExecutionRepository` e do builder de `GeraLandingStageExecution` no domínio `com.marketinghub`.
 - `geralanding.*.web` só pode acessar `geralanding.*.web` e `geralanding.*.service` da mesma etapa.
 - `geralanding.*.provisorio` só pode acessar `geralanding.*.provisorio` da mesma etapa.
-- `geralanding.*.service` só pode acessar classes `com.marketinghub` permitidas: classes do próprio pacote `service` da etapa, `Experiment`, `ExperimentRepository`, `GeraLandingStageExecution` e `GeraLandingStageExecutionRepository`.
+- `geralanding.*.service` só pode acessar classes `com.marketinghub` permitidas: classes da árvore interna `service` da mesma etapa (`service` e `service.*`), `Experiment`, `ExperimentRepository`, `GeraLandingStageExecution`, `GeraLandingStageExecutionRepository` e o builder de `GeraLandingStageExecution`.
 
 ## 2) Worker AI (ai-worker / `com.marketinghub.worker.geralanding`)
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2432,3 +2432,10 @@
 - Correção aplicada:
   - `docs/gera-landing/swagger-gera-landing-etapas.yaml` passou a documentar os seis endpoints do controller de wireframe: start, listagem, detalhe, pending, `recebe-prompt` e `recebe-resposta`;
   - foram adicionados parâmetros reutilizáveis e schemas para respostas, pendências e payloads específicos da etapa `landing-page-wireframe`.
+
+## 2026-05-29 — Regra ArchUnit para subpacotes internos de service do GeraLanding
+
+- Solicitação: alterar a regra de arquitetura do backend para permitir que classes em pacotes `service` acessem classes de pacotes internos `service.*`.
+- Correção aplicada:
+  - a regra ArchUnit de `com.marketinghub.geralanding..service..` passou a aceitar dependências para toda a árvore `geralanding.<etapa>.service` e `geralanding.<etapa>.service.*` da mesma etapa;
+  - o cânone de arquitetura do GeraLanding foi sincronizado para registrar a permissão explícita de dependência entre o pacote `service` e seus subpacotes internos.


### PR DESCRIPTION
### Motivation
- Allow services in `com.marketinghub.geralanding..service..` to depend on internal helper packages under the same stage (`geralanding.<etapa>.service.*`) while keeping existing explicit domain exceptions. 

### Description
- Relaxed the ArchUnit rule in `ArquiteturaTest` so `com.marketinghub.geralanding..service..` may depend on same-stage `service` packages and their `service.*` subpackages by adding `isSameStageServiceDependency` logic and updating the rule message. 
- Adjusted the `BackendWireframeController.recebePrompt` signature check in `ArquiteturaTest` to recognize `RecebePromptRequest` located in `com.marketinghub.geralanding.wireframe.service.recebeprompt`. 
- Synchronized the canonical architecture document `docs/canonical/geralanding-arquitetura-canon.v1.md` and recorded the change in `docs/registros/experimentos.md` to reflect the allowed `service.*` dependencies.

### Testing
- Ran the focused ArchUnit test with `../mvnw -Dtest=com.marketinghub.architecture.ArquiteturaTest test`, which passed (20 tests, 0 failures). 
- Ran the full module test suite with `../mvnw test`, which failed due to an unrelated H2 referential-integrity error in `FacebookPageControllerTest.setup` (existing data/isolation issue) and not because of the ArchUnit change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b6f7c5648321be7f987d0bd0061e)