### PR TITLE
Wireframe: send failures to `/recebe-resposta` and normalize backend error handling

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClient.java
@@ -123,15 +123,26 @@ public class GeraLandingWireframeBackendClient {
         return payload;
     }
 
-    /** Envia estado de falha da execução wireframe ao backend pelo callback específico recebe-resposta. */
+    /** Envia o JSON de erro da execução wireframe ao backend pelo callback específico recebe-resposta. */
     public void receiveFailure(String idJob, Long experimentId, String stageCode, String errorMessage, String errorDetail) {
         String baseUrl = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/internal/geralanding/wireframe/stage-executions");
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("experimentId", experimentId);
         body.put("stageCode", stageCode);
+        body.put("modelResponse", null);
+        body.put("inputTokens", null);
+        body.put("outputTokens", null);
+        body.put("costUsd", null);
+        body.put("openAiJobId", null);
         body.put("errorMessage", errorMessage);
         body.put("errorDetail", errorDetail);
-        webClient.post().uri(baseUrl + "/{idJob}/receive-result", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block();
+        log.info("Enviando JSON de erro wireframe ao backend. idJob={}, experimentId={}, stageCode={}, hasErrorMessage={}, hasErrorDetail={}",
+                idJob,
+                experimentId,
+                stageCode,
+                errorMessage != null && !errorMessage.isBlank(),
+                errorDetail != null && !errorDetail.isBlank());
+        webClient.post().uri(baseUrl + "/{idJob}/recebe-resposta", idJob).bodyValue(body).retrieve().bodyToMono(Void.class).block();
     }
 
     /** Envia ao backend o prompt despachado para IA e o identificador do job OpenAI conforme contrato recebe-prompt. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/wireframe/backend/GeraLandingWireframeBackendClientTest.java
@@ -2,9 +2,11 @@ package com.marketinghub.worker.geralanding.wireframe.backend;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.geralanding.wireframe.dto.GeraLandingStageExecutionDetailDto;
 import java.util.List;
+import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
@@ -86,6 +88,36 @@ class GeraLandingWireframeBackendClientTest {
                         java.util.Map.class,
                         value -> assertThat(value).containsEntry("primaryPromise", "Agenda cheia"));
         assertThat(server.getRequestCount()).isEqualTo(1);
+    }
+
+    /** Deve enviar falhas da etapa wireframe para o mesmo callback recebe-resposta usado no sucesso. */
+    @Test
+    void receiveFailureShouldCallRecebeRespostaWithErrorJson() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(202));
+        GeraLandingWireframeBackendClient client = new GeraLandingWireframeBackendClient(
+                WebClient.builder(),
+                server.url("/").toString(),
+                "/api",
+                new ObjectMapper());
+
+        client.receiveFailure(
+                "bbed57d0-dcc7-40ab-b936-20a19e21c7fe",
+                44L,
+                "landing-page-wireframe",
+                "Falha OpenAI",
+                "Stack trace resumido");
+
+        var request = server.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getPath())
+                .isEqualTo("/api/internal/geralanding/wireframe/stage-executions/bbed57d0-dcc7-40ab-b936-20a19e21c7fe/recebe-resposta");
+        Map<String, Object> payload = new ObjectMapper().readValue(request.getBody().readUtf8(), new TypeReference<>() {});
+        assertThat(payload)
+                .containsEntry("experimentId", 44)
+                .containsEntry("stageCode", "landing-page-wireframe")
+                .containsEntry("errorMessage", "Falha OpenAI")
+                .containsEntry("errorDetail", "Stack trace resumido");
+        assertThat(payload).containsKeys("modelResponse", "inputTokens", "outputTokens", "costUsd", "openAiJobId");
     }
 
     /** Cria resposta JSON para simular os endpoints reais do backend. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
@@ -151,9 +151,10 @@ public class BackendWireframeService {
             execution.setInputTokens(inputTokens);
             execution.setOutputTokens(outputTokens);
             execution.setCostUsd(costUsd);
-            String normalizedErrorMessage = StringUtils.hasText(errorMessage) ? errorMessage.trim() : null;
+            String normalizedErrorDetail = StringUtils.hasText(errorDetail) ? errorDetail.trim() : null;
+            String normalizedErrorMessage = normalizeErrorMessage(errorMessage, normalizedErrorDetail);
             execution.setErrorMessage(normalizedErrorMessage);
-            execution.setErrorDetail(StringUtils.hasText(errorDetail) ? errorDetail.trim() : null);
+            execution.setErrorDetail(normalizedErrorDetail);
             execution.setCompletedAt(Instant.now());
             execution.setStatus(normalizedErrorMessage != null ? STATUS_FAILED : STATUS_COMPLETED);
 
@@ -173,6 +174,17 @@ public class BackendWireframeService {
                     ex);
             throw ex;
         }
+    }
+
+    /** Normaliza a mensagem de erro e garante status FALHA quando o callback traz apenas detalhe técnico. */
+    private String normalizeErrorMessage(String errorMessage, String normalizedErrorDetail) {
+        if (StringUtils.hasText(errorMessage)) {
+            return errorMessage.trim();
+        }
+        if (StringUtils.hasText(normalizedErrorDetail)) {
+            return "Falha ao processar etapa wireframe";
+        }
+        return null;
     }
 
     /** Persiste o artefato JSON final do wireframe no experimento associado à execução concluída. */

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
@@ -250,4 +250,45 @@ class BackendWireframeServiceTest {
         verify(experimentRepository, never()).save(experiment);
     }
 
+
+    /** Deve marcar falha mesmo quando o callback recebe apenas detalhe técnico do erro. */
+    @Test
+    void markCompletedFromResponseShouldFailWhenOnlyErrorDetailIsPresent() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        BackendWireframeService service =
+                new BackendWireframeService(experimentRepository, executionRepository, new ObjectMapper());
+        Experiment experiment = mock(Experiment.class);
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(88L)
+                .experiment(experiment)
+                .stageCode("landing-page-wireframe")
+                .idJob("job-ia-detalhe".getBytes(StandardCharsets.UTF_8))
+                .status("AGUARDANDO_RETORNO_OPENAI")
+                .build();
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(any(byte[].class)))
+                .thenReturn(Optional.of(execution));
+
+        service.markCompletedFromResponse(
+                "job-ia-detalhe",
+                88L,
+                "landing-page-wireframe",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                " Stack trace sem mensagem principal ");
+
+        assertEquals("Falha ao processar etapa wireframe", execution.getErrorMessage());
+        assertEquals("Stack trace sem mensagem principal", execution.getErrorDetail());
+        assertNotNull(execution.getCompletedAt());
+        assertEquals("FALHA", execution.getStatus());
+        verify(executionRepository).save(execution);
+        verify(experiment, never()).setLandingPageWireframe(any());
+        verify(experimentRepository, never()).save(experiment);
+    }
+
+
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2480,3 +2480,12 @@
   - revisado o controller `BackendWireframeController`, que expõe endpoints públicos de start, listagem e detalhe da etapa wireframe, além dos endpoints internos `pending`, `recebe-prompt` e `recebe-resposta`;
   - `docs/canonical/geralanding-backend-swagger.v1.yaml` passou a documentar também os três endpoints públicos do controller;
   - adicionados no Swagger canônico o parâmetro `ExperimentId`, os schemas `WireframeStartResponse`, `WireframeStageExecutionSummary` e `WireframeStageExecutionDetail`, e a tag separada `landing-page-wireframe-internal` para diferenciar contratos internos consumidos pelo Worker AI.
+
+## 2026-05-29 — Falha do wireframe registrada pelo recebe-resposta
+
+- Solicitação: ajustar `receiveFailure` da etapa wireframe para chamar o mesmo callback `recebe-resposta` usado no sucesso, enviando o JSON do erro, e garantir que o backend grave a falha na tabela do GeraLanding com status `FALHA`.
+- Correção aplicada:
+  - `GeraLandingWireframeBackendClient.receiveFailure(...)` passou a enviar o payload de erro para `/api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-resposta`, eliminando a chamada legada `/receive-result` no caminho de falha;
+  - o JSON enviado em falha agora segue o contrato de `recebe-resposta`, com campos de resultado nulos e `errorMessage`/`errorDetail` preenchidos;
+  - `BackendWireframeService.markCompletedFromResponse(...)` passou a normalizar a falha também quando chegar apenas `errorDetail`, garantindo persistência de `error_message`, `error_detail`, `completed_at` e status `FALHA` sem gravar artefato no experimento;
+  - testes unitários cobrem o endpoint chamado pelo Worker AI e a persistência de falha no backend.


### PR DESCRIPTION
### Motivation

- Remove legacy `receive-result` callback and make the wireframe worker use the specific `recebe-resposta` callback for both success and failure to simplify integrations.
- Ensure the failure payload follows the same contract as success callbacks so the backend can process and record failures consistently.
- Guarantee the backend marks executions as `FALHA` even when the callback provides only an error detail without a main error message.

### Description

- `GeraLandingWireframeBackendClient.receiveFailure(...)` now posts the error JSON to `/api/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-resposta` and includes nulls for result fields plus `errorMessage`/`errorDetail`, and adds an informative log line. 
- `GeraLandingWireframeBackendClient` test `receiveFailureShouldCallRecebeRespostaWithErrorJson` was added to validate the outgoing POST path and payload shape. 
- `BackendWireframeService.markCompletedFromResponse(...)` was updated to use a new `normalizeErrorMessage` helper which returns a generic message when only `errorDetail` is present, persists `errorMessage`/`errorDetail`, sets `completedAt`, and forces status `FALHA` while avoiding artifact persistence on failures. 
- New unit test `markCompletedFromResponseShouldFailWhenOnlyErrorDetailIsPresent` was added to verify error normalization and failure status, and documentation `docs/registros/experimentos.md` was updated to record the change.

### Testing

- Ran backend service unit tests `mvn test -Dtest=BackendWireframeServiceTest,BackendWireframeControllerTest` and they passed. 
- Built the backend artifact with `mvn install -DskipTests` for use by the worker and then ran ai-worker tests `mvn test -Dtest=WireframePendingJobsServiceTest,ExperimentPipelineOpenAiClientTest`, which also passed. 
- New unit tests in `ai-worker` and `backend/ads-service` were executed and validated the callback path and error normalization behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19daed09188321b065c0967d986d16)