### PR TITLE
Enable OpenAI Wireframe worker and schedule it every 5 minutes; add configuration properties

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeExecutionScheduler.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 
+/** Responsabilidade: agendar o processamento periódico dos jobs pendentes da etapa wireframe no core OpenAI. */
 public class WireframeExecutionScheduler {
 
     private static final Logger log = LoggerFactory.getLogger(WireframeExecutionScheduler.class);
@@ -14,6 +15,7 @@ public class WireframeExecutionScheduler {
     private final StageWorker<WireframeInput, WireframeOutput> worker;
     private final WireframeWorkerProperties properties;
 
+    /** Recebe o worker e as propriedades usadas pelo ciclo agendado de wireframe. */
     public WireframeExecutionScheduler(
             StageWorker<WireframeInput, WireframeOutput> worker,
             WireframeWorkerProperties properties
@@ -22,7 +24,8 @@ public class WireframeExecutionScheduler {
         this.properties = properties;
     }
 
-    @Scheduled(cron = "${wireframe.worker.cron:0 */30 * * * *}")
+    /** Executa a cada cinco minutos o ciclo de processamento dos jobs pendentes de wireframe. */
+    @Scheduled(cron = "0 */5 * * * *")
     public void run() {
         ProcessingSummary summary = worker.processPending(properties.pendingLimit());
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeWorkerProperties.java
@@ -8,6 +8,7 @@ import org.springframework.validation.annotation.Validated;
 
 import java.time.Duration;
 
+/** Responsabilidade: concentrar as propriedades operacionais do worker OpenAI da etapa wireframe. */
 @Validated
 @ConfigurationProperties(prefix = "wireframe.worker")
 public record WireframeWorkerProperties(
@@ -31,20 +32,15 @@ public record WireframeWorkerProperties(
         String schemaName,
 
         @NotNull
-        Duration timeout,
-
-        @NotBlank
-        String cron
+        Duration timeout
 ) {
+    /** Normaliza valores opcionais usados pelo worker de wireframe quando a configuração externa omite o campo. */
     public WireframeWorkerProperties {
         if (apiPrefix == null || apiPrefix.isBlank()) {
             apiPrefix = "/api";
         }
         if (timeout == null) {
             timeout = Duration.ofMinutes(30);
-        }
-        if (cron == null || cron.isBlank()) {
-            cron = "0 */30 * * * *";
         }
     }
 }

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -60,3 +60,12 @@ framework-image.enabled=${FRAMEWORK_IMAGE_ENABLED:true}
 framework-image.rollout.percentage=${FRAMEWORK_IMAGE_ROLLOUT_PERCENTAGE:100}
 framework-image.scheduler.enabled=${FRAMEWORK_IMAGE_SCHEDULER_ENABLED:true}
 framework-image.webnization.scheduler.enabled=${FRAMEWORK_IMAGE_WEBNIZATION_SCHEDULER_ENABLED:true}
+
+wireframe.worker.enabled=${WIREFRAME_WORKER_ENABLED:true}
+wireframe.worker.pending-limit=${WIREFRAME_WORKER_PENDING_LIMIT:5}
+wireframe.worker.backend-base-url=${WIREFRAME_WORKER_BACKEND_BASE_URL:${backend.base-url}}
+wireframe.worker.api-prefix=${WIREFRAME_WORKER_API_PREFIX:${backend.api-prefix}}
+wireframe.worker.prompt-resource=${WIREFRAME_WORKER_PROMPT_RESOURCE:prompts/geralanding/landing-page-wireframe.md}
+wireframe.worker.schema-resource=${WIREFRAME_WORKER_SCHEMA_RESOURCE:prompts/geralanding/landing-page-wireframe-schema.json}
+wireframe.worker.schema-name=${WIREFRAME_WORKER_SCHEMA_NAME:experiment_pipeline_landing_page_wireframe}
+wireframe.worker.timeout=${WIREFRAME_WORKER_TIMEOUT:PT30M}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2499,3 +2499,17 @@
   - ai-worker/AGENTS.md
   - docs/registros/experimentos.md
   - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/monitor/WireframeExecutionScheduler.java
+
+## 2026-05-29 17:41:38 UTC-3
+- solicitação para ligar o novo worker OpenAI core da etapa wireframe do GeraLanding, retirar a variável de cron e executar o agendamento a cada 5 minutos.
+- raciocínio: o scheduler novo já existia no pacote `worker.openai.core.wireframe`, mas estava condicionado por propriedade desabilitada por padrão e usava cron parametrizado; a correção ativa o worker por configuração operacional e fixa o cron diretamente na anotação conforme regra de agendamentos Spring Boot.
+- registro do que foi feito: ajustado o scheduler de wireframe para cron literal de 5 minutos, removida a propriedade `cron` do record de configuração, adicionadas propriedades obrigatórias para habilitar o worker e apontar prompt/schema/backend, e incluídos comentários de responsabilidade nas classes/métodos Java alterados.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/registros/experimentos.md
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeExecutionScheduler.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeWorkerConfiguration.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeWorkerProperties.java
+  - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/MontaRequest.java
+  - ai-worker/src/main/resources/application.properties


### PR DESCRIPTION
### Motivation
- Activate the OpenAI core worker for the GeraLanding wireframe stage and replace the previous cron-configured scheduler with a fixed 5-minute schedule to ensure periodic processing.
- Consolidate required operational configuration for the wireframe worker into properties and provide sensible defaults when optional values are omitted.
- Expose and document the new worker configuration in `application.properties` so the service can be enabled and pointed at the correct backend, prompt and schema resources.

### Description
- Updated `WireframeExecutionScheduler` to use a literal `@Scheduled(cron = "0 */5 * * * *")` (every 5 minutes) and added explanatory responsibility comments; the scheduler now runs the worker cycle on that fixed interval.
- Removed the `cron` field from `WireframeWorkerProperties`, added class-level documentation, and implemented normalization for optional fields (`apiPrefix`, `timeout`) in the record constructor.
- Added required `wireframe.worker.*` configuration entries to `ai-worker/src/main/resources/application.properties` for enabling the worker and supplying `pending-limit`, `backend-base-url`, `api-prefix`, `prompt-resource`, `schema-resource`, `schema-name`, and `timeout` defaults.
- Updated experiment docs (`docs/registros/experimentos.md`) to record the change and rationale for switching the scheduler on and eliminating the external cron property.

### Testing
- Ran the module build and existing unit test suite for the `ai-worker` module via `./gradlew :ai-worker:build`, and the build and tests completed successfully.
- No additional integration tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f8e906d083218f361f185d52a27a)