### PR TITLE
Remove automatic scheduling for GeraLanding wireframe in ai-worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframeExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframeExecutionScheduler.java
@@ -1,15 +1,10 @@
 package com.marketinghub.worker.geralanding.wireframe.monitor;
 
-
 import com.marketinghub.worker.geralanding.wireframe.request.GeraLandingWireframeOpenAiExecutionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
 
-/** Agenda o processamento de jobs pendentes da etapa wireframe. */
-@Component
+/** Mantém o ciclo manual de processamento de jobs pendentes da etapa wireframe, sem agendamento automático. */
 public class WireframeExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(WireframeExecutionScheduler.class);
 
@@ -17,16 +12,16 @@ public class WireframeExecutionScheduler {
     private final WireframePendingJobsService pendingJobsService;
     private final int pendingLimit;
 
+    /** Recebe os serviços necessários para executar manualmente o ciclo da etapa wireframe. */
     public WireframeExecutionScheduler(GeraLandingWireframeOpenAiExecutionService executionService,
                                        WireframePendingJobsService pendingJobsService,
-                                       @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
+                                       int pendingLimit) {
         this.executionService = executionService;
         this.pendingJobsService = pendingJobsService;
         this.pendingLimit = Math.max(1, pendingLimit);
     }
 
-    /** Executa o ciclo da etapa wireframe consultando apenas o endpoint específico da etapa. */
-    @Scheduled(cron = "0 */15 * * * *")
+    /** Executa manualmente o ciclo da etapa wireframe consultando apenas o endpoint específico da etapa. */
     public void run() {
         long startedAt = System.currentTimeMillis();
         try {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2489,3 +2489,13 @@
   - o JSON enviado em falha agora segue o contrato de `recebe-resposta`, com campos de resultado nulos e `errorMessage`/`errorDetail` preenchidos;
   - `BackendWireframeService.markCompletedFromResponse(...)` passou a normalizar a falha também quando chegar apenas `errorDetail`, garantindo persistência de `error_message`, `error_detail`, `completed_at` e status `FALHA` sem gravar artefato no experimento;
   - testes unitários cobrem o endpoint chamado pelo Worker AI e a persistência de falha no backend.
+
+## 2026-05-29 16:53:52 UTC-3
+- solicitação para retirar o agendamento automático do `ai-worker` na etapa `geralanding.wireframe`.
+- raciocínio: a causa do processamento periódico estava na classe `WireframeExecutionScheduler`, com bean Spring e anotação `@Scheduled`; remover o vínculo com o agendador evita execução automática sem alterar o serviço de processamento manual.
+- registro do que foi feito: removido o agendamento Spring da etapa wireframe no pacote `com.marketinghub.worker.geralanding.wireframe.monitor`, mantendo o método `run()` apenas como ciclo manual e atualizando os comentários de responsabilidade.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/registros/experimentos.md
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframeExecutionScheduler.java


### PR DESCRIPTION
### Motivation
- Prevent the ai-worker from executing the geralanding.wireframe cycle automatically so processing runs only when invoked manually and avoid unintended periodic work.

### Description
- Removed the Spring bean and `@Scheduled` cron from `WireframeExecutionScheduler`, updated the constructor to accept `pendingLimit` directly, adjusted class comments to document manual invocation, and added an operational entry in `docs/registros/experimentos.md` describing the change.

### Testing
- Ran `cd backend/ads-service && mvn -DskipTests install` to install the local `ads-service` artifact (success) and `cd ai-worker && mvn test` to execute the ai-worker test suite (success; 118 tests run, 0 failures, 0 errors, 3 skipped), and verified removal of scheduling with `rg -n "@Scheduled|org\.springframework\.scheduling" ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe -S`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19eea4353c8321aa4d2cf48774e0e9)