### PR TITLE
Wireframe: unify receive-resposta callback and support failure reporting from Worker AI

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineBackendClient.java
@@ -150,60 +150,6 @@ public class ExperimentPipelineBackendClient {
                 .block();
     }
 
-    public void registerGeraLandingPrompt(Long experimentId,
-                                          String stageCode,
-                                          String jobId,
-                                          String promptContent,
-                                          String openAiJobId) {
-        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions");
-        Map<String, Object> body = new java.util.LinkedHashMap<>();
-        body.put("experimentId", experimentId);
-        body.put("stageCode", stageCode);
-        body.put("jobId", jobId);
-        body.put("promptContent", promptContent);
-        body.put("openAiJobId", openAiJobId);
-        webClient.post()
-                .uri(url)
-                .bodyValue(body)
-                .retrieve()
-                .bodyToMono(Void.class)
-                .doOnSuccess(ignored -> log.info("GeraLanding prompt execution persisted (experimentId={}, stageCode={}, jobId={})",
-                        experimentId, stageCode, jobId))
-                .doOnError(err -> log.warn("Failed to persist GeraLanding prompt execution (experimentId={}, stageCode={}, jobId={})",
-                        experimentId, stageCode, jobId, err))
-                .onErrorResume(err -> Mono.empty())
-                .block();
-    }
-
-
-
-    /**
-     * Registra no backend o retorno da OpenAI para uma execução do GeraLanding.
-     */
-    public void registerGeraLandingResult(Long experimentId,
-                                          String stageCode,
-                                          String jobId,
-                                          ExperimentPipelineJobCompletionPayload payload) {
-        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/stage-executions/", jobId, "/receive-result");
-        Map<String, Object> body = new java.util.LinkedHashMap<>();
-        body.put("experimentId", experimentId);
-        body.put("stageCode", stageCode);
-        body.put("modelResponse", payload.responseContent());
-        body.put("inputTokens", payload.inputTokens());
-        body.put("outputTokens", payload.outputTokens());
-        body.put("costUsd", payload.costUsd());
-        log.info("Enviando retorno para backend (jobId={}, url={}, payload={})", jobId, url, body);
-        webClient.post()
-                .uri(url)
-                .bodyValue(body)
-                .retrieve()
-                .bodyToMono(Void.class)
-                .doOnSuccess(ignored -> log.info("Retorno do GeraLanding enviado ao backend (jobId={}, url={})", jobId, url))
-                .doOnError(err -> log.error("Falha ao enviar retorno do GeraLanding ao backend (jobId={}, url={}, payload={})", jobId, url, body, err))
-                .onErrorResume(err -> Mono.empty())
-                .block();
-    }
-
     private Flux<ExperimentPipelineJobDto> handleListResponse(String uri,
                                                               HttpStatusCode status,
                                                               org.springframework.web.reactive.function.client.ClientResponse response) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineGenerationWorkerService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineGenerationWorkerService.java
@@ -27,6 +27,7 @@ public class ExperimentPipelineGenerationWorkerService {
         this.workerId = resolveWorkerId(configuredWorkerId);
     }
 
+    /** Processa pendências do pipeline legado sem acionar callbacks genéricos do GeraLanding. */
     public void processPending() {
         log.info("Experiment pipeline worker cycle started");
         if (!openAiClient.isEnabled()) {
@@ -51,10 +52,7 @@ public class ExperimentPipelineGenerationWorkerService {
                         claimed.id(), workerId, claimed.section());
                 backendClient.updateStage(claimed.id(), "SENT_TO_OPENAI");
                 backendClient.updateStage(claimed.id(), "WAITING_OPENAI");
-                String expectedModel = "gpt-5.2";
-                backendClient.registerGeraLandingPrompt(claimed.experimentId(), claimed.section(), claimed.id().toString(), claimed.requestBodyJson(), expectedModel);
                 ExperimentPipelineJobCompletionPayload payload = openAiClient.generate(claimed);
-                backendClient.registerGeraLandingResult(claimed.experimentId(), claimed.section(), claimed.id().toString(), payload);
                 log.info("Job {} received OpenAI output; completing job in backend", claimed.id());
                 completeInBackendWithRetry(claimed.id(), payload);
                 log.info("Job {} completed successfully", claimed.id());

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
@@ -123,7 +123,7 @@ public class GeraLandingWireframeBackendClient {
         return payload;
     }
 
-    /** Envia estado de falha da execução wireframe ao backend. */
+    /** Envia estado de falha da execução wireframe ao backend pelo callback específico recebe-resposta. */
     public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) {
         String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/wireframe/stage-executions");
         Map<String, Object> body = new LinkedHashMap<>();
@@ -131,17 +131,7 @@ public class GeraLandingWireframeBackendClient {
         body.put("stageCode", stageCode);
         body.put("errorMessage", errorMessage);
         body.put("errorDetail", errorDetail);
-        webClient.post().uri(baseUrl + "/{idJob}/receive-result", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block();
-    }
-
-    /** Registra no backend o dispatch do job wireframe para a OpenAI. */
-    public void receiveDispatch(String idJob, Long experimentId, String stageCode, String openAiJobId) {
-        String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/wireframe/stage-executions");
-        Map<String, Object> body = new LinkedHashMap<>();
-        body.put("experimentId", experimentId);
-        body.put("stageCode", stageCode);
-        body.put("openAiJobId", openAiJobId);
-        webClient.post().uri(baseUrl + "/{idJob}/receive-dispatch", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block();
+        webClient.post().uri(baseUrl + "/{idJob}/recebe-resposta", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block();
     }
 
     /** Envia ao backend o resultado final da etapa wireframe. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/response/RecebeResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/response/RecebeResponse.java
@@ -24,9 +24,6 @@ public class RecebeResponse {
      * Envia para o backend os dados de despacho e de resultado da etapa, incluindo a resposta crua da OpenAI.
      */
     public void processar(Long experimentId, String stageCode, String idJob, RecordWireframeResponse payload) {
-        if (payload != null && payload.openAiJobId() != null && !payload.openAiJobId().isBlank()) {
-            backendClient.receiveDispatch(idJob, experimentId, stageCode, payload.openAiJobId());
-        }
         log.info("Enviando payload de resultado ao backend. stageCode={}, idJob={}, experimentId={}, hasResponseContent={}, hasRawResponse={}",
                 stageCode,
                 idJob,

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
@@ -36,6 +36,7 @@ public class BackendWireframeService {
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
     private final ExperimentRepository experimentRepository;
     private final GeraLandingStageExecutionRepository executionRepository;
     private final ObjectMapper objectMapper;
@@ -123,7 +124,7 @@ public class BackendWireframeService {
         executionRepository.save(execution);
     }
 
-    /** Conclui a execução da etapa wireframe com a resposta final devolvida pelo Worker AI. */
+    /** Conclui ou falha a execução da etapa wireframe com a resposta devolvida pelo Worker AI. */
     @Transactional
     public void markCompletedFromResponse(
             String idJob,
@@ -133,7 +134,9 @@ public class BackendWireframeService {
             Integer inputTokens,
             Integer outputTokens,
             BigDecimal costUsd,
-            String openAiJobId) {
+            String openAiJobId,
+            String errorMessage,
+            String errorDetail) {
         GeraLandingStageExecution execution = executionRepository
                 .findTopByIdJobOrderByExecutionRequestedAtDesc(toDatabaseIdJob(idJob))
                 .or(() -> executionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
@@ -148,21 +151,25 @@ public class BackendWireframeService {
             execution.setInputTokens(inputTokens);
             execution.setOutputTokens(outputTokens);
             execution.setCostUsd(costUsd);
-            execution.setErrorMessage(null);
-            execution.setErrorDetail(null);
+            String normalizedErrorMessage = StringUtils.hasText(errorMessage) ? errorMessage.trim() : null;
+            execution.setErrorMessage(normalizedErrorMessage);
+            execution.setErrorDetail(StringUtils.hasText(errorDetail) ? errorDetail.trim() : null);
             execution.setCompletedAt(Instant.now());
-            execution.setStatus(STATUS_COMPLETED);
+            execution.setStatus(normalizedErrorMessage != null ? STATUS_FAILED : STATUS_COMPLETED);
 
             executionRepository.save(execution);
-            persistWireframeArtifactOnExperiment(execution, modelResponse);
+            if (normalizedErrorMessage == null) {
+                persistWireframeArtifactOnExperiment(execution, modelResponse);
+            }
         } catch (RuntimeException ex) {
             log.error(
-                    "Erro ao concluir resposta wireframe (idJob={}, experimentId={}, stageCode={}, openAiJobId={}, modelResponseLength={})",
+                    "Erro ao concluir resposta wireframe (idJob={}, experimentId={}, stageCode={}, openAiJobId={}, modelResponseLength={}, errorMessage={})",
                     idJob,
                     experimentId,
                     stageCode,
                     openAiJobId,
                     modelResponse != null ? modelResponse.length() : 0,
+                    errorMessage,
                     ex);
             throw ex;
         }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/receberesposta/RecebeRespostaRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/receberesposta/RecebeRespostaRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
-/** Representa o payload final enviado pelo Worker AI para concluir a resposta da etapa wireframe. */
+/** Representa o payload enviado pelo Worker AI para concluir ou falhar a resposta da etapa wireframe. */
 public record RecebeRespostaRequest(
         @NotNull Long experimentId,
         @NotBlank String stageCode,
@@ -12,4 +12,6 @@ public record RecebeRespostaRequest(
         Integer inputTokens,
         Integer outputTokens,
         BigDecimal costUsd,
-        String openAiJobId) {}
+        String openAiJobId,
+        String errorMessage,
+        String errorDetail) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -75,14 +75,15 @@ public class BackendWireframeController {
   public ResponseEntity<Void> recebeResposta(
       @PathVariable String idJob, @Valid @RequestBody RecebeRespostaRequest payload) {
     LOGGER.info(
-        "[GeraLanding][Wireframe] Recebida resposta da IA idJob={} experimentId={} stageCode={} openAiJobId={} inputTokens={} outputTokens={} costUsd={}",
+        "[GeraLanding][Wireframe] Recebida resposta da IA idJob={} experimentId={} stageCode={} openAiJobId={} inputTokens={} outputTokens={} costUsd={} hasError={}",
         idJob,
         payload.experimentId(),
         payload.stageCode(),
         payload.openAiJobId(),
         payload.inputTokens(),
         payload.outputTokens(),
-        payload.costUsd());
+        payload.costUsd(),
+        payload.errorMessage() != null && !payload.errorMessage().isBlank());
     executionService.markCompletedFromResponse(
         idJob,
         payload.experimentId(),
@@ -91,7 +92,9 @@ public class BackendWireframeController {
         payload.inputTokens(),
         payload.outputTokens(),
         payload.costUsd(),
-        payload.openAiJobId());
+        payload.openAiJobId(),
+        payload.errorMessage(),
+        payload.errorDetail());
     return ResponseEntity.accepted().build();
   }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
@@ -194,7 +194,9 @@ class BackendWireframeServiceTest {
                 321,
                 123,
                 new BigDecimal("0.045600"),
-                "openai-job-final");
+                "openai-job-final",
+                null,
+                null);
 
         assertEquals(modelResponse, execution.getModelResponse());
         assertEquals("openai-job-final", execution.getOpenAiJobId());
@@ -207,6 +209,45 @@ class BackendWireframeServiceTest {
         verify(experiment).setLandingPageWireframe(modelResponse);
         verify(experimentRepository).save(experiment);
         verify(experimentRepository, never()).findById(88L);
+    }
+
+    /** Deve marcar a execução como falha sem gravar artefato quando o Worker AI retorna erro. */
+    @Test
+    void markCompletedFromResponseShouldPersistFailureWithoutExperimentArtifact() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        BackendWireframeService service =
+                new BackendWireframeService(experimentRepository, executionRepository, new ObjectMapper());
+        Experiment experiment = mock(Experiment.class);
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(88L)
+                .experiment(experiment)
+                .stageCode("landing-page-wireframe")
+                .idJob("job-ia-erro".getBytes(StandardCharsets.UTF_8))
+                .status("AGUARDANDO_RETORNO_OPENAI")
+                .build();
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(any(byte[].class)))
+                .thenReturn(Optional.of(execution));
+
+        service.markCompletedFromResponse(
+                "job-ia-erro",
+                88L,
+                "landing-page-wireframe",
+                null,
+                null,
+                null,
+                null,
+                null,
+                " Falha OpenAI ",
+                " Detalhe técnico ");
+
+        assertEquals("Falha OpenAI", execution.getErrorMessage());
+        assertEquals("Detalhe técnico", execution.getErrorDetail());
+        assertNotNull(execution.getCompletedAt());
+        assertEquals("FALHA", execution.getStatus());
+        verify(executionRepository).save(execution);
+        verify(experiment, never()).setLandingPageWireframe(any());
+        verify(experimentRepository, never()).save(experiment);
     }
 
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -92,7 +92,9 @@ class BackendWireframeControllerTest {
                 120,
                 80,
                 new BigDecimal("0.012300"),
-                "openai-job-1");
+                "openai-job-1",
+                null,
+                null);
 
         var response = controller.recebeResposta("job-ia-1", payload);
 
@@ -105,7 +107,42 @@ class BackendWireframeControllerTest {
                 120,
                 80,
                 new BigDecimal("0.012300"),
-                "openai-job-1");
+                "openai-job-1",
+                null,
+                null);
+    }
+
+
+    /** Deve receber payload de erro e delegar a falha para o serviço da etapa wireframe. */
+    @Test
+    void recebeRespostaShouldDelegateErrorPayloadToWireframeService() {
+        BackendWireframeService executionService = mock(BackendWireframeService.class);
+        BackendWireframeController controller = new BackendWireframeController(executionService);
+        RecebeRespostaRequest payload = new RecebeRespostaRequest(
+                44L,
+                "landing-page-wireframe",
+                null,
+                null,
+                null,
+                null,
+                null,
+                "Falha OpenAI",
+                "Stack trace resumido");
+
+        var response = controller.recebeResposta("job-ia-erro", payload);
+
+        assertEquals(202, response.getStatusCode().value());
+        verify(executionService).markCompletedFromResponse(
+                "job-ia-erro",
+                44L,
+                "landing-page-wireframe",
+                null,
+                null,
+                null,
+                null,
+                null,
+                "Falha OpenAI",
+                "Stack trace resumido");
     }
 
     /** Deve serializar pending como lista com atributos experiment e jobid em cada item. */

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -59,7 +59,7 @@ paths:
       tags:
         - landing-page-wireframe
       summary: Recebe a resposta interna retornada pela IA no job de wireframe.
-      description: Endpoint inicial para o Worker AI informar a resposta da IA; nesta primeira versão o backend apenas aceita a chamada sem processar o payload.
+      description: Endpoint para o Worker AI informar sucesso ou falha da IA; o backend persiste métricas, artefato em sucesso e erro operacional em falha.
       operationId: recebeRespostaGeraLandingWireframeExecution
       parameters:
         - $ref: '#/components/parameters/IdJob'
@@ -71,7 +71,7 @@ paths:
               $ref: '#/components/schemas/RecebeRespostaRequest'
       responses:
         '202':
-          description: Resposta aceita sem processamento operacional nesta versão.
+          description: Resposta aceita e execução concluída ou marcada como falha.
 components:
   parameters:
     IdJob:
@@ -101,8 +101,51 @@ components:
         - jobidopenai
     RecebeRespostaRequest:
       type: object
-      description: Payload inicial da resposta da IA pelo Worker AI; campos definitivos serão especificados na próxima evolução do contrato.
-      additionalProperties: true
+      description: Payload de retorno da IA pelo Worker AI para sucesso ou falha da etapa wireframe.
+      additionalProperties: false
+      properties:
+        experimentId:
+          type: integer
+          format: int64
+          description: ID do experimento associado à execução.
+        stageCode:
+          type: string
+          minLength: 1
+          description: Código canônico da etapa.
+        modelResponse:
+          type: string
+          nullable: true
+          description: Resposta retornada pelo modelo quando a execução teve sucesso.
+        inputTokens:
+          type: integer
+          format: int32
+          nullable: true
+          description: Tokens de entrada reportados pelo provedor.
+        outputTokens:
+          type: integer
+          format: int32
+          nullable: true
+          description: Tokens de saída reportados pelo provedor.
+        costUsd:
+          type: number
+          format: double
+          nullable: true
+          description: Custo estimado da execução em dólar.
+        openAiJobId:
+          type: string
+          nullable: true
+          description: Identificador do job no provedor OpenAI.
+        errorMessage:
+          type: string
+          nullable: true
+          description: Mensagem operacional da falha quando a etapa não conclui.
+        errorDetail:
+          type: string
+          nullable: true
+          description: Detalhe técnico da falha quando disponível.
+      required:
+        - experimentId
+        - stageCode
     PendingStageExecution:
       type: object
       additionalProperties: false

--- a/docs/gera-landing/swagger-gera-landing-etapas.yaml
+++ b/docs/gera-landing/swagger-gera-landing-etapas.yaml
@@ -120,7 +120,7 @@ paths:
         - Gera Landing Wireframe Internal
       summary: Recebe resposta da IA para wireframe
       description: |
-        Recebe a resposta da IA para a etapa `landing-page-wireframe` e conclui a execução do job.
+        Recebe a resposta da IA para a etapa `landing-page-wireframe` e conclui ou falha a execução do job.
       parameters:
         - $ref: "#/components/parameters/IdJobPath"
       requestBody:
@@ -131,7 +131,7 @@ paths:
               $ref: "#/components/schemas/RecebeRespostaRequest"
       responses:
         "202":
-          description: Resposta recebida e execução concluída.
+          description: Resposta recebida e execução concluída ou marcada como falha.
         "400":
           description: Payload inválido.
         "404":
@@ -468,6 +468,14 @@ components:
           type: string
           nullable: true
           description: Identificador do job no provedor OpenAI.
+        errorMessage:
+          type: string
+          nullable: true
+          description: Mensagem operacional da falha quando o Worker AI não consegue concluir a etapa.
+        errorDetail:
+          type: string
+          nullable: true
+          description: Detalhe técnico da falha quando disponível.
 
     GeraLandingStartResponse:
       type: object

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2450,3 +2450,17 @@
 - Correção aplicada:
   - a regra ArchUnit de `com.marketinghub.geralanding..service..` passou a aceitar dependências para toda a árvore `geralanding.<etapa>.service` e `geralanding.<etapa>.service.*` da mesma etapa;
   - o cânone de arquitetura do GeraLanding foi sincronizado para registrar a permissão explícita de dependência entre o pacote `service` e seus subpacotes internos.
+## 2026-05-29 — Wireframe usa recebe-resposta para sucesso e falha
+
+- Solicitação: excluir o caminho legado de callback `receive-result` para a etapa wireframe, fazer o Worker AI chamar `recebe-resposta` tanto em sucesso quanto em erro, e ajustar o backend para tratar falhas nesse endpoint específico.
+- Correção aplicada:
+  - removidas do fluxo legado `experimentpipeline` as chamadas genéricas de registro do GeraLanding para `/internal/geralanding/stage-executions` e `/receive-result`;
+  - `GeraLandingWireframeBackendClient.receiveFailure(...)` passou a postar no endpoint específico `/api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-resposta`;
+  - o envio de sucesso da etapa wireframe deixou de tentar `receive-dispatch` antes de `recebe-resposta`, garantindo que o callback específico seja alcançado no caminho feliz;
+  - `RecebeRespostaRequest` da etapa wireframe passou a aceitar `errorMessage` e `errorDetail`;
+  - `BackendWireframeService.markCompletedFromResponse(...)` passou a marcar a execução como `FALHA` quando houver `errorMessage`, persistindo erro e detalhe sem gravar artefato no experimento; no sucesso mantém `CONCLUIDO` e grava o wireframe;
+  - Swagger canônico e Swagger operacional do GeraLanding foram sincronizados com o contrato de sucesso/falha do `recebe-resposta`.
+- Testes executados:
+  - `mvn test -Dtest=BackendWireframeServiceTest,BackendWireframeControllerTest` em `backend/ads-service`;
+  - `mvn install -DskipTests` em `backend/ads-service` para disponibilizar o artefato local usado pelo `ai-worker`;
+  - `mvn test -Dtest=WireframePendingJobsServiceTest,ExperimentPipelineOpenAiClientTest` em `ai-worker`.


### PR DESCRIPTION
### Motivation

- Unify and simplify the GeraLanding wireframe callback flow so the Worker AI reports both success and failure through a single endpoint and the backend can persist error information without writing invalid artifacts.
- Remove legacy generic callbacks from the experiment pipeline worker to avoid double-reporting and guarantee the wireframe-specific callback is used.

### Description

- The experiment worker no longer calls the removed generic `registerGeraLandingPrompt` and `registerGeraLandingResult` endpoints and avoids the legacy callbacks in `ExperimentPipelineGenerationWorkerService`.
- `GeraLandingWireframeBackendClient.receiveFailure` now posts to the wireframe-specific `.../recebe-resposta` endpoint and `receiveResult` also uses that path; the legacy `receive-dispatch`/`receive-result` routes were removed from the worker flow.
- The backend contract `RecebeRespostaRequest` was extended with `errorMessage` and `errorDetail`, `BackendWireframeController` and `BackendWireframeService.markCompletedFromResponse(...)` signatures were updated to accept these fields, and the service now sets status to `FALHA` (and stores trimmed error fields) when `errorMessage` is present while persisting the wireframe artifact only on success.
- Swagger/OpenAPI and documentation were updated to reflect the new `recebe-resposta` success/failure contract and to disallow additional properties in the request schema.
- Unit tests were added/updated to cover the failure path and controller delegation (`BackendWireframeServiceTest` and `BackendWireframeControllerTest`), and logging/error handling was adjusted to include the error message in failure logs.

### Testing

- Ran `mvn test -Dtest=BackendWireframeServiceTest,BackendWireframeControllerTest` in `backend/ads-service`, and the tests passed.
- Built the backend artifact with `mvn install -DskipTests` in `backend/ads-service` to use locally in the worker build, which completed successfully.
- Ran `mvn test -Dtest=WireframePendingJobsServiceTest,ExperimentPipelineOpenAiClientTest` in `ai-worker`, and those tests also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19c76278448321bb36f512631c02d9)