### PR TITLE
Increase WireframeExecutionScheduler cadence to 15 minutes

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframeExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframeExecutionScheduler.java
@@ -26,7 +26,7 @@ public class WireframeExecutionScheduler {
     }
 
     /** Executa o ciclo da etapa wireframe consultando apenas o endpoint específico da etapa. */
-    @Scheduled(cron = "0 */30 * * * *")
+    @Scheduled(cron = "0 */15 * * * *")
     public void run() {
         long startedAt = System.currentTimeMillis();
         try {


### PR DESCRIPTION
### Motivation
- Process pending wireframe jobs more frequently by reducing the scheduler interval from 30 minutes to 15 minutes.

### Description
- Update the `@Scheduled` cron expression in `WireframeExecutionScheduler` from `0 */30 * * * *` to `0 */15 * * * *` so the `run()` cycle executes every 15 minutes.

### Testing
- Executed unit tests with `./gradlew test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e6b53284832183124f102632c202)